### PR TITLE
outboxAction: fix a bug in accessing realm properties

### DIFF
--- a/src/outbox/outboxActions.js
+++ b/src/outbox/outboxActions.js
@@ -109,8 +109,8 @@ export const addToOutbox = (narrow: Narrow, content: string) => async (
     getUsersAndWildcards(users),
     streams,
     auth,
-    realm.realm_filter,
-    realm.realm_emoji,
+    realm.filters,
+    realm.emoji,
   );
   const localTime = Math.round(new Date().getTime() / 1000);
   dispatch(


### PR DESCRIPTION
I fix a minor bug in outboxAction. realm_filter and realm_emoji are undefined. The reason for this bug is we have realm_filter and realm_emoji at initailRealmData, while the realm at outboxAction doesn't have those properties. To verify further, I printed realm_filter and realm_emoji and they are undefined.  Please see attached for the console realm object with realm_filter and realm_emoji  at outboxAction.

![screen shot 2018-04-05 at 12 58 02 pm](https://user-images.githubusercontent.com/22877561/38380848-f8a8d82c-38d2-11e8-881e-dbb5dbb8ffa1.png)