### PR TITLE
Throw custom error object from within fetch function

### DIFF
--- a/src/api/apiFetch.js
+++ b/src/api/apiFetch.js
@@ -44,7 +44,13 @@ export const apiCall = async (
 
     if (!response.ok || json.result !== 'success') {
       console.log('Bad response for:', { auth, route, params, response }); // eslint-disable-line
-      throw Error(response);
+      throw Error(
+        JSON.stringify({
+          status: response.status,
+          statusText: response.statusText,
+          code: json.code,
+        }),
+      );
     }
 
     return resFunc(json);

--- a/src/events/eventActions.js
+++ b/src/events/eventActions.js
@@ -61,8 +61,9 @@ export const startEventPolling = (queueId: number, eventId: number) => async (
     } catch (e) {
       // protection from inadvertent DDOS
       await sleep(5000);
+      const error = JSON.parse(e.message);
       // The event queue is too old or has been garbage collected
-      if (e.status === 400 && (await e.json()).code === 'BAD_EVENT_QUEUE_ID') {
+      if (error.status === 400 && error.code === 'BAD_EVENT_QUEUE_ID') {
         dispatch(appRefresh());
         break;
       }


### PR DESCRIPTION
Throwing an object is not a good idea with standard Error class
and creating a custom Error class (which I tried) might be a
compatibility problem. So we just stringify a custom error object
which we then parse when needed.