### PR TITLE
fix: Disable Android Back Button in Tabs

### DIFF
--- a/src/main/MainTabs.js
+++ b/src/main/MainTabs.js
@@ -51,10 +51,13 @@ export default TabNavigator(
       },
     },
   },
-  tabsOptions({
-    tabBarComponent: TabBarBottom,
-    tabBarPosition: 'bottom',
-    showLabel: !!Platform.isPad,
-    showIcon: true,
-  }),
+  {
+    ...tabsOptions({
+      tabBarComponent: TabBarBottom,
+      tabBarPosition: 'bottom',
+      showLabel: !!Platform.isPad,
+      showIcon: true,
+    }),
+    backBehavior: 'none',
+  },
 );


### PR DESCRIPTION
This fixes the bug of erratic behavior of Android hardware
back button. The issue was that the TabNavigator did intercept
the button even when other screens were opened.

This is a simple and definitive fix - the back button will no
longer move you between tabs. Some big apps do use it, some other
big apps don't. So we don't have a preference for either of the
behaviors (but the new one fixes our issue!)