### PR TITLE
flow: Add types for Stream and Subscription

### DIFF
--- a/src/autocomplete/StreamAutocomplete.js
+++ b/src/autocomplete/StreamAutocomplete.js
@@ -31,7 +31,7 @@ class StreamAutocomplete extends PureComponent<Props> {
           keyboardShouldPersistTaps="always"
           initialNumToRender={streams.length}
           data={streams}
-          keyExtractor={item => item.stream_id}
+          keyExtractor={item => item.stream_id.toString()}
           renderItem={({ item }) => (
             <StreamItem
               name={item.name}

--- a/src/streams/StreamCard.js
+++ b/src/streams/StreamCard.js
@@ -40,7 +40,7 @@ export default class StreamCard extends PureComponent<Props> {
           <StreamIcon
             size={20}
             color={subscription.color || NULL_SUBSCRIPTION.color}
-            isMuted={subscription && !subscription.in_home_view}
+            isMuted={subscription ? !subscription.in_home_view : false}
             isPrivate={stream && stream.invite_only}
           />
           <RawLabel style={styles.streamText} text={name} numberOfLines={1} ellipsizeMode="tail" />

--- a/src/streams/SubscriptionsCard.js
+++ b/src/streams/SubscriptionsCard.js
@@ -2,7 +2,7 @@
 import React, { PureComponent } from 'react';
 import { View, StyleSheet } from 'react-native';
 
-import type { Actions, Narrow, SubscriptionsState } from '../types';
+import type { Actions, Narrow, Stream } from '../types';
 import StreamList from './StreamList';
 import { isStreamNarrow, streamNarrow } from '../utils/narrow';
 
@@ -16,7 +16,7 @@ const styles = StyleSheet.create({
 type Props = {
   actions: Actions,
   narrow: Narrow,
-  subscriptions: SubscriptionsState,
+  subscriptions: Stream[],
   unreadByStream: number[],
 };
 

--- a/src/types.js
+++ b/src/types.js
@@ -119,6 +119,20 @@ export type Stream = {
   color: string,
 };
 
+export type StreamsState = Stream[];
+
+export type Subscription = Stream & {
+  audible_notifications: boolean,
+  desktop_notifications: boolean,
+  email_address: string,
+  push_notifications: boolean,
+  is_old_stream: boolean,
+  push_notifications: boolean,
+  stream_weekly_traffic: number,
+};
+
+export type SubscriptionsState = Subscription[];
+
 export type ClientPresence = {
   [key: string]: Presence,
 };
@@ -245,7 +259,7 @@ export type LoadingState = {
 };
 
 export type MuteTuple = [string, string];
-export type MuteState = any; // MuteTuple[]
+export type MuteState = MuteTuple[];
 
 export type NavigationState = {
   index: number,
@@ -291,10 +305,6 @@ export type SettingsState = {
   experimentalFeaturesEnabled: boolean,
   streamNotification: boolean,
 };
-
-export type StreamsState = any; // [];
-
-export type SubscriptionsState = any; // [];
 
 export type TypingState = Object;
 
@@ -374,23 +384,6 @@ export type RealmEmojiType = {
 };
 
 export type LocalizableText = any; // string | { text: string, values: Object };
-
-export type Subscription = {
-  audible_notifications: boolean,
-  color: string,
-  description: string,
-  desktop_notifications: boolean,
-  email_address: string,
-  in_home_view: boolean,
-  invite_only: boolean,
-  name: string,
-  pin_to_top: boolean,
-  push_notifications: boolean,
-  stream_id: number,
-  is_old_stream: boolean,
-  push_notifications: boolean,
-  stream_weekly_traffic: number,
-};
 
 export type RenderedTimeDescriptor = {
   type: 'time',

--- a/src/utils/message.js
+++ b/src/utils/message.js
@@ -54,7 +54,7 @@ export const isSameRecipient = (message1: Message, message2: Message): boolean =
   }
 };
 
-export const isTopicMuted = (stream: string, topic: string, mute: string[] = []): boolean =>
+export const isTopicMuted = (stream: string, topic: string, mute: MuteState = []): boolean =>
   mute.some(x => x[0] === stream && x[1] === topic);
 
 export const shouldBeMuted = (


### PR DESCRIPTION
Subscription becomes a super-type of Stream

This will clarify many cases as we almost always use only the
'stream' part of the data even when using subscriptions