### PR TITLE
[WIP] [Android] Fix: unread count stuck at one on Android.

### DIFF
--- a/android/app/src/main/java/com/zulipmobile/AnchorScrollView.java
+++ b/android/app/src/main/java/com/zulipmobile/AnchorScrollView.java
@@ -417,13 +417,17 @@ public class AnchorScrollView extends ScrollView implements ReactClippingViewGro
 
     // Zulip changes
     private boolean isChildVisible(@Nonnull View child) {
+        //container
         int height = getHeight();
         int containerTop = getScrollY();
         int containerBottom = containerTop + height;
+
+        //child
         int viewTop = child.getTop();
         int viewBottom = child.getBottom();
 
-        return (viewTop >= containerTop && viewBottom <= containerBottom);
+        //check if child is visible or not
+        return (viewTop >= containerTop && viewBottom <= containerBottom) || child.getHeight() >= height;
     }
 
     // Zulip changes


### PR DESCRIPTION
Problem was if message is quite long (not fully visible on screen) then it was not considered as visible child.

Fix: #1291

@kunall17 can you verify when you get some time. :) 

There may be other cases as well, this PR solves one such case. :)