### PR TITLE
Fix #573: Message notice blocks compose box + doesn't hide itself

### DIFF
--- a/src/chat/Chat.js
+++ b/src/chat/Chat.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { KeyboardAvoidingView } from 'react-native';
 
 import { styles, OfflineNotice } from '../common';
-import { canSendToNarrow } from '../utils/narrow';
+import { canSendToNarrow, isPrivateNarrow, isStreamNarrow, isTopicNarrow } from '../utils/narrow';
 import { filterUnreadMessageIds, countUnread } from '../utils/unread';
 import { registerAppActivity } from '../utils/activity';
 import { queueMarkAsRead } from '../api';
@@ -38,9 +38,18 @@ export default class Chat extends React.Component {
     const showMessageList = !noMessages && !noMessagesButLoading;
     const unreadCount = countUnread(messages.map(msg => msg.id), readIds);
 
+    const isNarrowWithComposeBox = isStreamNarrow(narrow) ||
+      isTopicNarrow(narrow) ||
+      isPrivateNarrow(narrow);
+
     return (
       <KeyboardAvoidingView style={styles.screen} behavior="padding">
-        {(unreadCount > 0) && <UnreadNotice position="bottom" />}
+        {<UnreadNotice
+            position="bottom"
+            count={unreadCount}
+            shouldOffsetForInput={isNarrowWithComposeBox}
+            shouldShow={unreadCount > 0}
+        />}
         {!isOnline && <OfflineNotice />}
         {noMessages && <NoMessages narrow={narrow} />}
         {noMessagesButLoading && <MessageListLoading />}

--- a/src/compose/ComposeBox.js
+++ b/src/compose/ComposeBox.js
@@ -15,6 +15,7 @@ const styles = StyleSheet.create({
     borderTopWidth: 1,
     borderTopColor: BORDER_COLOR,
     backgroundColor: '#fff',
+    zIndex: 2
   },
 });
 


### PR DESCRIPTION
For #573 
1. Moved notice up in narrows with compose box.
2. Factored in scroll position therefore when scrolled to the very bottom, notice will hide regardless of any other factors 
3. Unread notice now shows unread count as well.