### PR TITLE
Fix broken link to server dev setup instructions

### DIFF
--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -21,7 +21,7 @@ npm install
 
 Unlike the [Zulip](https://github.com/zulip/zulip) server project, we use the host machine directly for development instead of provisioning a VM.
 
-You'll probably also want to install and provision a [Zulip dev VM](https://github.com/zulip/zulip/blob/master/README.dev.md) to use for testing.
+You'll probably also want to install and provision a [Zulip dev VM](https://zulip.readthedocs.io/en/latest/dev-overview.html) to use for testing.
 
 
 ## Running on iOS simulator


### PR DESCRIPTION
The existing link in the README is broken! [This commit](https://github.com/zulip/zulip/commit/f6c4e46afebafdbfca8d83040e5d843212ca6245) suggests that the correct link should be this Read the Docs page.

Please feel free to change if this should point somewhere else instead. :)