### PR TITLE
Improve message HTML rendering and add snapshot tests.

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   "devDependencies": {
     "babel-core": "^6.16.0",
     "babel-eslint": "^7.0.0",
+    "babel-jest": "^16.0.0",
     "babel-preset-react-native": "^1.9.0",
     "enzyme": "^2.4.1",
     "eslint": "^3.7.0",

--- a/src/api/apiFetch.js
+++ b/src/api/apiFetch.js
@@ -8,7 +8,7 @@ export type Auth = {
 
 const apiVersion = 'api/v1';
 
-const getAuthHeader = (email, apiKey) => {
+export const getAuthHeader = (email, apiKey) => {
   const encodedStr = `${email}:${apiKey}`;
   return `Basic ${base64.encode(encodedStr)}`;
 };

--- a/src/lib/message.js
+++ b/src/lib/message.js
@@ -32,3 +32,15 @@ export const sameRecipient = (msg1, msg2): boolean => {
       return false;
   }
 };
+
+export const rewriteLink = (uri, realm, authHeader) => {
+  if (uri.startsWith('/')) {
+    return {
+      uri: `${realm}${uri}`,
+      headers: {
+        Authorization: authHeader,
+      },
+    };
+  }
+  return { uri };
+};

--- a/src/message/MessageView.js
+++ b/src/message/MessageView.js
@@ -7,9 +7,9 @@ import {
   Text,
 } from 'react-native';
 
-import Avatar from '../common/Avatar';
+import { renderHtml } from './renderHtml';
 
-import MessageTextView from '../message/MessageTextView';
+import Avatar from '../common/Avatar';
 
 const styles = StyleSheet.create({
   message: {
@@ -40,24 +40,35 @@ const styles = StyleSheet.create({
 });
 
 export default class MessageView extends React.PureComponent {
+  constructor(props) {
+    super(props);
+    this.renderMessage();
+    this.state = {
+      message: null,
+    };
+  }
+
+  async renderMessage() {
+    const message = await renderHtml(this.props.message, this.props.context);
+    this.setState({ message });
+  }
 
   render() {
+    const { context, avatarUrl, timestamp, from } = this.props;
+
     return (
       <View style={styles.message}>
-        <Avatar avatarUrl={this.props.avatarUrl} />
+        <Avatar avatarUrl={context.rewriteLink(avatarUrl).uri} />
         <View style={styles.messageContent}>
           <View style={styles.messageHeader}>
             <Text style={styles.messageUser}>
-              {this.props.from}
+              {from}
             </Text>
             <Text style={styles.messageTime}>
-              {moment(this.props.timestamp * 1000).format('LT')}
+              {moment(timestamp * 1000).format('LT')}
             </Text>
           </View>
-          <MessageTextView
-            style={styles.message}
-            message={this.props.message}
-          />
+          {this.state.message}
         </View>
       </View>
     );

--- a/src/message/__tests__/__snapshots__/renderHtml-test.js.snap
+++ b/src/message/__tests__/__snapshots__/renderHtml-test.js.snap
@@ -1,0 +1,121 @@
+exports[`test Empty string 1`] = `<View />`;
+
+exports[`test Paragraph of text 1`] = `
+<View>
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    style={
+      Array [
+        Object {
+          "fontSize": 16,
+          "lineHeight": 22
+        }
+      ]
+    }>
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      onPress={null}
+      style={
+        Array [
+          Object {
+            "fontSize": 16,
+            "lineHeight": 22
+          }
+        ]
+      }>
+      Hey!
+    </Text>
+    
+    
+  </Text>
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    style={
+      Array [
+        Object {
+          "fontSize": 16,
+          "lineHeight": 22
+        }
+      ]
+    }>
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      onPress={null}
+      style={
+        Array [
+          Object {
+            "fontSize": 16,
+            "lineHeight": 22
+          }
+        ]
+      }>
+      This is a multi-paragraph message
+    </Text>
+  </Text>
+</View>
+`;
+
+exports[`test Short text 1`] = `
+<View>
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    onPress={undefined}
+    style={
+      Array [
+        Object {
+          "fontSize": 16,
+          "lineHeight": 22
+        }
+      ]
+    }>
+    Hi there!
+  </Text>
+</View>
+`;
+
+exports[`test Simple link 1`] = `
+<View>
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    style={
+      Array [
+        Object {
+          "fontSize": 16,
+          "lineHeight": 22
+        }
+      ]
+    }>
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      onPress={[Function anonymous]}
+      style={
+        Array [
+          Object {
+            "fontSize": 16,
+            "lineHeight": 22
+          },
+          Object {
+            "color": "#09f",
+            "fontWeight": "600"
+          }
+        ]
+      }>
+      Test link
+    </Text>
+  </Text>
+</View>
+`;

--- a/src/message/__tests__/renderHtml-test.js
+++ b/src/message/__tests__/renderHtml-test.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import { View } from 'react-native';
+import renderer from 'react-test-renderer';
+
+import { renderHtml } from '../renderHtml';
+
+// We need this hack for now (see: https://github.com/facebook/jest/issues/1760)
+beforeAll(() => {
+  global.Promise = require.requireActual('promise');
+});
+
+const check = (html) => async () => {
+  const rendered = await renderHtml(html);
+  const tree = renderer.create(
+    <View>{rendered}</View>
+  ).toJSON();
+  expect(tree).toMatchSnapshot();
+};
+
+// Text
+test('Empty string', check(''));
+
+test('Short text', check('Hi there!'));
+
+test('Paragraph of text', check(
+  '<p>Hey!</p>' +
+  '<p>This is a multi-paragraph message</p>'
+));
+
+// Links
+test('Simple link', check(
+  '<a href="https://example.com">Test link</a>'
+));

--- a/src/nav/MainScreen.js
+++ b/src/nav/MainScreen.js
@@ -163,7 +163,7 @@ class MainScreen extends React.Component {
             <StreamView
               messages={this.props.messages}
               subscriptions={this.props.subscriptions}
-              email={this.props.auth.get('email')}
+              auth={this.props.auth}
               caughtUp={this.props.caughtUp}
               fetchOlder={this.fetchOlder}
               fetchNewer={this.fetchNewer}

--- a/src/stream/StreamView.js
+++ b/src/stream/StreamView.js
@@ -9,7 +9,12 @@ import StreamMessageHeader from '../message/StreamMessageHeader';
 import PrivateMessageHeader from '../message/PrivateMessageHeader';
 
 import MessageView from '../message/MessageView';
-import { sameRecipient } from '../lib/message';
+import {
+  sameRecipient,
+  rewriteLink,
+} from '../lib/message';
+
+import { getAuthHeader } from '../api/apiFetch';
 
 const styles = StyleSheet.create({
   scrollView: {
@@ -37,7 +42,7 @@ export default class StreamView extends React.PureComponent {
         <PrivateMessageHeader
           key={`section_${item.id}`}
           recipients={item.display_recipient.filter(r =>
-            r.email !== this.props.email
+            r.email !== this.props.auth.get('email')
           )}
           item={item}
           narrow={this.props.narrow}
@@ -49,6 +54,13 @@ export default class StreamView extends React.PureComponent {
 
   populateStream(items) {
     const headerIndices = [];
+    const context = {
+      rewriteLink: (uri) => rewriteLink(
+        uri,
+        this.props.auth.get('realm'),
+        getAuthHeader(this.props.auth.get('email'), this.props.auth.get('apiKey')),
+      ),
+    };
     let prevItem;
     let totalIdx = 0;
     for (const item of this.props.messages) {
@@ -64,6 +76,7 @@ export default class StreamView extends React.PureComponent {
           message={item.content}
           timestamp={item.timestamp}
           avatarUrl={item.avatar_url}
+          context={context}
         />
       );
       totalIdx++;


### PR DESCRIPTION
We need to pass the realm and auth header to the HTML renderer because some images and links are relative (such as '/user_uploads/..'). For these we need to (1) prepend a base url (the realm) and (2) send along our Authorization header.

I'm passing along this information as a `rewriteUrl` function in a `context` object, but perhaps there's a better approach.