### PR TITLE
webView: [iOS] Prevent default longPress action on links.

### DIFF
--- a/src/render-html/css.js
+++ b/src/render-html/css.js
@@ -12,6 +12,7 @@ html {
   -ms-user-select: none; /* IE 10+ */
   user-select: none; /* Standard syntax */
   -khtml-user-select: none;
+  -webkit-touch-callout: none;
 }
 body {
   font-family: sans-serif;


### PR DESCRIPTION
So that only our actionSheet is shown. Fix: two actions are shown on long pressing links.