### PR TITLE
webView: Fix regression in getMessageNode.

### DIFF
--- a/src/render-html/es3.js
+++ b/src/render-html/es3.js
@@ -27,10 +27,12 @@ var sendMessage = function sendMessage(msg) {
 
 var getMessageNode = function getMessageNode(node) {
   var curNode = node;
+  var previousNode = node;
   while (curNode && curNode.parentNode && curNode !== documentBody) {
+    previousNode = curNode;
     curNode = curNode.parentNode;
   }
-  return curNode;
+  return previousNode;
 };
 
 var getMessageIdFromNode = function getMessageIdFromNode(node) {

--- a/src/render-html/js.js
+++ b/src/render-html/js.js
@@ -34,10 +34,12 @@ const sendMessage = msg => {
 
 const getMessageNode = node => {
   let curNode = node;
+  let previousNode = node;
   while (curNode && curNode.parentNode && curNode !== documentBody) {
+    previousNode = curNode;
     curNode = curNode.parentNode;
   }
-  return curNode;
+  return previousNode;
 };
 
 const getMessageIdFromNode = node => {


### PR DESCRIPTION
When loop breaks due to curNode !== documentBody, then previous node is the message node.