### PR TITLE
Redirect in-app links to appropriate messages and add tests.

### DIFF
--- a/src/main/MainScreenContainer.js
+++ b/src/main/MainScreenContainer.js
@@ -56,4 +56,5 @@ export default connect(state => ({
   narrow: state.chat.narrow,
   mute: state.mute,
   anchor: getAnchor(state),
+  users: state.users,
 }), boundActions)(MainScreenContainer);

--- a/src/message/MessageContainer.js
+++ b/src/message/MessageContainer.js
@@ -1,27 +1,44 @@
 import React from 'react';
+import { Linking } from 'react-native';
 import htmlparser from 'htmlparser2';
 
 import renderHtmlChildren from './html/renderHtmlChildren';
 import { narrowFromMessage } from '../utils/narrow';
 import MessageFull from './MessageFull';
 import MessageBrief from './MessageBrief';
+import { isUrlInAppLink, getFullUrl, getMessageIdFromLink, getNarrowFromLink } from '../utils/url';
 
 const htmlToDomTree = html => {
   let domTree = null;
-  const parser = new htmlparser.Parser(new htmlparser.DomHandler((err, dom) => {
-    if (!err) domTree = dom;
-  }));
+  const parser = new htmlparser.Parser(
+    new htmlparser.DomHandler((err, dom) => {
+      if (!err) domTree = dom;
+    }),
+  );
   parser.write(html);
   parser.done();
   return domTree;
 };
 
 export default class MessageContainer extends React.PureComponent {
-
   handlePress = () => {
     const { message, doNarrow } = this.props;
     doNarrow(narrowFromMessage(message), message.id);
-  }
+  };
+
+  inAppLinkPress = href => {
+    const { users, auth, doNarrow } = this.props;
+    const anchor = getMessageIdFromLink(href, auth.realm);
+    const narrow = getNarrowFromLink(href, auth.realm, users);
+    doNarrow(narrow, anchor);
+  };
+
+  regularLinkPress = href => Linking.openURL(getFullUrl(href, this.props.auth.realm));
+
+  handleLinkPress = href =>
+    (isUrlInAppLink(href, this.props.auth.realm) ? this.inAppLinkPress : this.regularLinkPress)(
+      href,
+    );
 
   render() {
     const { message, auth, avatarUrl, twentyFourHourTime, isBrief, doNarrow } = this.props;
@@ -37,7 +54,7 @@ export default class MessageContainer extends React.PureComponent {
         doNarrow={doNarrow}
         onPress={this.handlePress}
       >
-        {renderHtmlChildren({ childrenNodes: dom, auth })}
+        {renderHtmlChildren({ childrenNodes: dom, auth, onPress: this.handleLinkPress })}
       </MessageComponent>
     );
   }

--- a/src/message/html/HtmlNodeTag.js
+++ b/src/message/html/HtmlNodeTag.js
@@ -42,7 +42,7 @@ const specialTags = {
 const stylesFromClassNames = (classNames = '', styleObj) =>
   classNames.split(' ').map(className => styleObj[className]);
 
-export default ({ auth, attribs, name, cascadingStyle, childrenNodes }) => {
+export default ({ auth, attribs, name, cascadingStyle, childrenNodes, onPress }) => {
   const style = [
     styles[name],
     ...stylesFromClassNames(attribs.class, styles),
@@ -73,6 +73,7 @@ export default ({ auth, attribs, name, cascadingStyle, childrenNodes }) => {
       style={style}
       cascadingStyle={newCascadingStyle}
       childrenNodes={childrenNodes}
+      onPress={onPress}
     />
   );
 };

--- a/src/message/html/HtmlTagA.js
+++ b/src/message/html/HtmlTagA.js
@@ -1,11 +1,9 @@
 import React from 'react';
-import { Linking, Text } from 'react-native';
-
-import { getFullUrl } from '../../utils/url';
+import { Text } from 'react-native';
 import renderHtmlChildren from './renderHtmlChildren';
 
-export default ({ href, auth, childrenNodes, cascadingStyle, onPress }) => (
-  <Text onPress={() => Linking.openURL(getFullUrl(href, auth.realm))}>
-    {renderHtmlChildren({ childrenNodes, auth, cascadingStyle })}
+export default ({ onPress, href, ...restProps }) => (
+  <Text onPress={() => onPress(href)}>
+    {renderHtmlChildren({ onPress, ...restProps })}
   </Text>
 );

--- a/src/message/html/HtmlTagDiv.js
+++ b/src/message/html/HtmlTagDiv.js
@@ -3,8 +3,8 @@ import { View } from 'react-native';
 
 import renderHtmlChildren from './renderHtmlChildren';
 
-export default ({ auth, style, cascadingStyle, childrenNodes }) => (
+export default ({ style, ...restProps }) => (
   <View style={style}>
-    {renderHtmlChildren({ childrenNodes, auth, cascadingStyle })}
+    {renderHtmlChildren({ ...restProps })}
   </View>
 );

--- a/src/message/html/HtmlTagItalic.js
+++ b/src/message/html/HtmlTagItalic.js
@@ -4,8 +4,8 @@ import { Text } from 'react-native';
 import styles from './HtmlStyles';
 import renderHtmlChildren from './renderHtmlChildren';
 
-export default ({ target, auth, childrenNodes, cascadingStyle, onPress }) => (
+export default ({ cascadingStyle, ...restProps }) => (
   <Text style={[styles.b, cascadingStyle]}>
-    {renderHtmlChildren({ childrenNodes, auth, cascadingStyle })}
+    {renderHtmlChildren({ cascadingStyle, ...restProps })}
   </Text>
 );

--- a/src/message/html/HtmlTagLi.js
+++ b/src/message/html/HtmlTagLi.js
@@ -12,9 +12,11 @@ const styles = StyleSheet.create({
 
 const BULLET = '\u2022';
 
-export default ({ auth, childrenNodes, style, cascadingStyle }) => (
+export default ({ style, ...restProps }) => (
   <View style={style}>
     <Text style={styles.bullet}>{BULLET}</Text>
-    <Text>{renderHtmlChildren({ childrenNodes, auth, cascadingStyle })}</Text>
+    <Text>
+      {renderHtmlChildren({ ...restProps })}
+    </Text>
   </View>
 );

--- a/src/message/html/HtmlTagPre.js
+++ b/src/message/html/HtmlTagPre.js
@@ -3,8 +3,8 @@ import { View } from 'react-native';
 
 import HtmlTagSpan from './HtmlTagSpan';
 
-export default ({ style, data, childrenNodes, cascadingStyle }) => (
+export default ({ style, ...restProps }) => (
   <View style={style}>
-    <HtmlTagSpan childrenNodes={childrenNodes} cascadingStyle={cascadingStyle} />
+    <HtmlTagSpan {...restProps} />
   </View>
 );

--- a/src/message/html/HtmlTagSpan.js
+++ b/src/message/html/HtmlTagSpan.js
@@ -3,8 +3,8 @@ import { Text } from 'react-native';
 
 import renderHtmlChildren from './renderHtmlChildren';
 
-export default ({ style, auth, childrenNodes, cascadingStyle }) => (
+export default ({ style, cascadingStyle, ...restProps }) => (
   <Text style={[style, cascadingStyle]}>
-    {renderHtmlChildren({ childrenNodes, auth })}
+    {renderHtmlChildren({ ...restProps })}
   </Text>
 );

--- a/src/message/html/HtmlTagStrong.js
+++ b/src/message/html/HtmlTagStrong.js
@@ -4,8 +4,8 @@ import { Text } from 'react-native';
 import styles from './HtmlStyles';
 import renderHtmlChildren from './renderHtmlChildren';
 
-export default ({ target, auth, childrenNodes, cascadingStyle, onPress }) => (
+export default ({ cascadingStyle, ...restProps }) => (
   <Text style={[styles.b, cascadingStyle]}>
-    {renderHtmlChildren({ childrenNodes, auth, cascadingStyle })}
+    {renderHtmlChildren({ cascadingStyle, ...restProps })}
   </Text>
 );

--- a/src/message/html/renderHtmlChildren.js
+++ b/src/message/html/renderHtmlChildren.js
@@ -2,19 +2,20 @@ import React from 'react';
 
 import HtmlNode from './HtmlNode';
 
-export default ({ auth, cascadingStyle, childrenNodes }) =>
+export default ({ auth, cascadingStyle, childrenNodes, onPress }) =>
   childrenNodes &&
-    childrenNodes
-      .filter(x => x.data !== '\n')
-      .map((node, index) =>
-        <HtmlNode
-          key={index}
-          auth={auth}
-          cascadingStyle={cascadingStyle}
-          data={node.data}
-          name={node.name}
-          type={node.type}
-          attribs={node.attribs}
-          childrenNodes={node.children}
-        />
-      );
+  childrenNodes
+    .filter(x => x.data !== '\n')
+    .map((node, index) => (
+      <HtmlNode
+        key={index}
+        auth={auth}
+        cascadingStyle={cascadingStyle}
+        data={node.data}
+        name={node.name}
+        type={node.type}
+        attribs={node.attribs}
+        childrenNodes={node.children}
+        onPress={onPress}
+      />
+    ));

--- a/src/message/renderMessages.js
+++ b/src/message/renderMessages.js
@@ -13,7 +13,7 @@ import TimeRow from '../message/TimeRow';
 import { isSameRecipient, shouldBeMuted } from '../utils/message';
 import { isSameDay } from '../utils/date';
 
-export default ({ auth, subscriptions, messages, narrow, mute, doNarrow }) => {
+export default ({ auth, subscriptions, users, messages, narrow, mute, doNarrow }) => {
   const list = [];
   let prevItem;
 
@@ -65,6 +65,7 @@ export default ({ auth, subscriptions, messages, narrow, mute, doNarrow }) => {
         isBrief={shouldGroupWithPrev}
         doNarrow={doNarrow}
         avatarUrl={getFullUrl(item.avatar_url, auth.realm)}
+        users={users}
       />
     );
 

--- a/src/utils/__tests__/url-test.js
+++ b/src/utils/__tests__/url-test.js
@@ -1,4 +1,15 @@
-import { getFullUrl, getResource } from '../url';
+import {
+  getFullUrl,
+  getResource,
+  isUrlInAppLink,
+  isMessageLink,
+  isStreamLink,
+  isTopicLink,
+  isGroupLink,
+  isSpecialLink,
+  getNarrowFromLink,
+  getMessageIdFromLink,
+} from '../url';
 
 describe('getFullUrl', () => {
   test('when uri contains domain, do not change', () => {
@@ -20,10 +31,11 @@ describe('getResource', () => {
         Authorization: 'Basic am9obmRvZUBleGFtcGxlLmNvbTpzb21lQXBpS2V5', // eslint-disable-line
       },
     };
-    const resource = getResource(
-      'https://example.com/img.gif',
-      { realm: '', apiKey: 'someApiKey', email: 'johndoe@example.com' },
-    );
+    const resource = getResource('https://example.com/img.gif', {
+      realm: '',
+      apiKey: 'someApiKey',
+      email: 'johndoe@example.com',
+    });
     expect(resource).toEqual(expectedResult);
   });
 
@@ -34,10 +46,10 @@ describe('getResource', () => {
         Authorization: 'Basic dW5kZWZpbmVkOnNvbWVBcGlLZXk=', // eslint-disable-line
       },
     };
-    const resource = getResource(
-      '/img.gif',
-      { realm: 'https://example.com', apiKey: 'someApiKey' },
-    );
+    const resource = getResource('/img.gif', {
+      realm: 'https://example.com',
+      apiKey: 'someApiKey',
+    });
     expect(resource).toEqual(expectedResult);
   });
 
@@ -45,10 +57,240 @@ describe('getResource', () => {
     const expectedResult = {
       uri: 'https://another.com/img.gif',
     };
-    const resource = getResource(
-      'https://another.com/img.gif',
-      { realm: 'https://example.com', apiKey: 'someApiKey' },
-    );
+    const resource = getResource('https://another.com/img.gif', {
+      realm: 'https://example.com',
+      apiKey: 'someApiKey',
+    });
     expect(resource).toEqual(expectedResult);
+  });
+});
+
+describe('isUrlInAppLink', () => {
+  test('when link is external, return false', () => {
+    expect(isUrlInAppLink('https://example.com', 'https://another.com')).toBe(false);
+  });
+
+  test('when link is internal, but not in app, return false', () => {
+    expect(isUrlInAppLink('https://example.com/user_uploads', 'https://example.com')).toBe(false);
+  });
+
+  test('when link is internal and in app, return true', () => {
+    expect(isUrlInAppLink('https://example.com/#narrow/stream/jest', 'https://example.com')).toBe(
+      true,
+    );
+  });
+});
+
+describe('isMessageLink', () => {
+  test('only in-app link containing "near/<message-id>" is a message link', () => {
+    expect(isMessageLink('https://example.com/#narrow/stream/jest', 'https://example.com')).toBe(
+      false,
+    );
+    expect(isMessageLink('https://example.com/#narrow/#near/1', 'https://example.com')).toBe(true);
+  });
+});
+
+describe('isStreamLink', () => {
+  test('only in-app link containing "stream" is a stream link', () => {
+    expect(
+      isStreamLink('https://example.com/#narrow/pm-with/1,2-group', 'https://example.com'),
+    ).toBe(false);
+    expect(isStreamLink('https://example.com/#narrow/stream/jest', 'https://example.com')).toBe(
+      true,
+    );
+    expect(
+      isStreamLink('https://example.com/#narrow/stream/jest/topic/test', 'https://example.com'),
+    ).toBe(true);
+  });
+});
+
+describe('isTopicLink', () => {
+  test('only in-app link containing "topic" is a topic link', () => {
+    expect(
+      isTopicLink('https://example.com/#narrow/pm-with/1,2-group', 'https://example.com'),
+    ).toBe(false);
+    expect(isTopicLink('https://example.com/#narrow/stream/jest', 'https://example.com')).toBe(
+      false,
+    );
+    expect(
+      isTopicLink('https://example.com/#narrow/stream/jest/topic/test', 'https://example.com'),
+    ).toBe(true);
+    expect(
+      isTopicLink(
+        'https://example.com/#narrow/near/1/stream/jest/topic/test',
+        'https://example.com',
+      ),
+    ).toBe(true);
+  });
+});
+
+describe('isGroupLink', () => {
+  test('only in-app link containing "pm-with" is a group link', () => {
+    expect(
+      isGroupLink('https://example.com/#narrow/stream/jest/topic/test', 'https://example.com'),
+    ).toBe(false);
+    expect(
+      isGroupLink('https://example.com/#narrow/pm-with/1,2-group', 'https://example.com'),
+    ).toBe(true);
+    expect(
+      isGroupLink('https://example.com/#narrow/near/1/pm-with/1,2-group', 'https://example.com'),
+    ).toBe(true);
+  });
+});
+
+describe('isSpecialLink', () => {
+  test('only in-app link containing "is" is a special link', () => {
+    expect(
+      isSpecialLink('https://example.com/#narrow/stream/jest/topic/test', 'https://example.com'),
+    ).toBe(false);
+    expect(isSpecialLink('https://example.com/#narrow/is/private', 'https://example.com')).toBe(
+      true,
+    );
+    expect(isSpecialLink('https://example.com/#narrow/is/starred', 'https://example.com')).toBe(
+      true,
+    );
+    expect(isSpecialLink('https://example.com/#narrow/is/mentioned', 'https://example.com')).toBe(
+      true,
+    );
+  });
+});
+
+describe('getNarrowFromLink', () => {
+  const users = [
+    { email: 'abc@example.com', id: 1 },
+    { email: 'xyz@example.com', id: 2 },
+    { email: 'def@example.com', id: 3 },
+  ];
+
+  test('when link is not in-app link, return default homeNarrow', () => {
+    expect(getNarrowFromLink('https://example.com/user_uploads', 'https://example.com')).toEqual(
+      [],
+    );
+  });
+
+  test('when link is stream link, return matching streamNarrow', () => {
+    const expectedValue = [
+      {
+        operator: 'stream',
+        operand: 'jest',
+      },
+    ];
+    expect(
+      getNarrowFromLink('https://example.com/#narrow/stream/jest', 'https://example.com'),
+    ).toEqual(expectedValue);
+  });
+
+  test('when link is stream link, without realm info, return matching streamNarrow', () => {
+    const expectedValue = [
+      {
+        operator: 'stream',
+        operand: 'jest',
+      },
+    ];
+    expect(getNarrowFromLink('/#narrow/stream/jest', 'https://example.com')).toEqual(expectedValue);
+  });
+
+  test('when link is a topic link and encoded, decode stream and topic names and return matching streamNarrow and topicNarrow', () => {
+    const expectedValue = [
+      {
+        operator: 'stream',
+        operand: 'jest',
+      },
+      {
+        operator: 'topic',
+        operand: '(no topic)',
+      },
+    ];
+    expect(
+      getNarrowFromLink(
+        'https://example.com/#narrow/stream/jest/topic/(no.20topic)',
+        'https://example.com',
+      ),
+    ).toEqual(expectedValue);
+  });
+
+  test('when link is a group link, return matching groupNarrow', () => {
+    const expectedValue = [
+      {
+        operator: 'pm-with',
+        operand: 'abc@example.com,xyz@example.com,def@example.com',
+      },
+    ];
+    expect(
+      getNarrowFromLink(
+        'https://example.com/#narrow/pm-with/1,2,3-group',
+        'https://example.com',
+        users,
+      ),
+    ).toEqual(expectedValue);
+  });
+
+  test('when link is a special link, return matching specialNarrow', () => {
+    const expectedValue = [
+      {
+        operator: 'is',
+        operand: 'starred',
+      },
+    ];
+    expect(
+      getNarrowFromLink('https://example.com/#narrow/is/starred', 'https://example.com'),
+    ).toEqual(expectedValue);
+  });
+
+  test('when link is a message link, return matching narrow', () => {
+    expect(
+      getNarrowFromLink(
+        'https://example.com/#narrow/near/1/pm-with/1,3-group',
+        'https://example.com',
+        users,
+      ),
+    ).toEqual([
+      {
+        operator: 'pm-with',
+        operand: 'abc@example.com,def@example.com',
+      },
+    ]);
+    expect(
+      getNarrowFromLink(
+        'https://example.com/#narrow/near/1/stream/jest/topic/test',
+        'https://example.com',
+        users,
+      ),
+    ).toEqual([
+      {
+        operator: 'stream',
+        operand: 'jest',
+      },
+      {
+        operator: 'topic',
+        operand: 'test',
+      },
+    ]);
+  });
+});
+
+describe('getMessageIdFromLink', () => {
+  test('not message link', () => {
+    expect(
+      getMessageIdFromLink('https://example.com/#narrow/is/private', 'https://example.com'),
+    ).toBeUndefined();
+  });
+
+  test('when link is a group link, return anchor message id', () => {
+    expect(
+      getMessageIdFromLink(
+        'https://example.com/#narrow/near/1/pm-with/1,3-group',
+        'https://example.com',
+      ),
+    ).toBe(1);
+  });
+
+  test('when link is a topic link, return anchor message id', () => {
+    expect(
+      getMessageIdFromLink(
+        'https://example.com/#narrow/near/1/stream/jest/topic/test',
+        'https://example.com',
+      ),
+    ).toBe(1);
   });
 });

--- a/src/utils/url.js
+++ b/src/utils/url.js
@@ -1,19 +1,66 @@
 import base64 from 'base-64';
 import { Auth } from '../api/apiFetch';
+import { topicNarrow, streamNarrow, groupNarrow, specialNarrow } from './narrow';
+import { getUserById } from '../users/usersSelectors';
 
 export const getAuthHeader = (email: string, apiKey: string): ?string =>
   (apiKey ? `Basic ${base64.encode(`${email}:${apiKey}`)}` : undefined);
 
 export const encodeAsURI = (params): string =>
-  Object.keys(params).map((key) => (
-    `${encodeURIComponent(key)}=${encodeURIComponent(params[key])}`
-  )).join('&');
+  Object.keys(params)
+    .map(key => `${encodeURIComponent(key)}=${encodeURIComponent(params[key])}`)
+    .join('&');
 
 export const getFullUrl = (url: string, realm: string): string =>
   (url.startsWith('/') ? `${realm}${url}` : url);
 
 export const isUrlOnRealm = (url: string, realm: string): boolean =>
   url.startsWith('/') || url.startsWith(realm);
+
+export const isUrlInAppLink = (url: string, realm: string): boolean =>
+  (isUrlOnRealm(url, realm) ? url.split(realm).pop().startsWith('/#narrow') : false);
+
+export const isMessageLink = (url: string, realm: string): boolean =>
+  isUrlInAppLink(url, realm) && url.includes('near');
+
+export const isTopicLink = (url: string, realm: string): boolean =>
+  isUrlInAppLink(url, realm) && url.includes('topic');
+
+export const isGroupLink = (url: string, realm: string): boolean =>
+  isUrlInAppLink(url, realm) && url.includes('pm-with');
+
+export const isStreamLink = (url: string, realm: string): boolean =>
+  isUrlInAppLink(url, realm) && url.includes('stream');
+
+export const isSpecialLink = (url: string, realm: string): boolean =>
+  isUrlInAppLink(url, realm) && url.includes('is');
+
+export const getNarrowFromLink = (url: string, realm: string, users: []): [] => {
+  const paths = url.split(realm).pop().split('/');
+  if (isGroupLink(url, realm)) {
+    const recipients = paths[paths.length - 1].split('-')[0].split(',');
+    return groupNarrow(
+      recipients.map(recipient => getUserById(users, parseInt(recipient, 10)).email),
+    );
+  } else if (isTopicLink(url, realm)) {
+    return topicNarrow(
+      decodeURIComponent(paths[paths.lastIndexOf('stream') + 1].replace(/\./g, '%')),
+      decodeURIComponent(paths[paths.lastIndexOf('topic') + 1].replace(/\./g, '%')),
+    );
+  } else if (isStreamLink(url, realm)) {
+    return streamNarrow(
+      decodeURIComponent(paths[paths.lastIndexOf('stream') + 1].replace(/\./g, '%')),
+    );
+  } else if (isSpecialLink(url, realm)) {
+    return specialNarrow(paths[paths.length - 1]);
+  }
+  return [];
+};
+
+export const getMessageIdFromLink = (url: string, realm: string) => {
+  const paths = url.split(realm).pop().split('/');
+  return isMessageLink(url, realm) ? parseInt(paths[paths.lastIndexOf('near') + 1], 10) : undefined;
+};
 
 const getResourceWithAuth = (uri: string, auth: Auth) => ({
   uri: getFullUrl(uri, auth.realm),
@@ -27,6 +74,4 @@ const getResourceNoAuth = (uri: string) => ({
 });
 
 export const getResource = (uri: string, auth: Auth) =>
-  (isUrlOnRealm(uri, auth.realm) ?
-    getResourceWithAuth(uri, auth) :
-    getResourceNoAuth(uri));
+  (isUrlOnRealm(uri, auth.realm) ? getResourceWithAuth(uri, auth) : getResourceNoAuth(uri));


### PR DESCRIPTION
Fixes: #162

Redirects :
* stream, topic, private and special (example `is/starred` ) links
* message links (containing `near/<message_id>`)
* `#stream-name` to mentioned streams.

Added tests.

https://drive.google.com/open?id=0B4jK5QX65b0ZUEhiendsbDZrUGM

This pr uses the old doNarrow function which takes anchor as an argument. Once #523 is resolved, I'll fix the conflicts. Suggestions are welcome :).