### PR TITLE
Make `RealmScreen` more similar to the Electron app.

### DIFF
--- a/src/common/WebLink.js
+++ b/src/common/WebLink.js
@@ -3,6 +3,7 @@ import React, { PureComponent } from 'react';
 
 import connectWithActions from '../connectWithActions';
 import { Touchable, Label } from '../common';
+import { StyleObj } from '../types';
 import { getFullUrl } from '../utils/url';
 import openLink from '../utils/openLink';
 import { getCurrentRealm } from '../selectors';

--- a/src/common/WebLink.js
+++ b/src/common/WebLink.js
@@ -11,6 +11,8 @@ type Props = {
   label: string,
   href: string,
   realm: string,
+  style?: StyleObj,
+  labelStyle?: StyleObj,
 };
 
 class WebLink extends PureComponent<Props> {
@@ -27,11 +29,11 @@ class WebLink extends PureComponent<Props> {
 
   render() {
     const { styles } = this.context;
-    const { label } = this.props;
+    const { label, style, labelStyle } = this.props;
 
     return (
-      <Touchable>
-        <Label style={[styles.link]} text={label} onPress={this.handlePress} />
+      <Touchable style={style}>
+        <Label style={[styles.link, labelStyle]} text={label} onPress={this.handlePress} />
       </Touchable>
     );
   }

--- a/src/i18n/translations/messages_en.json
+++ b/src/i18n/translations/messages_en.json
@@ -17,6 +17,8 @@
   "Welcome": "Welcome",
   "Subscriptions": "Subscriptions",
   "Your server URL": "Your server URL",
+  "Register or log in to a Zulip organization to get started.": "Register or log in to a Zulip organization to get started.",
+  "your-organization.zulipchat.com": "your-organization.zulipchat.com",
   "Search": "Search",
   "Sign in": "Sign in",
   "Enter": "Enter",

--- a/src/start/RealmScreen.js
+++ b/src/start/RealmScreen.js
@@ -1,10 +1,10 @@
 /* @flow */
 import React, { PureComponent } from 'react';
-import { ScrollView, Keyboard } from 'react-native';
+import { ScrollView, Keyboard, StyleSheet } from 'react-native';
 
 import type { Actions } from '../types';
 import connectWithActions from '../connectWithActions';
-import { Label, Screen, ErrorMsg, ZulipButton, Input } from '../common';
+import { Label, Screen, ErrorMsg, ZulipButton, Input, WebLink } from '../common';
 import { getServerSettings } from '../api';
 import { fixRealmUrl } from '../utils/url';
 
@@ -18,6 +18,18 @@ type State = {
   error: ?string,
   progress: boolean,
 };
+
+const customStyles = StyleSheet.create({
+  heading: {
+    marginBottom: 32,
+  },
+  newOrgLink: {
+    marginTop: 24,
+  },
+  newOrgLinkLabel: {
+    textAlign: 'center',
+  },
+});
 
 class RealmScreen extends PureComponent<Props, State> {
   props: Props;
@@ -68,13 +80,17 @@ class RealmScreen extends PureComponent<Props, State> {
 
     return (
       <Screen title="Welcome" padding scrollView>
-        <Label text="Your server URL" />
+        <Label
+          text="Register or log in to a Zulip organization to get started."
+          style={[styles.heading2, customStyles.heading]}
+        />
+        <Label text="URL of Zulip organization" />
         <Input
           style={styles.smallMarginTop}
           autoFocus
           autoCorrect={false}
           autoCapitalize="none"
-          placeholder="Server URL"
+          placeholder="your-organization.zulipchat.com"
           returnKeyType="go"
           defaultValue={realm}
           onChangeText={value => this.setState({ realm: value })}
@@ -88,6 +104,12 @@ class RealmScreen extends PureComponent<Props, State> {
           text="Enter"
           progress={progress}
           onPress={this.tryRealm}
+        />
+        <WebLink
+          style={customStyles.newOrgLink}
+          labelStyle={customStyles.newOrgLinkLabel}
+          label="Or create a new organization on zulipchat.com."
+          href="https://zulipchat.com/create_realm/"
         />
       </Screen>
     );


### PR DESCRIPTION
Add a header above the URL input and add a link to create a new organization underneath. Also make some changes to placeholders and button text. See discussion here: https://goo.gl/QCZgLY.

Also, add style props to `WebLink` to help design the new `RealmScreen`.

**Screenshot**:

<img alt="new `RealmScreen` screenshot" src="https://user-images.githubusercontent.com/17259768/34644429-4eb12d74-f2eb-11e7-9829-2691a23ab921.png" width=320 />

Fix #1709.