### PR TITLE
presence: Make status detection consistent with web

### DIFF
--- a/src/users/__tests__/userHelpers-test.js
+++ b/src/users/__tests__/userHelpers-test.js
@@ -43,11 +43,11 @@ describe('statusFromPresence', () => {
     expect(result).toBe('offline');
   });
 
-  test('if status is not "offline" and last activity was between 5min and 1hr result is "idle"', () => {
+  test('if status is  "idle" and last activity is less than 140 seconds then result remain "idle"', () => {
     const presence = {
       aggregated: {
-        status: 'active',
-        timestamp: Math.trunc(Date.now() / 1000 - 20 * 60), // 20 minutes
+        status: 'idle',
+        timestamp: Math.trunc(Date.now() / 1000 - 60), // 1 minute
       },
     };
     const result = statusFromPresence(presence);
@@ -332,7 +332,7 @@ describe('groupUsersByStatus', () => {
     ]);
     const presence = {
       'allen@example.com': { aggregated: { status: 'active' } },
-      'bob@example.com': { aggregated: { status: 'idle', timestamp: Date.now() / 1000 - 10 * 60 } },
+      'bob@example.com': { aggregated: { status: 'idle', timestamp: Date.now() / 1000 - 10 } },
       'carter@example.com': { aggregated: { status: 'offline' } },
     };
     const expectedResult = {

--- a/src/users/userHelpers.js
+++ b/src/users/userHelpers.js
@@ -1,9 +1,11 @@
 /* @flow */
 import uniqby from 'lodash.uniqby';
-import differenceInMinutes from 'date-fns/difference_in_minutes';
+import differenceInSeconds from 'date-fns/difference_in_seconds';
 
 import type { Presence, User, UserStatus, PresenceState } from '../types';
 import { NULL_USER } from '../nullObjects';
+
+const OFFLINE_THRESHOLD_SECS = 140;
 
 export const statusFromPresence = (presence?: Presence): UserStatus => {
   if (!presence || !presence.aggregated) {
@@ -15,15 +17,13 @@ export const statusFromPresence = (presence?: Presence): UserStatus => {
   }
 
   const timestampDate = new Date(presence.aggregated.timestamp * 1000);
-  const diffToNowInMinutes = differenceInMinutes(Date.now(), timestampDate);
+  const diffToNowInSeconds = differenceInSeconds(Date.now(), timestampDate);
 
-  if (diffToNowInMinutes > 60) {
+  if (diffToNowInSeconds > OFFLINE_THRESHOLD_SECS) {
     return 'offline';
   }
-  if (diffToNowInMinutes > 5) {
-    return 'idle';
-  }
-  return 'active';
+
+  return presence.aggregated.status;
 };
 
 export const getUserByEmail = (users: User[], userEmail: string): User =>


### PR DESCRIPTION
Rework the 'too smart' approach to be consistent with the web app
which is mor important. Use OFFLINE_THRESHOLD_SECS = 140 if above
this threshold for the last activity the status is 'offline',
else it equals what was reported by the server.