### PR TITLE
Added ZulipStatusBar to AppNavigator and configured Reactotron for dev configuration.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,9 @@ package-lock.json
 # https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
 #
 ios/Pods/
+
+#Generated files
+#
+generated/
+intermediates/
+outputs/

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -99,6 +99,7 @@ android {
         minSdkVersion 16
         targetSdkVersion 22
         versionCode 13
+        multiDexEnabled true
         versionName "1.0.13"
         ndk {
             abiFilters "armeabi-v7a", "x86"

--- a/index.android.js
+++ b/index.android.js
@@ -1,5 +1,5 @@
 /* @flow */
-// import './src/ReactotronConfig';
+import './src/ReactotronConfig';
 
 import { AppRegistry } from 'react-native';
 import ZulipMobile from './src/ZulipMobile';

--- a/index.ios.js
+++ b/index.ios.js
@@ -1,5 +1,5 @@
 /* @flow */
-// import './src/ReactotronConfig';
+import './src/ReactotronConfig';
 
 import { AppRegistry } from 'react-native';
 import ZulipMobile from './src/ZulipMobile';

--- a/package.json
+++ b/package.json
@@ -108,8 +108,8 @@
     "jest-react-native": "^18.0.0",
     "prettier": "^1.11.1",
     "react-native-cli": "^2.0.1",
-    "reactotron-react-native": "^2.0.0-beta.1",
-    "reactotron-redux": "^2.0.0-beta.1",
+    "reactotron-react-native": "^1.14.0",
+    "reactotron-redux": "^1.13.0",
     "redux-mock-store": "^1.5.1"
   },
   "jest": {

--- a/src/ReactotronConfig.js
+++ b/src/ReactotronConfig.js
@@ -5,16 +5,19 @@ import { NativeModules } from 'react-native';
 import { reactotronRedux } from 'reactotron-redux';
 
 // uncomment the following lines to test on a device
-// let scriptHostname;
-// if (__DEV__) {
-//   const scriptURL = NativeModules.SourceCode.scriptURL;
-//   scriptHostname = scriptURL.split('://')[1].split(':')[0];
-// }
 
-Reactotron.configure(/*{ host: scriptHostname }*/) // controls connection & communication settings
+if (__DEV__) {
+  const scriptURL = NativeModules.SourceCode.scriptURL;
+  const scriptHostname = scriptURL.split('://')[1].split(':')[0]; //To retrieve scriptURL from device
+
+  console.logs = (text) => Reactotron.log(text,true);
+
+  //Comment out next lines to disable reactotron connection
+  Reactotron.configure({ host: scriptHostname, name: "Zulip Mobile" }) // controls connection & communication settings
   .useReactNative() // add all built-in react native plugins
   .use(reactotronRedux())
   .use(asyncStorage())
   .use(networking())
   .use(openInEditor())
   .connect();
+}

--- a/src/boot/store.js
+++ b/src/boot/store.js
@@ -2,19 +2,20 @@
 import { AsyncStorage } from 'react-native';
 import { applyMiddleware, compose, createStore } from 'redux';
 import { persistStore, autoRehydrate } from 'redux-persist';
+import Reactotron from 'reactotron-react-native';
 
 import rootReducer from './reducers';
 import middleware from './middleware';
 
 // AsyncStorage.clear(); // use to reset storage during development
 
-// uncomment the following lines to integrate reactotron with redux
-// const store = Reactotron.createStore(
-//   rootReducer,
-//   compose(autoRehydrate(), applyMiddleware(...middleware)),
-// );
+let store  = null; 
 
-const store = compose(applyMiddleware(...middleware), autoRehydrate())(createStore)(rootReducer);
+if(__DEV__) {
+  store = Reactotron.createStore(rootReducer, {},compose(applyMiddleware(...middleware), autoRehydrate()))
+} else {
+  store = compose(applyMiddleware(...middleware), autoRehydrate())(Reactotron.createStore)(rootReducer);
+}
 
 export const restore = (onFinished?: () => void) =>
   persistStore(

--- a/src/main/MainScreenWithTabs.js
+++ b/src/main/MainScreenWithTabs.js
@@ -1,4 +1,5 @@
 /* @flow */
+// @ts-check
 import React, { PureComponent } from 'react';
 import { View } from 'react-native';
 
@@ -15,7 +16,6 @@ export default class MainScreenWithTabs extends PureComponent<{}> {
 
     return (
       <View style={[styles.flexed, styles.backgroundColor]}>
-        <ZulipStatusBar />
         <MainTabs />
       </View>
     );

--- a/src/nav/AppWithNavigationState.js
+++ b/src/nav/AppWithNavigationState.js
@@ -1,11 +1,12 @@
 /* @noflow */
 import React, { PureComponent } from 'react';
-import { BackHandler } from 'react-native';
+import { BackHandler, View } from 'react-native';
 import { addNavigationHelpers } from 'react-navigation';
 import { createReduxBoundAddListener } from 'react-navigation-redux-helpers';
 
 import connectWithActions from '../connectWithActions';
 import { getCanGoBack, getNav } from '../selectors';
+import { ZulipStatusBar } from '../common';
 import AppNavigator from './AppNavigator';
 import type { Actions } from '../types';
 
@@ -36,13 +37,16 @@ class AppWithNavigation extends PureComponent<Props> {
     const addListener = createReduxBoundAddListener('root');
 
     return (
-      <AppNavigator
-        navigation={addNavigationHelpers({
-          state: nav,
-          dispatch,
-          addListener,
-        })}
-      />
+      <View style={{ flex:1 }}>
+        <ZulipStatusBar />
+        <AppNavigator
+          navigation={addNavigationHelpers({
+            state: nav,
+            dispatch,
+            addListener,
+          })}
+        />
+      </View>
     );
   }
 }


### PR DESCRIPTION
In this PR two things have been considered:-
1) Integrage Reactotron with Dev configuration 
2)Moving ZulipStatusBar to AppNavigator

Motivation:-
For 1)- Current integration of Reactotron is not tied to dev evironment. I have configured it in a way that it is only active for dev evironment and has no affect in production. I guess that one is the correct one.
For 2)- Right Now MainScreenWithTabs.js is placing ZulipStatusBar over MainTabs component. But actually it should be there in AppNavigator since a Status bar is a core component of a screen and needs to render regardless of the navigator currently active or on which screen we are. Even in React Native docs it's suggested to render StatusBar outside of navigator, if we are using a custom StatusBar(like we are doing here). https://facebook.github.io/react-native/docs/statusbar.html

Implementation:
For 1)- Encapsulated related reactotron functionality within` __DEV__` blocks.
For 2)- Moved ZulipStatusBar rendering to AppNavigator by importing it in AppNavigator and placing ZulipStatusBar above navigator.