### PR TITLE
Downgrade version of Flow.

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "eslint-plugin-jsx-a11y": "^2.2.2",
     "eslint-plugin-react": "^6.3.0",
     "eslint-plugin-react-native": "^2.0.0",
-    "flow-bin": "^0.33.0",
+    "flow-bin": "^0.32.0",
     "jest": "^15.1.1",
     "jest-cli": "^15.1.1",
     "jest-react-native": "^15.0.0",

--- a/src/common/__tests__/__snapshots__/ZulipButton-test.js.snap
+++ b/src/common/__tests__/__snapshots__/ZulipButton-test.js.snap
@@ -2,14 +2,14 @@ exports[`test renders correctly 1`] = `
 <View
   style={
     Array [
+      undefined,
       Object {
         "alignItems": "center",
         "borderRadius": 5,
         "flex": 1,
         "height": 44,
         "justifyContent": "center",
-        "marginBottom": 10,
-        "width": 260
+        "marginBottom": 10
       },
       Object {
         "backgroundColor": "#22693F"


### PR DESCRIPTION
The CI build is failing because React Native has type errors when checked against the latest version of Flow.