### PR TITLE
[Android] Fixes : #769  StatusBar color according to the theme

### DIFF
--- a/src/common/Screen.js
+++ b/src/common/Screen.js
@@ -7,7 +7,7 @@ import { LocalizableText, PopRouteAction, NavigationState } from '../types';
 import { ZulipStatusBar } from '../common';
 import ModalNavBar from '../nav/ModalNavBar';
 
-const styles = StyleSheet.create({
+const moreStyles = StyleSheet.create({
   screen: {
     flex: 1,
     flexDirection: 'column',
@@ -31,15 +31,23 @@ class Screen extends React.Component {
     popRoute: PopRouteAction,
   }
 
+  static contextTypes = {
+    styles: () => null,
+  };
+
   render() {
     const { keyboardAvoiding, title, nav, children, popRoute } = this.props;
     const WrapperView = keyboardAvoiding && Platform.OS === 'ios' ? KeyboardAvoidingView : View;
+    const { styles } = this.context;
+    const backgroundColor = StyleSheet.flatten(styles.background).backgroundColor;
 
     return (
-      <View style={styles.screen}>
-        <ZulipStatusBar />
+      <View style={moreStyles.screen}>
+        <ZulipStatusBar
+          backgroundColor={backgroundColor}
+        />
         <ModalNavBar title={title} popRoute={popRoute} nav={nav} />
-        <WrapperView style={styles.screenWrapper} behavior="padding">
+        <WrapperView style={moreStyles.screenWrapper} behavior="padding">
           {children}
         </WrapperView>
       </View>


### PR DESCRIPTION
Fixes : #769 
Used ZulipStatusbar and backgroundColor as per theme.

This solves status bar issue in dark theme from : 

- RealmScreen
- AuthScreen
- DevAuthScreen
- AccountDetailsScreen
- AccountPickScreen
- SettingsScreen

