### PR TITLE
webview: Move error handling inside `js.js`

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -44,7 +44,7 @@ const config: Config = {
   enableReduxLogging: isDevelopment && !!global.btoa,
   enableReduxSlowReducerWarnings: isDevelopment && !!global.btoa,
   enableSentry: !isDevelopment && !isEmulator,
-  enableWebViewErrorDisplay: false,
+  enableWebViewErrorDisplay: true,
   enableNotifications: !isEmulator,
   slowReducersThreshold: 5,
   sentryKey: 'ADD-DSN-HERE',

--- a/src/render-html/generatedEs3.js
+++ b/src/render-html/generatedEs3.js
@@ -14,14 +14,24 @@ var documentBody = document.body;
 
 if (!documentBody) throw new Error('No document.body element!');
 
+var sendMessage = function sendMessage(msg) {
+  window.postMessage(JSON.stringify(msg), '*');
+};
+
+window.onerror = function (message, source, line, column, error) {
+  if (window.enableWebViewErrorDisplay) {
+    var elementJsError = document.getElementById('js-error');
+    if (elementJsError) {
+      elementJsError.innerHTML = ['Message: ' + message + '<br>', 'Line: ' + line + ':' + column + '<br>', 'Error: ' + JSON.stringify(error) + '<br>'].join('');
+    }
+  }
+  return false;
+};
+
 var scrollEventsDisabled = true;
 var lastTouchEventTimestamp = 0;
 var lastTouchPositionX = -1;
 var lastTouchPositionY = -1;
-
-var sendMessage = function sendMessage(msg) {
-  window.postMessage(JSON.stringify(msg), '*');
-};
 
 var toggleElementHidden = function toggleElementHidden(elementId, hidden) {
   var element = document.getElementById(elementId);

--- a/src/render-html/js.js
+++ b/src/render-html/js.js
@@ -10,14 +10,28 @@ const documentBody = document.body;
 
 if (!documentBody) throw new Error('No document.body element!');
 
+const sendMessage = (msg: Object) => {
+  window.postMessage(JSON.stringify(msg), '*');
+};
+
+window.onerror = (message, source, line, column, error) => {
+  if (window.enableWebViewErrorDisplay) {
+    const elementJsError = document.getElementById('js-error');
+    if (elementJsError) {
+      elementJsError.innerHTML = [
+        `Message: ${message}<br>`,
+        `Line: ${line}:${column}<br>`,
+        `Error: ${JSON.stringify(error)}<br>`,
+      ].join('');
+    }
+  }
+  return false;
+};
+
 let scrollEventsDisabled = true;
 let lastTouchEventTimestamp = 0;
 let lastTouchPositionX = -1;
 let lastTouchPositionY = -1;
-
-const sendMessage = (msg: Object) => {
-  window.postMessage(JSON.stringify(msg), '*');
-};
 
 const toggleElementHidden = (elementId: string, hidden: boolean) => {
   const element = document.getElementById(elementId);

--- a/src/render-html/script.js
+++ b/src/render-html/script.js
@@ -3,20 +3,11 @@ import smoothScroll from './smoothScroll.min';
 import js from './generatedEs3';
 import config from '../config';
 
-const errorHandler = `
-window.onerror = function (message, source, line, column, error) {
-  var obj = JSON.stringify(error);
-  var errorStr = ['Message: ' + message + '<br>', 'Line: ' + line + ':' + column + '<br>', 'Error: ' + obj + '<br>'].join('');
-  document.getElementById('js-error').innerHTML = errorStr;
-  return false;
-};
-`;
-
 export default (anchor: number): string => `
 <script>
 window.__forceSmoothScrollPolyfill__ = true;
-${config.enableWebViewErrorDisplay ? errorHandler : ''}
 ${smoothScroll}
+window.enableWebViewErrorDisplay = ${config.enableWebViewErrorDisplay.toString()};
 document.addEventListener('DOMContentLoaded', function() {
   ${js}
   scrollToAnchor(${anchor});


### PR DESCRIPTION
This is in preparation to add webview error propagation to Sentry.

Also, enable the error reporting in-webview by default.