### PR TITLE
Delete drafts on sending message.

### DIFF
--- a/src/compose/ComposeBox.js
+++ b/src/compose/ComposeBox.js
@@ -167,7 +167,8 @@ export default class ComposeBox extends PureComponent<Props, State> {
 
     actions.addToOutbox(destinationNarrow, messageToSend);
 
-    this.setState({ message: '' }, () => this.tryUpdateDraft());
+    this.clearMessageInput();
+    actions.deleteDraft(JSON.stringify(narrow));
   };
 
   handleEdit = () => {

--- a/src/compose/ComposeBox.js
+++ b/src/compose/ComposeBox.js
@@ -167,7 +167,7 @@ export default class ComposeBox extends PureComponent<Props, State> {
 
     actions.addToOutbox(destinationNarrow, messageToSend);
 
-    this.clearMessageInput();
+    this.setState({ message: '' }, () => this.tryUpdateDraft());
   };
 
   handleEdit = () => {

--- a/src/compose/ComposeBox.js
+++ b/src/compose/ComposeBox.js
@@ -166,9 +166,9 @@ export default class ComposeBox extends PureComponent<Props, State> {
       : narrow;
 
     actions.addToOutbox(destinationNarrow, messageToSend);
+    actions.deleteDraft(JSON.stringify(narrow));
 
     this.clearMessageInput();
-    actions.deleteDraft(JSON.stringify(narrow));
   };
 
   handleEdit = () => {


### PR DESCRIPTION
Test the bug: Type a message then change the narrow, then narrow back to previous one, and now send message. Now close app (forcefully). Now on opening again, compose box contains that draft.

Part of #1835.