### PR TITLE
Improve screen component, realm & passwordAuth screen.

### DIFF
--- a/src/common/Screen.js
+++ b/src/common/Screen.js
@@ -28,14 +28,14 @@ const componentStyles = StyleSheet.create({
 });
 
 type Props = {
+  centerContent: boolean,
+  children: ChildrenArray<*>,
+  safeAreaInsets: Dimensions,
+  keyboardShouldPersistTaps?: 'never' | 'always' | 'handled',
   padding?: boolean,
   search?: boolean,
-  centerContent: boolean,
-  safeAreaInsets: Dimensions,
   title?: LocalizableText,
-  children: ChildrenArray<*>,
   searchBarOnChange?: (text: string) => void,
-  keyboardShouldPersistTaps?: 'never' | 'always' | 'handled',
 };
 
 class Screen extends PureComponent<Props> {
@@ -52,14 +52,14 @@ class Screen extends PureComponent<Props> {
 
   render() {
     const {
-      padding,
-      search,
       centerContent,
-      title,
       children,
-      safeAreaInsets,
-      searchBarOnChange,
       keyboardShouldPersistTaps,
+      padding,
+      safeAreaInsets,
+      search,
+      searchBarOnChange,
+      title,
     } = this.props;
     const { styles } = this.context;
     const ModalBar = search ? ModalSearchNavBar : ModalNavBar;

--- a/src/common/Screen.js
+++ b/src/common/Screen.js
@@ -35,6 +35,7 @@ type Props = {
   title?: LocalizableText,
   children: ChildrenArray<*>,
   searchBarOnChange?: (text: string) => void,
+  keyboardShouldPersistTaps?: 'never' | 'always' | 'handled',
 };
 
 class Screen extends PureComponent<Props> {
@@ -46,6 +47,7 @@ class Screen extends PureComponent<Props> {
 
   static defaultProps = {
     centerContent: false,
+    keyboardShouldPersistTaps: 'never',
   };
 
   render() {
@@ -57,6 +59,7 @@ class Screen extends PureComponent<Props> {
       children,
       safeAreaInsets,
       searchBarOnChange,
+      keyboardShouldPersistTaps,
     } = this.props;
     const { styles } = this.context;
     const ModalBar = search ? ModalSearchNavBar : ModalNavBar;
@@ -76,6 +79,7 @@ class Screen extends PureComponent<Props> {
               componentStyles.childrenWrapper,
               centerContent && componentStyles.content,
             ]}
+            keyboardShouldPersistTaps={keyboardShouldPersistTaps}
           >
             {children}
           </ScrollView>

--- a/src/start/PasswordAuthScreen.js
+++ b/src/start/PasswordAuthScreen.js
@@ -10,9 +10,6 @@ import { getAuth } from '../selectors';
 import { isValidEmailFormat } from '../utils/misc';
 
 const componentStyles = StyleSheet.create({
-  container: {
-    paddingBottom: 10,
-  },
   linksTouchable: {
     alignItems: 'flex-end',
   },
@@ -89,38 +86,36 @@ class PasswordAuthView extends PureComponent<Props, State> {
 
     return (
       <Screen title="Log in" centerContent padding keyboardShouldPersistTaps="always">
-        <View style={componentStyles.container}>
-          <Input
-            style={styles.smallMarginTop}
-            autoFocus={email.length === 0}
-            autoCapitalize="none"
-            autoCorrect={false}
-            blurOnSubmit={false}
-            keyboardType={ldap ? 'default' : 'email-address'}
-            placeholder={ldap ? 'Username' : 'Email'}
-            defaultValue={email}
-            onChangeText={newEmail => this.setState({ email: newEmail })}
-          />
-          <PasswordInput
-            style={[styles.smallMarginTop, styles.field]}
-            autoFocus={email.length !== 0}
-            placeholder="Password"
-            value={password}
-            onChangeText={newPassword => this.setState({ password: newPassword })}
-            blurOnSubmit={false}
-            onSubmitEditing={this.validateForm}
-          />
-          <ZulipButton
-            style={styles.smallMarginTop}
-            disabled={isButtonDisabled}
-            text="Log in"
-            progress={progress}
-            onPress={this.validateForm}
-          />
-          <ErrorMsg error={error} />
-          <View style={componentStyles.linksTouchable}>
-            <WebLink label="Forgot password?" href="/accounts/password/reset/" />
-          </View>
+        <Input
+          style={styles.smallMarginTop}
+          autoFocus={email.length === 0}
+          autoCapitalize="none"
+          autoCorrect={false}
+          blurOnSubmit={false}
+          keyboardType={ldap ? 'default' : 'email-address'}
+          placeholder={ldap ? 'Username' : 'Email'}
+          defaultValue={email}
+          onChangeText={newEmail => this.setState({ email: newEmail })}
+        />
+        <PasswordInput
+          style={[styles.smallMarginTop, styles.field]}
+          autoFocus={email.length !== 0}
+          placeholder="Password"
+          value={password}
+          onChangeText={newPassword => this.setState({ password: newPassword })}
+          blurOnSubmit={false}
+          onSubmitEditing={this.validateForm}
+        />
+        <ZulipButton
+          style={styles.smallMarginTop}
+          disabled={isButtonDisabled}
+          text="Log in"
+          progress={progress}
+          onPress={this.validateForm}
+        />
+        <ErrorMsg error={error} />
+        <View style={componentStyles.linksTouchable}>
+          <WebLink label="Forgot password?" href="/accounts/password/reset/" />
         </View>
       </Screen>
     );

--- a/src/start/PasswordAuthScreen.js
+++ b/src/start/PasswordAuthScreen.js
@@ -6,7 +6,7 @@ import type { Actions, Auth } from '../types';
 import connectWithActions from '../connectWithActions';
 import { fetchApiKey } from '../api';
 import { ErrorMsg, Input, PasswordInput, Screen, WebLink, ZulipButton } from '../common';
-import { getAuth, getOwnEmail } from '../selectors';
+import { getAuth } from '../selectors';
 import { isValidEmailFormat } from '../utils/misc';
 
 const componentStyles = StyleSheet.create({
@@ -21,7 +21,6 @@ const componentStyles = StyleSheet.create({
 type Props = {
   actions: Actions,
   auth: Auth,
-  email: string,
   navigation: Object,
 };
 
@@ -49,8 +48,8 @@ class PasswordAuthView extends PureComponent<Props, State> {
   };
 
   tryPasswordLogin = async () => {
-    const { actions, auth } = this.props;
-    const { ldap } = this.props.navigation.state.params;
+    const { actions, auth, navigation } = this.props;
+    const { ldap } = navigation.state.params;
     const { email, password } = this.state;
 
     this.setState({ progress: true, error: undefined });
@@ -130,5 +129,4 @@ class PasswordAuthView extends PureComponent<Props, State> {
 
 export default connectWithActions(state => ({
   auth: getAuth(state),
-  email: getOwnEmail(state),
 }))(PasswordAuthView);

--- a/src/start/PasswordAuthScreen.js
+++ b/src/start/PasswordAuthScreen.js
@@ -89,7 +89,7 @@ class PasswordAuthView extends PureComponent<Props, State> {
     const isButtonDisabled = password.length === 0 || !isValidEmailFormat(email);
 
     return (
-      <Screen title="Log in" padding centerContent>
+      <Screen title="Log in" centerContent padding keyboardShouldPersistTaps="always">
         <View style={componentStyles.container}>
           <Input
             style={styles.smallMarginTop}

--- a/src/start/RealmScreen.js
+++ b/src/start/RealmScreen.js
@@ -66,7 +66,7 @@ class RealmScreen extends PureComponent<Props, State> {
     const { progress, error, realm } = this.state;
 
     return (
-      <Screen title="Welcome" padding centerContent>
+      <Screen title="Welcome" padding centerContent keyboardShouldPersistTaps="always">
         <Label text="Organization URL" />
         <SmartUrlInput
           style={styles.marginTopBottom}


### PR DESCRIPTION
* screen: Add a optional prop keyboardShouldPersistTaps for scrollView. f9d9daa
* realmScreen: Fix two taps are required to press Enter button.  8fcf12c
* passwordAuthScreen: Fix two taps are required to press Log in button.  ab4f10d
* passwordAuthScreen: Clean up code. a91fcc7
  * Remove extra view wrapper.
  * Remove unwanted mapStateToProps props.