### PR TITLE
webView: fix loading state is not toggled.

### DIFF
--- a/src/render-html/MessageListWeb.js
+++ b/src/render-html/MessageListWeb.js
@@ -96,7 +96,6 @@ export default class MessageListWeb extends Component<Props> {
             <Text>{description}</Text>
           </View>
         )}
-        startInLoadingState
         javaScriptEnabled
         renderLoading={MessageListLoading}
       />


### PR DESCRIPTION
To reproduce: narrow to such topic whose message are locally stored. Activity indicator stops after fetching and compose box appears but renderLoading doesn't hides.
There are some regressions, we need to fix that first.