### PR TITLE
webview: Reuse sendMessage function in handleScrollEvent

### DIFF
--- a/src/render-html/generatedEs3.js
+++ b/src/render-html/generatedEs3.js
@@ -101,14 +101,14 @@ var handleScrollEvent = function handleScrollEvent() {
 
   var currentNodes = getStartAndEndNodes();
 
-  window.postMessage(JSON.stringify({
+  sendMessage({
     type: 'scroll',
     scrollY: window.scrollY,
     innerHeight: window.innerHeight,
     offsetHeight: documentBody.offsetHeight,
     startMessageId: Math.min(prevNodes.start, currentNodes.start),
     endMessageId: Math.max(prevNodes.end, currentNodes.end)
-  }), '*');
+  });
 
   var nearEnd = documentBody.offsetHeight - window.scrollY - window.innerHeight > 100;
   toggleElementHidden('scroll-bottom', !nearEnd);

--- a/src/render-html/js.js
+++ b/src/render-html/js.js
@@ -87,17 +87,14 @@ const handleScrollEvent = () => {
 
   const currentNodes = getStartAndEndNodes();
 
-  window.postMessage(
-    JSON.stringify({
-      type: 'scroll',
-      scrollY: window.scrollY,
-      innerHeight: window.innerHeight,
-      offsetHeight: documentBody.offsetHeight,
-      startMessageId: Math.min(prevNodes.start, currentNodes.start),
-      endMessageId: Math.max(prevNodes.end, currentNodes.end),
-    }),
-    '*',
-  );
+  sendMessage({
+    type: 'scroll',
+    scrollY: window.scrollY,
+    innerHeight: window.innerHeight,
+    offsetHeight: documentBody.offsetHeight,
+    startMessageId: Math.min(prevNodes.start, currentNodes.start),
+    endMessageId: Math.max(prevNodes.end, currentNodes.end),
+  });
 
   const nearEnd = documentBody.offsetHeight - window.scrollY - window.innerHeight > 100;
   toggleElementHidden('scroll-bottom', !nearEnd);


### PR DESCRIPTION
This was missed when the sendMessage was introduced.
No functionality changes intended