### PR TITLE
Cache everything in store except 'app' reducer

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -14,7 +14,7 @@ const store = compose(
 
 export const restore = (onFinished) =>
   persistStore(store, {
-    whitelist: ['accounts', 'settings'],
+    blacklist: ['app'],
     storage: AsyncStorage,
   }, onFinished);
 


### PR DESCRIPTION
Over the last 1-2 months, improvements on how the incoming data is handled means caching previous store data is now simple and seamless.
