### PR TITLE
flow: Fix Flow types for EditMessage

### DIFF
--- a/src/types.js
+++ b/src/types.js
@@ -169,10 +169,11 @@ export type ApiResponse = {
   msg: string,
 };
 
-export type EditMessage = any; /* {
+export type EditMessage = {
   id: number,
   content: string,
-} */
+  topic: string,
+};
 
 export type AuthenticationMethods = {
   dev: boolean,


### PR DESCRIPTION
types: topic property for the editMessage was missing in types. I added the missing property and fix flow type for editMessage.


![screen shot 2018-03-31 at 4 39 24 am](https://user-images.githubusercontent.com/22877561/38166550-6597fef6-34f3-11e8-8a24-d168ff0a6c36.png)
