### PR TITLE
Fix screen crashes

### DIFF
--- a/src/connectWithActions.js
+++ b/src/connectWithActions.js
@@ -10,6 +10,7 @@ let cachedBoundActions;
 const boundActions = (dispatch: Dispatch, ownProps: Object) => {
   if (!cachedBoundActions) {
     cachedBoundActions = {
+      dispatch,
       actions: bindActionCreators(actions, dispatch),
     };
   }


### PR DESCRIPTION
Fix crashes when swiping back from screens. 

<details><summary>Bug demo gif</summary><p>

![screen-bug](https://user-images.githubusercontent.com/4517681/32994092-d6fc58e2-cd62-11e7-8827-cc6290d88afc.gif)

</p></details>

<details><summary>Stack log</summary><p>

```
navigation.dispatch is not a function. (In 'navigation.dispatch(_NavigationActions2.default.back({ key: backFromScene.route.key }))', 'navigation.dispatch' is undefined)

<unknown>
CardStack.js:218:28
<unknown>
AnimatedValue.js:267:29
__debouncedOnEnd
Animation.js:59:19
__invokeCallback
MessageQueue.js:347:19
<unknown>
MessageQueue.js:137:28
__guard
MessageQueue.js:265:6
invokeCallbackAndReturnFlushedQueue
MessageQueue.js:136:17
```

</p></details>
