### PR TITLE
[WIP] Tries to fix #1666 ActionSheet text not completely visible

### DIFF
--- a/src/i18n/translations/messages_en.json
+++ b/src/i18n/translations/messages_en.json
@@ -46,6 +46,7 @@
   "Enter a password": "Enter a password",
   "Narrow to conversation": "Narrow to conversation",
   "Reply": "Reply",
+  "Reply   ": "Reply   ",
   "Copy to clipboard": "Copy to clipboard",
   "Mute topic": "Mute topic",
   "Unmute topic": "Unmute topic",

--- a/src/message/messageActionSheet.js
+++ b/src/message/messageActionSheet.js
@@ -179,7 +179,7 @@ const resolveMultiple = (message, auth, narrow, functions) =>
   });
 
 const actionSheetButtons: ActionSheetButtonType[] = [
-  { title: 'Reply', onPress: reply, onlyIf: isSentMessage },
+  { title: 'Reply   ', onPress: reply, onlyIf: isSentMessage },
   { title: 'Copy to clipboard', onPress: copyToClipboard, onlyIf: isNotDeleted },
   { title: 'Share', onPress: shareMessage, onlyIf: isNotDeleted },
   {


### PR DESCRIPTION

![screenshot_20180302-183908](https://user-images.githubusercontent.com/24983958/36900638-16e52d8e-1e4a-11e8-9718-03cf3f2ce9a5.jpg)

This PR is a proposed workaround to action sheet issue with oneplus and oppo devices using oneplus slate font. This is a bit too redundant but will fix the issue. #1666 