### PR TITLE
Avoid changing state when rehydrated messages same as incoming ones.

### DIFF
--- a/src/chat/__tests__/chatReducers-test.js
+++ b/src/chat/__tests__/chatReducers-test.js
@@ -674,7 +674,38 @@ describe('chatReducers', () => {
 
       const newState = chatReducers(initialState, action);
 
-      expect(...newState.messages[homeNarrowStr]).toBe(...commonMessages);
+      expect(...newState.messages[homeNarrowStr]).toEqual(...commonMessages);
+    });
+
+    test('when replaceExisting is true, deep equal is performed to separate common messages', () => {
+      const commonMessages = [{ id: 2, timestamp: 4 }, { id: 3, timestamp: 5 }];
+      const changedMessage = { id: 4, timestamp: 6, subject: 'new topic' };
+      const initialState = deepFreeze({
+        messages: {
+          [homeNarrowStr]: [
+            { id: 1, timestamp: 3 },
+            ...commonMessages,
+            { id: 4, timestamp: 6, subject: 'some topic' },
+          ],
+        },
+      });
+
+      const action = deepFreeze({
+        type: MESSAGE_FETCH_SUCCESS,
+        narrow: [],
+        messages: [{ id: 2, timestamp: 4 }, { id: 3, timestamp: 5 }, changedMessage],
+        replaceExisting: true,
+      });
+
+      const expectedState = {
+        messages: {
+          [homeNarrowStr]: [...commonMessages, changedMessage],
+        },
+      };
+
+      const newState = chatReducers(initialState, action);
+
+      expect(...newState.messages[homeNarrowStr]).toEqual(...expectedState.messages[homeNarrowStr]);
     });
   });
 });

--- a/src/chat/__tests__/chatReducers-test.js
+++ b/src/chat/__tests__/chatReducers-test.js
@@ -656,5 +656,25 @@ describe('chatReducers', () => {
 
       expect(newState).toEqual(expectedState);
     });
+
+    test('when replaceExisting is true, common messages are not replaced', () => {
+      const commonMessages = [{ id: 2, timestamp: 4 }, { id: 3, timestamp: 5 }];
+      const initialState = deepFreeze({
+        messages: {
+          [homeNarrowStr]: [{ id: 1, timestamp: 3 }, ...commonMessages],
+        },
+      });
+
+      const action = deepFreeze({
+        type: MESSAGE_FETCH_SUCCESS,
+        narrow: [],
+        messages: [{ id: 2, timestamp: 4 }, { id: 3, timestamp: 5 }],
+        replaceExisting: true,
+      });
+
+      const newState = chatReducers(initialState, action);
+
+      expect(...newState.messages[homeNarrowStr]).toBe(...commonMessages);
+    });
   });
 });

--- a/src/chat/chatReducers.js
+++ b/src/chat/chatReducers.js
@@ -1,4 +1,6 @@
 /* @flow */
+import isEqual from 'lodash.isequal';
+
 import type { ChatState, Action } from '../types';
 import {
   LOGOUT,
@@ -14,6 +16,7 @@ import {
 } from '../actionConstants';
 import { homeNarrow, isMessageInNarrow } from '../utils/narrow';
 import chatUpdater from './chatUpdater';
+import { getMessagesById } from '../selectors';
 
 const initialState: ChatState = {
   fetchingOlder: true,
@@ -55,10 +58,16 @@ export default (state: ChatState = initialState, action: Action) => {
       const key = JSON.stringify(action.narrow);
       const messages = state.messages[key] || [];
 
+      const messagesById = getMessagesById(state);
       const newMessages = action.replaceExisting
-        ? action.messages.map(item => messages.find(msg => msg.id === item.id) || item)
+        ? action.messages.map(
+            item =>
+              messagesById[item.id]
+                ? isEqual(messagesById[item.id], item) ? messagesById[item.id] : item
+                : item,
+          )
         : action.messages
-            .filter(x => !messages.find(msg => msg.id === x.id))
+            .filter(x => !messagesById[x.id])
             .concat(messages)
             .sort((a, b) => a.timestamp - b.timestamp);
 

--- a/src/chat/chatReducers.js
+++ b/src/chat/chatReducers.js
@@ -56,7 +56,7 @@ export default (state: ChatState = initialState, action: Action) => {
       const messages = state.messages[key] || [];
 
       const newMessages = action.replaceExisting
-        ? action.messages
+        ? action.messages.map(item => messages.find(msg => msg.id === item.id) || item)
         : action.messages
             .filter(x => !messages.find(msg => msg.id === x.id))
             .concat(messages)

--- a/src/chat/chatSelectors.js
+++ b/src/chat/chatSelectors.js
@@ -11,12 +11,15 @@ import {
   getReadFlags,
   getStreams,
 } from '../baseSelectors';
-import { specialNarrow } from '../utils/narrow';
+import { specialNarrow, homeNarrow } from '../utils/narrow';
 import { shouldBeMuted } from '../utils/message';
 import { countUnread } from '../utils/unread';
 import { NULL_MESSAGE, NULL_USER, NULL_SUBSCRIPTION } from '../nullObjects';
 
 const privateNarrowStr = JSON.stringify(specialNarrow('private'));
+
+const getMessagesFromChatState = state =>
+  state.messages[JSON.stringify(state.narrow || homeNarrow())] || [];
 
 export const getIsFetching = (state: GlobalState): boolean =>
   (state.app.needsInitialFetch && state.chat.fetchingOlder) || state.chat.fetchingOlder;
@@ -104,4 +107,11 @@ export const getUnreadCountInActiveNarrow = createSelector(
 export const getIfNoMessages = createSelector(
   getShownMessagesInActiveNarrow,
   messages => messages && messages.length === 0,
+);
+
+export const getMessagesById = createSelector(getMessagesFromChatState, messages =>
+  messages.reduce((msgById, message) => {
+    msgById[message.id] = message;
+    return msgById;
+  }, {}),
 );


### PR DESCRIPTION
This prevents some re-renders of Message related components during startup.

Added a test to cover this case.