### PR TITLE
Fix: Don't add muted streams to UnreadStreamsCard

### DIFF
--- a/src/unread/__tests__/unreadSelectors-test.js
+++ b/src/unread/__tests__/unreadSelectors-test.js
@@ -306,6 +306,33 @@ describe('getUnreadStreamsAndTopics', () => {
     expect(unreadCount).toEqual([]);
   });
 
+  test('Muted streams should not be included', () => {
+    const state = deepFreeze({
+      subscriptions: [
+        {
+          stream_id: 0,
+          name: 'stream 0',
+          color: 'red',
+          in_home_view: false,
+        },
+        {
+          stream_id: 2,
+          name: 'stream 2',
+          color: 'blue',
+          in_home_view: false,
+        },
+      ],
+      unread: {
+        streams: unreadStreamData,
+      },
+      mute: [],
+    });
+
+    const unreadCount = getUnreadStreamsAndTopics(state);
+
+    expect(unreadCount).toEqual([]);
+  });
+
   test('group data by stream and topics inside, count unread', () => {
     const state = deepFreeze({
       subscriptions: [
@@ -360,19 +387,22 @@ describe('getUnreadStreamsAndTopics', () => {
           stream_id: 2,
           color: 'green',
           name: 'def stream',
-          in_home_view: false,
+          in_home_view: true,
+          invite_only: false,
         },
         {
           stream_id: 1,
           color: 'blue',
           name: 'xyz stream',
           in_home_view: true,
+          invite_only: false,
         },
         {
           stream_id: 0,
           color: 'red',
           name: 'abc stream',
           in_home_view: true,
+          invite_only: false,
         },
       ],
       unread: {
@@ -420,6 +450,7 @@ describe('getUnreadStreamsAndTopics', () => {
         streamName: 'abc stream',
         color: 'red',
         isMuted: false,
+        isPrivate: false,
         unread: 5,
         data: [
           { key: 'a topic', topic: 'a topic', unread: 2, isMuted: false },
@@ -430,7 +461,8 @@ describe('getUnreadStreamsAndTopics', () => {
         key: 'def stream',
         streamName: 'def stream',
         color: 'green',
-        isMuted: true,
+        isMuted: false,
+        isPrivate: false,
         unread: 4,
         data: [
           { key: 'b topic', topic: 'b topic', unread: 2, isMuted: false },
@@ -442,6 +474,7 @@ describe('getUnreadStreamsAndTopics', () => {
         streamName: 'xyz stream',
         color: 'blue',
         isMuted: false,
+        isPrivate: false,
         unread: 2,
         data: [
           { key: 'd topic', topic: 'd topic', unread: 1, isMuted: false },

--- a/src/unread/unreadSelectors.js
+++ b/src/unread/unreadSelectors.js
@@ -116,6 +116,7 @@ export const getUnreadStreamsAndTopics = createSelector(
       const { name, color, in_home_view, invite_only } =
         subscriptionsById[stream.stream_id] || NULL_SUBSCRIPTION;
 
+      if (!in_home_view) return totals;
       if (!totals[stream.stream_id]) {
         totals[stream.stream_id] = {
           key: name,


### PR DESCRIPTION
Avoids adding the muted streams in getUnreadStreamsAndTopics as it results a blank tab 

![simulator screen shot - iphone 6 - 2018-01-13 at 20 05 06](https://user-images.githubusercontent.com/12700799/34906960-0feceb84-f89d-11e7-8037-b9bb881465eb.png)

Another way could be check if all the items in the array have true in the `isMuted` boolean, but would be a performance overhead!