### PR TITLE
Fix AutoComplete from showing up when typing Emails

### DIFF
--- a/src/autocomplete/__tests__/getAutocompleteFilter-test.js
+++ b/src/autocomplete/__tests__/getAutocompleteFilter-test.js
@@ -52,8 +52,8 @@ describe('getAutocompleteFilter', () => {
   test('get filter for more complicated text', () => {
     selection = { start: 9, end: 9 };
     expect(getAutocompleteFilter(':smile@ab', selection)).toEqual({
-      filter: 'ab',
-      lastWordPrefix: '@',
+      filter: 'smile@ab',
+      lastWordPrefix: ':',
     });
 
     selection = { start: 2, end: 2 };
@@ -61,8 +61,8 @@ describe('getAutocompleteFilter', () => {
 
     selection = { start: 12, end: 12 };
     expect(getAutocompleteFilter(':smile@ab cd', selection)).toEqual({
-      filter: 'ab cd',
-      lastWordPrefix: '@',
+      filter: 'smile@ab cd',
+      lastWordPrefix: ':',
     });
 
     selection = { start: 3, end: 3 };
@@ -97,8 +97,8 @@ describe('getAutocompleteFilter', () => {
 
     selection = { start: 11, end: 11 };
     expect(getAutocompleteFilter('@r@::@q@m p', selection)).toEqual({
-      filter: 'm p',
-      lastWordPrefix: '@',
+      filter: '@q@m p',
+      lastWordPrefix: ':',
     });
 
     selection = { start: 1, end: 1 };

--- a/src/autocomplete/getAutocompleteFilter.js
+++ b/src/autocomplete/getAutocompleteFilter.js
@@ -10,7 +10,7 @@ export default (text: string, selection: InputSelectionType) => {
   const lastIndex: number = Math.max(
     text.lastIndexOf(':'),
     text.lastIndexOf('#'),
-    text[text.lastIndexOf('@') - 1] === ' ' || text.lastIndexOf('@') === 0
+    [' ', '#', ':'].includes(text[text.lastIndexOf('@') - 1]) || text.lastIndexOf('@') === 0
       ? text.lastIndexOf('@')
       : -1,
   );

--- a/src/autocomplete/getAutocompleteFilter.js
+++ b/src/autocomplete/getAutocompleteFilter.js
@@ -10,8 +10,11 @@ export default (text: string, selection: InputSelectionType) => {
   const lastIndex: number = Math.max(
     text.lastIndexOf(':'),
     text.lastIndexOf('#'),
-    text.lastIndexOf('@'),
+    text[text.lastIndexOf('@') - 1] === ' ' || text.lastIndexOf('@') === 0
+      ? text.lastIndexOf('@')
+      : -1,
   );
+
   const lastWordPrefix: string = lastIndex !== -1 ? text[lastIndex] : '';
   const filter: string =
     text.length > lastIndex + 1 ? text.substring(lastIndex + 1, text.length) : '';


### PR DESCRIPTION
The AutoComplete View pops up when typing '@' to mention usernames, but when typing email addresses the same View pops up. This was fixed by checking whether the previous letter before the '@' is an empty space. This stops the view from showing as the letter before '@' would never be a space in an email.

Fixes:#1553