### PR TITLE
Fix create stream failing

### DIFF
--- a/src/streams/EditStreamCard.js
+++ b/src/streams/EditStreamCard.js
@@ -45,7 +45,7 @@ export default class EditStreamCard extends PureComponent<Props, State> {
     const { actions, ownEmail, streamId, initialValues } = this.props;
     const { name, description, isPrivate } = this.state;
 
-    if (!streamId) {
+    if (streamId === -1) {
       actions.createNewStream(name, description, [ownEmail], isPrivate);
     } else {
       actions.updateExistingStream(streamId, initialValues, { name, description, isPrivate });
@@ -93,7 +93,7 @@ export default class EditStreamCard extends PureComponent<Props, State> {
         />
         <ZulipButton
           style={styles.marginTop}
-          text={streamId ? 'Update' : 'Create'}
+          text={streamId === -1 ? 'Create' : 'Update'}
           disabled={name.length === 0}
           onPress={this.handlePerformAction}
         />


### PR DESCRIPTION
A change that returned -1 instead of undefined for streamId
messed up the UI logic and it always tried to update a stream
even a non existing one wiht ID of -1.

Fixes #2288