### PR TITLE
fix: Replace data in narrow on anchor 0 or Max value

### DIFF
--- a/src/chat/__tests__/chatReducers-test.js
+++ b/src/chat/__tests__/chatReducers-test.js
@@ -768,16 +768,16 @@ describe('chatReducers', () => {
       expect(newState).not.toBe(initialState);
     });
 
-    test('when replaceExisting is true, previous messages are replaced', () => {
+    test('when anchor is 0 previous messages are replaced', () => {
       const initialState = deepFreeze({
         [homeNarrowStr]: [{ id: 1, timestamp: 3 }, { id: 2, timestamp: 4 }],
       });
 
       const action = deepFreeze({
+        anchor: 0,
         type: MESSAGE_FETCH_COMPLETE,
         narrow: [],
         messages: [{ id: 3, timestamp: 2 }, { id: 4, timestamp: 1 }],
-        replaceExisting: true,
       });
 
       const expectedState = {
@@ -789,7 +789,28 @@ describe('chatReducers', () => {
       expect(newState).toEqual(expectedState);
     });
 
-    test('when replaceExisting is true, common messages are not replaced', () => {
+    test('when anchor is Number.MAX_SAFE_INTEGER previous messages are replaced', () => {
+      const initialState = deepFreeze({
+        [homeNarrowStr]: [{ id: 1, timestamp: 3 }, { id: 2, timestamp: 4 }],
+      });
+
+      const action = deepFreeze({
+        anchor: Number.MAX_SAFE_INTEGER,
+        type: MESSAGE_FETCH_COMPLETE,
+        narrow: [],
+        messages: [{ id: 3, timestamp: 2 }, { id: 4, timestamp: 1 }],
+      });
+
+      const expectedState = {
+        [homeNarrowStr]: [{ id: 3, timestamp: 2 }, { id: 4, timestamp: 1 }],
+      };
+
+      const newState = chatReducers(initialState, action);
+
+      expect(newState).toEqual(expectedState);
+    });
+
+    test('when anchor is 0 common messages are not replaced', () => {
       const commonMessages = [{ id: 2, timestamp: 4 }, { id: 3, timestamp: 5 }];
       const initialState = deepFreeze({
         [homeNarrowStr]: [{ id: 1, timestamp: 3 }, ...commonMessages],
@@ -797,9 +818,9 @@ describe('chatReducers', () => {
 
       const action = deepFreeze({
         type: MESSAGE_FETCH_COMPLETE,
+        anchor: 0,
         narrow: [],
         messages: [{ id: 2, timestamp: 4 }, { id: 3, timestamp: 5 }],
-        replaceExisting: true,
       });
 
       const newState = chatReducers(initialState, action);
@@ -807,7 +828,7 @@ describe('chatReducers', () => {
       expect(newState[homeNarrowStr]).toEqual(commonMessages);
     });
 
-    test('when replaceExisting is true, deep equal is performed to separate common messages', () => {
+    test('when anchor is 0 deep equal is performed to separate common messages', () => {
       const commonMessages = [{ id: 2, timestamp: 4 }, { id: 3, timestamp: 5 }];
       const changedMessage = { id: 4, timestamp: 6, subject: 'new topic' };
       const initialState = deepFreeze({
@@ -820,9 +841,9 @@ describe('chatReducers', () => {
 
       const action = deepFreeze({
         type: MESSAGE_FETCH_COMPLETE,
+        anchor: 0,
         narrow: [],
         messages: [{ id: 2, timestamp: 4 }, { id: 3, timestamp: 5 }, changedMessage],
-        replaceExisting: true,
       });
 
       const expectedState = {

--- a/src/chat/chatReducers.js
+++ b/src/chat/chatReducers.js
@@ -37,7 +37,8 @@ export default (state: MessageState = initialState, action: Action): MessageStat
       const key = JSON.stringify(action.narrow);
       const messages = state[key] || NULL_ARRAY;
       const messagesById = groupItemsById(messages);
-      const newMessages = action.replaceExisting
+      const replaceExisting = action.anchor === 0 || action.anchor === Number.MAX_SAFE_INTEGER;
+      const newMessages = replaceExisting
         ? action.messages.map(
             item =>
               messagesById[item.id]

--- a/src/message/fetchActions.js
+++ b/src/message/fetchActions.js
@@ -42,7 +42,6 @@ export const messageFetchComplete = (
   anchor: number,
   numBefore: number,
   numAfter: number,
-  replaceExisting: boolean = false,
 ): Action => async (dispatch: Dispatch, getState: GetState) =>
   dispatch({
     type: MESSAGE_FETCH_COMPLETE,
@@ -51,7 +50,6 @@ export const messageFetchComplete = (
     anchor,
     numBefore,
     numAfter,
-    replaceExisting,
   });
 
 export const backgroundFetchMessages = (
@@ -155,7 +153,7 @@ export const fetchEssentialInitialData = (): Action => async (
 
   dispatch(realmInit(initData));
   if (narrow && messages) {
-    dispatch(messageFetchComplete(messages, narrow, 0, halfCount, halfCount, true));
+    dispatch(messageFetchComplete(messages, narrow, 0, halfCount, halfCount));
   }
   dispatch(initialFetchComplete());
 
@@ -178,7 +176,7 @@ export const fetchRestOfInitialData = (): Action => async (
   ]);
   timing.end('Rest of server data');
 
-  dispatch(messageFetchComplete(messages, allPrivateNarrow, Number.MAX_SAFE_INTEGER, 100, 0, true));
+  dispatch(messageFetchComplete(messages, allPrivateNarrow, Number.MAX_SAFE_INTEGER, 100, 0));
   dispatch(initStreams(streams));
   if (auth.apiKey !== '' && (pushToken === '' || pushToken === undefined)) {
     refreshNotificationToken();


### PR DESCRIPTION
We used 'replaceExisting` value to determine if we should replace
current messages in fetched narrow with new messages.

This missed several key cases; we used it only on startup.

All cases where we need to replace data have an anchor of 0 or
Number.MAX_SAFE_INTEGER.

This is a fix for several erratic message list behaviors.