### PR TITLE
Add tests for Logo and Avatar

### DIFF
--- a/src/common/__tests__/Avatar-test.js
+++ b/src/common/__tests__/Avatar-test.js
@@ -1,0 +1,11 @@
+import 'react-native';
+import React from 'react';
+import renderer from 'react-test-renderer';
+import Avatar from '../Avatar';
+
+it('renders correctly', () => {
+  const tree = renderer.create(
+    <Avatar />
+  ).toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/src/common/__tests__/Logo-test.js
+++ b/src/common/__tests__/Logo-test.js
@@ -1,0 +1,11 @@
+import 'react-native';
+import React from 'react';
+import renderer from 'react-test-renderer';
+import Logo from '../Logo';
+
+it('renders correctly', () => {
+  const tree = renderer.create(
+    <Logo />
+  ).toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/src/common/__tests__/__snapshots__/Avatar-test.js.snap
+++ b/src/common/__tests__/__snapshots__/Avatar-test.js.snap
@@ -1,0 +1,16 @@
+exports[`test renders correctly 1`] = `
+<Image
+  resizeMode="contain"
+  source={
+    Object {
+      "uri": undefined
+    }
+  }
+  style={
+    Object {
+      "borderRadius": 16,
+      "height": 32,
+      "width": 32
+    }
+  } />
+`;

--- a/src/common/__tests__/__snapshots__/Logo-test.js.snap
+++ b/src/common/__tests__/__snapshots__/Logo-test.js.snap
@@ -1,0 +1,12 @@
+exports[`test renders correctly 1`] = `
+<Image
+  resizeMode="contain"
+  source={1}
+  style={
+    Object {
+      "alignSelf": "center",
+      "height": 100,
+      "width": 100
+    }
+  } />
+`;


### PR DESCRIPTION
Both tests passed for Logo.js and Avatar.js after running "npm test". I tried writing Image tests also based off of Jest documentation examples. The tests failed so I took out the Image tests for now.