### PR TITLE
Hide mode changer as there is only one compose option: compose text

### DIFF
--- a/src/compose/ComposeBox.js
+++ b/src/compose/ComposeBox.js
@@ -7,9 +7,10 @@ import { getAuth } from '../account/accountSelectors';
 import styles from '../styles';
 import ComposeText from './ComposeText';
 import CameraRollView from './CameraRollView';
-import ModeView from './ModeView';
 import { getLastTopicInActiveNarrow } from '../chat/chatSelectors';
 import { Auth, Narrow } from '../types';
+import StreamBox from './ModeViews/StreamBox';
+import { isTopicNarrow, isStreamNarrow } from '../utils/narrow';
 
 type Props = {
   onSend: (content: string) => void,
@@ -55,8 +56,9 @@ class ComposeBox extends React.Component {
 
     return (
       <View style={styles.composeBox}>
-        <View style={styles.wrapper}>
-          <ModeView
+        {(isTopicNarrow(narrow) || isStreamNarrow(narrow)) &&
+        <View style={styles.topicWrapper}>
+          <StreamBox
             optionSelected={optionSelected}
             handleOptionSelected={this.handleOptionSelected}
             setTopic={this.setTopic}
@@ -66,6 +68,7 @@ class ComposeBox extends React.Component {
             lastTopic={lastTopic}
           />
         </View>
+      }
         <View style={styles.divider} />
         <ActiveComposeComponent
           auth={auth}

--- a/src/styles/theme.js
+++ b/src/styles/theme.js
@@ -144,4 +144,7 @@ export default ({ color, backgroundColor, borderColor }) => ({
     height: CONTROL_SIZE * 3 / 4,
     borderColor: BORDER_COLOR,
   },
+  topicWrapper: {
+    height: 44, paddingLeft: 4, paddingRight: 4,
+  }
 });


### PR DESCRIPTION
As suggested by Boris 
![simulator screen shot 15-jun-2017 1 40 47 pm](https://user-images.githubusercontent.com/12700799/27171762-453c6eaa-51d0-11e7-832c-39af492176dd.png)

And removed the compose options for private narrow