### PR TITLE
Do not show mute icon in All Streams screen

### DIFF
--- a/src/streamlist/StreamList.js
+++ b/src/streamlist/StreamList.js
@@ -31,7 +31,6 @@ export default class StreamList extends React.Component {
             name={x.name}
             iconSize={16}
             isPrivate={x.invite_only}
-            isMuted={!x.in_home_view}
             description={showDescriptions && x.description}
             color={x.color}
             isSelected={x.name === selected}


### PR DESCRIPTION
Fixes #342
Not showing any mute or private icon because we don't have info for isPrivate and isMute for all streams.