### PR TITLE
Fix: Don't count muted streams/topics in unread notice

### DIFF
--- a/src/message/__tests__/__snapshots__/fetchActions-test.js.snap
+++ b/src/message/__tests__/__snapshots__/fetchActions-test.js.snap
@@ -61,8 +61,8 @@ exports[`fetchActions fetchMessagesAtFirstUnread message fetch start action is d
 Array [
   Object {
     "narrow": Array [],
-    "numAfter": 10,
-    "numBefore": 10,
+    "numAfter": 0,
+    "numBefore": 20,
     "type": "MESSAGE_FETCH_START",
   },
 ]

--- a/src/message/__tests__/__snapshots__/messageActions-test.js.snap
+++ b/src/message/__tests__/__snapshots__/messageActions-test.js.snap
@@ -32,8 +32,8 @@ Array [
         "operator": "stream",
       },
     ],
-    "numAfter": 10,
-    "numBefore": 10,
+    "numAfter": 0,
+    "numBefore": 20,
     "type": "MESSAGE_FETCH_START",
   },
 ]
@@ -57,8 +57,8 @@ Array [
         "operator": "stream",
       },
     ],
-    "numAfter": 10,
-    "numBefore": 10,
+    "numAfter": 0,
+    "numBefore": 20,
     "type": "MESSAGE_FETCH_START",
   },
 ]

--- a/src/unread/__tests__/unreadSelectors-test.js
+++ b/src/unread/__tests__/unreadSelectors-test.js
@@ -88,6 +88,8 @@ describe('getUnreadStreamTotal', () => {
       unread: {
         streams: [],
       },
+      subscriptions: [],
+      mute: [],
     });
 
     const unreadCount = getUnreadStreamTotal(state);
@@ -100,6 +102,21 @@ describe('getUnreadStreamTotal', () => {
       unread: {
         streams: unreadStreamData,
       },
+      subscriptions: [
+        {
+          stream_id: 0,
+          in_home_view: true,
+        },
+        {
+          stream_id: 0,
+          in_home_view: true,
+        },
+        {
+          stream_id: 2,
+          in_home_view: true,
+        },
+      ],
+      mute: [],
     });
 
     const unreadCount = getUnreadStreamTotal(state);
@@ -235,6 +252,8 @@ describe('getUnreadTotal', () => {
         huddles: [],
         mentions: [],
       },
+      subscriptions: [],
+      mute: [],
     });
 
     const unreadCount = getUnreadTotal(state);
@@ -250,6 +269,21 @@ describe('getUnreadTotal', () => {
         huddles: unreadHuddlesData,
         mentions: unreadMentionsData,
       },
+      subscriptions: [
+        {
+          stream_id: 0,
+          in_home_view: true,
+        },
+        {
+          stream_id: 0,
+          in_home_view: true,
+        },
+        {
+          stream_id: 2,
+          in_home_view: true,
+        },
+      ],
+      mute: [],
     });
 
     const unreadCount = getUnreadTotal(state);

--- a/src/unread/unreadSelectors.js
+++ b/src/unread/unreadSelectors.js
@@ -17,6 +17,7 @@ import { getOwnEmail } from '../account/accountSelectors';
 import { getPrivateMessages } from '../baseSelectors';
 import { getSubscriptionsById } from '../subscriptions/subscriptionSelectors';
 import { countUnread } from '../utils/unread';
+import { isTopicMuted } from '../utils/message';
 import {
   isHomeNarrow,
   isStreamNarrow,
@@ -33,8 +34,19 @@ export const getUnreadByStream = createSelector(getUnreadStreams, unreadStreams 
   }, {}),
 );
 
-export const getUnreadStreamTotal = createSelector(getUnreadStreams, unreadStreams =>
-  unreadStreams.reduce((total, stream) => total + stream.unread_message_ids.length, 0),
+export const getUnreadStreamTotal = createSelector(
+  getUnreadStreams,
+  getSubscriptionsById,
+  getMute,
+  (unreadStreams, subscriptionsById, mute) =>
+    unreadStreams.reduce(
+      (total, stream) =>
+        !subscriptionsById[stream.stream_id].in_home_view ||
+        isTopicMuted(subscriptionsById[stream.stream_id].name, stream.topic, mute)
+          ? total
+          : total + stream.unread_message_ids.length,
+      0,
+    ),
 );
 
 export const getUnreadByPms = createSelector(getUnreadPms, unreadPms =>


### PR DESCRIPTION
Now it matches the unread counts shown by Zulip app/website.