### PR TITLE
refactor: Do not use componentWillReceiveProps in MessageListWeb

### DIFF
--- a/src/render-html/MessageListWeb.js
+++ b/src/render-html/MessageListWeb.js
@@ -35,11 +35,10 @@ export default class MessageListWeb extends Component<Props> {
     webViewEventHandlers[handler](this.props, eventData); // $FlowFixMe
   };
 
-  componentWillReceiveProps = (nextProps: Props) => {
+  shouldComponentUpdate = (nextProps: Props) => {
     webViewHandleUpdates(this.props, nextProps, this.sendMessage);
+    return false;
   };
-
-  shouldComponentUpdate = () => false;
 
   render() {
     const { styles, theme } = this.context;


### PR DESCRIPTION
componentWillReceiveProps is being deprecated.
This moves the update call to shouldComponentUpdate
No functional changes intended.