### PR TITLE
Use gradle daemon in android to decrease build time

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -18,3 +18,4 @@
 # org.gradle.parallel=true
 
 android.useDeprecatedNdk=true
+org.gradle.daemon=true


### PR DESCRIPTION
Using gradle daemon in Android decreases build time. 🚀 
[A reference post](https://medium.com/@kevalpatel2106/how-to-decrease-your-gradle-build-time-by-65-310b572b0c43).