### PR TITLE
Disable throwing error in setTimeout in `apiFetch`.

### DIFF
--- a/src/api/apiFetch.js
+++ b/src/api/apiFetch.js
@@ -35,7 +35,8 @@ export const apiCall = async (
   try {
     if (!noTimeout) {
       timeout = setTimeout(() => {
-        throw Error(`Request timed out @ ${route}`);
+        // TODO (nw): the throw below does not get caught and crashes the app
+        // throw Error(`Request timed out @ ${route}`);
         // send APP_OFFLINE
       }, 5000);
     }


### PR DESCRIPTION
Throwing an error here crashes the app because it is uncaught so disabling for now until we have a more permanent fix.

Fixes #229