### PR TITLE
Fix activity indicator and network timeouts.

### DIFF
--- a/src/api/pollForEvents.js
+++ b/src/api/pollForEvents.js
@@ -9,5 +9,8 @@ export default (auth: Auth, queueId: number, lastEventId: number) =>
       last_event_id: lastEventId,
     },
     res => res,
-    { silent: true },
+    {
+      silent: true,
+      noTimeout: true,
+    },
   );


### PR DESCRIPTION
- Timeouts are now correctly handled (consumers of `apiFetch` need to handle the error though)
- The network activity indicator is shown if there's any pending network request that hasn't finished