### PR TITLE
error handling: Catch webview exceptions in Sentry

### DIFF
--- a/src/utils/logging.js
+++ b/src/utils/logging.js
@@ -6,7 +6,9 @@ export const logErrorRemotely = (e: Error, msg: string) => {
   if (config.enableSentry) {
     Sentry.captureException(e);
   }
-  if (config.enableErrorConsoleLogging) console.log(msg || '', e); // eslint-disable-line
+  if (config.enableErrorConsoleLogging) {
+    console.log(msg || '', e); // eslint-disable-line
+  }
 };
 
 export const logWarningToSentry = (msg: string) => {

--- a/src/webview/MessageListWeb.js
+++ b/src/webview/MessageListWeb.js
@@ -4,6 +4,7 @@ import { WebView } from 'react-native';
 
 import type { Props } from '../message/MessageListContainer';
 import type { WebviewInputMessage } from './webViewHandleUpdates';
+import type { MessageListEvent } from './webViewEventHandlers';
 import { getAuthHeader } from '../utils/url';
 import getHtml from './html/html';
 import renderMessagesAsHtml from './html/renderMessagesAsHtml';
@@ -29,8 +30,8 @@ export default class MessageListWeb extends Component<Props> {
     }
   };
 
-  handleMessage = (event: Object) => {
-    const eventData = JSON.parse(event.nativeEvent.data);
+  handleMessage = (event: { nativeEvent: { data: string } }) => {
+    const eventData: MessageListEvent = JSON.parse(event.nativeEvent.data);
     const handler = `handle${eventData.type.charAt(0).toUpperCase()}${eventData.type.slice(1)}`;
 
     webViewEventHandlers[handler](this.props, eventData); // $FlowFixMe

--- a/src/webview/js/generatedEs3.js
+++ b/src/webview/js/generatedEs3.js
@@ -22,10 +22,22 @@ window.onerror = function (message, source, line, column, error) {
   if (window.enableWebViewErrorDisplay) {
     var elementJsError = document.getElementById('js-error');
     if (elementJsError) {
-      elementJsError.innerHTML = ['Message: ' + message + '<br>', 'Line: ' + line + ':' + column + '<br>', 'Error: ' + JSON.stringify(error) + '<br>'].join('');
+      elementJsError.innerHTML = ['Message: ' + message + '<br>', 'Source: ' + source + '<br>', 'Line: ' + line + ':' + column + '<br>', 'Error: ' + JSON.stringify(error) + '<br>'].join('');
     }
   }
-  return false;
+
+  sendMessage({
+    type: 'error',
+    details: {
+      message: message,
+      source: source,
+      line: line,
+      column: column,
+      error: error
+    }
+  });
+
+  return true;
 };
 
 var scrollEventsDisabled = true;

--- a/src/webview/js/js.js
+++ b/src/webview/js/js.js
@@ -20,12 +20,25 @@ window.onerror = (message, source, line, column, error) => {
     if (elementJsError) {
       elementJsError.innerHTML = [
         `Message: ${message}<br>`,
+        `Source: ${source}<br>`,
         `Line: ${line}:${column}<br>`,
         `Error: ${JSON.stringify(error)}<br>`,
       ].join('');
     }
   }
-  return false;
+
+  sendMessage({
+    type: 'error',
+    details: {
+      message,
+      source,
+      line,
+      column,
+      error,
+    },
+  });
+
+  return true;
 };
 
 let scrollEventsDisabled = true;

--- a/src/webview/webViewEventHandlers.js
+++ b/src/webview/webViewEventHandlers.js
@@ -3,6 +3,7 @@ import { emojiReactionAdd, emojiReactionRemove, queueMarkAsRead } from '../api';
 import config from '../config';
 import type { Actions, Auth, FlagsState, Message, Narrow } from '../types';
 import { isUrlAnImage } from '../utils/url';
+import { logErrorRemotely } from '../utils/logging';
 import { filterUnreadMessagesInRange } from '../utils/unread';
 import { parseNarrowString } from '../utils/narrow';
 
@@ -57,6 +58,17 @@ type MessageListEventDebug = {
   type: 'debug',
 };
 
+type MessageListEventError = {
+  type: 'error',
+  details: {
+    message: string,
+    source: string,
+    line: number,
+    column: number,
+    error: Object,
+  },
+};
+
 export type MessageListEvent =
   | MessageListEventScroll
   | MessageListEventAvatar
@@ -65,7 +77,8 @@ export type MessageListEvent =
   | MessageListEventReaction
   | MessageListEventUrl
   | MessageListEventLongPress
-  | MessageListEventDebug;
+  | MessageListEventDebug
+  | MessageListEventError;
 
 type Props = {
   actions: Actions,
@@ -148,4 +161,8 @@ export const handleReaction = (props: Props, event: MessageListEventReaction) =>
 
 export const handleDebug = (props: Props, event: MessageListEventDebug) => {
   console.debug(props, event); // eslint-disable-line
+};
+
+export const handleError = (props: Props, event: MessageListEventError) => {
+  logErrorRemotely(new Error(event.details), 'WebView Exception');
 };


### PR DESCRIPTION
Add a new message type to webview and use it to pass any unhandled
exception back to the MessageListWeb component. Then send that data
via Sentry.