### PR TITLE
WIP: Link StackNavigation and TabNavigation routers

### DIFF
--- a/src/main/MainScreenWithTabs.js
+++ b/src/main/MainScreenWithTabs.js
@@ -3,21 +3,35 @@ import React, { PureComponent } from 'react';
 import { View } from 'react-native';
 
 import { ZulipStatusBar } from '../common';
+import AppNavigator from '../nav/AppNavigator';
 import MainTabs from './MainTabs';
 
-export default class MainScreenWithTabs extends PureComponent<{}> {
+console.log('AppNavigator.router', AppNavigator);
+
+class MainScreenWithTabs extends PureComponent<{}> {
+  // static router = AppNavigator.router;
+
   static contextTypes = {
     styles: () => null,
   };
 
+  componentWillReceiveProps(props) {
+    MainScreenWithTabs.router = props.router;
+  }
+
   render() {
     const { styles } = this.context;
-
+    const { navigation, router } = this.props;
+    console.log('ZIS PROPS', { navigation, router });
     return (
       <View style={[styles.flexed, styles.backgroundColor]}>
         <ZulipStatusBar />
-        <MainTabs />
+        <MainTabs router={router} navigation={navigation} />
       </View>
     );
   }
 }
+
+// MainScreenWithTabs.router = AppNavigator.router;
+
+export default MainScreenWithTabs;

--- a/src/nav/AppNavigator.js
+++ b/src/nav/AppNavigator.js
@@ -1,4 +1,5 @@
 /* @flow */
+import React from 'react';
 import { StackNavigator } from 'react-navigation';
 
 import AccountPickScreen from '../account/AccountPickScreen';
@@ -30,7 +31,10 @@ import EditStreamScreen from '../streams/EditStreamScreen';
 import NotificationsScreen from '../settings/NotificationsScreen';
 import TopicListScreen from '../topics/TopicListScreen';
 
-export default StackNavigator(
+// const MainTabsWithRouter = props => <MainScreenWithTabs navigation={props.navigation} />;
+// MainTabsWithRouter.router = MainScreenWithTabs.router;
+
+const AppNavigator = StackNavigator(
   {
     account: { screen: AccountPickScreen },
     'account-details': { screen: AccountDetailsScreen },
@@ -69,3 +73,7 @@ export default StackNavigator(
     },
   },
 );
+
+MainScreenWithTabs.router = AppNavigator.router;
+
+export default AppNavigator;


### PR DESCRIPTION
This is WIP that is not likely to be complete.
The issue with the navigation was that the TabNavigator and StackNavigator have two navigations and two routers.
The solution is to link them. This is close to being a solution, but a much better way of doing this is coming in V2.