### PR TITLE
Fix: Limit react-native-photo-view to 1.3.x.

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "react-native-drawer": "^2.3.0",
     "react-native-fetch-blob": "^0.10.8",
     "react-native-notifications": "^1.1.13",
-    "react-native-photo-view": "^1.4.0",
+    "react-native-photo-view": "1.3.0",
     "react-native-safari-view": "^2.0.0",
     "react-native-sentry": "^0.17.1",
     "react-native-simple-toast": "0.0.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4843,9 +4843,9 @@ react-native-notifications@^1.1.13:
     core-js "^1.0.0"
     uuid "^2.0.3"
 
-react-native-photo-view@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/react-native-photo-view/-/react-native-photo-view-1.4.0.tgz#b6cf3ccc471ca8164e5e9ba1a5ed7c38e64952a8"
+react-native-photo-view@1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/react-native-photo-view/-/react-native-photo-view-1.3.0.tgz#865974d93a9dd15e772e93fee074125b0b6909d3"
 
 react-native-safari-view@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
The recent library version 1.4.0 has a bug.

Also submitted an issue for the same here https://github.com/alwx/react-native-photo-view/issues/84