### PR TITLE
Improve autocomplete

### DIFF
--- a/src/autocomplete/EmojiAutocomplete.js
+++ b/src/autocomplete/EmojiAutocomplete.js
@@ -1,8 +1,8 @@
 /* @flow */
 import React, { PureComponent } from 'react';
 import { FlatList } from 'react-native';
-import { connect } from 'react-redux';
 
+import connectWithActions from '../connectWithActions';
 import { Popup } from '../common';
 import EmojiRow from '../emoji/EmojiRow';
 import getFilteredEmojiList from '../emoji/getFilteredEmojiList';
@@ -44,6 +44,6 @@ class EmojiAutocomplete extends PureComponent<Props> {
   }
 }
 
-export default connect((state: GlobalState) => ({
+export default connectWithActions((state: GlobalState) => ({
   realmEmoji: getRealmEmoji(state),
 }))(EmojiAutocomplete);

--- a/src/autocomplete/EmojiAutocomplete.js
+++ b/src/autocomplete/EmojiAutocomplete.js
@@ -1,22 +1,26 @@
 /* @flow */
 import React, { PureComponent } from 'react';
 import { FlatList } from 'react-native';
+import { connect } from 'react-redux';
 
 import { Popup } from '../common';
 import EmojiRow from '../emoji/EmojiRow';
 import getFilteredEmojiList from '../emoji/getFilteredEmojiList';
+import type { GlobalState, RealmEmojiType } from '../types';
+import { getRealmEmoji } from '../selectors';
 
 type Props = {
   filter: string,
+  realmEmoji: RealmEmojiType,
   onAutocomplete: (name: string) => void,
 };
 
-export default class EmojiAutocomplete extends PureComponent<Props> {
+class EmojiAutocomplete extends PureComponent<Props> {
   props: Props;
 
   render() {
-    const { filter, onAutocomplete } = this.props;
-    const emojis = getFilteredEmojiList(filter);
+    const { filter, realmEmoji, onAutocomplete } = this.props;
+    const emojis = getFilteredEmojiList(filter, realmEmoji);
 
     if (emojis.length === 0) return null;
 
@@ -27,9 +31,19 @@ export default class EmojiAutocomplete extends PureComponent<Props> {
           initialNumToRender={12}
           data={emojis}
           keyExtractor={item => item}
-          renderItem={({ item }) => <EmojiRow name={item} onPress={() => onAutocomplete(item)} />}
+          renderItem={({ item }) => (
+            <EmojiRow
+              realmEmoji={realmEmoji[item]}
+              name={item}
+              onPress={() => onAutocomplete(item)}
+            />
+          )}
         />
       </Popup>
     );
   }
 }
+
+export default connect((state: GlobalState) => ({
+  realmEmoji: getRealmEmoji(state),
+}))(EmojiAutocomplete);

--- a/src/baseSelectors.js
+++ b/src/baseSelectors.js
@@ -1,56 +1,11 @@
 /* @flow */
-<<<<<<< HEAD
 import { createSelector } from 'reselect';
-=======
-import type { GlobalState, Narrow, Message, Subscription, Stream, Presence, Outbox, RealmEmojiType } from './types';
->>>>>>> Show realm emojis in autocomplete.
 
 import { allPrivateNarrowStr } from './utils/narrow';
 import { getAllMessages } from './directSelectors';
 import { NULL_ARRAY } from './nullObjects';
 
-<<<<<<< HEAD
 export const getPrivateMessages = createSelector(
   getAllMessages,
   messages => messages[allPrivateNarrowStr] || NULL_ARRAY,
 );
-=======
-export const getDrafts = (state: GlobalState): Object => state.drafts;
-
-export const getMute = (state: GlobalState): Object => state.mute;
-
-export const getTyping = (state: GlobalState): Object => state.typing;
-
-export const getUsers = (state: GlobalState): any[] => state.users;
-
-export const getFetching = (state: GlobalState): Object => state.fetching;
-
-export const getFlags = (state: GlobalState): Object => state.flags;
-
-export const getReadFlags = (state: GlobalState): Object => state.flags.read;
-
-export const getAllMessages = (state: GlobalState): Message[] => state.chat.messages;
-
-export const getActiveNarrow = (state: GlobalState): Narrow => state.chat.narrow;
-
-export const getSubscriptions = (state: GlobalState): Subscription[] => state.subscriptions;
-
-export const getStreams = (state: GlobalState): Stream[] => state.streams;
-
-export const getPresence = (state: GlobalState): Presence[] => state.presence;
-
-export const getOutbox = (state: GlobalState): Outbox[] => state.outbox;
-
-export const getActiveNarrowString = (state: GlobalState): string =>
-  JSON.stringify(state.chat.narrow);
-
-export const getUnreadStreams = (state: GlobalState): Object[] => state.unread.streams;
-
-export const getUnreadPms = (state: GlobalState): Object[] => state.unread.pms;
-
-export const getUnreadHuddles = (state: GlobalState): Object[] => state.unread.huddles;
-
-export const getUnreadMentions = (state: GlobalState): number[] => state.unread.mentions;
-
-export const getRealmEmoji = (state: GlobalState): RealmEmojiType[] => state.realm.emoji;
->>>>>>> Show realm emojis in autocomplete.

--- a/src/baseSelectors.js
+++ b/src/baseSelectors.js
@@ -1,11 +1,56 @@
 /* @flow */
+<<<<<<< HEAD
 import { createSelector } from 'reselect';
+=======
+import type { GlobalState, Narrow, Message, Subscription, Stream, Presence, Outbox, RealmEmojiType } from './types';
+>>>>>>> Show realm emojis in autocomplete.
 
 import { allPrivateNarrowStr } from './utils/narrow';
 import { getAllMessages } from './directSelectors';
 import { NULL_ARRAY } from './nullObjects';
 
+<<<<<<< HEAD
 export const getPrivateMessages = createSelector(
   getAllMessages,
   messages => messages[allPrivateNarrowStr] || NULL_ARRAY,
 );
+=======
+export const getDrafts = (state: GlobalState): Object => state.drafts;
+
+export const getMute = (state: GlobalState): Object => state.mute;
+
+export const getTyping = (state: GlobalState): Object => state.typing;
+
+export const getUsers = (state: GlobalState): any[] => state.users;
+
+export const getFetching = (state: GlobalState): Object => state.fetching;
+
+export const getFlags = (state: GlobalState): Object => state.flags;
+
+export const getReadFlags = (state: GlobalState): Object => state.flags.read;
+
+export const getAllMessages = (state: GlobalState): Message[] => state.chat.messages;
+
+export const getActiveNarrow = (state: GlobalState): Narrow => state.chat.narrow;
+
+export const getSubscriptions = (state: GlobalState): Subscription[] => state.subscriptions;
+
+export const getStreams = (state: GlobalState): Stream[] => state.streams;
+
+export const getPresence = (state: GlobalState): Presence[] => state.presence;
+
+export const getOutbox = (state: GlobalState): Outbox[] => state.outbox;
+
+export const getActiveNarrowString = (state: GlobalState): string =>
+  JSON.stringify(state.chat.narrow);
+
+export const getUnreadStreams = (state: GlobalState): Object[] => state.unread.streams;
+
+export const getUnreadPms = (state: GlobalState): Object[] => state.unread.pms;
+
+export const getUnreadHuddles = (state: GlobalState): Object[] => state.unread.huddles;
+
+export const getUnreadMentions = (state: GlobalState): number[] => state.unread.mentions;
+
+export const getRealmEmoji = (state: GlobalState): RealmEmojiType[] => state.realm.emoji;
+>>>>>>> Show realm emojis in autocomplete.

--- a/src/common/Popup.js
+++ b/src/common/Popup.js
@@ -7,14 +7,10 @@ const styles = StyleSheet.create({
   popup: {
     marginLeft: 20,
     marginRight: 20,
+    margin: 2,
     borderRadius: 5,
-    shadowOffset: {
-      width: 0,
-      height: 0,
-    },
-    shadowRadius: 10,
     shadowOpacity: 0.25,
-    elevation: 5,
+    elevation: 3,
   },
 });
 

--- a/src/common/Popup.js
+++ b/src/common/Popup.js
@@ -14,6 +14,7 @@ const styles = StyleSheet.create({
     },
     shadowRadius: 10,
     shadowOpacity: 0.25,
+    elevation: 5,
   },
 });
 

--- a/src/directSelectors.js
+++ b/src/directSelectors.js
@@ -6,6 +6,7 @@ import type {
   TopicsState,
   GlobalState,
   Narrow,
+  RealmEmojiType,
   Subscription,
   Stream,
   Outbox,
@@ -52,3 +53,5 @@ export const getUnreadPms = (state: GlobalState): Object[] => state.unread.pms;
 export const getUnreadHuddles = (state: GlobalState): Object[] => state.unread.huddles;
 
 export const getUnreadMentions = (state: GlobalState): number[] => state.unread.mentions;
+
+export const getRealmEmoji = (state: GlobalState): RealmEmojiType[] => state.realm.emoji;

--- a/src/emoji/EmojiRow.js
+++ b/src/emoji/EmojiRow.js
@@ -10,7 +10,7 @@ import type { RealmEmojiType } from '../types';
 const styles = StyleSheet.create({
   emojiRow: {
     flexDirection: 'row',
-    padding: 2,
+    padding: 8,
     alignItems: 'center',
   },
   text: {

--- a/src/emoji/EmojiRow.js
+++ b/src/emoji/EmojiRow.js
@@ -4,6 +4,8 @@ import { StyleSheet, View } from 'react-native';
 
 import { RawLabel, Touchable } from '../common';
 import Emoji from '../emoji/Emoji';
+import RealmEmoji from './RealmEmoji';
+import type { RealmEmojiType } from '../types';
 
 const styles = StyleSheet.create({
   emojiRow: {
@@ -18,6 +20,7 @@ const styles = StyleSheet.create({
 
 type Props = {
   name: string,
+  realmEmoji: RealmEmojiType,
   onPress: () => void,
 };
 
@@ -25,11 +28,12 @@ export default class EmojiRow extends Component<Props> {
   props: Props;
 
   render() {
-    const { name, onPress } = this.props;
+    const { name, realmEmoji, onPress } = this.props;
+
     return (
       <Touchable onPress={onPress}>
         <View style={styles.emojiRow}>
-          <Emoji name={name} size={20} />
+          {realmEmoji ? <RealmEmoji name={name} /> : <Emoji name={name} size={20} />}
           <RawLabel style={styles.text} text={name} />
         </View>
       </Touchable>

--- a/src/emoji/__tests__/getFilteredEmojiList-test.js
+++ b/src/emoji/__tests__/getFilteredEmojiList-test.js
@@ -2,17 +2,32 @@ import getFilteredEmojiList from '../getFilteredEmojiList';
 
 describe('getFilteredEmojiList', () => {
   test('empty query returns all emojis', () => {
-    const list = getFilteredEmojiList('');
+    const list = getFilteredEmojiList('', {});
     expect(list.length).toEqual(1391);
   });
 
   test('non existing query returns empty list', () => {
-    const list = getFilteredEmojiList('qwerty');
+    const list = getFilteredEmojiList('qwerty', {});
     expect(list.length).toEqual(0);
   });
 
   test('returns a sorted list of emojis starting with query', () => {
-    const list = getFilteredEmojiList('go');
+    const list = getFilteredEmojiList('go', {});
     expect(list).toEqual(['goat', 'goblin', 'golf', 'golfer']);
+  });
+
+  test('search in realm emojis as well', () => {
+    const list = getFilteredEmojiList('don', { 'done': { source_url: '/user_avatars/2/emoji/done.png' } });
+    expect(list).toEqual(['done']);
+  });
+
+  test('remove duplicates', () => {
+    const list = getFilteredEmojiList('dog', { 'dog': { source_url: '/user_avatars/2/emoji/dog.png' } });
+    expect(list).toEqual(['dog', 'dog2', 'dog_face']);
+  });
+
+  test('return realm emojis which includes filter ', () => {
+    const list = getFilteredEmojiList('all', { 'small': { source_url: '/user_avatars/2/emoji/small.png' } });
+    expect(list).toEqual(['small']);
   });
 });

--- a/src/emoji/getFilteredEmojiList.js
+++ b/src/emoji/getFilteredEmojiList.js
@@ -1,7 +1,9 @@
 /* @flow */
 import emojiMap from './emojiMap';
+import type { RealmEmoji } from '../types';
 
-export default (query: string) =>
-  Object.keys(emojiMap)
+export default (query: string, realmEmoji: RealmEmoji) =>
+  Array.from(new Set([...Object.keys(emojiMap)
     .filter(x => x.indexOf(query) === 0)
-    .sort();
+    .sort(), ...Object.keys(realmEmoji).filter(emoji => emoji.startsWith(query)),
+    ...Object.keys(realmEmoji).filter(emoji => emoji.includes(query))]));

--- a/src/types.js
+++ b/src/types.js
@@ -384,6 +384,16 @@ export type MatchResult = Array<string> & { index: number, input: string };
 
 export type GetState = () => GlobalState;
 
+export type RealmEmojiType = {
+  author: {
+    email: string,
+    full_name: string,
+    id: number,
+  },
+  deactivated: boolean,
+  source_url: string,
+};
+
 export type ReactionType = {
   emoji_name: string,
   name: string,


### PR DESCRIPTION
- Fix: Autocomplete shodows not visible on Android.
- Show realm emojis in autocomplete.
- Show all items even if filter length is 0.
  - This gives an idea what's the use of @, :, # keywoards.
  - FB messenger, Slack, Whatsapp all have this.

Before
<img width="398" alt="screen shot 2017-09-07 at 11 41 01 am" src="https://user-images.githubusercontent.com/18511177/30148601-d61481b4-93c1-11e7-8ece-3757424dfd05.png">


After
<img width="398" alt="screen shot 2017-09-07 at 11 38 43 am" src="https://user-images.githubusercontent.com/18511177/30148600-d5adf048-93c1-11e7-8ff5-1b472ab9eb10.png">
