### PR TITLE
Increase ComposeBox zIndex to overlay unread notice

### DIFF
--- a/src/styles/theme.js
+++ b/src/styles/theme.js
@@ -119,6 +119,7 @@ export default ({ color, backgroundColor, borderColor }) => ({
     backgroundColor,
     borderTopWidth: 1,
     borderTopColor: borderColor,
+    zIndex: 2,
   },
   subheader: {
     flex: 1,


### PR DESCRIPTION
A recent merge undid an important change in zIndex of ComposeBox which results in unread notice to overlay ComposeBox. This PR undoes that change

![](https://puu.sh/vPEbJ/e9e4026188.gif)