### PR TITLE
[Android] Limit touchable area of avatars in message list.

### DIFF
--- a/src/common/ImageAvatar.js
+++ b/src/common/ImageAvatar.js
@@ -1,6 +1,6 @@
 /* @flow */
 import React, { PureComponent } from 'react';
-import { ImageBackground } from 'react-native';
+import { ImageBackground, View } from 'react-native';
 
 import { nullFunction } from '../nullObjects';
 import { Touchable } from './';
@@ -31,16 +31,18 @@ export default class ImageAvatar extends PureComponent<Props> {
       shape === 'rounded' ? size / 8 : shape === 'circle' ? size / 2 : shape === 'square' ? 0 : 0;
 
     return (
-      <Touchable onPress={onPress} style={touchableStyle}>
-        <ImageBackground
-          style={touchableStyle}
-          source={{ uri: avatarUrl }}
-          resizeMode="cover"
-          borderRadius={borderRadius}
-        >
-          {children}
-        </ImageBackground>
-      </Touchable>
+      <View>
+        <Touchable onPress={onPress} style={touchableStyle}>
+          <ImageBackground
+            style={touchableStyle}
+            source={{ uri: avatarUrl }}
+            resizeMode="cover"
+            borderRadius={borderRadius}
+          >
+            {children}
+          </ImageBackground>
+        </Touchable>
+      </View>
     );
   }
 }


### PR DESCRIPTION
Before
<img width="397" alt="screen shot 2017-10-12 at 9 42 16 am" src="https://user-images.githubusercontent.com/18511177/31479069-7c4ec400-af32-11e7-8e3e-d3b84586260f.png">

After
<img width="396" alt="screen shot 2017-10-12 at 9 29 03 am" src="https://user-images.githubusercontent.com/18511177/31479068-7bba930c-af32-11e7-8698-9fd4fc3bd5a1.png">
