### PR TITLE
Handle errors returned by event queue 18n-independently

### DIFF
--- a/src/events/eventActions.js
+++ b/src/events/eventActions.js
@@ -59,7 +59,7 @@ export const startEventPolling = (queueId: number, eventId: number) => async (
       lastEventId = Math.max.apply(null, [lastEventId, ...response.events.map(x => x.id)]);
     } catch (e) {
       // The event queue is too old or has been garbage collected
-      if (e.message.indexOf('too old') !== -1 || e.message.indexOf('Bad event queue id') !== -1) {
+      if (e.status === 400 && (await e.json()).code === 'BAD_EVENT_QUEUE_ID') {
         dispatch(appRefresh());
         break;
       }


### PR DESCRIPTION
Instead of parsing the status text which was never a great idea
and does break when api response is translated.

The logic now is exactly the same as in the front-end app.