### PR TITLE
Shorten realm input placeholder to 'your-org'

### DIFF
--- a/src/start/RealmScreen.js
+++ b/src/start/RealmScreen.js
@@ -69,7 +69,7 @@ class RealmScreen extends PureComponent<Props, State> {
         <Label text="Organization URL" />
         <SmartUrlInput
           style={styles.marginTopBottom}
-          defaultOrganization="your-organization"
+          defaultOrganization="your-org"
           protocol="https://"
           append=".zulipchat.com"
           shortAppend=".com"

--- a/src/utils/__tests__/url-test.js
+++ b/src/utils/__tests__/url-test.js
@@ -470,7 +470,7 @@ describe('fixRealmUrl', () => {
 describe('autoCompleteUrl', () => {
   test('when no value entered fill in default values', () => {
     const result = autoCompleteUrl('', 'https://', '.zulipchat.com', '');
-    expect(result).toEqual('https://your-organization.zulipchat.com');
+    expect(result).toEqual('https://your-org.zulipchat.com');
   });
 
   test('when an protocol is provided use it', () => {

--- a/src/utils/url.js
+++ b/src/utils/url.js
@@ -153,6 +153,6 @@ export const autoCompleteUrl = (
   append: string,
   shortAppend: string,
 ): string =>
-  `${hasProtocol(value) ? '' : protocol}${value || 'your-organization'}${
+  `${hasProtocol(value) ? '' : protocol}${value || 'your-org'}${
     value.indexOf('.') === -1 ? append : !value.match(/.+\..+\.+./g) ? shortAppend : ''
   }`;


### PR DESCRIPTION
This is so the input fits better on screen.
We will return the value back once we start hosting on `zulip.com`