### PR TITLE
Improved messageBox

### DIFF
--- a/src/compose/ComposeText.js
+++ b/src/compose/ComposeText.js
@@ -21,7 +21,7 @@ const MAX_HEIGHT = 200;
 const componentStyles = StyleSheet.create({
   wrapper: {
     flexDirection: 'row',
-    alignItems: 'center'
+    alignItems: 'flex-end'
   },
   messageBox: {
     flex: 1,


### PR DESCRIPTION
I think this should be done before release.

- Added border in the message box.
- Fixed the send button at the bottom.

Before Border: 
<img width="466" alt="screen shot 2017-06-17 at 12 22 52 am" src="https://user-images.githubusercontent.com/21558765/27241651-55fadc04-52f7-11e7-9686-ad903ebeedbb.png">

After border: 

<img width="467" alt="screen shot 2017-06-17 at 12 25 55 am" src="https://user-images.githubusercontent.com/21558765/27241662-61392b02-52f7-11e7-9ee2-1afbe7faffa4.png">

Before send button : 

<img width="466" alt="screen shot 2017-06-17 at 12 25 24 am" src="https://user-images.githubusercontent.com/21558765/27241694-76bd2276-52f7-11e7-9f06-6723e42bb5c4.png">

After send button : 
<img width="465" alt="screen shot 2017-06-17 at 12 26 32 am" src="https://user-images.githubusercontent.com/21558765/27241716-84d9bdf6-52f7-11e7-902d-e2618c11fa13.png">



