### PR TITLE
refactor: Make selection scrolling more precise

### DIFF
--- a/src/group/GroupCard.js
+++ b/src/group/GroupCard.js
@@ -51,10 +51,11 @@ export default class GroupCard extends PureComponent<Props, State> {
     const { selected } = this.state;
 
     const user = users.find(x => x.email === email);
-    this.setState({
-      selected: [...selected, user],
-    });
-    setTimeout(() => this.listRef.scrollToEnd(), 300);
+    if (user) {
+      this.setState({
+        selected: [...selected, user],
+      });
+    }
   };
 
   handleUserPress = (email: string) => {
@@ -82,6 +83,12 @@ export default class GroupCard extends PureComponent<Props, State> {
     const recipients = selected.map(user => user.email);
     actions.navigateBack();
     actions.doNarrow(groupNarrow(recipients));
+  };
+
+  componentDidUpdate = (prevProps: Props, prevState: State) => {
+    if (this.listRef && this.state.selected.length > prevState.selected.length) {
+      setTimeout(() => this.listRef.scrollToEnd());
+    }
   };
 
   render() {


### PR DESCRIPTION
* add checks for user is found and listRef is defined
* setTimeout is now more predictable

If we are selecting a user, we scroll the avatar list to the end
to ensure the last item just added is visible.

Previously we had to wait for some time until the component updates.
We did wait for 300msecs (magic number). Ensuring that the component
already did update we use setTimeout only to allow the UI to refresh
but we no longer need to wait 300msecs.