### PR TITLE
Do not call markAsRead if no function provided

### DIFF
--- a/src/message-list/MessageList.js
+++ b/src/message-list/MessageList.js
@@ -46,9 +46,12 @@ export default class MessageList extends React.PureComponent {
 
   onScroll = (e) => {
     const { messages, markAsRead } = this.props;
-    const visibleIds = e.visibleIds;
 
-    markAsRead(visibleIds.map((messageId) =>
+    if (!markAsRead) {
+      return;
+    }
+
+    markAsRead(e.visibleIds.map((messageId) =>
       messages.find((msg) => msg.id.toString() === messageId)
     ).filter((msg) => msg && msg.flags && msg.flags.indexOf('read') === -1));
   }


### PR DESCRIPTION
Fixes #383 

Search does not pass that function since we don't want to update read status.