### PR TITLE
Flow: fix flow types for Subscriptions

### DIFF
--- a/src/nullObjects.js
+++ b/src/nullObjects.js
@@ -78,6 +78,9 @@ export const NULL_SUBSCRIPTION: Subscription = {
   name: '',
   pin_to_top: false,
   stream_id: 0,
+  stream_weekly_traffic: 0,
+  push_notifications: false,
+  is_old_stream: false,
 };
 
 export const NULL_PRESENCE: Presence = {

--- a/src/nullObjects.js
+++ b/src/nullObjects.js
@@ -78,9 +78,6 @@ export const NULL_SUBSCRIPTION: Subscription = {
   name: '',
   pin_to_top: false,
   stream_id: 0,
-  stream_weekly_traffic: 0,
-  push_notifications: false,
-  is_old_stream: false,
 };
 
 export const NULL_PRESENCE: Presence = {

--- a/src/types.js
+++ b/src/types.js
@@ -334,7 +334,7 @@ export type RealmEmojiType = {
 
 export type LocalizableText = any; // string | { text: string, values: Object };
 
-export type DomElement = any; /* {
+export type DomElement = {
   name: string,
   type: string,
   attribs: Object,
@@ -342,7 +342,7 @@ export type DomElement = any; /* {
   parent: DomElement,
   prev: DomElement,
   children: DomElement[],
-} */
+};
 
 export type Subscription = {
   audible_notifications: boolean,

--- a/src/types.js
+++ b/src/types.js
@@ -68,7 +68,7 @@ export type MessageState = {
 
 export type UserStatus = 'active' | 'inactive' | 'offline';
 
-export type User = any; /* {
+export type User = {
   avatarUrl: string,
   email: string,
   fullName: string,
@@ -76,7 +76,7 @@ export type User = any; /* {
   isActive: boolean,
   isAdmin: boolean,
   isBot: boolean,
-} */
+};
 
 export type Presence = any; /* {
   client: string,

--- a/src/types.js
+++ b/src/types.js
@@ -273,14 +273,10 @@ export type ThemeType = 'default' | 'night';
 
 export type StatusBarStyle = 'light-content' | 'dark-content';
 
-export type SettingsState = {
+export type SettingsState = any; /* {
   locale: string,
   theme: ThemeType,
-  offlineNotification: boolean,
-  onlineNotification: boolean,
-  experimentalFeaturesEnabled: boolean,
-  streamNotification: boolean,
-};
+} */
 
 export type StreamsState = any; // [];
 
@@ -344,7 +340,7 @@ export type DomElement = {
   children: DomElement[],
 };
 
-export type Subscription = {
+export type Subscription = any; /* {
   audible_notifications: boolean,
   color: string,
   description: string,
@@ -355,10 +351,7 @@ export type Subscription = {
   name: string,
   pin_to_top: boolean,
   stream_id: number,
-  is_old_stream: boolean,
-  push_notifications: boolean,
-  stream_weekly_traffic: number,
-};
+} */
 
 export type Outbox = any; /* {
   content: string,

--- a/src/types.js
+++ b/src/types.js
@@ -273,10 +273,14 @@ export type ThemeType = 'default' | 'night';
 
 export type StatusBarStyle = 'light-content' | 'dark-content';
 
-export type SettingsState = any; /* {
+export type SettingsState = {
   locale: string,
   theme: ThemeType,
-} */
+  offlineNotification: boolean,
+  onlineNotification: boolean,
+  experimentalFeaturesEnabled: boolean,
+  streamNotification: boolean,
+};
 
 export type StreamsState = any; // [];
 
@@ -340,7 +344,7 @@ export type DomElement = any; /* {
   children: DomElement[],
 } */
 
-export type Subscription = any; /* {
+export type Subscription = {
   audible_notifications: boolean,
   color: string,
   description: string,
@@ -351,7 +355,10 @@ export type Subscription = any; /* {
   name: string,
   pin_to_top: boolean,
   stream_id: number,
-} */
+  is_old_stream: boolean,
+  push_notifications: boolean,
+  stream_weekly_traffic: number,
+};
 
 export type Outbox = any; /* {
   content: string,

--- a/src/types.js
+++ b/src/types.js
@@ -273,10 +273,14 @@ export type ThemeType = 'default' | 'night';
 
 export type StatusBarStyle = 'light-content' | 'dark-content';
 
-export type SettingsState = any; /* {
+export type SettingsState = {
   locale: string,
   theme: ThemeType,
-} */
+  offlineNotification: boolean,
+  onlineNotification: boolean,
+  experimentalFeaturesEnabled: boolean,
+  streamNotification: boolean,
+};
 
 export type StreamsState = any; // [];
 
@@ -340,7 +344,7 @@ export type DomElement = {
   children: DomElement[],
 };
 
-export type Subscription = any; /* {
+export type Subscription = {
   audible_notifications: boolean,
   color: string,
   description: string,
@@ -351,7 +355,10 @@ export type Subscription = any; /* {
   name: string,
   pin_to_top: boolean,
   stream_id: number,
-} */
+  is_old_stream: boolean,
+  push_notifications: boolean,
+  stream_weekly_traffic: number,
+};
 
 export type Outbox = any; /* {
   content: string,


### PR DESCRIPTION
push_notifications property was missing. So I console subscription and figured other properties were also missing. Currently, they are not causing any error but figured anytime they are accessed the flow test will fail so I  decided to add them anyways. Please see attached

![screen shot 2018-04-02 at 3 15 21 am](https://user-images.githubusercontent.com/22877561/38187635-83a6e6bc-3626-11e8-9dfa-8752437e309b.png)
 