### PR TITLE
Wrap ShortcutBadger as a module to be used in JS

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -174,6 +174,7 @@ dependencies {
     compile "me.leolin:ShortcutBadger:1.1.16@aar"
     compile "com.facebook.react:react-native:+"  // From node_modules
     compile 'com.android.support:customtabs:23.0.1'
+
 }
 
 // Run this once to be able to run the application with BUCK

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -2,6 +2,9 @@
     xmlns:tools="http://schemas.android.com/tools"
     package="com.zulipmobile">
 
+    <permission android:name="com.zulipmobile.permission.C2D_MESSAGE"
+        android:protectionLevel="signature" />
+    <uses-permission android:name="com.zulipmobile.permission.C2D_MESSAGE" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
@@ -12,6 +15,8 @@
         tools:node="remove"/>
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
+
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
 
     <application
       android:name=".MainApplication"
@@ -37,7 +42,16 @@
         </intent-filter>
       </activity>
       <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" />
-       <meta-data android:name="com.wix.reactnativenotifications.gcmSenderId" android:value="835904834568\0"/>
+        <receiver
+            android:name="com.google.android.gms.gcm.GcmReceiver"
+            android:exported="true"
+            android:permission="com.google.android.c2dm.permission.SEND" >
+            <intent-filter>
+                <action android:name="com.google.android.c2dm.intent.RECEIVE" />
+                <category android:name="com.zulipmobile" />
+            </intent-filter>
+        </receiver>
+        <meta-data android:name="com.wix.reactnativenotifications.gcmSenderId" android:value="835904834568\0"/>
     </application>
 
 </manifest>

--- a/android/app/src/main/java/com/zulipmobile/ZulipNativePackage.java
+++ b/android/app/src/main/java/com/zulipmobile/ZulipNativePackage.java
@@ -1,13 +1,12 @@
 package com.zulipmobile;
 
 import com.facebook.react.ReactPackage;
-import com.facebook.react.bridge.JavaScriptModule;
 import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.uimanager.ViewManager;
+import com.zulipmobile.notifications.BadgeCountUpdaterModule;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 public class ZulipNativePackage implements ReactPackage {
@@ -28,6 +27,7 @@ public class ZulipNativePackage implements ReactPackage {
         modules.add(new RNSecureRandom(reactContext));
         modules.add(new CloseAllCustomTabsAndroid(reactContext));
         modules.add(new ShareImageAndroid(reactContext));
+        modules.add(new BadgeCountUpdaterModule(reactContext));
         return modules;
     }
 

--- a/android/app/src/main/java/com/zulipmobile/notifications/BadgeCountUpdaterModule.java
+++ b/android/app/src/main/java/com/zulipmobile/notifications/BadgeCountUpdaterModule.java
@@ -1,0 +1,41 @@
+package com.zulipmobile.notifications;
+
+
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactContextBaseJavaModule;
+import com.facebook.react.bridge.ReactMethod;
+
+import me.leolin.shortcutbadger.ShortcutBadgeException;
+import me.leolin.shortcutbadger.ShortcutBadger;
+
+public class BadgeCountUpdaterModule extends ReactContextBaseJavaModule {
+
+    public BadgeCountUpdaterModule(ReactApplicationContext reactContext) {
+        super(reactContext);
+    }
+
+    @Override
+    public String getName() {
+        return "BadgeCountUpdaterModule";
+    }
+
+
+    @ReactMethod
+    public void setBadgeCount(int number) {
+        if (number == 0) {
+            removeCount();
+        } else {
+            ShortcutBadger.applyCount(this.getReactApplicationContext(), number);
+        }
+    }
+
+    @ReactMethod
+    public void removeCount() {
+        try {
+            ShortcutBadger.removeCountOrThrow(this.getReactApplicationContext());
+        } catch (ShortcutBadgeException e) {
+            e.printStackTrace();
+        }
+    }
+
+}

--- a/android/app/src/main/java/com/zulipmobile/notifications/GCMPushNotifications.java
+++ b/android/app/src/main/java/com/zulipmobile/notifications/GCMPushNotifications.java
@@ -35,7 +35,7 @@ import static com.zulipmobile.notifications.NotificationHelper.extractTotalMessa
 
 public class GCMPushNotifications extends PushNotification {
 
-    private static final int NOTIFICATION_ID = 435;
+    public static final int NOTIFICATION_ID = 435;
     public static final String ACTION_NOTIFICATIONS_DISMISS = "ACTION_NOTIFICATIONS_DISMISS";
     private LinkedHashMap<String, Pair<String, Integer>> conversations;
 

--- a/src/unread/unreadSelectors.js
+++ b/src/unread/unreadSelectors.js
@@ -158,6 +158,13 @@ export const getUnreadPrivateMessagesCount = createSelector(
   (privateMessages, readFlags) => countUnread(privateMessages.map(msg => msg.id), readFlags),
 );
 
+export const getUnreadByHuddlesMentionsAndPMs = createSelector(
+  getUnreadPmsTotal,
+  getUnreadHuddlesTotal,
+  getUnreadMentionsTotal,
+  (unreadPms, unreadHuddles, unreadMentions) => unreadPms + unreadHuddles + unreadMentions,
+);
+
 export const getUnreadCountInActiveNarrow = createSelector(
   getActiveNarrow,
   getStreams,


### PR DESCRIPTION
This implements the change of badge count through JS, so if there are some unread messages after they close the app, we can display them in the badge.
And if a notification is received while the app is closed we can increment the badge count and display.

Which count should we display
-  PMs + Group messages + mentions
- PMs + Group messages + stream messages  ?

@timabbott @borisyankov 

