### PR TITLE
Add initalNumToRender in unread & stream list.

### DIFF
--- a/src/streams/StreamList.js
+++ b/src/streams/StreamList.js
@@ -67,6 +67,7 @@ export default class StreamList extends PureComponent<Props> {
         style={styles.list}
         sections={sections}
         extraData={unreadByStream}
+        initialNumToRender={20}
         keyExtractor={item => item.stream_id}
         renderItem={({ item }) => (
           <StreamItem

--- a/src/unread/UnreadCards.js
+++ b/src/unread/UnreadCards.js
@@ -56,7 +56,7 @@ export default class UnreadCards extends PureComponent<Props> {
     return (
       <SectionList
         stickySectionHeadersEnabled
-        initialNumToRender={2}
+        initialNumToRender={20}
         sections={unreadCards}
         renderSectionHeader={({ section }) =>
           section.key === 'private' || section.isMuted ? null : (


### PR DESCRIPTION
Currently only few are rendered initially and its take
some time to render next batch. Easily obervable on
older Android physical devices.

*  90aa1f3
Actually in ea3b464
unread list was designed to be section list of section list,
so initalNumToRender was 2, but later it converted to single section section.


*  8074bd6
So for better user experience, render alteast as many
items which can fill screen.


For next level we can have something like get count dynamically according to the screen size. But will become complicated for now.
