### PR TITLE
Improve Account Switch

### DIFF
--- a/src/__tests__/reducers-test.js
+++ b/src/__tests__/reducers-test.js
@@ -1,0 +1,9 @@
+import reducers from '../reducers';
+
+describe('reducers', () => {
+  test('reducers return the default states on unknown action', () => {
+    expect(() =>
+      reducers({}, { type: 'UNKNOWN_ACTION' })
+    ).not.toThrow();
+  });
+});

--- a/src/app/__tests__/appReducers-test.js
+++ b/src/app/__tests__/appReducers-test.js
@@ -1,0 +1,19 @@
+import {
+  ACCOUNT_SWITCH,
+} from '../../constants';
+import appReducers from '../appReducers';
+
+describe('appReducers', () => {
+  describe('ACCOUNT_SWITCH', () => {
+    test('reissues initial fetch', () => {
+      const prevState = {};
+      const action = {
+        type: ACCOUNT_SWITCH,
+      };
+
+      const newState = appReducers(prevState, action);
+
+      expect(newState.needsInitialFetch).toBe(true);
+    });
+  });
+});

--- a/src/app/appReducers.js
+++ b/src/app/appReducers.js
@@ -27,6 +27,7 @@ export default (state = initialState, action) => {
     case ACCOUNT_SWITCH:
       return {
         ...state,
+        lastActivityTime: new Date(),
         needsInitialFetch: true,
       };
     case LOGIN_SUCCESS:

--- a/src/chat/__tests__/chatReducers-test.js
+++ b/src/chat/__tests__/chatReducers-test.js
@@ -14,6 +14,7 @@ import {
   EVENT_UPDATE_MESSAGE,
   EVENT_REACTION_ADD,
   EVENT_REACTION_REMOVE,
+  ACCOUNT_SWITCH,
 } from '../../constants';
 
 describe('chatReducers', () => {
@@ -448,6 +449,26 @@ describe('chatReducers', () => {
 
       expect(newState.messages).toEqual(expectedState.messages);
       expect(newState).not.toBe(initialState);
+    });
+  });
+
+  describe('ACCOUNT_SWITCH', () => {
+    test('no messages are retained, narrow is reset to "home"', () => {
+      const initialState = {
+        messages: {
+          'some_narrow': [],
+          'another_narrow': [],
+        },
+        narrow: [{ operator: 'is', operand: 'something' }],
+      };
+      const action = {
+        type: ACCOUNT_SWITCH,
+      };
+
+      const actualState = chatReducers(initialState, action);
+
+      expect(actualState.messages).toEqual({});
+      expect(actualState.narrow).toEqual([]);
     });
   });
 });

--- a/src/chat/chatReducers.js
+++ b/src/chat/chatReducers.js
@@ -13,19 +13,19 @@ import {
 import { homeNarrow, isMessageInNarrow } from '../utils/narrow';
 import chatUpdater from './chatUpdater';
 
-const getInitialState = () => ({
+const initialState = {
   fetching: { older: false, newer: false },
   caughtUp: { older: false, newer: false },
   narrow: homeNarrow(),
   messages: {},
-});
+};
 
-export default (state = getInitialState(), action) => {
+export default (state = initialState, action) => {
   switch (action.type) {
     case LOGOUT:
     case LOGIN_SUCCESS:
     case ACCOUNT_SWITCH:
-      return getInitialState();
+      return initialState;
 
     case MESSAGE_FETCH_START:
       return {

--- a/src/events/__tests__/eventReducers-test.js
+++ b/src/events/__tests__/eventReducers-test.js
@@ -1,0 +1,24 @@
+import eventReducers from '../eventReducers';
+import {
+  ACCOUNT_SWITCH,
+} from '../../constants';
+
+describe('eventReducers', () => {
+  describe('ACCOUNT_SWITCH', () => {
+    test('resets state to initial state', () => {
+      const initialState = {
+        queueId: 123,
+      };
+      const action = {
+        type: ACCOUNT_SWITCH,
+      };
+      const expectedState = {
+        queueId: null,
+      };
+
+      const actualState = eventReducers(initialState, action);
+
+      expect(actualState).toEqual(expectedState);
+    });
+  });
+});

--- a/src/mute/__tests__/mutetReducers-test.js
+++ b/src/mute/__tests__/mutetReducers-test.js
@@ -1,0 +1,20 @@
+import muteReducers from '../muteReducers';
+import {
+  ACCOUNT_SWITCH,
+} from '../../constants';
+
+describe('muteReducers', () => {
+  describe('ACCOUNT_SWITCH', () => {
+    test('resets state to initial state', () => {
+      const initialState = ['some_topic'];
+      const action = {
+        type: ACCOUNT_SWITCH,
+      };
+      const expectedState = [];
+
+      const actualState = muteReducers(initialState, action);
+
+      expect(actualState).toEqual(expectedState);
+    });
+  });
+});

--- a/src/mute/muteReducers.js
+++ b/src/mute/muteReducers.js
@@ -1,5 +1,6 @@
 import {
   REALM_INIT,
+  ACCOUNT_SWITCH,
 } from '../constants';
 
 const initialState = [];
@@ -8,6 +9,8 @@ export default (state = initialState, action) => {
   switch (action.type) {
     case REALM_INIT:
       return action.data.muted_topics;
+    case ACCOUNT_SWITCH:
+      return initialState;
     default:
       return state;
   }

--- a/src/realm/__tests__/realmtReducers-test.js
+++ b/src/realm/__tests__/realmtReducers-test.js
@@ -1,0 +1,22 @@
+import realmReducers from '../realmReducers';
+import {
+  ACCOUNT_SWITCH,
+} from '../../constants';
+
+describe('realmReducers', () => {
+  describe('ACCOUNT_SWITCH', () => {
+    test('resets state to initial state', () => {
+      const initialState = {};
+      const action = {
+        type: ACCOUNT_SWITCH,
+      };
+      const expectedState = {
+        twentyFourHourTime: false,
+      };
+
+      const actualState = realmReducers(initialState, action);
+
+      expect(actualState).toEqual(expectedState);
+    });
+  });
+});

--- a/src/realm/realmReducers.js
+++ b/src/realm/realmReducers.js
@@ -1,5 +1,6 @@
 import {
   REALM_INIT,
+  ACCOUNT_SWITCH,
 } from '../constants';
 
 // Initial state
@@ -14,6 +15,10 @@ const reducer = (state = initialState, action) => {
         ...state,
         twentyFourHourTime: action.data.twenty_four_hour_time,
       };
+
+    case ACCOUNT_SWITCH:
+      return initialState;
+
     default:
       return state;
   }

--- a/src/streamlist/__tests__/streamsReducers-test.js
+++ b/src/streamlist/__tests__/streamsReducers-test.js
@@ -1,0 +1,20 @@
+import streamsReducers from '../streamsReducers';
+import {
+  ACCOUNT_SWITCH,
+} from '../../constants';
+
+describe('streamsReducers', () => {
+  describe('ACCOUNT_SWITCH', () => {
+    test('resets state to initial state', () => {
+      const initialState = ['some_stream'];
+      const action = {
+        type: ACCOUNT_SWITCH,
+      };
+      const expectedState = [];
+
+      const actualState = streamsReducers(initialState, action);
+
+      expect(actualState).toEqual(expectedState);
+    });
+  });
+});

--- a/src/streamlist/streamsReducers.js
+++ b/src/streamlist/streamsReducers.js
@@ -3,6 +3,7 @@ import {
   EVENT_STREAM_ADD,
   EVENT_STREAM_REMOVE,
   EVENT_STREAM_UPDATE,
+  ACCOUNT_SWITCH,
 } from '../constants';
 
 const initialState = [];
@@ -11,12 +12,19 @@ export default (state = initialState, action) => {
   switch (action.type) {
     case INIT_STREAMS:
       return action.streams;
+
     case EVENT_STREAM_ADD:
       return state; // TODO
+
     case EVENT_STREAM_REMOVE:
       return state; // TODO
+
     case EVENT_STREAM_UPDATE:
       return state; // TODO
+
+    case ACCOUNT_SWITCH:
+      return initialState;
+
     default:
       return state;
   }

--- a/src/subscriptions/__tests__/subscriptionsReducers-test.js
+++ b/src/subscriptions/__tests__/subscriptionsReducers-test.js
@@ -3,6 +3,7 @@ import {
   EVENT_SUBSCRIPTION_REMOVE,
   EVENT_SUBSCRIPTION_PEER_ADD,
   EVENT_SUBSCRIPTION_PEER_REMOVE,
+  ACCOUNT_SWITCH,
 } from '../../constants';
 import subscriptionsReducers from '../subscriptionsReducers';
 
@@ -238,6 +239,20 @@ describe('subscriptionsReducers', () => {
       const newState = subscriptionsReducers(prevState, action);
 
       expect(newState).toEqual(expectedState);
+    });
+  });
+
+  describe('ACCOUNT_SWITCH', () => {
+    test('resets state to initial state', () => {
+      const initialState = ['some_stream'];
+      const action = {
+        type: ACCOUNT_SWITCH,
+      };
+      const expectedState = [];
+
+      const actualState = subscriptionsReducers(initialState, action);
+
+      expect(actualState).toEqual(expectedState);
     });
   });
 });

--- a/src/subscriptions/subscriptionsReducers.js
+++ b/src/subscriptions/subscriptionsReducers.js
@@ -17,7 +17,7 @@ export default (state = initialState, action) => {
     case LOGOUT:
     case LOGIN_SUCCESS:
     case ACCOUNT_SWITCH:
-      return [];
+      return initialState;
 
     case INIT_SUBSCRIPTIONS:
       return action.subscriptions;

--- a/src/users/__tests__/usersReducers-test.js
+++ b/src/users/__tests__/usersReducers-test.js
@@ -3,13 +3,14 @@ import {
   PRESENCE_RESPONSE,
   EVENT_USER_ADD,
   EVENT_PRESENCE,
+  ACCOUNT_SWITCH,
 } from '../../constants';
 import usersReducers, { activityFromPresence, timestampFromPresence } from '../usersReducers';
 
 const fiveSecsAgo = Math.floor(new Date() - 5) / 1000;
 
 describe('usersReducers', () => {
-  test('handles unknown action and no previous state by returning initial state, does not throw', () => {
+  test('handles unknown action and no state by returning initial state', () => {
     const newState = usersReducers(undefined, {});
     expect(newState).toBeDefined();
   });
@@ -96,17 +97,21 @@ describe('usersReducers', () => {
           },
         },
       };
-      const prevState = [{
-        full_name: 'Some Guy',
-        email: 'email@example.com',
-        status: 'offline',
-      }];
-      const expectedState = [{
-        full_name: 'Some Guy',
-        email: 'email@example.com',
-        status: 'active',
-        timestamp: fiveSecsAgo,
-      }];
+      const prevState = [
+        {
+          full_name: 'Some Guy',
+          email: 'email@example.com',
+          status: 'offline',
+        },
+      ];
+      const expectedState = [
+        {
+          full_name: 'Some Guy',
+          email: 'email@example.com',
+          status: 'active',
+          timestamp: fiveSecsAgo,
+        },
+      ];
 
       const newState = usersReducers(prevState, { type: PRESENCE_RESPONSE, presence });
 
@@ -128,17 +133,21 @@ describe('usersReducers', () => {
           },
         },
       };
-      const prevState = [{
-        full_name: 'Some Guy',
-        email: 'email@example.com',
-        status: 'offline',
-      }];
-      const expectedState = [{
-        full_name: 'Some Guy',
-        email: 'email@example.com',
-        status: 'active',
-        timestamp: fiveSecsAgo,
-      }];
+      const prevState = [
+        {
+          full_name: 'Some Guy',
+          email: 'email@example.com',
+          status: 'offline',
+        },
+      ];
+      const expectedState = [
+        {
+          full_name: 'Some Guy',
+          email: 'email@example.com',
+          status: 'active',
+          timestamp: fiveSecsAgo,
+        },
+      ];
 
       const newState = usersReducers(prevState, { type: PRESENCE_RESPONSE, presence });
 
@@ -190,35 +199,43 @@ describe('usersReducers', () => {
           },
         },
       };
-      const prevState = [{
-        full_name: 'Some Guy',
-        email: 'email@example.com',
-        status: 'offline',
-      }, {
-        full_name: 'John Doe',
-        email: 'johndoe@example.com',
-        status: 'offline',
-      }, {
-        full_name: 'Jane Doe',
-        email: 'janedoe@example.com',
-        status: 'offline',
-      }];
-      const expectedState = [{
-        full_name: 'Some Guy',
-        email: 'email@example.com',
-        status: 'offline',
-        timestamp: 1474527507,
-      }, {
-        full_name: 'John Doe',
-        email: 'johndoe@example.com',
-        status: 'active',
-        timestamp: fiveSecsAgo,
-      }, {
-        full_name: 'Jane Doe',
-        email: 'janedoe@example.com',
-        status: 'offline',
-        timestamp: 1475792203,
-      }];
+      const prevState = [
+        {
+          full_name: 'Some Guy',
+          email: 'email@example.com',
+          status: 'offline',
+        },
+        {
+          full_name: 'John Doe',
+          email: 'johndoe@example.com',
+          status: 'offline',
+        },
+        {
+          full_name: 'Jane Doe',
+          email: 'janedoe@example.com',
+          status: 'offline',
+        },
+      ];
+      const expectedState = [
+        {
+          full_name: 'Some Guy',
+          email: 'email@example.com',
+          status: 'offline',
+          timestamp: 1474527507,
+        },
+        {
+          full_name: 'John Doe',
+          email: 'johndoe@example.com',
+          status: 'active',
+          timestamp: fiveSecsAgo,
+        },
+        {
+          full_name: 'Jane Doe',
+          email: 'janedoe@example.com',
+          status: 'offline',
+          timestamp: 1475792203,
+        },
+      ];
 
       const newState = usersReducers(prevState, { type: PRESENCE_RESPONSE, presence });
 
@@ -235,14 +252,14 @@ describe('usersReducers', () => {
           user_id: 1,
           email: 'john@example.com',
           full_name: 'John Doe',
-        }
+        },
       };
       const expectedState = [
         {
           id: 1,
           email: 'john@example.com',
           fullName: 'John Doe',
-        }
+        },
       ];
 
       const actualState = usersReducers(initialState, action);
@@ -253,11 +270,13 @@ describe('usersReducers', () => {
 
   describe('EVENT_PRESENCE', () => {
     test('merges a single user presence', () => {
-      const prevState = [{
-        full_name: 'Some Guy',
-        email: 'email@example.com',
-        status: 'offline',
-      }];
+      const prevState = [
+        {
+          full_name: 'Some Guy',
+          email: 'email@example.com',
+          status: 'offline',
+        },
+      ];
       const action = {
         type: EVENT_PRESENCE,
         email: 'email@example.com',
@@ -268,16 +287,38 @@ describe('usersReducers', () => {
           },
         },
       };
-      const expectedState = [{
-        full_name: 'Some Guy',
-        email: 'email@example.com',
-        status: 'active',
-        timestamp: fiveSecsAgo,
-      }];
+      const expectedState = [
+        {
+          full_name: 'Some Guy',
+          email: 'email@example.com',
+          status: 'active',
+          timestamp: fiveSecsAgo,
+        },
+      ];
 
       const newState = usersReducers(prevState, action);
 
       expect(newState).toEqual(expectedState);
+    });
+  });
+
+  describe('ACCOUNT_SWITCH', () => {
+    test('resets state to initial state', () => {
+      const initialState = [
+        {
+          full_name: 'Some Guy',
+          email: 'email@example.com',
+          status: 'offline',
+        },
+      ];
+      const action = {
+        type: ACCOUNT_SWITCH,
+      };
+      const expectedState = [];
+
+      const actualState = usersReducers(initialState, action);
+
+      expect(actualState).toEqual(expectedState);
     });
   });
 });

--- a/src/users/usersReducers.js
+++ b/src/users/usersReducers.js
@@ -60,7 +60,11 @@ export default (state = initialState, action) => {
     case LOGOUT:
     case LOGIN_SUCCESS:
     case ACCOUNT_SWITCH:
-      return [];
+      return initialState;
+
+    case INIT_USERS:
+      return action.users.map(mapApiToStateUser);
+
     case PRESENCE_RESPONSE:
       return Object.keys(action.presence).reduce((currentState, email) => {
         const userIndex = state.findIndex(u => u.email === email);
@@ -71,18 +75,19 @@ export default (state = initialState, action) => {
 
         return currentState;
       }, [...state]);
-    case INIT_USERS: {
-      return action.users.map(mapApiToStateUser);
-    }
+
     case EVENT_USER_ADD:
       return [
         ...state,
         mapApiToStateUser(action.person),
       ];
+
     case EVENT_USER_REMOVE:
       return state; // TODO
+
     case EVENT_USER_UPDATE:
       return state; // TODO
+
     case EVENT_PRESENCE: {
       const userIndex = state.findIndex(u => u.email === action.email);
       if (userIndex === -1) return state;
@@ -93,6 +98,7 @@ export default (state = initialState, action) => {
 
       return newState;
     }
+
     default:
       return state;
   }

--- a/src/utils/__tests__/message-test.js
+++ b/src/utils/__tests__/message-test.js
@@ -109,7 +109,7 @@ describe('shouldBeMuted', () => {
     expect(isMuted).toBe(true);
   });
 
-  test.only('message in a stream is muted if the topic is muted and topic matches', () => {
+  test('message in a stream is muted if the topic is muted and topic matches', () => {
     const message = {
       display_recipient: 'stream',
       subject: 'topic',


### PR DESCRIPTION
Based on 'events' PR.

* Ensure all states are reset when switching accounts
* Add tests for all reducers to confirm