### PR TITLE
refactor: Rename InActiveNarrow to forNarrow.

### DIFF
--- a/src/autocomplete/TopicAutocomplete.js
+++ b/src/autocomplete/TopicAutocomplete.js
@@ -4,7 +4,7 @@ import { FlatList, StyleSheet } from 'react-native';
 
 import type { GlobalState } from '../types';
 import connectWithActions from '../connectWithActions';
-import { getTopicsInActiveNarrow } from '../selectors';
+import { getTopicsforNarrow } from '../selectors';
 import { Popup, RawLabel, Touchable } from '../common';
 import AnimatedScaleComponent from '../animation/AnimatedScaleComponent';
 
@@ -52,5 +52,5 @@ class TopicAutocomplete extends PureComponent<Props> {
 }
 
 export default connectWithActions((state: GlobalState) => ({
-  topics: getTopicsInActiveNarrow(state),
+  topics: getTopicsforNarrow(state),
 }))(TopicAutocomplete);

--- a/src/chat/UnreadNotice.js
+++ b/src/chat/UnreadNotice.js
@@ -4,7 +4,7 @@ import { StyleSheet, View } from 'react-native';
 
 import type { Narrow } from '../types';
 import connectWithActions from '../connectWithActions';
-import { getUnreadCountInActiveNarrow } from '../selectors';
+import { getUnreadCountforNarrow } from '../selectors';
 import { Label, RawLabel } from '../common';
 import { unreadToLimitedCount } from '../utils/unread';
 import MarkUnreadButton from './MarkUnreadButton';
@@ -63,5 +63,5 @@ class UnreadNotice extends PureComponent<Props> {
 }
 
 export default connectWithActions((state, props) => ({
-  unreadCount: getUnreadCountInActiveNarrow(props.narrow)(state),
+  unreadCount: getUnreadCountforNarrow(props.narrow)(state),
 }))(UnreadNotice);

--- a/src/chat/__tests__/chatSelectors-test.js
+++ b/src/chat/__tests__/chatSelectors-test.js
@@ -3,12 +3,12 @@ import deepFreeze from 'deep-freeze';
 import {
   getFirstMessageId,
   getLastMessageId,
-  getLastTopicInActiveNarrow,
-  getMessagesInActiveNarrow,
+  getLastTopicforNarrow,
+  getMessagesforNarrow,
 } from '../chatSelectors';
 import { homeNarrow, homeNarrowStr, privateNarrow, streamNarrow } from '../../utils/narrow';
 
-describe('getMessagesInActiveNarrow', () => {
+describe('getMessagesforNarrow', () => {
   test('if no outbox messages returns messages with no change', () => {
     const state = deepFreeze({
       messages: {
@@ -17,7 +17,7 @@ describe('getMessagesInActiveNarrow', () => {
       outbox: [],
     });
 
-    const anchor = getMessagesInActiveNarrow(homeNarrow)(state);
+    const anchor = getMessagesforNarrow(homeNarrow)(state);
 
     expect(anchor).toBe(state.messages['[]']);
   });
@@ -41,7 +41,7 @@ describe('getMessagesInActiveNarrow', () => {
       },
     });
 
-    const anchor = getMessagesInActiveNarrow(homeNarrow)(state);
+    const anchor = getMessagesforNarrow(homeNarrow)(state);
 
     const expectedState = deepFreeze([
       { id: 123 },
@@ -73,7 +73,7 @@ describe('getMessagesInActiveNarrow', () => {
       ],
     });
 
-    const anchor = getMessagesInActiveNarrow(homeNarrow)(state);
+    const anchor = getMessagesforNarrow(homeNarrow)(state);
 
     expect(anchor).toBe(state.messages[homeNarrowStr]);
   });
@@ -94,7 +94,7 @@ describe('getMessagesInActiveNarrow', () => {
       ],
     });
 
-    const anchor = getMessagesInActiveNarrow(privateNarrow('john@example.com'))(state);
+    const anchor = getMessagesforNarrow(privateNarrow('john@example.com'))(state);
 
     const expectedState = deepFreeze([{ id: 123 }]);
 
@@ -158,14 +158,14 @@ describe('getLastMessageId', () => {
   });
 });
 
-describe('getLastTopicInActiveNarrow', () => {
+describe('getLastTopicforNarrow', () => {
   test('when no messages yet, return empty string', () => {
     const state = deepFreeze({
       messages: {},
       outbox: [],
     });
 
-    const actualLastTopic = getLastTopicInActiveNarrow(homeNarrow)(state);
+    const actualLastTopic = getLastTopicforNarrow(homeNarrow)(state);
 
     expect(actualLastTopic).toEqual('');
   });
@@ -178,7 +178,7 @@ describe('getLastTopicInActiveNarrow', () => {
       outbox: [],
     });
 
-    const actualLastTopic = getLastTopicInActiveNarrow(homeNarrow)(state);
+    const actualLastTopic = getLastTopicforNarrow(homeNarrow)(state);
 
     expect(actualLastTopic).toEqual('Last subject');
   });
@@ -192,7 +192,7 @@ describe('getLastTopicInActiveNarrow', () => {
       outbox: [],
     });
 
-    const actualLastTopic = getLastTopicInActiveNarrow(narrow)(state);
+    const actualLastTopic = getLastTopicforNarrow(narrow)(state);
 
     expect(actualLastTopic).toEqual('');
   });
@@ -206,7 +206,7 @@ describe('getLastTopicInActiveNarrow', () => {
       outbox: [],
     });
 
-    const actualLastTopic = getLastTopicInActiveNarrow(narrow)(state);
+    const actualLastTopic = getLastTopicforNarrow(narrow)(state);
 
     expect(actualLastTopic).toEqual('Some subject');
   });

--- a/src/chat/chatSelectors.js
+++ b/src/chat/chatSelectors.js
@@ -43,12 +43,12 @@ export const outboxMessagesForCurrentNarrow = (narrow: Narrow) =>
     });
   });
 
-export const getFetchedMessagesInActiveNarrow = (narrow: Narrow) =>
+export const getFetchedMessagesforNarrow = (narrow: Narrow) =>
   createSelector(getAllMessages, allMessages => allMessages[JSON.stringify(narrow)] || NULL_ARRAY);
 
-export const getMessagesInActiveNarrow = (narrow: Narrow) =>
+export const getMessagesforNarrow = (narrow: Narrow) =>
   createSelector(
-    getFetchedMessagesInActiveNarrow(narrow),
+    getFetchedMessagesforNarrow(narrow),
     outboxMessagesForCurrentNarrow(narrow),
     (fetchedMessages, outboxMessages) => {
       if (outboxMessages.length === 0) {
@@ -59,30 +59,30 @@ export const getMessagesInActiveNarrow = (narrow: Narrow) =>
     },
   );
 
-export const getShownMessagesInActiveNarrow = (narrow: Narrow) =>
+export const getShownMessagesforNarrow = (narrow: Narrow) =>
   createSelector(
-    getMessagesInActiveNarrow(narrow),
+    getMessagesforNarrow(narrow),
     getSubscriptions,
     getMute,
-    (messagesInActiveNarrow, subscriptions, mute) =>
-      messagesInActiveNarrow.filter(item => !shouldBeMuted(item, narrow, subscriptions, mute)),
+    (messagesforNarrow, subscriptions, mute) =>
+      messagesforNarrow.filter(item => !shouldBeMuted(item, narrow, subscriptions, mute)),
   );
 
 export const getFirstMessageId = (narrow: Narrow) =>
   createSelector(
-    getFetchedMessagesInActiveNarrow(narrow),
+    getFetchedMessagesforNarrow(narrow),
     messages => (messages.length > 0 ? messages[0].id : undefined),
   );
 
 export const getLastMessageId = (narrow: Narrow) =>
   createSelector(
-    getFetchedMessagesInActiveNarrow(narrow),
+    getFetchedMessagesforNarrow(narrow),
     messages => (messages.length > 0 ? messages[messages.length - 1].id : undefined),
   );
 
-export const getLastTopicInActiveNarrow = (narrow: Narrow) =>
-  createSelector(getMessagesInActiveNarrow(narrow), messagesInActiveNarrow => {
-    const reversedMessages = messagesInActiveNarrow.slice().reverse();
+export const getLastTopicforNarrow = (narrow: Narrow) =>
+  createSelector(getMessagesforNarrow(narrow), messagesforNarrow => {
+    const reversedMessages = messagesforNarrow.slice().reverse();
     const lastMessageWithSubject = reversedMessages.find(msg => msg.subject) || NULL_MESSAGE;
     return lastMessageWithSubject.subject;
   });
@@ -113,7 +113,7 @@ export const getStreamInNarrow = (narrow: Narrow) =>
 
 export const getIfNoMessages = (narrow: Narrow) =>
   createSelector(
-    getShownMessagesInActiveNarrow(narrow),
+    getShownMessagesforNarrow(narrow),
     messages => messages && messages.length === 0,
   );
 

--- a/src/message/MessageListContainer.js
+++ b/src/message/MessageListContainer.js
@@ -31,7 +31,7 @@ import {
   getFetchingForActiveNarrow,
   getSubscriptions,
   getShowMessagePlaceholders,
-  getShownMessagesInActiveNarrow,
+  getShownMessagesforNarrow,
 } from '../selectors';
 import { filterUnreadMessageIds } from '../utils/unread';
 import { queueMarkAsRead } from '../api';
@@ -131,7 +131,7 @@ export default connectWithActions((state, props) => ({
   fetching: props.fetching || getFetchingForActiveNarrow(props.narrow)(state),
   flags: getFlags(state),
   isFetching: props.isFetching || getIsFetching(props.narrow)(state),
-  messages: props.messages || getShownMessagesInActiveNarrow(props.narrow)(state),
+  messages: props.messages || getShownMessagesforNarrow(props.narrow)(state),
   realmEmoji: getAllRealmEmoji(state),
   renderedMessages: props.renderedMessages || getRenderedMessages(props.narrow)(state),
   showMessagePlaceholders:

--- a/src/message/messageSelectors.js
+++ b/src/message/messageSelectors.js
@@ -3,27 +3,27 @@ import { createSelector } from 'reselect';
 
 import type { Narrow } from '../types';
 import { getFlags, getMute, getSubscriptions } from '../directSelectors';
-import { getShownMessagesInActiveNarrow } from '../chat/chatSelectors';
+import { getShownMessagesforNarrow } from '../chat/chatSelectors';
 import renderMessages from './renderMessages';
 import { findAnchor } from '../utils/message';
 import { NULL_MESSAGE } from '../nullObjects';
 
 export const getRenderedMessages = (narrow: Narrow) =>
-  createSelector(getShownMessagesInActiveNarrow(narrow), messages =>
+  createSelector(getShownMessagesforNarrow(narrow), messages =>
     renderMessages(messages, narrow),
   );
 
 export const getAnchorForActiveNarrow = (narrow: Narrow) =>
   createSelector(
-    getShownMessagesInActiveNarrow(narrow),
+    getShownMessagesforNarrow(narrow),
     getFlags,
     getSubscriptions,
     getMute,
     (messages, flags, subscriptions, mute) => findAnchor(messages, flags, subscriptions, mute),
   );
 
-export const getLastMessageInActiveNarrow = (narrow: Narrow) =>
+export const getLastMessageforNarrow = (narrow: Narrow) =>
   createSelector(
-    getShownMessagesInActiveNarrow(narrow),
+    getShownMessagesforNarrow(narrow),
     messages => (messages.length === 0 ? NULL_MESSAGE : messages[messages.length - 1]),
   );

--- a/src/message/messagesActions.js
+++ b/src/message/messagesActions.js
@@ -30,8 +30,8 @@ export const doNarrow = (narrow: Narrow, anchor: number = 0): Action => (
   dispatch(switchNarrow(narrow));
 
   const allMessages = getAllMessages(state);
-  const messagesInActiveNarrow = allMessages[JSON.stringify(narrow)] || NULL_ARRAY;
-  const tooFewMessages = messagesInActiveNarrow.length < config.messagesPerRequest / 2;
+  const messagesforNarrow = allMessages[JSON.stringify(narrow)] || NULL_ARRAY;
+  const tooFewMessages = messagesforNarrow.length < config.messagesPerRequest / 2;
 
   const caughtUp = state.caughtUp[JSON.stringify(narrow)] || NULL_CAUGHTUP;
   const isCaughtUp = caughtUp.newer && caughtUp.older;

--- a/src/topics/__tests__/topicsSelectors-test.js
+++ b/src/topics/__tests__/topicsSelectors-test.js
@@ -1,13 +1,13 @@
 import deepFreeze from 'deep-freeze';
 
-import { getTopicsInActiveNarrow, getLastMessageTopic } from '../topicSelectors';
+import { getTopicsforNarrow, getLastMessageTopic } from '../topicSelectors';
 import { homeNarrow, streamNarrow } from '../../utils/narrow';
 
-describe('getTopicsInActiveNarrow', () => {
+describe('getTopicsforNarrow', () => {
   test('when no topics return an empty list', () => {
     const state = deepFreeze({});
 
-    const topics = getTopicsInActiveNarrow(homeNarrow)(state);
+    const topics = getTopicsforNarrow(homeNarrow)(state);
 
     expect(topics).toEqual([]);
   });
@@ -20,7 +20,7 @@ describe('getTopicsInActiveNarrow', () => {
       },
     });
 
-    const topics = getTopicsInActiveNarrow(streamNarrow('hello'))(state);
+    const topics = getTopicsforNarrow(streamNarrow('hello'))(state);
 
     expect(topics).toEqual(['hi', 'wow']);
   });

--- a/src/topics/topicSelectors.js
+++ b/src/topics/topicSelectors.js
@@ -4,11 +4,11 @@ import { createSelector } from 'reselect';
 import type { Narrow } from '../types';
 import { getStreams, getTopics } from '../directSelectors';
 import { getCurrentRouteParams } from '../baseSelectors';
-import { getShownMessagesInActiveNarrow } from '../chat/chatSelectors';
+import { getShownMessagesforNarrow } from '../chat/chatSelectors';
 import { NULL_ARRAY } from '../nullObjects';
 import { isStreamNarrow, topicNarrow } from '../utils/narrow';
 
-export const getTopicsInActiveNarrow = (narrow: Narrow) =>
+export const getTopicsforNarrow = (narrow: Narrow) =>
   createSelector(getTopics, getStreams, (topics, streams) => {
     if (!isStreamNarrow(narrow)) {
       return NULL_ARRAY;
@@ -36,7 +36,7 @@ export const getTopicsInScreen = createSelector(
 
 export const getLastMessageTopic = (narrow: Narrow) =>
   createSelector(
-    getShownMessagesInActiveNarrow(narrow),
+    getShownMessagesforNarrow(narrow),
     messages => (messages.length === 0 ? '' : messages[messages.length - 1].subject),
   );
 

--- a/src/unread/unreadSelectors.js
+++ b/src/unread/unreadSelectors.js
@@ -165,7 +165,7 @@ export const getUnreadByHuddlesMentionsAndPMs = createSelector(
   (unreadPms, unreadHuddles, unreadMentions) => unreadPms + unreadHuddles + unreadMentions,
 );
 
-export const getUnreadCountInActiveNarrow = (narrow: Narrow) =>
+export const getUnreadCountforNarrow = (narrow: Narrow) =>
   createSelector(
     getStreams,
     getUsers,


### PR DESCRIPTION
This was suppossed to be part of #2020, but was missed at that time.