### PR TITLE
webView: fix js not working inside webView on Android.

### DIFF
--- a/src/message/html/js.js
+++ b/src/message/html/js.js
@@ -35,7 +35,7 @@ window.onerror = function(message, source, line, column, error) {
       'Line: ' + line,
       'Column: ' + column,
       'Error object: ' + JSON.stringify(error),
-    ].join(' - '),
+    ].join(' - ')
   );
   return false;
 };
@@ -68,7 +68,7 @@ window.addEventListener('scroll', function() {
       innerHeight: window.innerHeight,
       offsetHeight: document.body.offsetHeight,
     }),
-    '*',
+    '*'
   );
 });
 


### PR DESCRIPTION
Trailing comma is not allowed on Android.

(Another item added to list :p)
(will be creating a doc listing on this soon :))