### PR TITLE
compose: Avoid repeating topic in placeholder.

### DIFF
--- a/src/compose/__tests__/getComposeInputPlaceholder-test.js
+++ b/src/compose/__tests__/getComposeInputPlaceholder-test.js
@@ -42,13 +42,12 @@ describe('getComposeInputPlaceholder', () => {
     expect(placeholder).toEqual({ text: 'Message {recipient}', values: { recipient: '#Denmark' } });
   });
 
-  test('returns "Message #streamName topic:topicName" for stream narrow', () => {
+  test('returns properly for topic narrow', () => {
     const narrow = deepFreeze(topicNarrow('Denmark', 'Copenhagen'));
 
     const placeholder = getComposeInputPlaceholder(narrow);
     expect(placeholder).toEqual({
-      text: 'Message {recipient}',
-      values: { recipient: '#Denmark:Copenhagen' },
+      text: 'Reply',
     });
   });
 

--- a/src/compose/getComposeInputPlaceholder.js
+++ b/src/compose/getComposeInputPlaceholder.js
@@ -31,10 +31,7 @@ export default (narrow: Narrow, ownEmail: string, users: User[]): LocalizableTex
   }
 
   if (isTopicNarrow(narrow)) {
-    return {
-      text: 'Message {recipient}',
-      values: { recipient: `#${narrow[0].operand}:${narrow[1].operand}` },
-    };
+    return { text: 'Reply' };
   }
 
   return { text: 'Type a message' };


### PR DESCRIPTION
This never really looked good with the `#...:...` syntax, which looks
more like a leaked bit of code than like something intended for the
user to see.  Worse, when the topic gets a bit long, it overflows onto
a second line, which tends to get half-cut-off at the bottom and then
looks super broken.

Prevent that by just cutting the topic out entirely.  Fixes #1966.

These messages still don't feel quite right UI-wise, but we'll take
one step at a time.

Screenshot before:
![screenshot_1522889238](https://user-images.githubusercontent.com/28173/38342317-a2bb7e7e-3832-11e8-8cec-0f58ebe0b9ab.png)

and after:
![screenshot_1522889614](https://user-images.githubusercontent.com/28173/38342318-a2f13d70-3832-11e8-8939-7c08bb704a11.png)
