### PR TITLE
Fix: Compose menu icons are visible even in unexpanded state.

### DIFF
--- a/src/compose/ComposeMenu.js
+++ b/src/compose/ComposeMenu.js
@@ -15,6 +15,7 @@ const styles = StyleSheet.create({
   wrapper: {
     flexDirection: 'row',
     overflow: 'hidden',
+    backgroundColor: 'transparent',
   },
   touchable: {},
   button: {


### PR DESCRIPTION
Now it doesn't break animation :)