### PR TITLE
fix: Do not throw if messageInput reference is undefined

### DIFF
--- a/src/compose/ComposeBox.js
+++ b/src/compose/ComposeBox.js
@@ -220,7 +220,9 @@ export default class ComposeBox extends PureComponent<Props, State> {
         message: nextProps.editMessage ? nextProps.editMessage.content : '',
         topic,
       });
-      this.messageInput.focus();
+      if (this.messageInput) {
+        this.messageInput.focus();
+      }
     } else if (!isEqual(nextProps.narrow, this.props.narrow)) {
       this.tryUpdateDraft();
 
@@ -306,8 +308,10 @@ export default class ComposeBox extends PureComponent<Props, State> {
               maxHeight={MAX_HEIGHT}
               placeholder={placeholder}
               textInputRef={component => {
-                this.messageInput = component;
-                if (component) messageInputRef(component);
+                if (component) {
+                  this.messageInput = component;
+                  messageInputRef(component);
+                }
               }}
               value={message}
               onBlur={this.handleMessageBlur}


### PR DESCRIPTION
Fixes #2273

* make sure not to reset reference to messageInput
* check if the reference to messageInput is defined before focusing