### PR TITLE
Show loading for conversations if users data is loading

### DIFF
--- a/src/conversations/ConversationsCard.js
+++ b/src/conversations/ConversationsCard.js
@@ -44,7 +44,7 @@ export default class ConversationsCard extends PureComponent<Props> {
     const { styles } = this.context;
     const { actions, conversations, isLoading, presences, usersByEmail } = this.props;
 
-    if (conversations.length === 0 && isLoading) {
+    if (isLoading) {
       return <LoadingIndicator size={40} />;
     }
 


### PR DESCRIPTION
Conversation data may be fetched already but can not be shown
before users are loaded so show loading.