### PR TITLE
[WIP] Add About Page

### DIFF
--- a/src/about/AboutScreen.js
+++ b/src/about/AboutScreen.js
@@ -1,0 +1,136 @@
+import React from 'react';
+import { View,
+          Text,
+          StyleSheet,
+          TouchableOpacity,
+          Linking,
+        } from 'react-native';
+import Logo from './Logo';
+
+export const BRAND_COLOR = 'rgba(66, 163, 109, 1)';
+const styles = StyleSheet.create({
+  initialText: {
+    borderBottomWidth: 0,
+    shadowColor: BRAND_COLOR,
+    shadowOffset: { width: 0, height: 0 },
+    shadowOpacity: 0.5,
+    shadowRadius: 2,
+    elevation: 1,
+    paddingLeft: 3,
+    paddingRight: 3,
+    paddingBottom: 4,
+    marginTop: 3,
+    marginLeft: 5,
+    marginRight: 5,
+  },
+  mainHeader: {
+    marginTop: 40,
+    padding: 5,
+    color: BRAND_COLOR,
+    fontSize: 13,
+  },
+  mainText: {
+    fontSize: 18,
+    textAlign: 'center',
+    fontWeight: 'bold',
+  },
+  subText: {
+    fontSize: 14,
+    textAlign: 'center',
+    marginTop: 5,
+  },
+  screen: {
+    flex: 1,
+    padding: 10,
+  },
+  cardSection: {
+    padding: 3,
+    paddingTop: 5,
+  },
+  insideText: {
+    fontSize: 16,
+    marginBottom: 8,
+  },
+  grayedText: {
+    color: '#BDBDBD',
+    marginLeft: 4,
+    fontSize: 14,
+  },
+  outlineContent: {
+    flex: 1,
+    flexDirection: 'column',
+    justifyContent: 'space-between',
+    marginBottom: 100,
+  },
+  links: {
+    fontWeight: 'bold',
+  },
+  copyrights: {
+    color: '#BDBDBD',
+    textAlign: 'center',
+  },
+});
+class AboutScreen extends React.PureComponent {
+  render() {
+    return (
+      <View style={styles.screen}>
+        <Logo />
+        <Text style={styles.mainText}> Zulip Mobile App </Text>
+        <Text style={styles.subText}>
+          Zulip is a powerful open source chat application.
+        </Text>
+        <View style={styles.outlineContent}>
+          <View>
+            <Text style={styles.mainHeader}>About</Text>
+            <View style={styles.initialText}>
+              <TouchableOpacity>
+                <View style={styles.cardSection}>
+                  <Text style={styles.insideText}> Version</Text>
+                  <Text style={styles.grayedText}>Zulip App v0.3</Text>
+                </View>
+              </TouchableOpacity>
+            </View>
+            <View style={styles.initialText}>
+              <TouchableOpacity onPress={() => Linking.openURL('https://github.com/zulip/zulip-mobile/blob/master/LICENSE')}>
+                <View style={styles.cardSection}>
+                  <Text style={styles.insideText}> License</Text>
+                  <Text style={styles.grayedText}>Apache License 2.0</Text>
+                </View>
+              </TouchableOpacity>
+            </View>
+          </View>
+          <View>
+            <Text style={styles.mainHeader}>Contribute</Text>
+            <View style={styles.initialText}>
+              <View>
+                <View style={styles.cardSection}>
+                  <Text style={styles.insideText}>Codebase</Text>
+                  <Text style={styles.grayedText}>All our code is on
+                    <Text style={styles.links} onPress={() => Linking.openURL('https://github.com/zulip/')}> GitHub </Text>
+                  </Text>
+                </View>
+              </View>
+            </View>
+            <View style={styles.initialText}>
+              <View>
+                <View style={styles.cardSection}>
+                  <Text style={styles.insideText}> Get Started</Text>
+                  <Text style={styles.grayedText}>Check out our
+                    <Text style={styles.links} onPress={() => Linking.openURL('http://zulip.readthedocs.io/en/latest/readme-symlink.html#ways-to-contribute')}> contribution guide </Text>
+                  </Text>
+                </View>
+              </View>
+            </View>
+          </View>
+        </View>
+        <View >
+          <Text style={styles.copyrights}>
+          Copyright© Zulip 2017
+          </Text>
+        </View>
+      </View>
+    );
+  }
+}
+
+export default AboutScreen;

--- a/src/about/AboutStart.js
+++ b/src/about/AboutStart.js
@@ -1,0 +1,14 @@
+import React from 'react';
+
+import { Screen, } from '../common';
+import AboutScreen from './AboutScreen';
+
+export default class AboutStart extends React.PureComponent {
+  render() {
+    return (
+      <Screen title="About">
+        <AboutScreen {...this.props} />
+      </Screen>
+    );
+  }
+}

--- a/src/about/Logo.js
+++ b/src/about/Logo.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import {
+  Image,
+  StyleSheet,
+} from 'react-native';
+
+const styles = StyleSheet.create({
+  logo: {
+    width: 40,
+    height: 40,
+    margin: 10,
+    alignSelf: 'center',
+  },
+});
+
+export default () => (
+  <Image
+    style={styles.logo}
+    source={require('../../static/img/logo.png')}
+    resizeMode="contain"
+  />
+);

--- a/src/nav/Navigation.js
+++ b/src/nav/Navigation.js
@@ -14,6 +14,7 @@ import SearchMessagesScreen from '../search/SearchMessagesScreen';
 import UsersScreen from '../users/UsersScreen';
 import SubscriptionsScreen from '../subscriptions/SubscriptionsScreen';
 import ChatScreen from '../chat/ChatScreen';
+import AboutStart from '../about/AboutStart';
 
 const { CardStack: NavigationCardStack } = NavigationExperimental;
 
@@ -73,6 +74,8 @@ export default class Navigation extends React.Component {
         return <SubscriptionsScreen />;
       case 'chat':
         return <ChatScreen />;
+      case 'about':
+        return <AboutStart />;
       default:
         return <LoadingScreen />;
     }

--- a/src/nav/StreamSidebar.js
+++ b/src/nav/StreamSidebar.js
@@ -29,6 +29,11 @@ export default class StreamSidebar extends React.Component {
     pushRoute('search');
   };
 
+  handleAbout = () => {
+    const { pushRoute } = this.props;
+    pushRoute('about');
+  };
+
   render() {
     const { onNarrow } = this.props;
 
@@ -60,6 +65,11 @@ export default class StreamSidebar extends React.Component {
             name="Mentions"
             icon="md-at"
             onPress={() => onNarrow(specialNarrow('mentioned'))}
+          />
+          <SidebarRow
+            name="About"
+            icon="md-information-circle"
+            onPress={this.handleAbout}
           />
         </View>
         <SubscriptionsContainer onNarrow={onNarrow} />


### PR DESCRIPTION
PR for issue #398 
I have finished the page and layout looks something like this. 
<img width="429" alt="screen shot 2017-03-04 at 4 13 17 pm" src="https://cloud.githubusercontent.com/assets/25760507/23578120/9af4fb2c-00f5-11e7-9b40-386c46256e54.png">

I recorded the screen of the simulator to show how the about page works. The video can be downloaded here( it's small size, ~ 11mb) : 
https://drive.google.com/file/d/0B64YP_1m4mZHSDVPZmhobTVQa00/view?usp=sharing


@timabbott @neerajwahi  As you had assigned the issue, please give a feedback on the code and the about page.

@nashvail  I took the idea of yours to place the logo in centre and modified the UI for the about page a little. So, thanks for the help!





