### PR TITLE
Fix compose text default keyboard button

### DIFF
--- a/src/compose/ComposeText.js
+++ b/src/compose/ComposeText.js
@@ -103,15 +103,12 @@ class ComposeText extends React.Component {
         <ScrollView style={{ height }} contentContainerStyle={styles.messageBox}>
           <TextInput
             style={styles.composeInput}
-            blurOnSubmit
             ref={component => { this.textInput = component; }}
             multiline
             underlineColorAndroid="transparent"
-            returnKeyType="send"
             height={contentHeight}
             onContentSizeChange={this.handleContentSizeChange}
             onChangeText={this.handleChangeText}
-            onSubmitEditing={this.handleSend}
             placeholder="Type a message here"
           />
         </ScrollView>


### PR DESCRIPTION
This matches behavior of all other mobile apps:
* 'return' button instead of 'send'
* do not submit but create a new line
* do not lose focus on 'return'