### PR TITLE
Add git and Yarn installation to `docs/developer-guide.md`.

### DIFF
--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -10,6 +10,9 @@ iOS version can be run only on a macOS, while Android can be run on Linux, Windo
 
 ## Dev environment
 
+Before starting, make sure you have [git](https://git-scm.com/) and
+[Yarn](https://yarnpkg.com) installed.
+
 Setting up a dev environment should be as simple as running the commands
 below in your terminal:
 ```


### PR DESCRIPTION
I was working on the *Intro to Zulip Mobile Development* Google Code-in task, and I ran into the slight problem that I didn't have Yarn installed when setting up the development environment. 

This was not a major issue, as installing Yarn was simple and easy, but I thought it would be a good idea to make a simple change to the documentation so that others don't run into this minor inconvenience.