### PR TITLE
fix: No messages is not being displayed.

### DIFF
--- a/src/chat/Chat.js
+++ b/src/chat/Chat.js
@@ -10,8 +10,8 @@ import ComposeBox from '../compose/ComposeBox';
 
 export default class Chat extends React.Component {
   render() {
-    const { messages, narrow, caughtUp, fetching, isOnline } = this.props;
-    const noMessages = messages.length === 0 && caughtUp.older && caughtUp.newer;
+    const { messages, narrow, fetching, isOnline } = this.props;
+    const noMessages = messages.length === 0 && !(fetching.older || fetching.newer);
     const noMessagesButLoading = messages.length === 0 && (fetching.older || fetching.newer);
 
     return (

--- a/src/message/NoMessages.js
+++ b/src/message/NoMessages.js
@@ -2,6 +2,7 @@ import React from 'react';
 import {
   StyleSheet,
   Text,
+  View,
 } from 'react-native';
 
 import {
@@ -15,12 +16,16 @@ import {
 } from '../utils/narrow';
 
 const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
   text: {
     fontSize: 20,
     paddingLeft: 10,
     padding: 8,
     backgroundColor: 'white',
-    textAlign: 'center',
   }
 });
 
@@ -39,9 +44,13 @@ export default class NoMessages extends React.PureComponent {
   render() {
     const { narrow } = this.props;
     const message = messages.find(x => x.isFunc(narrow));
+    const { container, text } = styles;
 
     return (
-      <Text style={styles.text}>{message.text}</Text>
+      <View style={container}>
+        <Text style={text}>{message.text}</Text>
+        <Text>Why not start the conversation?</Text>
+      </View>
     );
   }
 }


### PR DESCRIPTION
Show No messages if messageList size is zero
and no fetching is in progress.

Fix:#518


![screenshot_1492595904](https://cloud.githubusercontent.com/assets/18511177/25175136/4dee3d7a-2517-11e7-97b4-51706e5c4afc.png)

`caughtUp` is true when we're at the last message in that direction. But if there are no messages then there is no sense of last message.