### PR TITLE
Use PendingNotifications for Android

### DIFF
--- a/src/nav/AppWithNavigationState.js
+++ b/src/nav/AppWithNavigationState.js
@@ -6,6 +6,7 @@ import { addNavigationHelpers } from 'react-navigation';
 import connectWithActions from '../connectWithActions';
 import { getCanGoBack } from '../selectors';
 import AppNavigator from './AppNavigator';
+import { tryInitialNotification } from '../utils/notifications';
 
 type Props = {
   canGoBack: boolean,
@@ -14,6 +15,7 @@ type Props = {
 class AppWithNavigation extends PureComponent<Props> {
   componentDidMount() {
     BackHandler.addEventListener('hardwareBackPress', this.handleBackButtonPress);
+    tryInitialNotification(this.props.actions.doNarrow);
   }
 
   componentWillUnmount() {

--- a/src/utils/notifications.android.js
+++ b/src/utils/notifications.android.js
@@ -1,5 +1,5 @@
 /* @flow */
-import { NotificationsAndroid } from 'react-native-notifications';
+import { NotificationsAndroid, PendingNotifications } from 'react-native-notifications';
 
 import type { Auth, Actions } from '../types';
 import { registerPush } from '../api';
@@ -36,4 +36,11 @@ export const initializeNotifications = (auth: Auth, saveTokenPush: Actions.saveT
 
 export const refreshNotificationToken = () => {
   NotificationsAndroid.refreshToken();
+};
+
+export const tryInitialNotification = async (doNarrow: Actions.doNarrow) => {
+  const data = await PendingNotifications.getInitialNotification();
+  if (data && data.getData) {
+    handlePendingNotifications(data, doNarrow);
+  }
 };

--- a/src/utils/notifications.ios.js
+++ b/src/utils/notifications.ios.js
@@ -46,3 +46,5 @@ export const handlePendingNotifications = async (
     }
   }
 };
+
+export const tryInitialNotification = async (doNarrow: Actions.doNarrow) => {};


### PR DESCRIPTION
As the current event callback method was not consistent for android, this will get the data after each launch in android and narrow on notification click 

tryInitialNotification in notifications.ios.js will be same as in #1643 which is to be tested by the provisioning profiles first! 