### PR TITLE
[iOS] Fix: compose box message input text is not aligned properly.

### DIFF
--- a/src/compose/ComposeBox.js
+++ b/src/compose/ComposeBox.js
@@ -34,7 +34,7 @@ const componentStyles = StyleSheet.create({
   },
   composeText: {
     flex: 1,
-    flexDirection: 'column',
+    justifyContent: 'center',
   },
   topic: {
     height: 30,
@@ -298,7 +298,10 @@ export default class ComposeBox extends PureComponent<Props, State> {
               />
             )}
             <MultilineInput
-              style={[styles.composeTextInput, { height: messageHeight }]}
+              style={[
+                styles.composeTextInput,
+                { height: messageHeight === MIN_HEIGHT ? MIN_HEIGHT - 12 : messageHeight },
+              ]}
               placeholder={placeholder}
               textInputRef={component => {
                 this.messageInput = component;


### PR DESCRIPTION
on master
<img width="328" alt="screen shot 2018-02-02 at 3 30 01 am" src="https://user-images.githubusercontent.com/18511177/35705779-71d3ecc2-07c9-11e8-926f-c47b4d8598f5.png">
<img width="327" alt="screen shot 2018-02-02 at 3 30 23 am" src="https://user-images.githubusercontent.com/18511177/35705783-72b14f9a-07c9-11e8-8a53-7b7a499fd7a7.png">

this PR
<img width="327" alt="screen shot 2018-02-02 at 3 28 16 am" src="https://user-images.githubusercontent.com/18511177/35705774-6fb25078-07c9-11e8-88cc-abd58be7b93c.png">
<img width="343" alt="screen shot 2018-02-02 at 3 28 41 am" src="https://user-images.githubusercontent.com/18511177/35705778-708ea460-07c9-11e8-8a03-0e1950d27fa8.png">
