### PR TITLE
webvew: Batch webview input messages

### DIFF
--- a/src/render-html/MessageListWeb.js
+++ b/src/render-html/MessageListWeb.js
@@ -23,7 +23,7 @@ export default class MessageListWeb extends Component<Props> {
     console.error(event); // eslint-disable-line
   };
 
-  sendMessage = (msg: WebviewInputMessage): void => {
+  sendMessages = (msg: WebviewInputMessage[]): void => {
     if (this.webview) {
       this.webview.postMessage(JSON.stringify(msg), '*');
     }
@@ -37,7 +37,7 @@ export default class MessageListWeb extends Component<Props> {
   };
 
   shouldComponentUpdate = (nextProps: Props) => {
-    webViewHandleUpdates(this.props, nextProps, this.sendMessage);
+    webViewHandleUpdates(this.props, nextProps, this.sendMessages);
     return false;
   };
 

--- a/src/render-html/generatedEs3.js
+++ b/src/render-html/generatedEs3.js
@@ -9,6 +9,7 @@ export default `
 'use strict';
 
 
+
 var documentBody = document.body;
 
 if (!documentBody) throw new Error('No document.body element!');
@@ -215,8 +216,10 @@ var messageHandlers = {
 };
 
 document.addEventListener('message', function (e) {
-  var msg = JSON.parse(e.data);
-  messageHandlers[msg.type](msg);
+  var messages = JSON.parse(e.data);
+  messages.forEach(function (msg) {
+    messageHandlers[msg.type](msg);
+  });
 });
 
 window.addEventListener('scroll', handleScrollEvent);

--- a/src/render-html/js.js
+++ b/src/render-html/js.js
@@ -1,4 +1,11 @@
 /* @flow */
+import type {
+  WebviewInputMessage,
+  MessageInputContent,
+  MessageInputFetching,
+  MessageInputTyping,
+} from './webViewHandleUpdates';
+
 const documentBody = document.body;
 
 if (!documentBody) throw new Error('No document.body element!');
@@ -153,7 +160,7 @@ const updateFunctions = {
   'scroll-to-bottom-if-near-bottom': updateContentAndScrollToBottomIfNearBottom,
 };
 
-const handleMessageContent = msg => {
+const handleMessageContent = (msg: MessageInputContent) => {
   scrollEventsDisabled = true;
   updateFunctions[msg.updateStrategy](msg);
   scrollEventsDisabled = false;
@@ -162,13 +169,13 @@ const handleMessageContent = msg => {
   }
 };
 
-const handleMessageFetching = msg => {
+const handleMessageFetching = (msg: MessageInputFetching) => {
   toggleElementHidden('message-loading', !msg.showMessagePlaceholders);
   toggleElementHidden('spinner-older', !msg.fetchingOlder);
   toggleElementHidden('spinner-newer', !msg.fetchingNewer);
 };
 
-const handleMessageTyping = msg => {
+const handleMessageTyping = (msg: MessageInputTyping) => {
   const elementTyping = document.getElementById('typing');
   if (elementTyping) {
     elementTyping.innerHTML = msg.content;
@@ -198,8 +205,11 @@ const messageHandlers = {
 // $FlowFixMe
 document.addEventListener('message', e => {
   // $FlowFixMe
-  const msg = JSON.parse(e.data);
-  messageHandlers[msg.type](msg);
+  const messages: WebviewInputMessage[] = JSON.parse(e.data);
+  messages.forEach((msg: WebviewInputMessage) => {
+    // $FlowFixMe
+    messageHandlers[msg.type](msg);
+  });
 });
 
 window.addEventListener('scroll', handleScrollEvent);


### PR DESCRIPTION
Send input messages as array of objects instead of several times
as a single object.

That increases performance, reliability and predictability.

There are several reports in the GitHub issues for React Native
that sometimes messages are not delivered when several sent in
quick succession. I could reproduce that, though very rarely.
Hopefully this code fixes that issue, but even if not, the
benefits remain.