### PR TITLE
Fix: Shows star to indicate starred messages(#418)

### DIFF
--- a/src/message/IconStarMessage.js
+++ b/src/message/IconStarMessage.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import { StyleSheet, View } from 'react-native';
+
+import { IconStar } from '../common/Icons';
+
+const styles = StyleSheet.create({
+  iconWrapper: {
+    marginTop: 4,
+    flex: 0.1
+  },
+  iconStar: {
+    fontSize: 20,
+    color: '#447C22',
+    alignSelf: 'flex-end'
+  }
+});
+
+export default () => (
+  <View style={styles.iconWrapper}>
+    <IconStar style={styles.iconStar} />
+  </View>
+);

--- a/src/message/MessageBrief.js
+++ b/src/message/MessageBrief.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { StyleSheet, TouchableWithoutFeedback, View } from 'react-native';
 
 import ReactionList from '../reactions/ReactionList';
+import IconStarMessage from './IconStarMessage';
 
 const styles = StyleSheet.create({
   message: {
@@ -12,6 +13,14 @@ const styles = StyleSheet.create({
     overflow: 'hidden',
     flex: 1,
   },
+  messageContentWrapper: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    justifyContent: 'space-between'
+  },
+  messageTextBodyWrapper: {
+    flex: 0.9
+  }
 });
 
 export default class MessageBrief extends React.PureComponent {
@@ -23,15 +32,20 @@ export default class MessageBrief extends React.PureComponent {
   };
 
   render() {
-    const { message, children, selfEmail, onLongPress } = this.props;
+    const { message, children, selfEmail, onLongPress, starred } = this.props;
 
     return (
       <View style={styles.message}>
-        <TouchableWithoutFeedback onLongPress={onLongPress}>
-          <View>
-            {children}
+        <View style={styles.messageContentWrapper}>
+          <View style={styles.messageTextBodyWrapper}>
+            <TouchableWithoutFeedback onLongPress={onLongPress}>
+              <View>
+                {children}
+              </View>
+            </TouchableWithoutFeedback>
           </View>
-        </TouchableWithoutFeedback>
+          {starred && <IconStarMessage />}
+        </View>
         <ReactionList
           messageId={message.id}
           reactions={message.reactions}

--- a/src/message/MessageContainer.js
+++ b/src/message/MessageContainer.js
@@ -39,6 +39,10 @@ export default class MessageContainer extends React.PureComponent {
     onLongPress(message);
   }
 
+  isStarred(message) {
+    return message.flags && !!~(message.flags.indexOf('starred'));
+  }
+
   render() {
     const { message, auth, avatarUrl, twentyFourHourTime, isBrief, doNarrow } = this.props;
     const MessageComponent = isBrief ? MessageBrief : MessageFull;
@@ -52,6 +56,7 @@ export default class MessageContainer extends React.PureComponent {
         selfEmail={auth.email}
         doNarrow={doNarrow}
         onLongPress={this.onLongPress}
+        starred={this.isStarred(message)}
       >
         {renderHtmlChildren({ childrenNodes: dom, auth, onPress: this.handleLinkPress })}
       </MessageComponent>

--- a/src/message/MessageFull.js
+++ b/src/message/MessageFull.js
@@ -6,6 +6,7 @@ import boundActions from '../boundActions';
 import { Avatar } from '../common';
 import Subheader from './Subheader';
 import ReactionList from '../reactions/ReactionList';
+import IconStarMessage from './IconStarMessage';
 
 const styles = StyleSheet.create({
   message: {
@@ -18,6 +19,14 @@ const styles = StyleSheet.create({
     flexDirection: 'column',
     marginLeft: 8,
   },
+  messageContentWrapper: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    justifyContent: 'space-between'
+  },
+  messageTextBodyWrapper: {
+    flex: 0.9
+  }
 });
 
 class MessageFull extends React.PureComponent {
@@ -34,7 +43,14 @@ class MessageFull extends React.PureComponent {
     this.props.pushRoute('account-details', this.props.message.sender_email);
 
   render() {
-    const { message, children, avatarUrl, twentyFourHourTime, selfEmail, onLongPress } = this.props;
+    const {
+      message,
+      children,
+      avatarUrl,
+      twentyFourHourTime,
+      selfEmail,
+      starred,
+      onLongPress } = this.props;
 
     return (
       <View style={styles.message}>
@@ -49,11 +65,16 @@ class MessageFull extends React.PureComponent {
             timestamp={message.timestamp}
             twentyFourHourTime={twentyFourHourTime}
           />
-          <TouchableWithoutFeedback onLongPress={onLongPress}>
-            <View>
-              {children}
+          <View style={styles.messageContentWrapper}>
+            <View style={styles.messageTextBodyWrapper}>
+              <TouchableWithoutFeedback onLongPress={onLongPress}>
+                <View>
+                  {children}
+                </View>
+              </TouchableWithoutFeedback>
             </View>
-          </TouchableWithoutFeedback>
+            {starred && <IconStarMessage />}
+          </View>
           <ReactionList
             messageId={message.id}
             reactions={message.reactions}


### PR DESCRIPTION
For #418  .
A star is shown next to messages that user has starred. The alignment is proper with neighboring elements both in landscape and portrait.

## Preview Portrait
![](https://puu.sh/uL63X/dd3f684aaf.png)
## Preview Landscape
![](https://puu.sh/uL65K/29f8364077.png)