### PR TITLE
Enhancement: Centers the labels on settings page

### DIFF
--- a/src/styles/theme.js
+++ b/src/styles/theme.js
@@ -114,8 +114,9 @@ export default ({ color, backgroundColor, borderColor, cardColor }: Props) => ({
   link: {
     marginTop: 10,
     fontSize: 15,
+    padding: 5,
     color: BRAND_COLOR,
-    textAlign: 'right',
+    textAlign: 'center',
   },
   optionRow: {
     flexDirection: 'row',

--- a/src/styles/theme.js
+++ b/src/styles/theme.js
@@ -112,9 +112,8 @@ export default ({ color, backgroundColor, borderColor, cardColor }: Props) => ({
     alignItems: 'stretch',
   },
   link: {
-    marginTop: 10,
     fontSize: 15,
-    padding: 5,
+    padding: 10,
     color: BRAND_COLOR,
     textAlign: 'center',
   },


### PR DESCRIPTION
Closes #1965. Centers the labels on settings page and also adds padding for better `onPress` accuracy.
Before:
![whatsapp image 2018-04-12 at 04 17 49](https://user-images.githubusercontent.com/24983958/38647191-ad00b4fe-3e08-11e8-85c6-622a6853d72b.jpeg)
After:
![whatsapp image 2018-04-12 at 04 18 01](https://user-images.githubusercontent.com/24983958/38647224-c29ac728-3e08-11e8-82b5-076c0084713f.jpeg)

This fix can be further improved but for now it looks better than the current state IMO.
