### PR TITLE
Fix: Add indicator for when new message arrives

### DIFF
--- a/src/chat/Chat.js
+++ b/src/chat/Chat.js
@@ -3,13 +3,15 @@ import { KeyboardAvoidingView } from 'react-native';
 
 import { styles, OfflineNotice } from '../common';
 import { canSendToNarrow } from '../utils/narrow';
-import { filterUnreadMessageIds } from '../utils/unread';
+import { filterUnreadMessageIds, countUnread } from '../utils/unread';
 import { registerAppActivity } from '../utils/activity';
 import { queueMarkAsRead } from '../api';
 import MessageList from '../message/MessageList';
 import MessageListLoading from '../message/MessageListLoading';
 import NoMessages from '../message/NoMessages';
 import ComposeBox from '../compose/ComposeBox';
+import UnreadNotice from './UnreadNotice';
+
 
 export default class Chat extends React.Component {
   handleMessageListScroll = e => {
@@ -30,13 +32,15 @@ export default class Chat extends React.Component {
   };
 
   render() {
-    const { messages, narrow, fetching, isOnline } = this.props;
+    const { messages, narrow, fetching, isOnline, readIds } = this.props;
     const noMessages = messages.length === 0 && !(fetching.older || fetching.newer);
     const noMessagesButLoading = messages.length === 0 && (fetching.older || fetching.newer);
     const showMessageList = !noMessages && !noMessagesButLoading;
+    const unreadCount = countUnread(messages.map(msg => msg.id), readIds);
 
     return (
       <KeyboardAvoidingView style={styles.screen} behavior="padding">
+        {(unreadCount > 0) && <UnreadNotice position="bottom" />}
         {!isOnline && <OfflineNotice />}
         {noMessages && <NoMessages narrow={narrow} />}
         {noMessagesButLoading && <MessageListLoading />}

--- a/src/chat/UnreadNotice.js
+++ b/src/chat/UnreadNotice.js
@@ -1,0 +1,101 @@
+import React from 'react';
+import { Animated, StyleSheet, Text, Easing } from 'react-native';
+import { IconDownArrow } from '../common/Icons';
+
+const styles = StyleSheet.create({
+  unreadContainer: {
+    padding: 2,
+    backgroundColor: '#96A3F9',
+    flexDirection: 'row',
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    zIndex: 1,
+    alignItems: 'center'
+  },
+  unreadText: {
+    flex: 0.9,
+    color: '#FFFFFF',
+    fontSize: 14
+  },
+  icon: {
+    flex: 0.05,
+    width: 14,
+    height: 14,
+    margin: 8,
+    fontSize: 14,
+    color: 'white',
+    textAlign: 'center',
+  }
+});
+
+const POSITIONS = {
+  top: 'top',
+  bottom: 'bottom'
+};
+
+const showAnimationConfig = {
+  toValue: 1,
+  duration: 400,
+  easing: Easing.bezier(0.17, 0.67, 0.11, 0.99)
+};
+
+const hideAnimationConfig = {
+  toValue: 0,
+  duration: 400,
+  easing: Easing.bezier(0.17, 0.67, 0.11, 0.99)
+};
+
+export default class UnreadNotice extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      translateAnimation: new Animated.Value(0)
+    };
+  }
+
+  componentDidMount() {
+    this.show();
+  }
+
+  hide = () => {
+    this.state.translateAnimation.setValue(1);
+    Animated.timing(this.state.translateAnimation, hideAnimationConfig).start();
+  };
+
+  show = () => {
+    this.state.translateAnimation.setValue(0);
+    Animated.timing(this.state.translateAnimation, showAnimationConfig).start();
+  };
+
+  dynamicContainerStyles = () => {
+    const { position } = this.props;
+    const translationMultiplier = position === POSITIONS.top ? -1 : 1;
+
+    return {
+      ...StyleSheet.flatten(styles.unreadContainer),
+      bottom: position === POSITIONS.bottom ? 0 : null,
+      top: position === POSITIONS.top ? 0 : null,
+      transform: [
+        {
+          translateY: this.state.translateAnimation.interpolate({
+            inputRange: [0, 1],
+            outputRange: [translationMultiplier * 50, 0]
+          })
+        }
+      ]
+    };
+  };
+
+  render() {
+    return (
+      <Animated.View style={this.dynamicContainerStyles()}>
+        <IconDownArrow style={[styles.icon, styles.downArrowIcon]} />
+        <Text style={styles.unreadText}>
+          New unread messages
+        </Text>
+      </Animated.View>
+    );
+  }
+}

--- a/src/common/Icons.js
+++ b/src/common/Icons.js
@@ -11,5 +11,6 @@ export const IconMute = (props) => <MaterialIcon name="volume-off" {...props} />
 export const IconStream = (props) => <FontAwesomeIcon name="hashtag" {...props} />;
 export const IconPrivate = (props) => <FontAwesomeIcon name="lock" {...props} />;
 export const IconPrivateChat = (props) => <IoniconsIcon name="md-text" {...props} />;
+export const IconDownArrow = (props) => <IoniconsIcon name="md-arrow-down" {...props} />;
 
 export default IoniconsIcon;

--- a/src/main/MainScreenContainer.js
+++ b/src/main/MainScreenContainer.js
@@ -57,4 +57,5 @@ export default connect(state => ({
   mute: state.mute,
   anchor: getAnchor(state),
   users: state.users,
+  readIds: state.flags.read
 }), boundActions)(MainScreenContainer);


### PR DESCRIPTION
Fixes #349 
![](https://puu.sh/vy0LE/62026d6b94.gif)

@borisyankov the onScroll surprisingly wasn't required in the implementation. `countUnread` handles the logic of when to show the indicator very well. I have added `position` prop to the `UnreadNotice` component which positions the notice on top or bottom of message list depending on what is supplies.