### PR TITLE
Fix: Line shown when no # stream suggestion matches.

### DIFF
--- a/src/autocomplete/StreamAutocomplete.js
+++ b/src/autocomplete/StreamAutocomplete.js
@@ -17,6 +17,8 @@ class StreamAutocomplete extends Component {
       .filter(x => x.name.toLowerCase().startsWith(filter.toLowerCase()))
       .slice(0, 5);
 
+    if (streams.length === 0) return null;
+
     return (
       <Popup>
         {streams.map(x => (


### PR DESCRIPTION
When there is no items in a # stream suggestion,
then there is a line coming up.

fix:#621

![9b59691f-86a3-4697-9ae3-ee7b219a253b](https://cloud.githubusercontent.com/assets/18511177/26339609/b0459fd2-3fa6-11e7-8d6e-055d34f8479f.jpg)
