### PR TITLE
Do not return undefined from getCurrentRouteParams

### DIFF
--- a/src/__tests__/baseSelectors-test.js
+++ b/src/__tests__/baseSelectors-test.js
@@ -23,6 +23,16 @@ describe('getCurrentRoute', () => {
 });
 
 describe('getCurrentRouteParams', () => {
+  test('return "undefined" even when there is no data', () => {
+    const state = deepFreeze({
+      nav: {},
+    });
+
+    const actualResult = getCurrentRouteParams(state);
+
+    expect(actualResult).toBe(undefined);
+  });
+
   test('return params of the current route', () => {
     const state = deepFreeze({
       nav: {

--- a/src/baseSelectors.js
+++ b/src/baseSelectors.js
@@ -20,6 +20,11 @@ export const getCurrentRouteParams = createSelector(
   (routes, index) => routes && routes[index] && routes[index].params,
 );
 
+export const getTopicListScreenParams = createSelector(
+  getCurrentRouteParams,
+  params => params || { streamId: -1 },
+);
+
 export const getTopMostNarrow = createSelector(getNav, nav => {
   const { routes } = nav;
   let { index } = nav;

--- a/src/topics/topicSelectors.js
+++ b/src/topics/topicSelectors.js
@@ -3,7 +3,7 @@ import { createSelector } from 'reselect';
 
 import type { Narrow } from '../types';
 import { getStreams, getTopics } from '../directSelectors';
-import { getCurrentRouteParams } from '../baseSelectors';
+import { getTopicListScreenParams } from '../baseSelectors';
 import { getShownMessagesForNarrow } from '../chat/chatSelectors';
 import { NULL_ARRAY } from '../nullObjects';
 import { isStreamNarrow, topicNarrow } from '../utils/narrow';
@@ -23,7 +23,7 @@ export const getTopicsForNarrow = (narrow: Narrow) =>
   });
 
 export const getTopicsInScreen = createSelector(
-  getCurrentRouteParams,
+  getTopicListScreenParams,
   getTopics,
   (params, topics) => topics[params.streamId],
 );


### PR DESCRIPTION
This selector is used in several screens.
Returning an empty object prevents potential bugs.
Fixes #2114