### PR TITLE
Do not dismiss keyboard on clicking auto complete row.

### DIFF
--- a/src/autocomplete/EmojiAutocomplete.js
+++ b/src/autocomplete/EmojiAutocomplete.js
@@ -22,6 +22,7 @@ export default class EmojiAutocomplete extends Component {
     return (
       <Popup>
         <FlatList
+          keyboardShouldPersistTaps="always"
           initialNumToRender={12}
           data={emojis}
           keyExtractor={item => item}

--- a/src/autocomplete/PeopleAutocomplete.js
+++ b/src/autocomplete/PeopleAutocomplete.js
@@ -26,6 +26,7 @@ class PeopleAutocomplete extends Component {
     return (
       <Popup>
         <FlatList
+          keyboardShouldPersistTaps="always"
           initialNumToRender={10}
           data={people}
           keyExtractor={item => item.email}

--- a/src/autocomplete/StreamAutocomplete.js
+++ b/src/autocomplete/StreamAutocomplete.js
@@ -24,6 +24,7 @@ class StreamAutocomplete extends Component {
     return (
       <Popup>
         <FlatList
+          keyboardShouldPersistTaps="always"
           initialNumToRender={streams.length}
           data={streams}
           keyExtractor={item => item.stream_id}


### PR DESCRIPTION
fix: Currently on selecting row dismisses keyboard and click is not grabbed by row.