### PR TITLE
NotificationDiagScreen: Removed padding from screen

### DIFF
--- a/src/diagnostics/NotificationDiagScreen.js
+++ b/src/diagnostics/NotificationDiagScreen.js
@@ -21,7 +21,7 @@ class NotificationDiagScreen extends PureComponent<Props> {
       'Initial notification': JSON.stringify(config.startup.notification),
     };
     return (
-      <Screen title="Notification Diagnostics" padding>
+      <Screen title="Notification Diagnostics">
         <FlatList
           data={Object.keys(variables)}
           keyExtractor={item => item}


### PR DESCRIPTION
The `Screen` component in `NotificationDiagScreen` was using the `padding` prop which was not allowing the dividers to reach the full width of the screen as well as making the spacing of the items look uneven. This has been removed.

Before:
![diag_before](https://user-images.githubusercontent.com/22353313/38922458-d6136bae-4315-11e8-8364-34cbe78d564f.png)

After:
![diag_after](https://user-images.githubusercontent.com/22353313/38922512-f3c41d1a-4315-11e8-850d-05af03cff6f3.png)
