### PR TITLE
No need to show action sheet on long press privateMessageHeader.

### DIFF
--- a/src/message/headers/MessageHeader.js
+++ b/src/message/headers/MessageHeader.js
@@ -80,7 +80,7 @@ export default class MessageHeader extends React.PureComponent {
           itemId={item.id}
           doNarrow={actions.doNarrow}
           style={styles.margin}
-          onLongPress={this.onLongPress}
+          onLongPress={() => {}}
         />
       );
     }


### PR DESCRIPTION
As there are no options for it. Action sheet does not look good
with only cancel option.

<img width="377" alt="screen shot 2017-07-13 at 9 22 01 am" src="https://user-images.githubusercontent.com/18511177/28149653-ec856f6c-67ac-11e7-8752-dd4c76c62464.png">
