### PR TITLE
Fix: warning when list of null users is shown in GroupTitle.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -53,6 +53,7 @@
     "react/sort-comp": 0,
     "react/jsx-filename-extension": 0,
     "react/no-unused-prop-types": 0,
+    "react/no-array-index-key": 0,
     "react/prefer-stateless-function": 0,
     "react/require-default-props": 0,
     "react/jsx-wrap-multilines": 0,

--- a/src/title/TitleGroup.js
+++ b/src/title/TitleGroup.js
@@ -30,7 +30,7 @@ export default class TitleGroup extends PureComponent<Props> {
       <View style={styles.wrapper}>
         {recipients.map((user, index) => (
           // eslint-disable-next-line react/no-array-index-key
-          <View key={`${user.email}${index}`} style={styles.avatar}>
+          <View key={index} style={styles.avatar}>
             <Avatar size={32} name={user.fullName} avatarUrl={user.avatarUrl} email={user.email} />
           </View>
         ))}

--- a/src/title/TitleGroup.js
+++ b/src/title/TitleGroup.js
@@ -28,8 +28,9 @@ export default class TitleGroup extends PureComponent<Props> {
 
     return (
       <View style={styles.wrapper}>
-        {recipients.map(user => (
-          <View key={user.email} style={styles.avatar}>
+        {recipients.map((user, index) => (
+          // eslint-disable-next-line react/no-array-index-key
+          <View key={`${user.email}${index}`} style={styles.avatar}>
             <Avatar size={32} name={user.fullName} avatarUrl={user.avatarUrl} email={user.email} />
           </View>
         ))}

--- a/src/title/TitleGroup.js
+++ b/src/title/TitleGroup.js
@@ -29,7 +29,6 @@ export default class TitleGroup extends PureComponent<Props> {
     return (
       <View style={styles.wrapper}>
         {recipients.map((user, index) => (
-          // eslint-disable-next-line react/no-array-index-key
           <View key={index} style={styles.avatar}>
             <Avatar size={32} name={user.fullName} avatarUrl={user.avatarUrl} email={user.email} />
           </View>


### PR DESCRIPTION
It takes some time to fetch users, until all are null having same email. So concat with index to get unique key.