### PR TITLE
Fix: LoadingIndicator spin is not being shown on Android.

### DIFF
--- a/src/common/LoadingIndicator.js
+++ b/src/common/LoadingIndicator.js
@@ -18,8 +18,8 @@ const styles = StyleSheet.create({
   semiCircle: {
     alignSelf: 'center',
     borderColor: 'black',
-    borderTopWidth: 1,
-    borderLeftWidth: 1,
+    borderStyle: 'dashed',
+    borderWidth: 2,
     borderRadius: 100,
   },
   logo: {


### PR DESCRIPTION
Problem is we cannot use `borderTopWidth` and `borderRadius` at the same time on Android.
If we are using  `borderTopWidth` then `borderRadius` should be 0 in order to make border visible.

![ezgif com-video-to-gif-4](https://user-images.githubusercontent.com/18511177/30687362-a60a72ae-9ed8-11e7-9680-8c2ab514532a.gif)
