### PR TITLE
notificationsScreen: Add OptionDivider

### DIFF
--- a/src/settings/NotificationsScreen.js
+++ b/src/settings/NotificationsScreen.js
@@ -4,7 +4,7 @@ import React, { PureComponent } from 'react';
 import type { Actions, Auth } from '../types';
 import connectWithActions from '../connectWithActions';
 import { getAuth, getSettings } from '../selectors';
-import { OptionRow, Screen } from '../common';
+import { OptionDivider, OptionRow, Screen } from '../common';
 import { toggleMobilePushSettings } from '../api';
 
 type Props = {
@@ -53,16 +53,19 @@ class NotificationsScreen extends PureComponent<Props> {
 
     return (
       <Screen title="Notifications">
+        <OptionDivider />
         <OptionRow
           label="Notifications when offline"
           defaultValue={offlineNotification}
           onValueChange={this.handleOfflineNotificationChange}
         />
+        <OptionDivider />
         <OptionRow
           label="Notifications when online"
           defaultValue={onlineNotification}
           onValueChange={this.handleOnlineNotificationChange}
         />
+        <OptionDivider />
         <OptionRow
           label="Stream notifications"
           defaultValue={streamNotification}


### PR DESCRIPTION
Added OptionRow component between the OptionRow components to match the
style of the main Settings screen.

Before:
![screenshot_20180408-124932](https://user-images.githubusercontent.com/16636569/38464620-6394daf2-3b2e-11e8-9654-4d4fce96a7f4.png)


After:
![screenshot_20180408-125909](https://user-images.githubusercontent.com/16636569/38464625-6a56b3a6-3b2e-11e8-892a-6a5336df5a28.png)
