### PR TITLE
fix: Display user status in group screen title

### DIFF
--- a/src/title/TitleGroup.js
+++ b/src/title/TitleGroup.js
@@ -2,7 +2,7 @@
 import React, { PureComponent } from 'react';
 import { StyleSheet, View } from 'react-native';
 
-import type { User } from '../types';
+import type { PresenceState, User } from '../types';
 import { Avatar } from '../common';
 
 const styles = StyleSheet.create({
@@ -18,19 +18,26 @@ const styles = StyleSheet.create({
 
 type Props = {
   recipients: User[],
+  presence: PresenceState,
 };
 
 export default class TitleGroup extends PureComponent<Props> {
   props: Props;
 
   render() {
-    const { recipients } = this.props;
+    const { recipients, presence } = this.props;
 
     return (
       <View style={styles.wrapper}>
         {recipients.map((user, index) => (
           <View key={user.email} style={styles.avatar}>
-            <Avatar size={24} name={user.fullName} avatarUrl={user.avatarUrl} email={user.email} />
+            <Avatar
+              size={32}
+              name={user.fullName}
+              avatarUrl={user.avatarUrl}
+              email={user.email}
+              presence={presence[user.email]}
+            />
           </View>
         ))}
       </View>

--- a/src/title/TitleGroupContainer.js
+++ b/src/title/TitleGroupContainer.js
@@ -1,8 +1,9 @@
 /* @flow */
 import connectWithActions from '../connectWithActions';
-import { getRecipientsInGroupNarrow } from '../selectors';
+import { getRecipientsInGroupNarrow, getPresence } from '../selectors';
 import TitleGroup from './TitleGroup';
 
 export default connectWithActions((state, props) => ({
   recipients: getRecipientsInGroupNarrow(props.narrow)(state),
+  presence: getPresence(state),
 }))(TitleGroup);


### PR DESCRIPTION
Pass presence and use it to display status in group chat screens
Increate avatar icon size for better consistency and so the status
dot does not hide half of the image.