### PR TITLE
Slide drawers only from edges

### DIFF
--- a/src/main/MainScreen.js
+++ b/src/main/MainScreen.js
@@ -18,7 +18,7 @@ const SideDrawer = (props) =>
       props.orientation === 'LANDSCAPE' ? 0.5 : 0.2
     }
     negotiatePan
-    panOpenMask={0.5}
+    panOpenMask={0.1}
     useInteractionManager
     tweenDuration={150}
     tweenHandler={(ratio) => ({


### PR DESCRIPTION
Fixes #334 

Increased from default 0.05 to 0.1 as discussed.
Hopefully this works both for phones with screen protector and prevents the issue.