### PR TITLE
fix: splitting message content in several lines.

### DIFF
--- a/src/message/MessageBrief.js
+++ b/src/message/MessageBrief.js
@@ -20,6 +20,9 @@ const styles = StyleSheet.create({
     alignItems: 'flex-start',
     justifyContent: 'space-between'
   },
+  childrenWrapper: {
+    flex: 1,
+  }
 });
 
 export default class MessageBrief extends React.PureComponent {
@@ -45,7 +48,7 @@ export default class MessageBrief extends React.PureComponent {
       <View style={styles.message}>
         <View style={styles.messageContentWrapper}>
           <TouchableWithoutFeedback onLongPress={onLongPress}>
-            <View>
+            <View style={styles.childrenWrapper}>
               {children}
             </View>
           </TouchableWithoutFeedback>


### PR DESCRIPTION
- Fill screen whole width with the children of MessageBreif.
- Make whole content touchable.

messages link https://chat.zulip.org/#narrow/stream/test.20here/topic/message.20rendering

on [current master](https://github.com/zulip/zulip-mobile/tree/134ac5196aaa2e2d7b96ef94906f2eb865b46251) 

<img width="371" alt="screen shot 2017-07-03 at 12 21 58 pm" src="https://user-images.githubusercontent.com/18511177/27781276-d1849e00-5fea-11e7-8e74-d109e915a9a7.png">
<img width="372" alt="screen shot 2017-07-03 at 12 22 02 pm" src="https://user-images.githubusercontent.com/18511177/27781278-d45a3c52-5fea-11e7-8477-5bc0102bed7d.png">


this PR
<img width="376" alt="screen shot 2017-07-03 at 12 13 03 pm" src="https://user-images.githubusercontent.com/18511177/27781265-c712746a-5fea-11e7-96e4-ade447bba924.png">

