### PR TITLE
webView: Fix message content overflow.

### DIFF
--- a/src/render-html/css.js
+++ b/src/render-html/css.js
@@ -97,16 +97,14 @@ th, td {
   display: flex;
   word-wrap: break-word;
   padding: 0.5em;
-  overflow: hidden;
 }
 .message-brief {
-  padding: 0 0.5em 0.5em 3.5em;
+  padding: 0 0 0.5em 3em;
 }
 .avatar {
   min-width: 2.5em;
   width: 2.5em;
   height: 2.5em;
-  margin-right: 0.5em;
 }
 .avatar img {
   width: 100%;
@@ -115,6 +113,8 @@ th, td {
 .content {
   width: 100%;
   max-width: 100%;
+  overflow: hidden;
+  padding: 0 0 0 0.5em;
 }
 .username {
   font-weight: bold;


### PR DESCRIPTION
on [master](https://github.com/zulip/zulip-mobile/tree/18f727713982bb2367763a79bd6d97b73d9b9ed8)
<img width="312" alt="screen shot 2018-02-10 at 9 06 18 pm" src="https://user-images.githubusercontent.com/18511177/36063704-4053cdf0-0ea6-11e8-9b3d-d55c4e36026b.png">


This PR
<img width="299" alt="screen shot 2018-02-10 at 9 05 26 pm" src="https://user-images.githubusercontent.com/18511177/36063697-317a194c-0ea6-11e8-8a3d-8eb8c5dd372c.png">

