### PR TITLE
Remove logic to disable sticky headers on android.

### DIFF
--- a/src/message/InfiniteScrollView.js
+++ b/src/message/InfiniteScrollView.js
@@ -104,7 +104,7 @@ export default class InfiniteScrollView extends PureComponent {
         onLayout={this._onScrollViewLayout}
         onScroll={this._onScroll}
         scrollEventThrottle={config.scrollCallbackThrottle}
-        stickyHeaderIndices={Platform.OS === 'ios' ? this.props.stickyHeaderIndices : undefined}
+        stickyHeaderIndices={this.props.stickyHeaderIndices}
         autoScrollToBottom={this.props.autoScrollToBottom}
         removeClippedSubviews>
         {this.props.children}


### PR DESCRIPTION
This commit  https://github.com/facebook/react-native/commit/407ec0023fb3d292bcb2583c9a1bb6791f2e046d has finally made it to RN47 and now we can remove this logic. The sticky headers by default won't work when clipped views optimisation is enabled.