### PR TITLE
Better handling of Keyboard on DrawerOpen.

### DIFF
--- a/src/main/MainScreen.js
+++ b/src/main/MainScreen.js
@@ -1,6 +1,6 @@
 /* @flow */
 import React, { PureComponent } from 'react';
-import { Keyboard, View } from 'react-native';
+import { View } from 'react-native';
 
 import { ZulipStatusBar } from '../common';
 import ChatContainer from '../chat/ChatContainer';
@@ -18,7 +18,6 @@ export default class MainScreen extends PureComponent<Props> {
   };
 
   handlePressStreams = () => {
-    Keyboard.dismiss();
     this.props.navigation.navigate('DrawerOpen');
   };
 

--- a/src/main/MainScreenWithDrawers.js
+++ b/src/main/MainScreenWithDrawers.js
@@ -1,6 +1,6 @@
 /* @TODO flow */
 import React, { PureComponent } from 'react';
-import { BackHandler } from 'react-native';
+import { BackHandler, Keyboard } from 'react-native';
 import { DrawerNavigator } from 'react-navigation';
 
 import MainScreen from './MainScreen';
@@ -23,6 +23,16 @@ export const Drawer = DrawerNavigator(
     drawerToggleRoute: 'DrawerToggle',
   },
 );
+
+const defaultGetStateForAction = Drawer.router.getStateForAction;
+
+Drawer.router.getStateForAction = (action, state) => {
+  if (state && action.type === 'Navigation/NAVIGATE' && action.routeName === 'DrawerOpen') {
+    Keyboard.dismiss();
+  }
+
+  return defaultGetStateForAction(action, state);
+};
 
 class MainScreenWithDrawers extends PureComponent<{}> {
   componentDidMount() {


### PR DESCRIPTION
Dismiss keyboard when drawer opens via swipe and hanburger icon.

Fix Keyboard is not dismissed on swiping to open drawer on Android.