### PR TITLE
Simplify doNarrow, MainNavScreen and fix inconsistencies

### DIFF
--- a/src/account-info/AccountDetails.js
+++ b/src/account-info/AccountDetails.js
@@ -1,7 +1,6 @@
 import React, { Component } from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 
-import config from '../config';
 import { Avatar, ZulipButton, UserStatusIndicator } from '../common';
 import { privateNarrow } from '../utils/narrow';
 
@@ -34,9 +33,8 @@ const styles = StyleSheet.create({
 export default class AccountDetails extends Component {
 
   handleChatPress = () => {
-    const { auth, email, fetchMessages, popRoute } = this.props;
-    fetchMessages(auth, Number.MAX_SAFE_INTEGER,
-      config.messagesPerRequest, 0, privateNarrow(email));
+    const { email, doNarrow, popRoute } = this.props;
+    doNarrow(privateNarrow(email));
     popRoute();
   };
 

--- a/src/account-info/AccountDetailsScreen.js
+++ b/src/account-info/AccountDetailsScreen.js
@@ -23,8 +23,8 @@ class AccountDetailsScreen extends Component {
   }
 
   render() {
-    const { auth, users, fetchMessages, popRoute } = this.props;
-    const { fullName, avatarUrl, status } = users.find(x => x.email === this.email) || { fullName: 'A', avatarUrl: '', status: 'unknown' };
+    const { auth, users, fetchMessages, doNarrow, popRoute } = this.props;
+    const { fullName, avatarUrl, status } = users.find(x => x.email === this.email);
     const fullAvatarUrl = getFullUrl(avatarUrl, auth.realm);
 
     return (
@@ -36,6 +36,7 @@ class AccountDetailsScreen extends Component {
           avatarUrl={fullAvatarUrl}
           status={status}
           fetchMessages={fetchMessages}
+          doNarrow={doNarrow}
           popRoute={popRoute}
         />
       </Screen>

--- a/src/api/queueMarkAsRead.js
+++ b/src/api/queueMarkAsRead.js
@@ -1,4 +1,4 @@
-import type { Auth } from '../types';
+import { Auth } from '../types';
 import messagesFlags from './messagesFlags';
 
 let unsentMessageIds = [];

--- a/src/chat/__tests__/chatReducers-test.js
+++ b/src/chat/__tests__/chatReducers-test.js
@@ -30,23 +30,16 @@ describe('chatReducers', () => {
   });
 
   describe('SWITCH_NARROW', () => {
-    test('changes current narrow and replaces messages', () => {
+    test('changes active narrow', () => {
       const initialState = {
-        messages: {
-          [streamNarrowStr]: [{ id: 1 }, { id: 3 }],
-        },
         narrow: [],
       };
       const action = {
         type: SWITCH_NARROW,
         narrow: streamNarrow('some stream'),
-        messages: [{ id: 2 }],
       };
       const expectedState = {
         narrow: streamNarrow('some stream'),
-        messages: {
-          [streamNarrowStr]: [{ id: 2 }],
-        },
         caughtUp: { older: false, newer: false },
         fetching: { older: false, newer: false },
       };

--- a/src/chat/chatReducers.js
+++ b/src/chat/chatReducers.js
@@ -36,14 +36,9 @@ export default (state = initialState, action) => {
       };
 
     case SWITCH_NARROW: {
-      const key = JSON.stringify(action.narrow);
       return {
         ...state,
         narrow: action.narrow,
-        messages: {
-          ...state.messages,
-          [key]: action.messages,
-        },
         fetching: { older: false, newer: false },
         caughtUp: { older: false, newer: false },
       };

--- a/src/common/ZulipButton.js
+++ b/src/common/ZulipButton.js
@@ -21,7 +21,7 @@ const styles = StyleSheet.create({
     backgroundColor: BRAND_COLOR,
   },
   secondaryFrame: {
-    borderWidth: 1,
+    borderWidth: 1.5,
     borderColor: BRAND_COLOR,
   },
   touchTarget: {

--- a/src/main-tabbed/MainScreen.js
+++ b/src/main-tabbed/MainScreen.js
@@ -7,19 +7,13 @@ import ConversationsContainer from '../conversations/ConversationsContainer';
 import SubscriptionsContainer from '../streamlist/SubscriptionsContainer';
 import AccountContainer from '../account-info/AccountContainer';
 
-export default class MainScreen extends React.Component {
-  render() {
-    const { doNarrow } = this.props;
-
-    return (
-      <ScrollableTabView
-        renderTabBar={() => <MainTabBar />}
-      >
-        <HomeTab doNarrow={doNarrow} />
-        <ConversationsContainer doNarrow={doNarrow} />
-        <SubscriptionsContainer doNarrow={doNarrow} />
-        <AccountContainer />
-      </ScrollableTabView>
-    );
-  }
-}
+export default () => (
+  <ScrollableTabView
+    renderTabBar={() => <MainTabBar />}
+  >
+    <HomeTab />
+    <ConversationsContainer />
+    <SubscriptionsContainer />
+    <AccountContainer />
+  </ScrollableTabView>
+);

--- a/src/main/MainScreen.js
+++ b/src/main/MainScreen.js
@@ -1,36 +1,11 @@
 import React from 'react';
 import { StatusBar } from 'react-native';
-import Drawer from 'react-native-drawer';
 
 import Chat from '../chat/Chat';
 import MainNavBar from '../nav/MainNavBar';
+import SideDrawer from './SideDrawer';
 import StreamSidebar from '../nav/StreamSidebar';
 import ConversationsContainer from '../conversations/ConversationsContainer';
-
-const SideDrawer = (props) =>
-  <Drawer
-    content={props.content}
-    open={props.open}
-    side={props.side}
-    tapToClose
-    openDrawerOffset={
-      props.orientation === 'LANDSCAPE' ? 0.4 : 0.2
-    }
-    negotiatePan
-    panOpenMask={0.1}
-    useInteractionManager
-    tweenDuration={150}
-    tweenHandler={(ratio) => ({
-      mainOverlay: {
-        opacity: ratio / 2,
-        backgroundColor: 'black',
-      }
-    })}
-    onOpenStart={props.onOpenStart}
-    onClose={props.onClose}
-  >
-    {props.children}
-  </Drawer>;
 
 export default class MainScreen extends React.Component {
 
@@ -43,13 +18,8 @@ export default class MainScreen extends React.Component {
   }
 
   render() {
-    const { doNarrow, narrow, orientation, subscriptions, pushRoute } = this.props;
+    const { doNarrow, orientation, pushRoute } = this.props;
     const { leftDrawerOpen, rightDrawerOpen } = this.state;
-
-    let color;
-    if (narrow.length !== 0 && narrow[0].operator === 'stream') {
-      color = (subscriptions.find((sub) => narrow[0].operand === sub.name)).color;
-    }
 
     return (
       <SideDrawer
@@ -77,7 +47,7 @@ export default class MainScreen extends React.Component {
           content={
             <ConversationsContainer
               onNarrow={newNarrow => {
-                if (newNarrow) doNarrow(newNarrow);
+                doNarrow(newNarrow);
                 this.setState({ rightDrawerOpen: false });
               }}
             />
@@ -91,7 +61,6 @@ export default class MainScreen extends React.Component {
           <MainNavBar
             onPressPeople={() => this.setState({ rightDrawerOpen: true })}
             onPressStreams={() => this.setState({ leftDrawerOpen: true })}
-            backgroundColor={color}
           >
             <Chat {...this.props} />
           </MainNavBar>

--- a/src/main/MainScreenContainer.js
+++ b/src/main/MainScreenContainer.js
@@ -1,28 +1,19 @@
 import React from 'react';
 import { connect } from 'react-redux';
+import isEqual from 'lodash.isequal';
 
 import config from '../config';
 import boundActions from '../boundActions';
-import { registerAppActivity } from '../utils/activity';
 import { getMessagesInActiveNarrow, getAnchor } from '../chat/chatSelectors';
 import { getAuth } from '../account/accountSelectors';
 import MainScreen from './MainScreen';
 
 class MainScreenContainer extends React.Component {
   componentWillReceiveProps(nextProps) {
-    const { auth, fetchMessages } = this.props;
+    const { auth, fetchMessagesAtFirstUnread, narrow } = this.props;
 
-    // Trigger a fetch when the current narrow is switched and there are no messages
-    if (JSON.stringify(this.props.narrow) !== JSON.stringify(nextProps.narrow) &&
-        nextProps.messages.length === 0) {
-      fetchMessages(
-        auth,
-        0,
-        config.messagesPerRequest / 2,
-        config.messagesPerRequest / 2,
-        nextProps.narrow,
-        true
-      );
+    if (!isEqual(narrow, nextProps.narrow) && nextProps.messages.length === 0) {
+      fetchMessagesAtFirstUnread(auth, nextProps.narrow);
     }
   }
 
@@ -31,29 +22,20 @@ class MainScreenContainer extends React.Component {
     if (!fetching.older && !caughtUp.older && anchor) {
       fetchMessages(auth, anchor.older, config.messagesPerRequest, 0, narrow);
     }
-  }
+  };
 
   fetchNewer = () => {
     const { auth, fetching, caughtUp, anchor, narrow, fetchMessages } = this.props;
     if (!fetching.newer && !caughtUp.newer && anchor) {
       fetchMessages(auth, anchor.newer, 0, config.messagesPerRequest, narrow);
     }
-  }
-
-  doNarrow = (newNarrow = [], anchor: number = Number.MAX_SAFE_INTEGER) => {
-    const { auth, switchNarrow, messages } = this.props;
-    registerAppActivity(auth);
-    requestIdleCallback(() =>
-      switchNarrow(newNarrow, messages.filter(msg => msg.id === anchor)
-    ));
-  }
+  };
 
   render() {
     return (
       <MainScreen
         fetchOlder={this.fetchOlder}
         fetchNewer={this.fetchNewer}
-        doNarrow={this.doNarrow}
         markAsRead={this.handleMarkAsRead}
         {...this.props}
       />
@@ -61,7 +43,7 @@ class MainScreenContainer extends React.Component {
   }
 }
 
-export default connect((state) => ({
+export default connect(state => ({
   auth: getAuth(state),
   isOnline: state.app.isOnline,
   orientation: state.app.orientation,

--- a/src/main/SideDrawer.js
+++ b/src/main/SideDrawer.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import Drawer from 'react-native-drawer';
+
+export default (props) =>
+  <Drawer
+    content={props.content}
+    open={props.open}
+    side={props.side}
+    tapToClose
+    openDrawerOffset={
+      props.orientation === 'LANDSCAPE' ? 0.4 : 0.2
+    }
+    negotiatePan
+    panOpenMask={0.1}
+    useInteractionManager
+    tweenDuration={150}
+    tweenHandler={(ratio) => ({
+      mainOverlay: {
+        opacity: ratio / 2,
+        backgroundColor: 'black',
+      }
+    })}
+    onOpenStart={props.onOpenStart}
+    onClose={props.onClose}
+  >
+    {props.children}
+  </Drawer>;

--- a/src/nav/MainNavBar.js
+++ b/src/nav/MainNavBar.js
@@ -1,8 +1,10 @@
 import React from 'react';
-import { Navigator, StatusBar, StyleSheet, View } from 'react-native';
+import { connect } from 'react-redux';
+import { StatusBar, StyleSheet, View } from 'react-native';
 
 import { styles } from '../common';
 import { BRAND_COLOR } from '../common/styles';
+import { isStreamNarrow } from '../utils/narrow';
 import Title from '../title/Title';
 import NavButton from './NavButton';
 
@@ -15,35 +17,37 @@ const moreStyles = StyleSheet.create({
   },
 });
 
-export default class MainNavBar extends React.Component {
+class MainNavBar extends React.Component {
   render() {
-    const { onPressStreams, onPressPeople } = this.props;
-    let { backgroundColor } = this.props;
+    const { narrow, subscriptions, onPressStreams, onPressPeople } = this.props;
 
-    let textColor = BRAND_COLOR;
-    if (backgroundColor) {
-      textColor = foregroundColorFromBackground(backgroundColor);
-    } else {
-      backgroundColor = '#ffffff';
-    }
+    const backgroundColor = isStreamNarrow(narrow) ?
+      (subscriptions.find((sub) => narrow[0].operand === sub.name)).color :
+      'white';
+
+    const textColor = isStreamNarrow(narrow) ?
+      foregroundColorFromBackground(backgroundColor) :
+      BRAND_COLOR;
 
     return (
-      <Navigator
-        initialRoute={{ name: 'Home', index: 0 }}
-        renderScene={(route) =>
-          <View style={moreStyles.wrapper}>
-            <StatusBar
-              barStyle={textColor === 'white' ? 'light-content' : 'dark-content'}
-            />
-            <View style={[styles.navBar, { backgroundColor }]}>
-              <NavButton name="ios-menu" color={textColor} onPress={onPressStreams} />
-              <Title color={textColor} />
-              <NavButton name="md-people" color={textColor} onPress={onPressPeople} />
-            </View>
-            {this.props.children}
-          </View>
-        }
-      />
+      <View style={moreStyles.wrapper}>
+        <StatusBar
+          barStyle={textColor === 'white' ? 'light-content' : 'dark-content'}
+        />
+        <View style={[styles.navBar, { backgroundColor }]}>
+          <NavButton name="ios-menu" color={textColor} onPress={onPressStreams} />
+          <Title color={textColor} />
+          <NavButton name="md-people" color={textColor} onPress={onPressPeople} />
+        </View>
+        {this.props.children}
+      </View>
     );
   }
 }
+
+export default connect(
+  (state) => ({
+    narrow: state.chat.narrow,
+    subscriptions: state.subscriptions,
+  })
+)(MainNavBar);

--- a/src/users/UserListCard.js
+++ b/src/users/UserListCard.js
@@ -1,7 +1,6 @@
 import React, { Component } from 'react';
 import { View, StyleSheet } from 'react-native';
 
-import config from '../config';
 import { privateNarrow } from '../utils/narrow';
 import UserList from './UserList';
 
@@ -29,9 +28,8 @@ export default class UserListCard extends Component {
   };
 
   handleUserNarrow = (email: string) => {
-    const { auth, popRoute, fetchMessages } = this.props;
-    fetchMessages(auth, Number.MAX_SAFE_INTEGER,
-      config.messagesPerRequest, 0, privateNarrow(email));
+    const { popRoute, doNarrow } = this.props;
+    doNarrow(privateNarrow(email));
     popRoute();
   }
 


### PR DESCRIPTION
Some parts of the code were not updated to latest approaches.

* Extract doNarrow to an action, less passing of the function around
* Extract SideDrawer to new file
* Simplify MainNavBar and remove old and unused Navigation component
* Remove the manual fetchMessage calls in few places and replace with doNarrow
