### PR TITLE
ui: Hide streams whose only unread topics are muted

### DIFF
--- a/src/unread/UnreadCards.js
+++ b/src/unread/UnreadCards.js
@@ -58,8 +58,9 @@ export default class UnreadCards extends PureComponent<Props> {
         stickySectionHeadersEnabled
         initialNumToRender={20}
         sections={unreadCards}
+        keyExtractor={item => item.key}
         renderSectionHeader={({ section }) =>
-          section.key === 'private' || section.isMuted ? null : (
+          section.key === 'private' || section.isMuted || section.unread === 0 ? null : (
             <StreamItem
               style={styles.groupHeader}
               name={section.streamName}


### PR DESCRIPTION
In the 'Unread' tab, if a stream has muted topics but all other
topics are read, hide them.

Add a keyExtractor property for performance purposes.