### PR TITLE
[WIP] Fix flow, jest unit test errors 

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -62,4 +62,4 @@ module.file_ext=.json
 module.file_ext=.jsx
 
 [version]
-^0.50.0
+^0.52.0

--- a/.flowconfig
+++ b/.flowconfig
@@ -62,4 +62,4 @@ module.file_ext=.json
 module.file_ext=.jsx
 
 [version]
-^0.49.1
+^0.50.0

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "lodash.isequal": "^4.4.0",
     "lodash.throttle": "^4.1.1",
     "lodash.uniqby": "^4.4.0",
+    "prop-types": "^15.5.10",
     "react": "16.0.0-alpha.12",
     "react-intl": "^2.2.3",
     "react-native": "^0.47.1",
@@ -90,7 +91,7 @@
     "eslint-plugin-react": "^7.2.0",
     "eslint-plugin-react-native": "^3.0.1",
     "eslint-plugin-spellcheck": "0.0.6",
-    "flow-bin": "^0.49.1",
+    "flow-bin": "0.50.0",
     "flow-typed": "^2.1.5",
     "jest": "^20.0.0",
     "jest-cli": "^20.0.0",
@@ -109,7 +110,10 @@
     "transformIgnorePatterns": [
       "node_modules/(?!react-native|@expo/react-native-action-sheet|react-navigation)"
     ],
-    "testPathIgnorePatterns": ["/node_modules/", "<rootDir>/__e2e__tests__"]
+    "testPathIgnorePatterns": [
+      "/node_modules/",
+      "<rootDir>/__e2e__tests__"
+    ]
   },
   "detox": {
     "configurations": {

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "eslint-plugin-react": "^7.2.0",
     "eslint-plugin-react-native": "^3.0.1",
     "eslint-plugin-spellcheck": "0.0.6",
-    "flow-bin": "0.50.0",
+    "flow-bin": "0.52.0",
     "flow-typed": "^2.1.5",
     "jest": "^20.0.0",
     "jest-cli": "^20.0.0",
@@ -110,10 +110,7 @@
     "transformIgnorePatterns": [
       "node_modules/(?!react-native|@expo/react-native-action-sheet|react-navigation)"
     ],
-    "testPathIgnorePatterns": [
-      "/node_modules/",
-      "<rootDir>/__e2e__tests__"
-    ]
+    "testPathIgnorePatterns": ["/node_modules/", "<rootDir>/__e2e__tests__"]
   },
   "detox": {
     "configurations": {

--- a/src/chat/chatSelectors.js
+++ b/src/chat/chatSelectors.js
@@ -18,14 +18,22 @@ import {
   isStreamNarrow,
   isHomeNarrow,
   homeNarrow,
-  allPrivateNarrowStr,
 } from '../utils/narrow';
 import { shouldBeMuted } from '../utils/message';
 import { countUnread } from '../utils/unread';
 import { NULL_MESSAGE, NULL_USER, NULL_SUBSCRIPTION } from '../nullObjects';
 
+const specialNarrow = (operand: string): Narrow => [
+  {
+    operator: 'is',
+    operand,
+  },
+];
+
+const privateNarrowStr = JSON.stringify(specialNarrow('private'));
+
 const getMessagesFromChatState = state =>
-  state.messages[JSON.stringify(state.narrow || homeNarrow)] || [];
+  state.messages[JSON.stringify(state.narrow || homeNarrow())] || [];
 
 export const getIsFetching = (state: GlobalState): boolean =>
   (state.app.needsInitialFetch && state.chat.fetchingOlder) || state.chat.fetchingOlder;
@@ -81,7 +89,7 @@ export const getLastMessageId = createSelector(
 
 export const getPrivateMessages = createSelector(
   getAllMessages,
-  messages => messages[allPrivateNarrowStr] || [],
+  messages => messages[privateNarrowStr] || [],
 );
 
 export const getUnreadPrivateMessagesCount = createSelector(

--- a/src/chat/chatSelectors.js
+++ b/src/chat/chatSelectors.js
@@ -33,7 +33,7 @@ const specialNarrow = (operand: string): Narrow => [
 const privateNarrowStr = JSON.stringify(specialNarrow('private'));
 
 const getMessagesFromChatState = state =>
-  state.messages[JSON.stringify(state.narrow || homeNarrow())] || [];
+  state.messages[JSON.stringify(state.narrow || homeNarrow)] || [];
 
 export const getIsFetching = (state: GlobalState): boolean =>
   (state.app.needsInitialFetch && state.chat.fetchingOlder) || state.chat.fetchingOlder;

--- a/src/common/Avatar.js
+++ b/src/common/Avatar.js
@@ -28,7 +28,7 @@ class Avatar extends PureComponent {
     status?: UserStatus,
     realm: string,
     shape: 'square' | 'rounded' | 'circle',
-    onPress: () => void,
+    onPress?: () => void,
   };
 
   static defaultProps = {

--- a/src/common/Avatar.js
+++ b/src/common/Avatar.js
@@ -1,4 +1,3 @@
-/* @flow */
 import React, { PureComponent } from 'react';
 import { StyleSheet } from 'react-native';
 import { connect } from 'react-redux';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2263,9 +2263,9 @@ flat-cache@^1.2.1:
     graceful-fs "^4.1.2"
     write "^0.2.1"
 
-flow-bin@0.50.0:
-  version "0.50.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.50.0.tgz#d4cdb2430dee1a3599f0eb6fe551146e3027256a"
+flow-bin@0.52.0:
+  version "0.52.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.52.0.tgz#b6d9abe8bcd1ee5c62df386451a4e2553cadc3a3"
 
 flow-parser@0.40.0:
   version "0.40.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2263,9 +2263,9 @@ flat-cache@^1.2.1:
     graceful-fs "^4.1.2"
     write "^0.2.1"
 
-flow-bin@^0.49.1:
-  version "0.49.1"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.49.1.tgz#c9e456b3173a7535a4ffaf28956352c63bb8e3e9"
+flow-bin@0.50.0:
+  version "0.50.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.50.0.tgz#d4cdb2430dee1a3599f0eb6fe551146e3027256a"
 
 flow-parser@0.40.0:
   version "0.40.0"


### PR DESCRIPTION
Currently disabled the flow type for the Avatar.js file

Now getting error's in selector test's 

```
yarn run jest subscriptionSelectors
yarn run v0.27.5
warning ../../../package.json: No license field
$ "/Users/kunall17/Project/react/zulip-mobile/node_modules/.bin/jest" "subscriptionSelectors"
 FAIL  src/subscriptions/__tests__/subscriptionSelectors-test.js
   Test suite failed to run

    Selector creators expect all input-selectors to be functions, instead received the following types: [undefined, function, function]
      
      at getDependencies (node_modules/reselect/lib/index.js:53:11)
      at node_modules/reselect/lib/index.js:71:24
      at Object.<anonymous> (src/unread/unreadSelectors.js:77:93)
      at Object.<anonymous> (src/conversations/conversationsSelectors.js:5:22)

Test Suites: 1 failed, 1 total
Tests:       0 total
Snapshots:   0 total
Time:        0.559s
Ran all test suites matching "subscriptionSelectors".
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```