### PR TITLE
diagnosticsScreen: Add margin to version label. 

### DIFF
--- a/src/diagnostics/DiagnosticsScreen.js
+++ b/src/diagnostics/DiagnosticsScreen.js
@@ -9,6 +9,8 @@ import { OptionButton, OptionDivider, Screen, RawLabel } from '../common';
 
 const styles = StyleSheet.create({
   versionLabel: {
+    marginTop: 8,
+    marginBottom: 8,
     textAlign: 'center',
   },
 });


### PR DESCRIPTION
This adds marginTop and marginBottom to the version label to make it
look centered and less congested.

Before: 
![screenshot_20180415-204553](https://user-images.githubusercontent.com/16636569/38780000-16f08212-40ee-11e8-99d2-49b1a70a1aa7.png)

After:
![screenshot_20180415-203807](https://user-images.githubusercontent.com/16636569/38780001-1f254e86-40ee-11e8-9b28-005f9004c56b.png)
