### PR TITLE
Fix: code block aren't rendered properly.

### DIFF
--- a/src/html/HtmlNodeTag.js
+++ b/src/html/HtmlNodeTag.js
@@ -12,6 +12,7 @@ import textStylesFromClass from './textStylesFromClass';
 import HtmlTagSpan from './tags/HtmlTagSpan';
 import HtmlTagSpanMention from './tags/HtmlTagSpanMention';
 import HtmlTagA from './tags/HtmlTagA';
+import HtmlTagDiv from './tags/HtmlTagDiv';
 import HtmlTagLi from './tags/HtmlTagLi';
 import HtmlTagImg from './tags/HtmlTagImg';
 import HtmlTagPre from './tags/HtmlTagPre';
@@ -32,6 +33,7 @@ const specialTags = {
   b: HtmlTagStrong,
   em: HtmlTagItalic,
   i: HtmlTagItalic,
+  div: HtmlTagDiv,
 };
 
 const stylesFromClassNames = (classNames: SupportedHtmlClasses = '', styleObj) =>


### PR DESCRIPTION
Before
<img width="323" alt="screen shot 2017-09-23 at 9 13 22 am" src="https://user-images.githubusercontent.com/18511177/30769899-3f3786e8-a040-11e7-9462-f7563c30468b.png">

After
<img width="327" alt="screen shot 2017-09-23 at 9 13 02 am" src="https://user-images.githubusercontent.com/18511177/30769900-3f685fa2-a040-11e7-8507-ca754135f7b4.png">
