### PR TITLE
fix: MessageList in Search Screen not visible

### DIFF
--- a/src/common/Screen.js
+++ b/src/common/Screen.js
@@ -75,7 +75,8 @@ class Screen extends PureComponent<Props> {
         >
           <ScrollView
             contentContainerStyle={[
-              componentStyles.childrenWrapper && centerContent ? componentStyles.content : null,
+              componentStyles.childrenWrapper,
+              centerContent && componentStyles.content,
             ]}
           >
             {children}


### PR DESCRIPTION
Revert bug introduced in #2184