### PR TITLE
fix: sortUserList now correctly uses presence

### DIFF
--- a/src/users/UserList.js
+++ b/src/users/UserList.js
@@ -35,7 +35,7 @@ export default class UserList extends PureComponent<Props> {
 
   render() {
     const { filter, style, users, presences, onPress, selected } = this.props;
-    const shownUsers = sortUserList(filterUserList(users, filter));
+    const shownUsers = sortUserList(filterUserList(users, filter), presences);
 
     if (shownUsers.length === 0) {
       return <SearchEmptyState text="No users found" />;

--- a/src/users/__tests__/userHelpers-test.js
+++ b/src/users/__tests__/userHelpers-test.js
@@ -183,27 +183,38 @@ describe('getAutocompleteSuggestion', () => {
 describe('sortUserList', () => {
   test('sorts list by name', () => {
     const users = deepFreeze([{ fullName: 'abc' }, { fullName: 'xyz' }, { fullName: 'jkl' }]);
-
+    const presences = {};
     const shouldMatch = [{ fullName: 'abc' }, { fullName: 'jkl' }, { fullName: 'xyz' }];
-    const sortedUsers = sortUserList(users);
+
+    const sortedUsers = sortUserList(users, presences);
+
     expect(sortedUsers).toEqual(shouldMatch);
   });
 
   test('prioritizes status', () => {
     const users = deepFreeze([
-      { fullName: 'abc', status: 'offline' },
-      { fullName: 'xyz', status: 'idle' },
-      { fullName: 'jkl', status: 'active' },
-      { fullName: 'abc', status: 'active' },
+      { fullName: 'Mark', email: 'mark@example.com' },
+      { fullName: 'John', email: 'john@example.com' },
+      { fullName: 'Bob', email: 'bob@example.com' },
+      { fullName: 'Rick', email: 'rick@example.com' },
     ]);
-
+    const presences = {
+      'mark@example.com': { aggregated: { status: 'offline' } },
+      'john@example.com': {
+        aggregated: { status: 'active', timestamp: Date.now() / 1000 - 120 * 60 },
+      },
+      'bob@example.com': { aggregated: { status: 'idle', timestamp: Date.now() / 1000 - 20 * 60 } },
+      'rick@example.com': { aggregated: { status: 'active', timestamp: Date.now() / 1000 } },
+    };
     const shouldMatch = [
-      { fullName: 'abc', status: 'active' },
-      { fullName: 'jkl', status: 'active' },
-      { fullName: 'xyz', status: 'idle' },
-      { fullName: 'abc', status: 'offline' },
+      { fullName: 'Rick', email: 'rick@example.com' },
+      { fullName: 'Bob', email: 'bob@example.com' },
+      { fullName: 'John', email: 'john@example.com' },
+      { fullName: 'Mark', email: 'mark@example.com' },
     ];
-    const sortedUsers = sortUserList(users);
+
+    const sortedUsers = sortUserList(users, presences);
+
     expect(sortedUsers).toEqual(shouldMatch);
   });
 });

--- a/src/users/userHelpers.js
+++ b/src/users/userHelpers.js
@@ -2,21 +2,8 @@
 import uniqby from 'lodash.uniqby';
 import differenceInMinutes from 'date-fns/difference_in_minutes';
 
-import type { Presence, User, UserStatus } from '../types';
+import type { Presence, User, UserStatus, PresenceState } from '../types';
 import { NULL_USER } from '../nullObjects';
-
-const statusOrder = status => {
-  switch (status) {
-    case 'active':
-      return 1;
-    case 'idle':
-      return 2;
-    case 'offline':
-      return 3;
-    default:
-      return 4;
-  }
-};
 
 export const statusFromPresence = (presence?: Presence): UserStatus => {
   if (!presence || !presence.aggregated) {
@@ -65,10 +52,24 @@ export const groupUsersByStatus = (users: User[], presences: Object): Object =>
     { active: [], idle: [], offline: [] },
   );
 
-export const sortUserList = (users: any[]): User[] =>
+const statusOrder = (presence: Presence): number => {
+  const status = statusFromPresence(presence);
+  switch (status) {
+    case 'active':
+      return 1;
+    case 'idle':
+      return 2;
+    case 'offline':
+      return 3;
+    default:
+      return 4;
+  }
+};
+
+export const sortUserList = (users: any[], presences: PresenceState): User[] =>
   [...users].sort(
     (x1, x2) =>
-      statusOrder(x1.status) - statusOrder(x2.status) ||
+      statusOrder(presences[x1.email]) - statusOrder(presences[x2.email]) ||
       x1.fullName.toLowerCase().localeCompare(x2.fullName.toLowerCase()),
   );
 


### PR DESCRIPTION
Start using statusFromPresence to correctly determine user list
sort order (first active, then idle, then offline).
Secondary sort when status is the same is done by name