### PR TITLE
webview: Make images a fixed height

### DIFF
--- a/src/render-html/css.js
+++ b/src/render-html/css.js
@@ -253,9 +253,8 @@ hr {
 .message_inline_image img,
 .twitter-image img {
   width: 100%;
-  max-height: 40vh;
-  object-fit: cover;
-  border-radius: 4px;
+  height: 30vh;
+  object-fit: contain;
 }
 blockquote {
   padding-left: 0.5em;


### PR DESCRIPTION
Remove flexibility of image heights.
This fixes an issue with images being different height while loading
and when loaded, thus messing up chat position.