### PR TITLE
Added server parsing logic

### DIFF
--- a/src/start/RealmScreen.js
+++ b/src/start/RealmScreen.js
@@ -33,22 +33,11 @@ class RealmScreen extends React.Component {
   }
 
   tryRealm = async () => {
-    const protocol = /:\/\//;
     let { realm } = this.state;
-    if (protocol.test(realm)) {
-      const tokens = realm.split(protocol);
-      switch (tokens[0]) {
-        case ('http'):
-          break;
-        case ('https'):
-          break;
-        default:
-          this.setState({ progress: false, error: 'Unsupported protocol' });
-          return;
-      }
-    } else {
+    if (realm.search(/\b(http|https):\/\//) === -1) {
       realm = `https://${realm}`;
     }
+
     this.setState({ progress: true, error: undefined });
 
     try {

--- a/src/start/RealmScreen.js
+++ b/src/start/RealmScreen.js
@@ -33,8 +33,22 @@ class RealmScreen extends React.Component {
   }
 
   tryRealm = async () => {
-    const { realm } = this.state;
-
+    const protocol = /:\/\//;
+    let { realm } = this.state;
+    if (protocol.test(realm)) {
+      const tokens = realm.split(protocol);
+      switch (tokens[0]) {
+        case ('http'):
+          break;
+        case ('https'):
+          break;
+        default:
+          this.setState({ progress: false, error: 'Unsupported protocol' });
+          return;
+      }
+    } else {
+      realm = `https://${realm}`;
+    }
     this.setState({ progress: true, error: undefined });
 
     try {
@@ -55,7 +69,7 @@ class RealmScreen extends React.Component {
     const { authBackends, progress, realm, error } = this.state;
 
     return (
-      <Screen title="Add Server" keybardAvoiding>
+      <Screen title="Add Server" keyboardAvoiding>
         <TextInput
           style={styles.input}
           autoFocus


### PR DESCRIPTION
Searches user entry for "://" at the server login page.  If present, checks for "http" or "https" preceding "://".  If one of these is not found, an error is thrown.  If "://" is not found "https://" is prepended to the user entry.