### PR TITLE
Fix: center align of quote text and bullets.

### DIFF
--- a/src/html/HtmlNodeTag.js
+++ b/src/html/HtmlNodeTag.js
@@ -100,7 +100,7 @@ export default class HtmlNodeTag extends PureComponent {
         target={attribs.target}
         src={attribs.src}
         href={attribs.href}
-        style={[style, styles.common]}
+        style={[styles.common, style]}
         cascadingStyle={newCascadingStyle}
         cascadingTextStyle={newCascadingStylesText}
         indexedViewsStyles={newIndexedViewsStyles}

--- a/src/html/HtmlStyles.js
+++ b/src/html/HtmlStyles.js
@@ -18,6 +18,7 @@ export default StyleSheet.create({
   li: {
     flexDirection: 'row',
     marginBottom: 4,
+    alignItems: 'flex-start',
   },
   div: {
     flexWrap: 'wrap',
@@ -94,6 +95,7 @@ export default StyleSheet.create({
     borderColor: 'rgba(127, 127, 127, 0.25)',
     borderLeftWidth: 4,
     paddingLeft: 4,
+    alignItems: 'flex-start',
   },
   emoji: {
     width: 24,


### PR DESCRIPTION
[current master](https://github.com/zulip/zulip-mobile/tree/2abfbac30bf763aa34d37d8a139627cfb717b0de)
<img width="336" alt="screen shot 2017-07-23 at 3 41 09 pm" src="https://user-images.githubusercontent.com/18511177/28498545-9e2f6520-6fbd-11e7-8787-eccfc13642c2.png">
<img width="320" alt="screen shot 2017-07-23 at 3 41 18 pm" src="https://user-images.githubusercontent.com/18511177/28498547-9eeb154a-6fbd-11e7-90f3-52e05fae7383.png">

this PR
<img width="73" alt="screen shot 2017-07-23 at 3 40 08 pm" src="https://user-images.githubusercontent.com/18511177/28498548-a724849e-6fbd-11e7-86d2-8dcad5f2af70.png">
<img width="319" alt="screen shot 2017-07-23 at 3 40 13 pm" src="https://user-images.githubusercontent.com/18511177/28498549-a8102020-6fbd-11e7-9cfa-dc49dd61e4f9.png">
