### PR TITLE
Show keyboard if dismissed in realm input. Fixes #2058

### DIFF
--- a/src/common/SmartUrlInput.js
+++ b/src/common/SmartUrlInput.js
@@ -59,7 +59,8 @@ export default class SmartUrlInput extends PureComponent<Props, State> {
   };
 
   urlPress = () => {
-    this.textInputRef.focus();
+    this.textInputRef.blur();
+    setTimeout(() => this.textInputRef.focus(), 100);
   };
 
   renderPlaceholderPart = (text: string) => (


### PR DESCRIPTION
Focus remains on the input, yet there is no keyboard.
Thus we need to first lose the focus and re-focus.