### PR TITLE
Move the home, private, starred icons to root sidebar

### DIFF
--- a/src/nav/Sidebar.js
+++ b/src/nav/Sidebar.js
@@ -2,6 +2,8 @@
 import React, { PureComponent } from 'react';
 import { StyleSheet, View } from 'react-native';
 
+import { homeNarrow, specialNarrow, allPrivateNarrow } from '../utils/narrow';
+import NavButton from './NavButton';
 import type { Actions, Dimensions, Narrow } from '../types';
 import connectWithActions from '../connectWithActions';
 import MainTabs from '../main/MainTabs';
@@ -10,6 +12,10 @@ const componentStyles = StyleSheet.create({
   container: {
     flex: 1,
     flexDirection: 'column',
+  },
+  iconList: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
   },
 });
 
@@ -37,7 +43,7 @@ class Sidebar extends PureComponent<Props> {
 
   render() {
     const { styles } = this.context;
-    const { safeAreaInsets } = this.props;
+    const { safeAreaInsets, actions } = this.props;
     const paddingStyles = {
       paddingTop: safeAreaInsets.top,
       paddingBottom: safeAreaInsets.bottom,
@@ -45,6 +51,19 @@ class Sidebar extends PureComponent<Props> {
 
     return (
       <View style={[componentStyles.container, paddingStyles, styles.background]}>
+        <View style={componentStyles.iconList}>
+          <NavButton name="home" onPress={() => this.doNarrowCloseDrawer(homeNarrow)} />
+          <NavButton name="mail" onPress={() => this.doNarrowCloseDrawer(allPrivateNarrow)} />
+          <NavButton
+            name="star"
+            onPress={() => this.doNarrowCloseDrawer(specialNarrow('starred'))}
+          />
+          <NavButton
+            name="at-sign"
+            onPress={() => this.doNarrowCloseDrawer(specialNarrow('mentioned'))}
+          />
+          <NavButton name="search" onPress={actions.navigateToSearch} />
+        </View>
         <MainTabs
           screenProps={{
             doNarrowCloseDrawer: this.doNarrowCloseDrawer,

--- a/src/nav/StreamTabsCard.js
+++ b/src/nav/StreamTabsCard.js
@@ -2,24 +2,16 @@
 import React, { PureComponent } from 'react';
 import { StyleSheet, View } from 'react-native';
 
-import connectWithActions from '../connectWithActions';
-import type { Actions, Narrow } from '../types';
-import { homeNarrow, specialNarrow, allPrivateNarrow } from '../utils/narrow';
-import NavButton from './NavButton';
+import type { Narrow } from '../types';
 import StreamTabs from './StreamTabs';
 
 const componentStyles = StyleSheet.create({
   container: {
     flex: 1,
   },
-  iconList: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-  },
 });
 
 type Props = {
-  actions: Actions,
   doNarrowCloseDrawer: (narrow: Narrow) => void,
 };
 
@@ -27,24 +19,14 @@ class StreamTabsCard extends PureComponent<Props> {
   props: Props;
 
   render() {
-    const { actions, doNarrowCloseDrawer } = this.props;
+    const { doNarrowCloseDrawer } = this.props;
 
     return (
       <View style={componentStyles.container}>
-        <View style={componentStyles.iconList}>
-          <NavButton name="home" onPress={() => doNarrowCloseDrawer(homeNarrow)} />
-          <NavButton name="mail" onPress={() => doNarrowCloseDrawer(allPrivateNarrow)} />
-          <NavButton name="star" onPress={() => doNarrowCloseDrawer(specialNarrow('starred'))} />
-          <NavButton
-            name="at-sign"
-            onPress={() => doNarrowCloseDrawer(specialNarrow('mentioned'))}
-          />
-          <NavButton name="search" onPress={actions.navigateToSearch} />
-        </View>
         <StreamTabs screenProps={{ doNarrowCloseDrawer }} />
       </View>
     );
   }
 }
 
-export default connectWithActions(null)(StreamTabsCard);
+export default StreamTabsCard;


### PR DESCRIPTION
This allows simpler navigation if someone is on the conversations tab they can narrow the home view

![simulator screen shot - iphone 6 - 2017-12-01 at 10 30 11](https://user-images.githubusercontent.com/12700799/33468484-a1a4b468-d682-11e7-86cb-a91d1e6e14a6.png)
