### PR TITLE
apiFetch: First check for bad response, then for ok response.

### DIFF
--- a/src/api/apiFetch.js
+++ b/src/api/apiFetch.js
@@ -42,15 +42,15 @@ export const apiCall = async (
     networkActivityStart(isSilent);
     const response = await apiFetch(auth, route, params);
 
-    if (!response.ok) {
-      throw Error(response.statusText);
-    }
-
     const json = await response.json();
 
     if (json.result !== 'success') {
       console.log('Bad response for:', auth, route, params); // eslint-disable-line
-      throw new Error(json.msg);
+      throw Error(json.msg);
+    }
+
+    if (!response.ok) {
+      throw Error(response.statusText);
     }
 
     return resFunc(json);


### PR DESCRIPTION
Fix: error message not being displayed in the failed edit
message dialog.
Before ([current master](https://github.com/zulip/zulip-mobile/tree/0c647303a266800355b8cabfdd4857c9fa300375))
https://chat.zulip.org/user_uploads/2/cd/inwDS-fao9JZN5FdjS7MSwXh/Simulator-Screen-Shot-iPhone-6-2018-03-31-at-04.47.49.png

This PR
<img width="346" alt="screen shot 2018-04-01 at 12 57 30 am" src="https://user-images.githubusercontent.com/18511177/38166881-ba09b97a-3548-11e8-97f0-91131f30e9e0.png">