### PR TITLE
Fix react-native-fetch-blob package crash

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "react-native": "^0.47.1",
     "react-native-device-info": "^0.11.0",
     "react-native-drawer": "^2.3.0",
-    "react-native-fetch-blob": "^0.10.7",
+    "react-native-fetch-blob": "^0.10.8",
     "react-native-notifications": "^1.1.13",
     "react-native-photo-view": "^1.3.0",
     "react-native-safari-view": "^2.0.0",


### PR DESCRIPTION
`Error: unterminated string constant in ./polyfill/Blog.js line 289`

Fixed in https://github.com/wkh237/react-native-fetch-blob/issues/455