### PR TITLE
[Android] Enable StickyHeaders in Unread and UserList.

### DIFF
--- a/src/unread/UnreadStreamsCard.js
+++ b/src/unread/UnreadStreamsCard.js
@@ -52,6 +52,7 @@ export default class UnreadStreamsCard extends PureComponent<Props> {
     return (
       <SectionList
         style={styles.list}
+        stickySectionHeadersEnabled
         initialNumToRender={20}
         sections={unreadStreamsAndTopics}
         renderSectionHeader={({ section }) =>

--- a/src/users/UserList.js
+++ b/src/users/UserList.js
@@ -52,6 +52,7 @@ export default class UserList extends PureComponent<Props> {
     return (
       <SectionList
         style={[styles.list, style]}
+        stickySectionHeadersEnabled
         keyboardShouldPersistTaps="always"
         initialNumToRender={20}
         sections={sections}


### PR DESCRIPTION
In RN 0.49 (or even in RN 0.48) sticky headers for Android are stable.