### PR TITLE
Integrated reactotron into application with dev configuration and added console.logs()

### DIFF
--- a/index.android.js
+++ b/index.android.js
@@ -1,5 +1,4 @@
 /* @flow */
-// import './src/ReactotronConfig';
 
 import { AppRegistry } from 'react-native';
 import ZulipMobile from './src/ZulipMobile';

--- a/index.ios.js
+++ b/index.ios.js
@@ -1,5 +1,4 @@
 /* @flow */
-// import './src/ReactotronConfig';
 
 import { AppRegistry } from 'react-native';
 import ZulipMobile from './src/ZulipMobile';

--- a/package.json
+++ b/package.json
@@ -108,8 +108,8 @@
     "jest-react-native": "^18.0.0",
     "prettier": "^1.11.1",
     "react-native-cli": "^2.0.1",
-    "reactotron-react-native": "^2.0.0-beta.1",
-    "reactotron-redux": "^2.0.0-beta.1",
+    "reactotron-react-native": "^1.14.0",
+    "reactotron-redux": "^1.13.0",
     "redux-mock-store": "^1.5.1"
   },
   "jest": {

--- a/src/ReactotronConfig.js
+++ b/src/ReactotronConfig.js
@@ -1,20 +1,21 @@
 /* eslint-disable */
-import Reactotron, { asyncStorage, networking, openInEditor } from 'reactotron-react-native';
-import { NativeModules } from 'react-native';
+if (__DEV__) {
+  const Reactotron_all = require('reactotron-react-native');
+  Reactotron = Reactotron_all.default;
+  const { asyncStorage, networking, openInEditor } = Reactotron_all;
+  const { reactotronRedux } = require('reactotron-redux');
+  const { NativeModules } = require('react-native');
+  const scriptURL = NativeModules.SourceCode.scriptURL;
+  const scriptHostname = scriptURL.split('://')[1].split(':')[0]; //To retrieve scriptURL from device
 
-import { reactotronRedux } from 'reactotron-redux';
+  console.logs = (data) => Reactotron.log(data,true);
 
-// uncomment the following lines to test on a device
-// let scriptHostname;
-// if (__DEV__) {
-//   const scriptURL = NativeModules.SourceCode.scriptURL;
-//   scriptHostname = scriptURL.split('://')[1].split(':')[0];
-// }
-
-Reactotron.configure(/*{ host: scriptHostname }*/) // controls connection & communication settings
+  //Comment out next lines to disable reactotron connection
+  Reactotron.configure({ host: scriptHostname, name: "Zulip Mobile" }) // controls connection & communication settings
   .useReactNative() // add all built-in react native plugins
   .use(reactotronRedux())
   .use(asyncStorage())
   .use(networking())
   .use(openInEditor())
   .connect();
+}

--- a/src/ZulipMobile.js
+++ b/src/ZulipMobile.js
@@ -1,5 +1,8 @@
 /* @flow */
+/* eslint-disable import/first */
+import './ReactotronConfig';
 import React from 'react';
+/* eslint-enable */
 
 import '../vendor/intl/intl';
 import StoreProvider from './boot/StoreProvider';

--- a/src/boot/store.js
+++ b/src/boot/store.js
@@ -9,13 +9,25 @@ import middleware from './middleware';
 
 // AsyncStorage.clear(); // use to reset storage during development
 
-// uncomment the following lines to integrate reactotron with redux
-// const store = Reactotron.createStore(
-//   rootReducer,
-//   compose(autoRehydrate(), applyMiddleware(...middleware)),
-// );
-
-const store = compose(applyMiddleware(...middleware), autoRehydrate())(createStore)(rootReducer);
+let store;
+/* eslint-disable no-undef, global-require, import/no-extraneous-dependencies */
+if (__DEV__) { // This block of code is never meant to execute in production
+  const Reactotron = require('reactotron-react-native').default;
+/* eslint-enable */
+  store = Reactotron.createStore(
+    rootReducer,
+    {},
+    compose(
+      applyMiddleware(...middleware),
+      autoRehydrate()
+      )
+    );
+} else {
+  store = compose(
+    applyMiddleware(...middleware),
+    autoRehydrate()
+  )(createStore)(rootReducer);
+}
 
 export const restore = (onFinished?: () => void) =>
   persistStore(
@@ -27,4 +39,6 @@ export const restore = (onFinished?: () => void) =>
     onFinished,
   );
 
-export default store;
+const exportStore = store; // Just a hack to avoid eslint error of exporting non const value.
+
+export default exportStore;


### PR DESCRIPTION
Current integration of Reactotron is not tied to dev evironment. I have configured it in a way that it is only active for dev evironment and has no affect in production. I guess this one is the correct one. And I have moved to Reactotron v1 because that is current stable version of Reactotron. Although v2 is also out but it is in beta stage currently and is known to have issues with windows. So for use in Zulip I think we should consider V1 for now.
For docs on how and why I did it this way please refer to:-
https://github.com/infinitered/reactotron/blob/v1.x/docs/quick-start-react-native.md
https://github.com/infinitered/reactotron/blob/v1.x/docs/plugin-redux.md
https://github.com/infinitered/reactotron/blob/v1.x/docs/tips.md#running-in-production