### PR TITLE
Use getVersion method to get app version.

### DIFF
--- a/src/diagnostics/DiagnosticsScreen.js
+++ b/src/diagnostics/DiagnosticsScreen.js
@@ -31,10 +31,7 @@ class DiagnosticsScreen extends PureComponent<Props> {
 
     return (
       <Screen title="Diagnostics">
-        <RawLabel
-          style={styles.versionLabel}
-          text={`App version: v${DeviceInfo.getReadableVersion()}`}
-        />
+        <RawLabel style={styles.versionLabel} text={`App version: v${DeviceInfo.getVersion()}`} />
         <OptionDivider />
         <OptionButton label="Variables" onPress={actions.navigateToVariables} />
         <OptionDivider />

--- a/src/diagnostics/DiagnosticsScreen.js
+++ b/src/diagnostics/DiagnosticsScreen.js
@@ -31,7 +31,7 @@ class DiagnosticsScreen extends PureComponent<Props> {
 
     return (
       <Screen title="Diagnostics">
-        <RawLabel style={styles.versionLabel} text={`App version: v${DeviceInfo.getVersion()}`} />
+        <RawLabel style={styles.versionLabel} text={`v${DeviceInfo.getVersion()}`} />
         <OptionDivider />
         <OptionButton label="Variables" onPress={actions.navigateToVariables} />
         <OptionDivider />


### PR DESCRIPTION
As it returns same as the version visible on Play Store/App Store.

`getReadableVersion` concats `appVersion` & `buildNumber`
https://github.com/rebeccahughes/react-native-device-info/blob/2f4d19deb3d991b4397e81a15346ed4c5ba83efb/deviceinfo.js#L57

So I thinks it's better to show only `appVersion`. (which will not create confusion among users, version mismatch in app and store)

Thoughts?
@borisyankov @kunall17 
 