### PR TITLE
Improve stability of navBar.

### DIFF
--- a/src/nav/MainNavBar.js
+++ b/src/nav/MainNavBar.js
@@ -3,7 +3,7 @@ import React, { PureComponent } from 'react';
 import { View } from 'react-native';
 
 import type { Actions, Narrow } from '../types';
-import connectWithActions from '../connectWithActions';
+import { connectWithActionsPreserveOnBack } from '../connectWithActions';
 import { ViewPlaceholder } from '../common';
 import Title from '../title/Title';
 import NavButton from './NavButton';
@@ -50,7 +50,7 @@ class MainNavBar extends PureComponent<Props> {
   }
 }
 
-export default connectWithActions((state, props) => ({
+export default connectWithActionsPreserveOnBack((state, props) => ({
   backgroundColor: getTitleBackgroundColor(props.narrow)(state),
   canGoBack: getCanGoBack(state),
   textColor: getTitleTextColor(props.narrow)(state),

--- a/src/nav/ModalNavBar.js
+++ b/src/nav/ModalNavBar.js
@@ -4,7 +4,7 @@ import { View } from 'react-native';
 import type { ChildrenArray } from 'react';
 
 import type { Actions, LocalizableText, StyleObj } from '../types';
-import connectWithActions from '../connectWithActions';
+import { connectWithActionsPreserveOnBack } from '../connectWithActions';
 import { NAVBAR_SIZE } from '../styles';
 import { Label, ViewPlaceholder } from '../common';
 import { getCanGoBack } from '../selectors';
@@ -67,6 +67,6 @@ class ModalNavBar extends PureComponent<Props> {
   }
 }
 
-export default connectWithActions(state => ({
+export default connectWithActionsPreserveOnBack(state => ({
   canGoBack: getCanGoBack(state),
 }))(ModalNavBar);

--- a/src/nav/ModalSearchNavBar.js
+++ b/src/nav/ModalSearchNavBar.js
@@ -3,7 +3,7 @@ import React, { PureComponent } from 'react';
 import { View, StyleSheet } from 'react-native';
 
 import type { Actions } from '../types';
-import connectWithActions from '../connectWithActions';
+import { connectWithActionsPreserveOnBack } from '../connectWithActions';
 import { getNav } from '../selectors';
 import { NAVBAR_SIZE } from '../styles';
 import { Label, SearchInput } from '../common';
@@ -88,6 +88,6 @@ class ModalSearchNavBar extends PureComponent<Props, State> {
   }
 }
 
-export default connectWithActions(state => ({
+export default connectWithActionsPreserveOnBack(state => ({
   nav: getNav(state),
 }))(ModalSearchNavBar);


### PR DESCRIPTION
Use connectWithActionsPreserveOnBack instead
of connectWithActions so that it do not
re-render unnecessary on navigating back.

This can be tested easily on Android, little bit old device.

It fixes the momentary flash of white color (from stream color)
in nav bar on navigating back to main screen.

In private narrow, back arrow is not visible for some millisecond
in transaction back to main screen.

In lightbox, it reduces re-render of header, when component
is about to unmount.


In search narrow, back arrow is not visible for some millisecond
in transaction back to main screen.