### PR TITLE
Made sure private messages have the same icon everywhere

### DIFF
--- a/src/common/Icons.js
+++ b/src/common/Icons.js
@@ -16,7 +16,7 @@ export const IconSend = (props: Object) => <MaterialIcon name="send" {...props} 
 export const IconMute = (props: Object) => <MaterialIcon name="volume-off" {...props} />;
 export const IconStream = (props: Object) => <FontAwesomeIcon name="hashtag" {...props} />;
 export const IconPrivate = (props: Object) => <FontAwesomeIcon name="lock" {...props} />;
-export const IconPrivateChat = (props: Object) => <IoniconsIcon name="md-text" {...props} />;
+export const IconPrivateChat = (props: Object) => <IoniconsIcon name="md-mail" {...props} />;
 export const IconDownArrow = (props: Object) => <IoniconsIcon name="md-arrow-down" {...props} />;
 
 export default IoniconsIcon;

--- a/src/title/TitleSpecial.js
+++ b/src/title/TitleSpecial.js
@@ -17,7 +17,7 @@ const styles = StyleSheet.create({
 
 const specials = {
   home: { name: 'Home', icon: 'md-home' },
-  private: { name: 'Private messages', icon: 'md-chatboxes' },
+  private: { name: 'Private messages', icon: 'md-mail' },
   starred: { name: 'Starred', icon: 'md-star' },
   mentioned: { name: 'Mentions', icon: 'md-at' },
 };


### PR DESCRIPTION
While other narrows have the same icon in header as in navigation, Private Messages don't. Fixed that to show an envelope icon, as in the web app.