### PR TITLE
refactor: Do not store new messages in narrows not open

### DIFF
--- a/src/chat/__tests__/chatReducers-test.js
+++ b/src/chat/__tests__/chatReducers-test.js
@@ -45,9 +45,6 @@ describe('chatReducers', () => {
 
       const expectedState = deepFreeze({
         [homeNarrowStr]: [{ id: 1 }, { id: 2 }],
-        [JSON.stringify(topicNarrow('some stream', 'some topic'))]: [
-          { id: 3, display_recipient: 'some stream', subject: 'some topic' },
-        ],
       });
 
       expect(newState).toEqual(expectedState);
@@ -79,7 +76,7 @@ describe('chatReducers', () => {
       expect(newState).not.toBe(initialState);
     });
 
-    test('if new message key is now present and is of type stream, then create key of topicNarrow type', () => {
+    test('if new message key does not exist do not create it', () => {
       const initialState = deepFreeze({
         [JSON.stringify(topicNarrow('some stream', 'some topic'))]: [{ id: 1 }, { id: 2 }],
       });
@@ -94,39 +91,6 @@ describe('chatReducers', () => {
 
       const expectedState = {
         [JSON.stringify(topicNarrow('some stream', 'some topic'))]: [{ id: 1 }, { id: 2 }],
-        [JSON.stringify(topicNarrow('stream', 'topic'))]: [
-          { id: 3, type: 'stream', display_recipient: 'stream', subject: 'topic' },
-        ],
-      };
-      expect(newState).toEqual(expectedState);
-    });
-
-    test('if new message key is not present and is of type private, then create key of groupNarrow type', () => {
-      const initialState = deepFreeze({
-        [JSON.stringify(topicNarrow('all', 'GCI'))]: [{ id: 1 }, { id: 2 }],
-      });
-
-      const action = deepFreeze({
-        type: EVENT_NEW_MESSAGE,
-        message: {
-          id: 3,
-          type: 'private',
-          display_recipient: [{ email: 'a@a.com' }, { email: 'b@b.com' }],
-        },
-        caughtUp: {},
-      });
-
-      const newState = chatReducers(initialState, action);
-
-      const expectedState = {
-        [JSON.stringify(topicNarrow('all', 'GCI'))]: [{ id: 1 }, { id: 2 }],
-        [JSON.stringify(groupNarrow(['a@a.com', 'b@b.com']))]: [
-          {
-            id: 3,
-            type: 'private',
-            display_recipient: [{ email: 'a@a.com' }, { email: 'b@b.com' }],
-          },
-        ],
       };
       expect(newState).toEqual(expectedState);
     });
@@ -156,40 +120,6 @@ describe('chatReducers', () => {
     const actualState = chatReducers(initialState, action);
 
     expect(actualState).toEqual(expectedState);
-  });
-
-  test('appends same id message to state', () => {
-    const initialState = deepFreeze({
-      [homeNarrowStr]: [
-        { id: 1 },
-        { id: 2, display_recipient: 'some stream', subject: 'some topic' },
-      ],
-    });
-
-    const action = deepFreeze({
-      type: EVENT_NEW_MESSAGE,
-      message: { id: 2, display_recipient: 'some stream', subject: 'some topic' },
-      caughtUp: {
-        [homeNarrowStr]: {
-          older: false,
-          newer: true,
-        },
-      },
-    });
-
-    const newState = chatReducers(initialState, action);
-
-    const expectedState = deepFreeze({
-      [homeNarrowStr]: [
-        { id: 1 },
-        { id: 2, display_recipient: 'some stream', subject: 'some topic' },
-      ],
-      [JSON.stringify(topicNarrow('some stream', 'some topic'))]: [
-        { id: 2, display_recipient: 'some stream', subject: 'some topic' },
-      ],
-    });
-
-    expect(newState).toEqual(expectedState);
   });
 
   test('message sent to topic is stored correctly', () => {

--- a/src/chat/chatReducers.js
+++ b/src/chat/chatReducers.js
@@ -78,7 +78,7 @@ const eventReactionRemove = (
 
 const eventNewMessage = (state: MessageState, action: EventNewMessageAction): MessageState => {
   let stateChange = false;
-  let newState = Object.keys(state).reduce((msg, key) => {
+  const newState = Object.keys(state).reduce((msg, key) => {
     const isInNarrow = isMessageInNarrow(action.message, JSON.parse(key), action.ownEmail);
     const isCaughtUp = action.caughtUp[key] && action.caughtUp[key].newer;
     const messageDoesNotExist =
@@ -93,16 +93,6 @@ const eventNewMessage = (state: MessageState, action: EventNewMessageAction): Me
 
     return msg;
   }, {});
-
-  const key = JSON.stringify(getNarrowFromMessage(action.message, action.ownEmail));
-  if (!stateChange && state[key] === undefined) {
-    // new message is in new narrow in which we don't have any message
-    stateChange = true;
-    newState = {
-      ...state,
-      [key]: [action.message],
-    };
-  }
 
   return stateChange ? newState : state;
 };


### PR DESCRIPTION
For every narrow we have data for that is caughtUp at 'newer'
we store new incoming messages from the event polling.

Previously we determined if a message should be put inside a
narrow even if no messages were loaded for it. This is not needed
and even does not serve as a good cache because on narrowing
we throw it away and reload new messages.

This also simplifies the code and makes it more predictive.