### PR TITLE
Enhancement: Adds Options onLongPress depending on the type of message

### DIFF
--- a/src/lightbox/LightboxActionSheet.js
+++ b/src/lightbox/LightboxActionSheet.js
@@ -33,9 +33,9 @@ type ButtonType = {
 };
 
 type ActionSheetOptionsType = {
-  showActionSheetWithOptions: (Object, (number) => void) => void,
   src: string,
   auth: Auth,
+  showActionSheetWithOptions: (Object, (number) => void) => void,
 };
 
 const downloadImage = async ({ src, auth }: DownloadImageType) => {

--- a/src/lightbox/LightboxActionSheet.js
+++ b/src/lightbox/LightboxActionSheet.js
@@ -32,6 +32,12 @@ type ButtonType = {
   onPress: (props: ButtonProps) => void | boolean | Promise<any>,
 };
 
+type ActionSheetOptionsType = {
+  showActionSheetWithOptions: (Object, (number) => void) => void,
+  src: string,
+  auth: Auth,
+};
+
 const downloadImage = async ({ src, auth }: DownloadImageType) => {
   try {
     await downloadFile(src, auth);
@@ -63,4 +69,23 @@ export const executeActionSheetAction = ({ title, ...props }: ExecuteActionSheet
   if (button) {
     button.onPress(props);
   }
+};
+
+export const openLightboxActionSheet =
+  ({ showActionSheetWithOptions, src, auth }: ActionSheetOptionsType) => {
+  const options = constructActionSheetButtons();
+  const cancelButtonIndex = options.length - 1;
+  showActionSheetWithOptions(
+    {
+      options,
+      cancelButtonIndex,
+    },
+    buttonIndex => {
+      executeActionSheetAction({
+        title: options[buttonIndex],
+        src,
+        auth,
+      });
+    },
+  );
 };

--- a/src/lightbox/LightboxContainer.js
+++ b/src/lightbox/LightboxContainer.js
@@ -10,7 +10,7 @@ import { getAuth } from '../selectors';
 import { getResource } from '../utils/url';
 import AnimatedLightboxHeader from './AnimatedLightboxHeader';
 import AnimatedLightboxFooter from './AnimatedLightboxFooter';
-import { constructActionSheetButtons, executeActionSheetAction } from './LightboxActionSheet';
+import { openLightboxActionSheet } from './LightboxActionSheet';
 import { NAVBAR_SIZE } from '../styles';
 
 const styles = StyleSheet.create({
@@ -60,22 +60,8 @@ class LightboxContainer extends PureComponent<Props, State> {
   };
 
   handleOptionsPress = () => {
-    const options = constructActionSheetButtons();
-    const cancelButtonIndex = options.length - 1;
     const { showActionSheetWithOptions, src, auth } = this.props;
-    showActionSheetWithOptions(
-      {
-        options,
-        cancelButtonIndex,
-      },
-      buttonIndex => {
-        executeActionSheetAction({
-          title: options[buttonIndex],
-          src,
-          auth,
-        });
-      },
-    );
+    openLightboxActionSheet({ showActionSheetWithOptions, src, auth });
   };
 
   getAnimationProps = () => ({

--- a/src/lightbox/LightboxContainer.js
+++ b/src/lightbox/LightboxContainer.js
@@ -59,10 +59,7 @@ class LightboxContainer extends PureComponent<Props, State> {
     }));
   };
 
-  handleOptionsPress = () => {
-    const { showActionSheetWithOptions, src, auth } = this.props;
-    openLightboxActionSheet({ showActionSheetWithOptions, src, auth });
-  };
+  handleOptionsPress = () => openLightboxActionSheet(this.props);
 
   getAnimationProps = () => ({
     easing: Easing.bezier(0.075, 0.82, 0.165, 1),

--- a/src/message/MessageListContainer.js
+++ b/src/message/MessageListContainer.js
@@ -1,7 +1,7 @@
 /* @flow */
 import React, { PureComponent } from 'react';
 import { connectActionSheet } from '@expo/react-native-action-sheet';
-
+import { Clipboard } from 'react-native';
 import type {
   Actions,
   Auth,
@@ -39,6 +39,7 @@ import { isUrlAnImage } from '../utils/url';
 import { filterUnreadMessageIds } from '../utils/unread';
 import { queueMarkAsRead } from '../api';
 import * as LightboxActionSheet from './../lightbox/LightboxActionSheet';
+import { showToast } from '../utils/info';
 
 export type Props = {
   actions: Actions,
@@ -128,8 +129,8 @@ class MessageListContainer extends PureComponent<Props> {
       );
       return;
     }
-    console.log(src);
-    // action sheet for url
+    Clipboard.setString(src);
+    showToast('Copied URL to Clipboard');
   }
 
   handleMessageListScroll = (e: Object) => {

--- a/src/message/MessageListContainer.js
+++ b/src/message/MessageListContainer.js
@@ -35,6 +35,7 @@ import {
   getShowMessagePlaceholders,
   getShownMessagesForNarrow,
 } from '../selectors';
+import { isUrlAnImage } from '../utils/url';
 import { filterUnreadMessageIds } from '../utils/unread';
 import { queueMarkAsRead } from '../api';
 
@@ -56,6 +57,7 @@ export type Props = {
   subscriptions: Subscription[],
   typingUsers: User[],
   listRef: (component: any) => void,
+  onUrlLongPress: (src: string) => void,
   onLongPress: (messageId: number, target: string) => void,
   onReplySelect: () => void,
   onScroll: (e: Event) => void,
@@ -105,6 +107,14 @@ class MessageListContainer extends PureComponent<Props> {
     );
   };
 
+  handleUrlLongPress = (src: string) => {
+    if (isUrlAnImage(src)) {
+      // here is the action sheet for image from lightbox
+      return;
+    }
+    // action sheet for url
+  }
+
   handleMessageListScroll = (e: Object) => {
     const { auth, debug, flags } = this.props;
     const visibleMessageIds = e.visibleIds ? e.visibleIds.map(x => +x) : [];
@@ -119,6 +129,7 @@ class MessageListContainer extends PureComponent<Props> {
     return (
       <MessageListWeb
         {...this.props}
+        onUrlLongPress={this.handleUrlLongPress}
         onLongPress={this.handleLongPress}
         onScroll={this.handleMessageListScroll}
       />

--- a/src/message/MessageListContainer.js
+++ b/src/message/MessageListContainer.js
@@ -1,7 +1,6 @@
 /* @flow */
 import React, { PureComponent } from 'react';
 import { connectActionSheet } from '@expo/react-native-action-sheet';
-import { Clipboard } from 'react-native';
 import type {
   Actions,
   Auth,
@@ -40,6 +39,7 @@ import { filterUnreadMessageIds } from '../utils/unread';
 import { queueMarkAsRead } from '../api';
 import { openLightboxActionSheet } from './../lightbox/LightboxActionSheet';
 import { showToast } from '../utils/info';
+import { copyToClipboard } from '../utils/clipboard';
 
 export type Props = {
   actions: Actions,
@@ -115,7 +115,7 @@ class MessageListContainer extends PureComponent<Props> {
       openLightboxActionSheet({ showActionSheetWithOptions, src, auth });
       return;
     }
-    Clipboard.setString(src);
+    copyToClipboard(src);
     showToast('Copied URL to Clipboard');
   }
 

--- a/src/message/MessageListContainer.js
+++ b/src/message/MessageListContainer.js
@@ -38,6 +38,7 @@ import {
 import { isUrlAnImage } from '../utils/url';
 import { filterUnreadMessageIds } from '../utils/unread';
 import { queueMarkAsRead } from '../api';
+import * as LightboxActionSheet from './../lightbox/LightboxActionSheet';
 
 export type Props = {
   actions: Actions,
@@ -109,9 +110,25 @@ class MessageListContainer extends PureComponent<Props> {
 
   handleUrlLongPress = (src: string) => {
     if (isUrlAnImage(src)) {
-      // here is the action sheet for image from lightbox
+      const options = LightboxActionSheet.constructActionSheetButtons();
+      const cancelButtonIndex = options.length - 1;
+      const { showActionSheetWithOptions, auth } = this.props;
+      showActionSheetWithOptions(
+        {
+          options,
+          cancelButtonIndex,
+        },
+        buttonIndex => {
+          LightboxActionSheet.executeActionSheetAction({
+            title: options[buttonIndex],
+            src,
+            auth,
+          });
+        },
+      );
       return;
     }
+    console.log(src);
     // action sheet for url
   }
 

--- a/src/message/MessageListContainer.js
+++ b/src/message/MessageListContainer.js
@@ -38,7 +38,7 @@ import {
 import { isUrlAnImage } from '../utils/url';
 import { filterUnreadMessageIds } from '../utils/unread';
 import { queueMarkAsRead } from '../api';
-import * as LightboxActionSheet from './../lightbox/LightboxActionSheet';
+import { openLightboxActionSheet } from './../lightbox/LightboxActionSheet';
 import { showToast } from '../utils/info';
 
 export type Props = {
@@ -111,22 +111,8 @@ class MessageListContainer extends PureComponent<Props> {
 
   handleUrlLongPress = (src: string) => {
     if (isUrlAnImage(src)) {
-      const options = LightboxActionSheet.constructActionSheetButtons();
-      const cancelButtonIndex = options.length - 1;
       const { showActionSheetWithOptions, auth } = this.props;
-      showActionSheetWithOptions(
-        {
-          options,
-          cancelButtonIndex,
-        },
-        buttonIndex => {
-          LightboxActionSheet.executeActionSheetAction({
-            title: options[buttonIndex],
-            src,
-            auth,
-          });
-        },
-      );
+      openLightboxActionSheet({ showActionSheetWithOptions, src, auth });
       return;
     }
     Clipboard.setString(src);

--- a/src/message/MessageListContainer.js
+++ b/src/message/MessageListContainer.js
@@ -111,8 +111,7 @@ class MessageListContainer extends PureComponent<Props> {
 
   handleUrlLongPress = (src: string) => {
     if (isUrlAnImage(src)) {
-      const { showActionSheetWithOptions, auth } = this.props;
-      openLightboxActionSheet({ showActionSheetWithOptions, src, auth });
+      openLightboxActionSheet({ ...this.props, src });
       return;
     }
     copyToClipboard(src);

--- a/src/message/messageActionSheet.js
+++ b/src/message/messageActionSheet.js
@@ -165,6 +165,10 @@ const shareMessage = ({ message }) => {
   });
 };
 
+const openUrl = ({ message }) => {
+  console.log(message.content);
+};
+
 const skip = () => false;
 
 type HeaderButtonType = {

--- a/src/message/messageActionSheet.js
+++ b/src/message/messageActionSheet.js
@@ -165,10 +165,6 @@ const shareMessage = ({ message }) => {
   });
 };
 
-const openUrl = ({ message }) => {
-  console.log(message.content);
-};
-
 const skip = () => false;
 
 type HeaderButtonType = {

--- a/src/render-html/generatedEs3.js
+++ b/src/render-html/generatedEs3.js
@@ -199,7 +199,22 @@ var handleLongPress = function handleLongPress(e) {
   if (!lastTouchEventTimestamp || Date.now() - lastTouchEventTimestamp < 500) return;
 
   lastTouchEventTimestamp = 0;
-
+  if (e.target.matches('a')) {
+    sendMessage({
+      type: 'urlLongPress',
+      href: e.target.getAttribute('href'),
+      messageId: +getMessageIdFromNode(e.target)
+    });
+    return;
+  }
+  if (e.target.parentNode.matches('a')) {
+    sendMessage({
+      type: 'urlLongPress',
+      href: e.target.parentNode.getAttribute('href'),
+      messageId: +getMessageIdFromNode(e.target.parentNode)
+    });
+    return;
+  }
   sendMessage({
     type: 'longPress',
     target: e.target.matches('.header') ? 'header' : 'message',

--- a/src/render-html/js.js
+++ b/src/render-html/js.js
@@ -180,7 +180,22 @@ const handleLongPress = e => {
   if (!lastTouchEventTimestamp || Date.now() - lastTouchEventTimestamp < 500) return;
 
   lastTouchEventTimestamp = 0;
-
+  if (e.target.matches('a')) {
+    sendMessage({
+      type: 'urlLongPress',
+      href: e.target.getAttribute('href'),
+      messageId: +getMessageIdFromNode(e.target),
+    });
+    return;
+  }
+  if (e.target.parentNode.matches('a')) {
+    sendMessage({
+      type: 'urlLongPress',
+      href: e.target.parentNode.getAttribute('href'),
+      messageId: +getMessageIdFromNode(e.target.parentNode),
+    });
+    return;
+  }
   sendMessage({
     type: 'longPress',
     target: e.target.matches('.header') ? 'header' : 'message',

--- a/src/render-html/webViewEventHandlers.js
+++ b/src/render-html/webViewEventHandlers.js
@@ -56,6 +56,7 @@ type Props = {
   messages: Message[],
   narrow: Narrow,
   onLongPress: (messageId: number, target: string) => void,
+  onUrlLongPress: (href: string) => void,
 };
 
 export const handleScroll = (props: Props, event: MessageListEventScroll) => {
@@ -115,6 +116,10 @@ export const handleUrl = (props: Props, event: MessageListEventUrl) => {
   }
 
   actions.messageLinkPress(event.href);
+};
+
+export const handleUrlLongPress = (props: Props, event: MessageListEventUrl) => {
+  props.onUrlLongPress(event.href);
 };
 
 export const handleReaction = (props: Props, event: MessageListEventReaction) => {

--- a/src/utils/clipboard.js
+++ b/src/utils/clipboard.js
@@ -1,0 +1,4 @@
+/* @flow */
+import { Clipboard } from 'react-native';
+
+export const copyToClipboard = (message: string) => Clipboard.setString(message);


### PR DESCRIPTION
Closes #2249 and #2122.

Before:
![before](https://user-images.githubusercontent.com/24983958/38621429-864ae950-3dbe-11e8-9984-0fa870dc3d8c.png)
After:
![after](https://user-images.githubusercontent.com/24983958/38621442-8bb493f0-3dbe-11e8-97aa-03eb7470791b.png)

This PR is focused on enhancing the `longPress` event in messages based on the type of message.
If the message is a normal text message it shows the regular `messageActionSheet`, else if the message is an image or image link it shows `lightBoxActionSheet` else if the message is a URL the URL gets copied to the clipboard directly.