### PR TITLE
Made offline notice prettier

### DIFF
--- a/src/common/OfflineNotice.js
+++ b/src/common/OfflineNotice.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 
-import { IconWarning } from '../common/Icons';
+import { IconOffline } from '../common/Icons';
 
 const styles = StyleSheet.create({
   block: {
@@ -9,11 +9,11 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     alignItems: 'center',
     padding: 8,
-    backgroundColor: 'yellow',
+    backgroundColor: '#FD3D26',
   },
   text: {
-    fontSize: 16,
-    fontWeight: 'bold',
+    fontSize: 14,
+    color: 'white'
   }
 });
 
@@ -21,13 +21,8 @@ export default class OfflineNotice extends React.Component {
   render() {
     return (
       <View style={styles.block}>
-        <IconWarning
-          style={styles.icon}
-          size={20}
-          color="black"
-        />
         <Text style={styles.text}>
-          You are currently offline
+          No internet connection
         </Text>
       </View>
     );


### PR DESCRIPTION
Replaced "You are currently offline" with "No internet connection". Saying "you're currently offline" can also be interpreted as being offline/online in chat. IMO "No internet connection" gets the message across better.
![](https://puu.sh/vYQEP/6b89ecef7b.png)