### PR TITLE
Reset navigation to AccountPickScreen on logout.

### DIFF
--- a/src/nav/navReducers.js
+++ b/src/nav/navReducers.js
@@ -2,7 +2,6 @@
 import { REHYDRATE } from 'redux-persist/constants';
 
 import type { NavigationState, Action } from '../types';
-import { navigateToAccountPicker } from './navActions';
 import { getFirstIfDeepEqual } from '../utils/immutability';
 import { getStateForRoute, getInitialRoute } from './navSelectors';
 import AppNavigator from './AppNavigator';
@@ -39,7 +38,7 @@ export default (
       );
 
     case LOGOUT:
-      return AppNavigator.router.getStateForAction(navigateToAccountPicker(), state);
+      return getStateForRoute('account');
 
     default:
       return AppNavigator.router.getStateForAction(action, state);


### PR DESCRIPTION
Instead of pushing new route, because on navigating back doesn't make sense. As no account is selected.