### PR TITLE
Improve connect with actions call.

### DIFF
--- a/src/nullObjects.js
+++ b/src/nullObjects.js
@@ -112,6 +112,7 @@ export const NULL_FETCHING: Fetching = {
 
 export const NULL_NAV_STATE: NavigationState = {
   index: -1,
+  isTransitioning: false,
   key: '',
   routes: [],
 };

--- a/src/types.js
+++ b/src/types.js
@@ -247,6 +247,7 @@ export type MuteState = any; // MuteTuple[]
 
 export type NavigationState = {
   index: number,
+  isTransitioning: boolean,
   key: string,
   routes: Array<any> /* <{
     key: string,

--- a/src/utils/misc.js
+++ b/src/utils/misc.js
@@ -26,7 +26,10 @@ export const removeEmptyValues = (obj: Object): Object => {
 };
 
 export const isStateGoingBack = (cur: Object, prev: Object): boolean =>
-  cur.nav.routes.length < prev.nav.routes.length || isEqual(cur, prev);
+  cur.nav.routes.length < prev.nav.routes.length ||
+  cur.nav.isTransitioning ||
+  prev.nav.isTransitioning ||
+  isEqual(cur, prev);
 
 export const groupItemsById = (items: Object[]): Object =>
   items.reduce((itemsById, item) => {


### PR DESCRIPTION
* refactor: Rename 'isStateGoingBack' to 'areStatesSeemsToBeEqual'.  a34d5f1
As it is custom implementation for `areStatesEqual` for connecting
component to redux store.
https://github.com/reactjs/react-redux/blob/master/docs/api.md#connectmapstatetoprops-mapdispatchtoprops-mergeprops-options
In this custom implementation, currently two cases are considered.
One is whether navigation is going back or not, that is new routes
count in less than previous one. And secondly is current and previous
states are equal. This method returns true when re-render is not
required even with state change, that is it is pretending
that states are same.
So 'areStatesSeemsToBeEqual' is better name for this method.
 
* connectReduxStore: Consider navigation intermediate transition state.  6b88176
Pretend that states are same if navigation is transitioning.
This saves a lot of re-render of component, when route is
pushed or popped from the stack. Thus improving performance
on navigating between different screens.
For example: here is a video for getting difference what this commit makes.
Observe the navBar background color just after clicking topic icon and again
navigating back from topic screen.
**Before this commit:** for a moment color changes from stream color to theme color
on button click and again switches back to stream color on returning back.
Thus re-rendering nav bar which is not at all needed.
https://chat.zulip.org/user_uploads/2/b0/xe2tvDPLPm1NXou3DwDJKXRb/before-commit-connect-with-store.mov
**After this commit:** no such color switches takes place.
https://chat.zulip.org/user_uploads/2/6b/qq5vEP01yQgb7CfEOv40CFDN/after-commit-connect-with-store.mov
e57e3c7


* flow: Add areStatesSeemsToBeEqual arguments type c671c6c