### PR TITLE
Fixes: #864 Aligns the forgot password to right in Android

### DIFF
--- a/src/start/PasswordAuthView.js
+++ b/src/start/PasswordAuthView.js
@@ -109,13 +109,15 @@ class PasswordAuthView extends React.Component {
         />
         <ZulipButton text="Sign in with password" progress={progress} onPress={this.validateForm} />
         <ErrorMsg error={error} />
-        <Touchable style={componentStyles.linksTouchable}>
-          <Label
-            style={[styles.link]}
-            onPress={() => openLink(forgotPasswordLink)}
-            text="Forgot password?"
-          />
-        </Touchable>
+        <View style={componentStyles.linksTouchable}>
+          <Touchable>
+            <Label
+              style={[styles.link]}
+              onPress={() => openLink(forgotPasswordLink)}
+              text="Forgot password?"
+            />
+          </Touchable>
+        </View>
       </View>
     );
   }

--- a/src/styles/theme.js
+++ b/src/styles/theme.js
@@ -80,6 +80,7 @@ export default ({ color, backgroundColor, borderColor }: Props) => ({
     marginTop: 10,
     fontSize: 15,
     color: BRAND_COLOR,
+    textAlign: 'right',
   },
   navigationCard: {
     backgroundColor,


### PR DESCRIPTION
fixes : #864

Kind of reverting this PR #811 

iOS. 
Current master : 

<img width="373" alt="screen shot 2017-07-11 at 3 22 18 am" src="https://user-images.githubusercontent.com/21558765/28042334-6ab97ce4-65ea-11e7-9f41-0e2d614c59b3.png">

Android : 

![screenshot_20170711-032243](https://user-images.githubusercontent.com/21558765/28042393-a3602f7a-65ea-11e7-94ce-42504547a6d3.jpg)

This PR : 

iOS:

<img width="376" alt="screen shot 2017-07-13 at 5 50 56 am" src="https://user-images.githubusercontent.com/21558765/28145585-f7b5e93c-6790-11e7-89cc-ec05d664f485.png">


Android : 
![19911782_1420150728061837_1835120685_o](https://user-images.githubusercontent.com/21558765/28145614-31728022-6791-11e7-933b-fe3bd67b3755.jpg)






