### PR TITLE
screen: Fix scroll is not working.

### DIFF
--- a/src/account/AccountPickScreen.js
+++ b/src/account/AccountPickScreen.js
@@ -39,7 +39,7 @@ class AccountPickScreen extends PureComponent<Props> {
     const { accounts, actions, auth } = this.props;
 
     return (
-      <Screen title="Pick account" padding>
+      <Screen title="Pick account" centerContent padding>
         <Centerer>
           {accounts.length === 0 && <Logo />}
           <AccountList

--- a/src/common/Screen.js
+++ b/src/common/Screen.js
@@ -2,7 +2,7 @@
 import React, { PureComponent } from 'react';
 import { StyleSheet, View, ScrollView } from 'react-native';
 
-import type { ChildrenArray, Dimensions, LocalizableText } from '../types';
+import type { ChildrenArray, Dimensions, LocalizableText, StyleObj } from '../types';
 import connectWithActions from '../connectWithActions';
 import { KeyboardAvoider, ZulipStatusBar } from '../common';
 import { getSession } from '../selectors';
@@ -33,6 +33,7 @@ type Props = {
   padding?: boolean,
   search?: boolean,
   title?: LocalizableText,
+  style?: StyleObj,
   searchBarOnChange?: (text: string) => void,
 };
 
@@ -59,6 +60,7 @@ class Screen extends PureComponent<Props> {
       safeAreaInsets,
       search,
       searchBarOnChange,
+      style,
       title,
     } = this.props;
     const { styles } = this.context;
@@ -79,7 +81,7 @@ class Screen extends PureComponent<Props> {
         >
           <ScrollView
             style={componentStyles.childrenWrapper}
-            contentContainerStyle={[centerContent && componentStyles.content]}
+            contentContainerStyle={[centerContent && componentStyles.content, style]}
             keyboardShouldPersistTaps={keyboardShouldPersistTaps}
           >
             {children}

--- a/src/common/Screen.js
+++ b/src/common/Screen.js
@@ -75,7 +75,6 @@ class Screen extends PureComponent<Props> {
         )}
         <KeyboardAvoider
           behavior="padding"
-          keyboardShouldPersistTaps="handled"
           style={[componentStyles.wrapper, padding && styles.padding]}
           contentContainerStyle={[padding && styles.padding]}
         >

--- a/src/common/Screen.js
+++ b/src/common/Screen.js
@@ -78,10 +78,8 @@ class Screen extends PureComponent<Props> {
           contentContainerStyle={[padding && styles.padding]}
         >
           <ScrollView
-            contentContainerStyle={[
-              componentStyles.childrenWrapper,
-              centerContent && componentStyles.content,
-            ]}
+            style={componentStyles.childrenWrapper}
+            contentContainerStyle={[centerContent && componentStyles.content]}
             keyboardShouldPersistTaps={keyboardShouldPersistTaps}
           >
             {children}

--- a/src/search/SearchMessagesScreen.js
+++ b/src/search/SearchMessagesScreen.js
@@ -17,13 +17,18 @@ export default class SearchMessagesScreen extends PureComponent<Props, State> {
     query: '',
   };
 
+  static contextTypes = {
+    styles: () => null,
+  };
+
   handleQueryChange = (query: string) => this.setState({ query });
 
   render() {
+    const { styles } = this.context;
     const { query } = this.state;
 
     return (
-      <Screen search autoFocus searchBarOnChange={this.handleQueryChange}>
+      <Screen search autoFocus searchBarOnChange={this.handleQueryChange} style={styles.flexed}>
         <SearchMessagesContainer query={query} />
       </Screen>
     );

--- a/src/start/AuthScreen.js
+++ b/src/start/AuthScreen.js
@@ -140,7 +140,7 @@ class AuthScreen extends PureComponent<Props> {
     const { serverSettings } = this.props.navigation.state.params;
 
     return (
-      <Screen title="Log in" padding>
+      <Screen title="Log in" centerContent padding>
         <Centerer>
           <RealmInfo
             name={serverSettings.realm_name}


### PR DESCRIPTION

* screen: Fix scroll is not working. 9dd39e8
Apply flexed style to scrollView instead
of its content wrapper.
If it is applied on its content wrapper then there
is no scope of scrolling.


* search message screen: Fix messageList is not visible. 2f58180
Actually the issue is webView is not visible if it's direct
or indirect parent is scrollView. It can be easily tested
by surrounding message list with scrollView in chat.js.
We can make it visible by applying flex:1 style to scrollView
contentContainerStyle, but then it will broke scroll.
So in this commit this style is only applied for search message
screen.
