### PR TITLE
Fix: stream icon color in AllStreamList in dark theme. 

### DIFF
--- a/src/streams/StreamItem.js
+++ b/src/streams/StreamItem.js
@@ -89,7 +89,9 @@ export default class StreamItem extends PureComponent<Props> {
       ? 'white'
       : color ||
         foregroundColorFromBackground(
-          backgroundColor || (StyleSheet.flatten(styles.backgroundColor) || {}).backgroundColor,
+          backgroundColor ||
+            (StyleSheet.flatten(styles.backgroundColor) || {}).backgroundColor ||
+            null,
         );
     const textColorStyle = isSelected
       ? { color: 'white' }

--- a/src/streams/StreamItem.js
+++ b/src/streams/StreamItem.js
@@ -87,9 +87,10 @@ export default class StreamItem extends PureComponent<Props> {
     ];
     const iconColor = isSelected
       ? 'white'
-      : backgroundColor
-        ? foregroundColorFromBackground(backgroundColor)
-        : color;
+      : color ||
+        foregroundColorFromBackground(
+          backgroundColor || (StyleSheet.flatten(styles.backgroundColor) || {}).backgroundColor,
+        );
     const textColorStyle = isSelected
       ? { color: 'white' }
       : backgroundColor

--- a/src/utils/color.js
+++ b/src/utils/color.js
@@ -1,10 +1,11 @@
 /* @flow */
 import Color from 'color';
+import type { ColorValue } from 'react-native/Libraries/StyleSheet/StyleSheetTypes';
 
-export const foregroundColorFromBackground = (color: string) =>
+export const foregroundColorFromBackground = (color: ColorValue): string =>
   Color(color).luminosity() > 0.4 ? 'black' : 'white';
 
-export const colorHashFromName = (name: string) => {
+export const colorHashFromName = (name: string): string => {
   let hash = 0;
   for (let i = 0; i < name.length; i++) hash = hash * 31 + name.charCodeAt(1);
   let colorHash = hash % 0xffffff;


### PR DESCRIPTION
This PR is just rework of #2036, with smaller, separate commits :)
#2036 is quite old and at that time we weren't following this commit style. So I thought of created new PR instead of pushing into that.

* refactor: Rename local styles variable to componentStyles.   a75ba2a
So that styles from context can be de-structured and can be used
easily. Like the same way we do in other components.

* streamItem: Improve logic to determine icon color. 0969136
If color is not undefined then use it else decide it from
background. As if someone is explicitly specifying color
then it is expecting it to be used, rather than computing.
Fix: stream icon color is black in all stream screen in dark theme.


* flow: Add null & undefined params type to foregroundColorFromBackground. 382419d
Return 'white' for null and undefined color.

* refactor: Remove color from unreadView streamItem.  48f096a
As we are already sending stream color via backgroundColor
prop. And we want text, icon color to be decided from the
background color.
This removes the confusion in stream item that text and
icon color should be taken either from color or backgroundColor.