### PR TITLE
Fix input fields overlap with Nav bar in landscape mode (#2071)

### DIFF
--- a/src/common/Screen.js
+++ b/src/common/Screen.js
@@ -1,6 +1,6 @@
 /* @flow */
 import React, { PureComponent } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { StyleSheet, View, ScrollView } from 'react-native';
 
 import type { ChildrenArray, Dimensions, LocalizableText } from '../types';
 import connectWithActions from '../connectWithActions';
@@ -14,6 +14,10 @@ const componentStyles = StyleSheet.create({
     flex: 1,
     justifyContent: 'center',
     alignItems: 'stretch',
+  },
+  content: {
+    flexGrow: 1,
+    justifyContent: 'center',
   },
   padding: {
     padding: 10,
@@ -56,7 +60,7 @@ class Screen extends PureComponent<Props> {
           style={[componentStyles.wrapper, padding && componentStyles.padding]}
           contentContainerStyle={[padding && componentStyles.padding]}
         >
-          {children}
+          <ScrollView contentContainerStyle={componentStyles.content}>{children}</ScrollView>
         </KeyboardAvoider>
       </View>
     );

--- a/src/common/Screen.js
+++ b/src/common/Screen.js
@@ -27,6 +27,7 @@ const componentStyles = StyleSheet.create({
 type Props = {
   padding?: boolean,
   search?: boolean,
+  centerContent: boolean,
   safeAreaInsets: Dimensions,
   scrollView: boolean,
   title?: LocalizableText,
@@ -43,10 +44,19 @@ class Screen extends PureComponent<Props> {
 
   static defaultProps = {
     scrollView: true,
+    centerContent: false,
   };
 
   render() {
-    const { padding, search, title, children, safeAreaInsets, searchBarOnChange } = this.props;
+    const {
+      padding,
+      search,
+      centerContent,
+      title,
+      children,
+      safeAreaInsets,
+      searchBarOnChange,
+    } = this.props;
     const { styles } = this.context;
     const ModalBar = search ? ModalSearchNavBar : ModalNavBar;
 
@@ -60,7 +70,9 @@ class Screen extends PureComponent<Props> {
           style={[componentStyles.wrapper, padding && componentStyles.padding]}
           contentContainerStyle={[padding && componentStyles.padding]}
         >
-          <ScrollView contentContainerStyle={componentStyles.content}>{children}</ScrollView>
+          <ScrollView contentContainerStyle={centerContent ? componentStyles.content : null}>
+            {children}
+          </ScrollView>
         </KeyboardAvoider>
       </View>
     );


### PR DESCRIPTION
BEFORE: 
![screenshot_20180316-222709](https://user-images.githubusercontent.com/16636569/37536109-b10edde4-296f-11e8-94f7-7dba6684df92.png)



AFTER:
![screenshot_20180316-225906](https://user-images.githubusercontent.com/16636569/37536127-bbc4def0-296f-11e8-96cc-915e29a93401.png)

Closes #2071
