### PR TITLE
ui: Make the topic input look less 'disabled'

### DIFF
--- a/src/compose/ComposeBox.js
+++ b/src/compose/ComposeBox.js
@@ -37,9 +37,11 @@ const componentStyles = StyleSheet.create({
     justifyContent: 'center',
   },
   topicInput: {
-    borderColor: 'transparent',
     padding: 4,
-    backgroundColor: 'rgba(127, 127, 127, 0.25)',
+    borderColor: 'rgba(127, 127, 127, 0.5)',
+    borderWidth: 1,
+    borderRadius: 3,
+    marginTop: 2,
   },
   button: {
     margin: 6,


### PR DESCRIPTION
This follows user feedback that the topic input looked disabled
and after a discsussion we agreed that it must be made more 'editable'

![simulator screen shot - iphone 8 plus - 2018-04-16 at 17 02 47](https://user-images.githubusercontent.com/867242/38813658-396d03a6-4198-11e8-8e38-2093080f4c4e.png)