### PR TITLE
Get first unread on initial fetch. Use message anchor when narrowing.

### DIFF
--- a/src/api/getMessages.js
+++ b/src/api/getMessages.js
@@ -6,6 +6,7 @@ export default async (
   numBefore: number,
   numAfter: number,
   narrow: Object,
+  useFirstUnread: false,
 ) =>
   apiGet(
     auth,
@@ -16,6 +17,7 @@ export default async (
       num_after: numAfter,
       narrow: JSON.stringify(narrow),
       apply_markdown: true,
+      use_first_unread_anchor: useFirstUnread,
     },
     res => res.messages,
   );

--- a/src/chat/__tests__/chatReducers-test.js
+++ b/src/chat/__tests__/chatReducers-test.js
@@ -30,16 +30,25 @@ describe('chatReducers', () => {
   });
 
   describe('SWITCH_NARROW', () => {
-    test('changes current narrow', () => {
+    test('changes current narrow and replaces messages', () => {
       const initialState = {
+        messages: {
+          [streamNarrowStr]: [{ id: 1 }, { id: 3 }],
+        },
         narrow: [],
       };
       const action = {
         type: SWITCH_NARROW,
         narrow: streamNarrow('some stream'),
+        messages: [{ id: 2 }],
       };
       const expectedState = {
         narrow: streamNarrow('some stream'),
+        messages: {
+          [streamNarrowStr]: [{ id: 2 }],
+        },
+        caughtUp: { older: false, newer: false },
+        fetching: { older: false, newer: false },
       };
 
       const newState = chatReducers(initialState, action);

--- a/src/chat/__tests__/chatSelectors-test.js
+++ b/src/chat/__tests__/chatSelectors-test.js
@@ -1,8 +1,8 @@
-import { getPointer, getRecentConversations } from '../chatSelectors';
+import { getAnchor, getRecentConversations } from '../chatSelectors';
 import { specialNarrow } from '../../utils/narrow';
 
-describe('getPointer', () => {
-  test('return max pointer when there are no messages', () => {
+describe('getAnchor', () => {
+  test('return max anchor when there are no messages', () => {
     const state = {
       chat: {
         narrow: [],
@@ -11,13 +11,13 @@ describe('getPointer', () => {
         },
       },
     };
-    expect(getPointer(state)).toEqual({
+    expect(getAnchor(state)).toEqual({
       older: Number.MAX_SAFE_INTEGER,
       newer: Number.MAX_SAFE_INTEGER,
     });
   });
 
-  test('when single message, pointer ids are the same', () => {
+  test('when single message, anchor ids are the same', () => {
     const state = {
       chat: {
         narrow: [],
@@ -28,10 +28,10 @@ describe('getPointer', () => {
         },
       }
     };
-    expect(getPointer(state)).toEqual({ older: 123, newer: 123 });
+    expect(getAnchor(state)).toEqual({ older: 123, newer: 123 });
   });
 
-  test('when 2 or more messages, pointer contains first and last message ids', () => {
+  test('when 2 or more messages, anchorf contains first and last message ids', () => {
     const state = {
       chat: {
         narrow: [],
@@ -44,7 +44,7 @@ describe('getPointer', () => {
         },
       },
     };
-    expect(getPointer(state)).toEqual({ older: 1, newer: 3 });
+    expect(getAnchor(state)).toEqual({ older: 1, newer: 3 });
   });
 });
 

--- a/src/chat/__tests__/chatSelectors-test.js
+++ b/src/chat/__tests__/chatSelectors-test.js
@@ -31,7 +31,7 @@ describe('getAnchor', () => {
     expect(getAnchor(state)).toEqual({ older: 123, newer: 123 });
   });
 
-  test('when 2 or more messages, anchorf contains first and last message ids', () => {
+  test('when 2 or more messages, anchor contains first and last message ids', () => {
     const state = {
       chat: {
         narrow: [],

--- a/src/chat/chatReducers.js
+++ b/src/chat/chatReducers.js
@@ -27,14 +27,6 @@ export default (state = getInitialState(), action) => {
     case ACCOUNT_SWITCH:
       return getInitialState();
 
-    case SWITCH_NARROW:
-      return {
-        ...state,
-        narrow: action.narrow,
-        fetching: action.fetching,
-        caughtUp: action.caughtUp,
-      };
-
     case MESSAGE_FETCH_START:
       return {
         ...state,
@@ -43,6 +35,7 @@ export default (state = getInitialState(), action) => {
         caughtUp: { ...state.caughtUp, ...action.caughtUp },
       };
 
+    case SWITCH_NARROW:
     case MESSAGE_FETCH_SUCCESS: {
       const key = JSON.stringify(action.narrow);
       const messages = state.messages[key] || [];
@@ -53,6 +46,7 @@ export default (state = getInitialState(), action) => {
 
       return {
         ...state,
+        narrow: action.type === SWITCH_NARROW ? action.narrow : state.narrow,
         messages: {
           ...state.messages,
           [key]: newMessages,

--- a/src/chat/chatReducers.js
+++ b/src/chat/chatReducers.js
@@ -35,10 +35,26 @@ export default (state = getInitialState(), action) => {
         caughtUp: { ...state.caughtUp, ...action.caughtUp },
       };
 
-    case SWITCH_NARROW:
+    case SWITCH_NARROW: {
+      const key = JSON.stringify(action.narrow);
+      return {
+        ...state,
+        narrow: action.narrow,
+        messages: {
+          ...state.messages,
+          [key]: action.messages,
+        },
+        fetching: { older: false, newer: false },
+        caughtUp: { older: false, newer: false },
+      };
+    }
+
     case MESSAGE_FETCH_SUCCESS: {
       const key = JSON.stringify(action.narrow);
       const messages = state.messages[key] || [];
+
+      // TODO: this is O(n^2) in the number of messages
+      // Since these are both sorted we can do this in O(n) time
       const newMessages = action.messages
         .filter(x => !messages.find(msg => msg.id === x.id))
         .concat(messages)
@@ -46,7 +62,6 @@ export default (state = getInitialState(), action) => {
 
       return {
         ...state,
-        narrow: action.type === SWITCH_NARROW ? action.narrow : state.narrow,
         messages: {
           ...state.messages,
           [key]: newMessages,

--- a/src/chat/chatSelectors.js
+++ b/src/chat/chatSelectors.js
@@ -7,7 +7,7 @@ export const getAllMessages = (state) =>
 export const getMessagesInActiveNarrow = (state) =>
   state.chat.messages[JSON.stringify(state.chat.narrow)] || [];
 
-export const getPointer = (state) => {
+export const getAnchor = (state) => {
   const messages = getMessagesInActiveNarrow(state);
 
   if (messages.length === 0) {

--- a/src/common/LoadingIndicator.js
+++ b/src/common/LoadingIndicator.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Animated, Easing, Image, StyleSheet, View } from 'react-native';
-import { BRAND_COLOR } from '../common/styles';
 
 const styles = StyleSheet.create({
   row: {

--- a/src/main/MainScreenContainer.js
+++ b/src/main/MainScreenContainer.js
@@ -2,29 +2,31 @@ import React from 'react';
 import { connect } from 'react-redux';
 
 import boundActions from '../boundActions';
-import { getMessagesInActiveNarrow, getPointer } from '../chat/chatSelectors';
+import { getMessagesInActiveNarrow, getAnchor } from '../chat/chatSelectors';
 import { getAuth } from '../account/accountSelectors';
 import MainScreen from './MainScreen';
 
 class MainScreenContainer extends React.Component {
 
   fetchOlder = () => {
-    const { auth, fetching, caughtUp, pointer, narrow, fetchMessages } = this.props;
-    if (!fetching.older && !caughtUp.older) {
-      fetchMessages(auth, pointer.older, 20, 0, narrow);
+    const { auth, fetching, caughtUp, anchor, narrow, fetchMessages } = this.props;
+    if (!fetching.older && !caughtUp.older && anchor) {
+      fetchMessages(auth, anchor.older, 20, 0, narrow);
     }
   }
 
   fetchNewer = () => {
-    const { auth, fetching, caughtUp, pointer, narrow, fetchMessages } = this.props;
-    if (!fetching.newer && !caughtUp.newer) {
-      fetchMessages(auth, pointer.newer, 0, 20, narrow);
+    const { auth, fetching, caughtUp, anchor, narrow, fetchMessages } = this.props;
+    if (!fetching.newer && !caughtUp.newer && anchor) {
+      fetchMessages(auth, anchor.newer, 0, 20, narrow);
     }
   }
 
-  doNarrow = (newNarrow = [], pointer: number = Number.MAX_SAFE_INTEGER) => {
-    const { switchNarrow } = this.props;
-    requestAnimationFrame(() => switchNarrow(newNarrow));
+  doNarrow = (newNarrow = [], anchor: number = Number.MAX_SAFE_INTEGER) => {
+    const { switchNarrow, messages } = this.props;
+    requestIdleCallback(() =>
+      switchNarrow(newNarrow, messages.filter(msg => msg.id === anchor)
+    ));
   }
 
   render() {
@@ -50,7 +52,7 @@ const mapStateToProps = (state) => ({
   caughtUp: state.chat.caughtUp,
   narrow: state.chat.narrow,
   mute: state.mute,
-  pointer: getPointer(state),
+  anchor: getAnchor(state),
 });
 
 export default connect(mapStateToProps, boundActions)(MainScreenContainer);

--- a/src/main/requestInitialServerData.js
+++ b/src/main/requestInitialServerData.js
@@ -15,7 +15,7 @@ export default (auth) =>
     dispatch({ type: INITIAL_DATA_FETCH });
     [
       fetchSubscriptions(auth),
-      fetchMessages(auth, Number.MAX_SAFE_INTEGER, 20, 0, homeNarrow()),
+      fetchMessages(auth, 0, 20, 1, homeNarrow(), true),
       fetchStreams(auth),
       fetchEvents(auth),
       fetchUsersAndStatus(auth),

--- a/src/message-list/InfiniteScrollView.js
+++ b/src/message-list/InfiniteScrollView.js
@@ -22,6 +22,11 @@ class InfiniteScrollView extends React.Component {
     }
   }
 
+  componentWillUpdate() {
+    this._sentStartForContentHeight = null;
+    this._sentEndForContentHeight = null;
+  }
+
   _onContentSizeChanged(contentWidth, contentHeight) {
     const oldContentHeight = this._contentHeight;
     this._contentHeight = contentHeight;

--- a/src/message-list/MessageList.js
+++ b/src/message-list/MessageList.js
@@ -21,11 +21,18 @@ export default class MessageList extends React.PureComponent {
   constructor() {
     super();
     this.mapIdToIdx = {};
+    this.state = {
+      autoScrollToBottom: false,
+    };
   }
 
   componentWillReceiveProps(nextProps) {
     const currentNarrow = JSON.stringify(this.props.narrow);
     const nextNarrow = JSON.stringify(nextProps.narrow);
+
+    this.setState({
+      autoScrollToBottom: this.props.caughtUp.newer && nextProps.caughtUp.newer,
+    });
 
     // Invalidate the existing message anchors if the narrow changes
     // (because we'll have a brand new set of messages)
@@ -107,7 +114,7 @@ export default class MessageList extends React.PureComponent {
         anchorMap={anchorMap}
         onStartReached={fetchOlder}
         onEndReached={fetchNewer}
-        autoScrollToBottom={caughtUp.newer}
+        autoScrollToBottom={this.state.autoScrollToBottom}
         onScroll={e => {}}
       >
         {messageList}

--- a/src/message-list/messagesActions.js
+++ b/src/message-list/messagesActions.js
@@ -8,8 +8,6 @@ import {
 export const switchNarrow = (narrow, messages) => ({
   type: SWITCH_NARROW,
   narrow,
-  fetching: { older: false, newer: false },
-  caughtUp: { older: false, newer: false },
   messages,
 });
 

--- a/src/message/headers/PrivateMessageHeader.js
+++ b/src/message/headers/PrivateMessageHeader.js
@@ -38,11 +38,11 @@ export default class PrivateMessageHeader extends React.PureComponent {
   }
 
   performNarrow = () => {
-    const { recipients, doNarrow } = this.props;
+    const { itemId, recipients, doNarrow } = this.props;
     const narrow = recipients.length === 1 ?
       privateNarrow(recipients[0].email) :
       groupNarrow(recipients.map(r => r.email));
-    doNarrow(narrow);
+    doNarrow(narrow, itemId);
   }
 
   render() {

--- a/src/message/headers/StreamMessageHeader.js
+++ b/src/message/headers/StreamMessageHeader.js
@@ -43,8 +43,8 @@ export default class StreamMessageHeader extends React.PureComponent {
   }
 
   performStreamNarrow = () => {
-    const { doNarrow, stream } = this.props;
-    doNarrow(streamNarrow(stream));
+    const { itemId, doNarrow, stream } = this.props;
+    doNarrow(streamNarrow(stream), itemId);
   }
 
   render() {

--- a/src/message/headers/TopicMessageHeader.js
+++ b/src/message/headers/TopicMessageHeader.js
@@ -29,9 +29,9 @@ export default class TopicMessageHeader extends React.PureComponent {
   }
 
   performTopicNarrow = () => {
-    const { doNarrow, stream, topic } = this.props;
+    const { itemId, doNarrow, stream, topic } = this.props;
 
-    doNarrow(topicNarrow(stream, topic));
+    doNarrow(topicNarrow(stream, topic), itemId);
   }
 
   render() {


### PR DESCRIPTION
- Use first unread option when fetching initial data. This puts the user at the point of the last unread message instead of at the newest message.

- Maintain position in stream or topic when narrowing by clicking on a message header.

Fixes #228. Fixes #230.