### PR TITLE
Fix: misplaced unread count in overlay.

### DIFF
--- a/src/common/ComponentWithOverlay.js
+++ b/src/common/ComponentWithOverlay.js
@@ -74,7 +74,7 @@ export default class ComponentWithOverlay extends PureComponent<Props> {
       styles.overlay,
       styles[overlayPosition],
       {
-        width: overlaySize,
+        minWidth: overlaySize,
         height: overlaySize,
         borderRadius: overlaySize,
         backgroundColor: overlayColor,

--- a/src/common/UnreadCount.js
+++ b/src/common/UnreadCount.js
@@ -69,7 +69,9 @@ export default class UnreadCount extends PureComponent<Props> {
 
     return (
       <View style={frameStyle}>
-        <Text style={textStyle}>{unreadToLimitedCount(count)}</Text>
+        <Text style={textStyle} numberOfLines={1}>
+          {unreadToLimitedCount(count)}
+        </Text>
       </View>
     );
   }


### PR DESCRIPTION
Now
<img width="67" alt="screen shot 2018-01-26 at 3 44 59 pm" src="https://user-images.githubusercontent.com/18511177/35435414-adec62ca-02b0-11e8-81b1-7eb8fc9fbf95.png">
<img width="59" alt="screen shot 2018-01-26 at 3 45 19 pm" src="https://user-images.githubusercontent.com/18511177/35435415-ae393708-02b0-11e8-9831-afb7d32fcd0d.png">
<img width="73" alt="screen shot 2018-01-26 at 3 45 33 pm" src="https://user-images.githubusercontent.com/18511177/35435416-ae801772-02b0-11e8-8bcc-c6b308232c5c.png">

Before
<img width="62" alt="screen shot 2018-01-26 at 3 51 46 pm" src="https://user-images.githubusercontent.com/18511177/35435456-ceb7a262-02b0-11e8-804c-ce04a139f94b.png">

