### PR TITLE
webView: Fix left side of the message content not completely visible.

### DIFF
--- a/src/render-html/css.js
+++ b/src/render-html/css.js
@@ -97,6 +97,7 @@ th, td {
   display: flex;
   word-wrap: break-word;
   padding: 0.5em;
+  overflow: hidden;
 }
 .message-brief {
   padding: 0 0.5em 0.5em 3.5em;
@@ -114,7 +115,6 @@ th, td {
 .content {
   width: 100%;
   max-width: 100%;
-  overflow: hidden;
 }
 .username {
   font-weight: bold;


### PR DESCRIPTION
On master
* only half bullets are visible
* Left border of mention not visible 
<img width="327" alt="screen shot 2018-02-02 at 5 19 32 am" src="https://user-images.githubusercontent.com/18511177/35709485-bace1ee8-07d8-11e8-98e6-6949dc8e653c.png">

This PR
<img width="323" alt="screen shot 2018-02-02 at 5 17 22 am" src="https://user-images.githubusercontent.com/18511177/35709482-b9ef7422-07d8-11e8-9cf7-438fa7649b25.png">

