### PR TITLE
Change the color of switches in off state

### DIFF
--- a/src/common/ZulipSwitch.js
+++ b/src/common/ZulipSwitch.js
@@ -49,7 +49,7 @@ export default class ZulipSwitch extends PureComponent<Props, State> {
       <Switch
         value={switchValue}
         onTintColor={BRAND_COLOR}
-        tintColor={BRAND_COLOR}
+        tintColor={'rgba(127, 127, 127, 0.25)'}
         onValueChange={this.handleValueChange}
         disabled={disabled}
       />


### PR DESCRIPTION
Switches had the same color for both the on and off states. This
commit changes the color of the switch in the off state to grey.

Fixes #1920