### PR TITLE
Made OptionRow and OptionButton the same height, and fixed Night Mode being squashed to the top

### DIFF
--- a/src/common/OptionRow.js
+++ b/src/common/OptionRow.js
@@ -13,6 +13,10 @@ const styles = StyleSheet.create({
     padding: 8,
     backgroundColor: 'rgba(127, 127, 127, 0.1)',
   },
+  optionTitle: {
+    padding: 8,
+    paddingLeft: 0,
+  },
 });
 
 type Props = {
@@ -30,7 +34,7 @@ export default class OptionRow extends PureComponent<Props> {
 
     return (
       <View style={[styles.optionRow, style]}>
-        <Label text={label} />
+        <Label style={styles.optionTitle} text={label} />
         <ZulipSwitch defaultValue={defaultValue} onValueChange={onValueChange} />
       </View>
     );


### PR DESCRIPTION
Added a divider above the "Night Mode" OptionRow in settingsCard. Also added padding to the Label component in OptionRow, so it matched the styling of Label component in OptionButton, which made both of them the same height.

Before:
![screenshot_20180330-022710](https://user-images.githubusercontent.com/22353313/38130144-75a00872-341f-11e8-99c1-bcc77350c2bb.png)

After:
![screenshot_20180330-022612](https://user-images.githubusercontent.com/22353313/38130148-7d4b1012-341f-11e8-9f6f-3baea515fcbc.png)


Also updated the developer guide, added the missing step to run `react-native start` before `react-native run-android` and a command to increase inotify watches to fix a common error while running `react-native start`.

UPDATE:
Screenshot before the OptionRow component was changed, notice the difference in height between the OptionRow and the OptionButton components beneath it.
![screenshot_20180401-173252](https://user-images.githubusercontent.com/22353313/38173249-a1852f16-35d8-11e8-8f07-9937d35770dd.png)
