### PR TITLE
group: Remove oneself from new group user list.

### DIFF
--- a/src/group/GroupContainer.js
+++ b/src/group/GroupContainer.js
@@ -1,10 +1,10 @@
 /* @flow */
-import { getOwnEmail, getUsers, getPresence } from '../selectors';
+import { getOwnEmail, getPresence, getUsersSansMe } from '../selectors';
 import connectWithActions from '../connectWithActions';
 import GroupCard from './GroupCard';
 
 export default connectWithActions(state => ({
   ownEmail: getOwnEmail(state),
-  users: getUsers(state),
+  users: getUsersSansMe(state),
   presences: getPresence(state),
 }))(GroupCard);

--- a/src/users/__tests__/userSelectors-test.js
+++ b/src/users/__tests__/userSelectors-test.js
@@ -8,6 +8,7 @@ import {
   getUsersStatusOffline,
   getUsersByEmail,
   getUsersById,
+  getUsersSansMe,
 } from '../userSelectors';
 
 describe('getAccountDetailsUser', () => {
@@ -206,5 +207,28 @@ describe('getUsersById', () => {
     const result = getUsersById(state);
 
     expect(result).toEqual(expectedResult);
+  });
+});
+
+describe('getUsersSansMe', () => {
+  test('returns all users except current user', () => {
+    const state = deepFreeze({
+      users: [
+        { email: 'me@example.com' },
+        { email: 'john@example.com' },
+        { email: 'doe@example.com' },
+      ],
+      accounts: [
+        { email: 'me@example.com' },
+      ],
+    });
+    const expectedResult = [
+        { email: 'john@example.com' },
+        { email: 'doe@example.com' },
+      ];
+
+    const actualResult = getUsersSansMe(state);
+
+    expect(actualResult).toEqual(expectedResult);
   });
 });

--- a/src/users/userSelectors.js
+++ b/src/users/userSelectors.js
@@ -66,3 +66,7 @@ export const getUsersById = createSelector(getUsers, users =>
     return usersById;
   }, {}),
 );
+
+export const getUsersSansMe = createSelector(getUsers, getOwnEmail, (users, ownEmail) =>
+  users.filter(user => user.email !== ownEmail)
+);


### PR DESCRIPTION
Fixes #2289. Currently, while creating a group a user is free to add himself to the group chat, which by default is done. This is unnecessary and this option is also not available in other group chat apps like slack or WhatsApp groups.