### PR TITLE
Improvements to new messages Indicator

### DIFF
--- a/src/chat/UnreadNotice.js
+++ b/src/chat/UnreadNotice.js
@@ -29,24 +29,32 @@ const styles = StyleSheet.create({
   }
 });
 
-const POSITIONS = {
-  top: 'top',
-  bottom: 'bottom'
-};
-
 const showAnimationConfig = {
   toValue: 1,
   duration: 400,
-  useNativeDriver: true,
-  easing: Easing.bezier(0.17, 0.67, 0.11, 0.99)
+  easing: Easing.bezier(0.17, 0.67, 0.11, 0.99),
+  useNativeDriver: true
 };
 
 const hideAnimationConfig = {
   toValue: 0,
   duration: 400,
-  useNativeDriver: true,
-  easing: Easing.bezier(0.17, 0.67, 0.11, 0.99)
+  easing: Easing.bezier(0.17, 0.67, 0.11, 0.99),
+  useNativeDriver: true
 };
+
+// Duration after which notice should hide
+const HIDE_DELAY = 1500;
+// The translation of notice interpolates this.translateAnimation from 0 to 1
+// Fraction of interpolation at which notice goes into peeking state
+const PEEKING_FRACTION = 0.3;
+// Amount notice should translate to get itself into the screen
+const MAX_TRANSLATION = 40;
+
+// Notice States
+const STATE_HIDDEN = 'hidden';
+const STATE_VISIBLE = 'visible';
+const STATE_PEEKING = 'peeking';
 
 export default class UnreadNotice extends React.Component {
   constructor(props) {
@@ -54,40 +62,81 @@ export default class UnreadNotice extends React.Component {
 
     this.state = {
       translateAnimation: new Animated.Value(0),
+      noticeState: STATE_HIDDEN
     };
+
+    this.hideTimeout = null;
   }
 
-  componentDidMount() {
-    this.show();
-  }
+  componentWillReceiveProps(nextProps) {
+    const { unreadCount, scrollOffset } = nextProps;
+    const { noticeState } = this.state;
 
-  hide = () => {
-    this.state.translateAnimation.setValue(1);
-    Animated.timing(this.state.translateAnimation, hideAnimationConfig).start();
-  };
+    const shouldBecomeVisible = (nextProps.unreadCount > this.props.unreadCount > 0) &&
+      scrollOffset > 0;
+
+    if (noticeState === STATE_PEEKING && unreadCount === 0) this.hidePeekingNotice();
+
+    if (noticeState === STATE_HIDDEN && shouldBecomeVisible) this.show();
+    else if (noticeState === STATE_PEEKING && shouldBecomeVisible) this.show();
+    else if (noticeState === STATE_VISIBLE && !shouldBecomeVisible) this.hide();
+  }
 
   show = () => {
     this.state.translateAnimation.setValue(0);
-    Animated.timing(this.state.translateAnimation, showAnimationConfig).start();
+    Animated.timing(this.state.translateAnimation, showAnimationConfig).start(() => {
+      this.setState({
+        noticeState: STATE_VISIBLE
+      });
+
+      // Notice should go into peeking state
+      clearTimeout(this.hideTimeout);
+      this.hideTimeout = setTimeout(this.hide, HIDE_DELAY);
+    });
+  };
+
+  hide = () => {
+    const { unreadCount } = this.props;
+    this.state.translateAnimation.setValue(1);
+    Animated.timing(this.state.translateAnimation,
+      Object.assign({}, hideAnimationConfig, { toValue: unreadCount === 0 ? 0 : PEEKING_FRACTION })
+    ).start(() => {
+      this.setState({
+        noticeState: this.state.translateAnimation._value === 0 ? // eslint-disable-line
+          STATE_HIDDEN :
+          STATE_PEEKING
+      });
+    });
+  }
+
+  hidePeekingNotice = () => {
+    this.state.translateAnimation.setValue(PEEKING_FRACTION);
+    Animated.timing(this.state.translateAnimation, hideAnimationConfig).start(() => {
+      this.setState({
+        noticeState: STATE_HIDDEN
+      });
+    });
   };
 
   dynamicContainerStyles = () => {
-    const { position, shouldOffsetForInput } = this.props;
-    const translationMultiplier = position === POSITIONS.top ? -1 : 1;
+    const { shouldOffsetForInput } = this.props;
 
     // In narrows where ComposeBox is present translate beyond ComposeBox to avoid blocking it
-    const translateTo = shouldOffsetForInput && position === POSITIONS.bottom ? -40 : 0;
-    const translateFrom = shouldOffsetForInput && position === POSITIONS.bottom ? 0 : 50;
+    const translateFrom = shouldOffsetForInput ? 0 : MAX_TRANSLATION;
+    const translateTo = shouldOffsetForInput ? -MAX_TRANSLATION : 0;
 
     return {
       ...StyleSheet.flatten(styles.unreadContainer),
-      bottom: position === POSITIONS.bottom ? 0 : null,
-      top: position === POSITIONS.top ? 0 : null,
+      bottom: 0,
+      opacity: this.state.translateAnimation.interpolate({
+        inputRange: [0, PEEKING_FRACTION, 1],
+        outputRange: [0, 1, 1]
+      }),
       transform: [
         {
           translateY: this.state.translateAnimation.interpolate({
             inputRange: [0, 1],
-            outputRange: [translationMultiplier * translateFrom, translateTo]
+            outputRange: [translateFrom, translateTo]
           })
         }
       ]
@@ -95,15 +144,15 @@ export default class UnreadNotice extends React.Component {
   };
 
   render() {
-    const { count } = this.props;
+    const { unreadCount } = this.props;
 
     return (
       <Animated.View style={this.dynamicContainerStyles()}>
-        <IconDownArrow style={[styles.icon, styles.downArrowIcon]} />
+        <IconDownArrow style={styles.icon} />
         <Text style={styles.unreadText}>
-          {count === 0 ?
-            'No' : count < 100 ?
-              count : '99+'} unread {count === 1 ? 'message' : 'messages'}
+          {unreadCount === 0 ?
+            'No' : unreadCount < 100 ?
+              unreadCount : '99+'} unread {unreadCount === 1 ? 'message' : 'messages'}
         </Text>
       </Animated.View>
     );


### PR DESCRIPTION
The PR aims at adding 3 states to unread notice, visible, hidden and peeking.

When the user is scrolled up and new message arrives the notice animates in stays for 2-3 seconds then goes into peeking mode.
Peeking mode is where the notice hides itself but not fully, just a thin blue bar at the very bottom of screen. This indicates there are new messages waiting below.

As new messages arrive and user is scrolled up the notice expands and goes again into peeking mode.

When user scrolls to the very bottom implying having read all the messages, the notice goes into hidden mode, no longer visible.


![](https://chat.zulip.org/user_uploads/2/27/KtsTa-fLJ143TSvVULmTc4j0/unread3.gif)