### PR TITLE
fix: Missed to rename deleteDraft to draftRemove

### DIFF
--- a/src/compose/ComposeBox.js
+++ b/src/compose/ComposeBox.js
@@ -174,7 +174,7 @@ export default class ComposeBox extends PureComponent<Props, State> {
       : narrow;
 
     actions.addToOutbox(destinationNarrow, messageToSend);
-    actions.deleteDraft(JSON.stringify(narrow));
+    actions.draftRemove(JSON.stringify(narrow));
 
     this.clearMessageInput();
   };


### PR DESCRIPTION
This will get caught when the 'actions' object is fully typed