### PR TITLE
Style changes to nav bar and message headers.

### DIFF
--- a/src/common/Screen.js
+++ b/src/common/Screen.js
@@ -41,7 +41,7 @@ class Screen extends React.Component {
     return (
       <View style={styles.screen}>
         <StatusBar
-          barStyle="light-content"
+          barStyle="dark-content"
           hidden={this.props.orientation === 'LANDSCAPE'}
         />
         <ModalNavBar title={title} popRoute={popRoute} nav={nav} />

--- a/src/common/styles.js
+++ b/src/common/styles.js
@@ -2,9 +2,9 @@ import { StyleSheet } from 'react-native';
 
 import { STATUSBAR_HEIGHT, CONTROL_SIZE, NAVBAR_HEIGHT } from './platform';
 
-export const BRAND_COLOR = 'rgba(86, 193, 129, 1)';
+export const BRAND_COLOR = 'rgba(66, 163, 109, 1)';
 export const HIGHLIGHT_COLOR = 'rgba(86, 164, 174, 0.5)';
-export const BORDER_COLOR = '#eee';
+export const BORDER_COLOR = '#ddd';
 
 export default StyleSheet.create({
   screen: {
@@ -72,18 +72,18 @@ export default StyleSheet.create({
   },
   navBar: {
     flexDirection: 'row',
-    backgroundColor: BRAND_COLOR,
+    backgroundColor: '#ffffff',
     paddingTop: STATUSBAR_HEIGHT,
     height: NAVBAR_HEIGHT,
     alignItems: 'center',
     justifyContent: 'space-between',
+    borderBottomWidth: 1,
+    borderColor: BORDER_COLOR,
   },
   navTitle: {
     flex: 1,
-    color: 'white',
+    color: BRAND_COLOR,
     textAlign: 'center',
     fontSize: 16,
-    lineHeight: CONTROL_SIZE,
-    height: CONTROL_SIZE,
   },
 });

--- a/src/main/MainScreen.js
+++ b/src/main/MainScreen.js
@@ -6,7 +6,6 @@ import Chat from '../chat/Chat';
 import MainNavBar from '../nav/MainNavBar';
 import StreamSidebar from '../nav/StreamSidebar';
 import ConversationsContainer from '../conversations/ConversationsContainer';
-import { BRAND_COLOR } from '../common/styles';
 
 const SideDrawer = (props) =>
   <Drawer

--- a/src/main/MainScreen.js
+++ b/src/main/MainScreen.js
@@ -47,7 +47,7 @@ export default class MainScreen extends React.Component {
     const { doNarrow, narrow, orientation, subscriptions } = this.props;
     const { leftDrawerOpen, rightDrawerOpen } = this.state;
 
-    let color = BRAND_COLOR;
+    let color;
     if (narrow.length !== 0 && narrow[0].operator === 'stream') {
       color = (subscriptions.find((sub) => narrow[0].operand === sub.name)).color;
     }

--- a/src/message/headers/MessageHeader.js
+++ b/src/message/headers/MessageHeader.js
@@ -1,9 +1,17 @@
 import React from 'react';
+import { StyleSheet } from 'react-native';
 
 import { isStreamNarrow, isTopicNarrow, isPrivateNarrow, isGroupNarrow } from '../../utils/narrow';
 import TopicMessageHeader from './TopicMessageHeader';
 import StreamMessageHeader from './StreamMessageHeader';
 import PrivateMessageHeader from './PrivateMessageHeader';
+
+const styles = StyleSheet.create({
+  margin: {
+    marginTop: 4,
+    marginBottom: 4,
+  },
+});
 
 export default class MessageHeader extends React.PureComponent {
 
@@ -25,6 +33,7 @@ export default class MessageHeader extends React.PureComponent {
           stream={item.display_recipient}
           topic={item.subject}
           doNarrow={doNarrow}
+          customStyle={styles.margin}
         />
       );
     }
@@ -43,6 +52,7 @@ export default class MessageHeader extends React.PureComponent {
           color={stream ? stream.color : '#ccc'}
           itemId={item.id}
           doNarrow={doNarrow}
+          customStyle={styles.margin}
         />
       );
     }
@@ -58,6 +68,7 @@ export default class MessageHeader extends React.PureComponent {
           recipients={recipients}
           itemId={item.id}
           doNarrow={doNarrow}
+          customStyle={styles.margin}
         />
       );
     }

--- a/src/message/headers/PrivateMessageHeader.js
+++ b/src/message/headers/PrivateMessageHeader.js
@@ -25,7 +25,7 @@ const styles = StyleSheet.create({
     color: 'white',
   },
   icon: {
-    padding: 8,
+    paddingLeft: 8,
   },
 });
 
@@ -46,11 +46,11 @@ export default class PrivateMessageHeader extends React.PureComponent {
   }
 
   render() {
-    const { recipients } = this.props;
+    const { recipients, customStyle } = this.props;
     const others = recipients.map(r => r.full_name).sort().join(', ');
 
     return (
-      <View style={styles.container}>
+      <View style={[styles.container, customStyle]}>
         <Touchable onPress={this.performNarrow}>
           <View style={styles.header}>
             <Icon name="md-text" color="white" size={16} style={styles.icon} />

--- a/src/message/headers/StreamMessageHeader.js
+++ b/src/message/headers/StreamMessageHeader.js
@@ -11,8 +11,9 @@ const styles = StyleSheet.create({
   header: {
     alignItems: 'center',
     flexDirection: 'row',
-    backgroundColor: '#eee',
+    backgroundColor: '#ddd',
     overflow: 'hidden',
+    height: 32,
   },
   stream: {
     padding: 8,
@@ -48,12 +49,12 @@ export default class StreamMessageHeader extends React.PureComponent {
   }
 
   render() {
-    const { stream, isPrivate, isMuted, topic, color, itemId, doNarrow } = this.props;
+    const { stream, isPrivate, isMuted, topic, color, itemId, doNarrow, customStyle } = this.props;
     const textColor = foregroundColorFromBackground(color);
     const iconType = isPrivate ? 'lock' : 'hashtag';
 
     return (
-      <View style={styles.header}>
+      <View style={[styles.header, customStyle]}>
         <Touchable onPress={this.performStreamNarrow}>
           <View style={[styles.header, { backgroundColor: color }]}>
             <StreamIcon

--- a/src/message/headers/TopicMessageHeader.js
+++ b/src/message/headers/TopicMessageHeader.js
@@ -2,6 +2,7 @@ import React from 'react';
 import {
   StyleSheet,
   Text,
+  View,
 } from 'react-native';
 
 import { Touchable } from '../../common';
@@ -9,14 +10,13 @@ import { topicNarrow } from '../../utils/narrow';
 
 const styles = StyleSheet.create({
   touch: {
-    flex: 1,
     justifyContent: 'center',
   },
   topic: {
     padding: 8,
     fontSize: 16,
     lineHeight: 16,
-    backgroundColor: '#eee',
+    backgroundColor: '#ddd',
   },
 });
 
@@ -35,14 +35,16 @@ export default class TopicMessageHeader extends React.PureComponent {
   }
 
   render() {
-    const { topic } = this.props;
+    const { topic, customStyle } = this.props;
 
     return (
-      <Touchable style={styles.touch} onPress={this.performTopicNarrow}>
-        <Text style={styles.topic} numberOfLines={1} ellipsizeMode="tail">
-          {topic}
-        </Text>
-      </Touchable>
+      <View style={customStyle}>
+        <Touchable style={styles.touch} onPress={this.performTopicNarrow}>
+          <Text style={styles.topic} numberOfLines={1} ellipsizeMode="tail">
+            {topic}
+          </Text>
+        </Touchable>
+      </View>
     );
   }
 }

--- a/src/message/headers/TopicMessageHeader.js
+++ b/src/message/headers/TopicMessageHeader.js
@@ -9,6 +9,9 @@ import { Touchable } from '../../common';
 import { topicNarrow } from '../../utils/narrow';
 
 const styles = StyleSheet.create({
+  wrapper: {
+    flex: 1,
+  },
   touch: {
     justifyContent: 'center',
   },
@@ -38,7 +41,7 @@ export default class TopicMessageHeader extends React.PureComponent {
     const { topic, customStyle } = this.props;
 
     return (
-      <View style={customStyle}>
+      <View style={[styles.wrapper, customStyle]}>
         <Touchable style={styles.touch} onPress={this.performTopicNarrow}>
           <Text style={styles.topic} numberOfLines={1} ellipsizeMode="tail">
             {topic}

--- a/src/nav/MainNavBar.js
+++ b/src/nav/MainNavBar.js
@@ -20,8 +20,12 @@ export default class MainNavBar extends React.Component {
     const { onPressStreams, onPressPeople } = this.props;
     let { backgroundColor } = this.props;
 
-    const textColor = backgroundColor ? foregroundColorFromBackground(backgroundColor) : BRAND_COLOR;
-    backgroundColor = backgroundColor ? backgroundColor : '#ffffff';
+    let textColor = BRAND_COLOR;
+    if (backgroundColor) {
+      textColor = foregroundColorFromBackground(backgroundColor);
+    } else {
+      backgroundColor = '#ffffff';
+    }
 
     return (
       <Navigator
@@ -33,7 +37,7 @@ export default class MainNavBar extends React.Component {
             />
             <View style={[styles.navBar, { backgroundColor }]}>
               <NavButton name="ios-menu" color={textColor} onPress={onPressStreams} />
-              <Title textColor={textColor} backgroundColor={backgroundColor} />
+              <Title color={textColor} />
               <NavButton name="md-people" color={textColor} onPress={onPressPeople} />
             </View>
             {this.props.children}

--- a/src/nav/MainNavBar.js
+++ b/src/nav/MainNavBar.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { Navigator, StatusBar, StyleSheet, View } from 'react-native';
 
 import { styles } from '../common';
+import { BRAND_COLOR } from '../common/styles';
 import Title from '../title/Title';
 import NavButton from './NavButton';
 
@@ -16,8 +17,12 @@ const moreStyles = StyleSheet.create({
 
 export default class MainNavBar extends React.Component {
   render() {
-    const { onPressStreams, onPressPeople, backgroundColor } = this.props;
-    const textColor = foregroundColorFromBackground(backgroundColor);
+    const { onPressStreams, onPressPeople } = this.props;
+    let { backgroundColor } = this.props;
+
+    const textColor = backgroundColor ? foregroundColorFromBackground(backgroundColor) : BRAND_COLOR;
+    backgroundColor = backgroundColor ? backgroundColor : '#ffffff';
+
     return (
       <Navigator
         initialRoute={{ name: 'Home', index: 0 }}
@@ -28,7 +33,7 @@ export default class MainNavBar extends React.Component {
             />
             <View style={[styles.navBar, { backgroundColor }]}>
               <NavButton name="ios-menu" color={textColor} onPress={onPressStreams} />
-              <Title backgroundColor={backgroundColor} />
+              <Title textColor={textColor} backgroundColor={backgroundColor} />
               <NavButton name="md-people" color={textColor} onPress={onPressPeople} />
             </View>
             {this.props.children}

--- a/src/nav/ModalNavBar.js
+++ b/src/nav/ModalNavBar.js
@@ -5,7 +5,10 @@ import { connect } from 'react-redux';
 import boundActions from '../boundActions';
 import { CONTROL_SIZE } from '../common/platform';
 import { styles } from '../common';
+import { BRAND_COLOR } from '../common/styles';
 import NavButton from './NavButton';
+
+import { foregroundColorFromBackground } from '../utils/color';
 
 class ModalNavBar extends React.Component {
 
@@ -22,7 +25,7 @@ class ModalNavBar extends React.Component {
     return (
       <View style={styles.navBar}>
         {nav.index > 0 &&
-          <NavButton name="ios-arrow-back" color="white" onPress={popRoute} />
+          <NavButton name="ios-arrow-back" color={BRAND_COLOR} onPress={popRoute} />
         }
         <Text style={textStyle}>
           {title}

--- a/src/nav/ModalNavBar.js
+++ b/src/nav/ModalNavBar.js
@@ -8,8 +8,6 @@ import { styles } from '../common';
 import { BRAND_COLOR } from '../common/styles';
 import NavButton from './NavButton';
 
-import { foregroundColorFromBackground } from '../utils/color';
-
 class ModalNavBar extends React.Component {
 
   props: {

--- a/src/title/Title.js
+++ b/src/title/Title.js
@@ -31,12 +31,12 @@ const titles = [
 
 class Title extends React.PureComponent {
   render() {
-    const { narrow, backgroundColor } = this.props;
+    const { narrow } = this.props;
     const titleType = titles.find(x => x.isFunc(narrow));
 
     if (!titleType) return null;
 
-    return <titleType.component {...this.props} color={backgroundColor} />;
+    return <titleType.component {...this.props} />;
   }
 }
 

--- a/src/title/TitleHome.js
+++ b/src/title/TitleHome.js
@@ -4,12 +4,13 @@ import TitleSpecial from './TitleSpecial';
 export default class TitleHome extends React.PureComponent {
 
   render() {
-    const { color } = this.props;
+    const { textColor, backgroundColor } = this.props;
 
     return (
       <TitleSpecial
         narrow={[{ operand: 'home' }]}
-        backgroundColor={color}
+        textColor={textColor}
+        backgroundColor={backgroundColor}
       />
     );
   }

--- a/src/title/TitleHome.js
+++ b/src/title/TitleHome.js
@@ -4,14 +4,10 @@ import TitleSpecial from './TitleSpecial';
 export default class TitleHome extends React.PureComponent {
 
   render() {
-    const { textColor, backgroundColor } = this.props;
+    const { color } = this.props;
 
     return (
-      <TitleSpecial
-        narrow={[{ operand: 'home' }]}
-        textColor={textColor}
-        backgroundColor={backgroundColor}
-      />
+      <TitleSpecial narrow={[{ operand: 'home' }]} color={color} />
     );
   }
 }

--- a/src/title/TitlePrivate.js
+++ b/src/title/TitlePrivate.js
@@ -18,7 +18,7 @@ const styles = StyleSheet.create({
 
 export default class TitlePrivate extends React.PureComponent {
   render() {
-    const { narrow, realm, users, color } = this.props;
+    const { narrow, realm, users, textColor } = this.props;
     const user = users.find(x => x.email === narrow[0].operand);
     const fullAvatarUrl = getFullUrl(user.avatarUrl, realm);
 
@@ -29,7 +29,7 @@ export default class TitlePrivate extends React.PureComponent {
           name={user.fullName}
           avatarUrl={fullAvatarUrl}
         />
-        <Text style={[styles.title, { color: foregroundColorFromBackground(color) }]}>
+        <Text style={[styles.title, { color: textColor }]}>
           {user.fullName}
         </Text>
       </View>

--- a/src/title/TitlePrivate.js
+++ b/src/title/TitlePrivate.js
@@ -3,7 +3,6 @@ import { StyleSheet, Text, View } from 'react-native';
 
 import { Avatar } from '../common';
 import { getFullUrl } from '../utils/url';
-import { foregroundColorFromBackground } from '../utils/color';
 
 const styles = StyleSheet.create({
   wrapper: {
@@ -18,7 +17,7 @@ const styles = StyleSheet.create({
 
 export default class TitlePrivate extends React.PureComponent {
   render() {
-    const { narrow, realm, users, textColor } = this.props;
+    const { narrow, realm, users, color } = this.props;
     const user = users.find(x => x.email === narrow[0].operand);
     const fullAvatarUrl = getFullUrl(user.avatarUrl, realm);
 
@@ -29,7 +28,7 @@ export default class TitlePrivate extends React.PureComponent {
           name={user.fullName}
           avatarUrl={fullAvatarUrl}
         />
-        <Text style={[styles.title, { color: textColor }]}>
+        <Text style={[styles.title, { color }]}>
           {user.fullName}
         </Text>
       </View>

--- a/src/title/TitleSpecial.js
+++ b/src/title/TitleSpecial.js
@@ -5,7 +5,6 @@ import {
   View,
 } from 'react-native';
 import Icon from 'react-native-vector-icons/Ionicons';
-import { foregroundColorFromBackground } from '../utils/color';
 
 const styles = StyleSheet.create({
   wrapper: {
@@ -27,13 +26,13 @@ const specials = {
 
 export default class TitleSpecial extends React.PureComponent {
   render() {
-    const { narrow, textColor, backgroundColor } = this.props;
+    const { narrow, color } = this.props;
     const { name, icon } = specials[narrow[0].operand];
 
     return (
       <View style={styles.wrapper}>
-        <Icon name={icon} size={20} color={textColor} />
-        <Text style={[styles.title, { color: textColor }]}>
+        <Icon name={icon} size={20} color={color} />
+        <Text style={[styles.title, { color }]}>
           {name}
         </Text>
       </View>

--- a/src/title/TitleSpecial.js
+++ b/src/title/TitleSpecial.js
@@ -27,9 +27,8 @@ const specials = {
 
 export default class TitleSpecial extends React.PureComponent {
   render() {
-    const { narrow, backgroundColor } = this.props;
+    const { narrow, textColor, backgroundColor } = this.props;
     const { name, icon } = specials[narrow[0].operand];
-    const textColor = foregroundColorFromBackground(backgroundColor);
 
     return (
       <View style={styles.wrapper}>

--- a/src/title/TitleStream.js
+++ b/src/title/TitleStream.js
@@ -12,8 +12,7 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
   },
-  title: {
-    fontSize: 16,
+  margin: {
     marginLeft: 4,
   },
 });
@@ -26,23 +25,29 @@ export default class TitleStream extends React.PureComponent {
   }
 
   render() {
-    const { narrow, subscriptions, color } = this.props;
+    const { narrow, subscriptions, textColor } = this.props;
     const stream = subscriptions.find(x => x.name === narrow[0].operand);
     const iconType = stream.invite_only ? 'lock' : 'hashtag';
-    const textColor = foregroundColorFromBackground(color);
+
+    const fontSize = narrow.length > 1 ? 14 : 16;
+    let titleStyles = [styles.margin];
+    titleStyles.push({ fontSize });
+    titleStyles.push({ color: textColor });
+
+    console.log(narrow);
     return (
       <View style={styles.wrapper}>
         <Icon
           name={iconType}
           color={textColor}
-          size={16}
+          size={fontSize}
         />
-        <Text style={[styles.title, { color: textColor }]}>
+        <Text style={titleStyles}>
           {stream.name}
         </Text>
         {narrow.length > 1 &&
-          <Text style={styles.title}>
-            &gt; {narrow[1].operand}
+          <Text style={titleStyles}>
+            {'\u203a'} {narrow[1].operand}
           </Text>
         }
       </View>

--- a/src/title/TitleStream.js
+++ b/src/title/TitleStream.js
@@ -5,7 +5,6 @@ import {
   View,
 } from 'react-native';
 import Icon from 'react-native-vector-icons/FontAwesome';
-import { foregroundColorFromBackground } from '../utils/color';
 
 const styles = StyleSheet.create({
   wrapper: {
@@ -30,11 +29,11 @@ export default class TitleStream extends React.PureComponent {
     const iconType = stream.invite_only ? 'lock' : 'hashtag';
 
     const fontSize = narrow.length > 1 ? 14 : 16;
-    let titleStyles = [styles.margin];
+
+    const titleStyles = [styles.margin];
     titleStyles.push({ fontSize });
     titleStyles.push({ color: textColor });
 
-    console.log(narrow);
     return (
       <View style={styles.wrapper}>
         <Icon


### PR DESCRIPTION
- Make BRAND_COLOR slightly darker
- Use dark text on light background in nav bar for non-narrowed views
- Add some margin around message headers
- Fix a few styling bugs

New look for Home:
<img width="373" alt="screenshot 2017-02-14 21 37 41" src="https://cloud.githubusercontent.com/assets/4666213/22961835/da1ecc66-f2fd-11e6-9072-bff63973ef31.png">

This better distinguishes special views (like Home or Private Messages) visually from narrows to streams or topics.