### PR TITLE
webView: Create helper method to validate target is msg-raw-content.

### DIFF
--- a/src/render-html/es3.js
+++ b/src/render-html/es3.js
@@ -38,6 +38,15 @@ var getMessageIdFromNode = function getMessageIdFromNode(node) {
   return msgNode && msgNode.getAttribute('data-msg-id');
 };
 
+var isTargetIsMessageContent = function isTargetIsMessageContent(target) {
+  var curNode = target;
+  while (curNode && curNode.parentNode && curNode.parentNode !== documentBody) {
+    if (curNode.matches('.msg-raw-content')) return true;
+    curNode = curNode.parentNode;
+  }
+  return false;
+};
+
 var scrollToBottom = function scrollToBottom() {
   window.scroll({ left: 0, top: documentBody.scrollHeight, behavior: 'smooth' });
 };

--- a/src/render-html/js.js
+++ b/src/render-html/js.js
@@ -45,6 +45,15 @@ const getMessageIdFromNode = node => {
   return msgNode && msgNode.getAttribute('data-msg-id');
 };
 
+const isTargetIsMessageContent = target => {
+  let curNode = target;
+  while (curNode && curNode.parentNode && curNode.parentNode !== documentBody) {
+    if (curNode.matches('.msg-raw-content')) return true;
+    curNode = curNode.parentNode;
+  }
+  return false;
+};
+
 const scrollToBottom = () => {
   window.scroll({ left: 0, top: documentBody.scrollHeight, behavior: 'smooth' });
 };

--- a/src/render-html/messageAsHtml.js
+++ b/src/render-html/messageAsHtml.js
@@ -13,7 +13,9 @@ const messageDiv = (id, msgClass, flags) =>
 const briefMessageAsHtml = ({ id, content, flags, timeEdited, isOutbox, reactions, ownEmail }) => `
 ${messageDiv(id, 'message-brief', flags)}
   <div class="content">
-    ${content}
+    <div class="msg-raw-content">
+      ${content}
+    </div>
     ${messageTagsAsHtml(flags, timeEdited, isOutbox)}
     ${messageReactionListAsHtml(reactions, id, ownEmail)}
   </div>
@@ -49,7 +51,9 @@ ${messageDiv(id, 'message-full', flags)}
         ${shortTime(timestamp * 1000, twentyFourHourTime)}
       </div>
     </div>
-    ${content}
+    <div class="msg-raw-content">
+      ${content}
+    </div>
     ${messageTagsAsHtml(flags, timeEdited, isOutbox)}
     ${messageReactionListAsHtml(reactions, id, ownEmail)}
   </div>


### PR DESCRIPTION
As only long press on msg-content needs to be considered (not headers, reations, tags avatar etc.).