### PR TITLE
Prevent duplicate re-renders of renderMessages, MainScreen, messageActionSheet.

### DIFF
--- a/src/main/MainScreenContainer.js
+++ b/src/main/MainScreenContainer.js
@@ -26,15 +26,24 @@ class MainScreenContainer extends React.Component {
   }
 
   render() {
+    const { doNarrow, messages, orientation, pushRoute } = this.props;
     return (
-      <MainScreen {...this.props} />
+      <MainScreen
+        doNarrow={doNarrow}
+        messages={messages}
+        orientation={orientation}
+        pushRoute={pushRoute}
+      />
     );
   }
 }
 
-export default connect(state => ({
-  auth: getAuth(state),
-  narrow: state.chat.narrow,
-  messages: getShownMessagesInActiveNarrow(state),
-  orientation: state.app.orientation,
-}), boundActions)(MainScreenContainer);
+export default connect(
+  state => ({
+    auth: getAuth(state),
+    narrow: state.chat.narrow,
+    messages: getShownMessagesInActiveNarrow(state),
+    orientation: state.app.orientation,
+  }),
+  boundActions,
+)(MainScreenContainer);

--- a/src/message/MessageList.js
+++ b/src/message/MessageList.js
@@ -7,10 +7,13 @@ import { LoadingIndicator } from '../common';
 import MessageTyping from '../message/MessageTyping';
 import InfiniteScrollView from './InfiniteScrollView';
 import renderMessages from './renderMessages';
-import { constructActionButtons, executeActionSheetAction, constructHeaderActionButtons } from './messageActionSheet';
+import {
+  constructActionButtons,
+  executeActionSheetAction,
+  constructHeaderActionButtons,
+} from './messageActionSheet';
 
 class MessageList extends React.PureComponent {
-
   static contextTypes = {
     styles: () => null,
   };
@@ -25,39 +28,46 @@ class MessageList extends React.PureComponent {
     this.autoScrollToBottom = this.props.caughtUp.newer && nextProps.caughtUp.newer;
   }
 
-  handleHeaderLongPress = (item) => {
-    const { subscriptions, mute } = this.props;
+  handleHeaderLongPress = item => {
+    const { subscriptions, mute, doNarrow, auth } = this.props;
     const options = constructHeaderActionButtons({ item, subscriptions, mute });
-    const callback = (buttonIndex) => {
+    const callback = buttonIndex => {
       executeActionSheetAction({
         title: options[buttonIndex],
         message: item,
         header: true,
-        ...this.props
+        doNarrow,
+        auth,
+        subscriptions
       });
     };
     this.showActionSheet({ options, cancelButtonIndex: options.length - 1, callback });
-  }
+  };
 
   showActionSheet = ({ options, cancelButtonIndex, callback }) => {
-    this.props.showActionSheetWithOptions({
-      options,
-      cancelButtonIndex,
-    }, callback);
-  }
+    this.props.showActionSheetWithOptions(
+      {
+        options,
+        cancelButtonIndex,
+      },
+      callback,
+    );
+  };
 
-  handleLongPress = (message) => {
-    const { auth, narrow, subscriptions, mute, flags } = this.props;
+  handleLongPress = message => {
+    const { auth, narrow, subscriptions, mute, flags, doNarrow } = this.props;
     const options = constructActionButtons({ message, auth, narrow, subscriptions, mute, flags });
-    const callback = (buttonIndex) => {
+    const callback = buttonIndex => {
       executeActionSheetAction({
         title: options[buttonIndex],
         message,
-        ...this.props
+        doNarrow,
+        auth,
+        subscriptions
       });
     };
     this.showActionSheet({ options, cancelButtonIndex: options.length - 1, callback });
-  }
+  };
 
   render() {
     const { styles } = this.context;
@@ -70,12 +80,30 @@ class MessageList extends React.PureComponent {
       singleFetchProgress,
       onScroll,
       typingUsers,
+      auth,
+      subscriptions,
+      users,
+      messages,
+      narrow,
+      mute,
+      doNarrow,
+      flags,
+      twentyFourHourTime,
     } = this.props;
 
     const messageList = renderMessages({
       onLongPress: this.handleLongPress,
       onHeaderLongPress: this.handleHeaderLongPress,
-      ...this.props,
+      auth,
+      subscriptions,
+      users,
+      messages,
+      narrow,
+      mute,
+      doNarrow,
+      flags,
+      pushRoute,
+      twentyFourHourTime,
     });
 
     // `headerIndices` tell the scroll view which components are headers

--- a/src/message/headers/MessageHeader.js
+++ b/src/message/headers/MessageHeader.js
@@ -24,7 +24,7 @@ export default class MessageHeader extends React.PureComponent {
     subscriptions: any[],
     doNarrow: () => void,
     narrow: () => {},
-    onHeaderLongPress: () => void,
+    onHeaderLongPress: (item: Object) => void,
   }
 
   onLongPress = () => {

--- a/src/message/messageActionSheet.js
+++ b/src/message/messageActionSheet.js
@@ -46,7 +46,7 @@ type ExecuteActionSheetActionType = {
   message: Object,
   subscriptions: any[],
   doNarrow?: DoNarrowAction,
-  header: boolean,
+  header?: boolean,
 };
 
 type ConstructActionButtonsType = {

--- a/src/message/renderMessages.js
+++ b/src/message/renderMessages.js
@@ -18,8 +18,8 @@ type Props = {
   flags: Object,
   narrow: Narrow,
   doNarrow: DoNarrowAction,
-  onLongPress: () => void,
-  onHeaderLongPress: () => void,
+  onLongPress: (message: Object) => void,
+  onHeaderLongPress: (item: Object) => void,
   pushRoute: PushRouteAction,
   twentyFourHourTime: boolean,
 };


### PR DESCRIPTION
This just prevents duplicate re-renders of `renderMessages`, `MainScreen` and `messageActionSheet`.

Some data
before
<img width="1243" alt="screen shot 2017-07-07 at 12 09 11 pm" src="https://user-images.githubusercontent.com/14239866/27947350-1f9fa0be-6313-11e7-9ed7-e4e9b2876543.png">

after
<img width="1244" alt="screen shot 2017-07-07 at 12 02 20 pm" src="https://user-images.githubusercontent.com/14239866/27947361-270a826a-6313-11e7-8f5a-70b15e94d917.png">

this was profiled during fetching of new messages using `MessageList.js`.