### PR TITLE
Change Navigation bar color on narrowing to stream.

### DIFF
--- a/src/common/styles.js
+++ b/src/common/styles.js
@@ -70,7 +70,6 @@ export default StyleSheet.create({
     justifyContent: 'space-between',
   },
   navButton: {
-    color: 'white',
     textAlign: 'center',
     fontSize: 26,
     width: CONTROL_SIZE,

--- a/src/main/MainScreen.js
+++ b/src/main/MainScreen.js
@@ -7,6 +7,7 @@ import MainNavBar from '../nav/MainNavBar';
 import StreamSidebar from '../nav/StreamSidebar';
 import ConversationsContainer from '../conversations/ConversationsContainer';
 import requestInitialServerData from './requestInitialServerData';
+import { BRAND_COLOR } from '../common/styles';
 
 export default class MainScreen extends React.Component {
 
@@ -15,7 +16,11 @@ export default class MainScreen extends React.Component {
   }
 
   render() {
-    const { streamlistOpened, doNarrow } = this.props;
+    const { streamlistOpened, doNarrow, narrow, subscriptions } = this.props;
+    let color = BRAND_COLOR;
+    if (narrow.length !== 0 && narrow[0].operator === 'stream') {
+      color = (subscriptions.find((sub) => narrow[0].operand === sub.name)).color;
+    }
 
     return (
       <Drawer
@@ -77,6 +82,7 @@ export default class MainScreen extends React.Component {
           <MainNavBar
             onPressPeople={() => this.peopleDrawer.open()}
             openStreamList={() => this.streamDrawer.open()}
+            backgroundColor={color}
           >
             <Chat {...this.props} />
           </MainNavBar>

--- a/src/nav/MainNavBar.js
+++ b/src/nav/MainNavBar.js
@@ -10,6 +10,8 @@ import styles from '../common/styles';
 
 import Title from '../title/Title';
 
+import { foregroundColorFromBackground } from '../utils/color';
+
 const moreStyles = StyleSheet.create({
   wrapper: {
     flex: 1,
@@ -19,17 +21,17 @@ const moreStyles = StyleSheet.create({
 
 export default class MainNavBar extends React.Component {
   render() {
-    const { openStreamList, onPressPeople } = this.props;
-
+    const { openStreamList, onPressPeople, backgroundColor } = this.props;
+    const textColor = foregroundColorFromBackground(backgroundColor);
     return (
       <Navigator
         initialRoute={{ name: 'Home', index: 0 }}
         renderScene={(route) =>
           <View style={moreStyles.wrapper}>
-            <View style={styles.navBar}>
-              <Icon style={styles.navButton} name="ios-menu" onPress={openStreamList} />
-              <Title />
-              <Icon style={styles.navButton} name="md-people" onPress={onPressPeople} />
+            <View style={[styles.navBar, { backgroundColor }]}>
+              <Icon style={[styles.navButton, { color: textColor }]} name="ios-menu" onPress={openStreamList} />
+              <Title backgroundColor={backgroundColor} />
+              <Icon style={[styles.navButton, { color: textColor }]} name="md-people" onPress={onPressPeople} />
             </View>
             {this.props.children}
           </View>

--- a/src/title/Title.js
+++ b/src/title/Title.js
@@ -31,12 +31,12 @@ const titles = [
 
 class Title extends React.PureComponent {
   render() {
-    const { narrow } = this.props;
+    const { narrow, backgroundColor } = this.props;
     const titleType = titles.find(x => x.isFunc(narrow));
 
     if (!titleType) return null;
 
-    return <titleType.component {...this.props} />;
+    return <titleType.component {...this.props} color={backgroundColor} />;
   }
 }
 

--- a/src/title/TitleHome.js
+++ b/src/title/TitleHome.js
@@ -1,5 +1,16 @@
 import React from 'react';
 import TitleSpecial from './TitleSpecial';
 
-export default () =>
-  <TitleSpecial narrow={[{ operand: 'home' }]} />;
+export default class TitleHome extends React.PureComponent {
+
+  render() {
+    const { color } = this.props;
+
+    return (
+      <TitleSpecial
+        narrow={[{ operand: 'home' }]}
+        backgroundColor={color}
+      />
+    );
+  }
+}

--- a/src/title/TitlePrivate.js
+++ b/src/title/TitlePrivate.js
@@ -3,6 +3,7 @@ import { StyleSheet, Text, View } from 'react-native';
 
 import { Avatar } from '../common';
 import { getFullUrl } from '../utils/url';
+import { foregroundColorFromBackground } from '../utils/color';
 
 const styles = StyleSheet.create({
   wrapper: {
@@ -10,7 +11,6 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   title: {
-    color: 'white',
     fontSize: 16,
     paddingLeft: 4,
   },
@@ -18,7 +18,7 @@ const styles = StyleSheet.create({
 
 export default class TitlePrivate extends React.PureComponent {
   render() {
-    const { narrow, realm, users } = this.props;
+    const { narrow, realm, users, color } = this.props;
     const user = users.find(x => x.email === narrow[0].operand);
     const fullAvatarUrl = getFullUrl(user.avatarUrl, realm);
 
@@ -29,7 +29,7 @@ export default class TitlePrivate extends React.PureComponent {
           name={user.fullName}
           avatarUrl={fullAvatarUrl}
         />
-        <Text style={styles.title}>
+        <Text style={[styles.title, { color: foregroundColorFromBackground(color) }]}>
           {user.fullName}
         </Text>
       </View>

--- a/src/title/TitleSpecial.js
+++ b/src/title/TitleSpecial.js
@@ -5,6 +5,7 @@ import {
   View,
 } from 'react-native';
 import Icon from 'react-native-vector-icons/Ionicons';
+import { foregroundColorFromBackground } from '../utils/color';
 
 const styles = StyleSheet.create({
   wrapper: {
@@ -12,7 +13,6 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   title: {
-    color: 'white',
     fontSize: 16,
     marginLeft: 4,
   },
@@ -27,13 +27,14 @@ const specials = {
 
 export default class TitleSpecial extends React.PureComponent {
   render() {
-    const { narrow } = this.props;
+    const { narrow, backgroundColor } = this.props;
     const { name, icon } = specials[narrow[0].operand];
+    const textColor = foregroundColorFromBackground(backgroundColor);
 
     return (
       <View style={styles.wrapper}>
-        <Icon name={icon} size={20} color="white" />
-        <Text style={styles.title}>
+        <Icon name={icon} size={20} color={textColor} />
+        <Text style={[styles.title, { color: textColor }]}>
           {name}
         </Text>
       </View>

--- a/src/title/TitleStream.js
+++ b/src/title/TitleStream.js
@@ -5,6 +5,7 @@ import {
   View,
 } from 'react-native';
 import Icon from 'react-native-vector-icons/FontAwesome';
+import { foregroundColorFromBackground } from '../utils/color';
 
 const styles = StyleSheet.create({
   wrapper: {
@@ -12,7 +13,6 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   title: {
-    color: 'white',
     fontSize: 16,
     marginLeft: 4,
   },
@@ -26,18 +26,18 @@ export default class TitleStream extends React.PureComponent {
   }
 
   render() {
-    const { narrow, subscriptions } = this.props;
+    const { narrow, subscriptions, color } = this.props;
     const stream = subscriptions.find(x => x.name === narrow[0].operand);
     const iconType = stream.invite_only ? 'lock' : 'hashtag';
-
+    const textColor = foregroundColorFromBackground(color);
     return (
       <View style={styles.wrapper}>
         <Icon
           name={iconType}
-          color="white"
+          color={textColor}
           size={16}
         />
-        <Text style={styles.title}>
+        <Text style={[styles.title, { color: textColor }]}>
           {stream.name}
         </Text>
         {narrow.length > 1 &&


### PR DESCRIPTION
Change background color of navigation bar to the color associated with stream.
Fix:#245

Used `foregroundColorFromBackground` to determine the color of the title and drawer icons.

![screenshot from 2017-02-01 01-50-07](https://cloud.githubusercontent.com/assets/18511177/22483260/75f5d67a-e822-11e6-8a93-92a31a11d958.png)
![screenshot from 2017-02-01 01-52-30](https://cloud.githubusercontent.com/assets/18511177/22483259/75f4a246-e822-11e6-95bb-e23e018e12ed.png)
