### PR TITLE
usability: Create and Edit sream screen one-tap on buttons

### DIFF
--- a/src/streams/CreateStreamScreen.js
+++ b/src/streams/CreateStreamScreen.js
@@ -7,7 +7,7 @@ import EditStreamContainer from './EditStreamContainer';
 export default class CreateStreamScreen extends PureComponent<{}> {
   render() {
     return (
-      <Screen title="Create new stream" padding>
+      <Screen title="Create new stream" padding keyboardShouldPersistTaps="handled">
         <EditStreamContainer />
       </Screen>
     );

--- a/src/streams/EditStreamScreen.js
+++ b/src/streams/EditStreamScreen.js
@@ -7,7 +7,7 @@ import EditStreamContainer from './EditStreamContainer';
 export default class EditStreamScreen extends PureComponent<{}> {
   render() {
     return (
-      <Screen title="Edit stream" padding>
+      <Screen title="Edit stream" padding keyboardShouldPersistTaps="handled">
         <EditStreamContainer />
       </Screen>
     );


### PR DESCRIPTION
Make sure we do not ignore the first tap on buttons in
Create & Edit screens, activate on first tap.