### PR TITLE
webView: Fix bg color of brief messages containing self-mentions.

### DIFF
--- a/src/render-html/css.js
+++ b/src/render-html/css.js
@@ -97,8 +97,7 @@ th, td {
   padding: 0.5em;
 }
 .message-brief {
-  padding-top: 0;
-  margin-left: 3em;
+  padding: 0 0 0 3.5em;
 }
 .avatar {
   min-width: 2.5em;


### PR DESCRIPTION
<img width="292" alt="screen shot 2018-01-09 at 8 06 21 pm" src="https://user-images.githubusercontent.com/18511177/34726115-18915832-f579-11e7-855f-110aaca914ac.png">
<img width="289" alt="screen shot 2018-01-09 at 8 09 28 pm" src="https://user-images.githubusercontent.com/18511177/34726117-19815cba-f579-11e7-9bc9-5844ad8bb289.png">
