### PR TITLE
Don't show tick/done icon if realm is logged out.

### DIFF
--- a/src/account/AccountItem.js
+++ b/src/account/AccountItem.js
@@ -53,17 +53,16 @@ export default class AccountItem extends React.PureComponent {
     this.props.onRemove(this.props.index);
 
   render() {
-    const { email, realm, index, canRemove } = this.props;
-    const isSelected = index === 0;
+    const { email, realm, showDoneIcon } = this.props;
 
     return (
       <Touchable style={styles.wrapper} onPress={this.handleSelect}>
-        <View style={[styles.accountItem, isSelected && styles.selectedAccountItem]}>
+        <View style={[styles.accountItem, showDoneIcon && styles.selectedAccountItem]}>
           <View style={styles.details}>
             <Text style={[styles.text, styles.selectedText]}>{email}</Text>
             <Text style={[styles.text, styles.selectedText]}>{realm}</Text>
           </View>
-          {canRemove ?
+          {!showDoneIcon ?
             <IconCancel
               style={styles.icon}
               size={32}

--- a/src/account/AccountList.js
+++ b/src/account/AccountList.js
@@ -12,7 +12,7 @@ export default class AccountList extends React.PureComponent {
   };
 
   render() {
-    const { accounts, onAccountSelect, onAccountRemove } = this.props;
+    const { accounts, onAccountSelect, onAccountRemove, auth } = this.props;
 
     return (
       <View>
@@ -20,7 +20,7 @@ export default class AccountList extends React.PureComponent {
           <AccountItem
             key={i}
             index={i}
-            canRemove={i !== 0}
+            showDoneIcon={i === 0 && auth.apiKey !== '' && auth.apiKey === account.apiKey}
             {...account}
             onSelect={onAccountSelect}
             onRemove={onAccountRemove}

--- a/src/account/AccountPickScreen.js
+++ b/src/account/AccountPickScreen.js
@@ -39,7 +39,7 @@ class AccountPickScreen extends React.Component {
     this.props.removeAccount(index);
 
   render() {
-    const { accounts } = this.props;
+    const { accounts, auth } = this.props;
 
     return (
       <Screen title="Pick account">
@@ -50,6 +50,7 @@ class AccountPickScreen extends React.Component {
               accounts={accounts}
               onAccountSelect={this.handleAccountSelect}
               onAccountRemove={this.handleAccountRemove}
+              auth={auth}
             />
             <ZulipButton
               text="Add new account"


### PR DESCRIPTION
in AccountPickScreen.

https://github.com/zulip/zulip-mobile/issues/536

Now it looks like this
on clicking **Switch Account** => show tick/done icon (was shown before too)
on clicking **Logout** => show remove icon.

![ezgif com-crop 11](https://cloud.githubusercontent.com/assets/18511177/25680584/03f36d18-306f-11e7-9b12-303d2390642f.gif)
