### PR TITLE
Reworking UI of all menus

### DIFF
--- a/src/streams/StreamCard.js
+++ b/src/streams/StreamCard.js
@@ -18,6 +18,9 @@ const styles = StyleSheet.create({
   descriptionText: {
     opacity: 0.8,
   },
+  padding: {
+    padding: 16,
+  },
 });
 
 type Props = {
@@ -35,7 +38,7 @@ export default class StreamCard extends PureComponent<Props> {
     const description = subscription.description || stream.description;
 
     return (
-      <View>
+      <View style={styles.padding}>
         <View style={styles.streamRow}>
           <StreamIcon
             size={20}

--- a/src/streams/StreamScreen.js
+++ b/src/streams/StreamScreen.js
@@ -1,5 +1,6 @@
 /* @flow */
 import React, { PureComponent } from 'react';
+import { View } from 'react-native';
 
 import type { Actions, Stream, Subscription } from '../types';
 import connectWithActions from '../connectWithActions';
@@ -59,7 +60,7 @@ class StreamScreen extends PureComponent<Props> {
     const { styles } = this.context;
 
     return (
-      <Screen title="Stream" padding>
+      <Screen title="Stream">
         <StreamCard stream={stream} subscription={subscription} />
         <OptionRow
           label="Pinned"
@@ -78,8 +79,10 @@ class StreamScreen extends PureComponent<Props> {
           customStyle={this.context.styles.backgroundColor}
         />
         <OptionDivider />
-        <ZulipButton style={styles.marginTop} text="Topics" onPress={this.handleTopics} />
-        <ZulipButton style={styles.marginTop} text="Edit" onPress={this.handleEdit} />
+        <View style={styles.padding}>
+          <ZulipButton text="Topics" onPress={this.handleTopics} />
+          <ZulipButton style={styles.marginTop} text="Edit" onPress={this.handleEdit} />
+        </View>
       </Screen>
     );
   }

--- a/src/styles/theme.js
+++ b/src/styles/theme.js
@@ -62,7 +62,7 @@ export default ({ color, backgroundColor, borderColor, cardColor, dividerColor }
     fontSize: 15,
   },
   padding: {
-    padding: 8,
+    padding: 16,
   },
   icon: {
     color,


### PR DESCRIPTION
Reworked the UI of menus to achieve a more modern design consistent with Material Design guidelines.

Screenshot of settings screen before:
![settingscard_before](https://user-images.githubusercontent.com/22353313/38702990-b03d25be-3ebf-11e8-9577-96f2b7f28721.png)

Screenshot of settings screen after current changes:
![settingscard](https://user-images.githubusercontent.com/22353313/38772574-8ac9ce4c-4057-11e8-8f72-874b14494ebb.png)


In night mode:
![settingscard_night](https://user-images.githubusercontent.com/22353313/38772577-98ea936c-4057-11e8-85f1-09fc1bffa93e.png)


The `OptionDivider` component has been converted to a class based component in order to access `styles` via context like other common components.

Commit 8123dfc adds a padding around the version number in `DiagnosticsScreen` to make it look less crowded.
![vernumpadding](https://user-images.githubusercontent.com/22353313/38832104-25170f36-41df-11e8-88ee-3db5cad1c148.png)
