### PR TITLE
Fix Empty View from Rendering when Conversations list is Empty

### DIFF
--- a/src/conversations/UnreadConversationsContainer.js
+++ b/src/conversations/UnreadConversationsContainer.js
@@ -10,8 +10,11 @@ export default connectWithActions(state => ({
   conversations: getUnreadConversations(state),
   presences: getPresence(state),
   usersByEmail: getUsersByEmail(state),
-}))(props => (
-  <FlexView>
-    <ConversationList {...props} />
-  </FlexView>
-));
+}))(
+  props =>
+    props.conversations.length > 0 ? (
+      <FlexView>
+        <ConversationList {...props} />
+      </FlexView>
+    ) : null,
+);


### PR DESCRIPTION
The conversations list when empty would not render anything, this fix would stop UnreadConversationContainer from rendering when there are no unread conversations
Fix: #1999