### PR TITLE
keyboard: Do not 'swallow' first taps in group screen

### DIFF
--- a/src/group/GroupScreen.js
+++ b/src/group/GroupScreen.js
@@ -20,7 +20,11 @@ export default class GroupScreen extends PureComponent<{}, State> {
   render() {
     const { filter } = this.state;
     return (
-      <Screen search searchBarOnChange={this.handleFilterChange}>
+      <Screen
+        search
+        keyboardShouldPersistTaps="handled"
+        searchBarOnChange={this.handleFilterChange}
+      >
         <GroupContainer filter={filter} />
       </Screen>
     );


### PR DESCRIPTION
We open Create Group screen with a keyboard open. That is OK.
But then tapping on a user as a first action hides the keyboard
but does not add the user.

Instead, tapping the user now adds it, and tapping outside the
user list will hide the keyboard.