### PR TITLE
fix: Messages in muted topics should be visible

### DIFF
--- a/src/utils/__tests__/message-test.js
+++ b/src/utils/__tests__/message-test.js
@@ -6,7 +6,7 @@ import {
   isMessageRead,
   findFirstUnread,
 } from '../message';
-import { homeNarrow } from '../narrow';
+import { homeNarrow, topicNarrow } from '../narrow';
 
 describe('normalizeRecipients', () => {
   test('joins emails from recipients, sorted, trimmed, not including missing ones', () => {
@@ -108,6 +108,19 @@ describe('shouldBeMuted', () => {
     };
 
     const isMuted = shouldBeMuted(message, homeNarrow, []);
+
+    expect(isMuted).toBe(false);
+  });
+
+  test('messages when narrowed to a topic are never muted', () => {
+    const message = {
+      display_recipient: 'stream',
+      subject: 'some topic',
+    };
+    const narrow = topicNarrow('some topic');
+    const mutes = [['stream', 'some topic']];
+
+    const isMuted = shouldBeMuted(message, narrow, [], mutes);
 
     expect(isMuted).toBe(false);
   });

--- a/src/utils/message.js
+++ b/src/utils/message.js
@@ -1,6 +1,6 @@
 /* @flow */
 import type { FlagsState, Recipient, Narrow, Message, MuteState, Subscription } from '../types';
-import { homeNarrow } from './narrow';
+import { homeNarrow, isTopicNarrow } from './narrow';
 
 // TODO types: this union is confusing
 export const normalizeRecipients = (recipients: { email: string }[] | string) =>
@@ -65,6 +65,10 @@ export const shouldBeMuted = (
 ): boolean => {
   if (typeof message.display_recipient !== 'string') {
     return false; // private/group messages are not muted
+  }
+
+  if (isTopicNarrow(narrow)) {
+    return false; // never hide a message when narrowed to topic
   }
 
   if (narrow.length === 0) {


### PR DESCRIPTION
When narrowed to a muted topic we should always show the messages
and hide them when in stream & home narrows.

Fixes #2206