### PR TITLE
Fix: extra message header is shown.

### DIFF
--- a/src/message/MessageListSection.js
+++ b/src/message/MessageListSection.js
@@ -14,7 +14,7 @@ export default class MessageListSection extends PureComponent<Props> {
   render() {
     const { message } = this.props;
 
-    if (!message) return null;
+    if (!message || Object.keys(message).length === 0) return null;
 
     return <MessageHeaderContainer message={message} />;
   }

--- a/src/message/cachedMessageRender.js
+++ b/src/message/cachedMessageRender.js
@@ -21,9 +21,7 @@ export default (
   if (!isEqual(lastRenderedMessages, renderedMessages)) {
     const rendered: Object[] = renderedMessages.reduce((result, section) => {
       result.push(
-        Object.keys(section.message).length > 0 && (
-          <MessageListSection key={section.key} message={section.message} />
-        ),
+        <MessageListSection key={section.key} message={section.message} />,
         section.data.map(item => <MessageListItem onReplySelect={onReplySelect} {...item} />),
       );
 

--- a/src/message/cachedMessageRender.js
+++ b/src/message/cachedMessageRender.js
@@ -21,9 +21,12 @@ export default (
   if (!isEqual(lastRenderedMessages, renderedMessages)) {
     const rendered: Object[] = renderedMessages.reduce((result, section) => {
       result.push(
-        <MessageListSection key={section.key} message={section.message} />,
+        Object.keys(section.message).length > 0 && (
+          <MessageListSection key={section.key} message={section.message} />
+        ),
         section.data.map(item => <MessageListItem onReplySelect={onReplySelect} {...item} />),
       );
+
       return result;
     }, []);
     const messageList: ChildrenArray<*> = React.Children.toArray(rendered);


### PR DESCRIPTION
Push header only if there is valid message under it. Don't push if it only contains times item.

Before
<img width="291" alt="screen shot 2017-12-13 at 3 22 19 am" src="https://user-images.githubusercontent.com/18511177/33910477-e3e9a582-dfb4-11e7-8e7d-daec1eb2d5d5.png">
<img width="297" alt="screen shot 2017-12-13 at 3 22 37 am" src="https://user-images.githubusercontent.com/18511177/33910478-e42b19e0-dfb4-11e7-991e-3fd80aba2bf3.png">


After
<img width="299" alt="screen shot 2017-12-13 at 3 23 43 am" src="https://user-images.githubusercontent.com/18511177/33910526-0b2dfea4-dfb5-11e7-99fa-fb644862c4ff.png">
