### PR TITLE
Navigate to Account picker screen after logout

### DIFF
--- a/src/account-info/LogoutButton.js
+++ b/src/account-info/LogoutButton.js
@@ -41,9 +41,6 @@ class LogoutButton extends PureComponent {
     const { accounts, actions } = this.props;
     this.shutdownPUSH();
     actions.logout(accounts);
-    const accountsLoggedOut = accounts.slice();
-    accountsLoggedOut[0].apiKey = '';
-    actions.resetNavigation();
   };
 
   render() {


### PR DESCRIPTION
Changing the state with `actions.logout()` & calling `actions.resetNavigation()` was returning undefined accounts in getInitialRoute, hence even if more than 1 account the app was navigating to RealmScreen

And the code isn't required and will now navigation to account picker screen! 