### PR TITLE
fix crash for invalid url

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "entities": "^1.1.1",
     "events": "^2.0.0",
     "htmlparser2": "^3.9.2",
-    "is-url": "^1.2.4",
     "lodash.escape": "^4.0.1",
     "lodash.isequal": "^4.4.0",
     "lodash.throttle": "^4.1.1",

--- a/src/api/apiFetch.js
+++ b/src/api/apiFetch.js
@@ -1,6 +1,4 @@
 /* @flow */
-import isUrl from 'is-url';
-
 import type { Auth, ResponseExtractionFunc } from '../types';
 import { getAuthHeader, encodeAsURI } from '../utils/url';
 import userAgent from '../utils/userAgent';
@@ -10,10 +8,6 @@ const apiVersion = 'api/v1';
 
 export const apiFetch = async (auth: Auth, route: string, params: Object = {}) => {
   const url = `${auth.realm}/${apiVersion}/${route}`;
-
-  if (!isUrl(url)) {
-    throw new Error(`Invalid url ${url}`);
-  }
 
   const contentType =
     params.body instanceof FormData

--- a/src/start/RealmScreen.js
+++ b/src/start/RealmScreen.js
@@ -1,8 +1,6 @@
 /* @flow */
 import React, { PureComponent } from 'react';
 import { ScrollView, Keyboard } from 'react-native';
-import isUrl from 'is-url';
-
 import type { Actions } from '../types';
 import connectWithActions from '../connectWithActions';
 import { ErrorMsg, Label, SmartUrlInput, Screen, ZulipButton } from '../common';
@@ -35,9 +33,21 @@ class RealmScreen extends PureComponent<Props, State> {
     error: undefined,
   };
 
+  isURL = str => {
+    const pattern = new RegExp(
+      '^(https?:\\/\\/)?' +
+        '((([a-z\\d]([a-z\\d-]*[a-z\\d])*)\\.?)+[a-z]{2,}|' +
+        '((\\d{1,3}\\.){3}\\d{1,3}))' +
+        '(\\:\\d+)?(\\/[-a-z\\d%_.~+]*)*' +
+        '(\\?[;&a-z\\d%_.~+=-]*)?' +
+        '(\\#[-a-z\\d_]*)?$',
+      'i',
+    );
+    return pattern.test(str);
+  };
+
   tryRealm = async () => {
     const { realm } = this.state;
-
     this.setState({
       realm,
       progress: true,
@@ -93,7 +103,7 @@ class RealmScreen extends PureComponent<Props, State> {
           text="Enter"
           progress={progress}
           onPress={this.tryRealm}
-          disabled={!isUrl(realm)}
+          disabled={!this.isURL(realm)}
         />
       </Screen>
     );

--- a/yarn.lock
+++ b/yarn.lock
@@ -3623,10 +3623,6 @@ is-typedarray@^1.0.0, is-typedarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
 
-is-url@^1.2.4:
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/is-url/-/is-url-1.2.4.tgz#04a4df46d28c4cff3d73d01ff06abeb318a1aa52"
-
 is-utf8@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"


### PR DESCRIPTION
This library https://github.com/segmentio/is-url is very buggy and lead to the app crashing.
It fails on several test cases.
https://chat..zulip.org --> true
https://chat.zulip..org --> true
https://chat.zulip.org.. --> true

Instead, I replace the library with a function using a regular expression which passes all the test cases above. 

https://chat..zulip.org --> false
https://chat.zulip..org --> false
https://chat.zulip.org.. --> false