### PR TITLE
Fix: Placeholder ends with ... after a certain length

### DIFF
--- a/src/common/Input.js
+++ b/src/common/Input.js
@@ -43,6 +43,8 @@ export default class Input extends PureComponent<Props> {
     this.textInput.clear();
   };
 
+  formatText = (text) => text.length > 35 ? text.substring(0, 35).concat('...') : text;
+
   render() {
     const { styles } = this.context;
     const { style, placeholder, textInputRef, ...restProps } = this.props;
@@ -57,7 +59,7 @@ export default class Input extends PureComponent<Props> {
         {text => (
           <TextInput
             style={[styles.input, style]}
-            placeholder={text}
+            placeholder={this.formatText(text)}
             placeholderTextColor={HALF_COLOR}
             ref={(component: any) => {
               this.textInput = component;


### PR DESCRIPTION
Fixes #1966 : Takes a substring of placeholder if it is lengthier than 35 characters and postfixes '...' to it.
![screenshot_20180303-150304](https://user-images.githubusercontent.com/24983958/36932759-1b92ac26-1ef4-11e8-921c-556320159717.jpg)
