### PR TITLE
Fix: button is enabled just after typing `https://` or 'http://' in the realm input.

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "entities": "^1.1.1",
     "events": "^2.0.0",
     "htmlparser2": "^3.9.2",
+    "is-url": "^1.2.4",
     "lodash.escape": "^4.0.1",
     "lodash.isequal": "^4.4.0",
     "lodash.throttle": "^4.1.1",
@@ -76,7 +77,6 @@
     "stream": "^0.0.2",
     "string.fromcodepoint": "^0.2.1",
     "url-parse": "^1.2.0",
-    "valid-url": "^1.0.9",
     "zulip-markdown-parser": "^1.0.4"
   },
   "devDependencies": {

--- a/src/api/apiFetch.js
+++ b/src/api/apiFetch.js
@@ -1,5 +1,5 @@
 /* @flow */
-import { isUri } from 'valid-url';
+import isUrl from 'is-url';
 
 import type { Auth, ResponseExtractionFunc } from '../types';
 import { getAuthHeader, encodeAsURI } from '../utils/url';
@@ -11,7 +11,7 @@ const apiVersion = 'api/v1';
 export const apiFetch = async (auth: Auth, route: string, params: Object = {}) => {
   const url = `${auth.realm}/${apiVersion}/${route}`;
 
-  if (!isUri(url)) {
+  if (!isUrl(url)) {
     throw new Error(`Invalid url ${url}`);
   }
 

--- a/src/start/RealmScreen.js
+++ b/src/start/RealmScreen.js
@@ -1,6 +1,7 @@
 /* @flow */
 import React, { PureComponent } from 'react';
 import { ScrollView, Keyboard } from 'react-native';
+import isUrl from 'is-url';
 
 import type { Actions } from '../types';
 import connectWithActions from '../connectWithActions';
@@ -85,7 +86,7 @@ class RealmScreen extends PureComponent<Props, State> {
           text="Enter"
           progress={progress}
           onPress={this.tryRealm}
-          disabled={!realm}
+          disabled={!isUrl(realm)}
         />
       </Screen>
     );

--- a/yarn.lock
+++ b/yarn.lock
@@ -3501,6 +3501,10 @@ is-typedarray@^1.0.0, is-typedarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
 
+is-url@^1.2.4:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/is-url/-/is-url-1.2.4.tgz#04a4df46d28c4cff3d73d01ff06abeb318a1aa52"
+
 is-utf8@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
@@ -7020,10 +7024,6 @@ uuid@^2.0.3:
 uuid@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.1.0.tgz#3dd3d3e790abc24d7b0d3a034ffababe28ebbc04"
-
-valid-url@^1.0.9:
-  version "1.0.9"
-  resolved "https://registry.yarnpkg.com/valid-url/-/valid-url-1.0.9.tgz#1c14479b40f1397a75782f115e4086447433a200"
 
 validate-npm-package-license@^3.0.1:
   version "3.0.1"


### PR DESCRIPTION
[current master](https://github.com/zulip/zulip-mobile/tree/0c647303a266800355b8cabfdd4857c9fa300375)
<img width="333" alt="screen shot 2018-03-31 at 11 29 11 pm" src="https://user-images.githubusercontent.com/18511177/38166092-ab7e17be-353b-11e8-9175-9fb275e330a5.png">
<img width="324" alt="screen shot 2018-03-31 at 11 29 21 pm" src="https://user-images.githubusercontent.com/18511177/38166093-abe01324-353b-11e8-8ded-1f6848bb4b38.png">

This PR
<img width="318" alt="screen shot 2018-03-31 at 11 27 50 pm" src="https://user-images.githubusercontent.com/18511177/38166090-aa4a566e-353b-11e8-9393-d77a4a9de104.png">
<img width="322" alt="screen shot 2018-03-31 at 11 28 19 pm" src="https://user-images.githubusercontent.com/18511177/38166091-aaae787e-353b-11e8-836f-13e08af8d707.png">
