### PR TITLE
Fix network activity indicator.

### DIFF
--- a/src/api/pollForEvents.js
+++ b/src/api/pollForEvents.js
@@ -9,5 +9,5 @@ export default (auth: Auth, queueId: number, lastEventId: number) =>
       last_event_id: lastEventId,
     },
     res => res,
-    true,
+    { silent: true },
   );


### PR DESCRIPTION
We sometimes need to fetch silently (for example, because `pollForEvents` long polls).