### PR TITLE
Fix: headers not being shown in user screen.

### DIFF
--- a/src/users/UserList.js
+++ b/src/users/UserList.js
@@ -48,7 +48,8 @@ export default class UserList extends PureComponent {
             onPress={onNarrow}
             realm={realm}
           />}
-        renderSectionHeader={(xx, x) => <RawLabel style={styles.groupHeader} text={x} />}
+        renderSectionHeader={({ section }) =>
+          <RawLabel style={styles.groupHeader} text={section.key} />}
       />
     );
   }


### PR DESCRIPTION
this PR
<img width="380" alt="screen shot 2017-07-19 at 11 11 30 am" src="https://user-images.githubusercontent.com/18511177/28352541-a14568dc-6c74-11e7-8ac9-84ecbfbca316.png">


How do we want to sort users?
- Using status (active, idle, inactive like in web). In this case name initials header will not be useful, we can have status headers.
- Using name. In this case name initial headers are nice.
- Combined. First creating sections according to names and then sorting each section according to status (active, idle, inactive).