### PR TITLE
Fix: tabs icons are not visible on Android.

### DIFF
--- a/src/main/MainTabIcon.js
+++ b/src/main/MainTabIcon.js
@@ -3,7 +3,7 @@ import React from 'react';
 import { StyleSheet, View } from 'react-native';
 
 const styles = StyleSheet.create({
-  icon: {
+  wrapper: {
     flex: 1,
     padding: 10,
     justifyContent: 'center',
@@ -17,7 +17,7 @@ type Props = {
 };
 
 export default ({ Icon, color }: Props) => (
-  <View>
-    <Icon style={styles.icon} size={24} color={color} />
+  <View style={styles.wrapper}>
+    <Icon size={24} color={color} />
   </View>
 );

--- a/src/main/MainTabs.js
+++ b/src/main/MainTabs.js
@@ -30,7 +30,9 @@ export default TabNavigator(
     conversations: {
       screen: props => <ConversationsContainer {...props.screenProps} />,
       navigationOptions: {
-        tabBarLabel: ({ tintColor }) => <IconUnreadConversations color={tintColor} />,
+        tabBarLabel: ({ tintColor }) => (
+          <MainTabIcon Icon={IconUnreadConversations} color={tintColor} />
+        ),
         // tabBarIcon: ({ tintColor }) => <IconUnreadConversations color={tintColor} />,
       },
     },


### PR DESCRIPTION
Again back to normal :)
iOS
<img width="303" alt="screen shot 2018-03-05 at 2 05 08 am" src="https://user-images.githubusercontent.com/18511177/36950274-d25f6ac2-2019-11e8-80d8-8e3ec91a0c95.png">
Android
<img width="461" alt="screen shot 2018-03-05 at 2 05 13 am" src="https://user-images.githubusercontent.com/18511177/36950275-d2b05f04-2019-11e8-960f-a49485dc4b60.png">
