### PR TITLE
webView: Fix regressions in message tags.

### DIFF
--- a/src/render-html/messageTagsAsHtml.js
+++ b/src/render-html/messageTagsAsHtml.js
@@ -10,7 +10,7 @@ export default (flags: Object, timeEdited?: number, isOutbox: boolean) => {
   return `
 <div class="message-tags">
   ${timeEdited ? `<span class="message-tag">edited ${editedTime} ago</span>` : ''}
-  ${flags.indexOf('starred') > -1} ? '<span class="message-tag">starred</span>' : ''}
+  ${flags.indexOf('starred') > -1 ? '<span class="message-tag">starred</span>' : ''}
   ${isOutbox ? '<span class="activity-indicator" /span>' : ''}
 </div>
   `;


### PR DESCRIPTION
Before
<img width="391" alt="screen shot 2018-01-09 at 7 08 35 pm" src="https://user-images.githubusercontent.com/18511177/34724030-7b29c90e-f572-11e7-860a-95a6b60af3fb.png">

This PR
<img width="387" alt="screen shot 2018-01-09 at 7 18 53 pm" src="https://user-images.githubusercontent.com/18511177/34724031-7bcce4c2-f572-11e7-8650-1dab0116c621.png">