### PR TITLE
Fix: Narrow to correct sender on notification press

### DIFF
--- a/android/app/src/main/java/com/zulipmobile/notifications/GCMPushNotifications.java
+++ b/android/app/src/main/java/com/zulipmobile/notifications/GCMPushNotifications.java
@@ -15,6 +15,7 @@ import android.util.Pair;
 
 import com.wix.reactnativenotifications.core.AppLaunchHelper;
 import com.wix.reactnativenotifications.core.AppLifecycleFacade;
+import com.wix.reactnativenotifications.core.InitialNotificationHolder;
 import com.wix.reactnativenotifications.core.JsIOHelper;
 import com.wix.reactnativenotifications.core.ProxyService;
 import com.wix.reactnativenotifications.core.notification.PushNotification;
@@ -60,6 +61,11 @@ public class GCMPushNotifications extends PushNotification {
 
     @Override
     public void onOpened() {
+        try {
+            InitialNotificationHolder.getInstance().set(getProps());
+        } catch (Exception e) {
+            Log.e("PendingNotif error", e.toString());
+        }
         super.onOpened();
         clearConversations(conversations);
         try {

--- a/src/boot/AppEventHandlers.js
+++ b/src/boot/AppEventHandlers.js
@@ -43,7 +43,12 @@ class AppEventHandlers extends PureComponent {
     const { auth, actions, needsInitialFetch } = this.props;
     registerAppActivity(auth, state === 'active');
     actions.appState(state === 'active');
-    if (state === 'active' && Platform.OS === 'android' && !needsInitialFetch) {
+    if (
+      state === 'active' &&
+      Platform.OS === 'android' &&
+      !needsInitialFetch &&
+      auth.realm !== ''
+    ) {
       handlePendingNotifications(actions.doNarrow);
     }
   };

--- a/src/boot/AppEventHandlers.js
+++ b/src/boot/AppEventHandlers.js
@@ -1,6 +1,6 @@
 /* @flow */
 import React, { PureComponent } from 'react';
-import { AppState, BackHandler, NetInfo, View } from 'react-native';
+import { AppState, BackHandler, NetInfo, View, Platform } from 'react-native';
 import { connect } from 'react-redux';
 import SafeArea from 'react-native-safe-area';
 
@@ -8,6 +8,7 @@ import { Auth, Actions } from '../types';
 import boundActions from '../boundActions';
 import { getAuth, getNavigationIndex } from '../selectors';
 import { registerAppActivity } from '../utils/activity';
+import { handlePendingNotifications } from '../utils/notifications';
 
 type Props = {
   auth: Auth,
@@ -39,9 +40,12 @@ class AppEventHandlers extends PureComponent {
   };
 
   handleAppStateChange = state => {
-    const { auth, actions } = this.props;
+    const { auth, actions, needsInitialFetch } = this.props;
     registerAppActivity(auth, state === 'active');
     actions.appState(state === 'active');
+    if (state === 'active' && Platform.OS === 'android' && !needsInitialFetch) {
+      handlePendingNotifications(actions.doNarrow);
+    }
   };
 
   handleBackButtonPress = () => {

--- a/src/utils/notifications.android.js
+++ b/src/utils/notifications.android.js
@@ -6,7 +6,7 @@ import { streamNarrow, privateNarrow } from '../utils/narrow';
 import type { Auth } from '../types';
 import { logErrorRemotely } from '../utils/logging';
 
-const handlePendingNotifications = async switchNarrow => {
+export const handlePendingNotifications = async switchNarrow => {
   const notification = await PendingNotifications.getInitialNotification();
   if (notification) {
     const data = notification.getData();


### PR DESCRIPTION
Crashing when application in dead state occasionally, but working perfect if app in background