### PR TITLE
url: Replace is-url with url-regex for precise url validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "entities": "^1.1.1",
     "events": "^2.0.0",
     "htmlparser2": "^3.9.2",
-    "is-url": "^1.2.4",
     "lodash.escape": "^4.0.1",
     "lodash.isequal": "^4.4.0",
     "lodash.throttle": "^4.1.1",
@@ -77,6 +76,7 @@
     "stream": "^0.0.2",
     "string.fromcodepoint": "^0.2.1",
     "url-parse": "^1.3.0",
+    "url-regex": "^4.1.1",
     "zulip-markdown-parser": "^1.0.4"
   },
   "devDependencies": {

--- a/src/utils/url.js
+++ b/src/utils/url.js
@@ -1,6 +1,6 @@
 /* @flow */
 import base64 from 'base-64';
-import isUrl from 'is-url';
+import urlRegex from 'url-regex';
 
 import type { Auth, Narrow } from '../types';
 import { homeNarrow, topicNarrow, streamNarrow, groupNarrow, specialNarrow } from './narrow';
@@ -159,4 +159,4 @@ export const autocompleteUrl = (
       }`
     : '';
 
-export const isValidUrl: (url: string) => boolean = isUrl;
+export const isValidUrl = (url: string): boolean => urlRegex({ exact: true }).test(url);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3471,6 +3471,10 @@ invert-kv@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-1.0.0.tgz#104a8e4aaca6d3d8cd157a8ef8bfab2d7a3ffdb6"
 
+ip-regex@^1.0.1:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/ip-regex/-/ip-regex-1.0.3.tgz#dc589076f659f419c222039a33316f1c7387effd"
+
 is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
@@ -6986,6 +6990,10 @@ timed-out@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/timed-out/-/timed-out-4.0.1.tgz#f32eacac5a175bea25d7fab565ab3ed8741ef56f"
 
+tlds@^1.187.0:
+  version "1.203.1"
+  resolved "https://registry.yarnpkg.com/tlds/-/tlds-1.203.1.tgz#4dc9b02f53de3315bc98b80665e13de3edfc1dfc"
+
 tmp@^0.0.31:
   version "0.0.31"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.31.tgz#8f38ab9438e17315e5dbd8b3657e8bfb277ae4a7"
@@ -7148,6 +7156,13 @@ url-parse@^1.3.0:
   dependencies:
     querystringify "~1.0.0"
     requires-port "~1.0.0"
+
+url-regex@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/url-regex/-/url-regex-4.1.1.tgz#a5617b22e15e26dac57ce74c3f52088bcdfec995"
+  dependencies:
+    ip-regex "^1.0.1"
+    tlds "^1.187.0"
 
 url-to-options@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
is-url validates only 'loosely' according to their own description.
Some important cases were missed (double dots etc.) and on
Android this results in a crash.

url-regex uses a very well tested and almost 'famous' regex:
https://gist.github.com/dperini/729294

As seen here it tests all tests but the '_' one:
https://mathiasbynens.be/demo/url-regex

We do not allow underscores in our subdomains and it is
very uncommon character to be used, also not valid in domain names.