### PR TITLE
Make prefetching new messages earlier by increasing thresholds.

### DIFF
--- a/src/message-list/InfiniteScrollView.js
+++ b/src/message-list/InfiniteScrollView.js
@@ -2,8 +2,8 @@
 import React from 'react';
 import { ScrollView } from 'react-native';
 
-const DEFAULT_START_REACHED_THRESHOLD = 500;
-const DEFAULT_END_REACHED_THRESHOLD = 500;
+const DEFAULT_START_REACHED_THRESHOLD = 2500;
+const DEFAULT_END_REACHED_THRESHOLD = 2500;
 const DEFAULT_SCROLL_CALLBACK_THROTTLE = 50;
 
 class InfiniteScrollView extends React.Component {


### PR DESCRIPTION
Change DEFAULT_START_REACHED_THRESHOLD and DEFAULT_END_REACHED_THRESHOLD
to higher value, now unfetched messages will be fetched earlier
and user won't see time spinner.

Fixes: #238.