### PR TITLE
Added initialNumToRender prop in LanguagePicker.

### DIFF
--- a/src/settings/LanguagePicker.js
+++ b/src/settings/LanguagePicker.js
@@ -26,6 +26,7 @@ export default class LanguagePicker extends PureComponent<Props> {
     return (
       <FlatList
         ItemSeparatorComponent={() => <View style={styles.separator} />}
+        initialNumToRender={languages.length}
         data={languages}
         keyExtractor={item => item.locale}
         renderItem={({ item }) => (


### PR DESCRIPTION
Fix: shift of list from center to top of the screen after few seconds.