### PR TITLE
Check for URL validity in apiFetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "stream": "^0.0.2",
     "string.fromcodepoint": "^0.2.1",
     "url-parse": "^1.2.0",
+    "valid-url": "^1.0.9",
     "zulip-markdown-parser": "^1.0.4"
   },
   "devDependencies": {

--- a/src/api/apiFetch.js
+++ b/src/api/apiFetch.js
@@ -1,4 +1,6 @@
 /* @flow */
+import { isUri } from 'valid-url';
+
 import type { Auth, ResponseExtractionFunc } from '../types';
 import { getAuthHeader, encodeAsURI } from '../utils/url';
 import userAgent from '../utils/userAgent';
@@ -8,6 +10,11 @@ const apiVersion = 'api/v1';
 
 export const apiFetch = async (auth: Auth, route: string, params: Object = {}) => {
   const url = `${auth.realm}/${apiVersion}/${route}`;
+
+  if (!isUri(url)) {
+    throw new Error(`Invalid url ${url}`);
+  }
+
   const contentType =
     params.body instanceof FormData
       ? 'multipart/form-data'

--- a/src/message/__tests__/fetchActions-test.js
+++ b/src/message/__tests__/fetchActions-test.js
@@ -24,6 +24,11 @@ describe('fetchActions', () => {
     test('message fetch success action is dispatched after successful fetch', async () => {
       const store = mockStore({
         ...navStateWithNarrow(homeNarrow),
+        accounts: [
+          {
+            realm: 'https://example.com',
+          },
+        ],
         messages: {
           [streamNarrowStr]: [{ id: 1 }],
         },

--- a/yarn.lock
+++ b/yarn.lock
@@ -6989,6 +6989,10 @@ uuid@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.1.0.tgz#3dd3d3e790abc24d7b0d3a034ffababe28ebbc04"
 
+valid-url@^1.0.9:
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/valid-url/-/valid-url-1.0.9.tgz#1c14479b40f1397a75782f115e4086447433a200"
+
 validate-npm-package-license@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz#2804babe712ad3379459acfbe24746ab2c303fbc"


### PR DESCRIPTION
Calling 'fetch' with invalid URL in iOS correctly throws an
exception. On Android though it throws inside Java code and
leads to a crash.

Ideally we will catch invalid URLs even earler, but this adds an
important guard clause and additional info in the exception,
ensuring it is thrown within our JS code.