### PR TITLE
Fix: status bar backgroundColor in dark theme on Android.

### DIFF
--- a/src/common/ZulipStatusBar.js
+++ b/src/common/ZulipStatusBar.js
@@ -2,10 +2,12 @@
 import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';
 import { Platform, StatusBar, View } from 'react-native';
+import Color from 'color';
 
 import { STATUSBAR_HEIGHT } from '../styles/platform';
 import { getTitleBackgroundColor, getTitleTextColor } from '../selectors';
 import getStatusBarStyle from '../utils/getStatusBarStyle';
+import getStatusBarColor from '../utils/getStatusBarColor';
 
 class ZulipStatusBar extends PureComponent {
   static contextTypes = {
@@ -27,13 +29,14 @@ class ZulipStatusBar extends PureComponent {
     const { theme, backgroundColor, textColor, hidden } = this.props;
     const style = { height: STATUSBAR_HEIGHT, backgroundColor };
     const barStyle = getStatusBarStyle(backgroundColor, textColor, theme);
+    const statusBarColor = getStatusBarColor(backgroundColor, theme);
     return (
       <View style={style}>
         <StatusBar
           animated
           showHideTransition="slide"
           hidden={hidden && Platform.OS !== 'android'}
-          backgroundColor={backgroundColor}
+          backgroundColor={Color(statusBarColor).darken(0.4)}
           barStyle={barStyle}
         />
       </View>

--- a/src/utils/__tests__/getStatusBarColor-test.js
+++ b/src/utils/__tests__/getStatusBarColor-test.js
@@ -1,0 +1,66 @@
+/* @flow */
+import deepFreeze from 'deep-freeze';
+
+import { streamNarrow, topicNarrow, privateNarrow, specialNarrow, groupNarrow } from '../narrow';
+import getStatusBarColor from '../getStatusBarColor';
+import { getTitleBackgroundColor } from '../../selectors';
+
+const themeNight = 'night';
+const themeDefault = 'default';
+
+const subscriptions = [{ name: 'all', color: '#fff' }, { name: 'announce', color: '#000' }];
+const defaultNav = {
+  index: 0,
+  routes: [{ routeName: 'main' }],
+};
+
+describe('getStatusBarColor', () => {
+  test('return bar color according to theme for screens other than main', () => {
+    const state = deepFreeze({ chat: { narrow: [] }, subscriptions, nav: defaultNav });
+    expect(getStatusBarColor(getTitleBackgroundColor(state), themeDefault)).toEqual('white');
+  });
+
+  test('return bar color according to stream color for stream and topic narrow in main screen', () => {
+    let state = deepFreeze({
+      chat: { narrow: streamNarrow('all') },
+      subscriptions,
+      nav: defaultNav,
+    });
+    expect(getStatusBarColor(getTitleBackgroundColor(state), themeDefault)).toEqual('#fff');
+
+    state = deepFreeze({
+      chat: { narrow: topicNarrow('all', 'announce') },
+      subscriptions,
+      nav: defaultNav,
+    });
+    expect(getStatusBarColor(getTitleBackgroundColor(state), themeDefault)).toEqual('#fff');
+  });
+
+  test('returns color according to theme for private, group, home and special narrow', () => {
+    let state = deepFreeze({
+      chat: { narrow: privateNarrow('abc@zulip.com') },
+      subscriptions,
+      nav: defaultNav,
+    });
+    expect(getStatusBarColor(getTitleBackgroundColor(state), themeDefault)).toEqual('white');
+
+    expect(getStatusBarColor(getTitleBackgroundColor(state), themeNight)).toEqual('#212D3B');
+
+    state = deepFreeze({ chat: { narrow: [] }, subscriptions, nav: defaultNav });
+    expect(getStatusBarColor(getTitleBackgroundColor(state), themeDefault)).toEqual('white');
+
+    state = deepFreeze({
+      chat: { narrow: groupNarrow(['abc@zulip.com', 'def@zulip.com']) },
+      subscriptions,
+      nav: defaultNav,
+    });
+    expect(getStatusBarColor(getTitleBackgroundColor(state), themeDefault)).toEqual('white');
+
+    state = deepFreeze({
+      chat: { narrow: specialNarrow('private') },
+      subscriptions,
+      nav: defaultNav,
+    });
+    expect(getStatusBarColor(getTitleBackgroundColor(state), themeDefault)).toEqual('white');
+  });
+});

--- a/src/utils/getStatusBarColor.js
+++ b/src/utils/getStatusBarColor.js
@@ -1,0 +1,5 @@
+/* @flow */
+import type { ThemeType } from '../types';
+
+export default (backgroundColor: string, theme: ThemeType): string =>
+  backgroundColor === 'transparent' ? (theme === 'night' ? '#212D3B' : 'white') : backgroundColor;


### PR DESCRIPTION
current 
<img width="447" alt="screen shot 2017-08-31 at 5 48 18 pm" src="https://user-images.githubusercontent.com/18511177/29922767-ada2a73a-8e74-11e7-8bd5-a54020059796.png">
<img width="448" alt="screen shot 2017-08-31 at 5 48 38 pm" src="https://user-images.githubusercontent.com/18511177/29922768-adff36a8-8e74-11e7-85a6-c353768f17c4.png">

this PR
<img width="450" alt="screen shot 2017-08-31 at 5 43 41 pm" src="https://user-images.githubusercontent.com/18511177/29922792-cd05311a-8e74-11e7-9a37-dd343c6c3812.png">
<img width="450" alt="screen shot 2017-08-31 at 5 43 53 pm" src="https://user-images.githubusercontent.com/18511177/29922796-cd717776-8e74-11e7-92e9-e24580b30379.png">
<img width="445" alt="screen shot 2017-08-31 at 5 44 18 pm" src="https://user-images.githubusercontent.com/18511177/29922797-cd724b38-8e74-11e7-8d52-879d7434f34e.png">
<img width="450" alt="screen shot 2017-08-31 at 5 44 40 pm" src="https://user-images.githubusercontent.com/18511177/29922794-cd70d62c-8e74-11e7-9af5-86fc5476a28a.png">
<img width="448" alt="screen shot 2017-08-31 at 5 44 54 pm" src="https://user-images.githubusercontent.com/18511177/29922798-cd73b130-8e74-11e7-9260-642072cca207.png">
<img width="448" alt="screen shot 2017-08-31 at 5 45 26 pm" src="https://user-images.githubusercontent.com/18511177/29922795-cd70d4b0-8e74-11e7-8ec1-c7ee3259b779.png">
<img width="446" alt="screen shot 2017-08-31 at 5 46 09 pm" src="https://user-images.githubusercontent.com/18511177/29922793-cd43a88c-8e74-11e7-9bf1-2a9707c8cc62.png">
<img width="447" alt="screen shot 2017-08-31 at 5 46 21 pm" src="https://user-images.githubusercontent.com/18511177/29922799-cd812f9a-8e74-11e7-9de6-9d718c1dbc2b.png">
