### PR TITLE
refactor: Treat safe area insets more precisely

### DIFF
--- a/src/boot/AppEventHandlers.js
+++ b/src/boot/AppEventHandlers.js
@@ -71,7 +71,9 @@ class AppEventHandlers extends PureComponent<Props> {
     NetInfo.addEventListener('connectionChange', this.handleConnectivityChange);
     AppState.addEventListener('change', this.handleAppStateChange);
     AppState.addEventListener('memoryWarning', this.handleMemoryWarning);
-    SafeArea.getSafeAreaInsetsForRootView().then(actions.initSafeAreaInsets);
+    SafeArea.getSafeAreaInsetsForRootView().then(params =>
+      actions.initSafeAreaInsets(params.safeAreaInsets),
+    );
     Orientation.addOrientationListener(this.handleOrientationChange);
     addNotificationListener(this.handleNotificationOpen);
   }

--- a/src/session/sessionActions.js
+++ b/src/session/sessionActions.js
@@ -54,7 +54,7 @@ export const appRefresh = (): AppRefreshAction => ({
 
 export const initSafeAreaInsets = (safeAreaInsets: Dimensions): InitSafeAreaInsetsAction => ({
   type: INIT_SAFE_AREA_INSETS,
-  ...safeAreaInsets,
+  safeAreaInsets,
 });
 
 export const appOrientation = (orientation: string) => (


### PR DESCRIPTION
Currently the `getSafeAreaInsetsForRootView` returns only the data
we want, but it might change. Instead we decouple the return format
from our action parameters and pass only the safeAreaInsets object.

This also helps with Flow typing later