### PR TITLE
Rework ComposeMenu to have menu construction like message action sheet

### DIFF
--- a/src/compose/ComposeMenu.js
+++ b/src/compose/ComposeMenu.js
@@ -4,6 +4,7 @@ import { StyleSheet } from 'react-native';
 
 import { Touchable } from '../common';
 import { IconPlus } from '../common/Icons';
+import { executeActionSheetAction, constructActionButtons } from './composeActionSheet';
 
 const componentStyles = StyleSheet.create({
   touchable: {},
@@ -15,29 +16,23 @@ const componentStyles = StyleSheet.create({
 
 export default class ComposeMenu extends React.Component {
   handlePress = () => {
+    const { narrow } = this.props;
+    const options = constructActionButtons({
+      narrow,
+    });
+    const callback = buttonIndex => {
+      executeActionSheetAction({
+        title: options[buttonIndex],
+        actions: this.props.actions,
+      });
+    };
+
     this.props.showActionSheetWithOptions(
       {
-        options: ['Toggle compose tools', 'Create group', 'Cancel'],
-        cancelButtonIndex: 2,
+        options,
+        cancelButtonIndex: options.length - 1,
       },
-      buttonIndex => {
-        switch (buttonIndex) {
-          case 0: {
-            const { actions } = this.props;
-            actions.toggleComposeTools();
-            break;
-          }
-
-          case 1: {
-            const { actions } = this.props;
-            actions.navigateToCreateGroup();
-            break;
-          }
-
-          default:
-            break;
-        }
-      },
+      callback,
     );
   };
 

--- a/src/compose/ComposeMenuContainer.js
+++ b/src/compose/ComposeMenuContainer.js
@@ -6,6 +6,7 @@ import { connectActionSheet } from '@expo/react-native-action-sheet';
 
 import boundActions from '../boundActions';
 import ComposeMenu from './ComposeMenu';
+import { getActiveNarrow } from '../selectors';
 
 const ConnectedComposeMenu = connectActionSheet(ComposeMenu);
 
@@ -15,7 +16,12 @@ const componentStyles = StyleSheet.create({
   },
 });
 
-export default connect(null, boundActions)(props => (
+export default connect(
+  state => ({
+    narrow: getActiveNarrow(state),
+  }),
+  boundActions,
+)(props => (
   <View style={componentStyles.wrapper}>
     <ConnectedComposeMenu {...props} />
   </View>

--- a/src/compose/composeActionSheet.js
+++ b/src/compose/composeActionSheet.js
@@ -1,5 +1,5 @@
 /* @flow */
-import type { Actions } from '../types';
+import type { Actions, ActionSheetButtonType } from '../types';
 import { isStreamNarrow } from '../utils/narrow';
 
 type ConstructActionButtonsType = {
@@ -11,7 +11,7 @@ type ExecuteActionSheetParams = {
   actions: Actions,
 };
 
-const actionSheetButtons: ButtonType[] = [
+const actionSheetButtons: ActionSheetButtonType[] = [
   {
     title: 'Toggle compose tools',
     onPress: ({ actions }) => actions.toggleComposeTools(),

--- a/src/compose/composeActionSheet.js
+++ b/src/compose/composeActionSheet.js
@@ -1,0 +1,40 @@
+/* @flow */
+import type { Actions } from '../types';
+import { isStreamNarrow } from '../utils/narrow';
+
+type ConstructActionButtonsType = {
+  narrow: [],
+};
+
+type ExecuteActionSheetParams = {
+  title: string,
+  actions: Actions,
+};
+
+const actionSheetButtons: ButtonType[] = [
+  {
+    title: 'Toggle compose tools',
+    onPress: ({ actions }) => actions.toggleComposeTools(),
+    onlyIf: isStreamNarrow,
+  },
+  {
+    title: 'Create group',
+    onPress: ({ actions }) => {
+      actions.navigateToCreateGroup();
+    },
+  },
+];
+
+export const constructActionButtons = ({ narrow }: ConstructActionButtonsType) => {
+  const buttons = actionSheetButtons.filter(x => !x.onlyIf || x.onlyIf(narrow)).map(x => x.title);
+
+  buttons.push('Cancel');
+  return buttons;
+};
+
+export const executeActionSheetAction = ({ title, ...props }: ExecuteActionSheetParams) => {
+  const button = actionSheetButtons.find(x => x.title === title);
+  if (button) {
+    button.onPress(props);
+  }
+};

--- a/src/message/messageActionSheet.js
+++ b/src/message/messageActionSheet.js
@@ -1,6 +1,6 @@
 /* @flow */
 import { Clipboard, Share } from 'react-native';
-import type { Actions, Auth, Message } from '../types';
+import type { Actions, Auth, Message, ActionSheetButtonType } from '../types';
 import { narrowFromMessage, isHomeNarrow, isStreamNarrow, isSpecialNarrow } from '../utils/narrow';
 import { getSingleMessage } from '../api';
 import { isTopicMuted } from '../utils/message';
@@ -166,12 +166,6 @@ const shareMessage = ({ message }) => {
 
 const skip = () => false;
 
-type ButtonType = {
-  title: string,
-  onPress: (props: ButtonProps) => void | boolean | Promise<any>,
-  onlyIf?: (props: AuthMessageAndNarrow) => boolean,
-};
-
 type HeaderButtonType = {
   title: string,
   onPress: (props: ButtonProps) => void | boolean | Promise<any>,
@@ -184,7 +178,7 @@ const resolveMultiple = (message, auth, narrow, functions) =>
     return true;
   });
 
-const actionSheetButtons: ButtonType[] = [
+const actionSheetButtons: ActionSheetButtonType[] = [
   { title: 'Reply', onPress: reply, onlyIf: isSentMessage },
   { title: 'Copy to clipboard', onPress: copyToClipboard },
   { title: 'Share', onPress: shareMessage },

--- a/src/types.js
+++ b/src/types.js
@@ -445,3 +445,9 @@ export type AuthenticationMethods = {
 export type ServerSettings = {
   auth_methods: AuthenticationMethods,
 };
+
+export type ActionSheetButtonType = {
+  title: string,
+  onPress: (props: ButtonProps) => void | boolean | Promise<any>,
+  onlyIf?: (props: AuthMessageAndNarrow) => boolean,
+};


### PR DESCRIPTION
It changes the menu construction & hides the 'Toggle compose tools' in the topic narrow