### PR TITLE
Fix: message not mark as read in Android.

### DIFF
--- a/android/app/src/main/java/com/zulipmobile/AnchorScrollView.java
+++ b/android/app/src/main/java/com/zulipmobile/AnchorScrollView.java
@@ -154,7 +154,7 @@ public class AnchorScrollView extends ScrollView implements ReactClippingViewGro
                         }
 
                         findAnchorView();
-                        AnchorScrollViewHelper.emitScrollEvent(scrollView, null);
+                        AnchorScrollViewHelper.emitScrollEvent(scrollView, getVisibleIds());
                     }
                 }
             };


### PR DESCRIPTION
Fix: visibles id's not being send from AnchorScrollView.

Sorry, at that time I was only focussed no scroll events, forgot about visible id's.