### PR TITLE
Disable SubmitButton if message contains only whitespace

### DIFF
--- a/src/compose/ComposeText.js
+++ b/src/compose/ComposeText.js
@@ -137,7 +137,11 @@ export default class ComposeText extends PureComponent {
             placeholder={placeholder}
           />
         </ScrollView>
-        <SubmitButton disabled={text.length === 0} onPress={submit} editMessage={editMessage} />
+        <SubmitButton
+          disabled={text.trim().length === 0}
+          onPress={submit}
+          editMessage={editMessage}
+        />
       </View>
     );
   }


### PR DESCRIPTION
Fixes : https://github.com/zulip/zulip-mobile/issues/879


