### PR TITLE
Add statusFromPresence function

### DIFF
--- a/src/users/userHelpers.js
+++ b/src/users/userHelpers.js
@@ -1,8 +1,9 @@
 /* @flow */
 import uniqby from 'lodash.uniqby';
+import differenceInMinutes from 'date-fns/difference_in_minutes';
 
+import type { Presence, User, UserStatus } from '../types';
 import { NULL_USER, NULL_PRESENCE_AGGREGATED } from '../nullObjects';
-import type { User } from '../types';
 
 const statusOrder = status => {
   switch (status) {
@@ -15,6 +16,27 @@ const statusOrder = status => {
     default:
       return 4;
   }
+};
+
+export const statusFromPresence = (presence: Presence): UserStatus => {
+  if (!presence || !presence.aggregated) {
+    return 'offline';
+  }
+
+  if (presence.aggregated.status === 'offline') {
+    return 'offline';
+  }
+
+  const timestampDate = new Date(presence.aggregated.timestamp * 1000);
+  const diffToNowInMinutes = differenceInMinutes(Date.now(), timestampDate);
+
+  if (diffToNowInMinutes > 60) {
+    return 'offline';
+  }
+  if (diffToNowInMinutes > 5) {
+    return 'idle';
+  }
+  return 'active';
 };
 
 export const getUserByEmail = (users: any[], userEmail: string) =>


### PR DESCRIPTION
We need more processing of presence data we get from the server
in order to get useful information.

We might want to do changes to the logic later, in  mobile
there does not seem to be a meaningful 'idle' state.

* status is offline if the aggregate presence is "offline"
* status is idle if presence timestamp is less than 1hr
* status is active if timestamp of last activity is less than 5mins