### PR TITLE
chat: Remove unused prop passed to ComposeBox

### DIFF
--- a/src/chat/Chat.js
+++ b/src/chat/Chat.js
@@ -45,7 +45,7 @@ export default class Chat extends React.Component {
         {noMessages && <NoMessages narrow={narrow} />}
         {noMessagesButLoading && <MessageListLoading />}
         {showMessageList && <MessageList onScroll={this.handleMessageListScroll} {...this.props} />}
-        {canSendToNarrow(narrow) && <ComposeBox onSend={this.sendMessage} />}
+        {canSendToNarrow(narrow) && <ComposeBox />}
       </KeyboardAvoidingView>
     );
   }


### PR DESCRIPTION
ComposeBox was being passed an undefined (and unused) onSend prop.