### PR TITLE
navigation: Fix regression in getCanGoBack selector.

### DIFF
--- a/src/nav/__tests__/navSelectors-test.js
+++ b/src/nav/__tests__/navSelectors-test.js
@@ -1,11 +1,32 @@
 import deepFreeze from 'deep-freeze';
 import {
+  getCanGoBack,
   getInitialNavState,
   getSameRoutesCount,
   getSameRoutesAndParamsCount,
   getPreviousDifferentRoute,
   getPreviousDifferentRouteAndParams,
 } from '../navSelectors';
+
+describe('getCanGoBack', () => {
+  test('return true if current route in the stack is not the only route', () => {
+    const state = deepFreeze({
+      nav: {
+        index: 1,
+      },
+    });
+    expect(getCanGoBack(state)).toBe(true);
+  });
+
+  test('return false if current route in the stack is the only route', () => {
+    const state = deepFreeze({
+      nav: {
+        index: 0,
+      },
+    });
+    expect(getCanGoBack(state)).toBe(false);
+  });
+});
 
 describe('getInitialNavState', () => {
   test('when no previous navigation is given do not throw but return some result', () => {

--- a/src/nav/navSelectors.js
+++ b/src/nav/navSelectors.js
@@ -10,8 +10,7 @@ import { getAuth } from '../account/accountSelectors';
 import AppNavigator from './AppNavigator';
 import { getNarrowFromNotificationData } from '../utils/notificationsCommon';
 
-export const getCanGoBack = (state: GlobalState) =>
-  state.nav.index > 0 && state.nav.routes[state.nav.index].routeName !== 'lightbox';
+export const getCanGoBack = (state: GlobalState) => state.nav.index > 0;
 
 export const getSameRoutesCount = createSelector(getNav, nav => {
   let i = nav.routes.length - 1;


### PR DESCRIPTION
If current route is lighbox then also we can go back.
Created new selector isCurrentRouteIsLightbox, which
can be used to distinguish such cases and back arrow
button can be rendered accordingly.

Fix: #2127.