### PR TITLE
Fix: safe-area-insets event is fired on every launch.

### DIFF
--- a/ios/ZulipMobile.xcodeproj/project.pbxproj
+++ b/ios/ZulipMobile.xcodeproj/project.pbxproj
@@ -5,7 +5,6 @@
 	};
 	objectVersion = 46;
 	objects = {
-
 /* Begin PBXBuildFile section */
 		00C302E51ABCBA2D00DB3ED1 /* libRCTActionSheet.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 00C302AC1ABCB8CE00DB3ED1 /* libRCTActionSheet.a */; };
 		00C302E71ABCBA2D00DB3ED1 /* libRCTGeolocation.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 00C302BA1ABCB90400DB3ED1 /* libRCTGeolocation.a */; };
@@ -46,7 +45,6 @@
 		C2FB87564E22416A9EDEABD3 /* EvilIcons.ttf in Resources */ = {isa = PBXBuildFile; fileRef = AEF58326BC25479294083E9C /* EvilIcons.ttf */; };
 		C478B42A63D649EFA2CFD12D /* SimpleLineIcons.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 9E53FD60A6D0409A8E58DCB5 /* SimpleLineIcons.ttf */; };
 		C866080E83494D1C8B535591 /* libRNSafeArea.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 1AED53B5E6AA4E0AA52DB0C1 /* libRNSafeArea.a */; };
-		C9F58827F1CF47999850925A /* libRCTOrientation.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5597847AA2A04FEE894C9C9E /* libRCTOrientation.a */; };
 		CF15A6B21E5C0C8A003EA77F /* UIView+Tag.m in Sources */ = {isa = PBXBuildFile; fileRef = CF15A6B11E5C0C8A003EA77F /* UIView+Tag.m */; };
 		CF15A6B61E5C56E5003EA77F /* OptimizedGifDecoder.m in Sources */ = {isa = PBXBuildFile; fileRef = CF15A6B51E5C56E5003EA77F /* OptimizedGifDecoder.m */; };
 		CF1953241E5BE67D00B14FF0 /* AnchorScrollView.m in Sources */ = {isa = PBXBuildFile; fileRef = CF1953231E5BE67D00B14FF0 /* AnchorScrollView.m */; };
@@ -57,11 +55,8 @@
 		D6D40984ED07473499B3F0C9 /* libRNDeviceInfo.a in Frameworks */ = {isa = PBXBuildFile; fileRef = D5664A74FA8048439CBAB734 /* libRNDeviceInfo.a */; };
 		DBC5C3186FE64F94BD3CDC19 /* MaterialCommunityIcons.ttf in Resources */ = {isa = PBXBuildFile; fileRef = A2070A88714C43ED8AF708C3 /* MaterialCommunityIcons.ttf */; };
 		FF359794CBFF4ABF92423426 /* libRCTToast.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 2CFB39BBD9094475BB03A3E4 /* libRCTToast.a */; };
-<<<<<<< HEAD
 		C9F58827F1CF47999850925A /* libRCTOrientation.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5597847AA2A04FEE894C9C9E /* libRCTOrientation.a */; };
 		757248247DDE47D3A310353E /* libRNImagePicker.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 875BCBF7DC0645ACBA61563B /* libRNImagePicker.a */; };
-=======
->>>>>>> Fix: safe-area-insets event is fired on every launch.
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -113,34 +108,6 @@
 			proxyType = 2;
 			remoteGlobalIDString = 134814201AA4EA6300B7C361;
 			remoteInfo = RNSentry;
-		};
-		0A94D55D1FA5B89200033CD5 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 139FDEE61B06529A00C62182 /* RCTWebSocket.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 3DBE0D001F3B181A0099AA32;
-			remoteInfo = fishhook;
-		};
-		0A94D55F1FA5B89200033CD5 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 139FDEE61B06529A00C62182 /* RCTWebSocket.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 3DBE0D0D1F3B181C0099AA32;
-			remoteInfo = "fishhook-tvOS";
-		};
-		0A94D56F1FA5B89200033CD5 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = ACCD980949044096B1BAD249 /* RNDeviceInfo.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = E72EC1401F7ABB5A0001BC90;
-			remoteInfo = "RNDeviceInfo-tvOS";
-		};
-		0A94D57C1FA5B89300033CD5 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 713A523038564C27B0D2C2F7 /* RCTOrientation.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 134814201AA4EA6300B7C361;
-			remoteInfo = RCTOrientation;
 		};
 		0AE8C1771F1B39AB00E5534E /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -420,11 +387,9 @@
 		3C4249C61EF6E05C00D245F1 /* RNNotifications.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RNNotifications.xcodeproj; path = "../node_modules/react-native-notifications/RNNotifications/RNNotifications.xcodeproj"; sourceTree = "<group>"; };
 		3C4249EC1EF6E16500D245F1 /* ZulipMobile.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; name = ZulipMobile.entitlements; path = ZulipMobile/ZulipMobile.entitlements; sourceTree = "<group>"; };
 		51E1EDA028654E17A35C5BCA /* MaterialIcons.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = MaterialIcons.ttf; path = "../node_modules/react-native-vector-icons/Fonts/MaterialIcons.ttf"; sourceTree = "<group>"; };
-		5597847AA2A04FEE894C9C9E /* libRCTOrientation.a */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = archive.ar; path = libRCTOrientation.a; sourceTree = "<group>"; };
 		6922647B10C64653A76BF3E5 /* RCTToast.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = RCTToast.xcodeproj; path = "../node_modules/@remobile/react-native-toast/ios/RCTToast.xcodeproj"; sourceTree = "<group>"; };
 		6DA76D9085EA458BB979ED8D /* RNVectorIcons.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = RNVectorIcons.xcodeproj; path = "../node_modules/react-native-vector-icons/RNVectorIcons.xcodeproj"; sourceTree = "<group>"; };
 		6DE2C81628724C8AA4862247 /* libRNSound.a */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = archive.ar; path = libRNSound.a; sourceTree = "<group>"; };
-		713A523038564C27B0D2C2F7 /* RCTOrientation.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = RCTOrientation.xcodeproj; path = "../node_modules/react-native-orientation/iOS/RCTOrientation.xcodeproj"; sourceTree = "<group>"; };
 		78C398B01ACF4ADC00677621 /* RCTLinking.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTLinking.xcodeproj; path = "../node_modules/react-native/Libraries/LinkingIOS/RCTLinking.xcodeproj"; sourceTree = "<group>"; };
 		832341B01AAA6A8300B99B32 /* RCTText.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTText.xcodeproj; path = "../node_modules/react-native/Libraries/Text/RCTText.xcodeproj"; sourceTree = "<group>"; };
 		8B355454DEEB4F28A5B4F8CA /* RNSafeArea.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = RNSafeArea.xcodeproj; path = "../node_modules/react-native-safe-area/ios/RNSafeArea.xcodeproj"; sourceTree = "<group>"; };
@@ -463,13 +428,10 @@
 		E518466F398E458DA2C685AF /* libSafariViewManager.a */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = archive.ar; path = libSafariViewManager.a; sourceTree = "<group>"; };
 		F56CBB1B9A6449F895C858C6 /* Entypo.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = Entypo.ttf; path = "../node_modules/react-native-vector-icons/Fonts/Entypo.ttf"; sourceTree = "<group>"; };
 		FC7EC6A752C243FB9F1B8442 /* RNFetchBlob.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = RNFetchBlob.xcodeproj; path = "../node_modules/react-native-fetch-blob/ios/RNFetchBlob.xcodeproj"; sourceTree = "<group>"; };
-<<<<<<< HEAD
 		713A523038564C27B0D2C2F7 /* RCTOrientation.xcodeproj */ = {isa = PBXFileReference; name = "RCTOrientation.xcodeproj"; path = "../node_modules/react-native-orientation/iOS/RCTOrientation.xcodeproj"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = wrapper.pb-project; explicitFileType = undefined; includeInIndex = 0; };
 		5597847AA2A04FEE894C9C9E /* libRCTOrientation.a */ = {isa = PBXFileReference; name = "libRCTOrientation.a"; path = "libRCTOrientation.a"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = archive.ar; explicitFileType = undefined; includeInIndex = 0; };
 		CFBB80590829494E985F601B /* RNImagePicker.xcodeproj */ = {isa = PBXFileReference; name = "RNImagePicker.xcodeproj"; path = "../node_modules/react-native-image-picker/ios/RNImagePicker.xcodeproj"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = wrapper.pb-project; explicitFileType = undefined; includeInIndex = 0; };
 		875BCBF7DC0645ACBA61563B /* libRNImagePicker.a */ = {isa = PBXFileReference; name = "libRNImagePicker.a"; path = "libRNImagePicker.a"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = archive.ar; explicitFileType = undefined; includeInIndex = 0; };
-=======
->>>>>>> Fix: safe-area-insets event is fired on every launch.
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -585,14 +547,6 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
-		0A94D5791FA5B89200033CD5 /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				0A94D57D1FA5B89300033CD5 /* libRCTOrientation.a */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
 		0AE8C1741F1B39AA00E5534E /* Products */ = {
 			isa = PBXGroup;
 			children = (
@@ -631,8 +585,6 @@
 			children = (
 				139FDEF41B06529B00C62182 /* libRCTWebSocket.a */,
 				CF68BE191E2CD177001D50C6 /* libRCTWebSocket-tvOS.a */,
-				0A94D55E1FA5B89200033CD5 /* libfishhook.a */,
-				0A94D5601FA5B89200033CD5 /* libfishhook-tvOS.a */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -812,7 +764,6 @@
 			isa = PBXGroup;
 			children = (
 				A1F9F7571E1BE26300A70FA5 /* libRNDeviceInfo.a */,
-				0A94D5701FA5B89200033CD5 /* libRNDeviceInfo-tvOS.a */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -828,9 +779,6 @@
 				C2F7E19951E64FC7B6BBE612 /* libRNFetchBlob.a */,
 				B83DDAD2507A4F0EB47660BD /* libRNSentry.a */,
 				1013EA9DAA5C4F618516419E /* libLRDRCTSimpleToast.a */,
-				09AC2386C1724D5BA93B51E9 /* libRNPhotoView.a */,
-				1AED53B5E6AA4E0AA52DB0C1 /* libRNSafeArea.a */,
-				5597847AA2A04FEE894C9C9E /* libRCTOrientation.a */,
 			);
 			name = "Recovered References";
 			sourceTree = "<group>";
@@ -998,10 +946,6 @@
 					ProjectRef = 00C302D31ABCB9D200DB3ED1 /* RCTNetwork.xcodeproj */;
 				},
 				{
-					ProductGroup = 0A94D5791FA5B89200033CD5 /* Products */;
-					ProjectRef = 713A523038564C27B0D2C2F7 /* RCTOrientation.xcodeproj */;
-				},
-				{
 					ProductGroup = 139105B71AF99BAD00B5F7CC /* Products */;
 					ProjectRef = 139105B61AF99BAD00B5F7CC /* RCTSettings.xcodeproj */;
 				},
@@ -1111,34 +1055,6 @@
 			fileType = archive.ar;
 			path = libRNSentry.a;
 			remoteRef = 0A443F401F17F9F6008AB961 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		0A94D55E1FA5B89200033CD5 /* libfishhook.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = libfishhook.a;
-			remoteRef = 0A94D55D1FA5B89200033CD5 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		0A94D5601FA5B89200033CD5 /* libfishhook-tvOS.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = "libfishhook-tvOS.a";
-			remoteRef = 0A94D55F1FA5B89200033CD5 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		0A94D5701FA5B89200033CD5 /* libRNDeviceInfo-tvOS.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = "libRNDeviceInfo-tvOS.a";
-			remoteRef = 0A94D56F1FA5B89200033CD5 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		0A94D57D1FA5B89300033CD5 /* libRCTOrientation.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = libRCTOrientation.a;
-			remoteRef = 0A94D57C1FA5B89300033CD5 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 		0AE8C1781F1B39AB00E5534E /* libLRDRCTSimpleToast.a */ = {

--- a/ios/ZulipMobile.xcodeproj/project.pbxproj
+++ b/ios/ZulipMobile.xcodeproj/project.pbxproj
@@ -5,6 +5,7 @@
 	};
 	objectVersion = 46;
 	objects = {
+
 /* Begin PBXBuildFile section */
 		00C302E51ABCBA2D00DB3ED1 /* libRCTActionSheet.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 00C302AC1ABCB8CE00DB3ED1 /* libRCTActionSheet.a */; };
 		00C302E71ABCBA2D00DB3ED1 /* libRCTGeolocation.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 00C302BA1ABCB90400DB3ED1 /* libRCTGeolocation.a */; };
@@ -45,6 +46,7 @@
 		C2FB87564E22416A9EDEABD3 /* EvilIcons.ttf in Resources */ = {isa = PBXBuildFile; fileRef = AEF58326BC25479294083E9C /* EvilIcons.ttf */; };
 		C478B42A63D649EFA2CFD12D /* SimpleLineIcons.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 9E53FD60A6D0409A8E58DCB5 /* SimpleLineIcons.ttf */; };
 		C866080E83494D1C8B535591 /* libRNSafeArea.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 1AED53B5E6AA4E0AA52DB0C1 /* libRNSafeArea.a */; };
+		C9F58827F1CF47999850925A /* libRCTOrientation.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5597847AA2A04FEE894C9C9E /* libRCTOrientation.a */; };
 		CF15A6B21E5C0C8A003EA77F /* UIView+Tag.m in Sources */ = {isa = PBXBuildFile; fileRef = CF15A6B11E5C0C8A003EA77F /* UIView+Tag.m */; };
 		CF15A6B61E5C56E5003EA77F /* OptimizedGifDecoder.m in Sources */ = {isa = PBXBuildFile; fileRef = CF15A6B51E5C56E5003EA77F /* OptimizedGifDecoder.m */; };
 		CF1953241E5BE67D00B14FF0 /* AnchorScrollView.m in Sources */ = {isa = PBXBuildFile; fileRef = CF1953231E5BE67D00B14FF0 /* AnchorScrollView.m */; };
@@ -55,8 +57,11 @@
 		D6D40984ED07473499B3F0C9 /* libRNDeviceInfo.a in Frameworks */ = {isa = PBXBuildFile; fileRef = D5664A74FA8048439CBAB734 /* libRNDeviceInfo.a */; };
 		DBC5C3186FE64F94BD3CDC19 /* MaterialCommunityIcons.ttf in Resources */ = {isa = PBXBuildFile; fileRef = A2070A88714C43ED8AF708C3 /* MaterialCommunityIcons.ttf */; };
 		FF359794CBFF4ABF92423426 /* libRCTToast.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 2CFB39BBD9094475BB03A3E4 /* libRCTToast.a */; };
+<<<<<<< HEAD
 		C9F58827F1CF47999850925A /* libRCTOrientation.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5597847AA2A04FEE894C9C9E /* libRCTOrientation.a */; };
 		757248247DDE47D3A310353E /* libRNImagePicker.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 875BCBF7DC0645ACBA61563B /* libRNImagePicker.a */; };
+=======
+>>>>>>> Fix: safe-area-insets event is fired on every launch.
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -108,6 +113,34 @@
 			proxyType = 2;
 			remoteGlobalIDString = 134814201AA4EA6300B7C361;
 			remoteInfo = RNSentry;
+		};
+		0A94D55D1FA5B89200033CD5 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 139FDEE61B06529A00C62182 /* RCTWebSocket.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 3DBE0D001F3B181A0099AA32;
+			remoteInfo = fishhook;
+		};
+		0A94D55F1FA5B89200033CD5 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 139FDEE61B06529A00C62182 /* RCTWebSocket.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 3DBE0D0D1F3B181C0099AA32;
+			remoteInfo = "fishhook-tvOS";
+		};
+		0A94D56F1FA5B89200033CD5 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = ACCD980949044096B1BAD249 /* RNDeviceInfo.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = E72EC1401F7ABB5A0001BC90;
+			remoteInfo = "RNDeviceInfo-tvOS";
+		};
+		0A94D57C1FA5B89300033CD5 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 713A523038564C27B0D2C2F7 /* RCTOrientation.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 134814201AA4EA6300B7C361;
+			remoteInfo = RCTOrientation;
 		};
 		0AE8C1771F1B39AB00E5534E /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -387,9 +420,11 @@
 		3C4249C61EF6E05C00D245F1 /* RNNotifications.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RNNotifications.xcodeproj; path = "../node_modules/react-native-notifications/RNNotifications/RNNotifications.xcodeproj"; sourceTree = "<group>"; };
 		3C4249EC1EF6E16500D245F1 /* ZulipMobile.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; name = ZulipMobile.entitlements; path = ZulipMobile/ZulipMobile.entitlements; sourceTree = "<group>"; };
 		51E1EDA028654E17A35C5BCA /* MaterialIcons.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = MaterialIcons.ttf; path = "../node_modules/react-native-vector-icons/Fonts/MaterialIcons.ttf"; sourceTree = "<group>"; };
+		5597847AA2A04FEE894C9C9E /* libRCTOrientation.a */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = archive.ar; path = libRCTOrientation.a; sourceTree = "<group>"; };
 		6922647B10C64653A76BF3E5 /* RCTToast.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = RCTToast.xcodeproj; path = "../node_modules/@remobile/react-native-toast/ios/RCTToast.xcodeproj"; sourceTree = "<group>"; };
 		6DA76D9085EA458BB979ED8D /* RNVectorIcons.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = RNVectorIcons.xcodeproj; path = "../node_modules/react-native-vector-icons/RNVectorIcons.xcodeproj"; sourceTree = "<group>"; };
 		6DE2C81628724C8AA4862247 /* libRNSound.a */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = archive.ar; path = libRNSound.a; sourceTree = "<group>"; };
+		713A523038564C27B0D2C2F7 /* RCTOrientation.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = RCTOrientation.xcodeproj; path = "../node_modules/react-native-orientation/iOS/RCTOrientation.xcodeproj"; sourceTree = "<group>"; };
 		78C398B01ACF4ADC00677621 /* RCTLinking.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTLinking.xcodeproj; path = "../node_modules/react-native/Libraries/LinkingIOS/RCTLinking.xcodeproj"; sourceTree = "<group>"; };
 		832341B01AAA6A8300B99B32 /* RCTText.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTText.xcodeproj; path = "../node_modules/react-native/Libraries/Text/RCTText.xcodeproj"; sourceTree = "<group>"; };
 		8B355454DEEB4F28A5B4F8CA /* RNSafeArea.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = RNSafeArea.xcodeproj; path = "../node_modules/react-native-safe-area/ios/RNSafeArea.xcodeproj"; sourceTree = "<group>"; };
@@ -428,10 +463,13 @@
 		E518466F398E458DA2C685AF /* libSafariViewManager.a */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = archive.ar; path = libSafariViewManager.a; sourceTree = "<group>"; };
 		F56CBB1B9A6449F895C858C6 /* Entypo.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = Entypo.ttf; path = "../node_modules/react-native-vector-icons/Fonts/Entypo.ttf"; sourceTree = "<group>"; };
 		FC7EC6A752C243FB9F1B8442 /* RNFetchBlob.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = RNFetchBlob.xcodeproj; path = "../node_modules/react-native-fetch-blob/ios/RNFetchBlob.xcodeproj"; sourceTree = "<group>"; };
+<<<<<<< HEAD
 		713A523038564C27B0D2C2F7 /* RCTOrientation.xcodeproj */ = {isa = PBXFileReference; name = "RCTOrientation.xcodeproj"; path = "../node_modules/react-native-orientation/iOS/RCTOrientation.xcodeproj"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = wrapper.pb-project; explicitFileType = undefined; includeInIndex = 0; };
 		5597847AA2A04FEE894C9C9E /* libRCTOrientation.a */ = {isa = PBXFileReference; name = "libRCTOrientation.a"; path = "libRCTOrientation.a"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = archive.ar; explicitFileType = undefined; includeInIndex = 0; };
 		CFBB80590829494E985F601B /* RNImagePicker.xcodeproj */ = {isa = PBXFileReference; name = "RNImagePicker.xcodeproj"; path = "../node_modules/react-native-image-picker/ios/RNImagePicker.xcodeproj"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = wrapper.pb-project; explicitFileType = undefined; includeInIndex = 0; };
 		875BCBF7DC0645ACBA61563B /* libRNImagePicker.a */ = {isa = PBXFileReference; name = "libRNImagePicker.a"; path = "libRNImagePicker.a"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = archive.ar; explicitFileType = undefined; includeInIndex = 0; };
+=======
+>>>>>>> Fix: safe-area-insets event is fired on every launch.
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -547,6 +585,14 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
+		0A94D5791FA5B89200033CD5 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				0A94D57D1FA5B89300033CD5 /* libRCTOrientation.a */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
 		0AE8C1741F1B39AA00E5534E /* Products */ = {
 			isa = PBXGroup;
 			children = (
@@ -585,6 +631,8 @@
 			children = (
 				139FDEF41B06529B00C62182 /* libRCTWebSocket.a */,
 				CF68BE191E2CD177001D50C6 /* libRCTWebSocket-tvOS.a */,
+				0A94D55E1FA5B89200033CD5 /* libfishhook.a */,
+				0A94D5601FA5B89200033CD5 /* libfishhook-tvOS.a */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -764,6 +812,7 @@
 			isa = PBXGroup;
 			children = (
 				A1F9F7571E1BE26300A70FA5 /* libRNDeviceInfo.a */,
+				0A94D5701FA5B89200033CD5 /* libRNDeviceInfo-tvOS.a */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -779,6 +828,9 @@
 				C2F7E19951E64FC7B6BBE612 /* libRNFetchBlob.a */,
 				B83DDAD2507A4F0EB47660BD /* libRNSentry.a */,
 				1013EA9DAA5C4F618516419E /* libLRDRCTSimpleToast.a */,
+				09AC2386C1724D5BA93B51E9 /* libRNPhotoView.a */,
+				1AED53B5E6AA4E0AA52DB0C1 /* libRNSafeArea.a */,
+				5597847AA2A04FEE894C9C9E /* libRCTOrientation.a */,
 			);
 			name = "Recovered References";
 			sourceTree = "<group>";
@@ -946,6 +998,10 @@
 					ProjectRef = 00C302D31ABCB9D200DB3ED1 /* RCTNetwork.xcodeproj */;
 				},
 				{
+					ProductGroup = 0A94D5791FA5B89200033CD5 /* Products */;
+					ProjectRef = 713A523038564C27B0D2C2F7 /* RCTOrientation.xcodeproj */;
+				},
+				{
 					ProductGroup = 139105B71AF99BAD00B5F7CC /* Products */;
 					ProjectRef = 139105B61AF99BAD00B5F7CC /* RCTSettings.xcodeproj */;
 				},
@@ -1055,6 +1111,34 @@
 			fileType = archive.ar;
 			path = libRNSentry.a;
 			remoteRef = 0A443F401F17F9F6008AB961 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		0A94D55E1FA5B89200033CD5 /* libfishhook.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = libfishhook.a;
+			remoteRef = 0A94D55D1FA5B89200033CD5 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		0A94D5601FA5B89200033CD5 /* libfishhook-tvOS.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = "libfishhook-tvOS.a";
+			remoteRef = 0A94D55F1FA5B89200033CD5 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		0A94D5701FA5B89200033CD5 /* libRNDeviceInfo-tvOS.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = "libRNDeviceInfo-tvOS.a";
+			remoteRef = 0A94D56F1FA5B89200033CD5 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		0A94D57D1FA5B89300033CD5 /* libRCTOrientation.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = libRCTOrientation.a;
+			remoteRef = 0A94D57C1FA5B89300033CD5 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 		0AE8C1781F1B39AB00E5534E /* libLRDRCTSimpleToast.a */ = {

--- a/src/actions.js
+++ b/src/actions.js
@@ -1,6 +1,7 @@
 /* @flow */
 export * from './app/appActions';
 export * from './account/accountActions';
+export * from './device/deviceActions';
 export * from './events/eventActions';
 export * from './nav/navActions';
 export * from './drafts/draftsActions';

--- a/src/app/appActions.js
+++ b/src/app/appActions.js
@@ -1,12 +1,11 @@
 /* @flow */
-import type { Action, Dimensions, Dispatch, GetState } from '../types';
+import type { Action, Dispatch, GetState } from '../types';
 import {
   APP_ONLINE,
   APP_ORIENTATION,
   APP_STATE,
   APP_REFRESH,
   DEBUG_FLAG_TOGGLE,
-  INIT_SAFE_AREA_INSETS,
   TOGGLE_COMPOSE_TOOLS,
   CANCEL_EDIT_MESSAGE,
   START_EDIT_MESSAGE,
@@ -33,11 +32,6 @@ export const appState = (isActive: boolean): Action => ({
 
 export const appRefresh = () => ({
   type: APP_REFRESH,
-});
-
-export const initSafeAreaInsets = (safeAreaInsets: Dimensions) => ({
-  type: INIT_SAFE_AREA_INSETS,
-  ...safeAreaInsets,
 });
 
 export const appOrientation = (orientation: string): Action => (

--- a/src/app/appReducers.js
+++ b/src/app/appReducers.js
@@ -9,7 +9,6 @@ import {
   APP_ACTIVITY,
   ACCOUNT_SWITCH,
   REALM_INIT,
-  INIT_SAFE_AREA_INSETS,
   INITIAL_FETCH_COMPLETE,
   APP_ORIENTATION,
   APP_STATE,
@@ -34,12 +33,6 @@ const initialState: AppState = {
   orientation: 'PORTRAIT',
   outboxSending: false,
   pushToken: '',
-  safeAreaInsets: {
-    bottom: 0,
-    left: 0,
-    right: 0,
-    top: 0,
-  },
   debug: {
     htmlMessages: false,
     unreadMessages: false,
@@ -98,12 +91,6 @@ export default (state: AppState = initialState, action: Action) => {
       return {
         ...state,
         needsInitialFetch: false,
-      };
-
-    case INIT_SAFE_AREA_INSETS:
-      return {
-        ...state,
-        safeAreaInsets: action.safeAreaInsets,
       };
 
     case APP_ORIENTATION:

--- a/src/boot/AppEventHandlers.js
+++ b/src/boot/AppEventHandlers.js
@@ -25,6 +25,7 @@ type Props = {
   actions: Actions,
   children?: ChildrenArray<*>,
   safeAreaInsets: SafeAreaInsets,
+  orientation: string,
 };
 
 class AppEventHandlers extends PureComponent<Props> {
@@ -58,8 +59,6 @@ class AppEventHandlers extends PureComponent<Props> {
   };
 
   componentWillMount() {
-    const { actions } = this.props;
-
     NetInfo.addEventListener('connectionChange', this.handleConnectivityChange);
     AppState.addEventListener('change', this.handleAppStateChange);
     AppState.addEventListener('memoryWarning', this.handleMemoryWarning);

--- a/src/boot/AppEventHandlers.js
+++ b/src/boot/AppEventHandlers.js
@@ -74,8 +74,8 @@ class AppEventHandlers extends PureComponent<Props> {
   }
 
   componentWillUpdate(nextProps) {
-    const { actions, safeAreaInsets, isHydrated } = nextProps;
-    if (safeAreaInsets === undefined && isHydrated) {
+    const { actions, safeAreaInsets, isHydrated, orientation } = nextProps;
+    if ((safeAreaInsets === undefined && isHydrated) || orientation !== this.props.orientation) {
       SafeArea.getSafeAreaInsetsForRootView().then(actions.initSafeAreaInsets);
     }
   }
@@ -90,4 +90,5 @@ export default connectWithActions(state => ({
   needsInitialFetch: state.app.needsInitialFetch,
   safeAreaInsets: state.device.safeAreaInsets,
   isHydrated: state.app.isHydrated,
+  orientation: state.app.orientation,
 }))(AppEventHandlers);

--- a/src/boot/reducers.js
+++ b/src/boot/reducers.js
@@ -12,6 +12,7 @@ import caughtUp from '../caughtup/caughtUpReducers';
 import chat from '../chat/chatReducers';
 import fetching from '../chat/fetchingReducers';
 import flags from '../chat/flagsReducers';
+import device from '../device/deviceReducers';
 import mute from '../mute/muteReducers';
 import nav from '../nav/navReducers';
 import realm from '../realm/realmReducers';
@@ -34,6 +35,7 @@ const reducers = {
   app,
   caughtUp,
   chat,
+  device,
   fetching,
   drafts,
   flags,

--- a/src/common/Screen.js
+++ b/src/common/Screen.js
@@ -7,6 +7,7 @@ import connectWithActions from '../connectWithActions';
 import { KeyboardAvoider, ZulipStatusBar } from '../common';
 import ModalNavBar from '../nav/ModalNavBar';
 import ModalSearchNavBar from '../nav/ModalSearchNavBar';
+import { NULL_SAFE_AREA_INSETS } from '../nullObjects';
 
 const componentStyles = StyleSheet.create({
   screenWrapper: {
@@ -54,7 +55,9 @@ class Screen extends PureComponent<Props> {
     const ModalBar = search ? ModalSearchNavBar : ModalNavBar;
 
     return (
-      <View style={[styles.screen, { marginBottom: safeAreaInsets.bottom }]}>
+      <View
+        style={[styles.screen, { marginBottom: (safeAreaInsets || NULL_SAFE_AREA_INSETS).bottom }]}
+      >
         <ZulipStatusBar />
         <ModalBar title={title} searchBarOnChange={searchBarOnChange} />
         <View style={componentStyles.screenWrapper}>

--- a/src/common/ZulipStatusBar.js
+++ b/src/common/ZulipStatusBar.js
@@ -8,6 +8,7 @@ import connectWithActions from '../connectWithActions';
 import { getTitleBackgroundColor, getTitleTextColor } from '../selectors';
 import getStatusBarStyle from '../utils/getStatusBarStyle';
 import getStatusBarColor from '../utils/getStatusBarColor';
+import { NULL_SAFE_AREA_INSETS } from '../nullObjects';
 
 type Props = {
   barStyle?: StatusBarStyle,
@@ -31,7 +32,10 @@ class ZulipStatusBar extends PureComponent<Props> {
 
   render() {
     const { theme, backgroundColor, textColor, hidden, barStyle, safeAreaInsets } = this.props;
-    const style = { height: hidden ? 0 : safeAreaInsets.top, backgroundColor };
+    const style = {
+      height: hidden ? 0 : (safeAreaInsets || NULL_SAFE_AREA_INSETS).top,
+      backgroundColor,
+    };
     const statusBarStyle = !barStyle
       ? getStatusBarStyle(backgroundColor, textColor, theme)
       : barStyle;
@@ -51,7 +55,7 @@ class ZulipStatusBar extends PureComponent<Props> {
 }
 
 export default connectWithActions((state, props) => ({
-  safeAreaInsets: state.app.safeAreaInsets,
+  safeAreaInsets: state.device.safeAreaInsets,
   theme: state.settings.theme,
   backgroundColor: !props.backgroundColor ? getTitleBackgroundColor(state) : props.backgroundColor,
   textColor: getTitleTextColor(state),

--- a/src/compose/ComposeBoxContainer.js
+++ b/src/compose/ComposeBoxContainer.js
@@ -5,12 +5,13 @@ import { getAuth, getLastTopicInActiveNarrow, canSendToActiveNarrow } from '../s
 import { getIsActiveStreamSubscribed } from '../subscriptions/subscriptionSelectors';
 import { getDraftForActiveNarrow } from '../drafts/draftsSelectors';
 import ComposeBox from './ComposeBox';
+import { NULL_SAFE_AREA_INSETS } from '../nullObjects';
 
 export default connectWithActions((state: GlobalState) => ({
   auth: getAuth(state),
   narrow: state.chat.narrow,
   users: state.users,
-  safeAreaInsets: state.app.safeAreaInsets,
+  safeAreaInsets: state.device.safeAreaInsets || NULL_SAFE_AREA_INSETS,
   composeTools: state.app.composeTools,
   lastTopic: getLastTopicInActiveNarrow(state),
   isSubscribed: getIsActiveStreamSubscribed(state),

--- a/src/device/__tests__/deviceReducers-test.js
+++ b/src/device/__tests__/deviceReducers-test.js
@@ -1,0 +1,41 @@
+import deepFreeze from 'deep-freeze';
+
+import { INIT_SAFE_AREA_INSETS } from '../../actionConstants';
+import deviceReducers from '../deviceReducers';
+
+describe('appReducers', () => {
+  describe('INIT_SAFE_AREA_INSETS', () => {
+    test('Store updated safe area insets', () => {
+      const prevState = deepFreeze({
+        safeAreaInsets: {
+          bottom: 0,
+          left: 0,
+          right: 0,
+          top: 0,
+        },
+      });
+
+      const action = deepFreeze({
+        type: INIT_SAFE_AREA_INSETS,
+        safeAreaInsets: {
+          bottom: 0,
+          left: 0,
+          right: 0,
+          top: 20,
+        },
+      });
+
+      const expectedState = {
+        safeAreaInsets: {
+          bottom: 0,
+          left: 0,
+          right: 0,
+          top: 20,
+        },
+      };
+      const newState = deviceReducers(prevState, action);
+
+      expect(newState).toEqual(expectedState);
+    });
+  });
+});

--- a/src/device/deviceActions.js
+++ b/src/device/deviceActions.js
@@ -1,0 +1,8 @@
+/* @flow */
+import type { Dimensions } from '../types';
+import { INIT_SAFE_AREA_INSETS } from '../actionConstants';
+
+export const initSafeAreaInsets = (safeAreaInsets: Dimensions) => ({
+  type: INIT_SAFE_AREA_INSETS,
+  ...safeAreaInsets,
+});

--- a/src/device/deviceReducers.js
+++ b/src/device/deviceReducers.js
@@ -1,0 +1,20 @@
+/* @flow */
+import { DeviceState, Action } from '../types';
+import { INIT_SAFE_AREA_INSETS } from '../actionConstants';
+
+const initialState: DeviceState = {
+  safeAreaInsets: undefined,
+};
+
+export default (state: DeviceState = initialState, action: Action) => {
+  switch (action.type) {
+    case INIT_SAFE_AREA_INSETS:
+      return {
+        ...state,
+        safeAreaInsets: action.safeAreaInsets,
+      };
+
+    default:
+      return state;
+  }
+};

--- a/src/nav/Sidebar.js
+++ b/src/nav/Sidebar.js
@@ -5,6 +5,7 @@ import { StyleSheet, View } from 'react-native';
 import type { Actions, Dimensions, Narrow } from '../types';
 import connectWithActions from '../connectWithActions';
 import MainTabs from '../main/MainTabs';
+import { NULL_SAFE_AREA_INSETS } from '../nullObjects';
 
 const componentStyles = StyleSheet.create({
   container: {
@@ -39,8 +40,8 @@ class Sidebar extends PureComponent<Props> {
     const { styles } = this.context;
     const { safeAreaInsets } = this.props;
     const paddingStyles = {
-      paddingTop: safeAreaInsets.top,
-      paddingBottom: safeAreaInsets.bottom,
+      paddingTop: (safeAreaInsets || NULL_SAFE_AREA_INSETS).top,
+      paddingBottom: (safeAreaInsets || NULL_SAFE_AREA_INSETS).bottom,
     };
 
     return (
@@ -57,5 +58,5 @@ class Sidebar extends PureComponent<Props> {
 }
 
 export default connectWithActions(state => ({
-  safeAreaInsets: state.app.safeAreaInsets,
+  safeAreaInsets: state.device.safeAreaInsets,
 }))(Sidebar);

--- a/src/nullObjects.js
+++ b/src/nullObjects.js
@@ -8,6 +8,7 @@ import type {
   Presence,
   CaughtUp,
   Fetching,
+  SafeAreaInsets,
 } from './types';
 
 export const nullFunction = () => {};
@@ -84,4 +85,11 @@ export const NULL_CAUGHTUP: CaughtUp = {
 export const NULL_FETCHING: Fetching = {
   older: false,
   newer: false,
+};
+
+export const NULL_SAFE_AREA_INSETS: SafeAreaInsets = {
+  bottom: 0,
+  left: 0,
+  right: 0,
+  top: 0,
 };

--- a/src/types.js
+++ b/src/types.js
@@ -289,6 +289,17 @@ export type AppState = {
   outboxSending: boolean,
 };
 
+export type SafeAreaInsets = {
+  top: number,
+  bottom: number,
+  right: number,
+  left: number,
+};
+
+export type DeviceState = {
+  safeAreaInsets: SafeAreaInsets,
+};
+
 export type ChatState = {
   narrow: Narrow,
   messages: Object,


### PR DESCRIPTION
Safe area parameters are only dependent on device, so we can store it one time and use it in future instead of recalculating.