### PR TITLE
Prevent mutating msgs array in active narrow in getLastTOpicInActiveNarrow().

### DIFF
--- a/src/chat/chatSelectors.js
+++ b/src/chat/chatSelectors.js
@@ -88,6 +88,6 @@ export const getCurrentTypingUsers = state => {
 
 export const getLastTopicInActiveNarrow = state => {
   const messagesInActiveNarrow = getMessagesInActiveNarrow(state);
-  const lastMessageWithSubject = messagesInActiveNarrow.reverse().find(msg => msg.subject);
+  const lastMessageWithSubject = messagesInActiveNarrow.slice().reverse().find(msg => msg.subject);
   return (lastMessageWithSubject && lastMessageWithSubject.subject) || '';
 };


### PR DESCRIPTION
This fixes a bug where the message list moved(reverses) during presence events.