### PR TITLE
Fix Input ref passing

### DIFF
--- a/src/common/Input.js
+++ b/src/common/Input.js
@@ -11,7 +11,7 @@ export default class Input extends Component {
   };
 
   render() {
-    const { style, placeholder, ...restProps } = this.props;
+    const { style, placeholder, textInputRef, ...restProps } = this.props;
 
     return (
       <FormattedMessage id={placeholder} defaultMessage={placeholder}>
@@ -20,6 +20,7 @@ export default class Input extends Component {
             style={[styles.input, style]}
             placeholder={text}
             placeholderTextColor={HALF_COLOR}
+            ref={component => { if (textInputRef) textInputRef(component); }}
             {...restProps}
           />
         )}

--- a/src/compose/ComposeText.js
+++ b/src/compose/ComposeText.js
@@ -100,7 +100,7 @@ class ComposeText extends React.Component {
           <ScrollView style={{ height }} contentContainerStyle={componentStyles.messageBox}>
             <Input
               style={styles.composeText}
-              ref={component => { this.textInput = component; }}
+              textInputRef={component => { this.textInput = component; }}
               multiline
               underlineColorAndroid="transparent"
               height={contentHeight}


### PR DESCRIPTION
This fixes a critical bug that prevents sending of messages.

The fix is a general ref parameter passing from a custom Input component to the wrapped TextInput.