### PR TITLE
Fix crash: revert 'ellipsizeMode' in UnreadCount

### DIFF
--- a/src/common/UnreadCount.js
+++ b/src/common/UnreadCount.js
@@ -71,7 +71,7 @@ export default class UnreadCount extends PureComponent<Props> {
 
     return (
       <View style={frameStyle}>
-        <Text style={textStyle} numberOfLines={1} ellipsizeMode="clip">
+        <Text style={textStyle} numberOfLines={1}>
           {unreadToLimitedCount(count)}
         </Text>
       </View>


### PR DESCRIPTION
In many versions of Android this causes a crash for unknown reason