### PR TITLE
Flow: fix flow types for Recipient

### DIFF
--- a/src/types.js
+++ b/src/types.js
@@ -158,11 +158,12 @@ export type NarrowElement = {
 
 export type Narrow = NarrowElement[];
 
-export type Recipient = any; /* {
+export type Recipient = {
   display_recipient: string,
   subject: string,
   email: string,
-} */
+  id: number,
+};
 
 export type ApiResponse = {
   result: string,


### PR DESCRIPTION
I printed out recipient and realized that the id property was missing. 