### PR TITLE
refactor: Abstract away where isValidUrl function comes from

### DIFF
--- a/src/api/apiFetch.js
+++ b/src/api/apiFetch.js
@@ -1,8 +1,6 @@
 /* @flow */
-import isUrl from 'is-url';
-
 import type { Auth, ResponseExtractionFunc } from '../types';
-import { getAuthHeader, encodeAsURI } from '../utils/url';
+import { getAuthHeader, encodeAsURI, isValidUrl } from '../utils/url';
 import userAgent from '../utils/userAgent';
 import { networkActivityStart, networkActivityStop } from '../utils/networkActivity';
 
@@ -11,7 +9,7 @@ const apiVersion = 'api/v1';
 export const apiFetch = async (auth: Auth, route: string, params: Object = {}) => {
   const url = `${auth.realm}/${apiVersion}/${route}`;
 
-  if (!isUrl(url)) {
+  if (!isValidUrl(url)) {
     throw new Error(`Invalid url ${url}`);
   }
 

--- a/src/start/RealmScreen.js
+++ b/src/start/RealmScreen.js
@@ -1,11 +1,11 @@
 /* @flow */
 import React, { PureComponent } from 'react';
 import { ScrollView, Keyboard } from 'react-native';
-import isUrl from 'is-url';
 
 import type { Actions } from '../types';
 import connectWithActions from '../connectWithActions';
 import { ErrorMsg, Label, SmartUrlInput, Screen, ZulipButton } from '../common';
+import { isValidUrl } from '../utils/url';
 import { getServerSettings } from '../api';
 
 type Props = {
@@ -93,7 +93,7 @@ class RealmScreen extends PureComponent<Props, State> {
           text="Enter"
           progress={progress}
           onPress={this.tryRealm}
-          disabled={!isUrl(realm)}
+          disabled={!isValidUrl(realm)}
         />
       </Screen>
     );

--- a/src/utils/url.js
+++ b/src/utils/url.js
@@ -1,5 +1,6 @@
 /* @flow */
 import base64 from 'base-64';
+import isUrl from 'is-url';
 
 import type { Auth, Narrow } from '../types';
 import { homeNarrow, topicNarrow, streamNarrow, groupNarrow, specialNarrow } from './narrow';
@@ -157,3 +158,5 @@ export const autocompleteUrl = (
         value.indexOf('.') === -1 ? append : !value.match(/.+\..+\.+./g) ? shortAppend : ''
       }`
     : '';
+
+export const isValidUrl: (url: string) => boolean = isUrl;


### PR DESCRIPTION
Often it is useful to abstract where a function is coming from.
We have reworked the url validation function several times.
This will focus any further changes in one place.

We make sure to call the function a name that will not change
and currently just reuse isUrl.