### PR TITLE
iOS: Ask for add photos to library privacy.

### DIFF
--- a/ios/ZulipMobile/Info.plist
+++ b/ios/ZulipMobile/Info.plist
@@ -54,6 +54,8 @@
 	  <string></string>
     <key>NSPhotoLibraryUsageDescription</key>
     <string>Upload photos to a Zulip realm</string>
+		<key>NSPhotoLibraryAddUsageDescription</key>
+		<string>Download photos from Zulip realm</string>
     <key>UIAppFonts</key>
     <array>
       <string>Entypo.ttf</string>


### PR DESCRIPTION
Add `NSPhotoLibraryAddUsageDescription` key and
value to Info.plist. Now when user try's to download
photo from lightbox, dialog is popped to take permission.

This preference is considered while downloading next time.

When permssion is not allowed, CameraRoll throws error
which is then caught and can't download toast message is shown.

This fixes: app becomes unrespossive on selecting download
option in lightbox actionsheet when permission is not given.

Fix: #2216

https://developer.apple.com/library/content/documentation/General/Reference/InfoPlistKeyReference/Articles/CocoaKeys.html