### PR TITLE
Fixing crash on startup where reactions was null upon login

### DIFF
--- a/src/reactions/ReactionList.js
+++ b/src/reactions/ReactionList.js
@@ -21,13 +21,9 @@ export default class ReactionList extends React.PureComponent {
   render() {
     const { messageId, reactions, selfEmail } = this.props;
 
-    if( typeof reactions !== 'undefined' ) { 
-    	if (reactions.length === 0) {
+    if (!reactions || reactions.length === 0) {
       		return null;
     	}
-    } else {
-	return null;
-    }
 
     const aggregated = aggregateReactions(reactions, selfEmail);
 

--- a/src/reactions/ReactionList.js
+++ b/src/reactions/ReactionList.js
@@ -21,8 +21,12 @@ export default class ReactionList extends React.PureComponent {
   render() {
     const { messageId, reactions, selfEmail } = this.props;
 
-    if (reactions.length === 0) {
-      return null;
+    if( typeof reactions !== 'undefined' ) { 
+    	if (reactions.length === 0) {
+      		return null;
+    	}
+    } else {
+	return null;
     }
 
     const aggregated = aggregateReactions(reactions, selfEmail);


### PR DESCRIPTION
We started tested zulip-mobile this morning and were getting an exception after login to our server with reactions being null, causing the app to fail to startup and be unusable.

This quick fix checks if reactions is actually defined, and if it isn't, follows the existing app logic to return null.

So far basic testing shows this allows us to complete the login process, load the main UI, and actually start to use the application.

