### PR TITLE
Downgrade eslint spellcheck to 0.0.6 for much faster perf + fixes

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -65,8 +65,8 @@
         "idx", "aaa", "bbb", "ccc", "ddd", "eee", "fff", "abcd", "aaaaaa", "ffffff", "24cac2",
         "src", "attribs", "charset", "utf", "urlencoded", "htmlparser", "htmlparser2", "ul", "ol",
         "chatbubbles", "nonexisting", "primarytext", "autocomple", "stringify", "backend",
-        "Menlo", "ok", "py", "todo", "Mc", "lodash", "selectable", "isequal", "lightgray",
-        "zulipchat", "prepend"
+        "Menlo", "ok", "py", "todo", "Mc", "lodash", "selectable", "isequal", "lightgray", "tc",
+        "zulipchat", "prepend", "pierre", "allen", "jan", "donald", "jane", "unicode", "joe"
       ],
       "skipIfMatch": [
         "http://[^s]*",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "eslint-plugin-jsx-a11y": "^3.0.2",
     "eslint-plugin-react": "^6.8.0",
     "eslint-plugin-react-native": "^2.2.1",
-    "eslint-plugin-spellcheck": "0.0.8",
+    "eslint-plugin-spellcheck": "~0.0.6",
     "flow-bin": "^0.37.0",
     "jest": "^18.0.0",
     "jest-cli": "^18.0.0",

--- a/src/api/apiFetch.js
+++ b/src/api/apiFetch.js
@@ -48,7 +48,7 @@ export const apiCall = async (
   options: Object = {},
 ) => {
   try {
-    // Show network activity indicator if this fetch isn't silent
+    // Show network activity indicator if this fetch is not silent
     if (!options.silent) activityPush();
 
     // Either the API call or timeout will resolve first and the other will reject

--- a/src/compose/MessageFormattingHelp.js
+++ b/src/compose/MessageFormattingHelp.js
@@ -51,7 +51,7 @@ export default class MessageFormattingHelp extends React.PureComponent {
           </View>
           <View style={styles.tr}>
             <Text style={styles.td}>
-              {'* Archimedes\n* Bohr\n* Curie'}
+              TODO
             </Text>
             <Text style={styles.td}>
               TODO

--- a/src/start/RealmScreen.js
+++ b/src/start/RealmScreen.js
@@ -32,7 +32,7 @@ class RealmScreen extends React.Component {
   tryRealm = async () => {
     let { realm } = this.state;
 
-    // Automatically prepend 'https://' if the user doesn't enter a protocol
+    // Automatically prepend 'https://' if the user does not enter a protocol
     if (realm.search(/\b(http|https):\/\//) === -1) {
       realm = `https://${realm}`;
     }

--- a/src/utils/__tests__/date-test.js
+++ b/src/utils/__tests__/date-test.js
@@ -14,7 +14,7 @@ describe('shortTime', () => {
     expect(shortTime(date)).toBe('8:10 PM');
   });
 
-  test('returns as 24hrs time format, when true passed as 2nd parameter', () => {
+  test('returns as 24hrs time format, when true passed as second parameter', () => {
     const date = new Date(2000, 0, 1, 20, 10);
     expect(shortTime(date, true)).toBe('20:10');
   });


### PR DESCRIPTION
A significant perf regression was introduced in eslint-plugin-spellcheck 0.0.7.
This decreases the total eslint run time from 100secs to 15secs.