### PR TITLE
Limit eslint-plugin-spellcheck to v0.0.6 due to perf issues.

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "eslint-plugin-jsx-a11y": "^5.0.1",
     "eslint-plugin-react": "~7.0.0",
     "eslint-plugin-react-native": "^2.2.1",
-    "eslint-plugin-spellcheck": "~0.0.6",
+    "eslint-plugin-spellcheck": "0.0.6",
     "flow-bin": "~0.40.0",
     "jest": "^20.0.0",
     "jest-cli": "^20.0.0",

--- a/src/start/AuthScreen.js
+++ b/src/start/AuthScreen.js
@@ -99,7 +99,7 @@ class AuthScreen extends React.PureComponent {
         return;
       }
 
-      // If we've made it this far we have a valid API key
+      // If we have made it this far we have a valid API key
       const apiKey = extractApiKey(query.otp_encrypted_api_key, this.otp);
 
       // Reset stored one time pad

--- a/yarn.lock
+++ b/yarn.lock
@@ -2589,13 +2589,13 @@ eslint-plugin-react@~7.0.0:
     has "^1.0.1"
     jsx-ast-utils "^1.3.4"
 
-eslint-plugin-spellcheck@~0.0.6:
-  version "0.0.8"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-spellcheck/-/eslint-plugin-spellcheck-0.0.8.tgz#7f01ab233c2e658c1996a259aecd4e825894ac92"
+eslint-plugin-spellcheck@0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-spellcheck/-/eslint-plugin-spellcheck-0.0.6.tgz#bd5b5c93864dee3baa2db4f603983c8e29d39634"
   dependencies:
-    globals "^9.9.0"
-    hunspell-spellchecker "^1.0.2"
-    lodash "^4.14.2"
+    globals "^6.4.1"
+    hunspell-spellchecker "^1.0.0"
+    lodash "^3.3.1"
 
 eslint@^3.12.2:
   version "3.19.0"
@@ -3167,11 +3167,11 @@ global@^4.3.0, global@~4.3.0:
     min-document "^2.19.0"
     process "~0.5.1"
 
-globals@^6.4.0:
+globals@^6.4.0, globals@^6.4.1:
   version "6.4.1"
   resolved "https://registry.yarnpkg.com/globals/-/globals-6.4.1.tgz#8498032b3b6d1cc81eebc5f79690d8fe29fabf4f"
 
-globals@^9.0.0, globals@^9.14.0, globals@^9.9.0:
+globals@^9.0.0, globals@^9.14.0:
   version "9.17.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-9.17.0.tgz#0c0ca696d9b9bb694d2e5470bd37777caad50286"
 
@@ -3369,7 +3369,7 @@ http-signature@~1.1.0:
     jsprim "^1.2.2"
     sshpk "^1.7.0"
 
-hunspell-spellchecker@^1.0.2:
+hunspell-spellchecker@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/hunspell-spellchecker/-/hunspell-spellchecker-1.0.2.tgz#a10b0bd2fa00a65ab62a4c6b734ce496d318910e"
 
@@ -4358,11 +4358,11 @@ lodash@4.16.2:
   version "4.16.2"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.16.2.tgz#3e626db827048a699281a8a125226326cfc0e652"
 
-lodash@4.x, lodash@^4.0.0, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.14.2, lodash@^4.16.6, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.6.1, lodash@^4.8.0:
+lodash@4.x, lodash@^4.0.0, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.16.6, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.6.1, lodash@^4.8.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
-lodash@^3.10.0, lodash@^3.10.1, lodash@^3.5.0, lodash@^3.9.1, lodash@^3.9.3:
+lodash@^3.10.0, lodash@^3.10.1, lodash@^3.3.1, lodash@^3.5.0, lodash@^3.9.1, lodash@^3.9.3:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
 


### PR DESCRIPTION
v0.0.6 `eslint-plugin-spellcheck` runs in ~11 secs and v0.0.7 runs in ~89 secs