### PR TITLE
Handle presenceToHumanTime incorrect parameters

### DIFF
--- a/src/utils/__tests__/date-test.js
+++ b/src/utils/__tests__/date-test.js
@@ -66,6 +66,10 @@ describe('humanDate', () => {
 });
 
 describe('presenceToHumanTime', () => {
+  test('passing an invalid value does not throw but returns "never"', () => {
+    expect(presenceToHumanTime(undefined)).toBe('never');
+  });
+
   test('given a presence return human readable time', () => {
     const presence = {
       aggregated: {

--- a/src/utils/date.js
+++ b/src/utils/date.js
@@ -27,6 +27,8 @@ export const humanDate = (date: Date): string => {
 };
 
 export const presenceToHumanTime = (presence: Presence): string => {
+  if (!presence || !presence.aggregated) return 'never';
+
   const lastTimeActive = new Date(presence.aggregated.timestamp * 1000);
   return differenceInSeconds(Date.now(), lastTimeActive) < 60
     ? 'now'


### PR DESCRIPTION
This handles the case where presence data is not available
but the function is called anyways

Fixes #2242