### PR TITLE
flow: Fix flow types for SettingsState

### DIFF
--- a/src/types.js
+++ b/src/types.js
@@ -273,10 +273,14 @@ export type ThemeType = 'default' | 'night';
 
 export type StatusBarStyle = 'light-content' | 'dark-content';
 
-export type SettingsState = any; /* {
+export type SettingsState = {
   locale: string,
   theme: ThemeType,
-} */
+  offlineNotification: boolean,
+  onlineNotification: boolean,
+  experimentalFeaturesEnabled: boolean,
+  streamNotification: boolean,
+};
 
 export type StreamsState = any; // [];
 


### PR DESCRIPTION
Fix the type of settingState by adding 4 missing properties. I checked the reducer and realized that those properties were missing.