### PR TITLE
screen: Fix scrolling in ScrollView

### DIFF
--- a/src/common/Screen.js
+++ b/src/common/Screen.js
@@ -75,8 +75,7 @@ class Screen extends PureComponent<Props> {
         >
           <ScrollView
             contentContainerStyle={[
-              componentStyles.childrenWrapper,
-              centerContent ? componentStyles.content : null,
+              componentStyles.childrenWrapper && centerContent ? componentStyles.content : null,
             ]}
           >
             {children}


### PR DESCRIPTION
The ScrollView wasn't scrolling in the Screen component and due to this, it was difficult to access the input fields in landscape orientation. 