### PR TITLE
webView: fix regression in js.

### DIFF
--- a/src/render-html/js.js
+++ b/src/render-html/js.js
@@ -9,7 +9,7 @@ window.onerror = function(message, source, line, column, error) {
       'Line: ' + line,
       'Column: ' + column,
       'Error object: ' + JSON.stringify(error),
-    ].join(' - '),
+    ].join(' - ')
   );
   return false;
 };
@@ -100,7 +100,7 @@ window.addEventListener('scroll', function() {
       innerHeight: window.innerHeight,
       offsetHeight: document.body.offsetHeight,
     }),
-    '*',
+    '*'
   );
 });
 


### PR DESCRIPTION
Trailing commas are not supported on Android.