### PR TITLE
tests: Add a test for PM narrow to chatReducers

### DIFF
--- a/src/chat/__tests__/chatReducers-test.js
+++ b/src/chat/__tests__/chatReducers-test.js
@@ -132,6 +132,32 @@ describe('chatReducers', () => {
     });
   });
 
+  test('if new message is private or group add it to the "allPrivate" narrow', () => {
+    const initialState = deepFreeze({
+      [allPrivateNarrowStr]: [],
+    });
+    const message = {
+      id: 1,
+      type: 'private',
+      display_recipient: [{ email: 'me@example.com' }, { email: 'a@a.com' }, { email: 'b@b.com' }],
+    };
+    const action = deepFreeze({
+      type: EVENT_NEW_MESSAGE,
+      message,
+      ownEmail: 'me@example.com',
+      caughtUp: {
+        [allPrivateNarrowStr]: { older: true, newer: true },
+      },
+    });
+    const expectedState = {
+      [allPrivateNarrowStr]: [message],
+    };
+
+    const actualState = chatReducers(initialState, action);
+
+    expect(actualState).toEqual(expectedState);
+  });
+
   test('appends same id message to state', () => {
     const initialState = deepFreeze({
       [homeNarrowStr]: [


### PR DESCRIPTION
Ensures messages are added to the PM special narrow
The test is already passing but it includes case not previously tested