### PR TITLE
Change getTitle & getTitleTextColor according to current navigation route

### DIFF
--- a/src/baseSelectors.js
+++ b/src/baseSelectors.js
@@ -7,6 +7,8 @@ export const getTyping = (state: GlobalState): Object => state.typing;
 
 export const getUsers = (state: GlobalState): any[] => state.users;
 
+export const getNav = (state: GlobalState): any[] => state.nav;
+
 export const getFlags = (state: GlobalState): Object => state.flags;
 
 export const getReadFlags = (state: GlobalState): Object => state.flags.read;

--- a/src/baseSelectors.js
+++ b/src/baseSelectors.js
@@ -7,8 +7,6 @@ export const getTyping = (state: GlobalState): Object => state.typing;
 
 export const getUsers = (state: GlobalState): any[] => state.users;
 
-export const getNav = (state: GlobalState): any[] => state.nav;
-
 export const getFlags = (state: GlobalState): Object => state.flags;
 
 export const getReadFlags = (state: GlobalState): Object => state.flags.read;

--- a/src/message/InfiniteScrollView.js
+++ b/src/message/InfiniteScrollView.js
@@ -22,14 +22,14 @@ export default class InfiniteScrollView extends PureComponent {
     onStartReached?: () => void,
     onEndReached?: () => void,
     onReplySelect: () => void,
-    onScroll: (e: Event) => void
+    onScroll: (e: Event) => void,
   };
 
   static defaultProps = {
     onStartReached: nullFunction,
     onEndReached: nullFunction,
     startReachedThreshold: config.messageListThreshold,
-    endReachedThreshold: config.messageListThreshold
+    endReachedThreshold: config.messageListThreshold,
   };
 
   _scrollOffset: number;
@@ -113,8 +113,7 @@ export default class InfiniteScrollView extends PureComponent {
         ref={component => {
           const { listRef } = this.props;
           if (listRef) listRef(component);
-        }}
-      >
+        }}>
         {this.props.children}
       </AnchorScrollView>
     );

--- a/src/title/__tests__/titleSelectors-test.js
+++ b/src/title/__tests__/titleSelectors-test.js
@@ -13,53 +13,140 @@ import { foregroundColorFromBackground } from '../../utils/color';
 import { BRAND_COLOR } from '../../styles';
 
 const subscriptions = [{ name: 'all', color: '#fff' }, { name: 'announce', color: '#000' }];
-
+const defaultNav = {
+  index: 0,
+  routes: [{ routeName: 'main' }],
+};
+const otherNav = {
+  index: 1,
+  routes: [{ routeName: 'main' }, { routeName: 'account' }],
+};
 describe('getTitleBackgroundColor', () => {
+  test('return transparent color for account', () => {
+    let state = deepFreeze({
+      chat: { narrow: streamNarrow('all') },
+      subscriptions,
+      nav: otherNav,
+    });
+    expect(getTitleBackgroundColor(state)).toEqual('transparent');
+
+    state = deepFreeze({
+      chat: { narrow: privateNarrow('hamlet@example.com') },
+      subscriptions,
+      nav: defaultNav,
+    });
+    expect(getTitleBackgroundColor(state)).toEqual('transparent');
+  });
+
   test('return stream color for stream and topic narrow', () => {
-    let state = deepFreeze({ chat: { narrow: streamNarrow('all') }, subscriptions });
+    let state = deepFreeze({
+      chat: { narrow: streamNarrow('all') },
+      subscriptions,
+      nav: defaultNav,
+    });
     expect(getTitleBackgroundColor(state)).toEqual('#fff');
 
-    state = deepFreeze({ chat: { narrow: topicNarrow('announce', '@all') }, subscriptions });
+    state = deepFreeze({
+      chat: { narrow: topicNarrow('announce', '@all') },
+      subscriptions,
+      nav: defaultNav,
+    });
     expect(getTitleBackgroundColor(state)).toEqual('#000');
   });
 
   test('return null stream color for invalid stream or unknown subscriptions', () => {
-    const state = deepFreeze({ chat: { narrow: streamNarrow('feedback') }, subscriptions });
+    const state = deepFreeze({
+      chat: { narrow: streamNarrow('feedback') },
+      subscriptions,
+      nav: defaultNav,
+    });
     expect(getTitleBackgroundColor(state)).toEqual('gray');
   });
 
   test('return transparent for other narrow and screens', () => {
-    let state = deepFreeze({ chat: { narrow: privateNarrow('a@a.com') }, subscriptions });
+    let state = deepFreeze({
+      chat: { narrow: privateNarrow('a@a.com') },
+      subscriptions,
+      nav: defaultNav,
+    });
     expect(getTitleBackgroundColor(state)).toEqual('transparent');
 
-    state = deepFreeze({ chat: { narrow: groupNarrow(['a@a.com', 'b@b.com']) }, subscriptions });
+    state = deepFreeze({
+      chat: { narrow: groupNarrow(['a@a.com', 'b@b.com']) },
+      subscriptions,
+      nav: defaultNav,
+    });
     expect(getTitleBackgroundColor(state)).toEqual('transparent');
 
-    state = deepFreeze({ chat: { narrow: [] }, subscriptions });
+    state = deepFreeze({
+      chat: { narrow: [] },
+      subscriptions,
+      nav: defaultNav,
+    });
     expect(getTitleBackgroundColor(state)).toEqual('transparent');
 
-    state = deepFreeze({ chat: { narrow: specialNarrow('private') }, subscriptions });
+    state = deepFreeze({
+      chat: { narrow: specialNarrow('private') },
+      subscriptions,
+      nav: defaultNav,
+    });
     expect(getTitleBackgroundColor(state)).toEqual('transparent');
   });
 });
 
 describe('getTitleTextColor', () => {
+  test('for account nav get use foregroundColorFromBackground', () => {
+    let state = deepFreeze({
+      chat: { narrow: streamNarrow('all') },
+      subscriptions,
+      nav: otherNav,
+    });
+    expect(getTitleTextColor(state)).toEqual('rgba(82, 194, 175, 1)');
+
+    state = deepFreeze({
+      chat: { narrow: topicNarrow('announce', '@all') },
+      subscriptions,
+      nav: otherNav,
+    });
+    expect(getTitleTextColor(state)).toEqual('rgba(82, 194, 175, 1)');
+  });
+
   test('for stream and topic narrow get use foregroundColorFromBackground', () => {
-    let state = deepFreeze({ chat: { narrow: streamNarrow('all') }, subscriptions });
+    let state = deepFreeze({
+      chat: { narrow: streamNarrow('all') },
+      subscriptions,
+      nav: defaultNav,
+    });
     expect(getTitleTextColor(state)).toEqual(foregroundColorFromBackground('#fff'));
 
-    state = deepFreeze({ chat: { narrow: topicNarrow('announce', '@all') }, subscriptions });
+    state = deepFreeze({
+      chat: { narrow: topicNarrow('announce', '@all') },
+      subscriptions,
+      nav: defaultNav,
+    });
     expect(getTitleTextColor(state)).toEqual(foregroundColorFromBackground('#000'));
   });
 
   test('for other narrow get BRAND_COLOR', () => {
-    let state = deepFreeze({ chat: { narrow: privateNarrow('a@a.com') }, subscriptions });
+    let state = deepFreeze({
+      chat: { narrow: privateNarrow('a@a.com') },
+      subscriptions,
+      nav: defaultNav,
+    });
     expect(getTitleTextColor(state)).toEqual(BRAND_COLOR);
 
-    state = deepFreeze({ chat: { narrow: groupNarrow(['a@a.com', 'b@b.com']) }, subscriptions });
+    state = deepFreeze({
+      chat: { narrow: groupNarrow(['a@a.com', 'b@b.com']) },
+      subscriptions,
+      nav: defaultNav,
+    });
     expect(getTitleTextColor(state)).toEqual(BRAND_COLOR);
 
-    state = deepFreeze({ chat: { narrow: specialNarrow('search') }, subscriptions });
+    state = deepFreeze({
+      chat: { narrow: specialNarrow('search') },
+      subscriptions,
+      nav: defaultNav,
+    });
     expect(getTitleTextColor(state)).toEqual(BRAND_COLOR);
   });
 });

--- a/src/title/titleSelectors.js
+++ b/src/title/titleSelectors.js
@@ -2,7 +2,7 @@
 import { createSelector } from 'reselect';
 
 import { BRAND_COLOR } from '../styles';
-import { getSubscriptions, getActiveNarrow } from '../selectors';
+import { getSubscriptions, getActiveNarrow, getCurrentRoute } from '../selectors';
 import { foregroundColorFromBackground } from '../utils/color';
 import { isStreamNarrow, isTopicNarrow } from '../utils/narrow';
 import { NULL_SUBSCRIPTION } from '../nullObjects';
@@ -10,8 +10,9 @@ import { NULL_SUBSCRIPTION } from '../nullObjects';
 export const getTitleBackgroundColor = createSelector(
   getActiveNarrow,
   getSubscriptions,
-  (narrow, subscriptions) =>
-    isStreamNarrow(narrow) || isTopicNarrow(narrow)
+  getCurrentRoute,
+  (narrow, subscriptions, route) =>
+    route === 'main' && (isStreamNarrow(narrow) || isTopicNarrow(narrow))
       ? (subscriptions.find(sub => narrow[0].operand === sub.name) || NULL_SUBSCRIPTION).color
       : 'transparent',
 );
@@ -19,8 +20,9 @@ export const getTitleBackgroundColor = createSelector(
 export const getTitleTextColor = createSelector(
   getTitleBackgroundColor,
   getActiveNarrow,
-  (backgroundColor, narrow) =>
-    backgroundColor && (isStreamNarrow(narrow) || isTopicNarrow(narrow))
+  getCurrentRoute,
+  (backgroundColor, narrow, route) =>
+    backgroundColor && route === 'main' && (isStreamNarrow(narrow) || isTopicNarrow(narrow))
       ? foregroundColorFromBackground(backgroundColor)
       : BRAND_COLOR,
 );

--- a/src/utils/__tests__/getStatusBarStyle-test.js
+++ b/src/utils/__tests__/getStatusBarStyle-test.js
@@ -15,30 +15,46 @@ const LIGHT_CONTENT_STYLE = 'light-content';
 const DARK_CONTENT_STYLE = 'dark-content';
 
 const subscriptions = [{ name: 'all', color: '#fff' }, { name: 'announce', color: '#000' }];
+const defaultNav = {
+  index: 0,
+  routes: [{ routeName: 'main' }],
+};
 
 describe('getStatusBarStyle', () => {
   test('return bar style according to theme for screens other than main', () => {
-    const state = deepFreeze({ chat: { narrow: [] }, subscriptions });
+    const state = deepFreeze({ chat: { narrow: [] }, subscriptions, nav: defaultNav });
     expect(getStatusBarStyle(getTitleBackgroundColor(state), darkTextColor, themeDefault)).toEqual(
       DARK_CONTENT_STYLE,
     );
   });
 
   test('return bar style according to text color for stream and topic narrow in main screen', () => {
-    let state = deepFreeze({ chat: { narrow: streamNarrow('all') }, subscriptions });
+    let state = deepFreeze({
+      chat: { narrow: streamNarrow('all') },
+      subscriptions,
+      nav: defaultNav,
+    });
     expect(getStatusBarStyle(state, darkTextColor, themeDefault)).toEqual(DARK_CONTENT_STYLE);
 
-    state = deepFreeze({ chat: { narrow: topicNarrow('all', 'announce') }, subscriptions });
+    state = deepFreeze({
+      chat: { narrow: topicNarrow('all', 'announce') },
+      subscriptions,
+      nav: defaultNav,
+    });
     expect(getStatusBarStyle(state, lightTextColor, themeDefault)).toEqual(LIGHT_CONTENT_STYLE);
   });
 
   test('returns style according to theme for private, group, home and special narrow', () => {
-    let state = deepFreeze({ chat: { narrow: privateNarrow('abc@zulip.com') }, subscriptions });
+    let state = deepFreeze({
+      chat: { narrow: privateNarrow('abc@zulip.com') },
+      subscriptions,
+      nav: defaultNav,
+    });
     expect(getStatusBarStyle(state, darkTextColor, themeDefault)).toEqual(DARK_CONTENT_STYLE);
 
     expect(getStatusBarStyle(state, lightTextColor, themeNight)).toEqual(LIGHT_CONTENT_STYLE);
 
-    state = deepFreeze({ chat: { narrow: [] }, subscriptions });
+    state = deepFreeze({ chat: { narrow: [] }, subscriptions, nav: defaultNav });
     expect(getStatusBarStyle(state, darkTextColor, themeDefault)).toEqual(DARK_CONTENT_STYLE);
 
     state = deepFreeze({
@@ -47,7 +63,11 @@ describe('getStatusBarStyle', () => {
     });
     expect(getStatusBarStyle(state, darkTextColor, themeDefault)).toEqual(DARK_CONTENT_STYLE);
 
-    state = deepFreeze({ chat: { narrow: specialNarrow('private') }, subscriptions });
+    state = deepFreeze({
+      chat: { narrow: specialNarrow('private') },
+      subscriptions,
+      nav: defaultNav,
+    });
     expect(getStatusBarStyle(state, darkTextColor, themeDefault)).toEqual(DARK_CONTENT_STYLE);
   });
 });


### PR DESCRIPTION
Suppose we are in topic narrow and status bar is coloured

![simulator screen shot 26-aug-2017 11 51 16 pm](https://user-images.githubusercontent.com/12700799/29744027-e62db298-8ab9-11e7-8c2c-95f4e32117d7.png)
It shows like this on current master 
![simulator screen shot 26-aug-2017 11 53 17 pm](https://user-images.githubusercontent.com/12700799/29744025-e62c025e-8ab9-11e7-90d3-d46b6808335d.png)

Now like this 

![simulator screen shot 26-aug-2017 11 51 08 pm](https://user-images.githubusercontent.com/12700799/29744026-e62d61e4-8ab9-11e7-80f7-c413b9b506f1.png)


