### PR TITLE
Removed sticky header from userList as they are not stable on scroll.

### DIFF
--- a/src/users/UserList.js
+++ b/src/users/UserList.js
@@ -50,7 +50,6 @@ export default class UserList extends PureComponent {
     return (
       <SectionList
         style={[styles.list, style]}
-        stickySectionHeadersEnabled
         keyboardShouldPersistTaps="always"
         initialNumToRender={20}
         sections={sections}


### PR DESCRIPTION
Tested on latest beta 2.1.33

We can enable in RN0.48 or so, if it gets stable.