### PR TITLE
Fix: Spacing in StreamScreen

### DIFF
--- a/src/streams/StreamScreen.js
+++ b/src/streams/StreamScreen.js
@@ -3,7 +3,7 @@ import React, { PureComponent } from 'react';
 
 import type { Actions, Stream, Subscription } from '../types';
 import connectWithActions from '../connectWithActions';
-import { OptionRow, Screen, ZulipButton } from '../common';
+import { OptionRow, Screen, ZulipButton, OptionDivider } from '../common';
 import { getStreams, getSubscriptions } from '../selectors';
 import { NULL_STREAM, NULL_SUBSCRIPTION } from '../nullObjects';
 import StreamCard from './StreamCard';
@@ -61,16 +61,19 @@ class StreamScreen extends PureComponent<Props> {
     return (
       <Screen title="Stream" padding>
         <StreamCard stream={stream} subscription={subscription} />
+        <OptionDivider />
         <OptionRow
           label="Pinned"
           defaultValue={subscription.pin_to_top}
           onValueChange={this.handleTogglePinStream}
         />
+        <OptionDivider />
         <OptionRow
           label="Muted"
           defaultValue={stream.in_home_view === false}
           onValueChange={this.handleToggleMuteStream}
         />
+        <OptionDivider />
         <OptionRow
           label="Notifications"
           defaultValue={subscription.push_notifications}


### PR DESCRIPTION
Fixes the spacing between `OptionRow` components in the `StreamScreen` component by adding `OptionDivider`

Before:
![screenshot_20180409-140831](https://user-images.githubusercontent.com/22353313/38488262-85151232-3c00-11e8-831c-62cae2499c28.png)

After:
![screenshot_20180409-140816](https://user-images.githubusercontent.com/22353313/38488270-8cafc78a-3c00-11e8-94be-ee4de3421bb3.png)

The commits described below has since been removed:
_The second commit adds OptionDivider between rows in TopicList and increases the padding from 8 to 16 to match components found in other menus such as OptionRow. The 3rd commit removes padding from TopicListScreen as it seems unnecessary since there is no text or other elements that would require padding._

