### PR TITLE
Limit react-native-photo-view to v1.2.x.

### DIFF
--- a/android/app/src/main/java/com/zulipmobile/MainApplication.java
+++ b/android/app/src/main/java/com/zulipmobile/MainApplication.java
@@ -45,6 +45,7 @@ public class MainApplication extends Application implements ReactApplication, IN
             return Arrays.<ReactPackage>asList(
                     new FabricPackage(),
                     new MainReactPackage(),
+                    new PhotoViewPackage(),
                     new RCTToastPackage(),
                     new RNFetchBlobPackage(),
                     new RNSoundPackage(),

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "react-native-fabric-crashlytics": "^0.1.8",
     "react-native-notifications": "^1.1.10",
     "react-native-fetch-blob": "^0.10.5",
-    "react-native-photo-view": "^1.2.0",
+    "react-native-photo-view": "~1.2.0",
     "react-native-safari-view": "^2.0.0",
     "react-native-scrollable-tab-view": "^0.7.0",
     "react-native-sound": "^0.10.1",


### PR DESCRIPTION
The newest version of this library 1.3.0 is incompatible with RN version less than 0.44 (after this commit https://github.com/alwx/react-native-photo-view/commit/af80c43cd39838a89ce4243fd675109561fd596c). Tested the changes on android and ios devices 👍 