### PR TITLE
Fix #597: Reaction list no longer misaligns on new row

### DIFF
--- a/src/reactions/ReactionList.js
+++ b/src/reactions/ReactionList.js
@@ -8,6 +8,7 @@ const styles = StyleSheet.create({
   reactions: {
     flexDirection: 'row',
     flexWrap: 'wrap',
+    alignItems: 'flex-start'
   },
 });
 


### PR DESCRIPTION
Fixes #597 
![](https://puu.sh/vOKb8/27fe4d46e1.png)