### PR TITLE
Fix: Show loading indicator for topics instead of message

### DIFF
--- a/src/topics/TopicList.js
+++ b/src/topics/TopicList.js
@@ -4,7 +4,7 @@ import { FlatList, StyleSheet } from 'react-native';
 
 import type { TopicDetails } from '../types';
 import TopicItem from '../streams/TopicItem';
-import { SectionSeparatorBetween, SearchEmptyState } from '../common';
+import { LoadingIndicator, SectionSeparatorBetween, SearchEmptyState } from '../common';
 
 const styles = StyleSheet.create({
   list: {
@@ -14,7 +14,7 @@ const styles = StyleSheet.create({
 });
 
 type Props = {
-  topics: TopicDetails[],
+  topics: ?(TopicDetails[]),
   unreadByStream: number[],
   onPress: (stream: string, topic: string) => void,
 };
@@ -32,6 +32,10 @@ export default class TopicList extends PureComponent<Props> {
 
   render() {
     const { topics, onPress } = this.props;
+
+    if (!topics) {
+      return <LoadingIndicator size={40} />;
+    }
 
     if (topics.length === 0) {
       return <SearchEmptyState text="No topics found" />;

--- a/src/topics/topicSelectors.js
+++ b/src/topics/topicSelectors.js
@@ -25,13 +25,7 @@ export const getTopicsForNarrow = (narrow: Narrow) =>
 export const getTopicsInScreen = createSelector(
   getCurrentRouteParams,
   getTopics,
-  (params, topics) => {
-    if (!params.streamId || !topics[params.streamId]) {
-      return NULL_ARRAY;
-    }
-
-    return topics[params.streamId];
-  },
+  (params, topics) => topics[params.streamId],
 );
 
 export const getLastMessageTopic = (narrow: Narrow) =>


### PR DESCRIPTION
Returning undefined from selector allows us to differentiate
between empty stream and topics not yet loaded.