### PR TITLE
Hide the statusbar in landscape mode.

### DIFF
--- a/src/common/ZulipStatusBar.js
+++ b/src/common/ZulipStatusBar.js
@@ -16,6 +16,7 @@ type Props = {
   backgroundColor: string,
   safeAreaInsets: Dimensions,
   textColor: string,
+  orientation: string,
 };
 
 class ZulipStatusBar extends PureComponent<Props> {
@@ -30,22 +31,24 @@ class ZulipStatusBar extends PureComponent<Props> {
   };
 
   render() {
-    const { theme, backgroundColor, textColor, hidden, barStyle, safeAreaInsets } = this.props;
+    const { theme, backgroundColor, textColor, hidden, barStyle, safeAreaInsets,
+            orientation } = this.props;
     const style = { height: hidden ? 0 : safeAreaInsets.top, backgroundColor };
     const statusBarStyle = !barStyle
       ? getStatusBarStyle(backgroundColor, textColor, theme)
       : barStyle;
     const statusBarColor = getStatusBarColor(backgroundColor, theme);
     return (
-      <View style={style}>
-        <StatusBar
-          animated
-          showHideTransition="slide"
-          hidden={hidden && Platform.OS !== 'android'}
-          backgroundColor={Color(statusBarColor).darken(0.1)}
-          barStyle={statusBarStyle}
-        />
-      </View>
+      orientation === 'PORTRAIT' &&
+        <View style={style}>
+          <StatusBar
+            animated
+            showHideTransition="slide"
+            hidden={hidden && Platform.OS !== 'android'}
+            backgroundColor={Color(statusBarColor).darken(0.1)}
+            barStyle={statusBarStyle}
+          />
+        </View>
     );
   }
 }
@@ -55,4 +58,5 @@ export default connectWithActions((state, props) => ({
   theme: state.settings.theme,
   backgroundColor: !props.backgroundColor ? getTitleBackgroundColor(state) : props.backgroundColor,
   textColor: getTitleTextColor(state),
+  orientation: state.app.orientation,
 }))(ZulipStatusBar);

--- a/src/main/MainScreen.js
+++ b/src/main/MainScreen.js
@@ -8,6 +8,7 @@ import MainNavBar from '../nav/MainNavBar';
 
 type Props = {
   navigation: any,
+  orientation: string,
 };
 
 export default class MainScreen extends PureComponent<Props> {


### PR DESCRIPTION
This is a part of #1606 that's being split off into its own PR (see #1606 for more details). It hides the statusbar when the user is in landscape mode. 

(Done for the *"Issue #1187 Slimmer nav bar in landscape mode"* Google Code-in task.) 