### PR TITLE
flow: Create a file for API types and add ApiUser

### DIFF
--- a/src/api/apiTypes.js
+++ b/src/api/apiTypes.js
@@ -1,0 +1,14 @@
+/* @flow */
+export type ApiUser = {
+  avatar_url: string,
+  bot_type?: number,
+  bot_owner?: string,
+  email: string,
+  full_name: string,
+  is_admin: boolean,
+  is_active: boolean,
+  is_bot: boolean,
+  profile_data?: Object,
+  timezone: string,
+  user_id: 5584,
+};

--- a/src/api/users/getUsers.js
+++ b/src/api/users/getUsers.js
@@ -1,6 +1,6 @@
 /* @flow */
-import type { Auth } from '../../types';
+import type { Auth, ApiUser } from '../../types';
 import { apiGet } from '../apiFetch';
 
-export default (auth: Auth): any =>
+export default (auth: Auth): Promise<ApiUser[]> =>
   apiGet(auth, 'users', res => res.members, { client_gravatar: true });

--- a/src/types.js
+++ b/src/types.js
@@ -7,6 +7,7 @@ export type AnimatedValue = any; // { AnimatedValue } from 'react-native';
 export type MapStateToProps = any; // { MapStateToProps } from 'react-redux';
 
 export type * from './actionTypes';
+export type * from './api/apiTypes';
 
 export type StyleObj = any;
 export type Dispatch = any;

--- a/src/users/usersReducers.js
+++ b/src/users/usersReducers.js
@@ -1,5 +1,7 @@
 /* @flow */
 import type {
+  User,
+  ApiUser,
   UsersState,
   UsersAction,
   InitUsersAction,
@@ -18,7 +20,7 @@ import {
 } from '../actionConstants';
 import { NULL_ARRAY } from '../nullObjects';
 
-const mapApiToStateUser = user => ({
+const mapApiToStateUser = (user: ApiUser): User => ({
   id: user.user_id,
   email: user.email,
   fullName: user.full_name,


### PR DESCRIPTION
We need to have types for the incoming API data.
A good place to start is our User and its API counterpart.
All types will be prefixes with `Api` to distinguish them.