### PR TITLE
Extract activity text from TitlePrivate to separate component

### DIFF
--- a/src/title/ActivityText.js
+++ b/src/title/ActivityText.js
@@ -1,0 +1,38 @@
+/* @flow */
+import React, { PureComponent } from 'react';
+import { StyleSheet, Text } from 'react-native';
+
+import connectWithActions from '../connectWithActions';
+import { getPresence } from '../selectors';
+import { presenceToHumanTime } from '../utils/date';
+
+const styles = StyleSheet.create({
+  time: {
+    fontSize: 13,
+    paddingLeft: 8,
+  },
+});
+
+type Props = {
+  email: string,
+  color: string,
+  presences: Object,
+};
+
+class ActivityText extends PureComponent<Props> {
+  render() {
+    const { presences, email, color } = this.props;
+
+    if (!presences[email]) {
+      return null;
+    }
+
+    const activity = presenceToHumanTime(presences[email]);
+
+    return <Text style={[styles.time, { color }]}>Active {activity}</Text>;
+  }
+}
+
+export default connectWithActions((state, props) => ({
+  presences: getPresence(state),
+}))(ActivityText);

--- a/src/title/TitlePrivate.js
+++ b/src/title/TitlePrivate.js
@@ -4,7 +4,7 @@ import { StyleSheet, Text, View } from 'react-native';
 
 import type { User } from '../types';
 import { Avatar } from '../common';
-import { presenceToHumanTime } from '../utils/date';
+import ActivityText from './ActivityText';
 
 const styles = StyleSheet.create({
   wrapper: {
@@ -16,23 +16,17 @@ const styles = StyleSheet.create({
     fontSize: 18,
     paddingLeft: 8,
   },
-  time: {
-    fontSize: 13,
-    paddingLeft: 8,
-  },
 });
 
 type Props = {
   user: User,
   color: string,
-  presences: Object,
 };
 
 export default class TitlePrivate extends PureComponent<Props> {
   render() {
-    const { presences, user, color } = this.props;
+    const { user, color } = this.props;
     const { fullName, avatarUrl, email } = user;
-    const activity = presenceToHumanTime(presences[email]);
 
     return (
       <View style={styles.wrapper}>
@@ -41,7 +35,7 @@ export default class TitlePrivate extends PureComponent<Props> {
           <Text style={[styles.title, { color }]} numberOfLines={1} ellipsizeMode="tail">
             {fullName}
           </Text>
-          <Text style={[styles.time, { color }]}>Active {activity}</Text>
+          <ActivityText color={color} email={email} />
         </View>
       </View>
     );

--- a/src/title/TitlePrivateContainer.js
+++ b/src/title/TitlePrivateContainer.js
@@ -1,9 +1,8 @@
 /* @flow */
 import connectWithActions from '../connectWithActions';
-import { getPresence, getUserInPmNarrow } from '../selectors';
+import { getUserInPmNarrow } from '../selectors';
 import TitlePrivate from './TitlePrivate';
 
 export default connectWithActions((state, props) => ({
-  presences: getPresence(state),
   user: getUserInPmNarrow(props.narrow)(state),
 }))(TitlePrivate);


### PR DESCRIPTION
Makes it reusable (will likely add it to AccountDetails too)
In rare cases we might not have presence data loaded, checks for
undefined and does not render if so.

Fixes #2104