### PR TITLE
Fixed https:// in the ServerURL 

### DIFF
--- a/src/start/RealmScreen.js
+++ b/src/start/RealmScreen.js
@@ -56,7 +56,7 @@ class RealmScreen extends React.Component {
   }
 
   tryRealm = async () => {
-    let { realm } = this.state;
+    const { realm } = this.state;
 
     this.setState({
       realm: fixRealmUrl(realm),

--- a/src/start/RealmScreen.js
+++ b/src/start/RealmScreen.js
@@ -58,13 +58,6 @@ class RealmScreen extends React.Component {
   tryRealm = async () => {
     let { realm } = this.state;
 
-    // Automatically prepend 'https://' if the user does not enter a protocol
-    if (realm.search(/\b(http|https):\/\//) === -1) {
-      realm = `https://${realm}`;
-    }
-
-    realm = realm.replace(/\/$/, '');
-
     this.setState({
       realm: fixRealmUrl(realm),
       progress: true,

--- a/src/utils/url.js
+++ b/src/utils/url.js
@@ -85,7 +85,5 @@ export const fixRealmUrl = (url: string) => {
     url = `https://${url}`;
   }
 
-  url = url.replace(/\/$/, '');
-
   return url;
 };


### PR DESCRIPTION
@borisyankov  Please review

Whenever there is no url in the input box and pressing enter `https://https:` is appended. 

Before : 
<img width="377" alt="screen shot 2017-06-23 at 10 15 04 am" src="https://user-images.githubusercontent.com/21558765/27467196-ee9e129a-57fd-11e7-9fc8-87858af36161.png">


pressing enter only appends `https://`
After :
<img width="375" alt="screen shot 2017-06-23 at 10 16 09 am" src="https://user-images.githubusercontent.com/21558765/27467225-3e6160ca-57fe-11e7-8951-8bef6751ada0.png">

