### PR TITLE
Adds animation in Custom Tabs

### DIFF
--- a/android/app/src/main/java/com/zulipmobile/CustomTabsAndroid.java
+++ b/android/app/src/main/java/com/zulipmobile/CustomTabsAndroid.java
@@ -25,6 +25,8 @@ public class CustomTabsAndroid extends ReactContextBaseJavaModule {
     @ReactMethod
     public void openURL(String url) throws NullPointerException {
         CustomTabsIntent.Builder builder = new CustomTabsIntent.Builder();
+        builder.setStartAnimations(getReactApplicationContext().getCurrentActivity(), R.anim.slide_in_right, R.anim.slide_out_left);
+        builder.setExitAnimations(getReactApplicationContext().getCurrentActivity(), R.anim.slide_in_left, R.anim.slide_out_right);
         CustomTabsIntent customTabsIntent = builder.build();
         customTabsIntent.launchUrl(getReactApplicationContext().getCurrentActivity(), Uri.parse(url));
     }

--- a/android/app/src/main/res/anim/slide_in_left.xml
+++ b/android/app/src/main/res/anim/slide_in_left.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set
+    xmlns:android="http://schemas.android.com/apk/res/android">
+    <translate
+        android:fromXDelta="-100%p"
+        android:toXDelta="0"
+        android:duration="@android:integer/config_mediumAnimTime"/>
+</set>

--- a/android/app/src/main/res/anim/slide_in_right.xml
+++ b/android/app/src/main/res/anim/slide_in_right.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set
+    xmlns:android="http://schemas.android.com/apk/res/android">
+    <translate
+        android:fromXDelta="100%p"
+        android:toXDelta="0"
+        android:duration="@android:integer/config_mediumAnimTime"/>
+</set>

--- a/android/app/src/main/res/anim/slide_out_left.xml
+++ b/android/app/src/main/res/anim/slide_out_left.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set
+    xmlns:android="http://schemas.android.com/apk/res/android">
+    <translate
+        android:fromXDelta="0"
+        android:toXDelta="-100%p"
+        android:duration="@android:integer/config_mediumAnimTime"/>
+</set>

--- a/android/app/src/main/res/anim/slide_out_right.xml
+++ b/android/app/src/main/res/anim/slide_out_right.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set
+    xmlns:android="http://schemas.android.com/apk/res/android">
+    <translate
+        android:fromXDelta="0"
+        android:toXDelta="100%p"
+        android:duration="@android:integer/config_mediumAnimTime"/>
+</set>


### PR DESCRIPTION
Part of https://github.com/zulip/zulip-mobile/issues/920

Android inbuit transition don't have transition like `android.R.anim.slide_in_right` and `android.R.anim.slide_out_left` . So i added the anim xml file to do so. 

![demo](https://user-images.githubusercontent.com/21558765/28496059-020736ca-6f7f-11e7-9c78-e29432d6cb29.gif)
