### PR TITLE
Sort conversations by message id

### DIFF
--- a/src/conversations/__tests__/conversationsSelectors-test.js
+++ b/src/conversations/__tests__/conversationsSelectors-test.js
@@ -52,11 +52,11 @@ describe('getRecentConversations', () => {
             ],
           },
           {
-            id: 4,
+            id: 1,
             display_recipient: [{ id: 0, email: 'me@example.com' }],
           },
           {
-            id: 5,
+            id: 0,
             display_recipient: [
               { id: 0, email: 'me@example.com' },
               { id: 1, email: 'john@example.com' },
@@ -93,24 +93,28 @@ describe('getRecentConversations', () => {
       {
         ids: '1',
         recipients: 'john@example.com',
+        msgId: 3,
         timestamp: 0,
         unread: 2,
       },
       {
         ids: '2',
         recipients: 'mark@example.com',
+        msgId: 2,
         timestamp: 0,
         unread: 1,
       },
       {
         ids: '0',
         recipients: 'me@example.com',
+        msgId: 1,
         timestamp: 0,
         unread: 1,
       },
       {
         ids: '0,1,2',
         recipients: 'john@example.com,mark@example.com',
+        msgId: 0,
         timestamp: 0,
         unread: 1,
       },
@@ -127,6 +131,7 @@ describe('getRecentConversations', () => {
       messages: {
         [privatesNarrowStr]: [
           {
+            id: 2,
             display_recipient: [
               { id: 0, email: 'me@example.com' },
               { id: 1, email: 'john@example.com' },
@@ -134,6 +139,7 @@ describe('getRecentConversations', () => {
             timestamp: 2,
           },
           {
+            id: 1,
             display_recipient: [
               { id: 0, email: 'me@example.com' },
               { id: 2, email: 'mark@example.com' },
@@ -141,6 +147,7 @@ describe('getRecentConversations', () => {
             timestamp: 1,
           },
           {
+            id: 4,
             display_recipient: [
               { id: 0, email: 'me@example.com' },
               { id: 1, email: 'john@example.com' },
@@ -148,6 +155,7 @@ describe('getRecentConversations', () => {
             timestamp: 4,
           },
           {
+            id: 3,
             display_recipient: [
               { id: 0, email: 'me@example.com' },
               { id: 2, email: 'mark@example.com' },
@@ -155,6 +163,7 @@ describe('getRecentConversations', () => {
             timestamp: 3,
           },
           {
+            id: 5,
             display_recipient: [
               { id: 0, email: 'me@example.com' },
               { id: 1, email: 'john@example.com' },
@@ -163,6 +172,7 @@ describe('getRecentConversations', () => {
             timestamp: 5,
           },
           {
+            id: 6,
             display_recipient: [{ id: 0, email: 'me@example.com' }],
             timestamp: 6,
           },
@@ -196,24 +206,28 @@ describe('getRecentConversations', () => {
       {
         ids: '0',
         recipients: 'me@example.com',
+        msgId: 6,
         timestamp: 6,
         unread: 1,
       },
       {
         ids: '0,1,2',
         recipients: 'john@example.com,mark@example.com',
+        msgId: 5,
         timestamp: 5,
         unread: 1,
       },
       {
         ids: '1',
         recipients: 'john@example.com',
+        msgId: 4,
         timestamp: 4,
         unread: 2,
       },
       {
         ids: '2',
         recipients: 'mark@example.com',
+        msgId: 3,
         timestamp: 3,
         unread: 1,
       },


### PR DESCRIPTION
Sorting by timestamp is generally correct but sometimes
the values are equal and sorting by message id is preferrable.

Additionally including the last message id helps us with upcoming
feature where we will display part of the last message text.