### PR TITLE
Apply bold, italic, links, strikethrough styles in messages.

### DIFF
--- a/src/html/HtmlNodeTag.js
+++ b/src/html/HtmlNodeTag.js
@@ -5,6 +5,7 @@ import type { StyleObj } from 'react-native/Libraries/StyleSheet/StyleSheetTypes
 import { Auth } from '../types';
 import styles from './HtmlStyles';
 import cascadingStyles from './cascadingStylesView';
+import cascadingStylesText from './cascadingStylesText';
 import HtmlTagSpan from './tags/HtmlTagSpan';
 import HtmlTagA from './tags/HtmlTagA';
 import HtmlTagLi from './tags/HtmlTagLi';
@@ -51,11 +52,13 @@ type Props = {
   attribs: Object,
   name: string,
   cascadingStyle: StyleObj,
+  cascadingTextStyle: StyleObj,
   childrenNodes: Object[],
   onPress: () => void,
 }
 
-export default ({ auth, attribs, name, cascadingStyle, childrenNodes, onPress }: Props) => {
+export default ({ auth, attribs, name, cascadingStyle,
+  cascadingTextStyle, childrenNodes, onPress }: Props) => {
   const style = [
     styles[name],
     ...stylesFromClassNames(attribs.class, styles),
@@ -64,6 +67,11 @@ export default ({ auth, attribs, name, cascadingStyle, childrenNodes, onPress }:
     cascadingStyle,
     cascadingStyles[name],
     ...stylesFromClassNames(attribs.class, cascadingStyles),
+  ];
+  const newCascadingStylesText = [
+    cascadingTextStyle,
+    cascadingStylesText[name],
+    ...stylesFromClassNames(attribs.class, cascadingStylesText),
   ];
 
   let HtmlComponent = specialTags[name] || HtmlTagSpan;
@@ -82,6 +90,7 @@ export default ({ auth, attribs, name, cascadingStyle, childrenNodes, onPress }:
       href={attribs.href}
       style={style}
       cascadingStyle={newCascadingStyle}
+      cascadingTextStyle={newCascadingStylesText}
       childrenNodes={childrenNodes}
       onPress={onPress}
     />

--- a/src/html/HtmlNodeText.js
+++ b/src/html/HtmlNodeText.js
@@ -1,14 +1,17 @@
 /* @flow */
 import React from 'react';
 import entities from 'entities';
+import type { StyleObj } from 'react-native/Libraries/StyleSheet/StyleSheetTypes';
 import { RawLabel } from '../common';
 
 type Props = {
   data: string,
+  cascadingTextStyle: StyleObj,
 };
 
-export default ({ data }: Props) => (
+export default ({ data, cascadingTextStyle }: Props) => (
   <RawLabel
+    style={cascadingTextStyle}
     text={entities.decodeHTML(data).replace(/\n$/, '')}
   />
 );

--- a/src/html/renderHtmlChildren.js
+++ b/src/html/renderHtmlChildren.js
@@ -9,10 +9,12 @@ type Props = {
   auth: Auth,
   childrenNodes: Object[],
   cascadingStyle: StyleObj,
+  cascadingTextStyle: StyleObj,
   onPress: () => void,
 }
 
-export default ({ auth, cascadingStyle, childrenNodes, onPress }: Props) =>
+export default ({ auth, cascadingStyle, childrenNodes,
+  cascadingTextStyle, onPress }: Props) =>
   childrenNodes &&
   childrenNodes
     .filter(x => x.data !== '\n')
@@ -21,6 +23,7 @@ export default ({ auth, cascadingStyle, childrenNodes, onPress }: Props) =>
         key={index}
         auth={auth}
         cascadingStyle={cascadingStyle}
+        cascadingTextStyle={cascadingTextStyle}
         data={node.data}
         name={node.name}
         type={node.type}

--- a/src/html/tags/HtmlTagA.js
+++ b/src/html/tags/HtmlTagA.js
@@ -1,10 +1,11 @@
 import React from 'react';
 
+import styles from '../HtmlStyles';
 import { Touchable } from '../../common';
 import renderHtmlChildren from '../renderHtmlChildren';
 
-export default ({ onPress, href, ...restProps }) => (
-  <Touchable onPress={() => onPress(href)}>
+export default ({ onPress, href, cascadingStyle, ...restProps }) => (
+  <Touchable style={[styles.a, cascadingStyle]} onPress={() => onPress(href)}>
     {renderHtmlChildren({ href, ...restProps })}
   </Touchable>
 );


### PR DESCRIPTION
Message text color set to black for Android.

Fix:#642

Android
![782bc0ab-9410-47c3-ad75-299af79a378c-2](https://cloud.githubusercontent.com/assets/18511177/26529219/c3036c9e-43d9-11e7-9414-ecaa84433e47.jpg)

iOS
![782bc0ab-9410-47c3-ad75-299af79a378c](https://cloud.githubusercontent.com/assets/18511177/26529220/c3b333b8-43d9-11e7-9ec7-7f32715d3780.jpg)
