### PR TITLE
Fix: Downgrade photoview dependency to 1.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "react-native-drawer": "^2.3.0",
     "react-native-fetch-blob": "^0.10.5",
     "react-native-notifications": "^1.1.12",
-    "react-native-photo-view": "~1.3.0",
+    "react-native-photo-view": "1.2.0",
     "react-native-safari-view": "^2.0.0",
     "react-native-sentry": "^0.14.5",
     "react-native-simple-toast": "0.0.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4056,9 +4056,9 @@ react-native-notifications@^1.1.12:
     core-js "^1.0.0"
     uuid "^2.0.3"
 
-react-native-photo-view@~1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/react-native-photo-view/-/react-native-photo-view-1.3.0.tgz#865974d93a9dd15e772e93fee074125b0b6909d3"
+react-native-photo-view@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/react-native-photo-view/-/react-native-photo-view-1.2.0.tgz#d379d368b1a13f272f9672af2b0ce5c96fa15409"
 
 react-native-safari-view@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Not sure if other folks are getting this error 
```
Bundling `index.android.js`  100.0(1/1), done.
error: bundling: UnableToResolveError: Unable to resolve module `react-native/Libraries/Components/View/ViewPropTypes` from `/Users/kunall17/Project/react/zulip-mobile/node_modules/react-native-photo-view/PhotoView.android.js`: Module does not exist in the module map or in these directories:
  /Users/kunall17/Project/react/zulip-mobile/node_modules/react-native/Libraries/Components/View
,   /Users/kunall17/node_modules/react-native/Libraries/Components/View

This might be related to https://github.com/facebook/react-native/issues/4968
To resolve try the following:
  1. Clear watchman watches: `watchman watch-del-all`.
  2. Delete the `node_modules` folder: `rm -rf node_modules && npm install`.
  3. Reset packager cache: `rm -fr $TMPDIR/react-*` or `npm start --reset-cache`.
    at p.catch.error (/Users/kunall17/Project/react/zulip-mobile/node_modules/react-native/packager/src/node-haste/DependencyGraph/ResolutionRequest.js:366:19)
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:169:7)
Bundling `index.android.js`  83.6(620/678), failed.
```