### PR TITLE
error handling: Throw the whole response on fetch error

### DIFF
--- a/src/api/apiFetch.js
+++ b/src/api/apiFetch.js
@@ -42,13 +42,9 @@ export const apiCall = async (
 
     const json = await response.json();
 
-    if (json.result !== 'success') {
-      console.log('Bad response for:', auth, route, params); // eslint-disable-line
-      throw Error(json.msg);
-    }
-
-    if (!response.ok) {
-      throw Error(response.statusText);
+    if (!response.ok || json.result !== 'success') {
+      console.log('Bad response for:', { auth, route, params, response }); // eslint-disable-line
+      throw Error(response);
     }
 
     return resFunc(json);


### PR DESCRIPTION
* handle both response error and error in json the same way
* do throw the whole response so the catcher has access to all fields
* verified, no changed to any other code needed, as currently none
of the try-catch-ers of fetch calls care about the error object