### PR TITLE
[WIP] streamLink: Fix navigation to streams from messages issue.

### DIFF
--- a/src/message/messagesActions.js
+++ b/src/message/messagesActions.js
@@ -7,7 +7,7 @@ import { SWITCH_NARROW } from '../actionConstants';
 import { getMessageIdFromLink, getNarrowFromLink, isUrlInAppLink, getFullUrl } from '../utils/url';
 import openLink from '../utils/openLink';
 import { fetchMessagesAtFirstUnread, fetchMessagesAroundAnchor } from './fetchActions';
-import { validateNarrow } from '../utils/narrow';
+import { validateNarrow, fixStreamNarrowOperand } from '../utils/narrow';
 
 export const switchNarrow = (narrow: Narrow): SwitchNarrowAction => ({
   type: SWITCH_NARROW,
@@ -17,11 +17,17 @@ export const switchNarrow = (narrow: Narrow): SwitchNarrowAction => ({
 const isNarrowValid = (narrow: Narrow, state: GlobalState): boolean =>
   validateNarrow(narrow, getStreams(state), getUsers(state));
 
+const fixStreamNarrow = (narrow: Narrow, state: GlobalState) =>
+  fixStreamNarrowOperand(narrow, getStreams(state));
+
 export const doNarrow = (narrow: Narrow, anchor: number = 0) => (
   dispatch: Dispatch,
   getState: GetState,
 ) => {
   const state = getState();
+
+  fixStreamNarrow(narrow, state);
+
   if (!isNarrowValid(narrow, state) || !getIsHydrated(state)) {
     return;
   }

--- a/src/utils/__tests__/url-test.js
+++ b/src/utils/__tests__/url-test.js
@@ -589,6 +589,9 @@ describe('appendAuthToImages', () => {
     const input = '<img src="/user_uploads/img.png">"But soft,"';
     const expected = '<img src="/user_uploads/img.png?api_key=some_key">"But soft,"';
     expect(appendAuthToImages(input, auth)).toEqual(expected);
+  });
+});
+
 describe('extractStreamName', () => {
   test('when no value is entered return empty string', () => {
     const result = extractStreamName('21-example');

--- a/src/utils/__tests__/url-test.js
+++ b/src/utils/__tests__/url-test.js
@@ -17,6 +17,8 @@ import {
   fixRealmUrl,
   autocompleteUrl,
   appendAuthToImages,
+  extractStreamName,
+  extractStreamID,
 } from '../url';
 
 import { streamNarrow, topicNarrow } from '../narrow';
@@ -587,5 +589,96 @@ describe('appendAuthToImages', () => {
     const input = '<img src="/user_uploads/img.png">"But soft,"';
     const expected = '<img src="/user_uploads/img.png?api_key=some_key">"But soft,"';
     expect(appendAuthToImages(input, auth)).toEqual(expected);
+describe('extractStreamName', () => {
+  test('when no value is entered return empty string', () => {
+    const result = extractStreamName('21-example');
+    expect(result).toEqual('example');
+  });
+
+  test('when empty string provided, return empty string', () => {
+    const result = extractStreamName('');
+    expect(result).toEqual('');
+  });
+
+  test('when no parameter provided, return empty string ', () => {
+    const result = extractStreamName();
+    expect(result).toEqual('');
+  });
+
+  test('when stream_name includes numbers and dash, only remove the appended stream_id', () => {
+    const result = extractStreamName('21-example-21-');
+    expect(result).toEqual('example-21-');
+  });
+
+  test('when stream_name includes numbers and not preceding dash, do not change the original', () => {
+    const result = extractStreamName('example-21');
+    expect(result).toEqual('example-21');
+  });
+
+  test('when there is no appended stream_id, do not change the original', () => {
+    const result = extractStreamName('example');
+    expect(result).toEqual('example');
+  });
+
+  test('when there are multiple dashes and numbers in stream_name, only remove the appended stream_id', () => {
+    const result = extractStreamName('21---example-21-');
+    expect(result).toEqual('--example-21-');
+  });
+});
+
+describe('extractStreamID', () => {
+  test('when empty string provided, return 0', () => {
+    const result = extractStreamID('');
+    expect(result).toEqual(0);
+  });
+
+  test('when no parameter provided, return 0', () => {
+    const result = extractStreamID();
+    expect(result).toEqual(0);
+  });
+
+  test('when there is a number followed by dash, extract it', () => {
+    const result = extractStreamID('11-example');
+    expect(result).toEqual(11);
+  });
+
+  test('when there are numbers followed by dash, extract only the appended number', () => {
+    const result = extractStreamID('11-example-12-');
+    expect(result).toEqual(11);
+  });
+
+  test('when there are numbers and multiple dashes, extract only the appended number', () => {
+    const result = extractStreamID('11---example--12-');
+    expect(result).toEqual(11);
+  });
+
+  test('when there are dash(es) in front, do not extract anything', () => {
+    const result = extractStreamID('-11-example');
+    expect(result).toEqual(0);
+  });
+
+  test('when there is a number in front not followed by dash, do not extract it', () => {
+    const result = extractStreamID('11example');
+    expect(result).toEqual(0);
+  });
+
+  test('when there is no appended number, do not extract anything', () => {
+    const result = extractStreamID('example');
+    expect(result).toEqual(0);
+  });
+
+  test('when there is a dash followed by number in the middle, do not extract it', () => {
+    const result = extractStreamID('example-11-example');
+    expect(result).toEqual(0);
+  });
+
+  test('when there is a dash followed by number in the end, do not extract it', () => {
+    const result = extractStreamID('example-11');
+    expect(result).toEqual(0);
+  });
+
+  test('when there is an appended number that is not integer, do not extract it', () => {
+    const result = extractStreamID('11.1-example');
+    expect(result).toEqual(0);
   });
 });

--- a/src/utils/narrow.js
+++ b/src/utils/narrow.js
@@ -5,6 +5,7 @@ import unescape from 'lodash.unescape';
 
 import type { Narrow, Message, Stream, User } from '../types';
 import { normalizeRecipients } from './message';
+import { streamNameFromSlug } from './url';
 
 export const homeNarrow: Narrow = [];
 
@@ -150,6 +151,12 @@ export const getNarrowFromMessage = (message: Message, email: string) => {
   }
 
   return streamNarrow(message.display_recipient);
+};
+
+export const fixStreamNarrowOperand = (narrow: Narrow, streams: Stream[]) => {
+  if (isStreamOrTopicNarrow(narrow)) {
+    narrow[0].operand = streamNameFromSlug(narrow[0].operand, streams);
+  }
 };
 
 export const validateNarrow = (narrow: Narrow, streams: Stream[], users: User[]): boolean => {

--- a/src/utils/url.js
+++ b/src/utils/url.js
@@ -83,6 +83,17 @@ export const getEmojiUrl = (unicode: string): string =>
   `/static/generated/emoji/images/emoji/unicode/${unicode}.png`;
 
 export const getNarrowFromLink = (url: string, realm: string, users: User[]): Narrow => {
+// New url scheme: #narrow/stream/{stream_id}-{stream_name}. We need to extract the stream_name.
+export const extractStreamName = (streamNameWithNumberAppended: string = ''): string =>
+  streamNameWithNumberAppended.trim().replace(/^\d+-/, '');
+
+// We need to extract the stream_id from the new format.
+export const extractStreamID = (streamNameWithNumberAppended: string = ''): number => {
+  const streamID = (/^\d+(?=-)/).exec(streamNameWithNumberAppended.trim());
+  return streamID !== null ? parseInt(streamID, 10) : 0;
+};
+
+export const getNarrowFromLink = (url: string, realm: string, users: any[]): Narrow => {
   const paths = getPathsFromUrl(url, realm);
 
   if (isGroupLink(url, realm)) {
@@ -91,12 +102,16 @@ export const getNarrowFromLink = (url: string, realm: string, users: User[]): Na
       recipients.map((recipient: string) => getUserById(users, parseInt(recipient, 10)).email),
     );
   } else if (isTopicLink(url, realm)) {
+    const streamNameWithNumberAppended = decodeURIComponent(transformToEncodedURI(paths[1]));
     return topicNarrow(
-      decodeURIComponent(transformToEncodedURI(paths[1])),
+      extractStreamName(streamNameWithNumberAppended),
       decodeURIComponent(transformToEncodedURI(paths[3])),
     );
   } else if (isStreamLink(url, realm)) {
-    return streamNarrow(decodeURIComponent(transformToEncodedURI(paths[1])));
+    const streamNameWithNumberAppended = decodeURIComponent(transformToEncodedURI(paths[1]));
+    return streamNarrow(
+      extractStreamName(streamNameWithNumberAppended)
+    );
   } else if (isSpecialLink(url, realm)) {
     return specialNarrow(paths[1]);
   }


### PR DESCRIPTION
Streams have been started to named with `streamID` appended to the front.

New url format:
`/#narrow/stream/{stream_id}-{stream_name}`

To properly navigate to streams(also topics and conversations) from in-message # links,
(e.g. #mobile, #general), we need to first check presence of `stream_id` in the url, if indeed it is present, do operations with using `stream_id`. Otherwise, use `stream_name`.

This PR will fix **#2312**. (Currently WIP, because the logic has been changed).
