### PR TITLE
Enable zulipbot build notifications.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,11 @@ node_js:
   - 6.0
 notifications:
   email: false
+  webhooks:
+    urls:
+      - https://zulip.org/zulipbot/travis
+    on_success: always
+    on_failure: always
 before_install:
   - npm install
 install:


### PR DESCRIPTION
PRs labeled with the "travis updates" label will receive build notifications from zulipbot.

**Usage:**
Comment `@zulipbot label "travis updates"` on a pull request to label the pull request with the "travis updates" label. When the Travis build of the PR is complete, zulipbot will post a comment on the build status.

**Note:** It is highly recommended that a "travis updates" label be created in the repository (if else, zulipbot will automatically add a default-colored "travis updates" label).