### PR TITLE
Clear outbox on account switch.

### DIFF
--- a/src/outbox/outboxReducers.js
+++ b/src/outbox/outboxReducers.js
@@ -4,6 +4,7 @@ import {
   MESSAGE_SEND_START,
   EVENT_NEW_MESSAGE,
   LOGOUT,
+  ACCOUNT_SWITCH,
   DELETE_OUTBOX_MESSAGE,
   MESSAGE_SEND_COMPLETE,
 } from '../actionConstants';
@@ -25,6 +26,7 @@ export default (state: OutboxState = initialState, action: Action): OutboxState 
     case EVENT_NEW_MESSAGE:
       return filterArray(state, item => item && item.timestamp !== +action.localMessageId);
 
+    case ACCOUNT_SWITCH:
     case LOGOUT:
       return initialState;
 


### PR DESCRIPTION
Fix: unsent messages are being shown in another account.

Next task: will be to preserve outbox & club messages with `realm` and `email` so that app is not sending unnecessary requests via another account.

For now we can take this in and next task in another PR.