### PR TITLE
First message request replaces cached messages

### DIFF
--- a/src/api/getMessages.js
+++ b/src/api/getMessages.js
@@ -1,11 +1,13 @@
+import { Auth, Narrow } from '../types';
+
 import { apiGet } from './apiFetch';
 
 export default async (
-  auth,
+  auth: Auth,
   anchor: number,
   numBefore: number,
   numAfter: number,
-  narrow: Object,
+  narrow: Narrow,
   useFirstUnread: boolean = false,
 ) =>
   apiGet(

--- a/src/chat/__tests__/chatReducers-test.js
+++ b/src/chat/__tests__/chatReducers-test.js
@@ -409,6 +409,38 @@ describe('chatReducers', () => {
       expect(newState).not.toBe(initialState);
     });
 
+    test('if replacePrevious is true messages are not merged but replaced', () => {
+      const initialState = {
+        messages: {
+          [homeNarrowStr]: [
+            { id: 1 },
+            { id: 2 },
+            { id: 3 },
+          ],
+        },
+      };
+      const action = {
+        type: MESSAGE_FETCH_SUCCESS,
+        narrow: [],
+        messages: [
+          { id: 5 },
+        ],
+        replacePrevious: true,
+      };
+      const expectedState = {
+        messages: {
+          [homeNarrowStr]: [
+            { id: 5 },
+          ],
+        },
+      };
+
+      const newState = chatReducers(initialState, action);
+
+      expect(newState.messages).toEqual(expectedState.messages);
+      expect(newState).not.toBe(initialState);
+    });
+
     test('added messages are sorted by timestamp', () => {
       const initialState = {
         messages: {

--- a/src/chat/chatReducers.js
+++ b/src/chat/chatReducers.js
@@ -46,12 +46,14 @@ export default (state = initialState, action) => {
 
     case MESSAGE_FETCH_SUCCESS: {
       const key = JSON.stringify(action.narrow);
-      const messages = state.messages[key] || [];
+      const prevMessages = state.messages[key] || [];
 
-      const newMessages = action.messages
-        .filter(x => !messages.find(msg => msg.id === x.id))
-        .concat(messages)
-        .sort((a, b) => a.timestamp - b.timestamp);
+      const newMessages = action.replacePrevious
+        ? action.messages
+        : action.messages
+            .filter(x => !prevMessages.find(msg => msg.id === x.id))
+            .concat(prevMessages)
+            .sort((a, b) => a.timestamp - b.timestamp);
 
       return {
         ...state,

--- a/src/message/messagesActions.js
+++ b/src/message/messagesActions.js
@@ -27,24 +27,35 @@ export const messageFetchStart = (narrow, fetching) => ({
   fetching,
 });
 
-export const messageFetchSuccess = (messages, narrow, fetching, caughtUp) => ({
+export const messageFetchSuccess = (messages, narrow, fetching, caughtUp, replacePrevious) => ({
   type: MESSAGE_FETCH_SUCCESS,
   messages,
   narrow,
   fetching,
   caughtUp,
+  replacePrevious,
 });
 
 export const backgroundFetchMessages = (
-  auth,
+  auth: Auth,
   anchor: number,
   numBefore: number,
   numAfter: number,
-  narrow,
-  useFirstUnread = false,
+  narrow: Narrow,
+  useFirstUnread: boolean = false,
+  replacePrevious: boolean = false,
 ) =>
   async (dispatch) => {
-    const messages = await getMessages(auth, anchor, numBefore, numAfter, narrow, useFirstUnread);
+    const messages = await getMessages(
+      auth,
+      anchor,
+      numBefore,
+      numAfter,
+      narrow,
+      useFirstUnread,
+      replacePrevious,
+    );
+
     let caughtUp = { older: false, newer: false };
     if (!useFirstUnread) {
       // Find the anchor in the results (or set it past the end of the list)
@@ -70,16 +81,18 @@ export const backgroundFetchMessages = (
         ...(numAfter ? { newer: false } : {}),
       },
       caughtUp,
+      replacePrevious,
     ));
   };
 
 export const fetchMessages = (
-  auth,
+  auth: Auth,
   anchor: number,
   numBefore: number,
   numAfter: number,
-  narrow,
-  useFirstUnread = false,
+  narrow: Narrow,
+  useFirstUnread: boolean = false,
+  replacePrevious: boolean = false,
 ) =>
   async dispatch => {
     if (numBefore < 0 || numAfter < 0) {
@@ -92,7 +105,15 @@ export const fetchMessages = (
         ...(numAfter ? { newer: true } : {}),
       }),
     );
-    dispatch(backgroundFetchMessages(auth, anchor, numBefore, numAfter, narrow, useFirstUnread));
+    dispatch(backgroundFetchMessages(
+      auth,
+      anchor,
+      numBefore,
+      numAfter,
+      narrow,
+      useFirstUnread,
+      replacePrevious,
+    ));
   };
 
 export const fetchMessagesAtFirstUnread = (auth: Auth, narrow: Narrow) =>

--- a/src/realm/realmActions.js
+++ b/src/realm/realmActions.js
@@ -18,7 +18,13 @@ export const fetchEssentialInitialData = (auth) =>
       await tryUntilSuccessful(() => getMessages(auth, 0, 10, 10, homeNarrow(), true)),
     ]);
 
-    dispatch(messageFetchSuccess(messages, homeNarrow(), { older: false, newer: false }));
+    dispatch(messageFetchSuccess(
+      messages,
+      homeNarrow(),
+      { older: false, newer: false },
+      {},
+      true,
+    ));
     dispatch(initSubscriptions(subscriptions));
     dispatch(initialFetchComplete());
   };


### PR DESCRIPTION
Fixes an issue with invalidating cached messages

* Add a new parameter to MESSAGE_FETCH_SUCCESS to optionally replace existing messages
* Initial message requests replace cached messages