### PR TITLE
fix: Correct state mutation of EVENT_TYPING_STOP

### DIFF
--- a/src/typing/__tests__/typingReducers-test.js
+++ b/src/typing/__tests__/typingReducers-test.js
@@ -154,10 +154,11 @@ describe('typingReducers', () => {
           { email: 'me@example.com', user_id: 2 },
         ],
         ownEmail: 'me@example.com',
+        time: 123456789,
       });
 
       const expectedState = {
-        'john@example.com': [2],
+        'john@example.com': { time: 123456789, userIds: [2] },
       };
 
       const newState = typingReducers(initialState, action);

--- a/src/typing/typingReducers.js
+++ b/src/typing/typingReducers.js
@@ -60,7 +60,10 @@ export default (state: TypingState = initialState, action: Action): TypingState 
       if (newTypingUsers.length > 0) {
         return {
           ...state,
-          [normalizedRecipients]: newTypingUsers,
+          [normalizedRecipients]: {
+            time: action.time,
+            userIds: newTypingUsers,
+          },
         };
       }
 


### PR DESCRIPTION
This happened sometimes when two users are typing and one stops.
Unfortunately the unit-test covering that case was also wrong.

This also very likely fixes the repeated audio bug