### PR TITLE
Fix: Dev auth screen crashing on handleDevAuth()

### DIFF
--- a/src/nav/navReducers.js
+++ b/src/nav/navReducers.js
@@ -26,9 +26,10 @@ export default (
     case ACCOUNT_SWITCH:
       return getStateForRoute(getInitialRoute(state));
 
-    case SET_AUTH_TYPE:
+    case SET_AUTH_TYPE: {
+      if (action.authType === 'dev') return null;
       return AppNavigator.router.getStateForAction(navigateToAuth(action.serverSettings), state);
-
+    }
     case LOGIN_SUCCESS:
     case INITIAL_FETCH_COMPLETE:
       return getStateForRoute('main');

--- a/src/start/AuthScreen.js
+++ b/src/start/AuthScreen.js
@@ -3,7 +3,7 @@ import React, { PureComponent } from 'react';
 import { View, Image, StyleSheet } from 'react-native';
 import { connect } from 'react-redux';
 
-import { Action } from '../types';
+import { Action, Actions } from '../types';
 import boundActions from '../boundActions';
 import { RawLabel, Screen, ZulipButton } from '../common';
 import { getCurrentRealm } from '../selectors';
@@ -37,13 +37,12 @@ class AuthScreen extends PureComponent {
     setAuthType: Action,
     navigation: Object,
     navigateToDev: () => void,
+    actions: Actions,
   };
 
   handleDevAuth = () => {
-    const { setAuthType, navigateToDev } = this.props;
-
-    setAuthType('dev');
-    navigateToDev();
+    this.props.actions.setAuthType('dev');
+    this.props.actions.navigateToDev();
   };
 
   render() {

--- a/src/start/DevAuthScreen.js
+++ b/src/start/DevAuthScreen.js
@@ -71,7 +71,7 @@ class DevAuthScreen extends PureComponent {
     const { directAdmins, directUsers, error } = this.state;
 
     return (
-      <Screen title="Pick a dev account">
+      <Screen title="Pick a dev account" padding>
         <View style={styles.container}>
           {error && <ErrorMsg error={error} />}
           <Text style={[styles.field, styles.heading2]}>Administrators</Text>

--- a/src/types.js
+++ b/src/types.js
@@ -187,6 +187,16 @@ export type EditMessage = {
 
 export type Action = Object;
 
+export type AuthenticationMethods = {
+  dev: boolean,
+  github: boolean,
+  google: boolean,
+  password: boolean,
+};
+export type ServerSettings = {
+  auth_methods: AuthenticationMethods,
+};
+
 export type Actions = {
   appOnline: (isOnline: boolean) => Action,
   addToOutbox: (
@@ -224,7 +234,7 @@ export type Actions = {
   navigateToUsersScreen: () => Action,
   navigateToSearch: () => Action,
   navigateToSettings: () => Action,
-  navigateToAuth: (authType: string) => Action,
+  navigateToAuth: (serverSettings: ServerSettings) => Action,
   navigateToAccountPicker: () => Action,
   navigateToAccountDetails: (email: string) => Action,
   navigateToGroupDetails: (recipients: UserType) => Action,
@@ -434,17 +444,6 @@ export type TimingItem = {
 };
 
 export type Reducer = (state: GlobalState, action: Action) => GlobalState;
-
-export type AuthenticationMethods = {
-  dev: boolean,
-  github: boolean,
-  google: boolean,
-  password: boolean,
-};
-
-export type ServerSettings = {
-  auth_methods: AuthenticationMethods,
-};
 
 export type ActionSheetButtonType = {
   title: string,


### PR DESCRIPTION
I don't understand why `setAuthType` is required which was causing the bug! 

Still the in the dev auth screen the text Administrators & Normal users are not visible which I think is because of KeyboardAvoidingView doesn't detect any TextInput so no padding is added and the Administrators text is going under the toolbar in iOS (Not sure if this 100% true) 