### PR TITLE
fix: Store keys even for empty message gets

### DIFF
--- a/src/chat/__tests__/chatReducers-test.js
+++ b/src/chat/__tests__/chatReducers-test.js
@@ -705,20 +705,23 @@ describe('chatReducers', () => {
   });
 
   describe('MESSAGE_FETCH_COMPLETE', () => {
-    test('if no messages returned do not mutate state', () => {
+    test('if no messages returned still create the key in state', () => {
       const initialState = deepFreeze({
         [homeNarrowStr]: [{ id: 1 }, { id: 2 }, { id: 3 }],
       });
-
       const action = deepFreeze({
         type: MESSAGE_FETCH_COMPLETE,
-        narrow: [],
+        narrow: privateNarrow('mark@example.com'),
         messages: [],
       });
+      const expectedState = {
+        [homeNarrowStr]: [{ id: 1 }, { id: 2 }, { id: 3 }],
+        [JSON.stringify(privateNarrow('mark@example.com'))]: [],
+      };
 
       const newState = chatReducers(initialState, action);
 
-      expect(newState).toBe(initialState);
+      expect(newState).toEqual(expectedState);
     });
 
     test('no duplicate messages', () => {

--- a/src/chat/chatReducers.js
+++ b/src/chat/chatReducers.js
@@ -34,10 +34,6 @@ const messageFetchComplete = (
   state: MessageState,
   action: MessageFetchCompleteAction,
 ): MessageState => {
-  if (action.messages.length === 0) {
-    return state;
-  }
-
   const key = JSON.stringify(action.narrow);
   const messages = state[key] || NULL_ARRAY;
   const messagesById = groupItemsById(messages);


### PR DESCRIPTION
Fixes #2296

Two architecture choices done at different times clashed to produce
this incorrect (and covered by tests) behavior!

We didn't store incomming messages for which you don't have yet
keys in the message store. But since we also didn't store empty
response from narrowing this made sure we do not store any messages
sent to a narrow with no messages.