### PR TITLE
Remove duplicate react-native-notifications from settings.gradle

### DIFF
--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,8 +1,6 @@
 rootProject.name = 'ZulipMobile'
 include ':react-native-orientation'
 project(':react-native-orientation').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-orientation/android')
-include ':react-native-notifications'
-project(':react-native-notifications').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-notifications/android')
 include ':react-native-sentry'
 project(':react-native-sentry').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-sentry/android')
 include ':@remobile/react-native-toast'


### PR DESCRIPTION
At line 21 there is already setting for `reactnativenotifications`

https://github.com/wix/react-native-notifications#android-1
