### PR TITLE
Do not persist navigation state between runs

### DIFF
--- a/src/boot/store.js
+++ b/src/boot/store.js
@@ -20,7 +20,16 @@ export const restore = (onFinished?: () => void) =>
   persistStore(
     store,
     {
-      blacklist: ['caughtUp', 'fetching', 'presence', 'session', 'topics', 'typing', 'users'],
+      blacklist: [
+        'caughtUp',
+        'fetching',
+        'nav',
+        'presence',
+        'session',
+        'topics',
+        'typing',
+        'users',
+      ],
       storage: AsyncStorage,
     },
     onFinished,

--- a/src/nav/__tests__/navSelectors-test.js
+++ b/src/nav/__tests__/navSelectors-test.js
@@ -2,6 +2,16 @@ import deepFreeze from 'deep-freeze';
 import { getInitialNavState, getSameRoutesCount, getPreviousDifferentRoute } from '../navSelectors';
 
 describe('getInitialNavState', () => {
+  test('when no previous navigation is given do not throw but return some result', () => {
+    const state = deepFreeze({
+      accounts: [{ apiKey: '123' }],
+    });
+
+    const nav = getInitialNavState(state);
+
+    expect(nav.routes.length).toEqual(1);
+  });
+
   test('if logged in, preserve the state', () => {
     const state = deepFreeze({
       accounts: [{ apiKey: '123' }],

--- a/src/nav/navSelectors.js
+++ b/src/nav/navSelectors.js
@@ -56,7 +56,7 @@ export const getInitialNavState = createSelector(
     }
 
     const state =
-      nav.routes.length === 1 && nav.routes[0].routeName === 'loading'
+      !nav || (nav.routes.length === 1 && nav.routes[0].routeName === 'loading')
         ? getStateForRoute('main')
         : nav;
 


### PR DESCRIPTION
Most competitive chat apps and most general purpose apps do not
persist deep navigation state between runs. It does not seem suitable
for us too. In future we should consider storing a single narrow
navigation as a possibly better solution.