### PR TITLE
Fixes casing and added strings in message_en

### DIFF
--- a/src/i18n/translations/messages_en.json
+++ b/src/i18n/translations/messages_en.json
@@ -60,4 +60,9 @@
   "Forgot password?": "Forgot password?",
   "Members": "Members",
   "Group details": "Group details",
+  "Share": "Share",
+  "Edit message": "Edit message",
+  "Star message": "Star message",
+  "Unstar message": "Unstar message",
+  "Cancel": "Cancel",
 }

--- a/src/message/messageActionSheet.js
+++ b/src/message/messageActionSheet.js
@@ -140,11 +140,11 @@ const actionSheetButtons: ButtonType[] = [
   { title: 'Reply', onPress: reply },
   { title: 'Copy to clipboard', onPress: copyToClipboard },
   { title: 'Share', onPress: shareMessage },
-  { title: 'Edit Message', onPress: editMessage, onlyIf: isSentBySelfAndNarrowed },
+  { title: 'Edit message', onPress: editMessage, onlyIf: isSentBySelfAndNarrowed },
   // If skip then covered in constructActionButtons
   { title: 'Narrow to conversation', onPress: narrowToConversation, onlyIf: skip },
-  { title: 'Star Message', onPress: starMessage, onlyIf: skip },
-  { title: 'Unstar Message', onPress: unstarMessage, onlyIf: skip },
+  { title: 'Star message', onPress: starMessage, onlyIf: skip },
+  { title: 'Unstar message', onPress: unstarMessage, onlyIf: skip },
   { title: 'Cancel', onPress: skip, onlyIf: skip },
 ];
 


### PR DESCRIPTION
Just noticed that these string were not in perfect casing which zulip follows and weren't also in the `message_en.json` file