### PR TITLE
cleanup: Remove platform-specific UI constants

### DIFF
--- a/src/chat/chatReducers.js
+++ b/src/chat/chatReducers.js
@@ -23,7 +23,7 @@ import {
   EVENT_REACTION_REMOVE,
   EVENT_UPDATE_MESSAGE,
 } from '../actionConstants';
-import { isMessageInNarrow, getNarrowFromMessage } from '../utils/narrow';
+import { isMessageInNarrow } from '../utils/narrow';
 import { groupItemsById } from '../utils/misc';
 import chatUpdater from './chatUpdater';
 import { NULL_ARRAY, NULL_OBJECT } from '../nullObjects';

--- a/src/render-html/css.js
+++ b/src/render-html/css.js
@@ -2,7 +2,7 @@
 /* eslint-disable */
 import type { ThemeType } from '../types';
 import { codeToEmojiMap } from '../emoji/emojiMap';
-import { BORDER_COLOR, BRAND_COLOR, REACTION_HEIGHT, REACTION_SPINNER_OFFSET } from '../styles';
+import { BORDER_COLOR, BRAND_COLOR } from '../styles';
 import cssEmojis from './cssEmojis';
 
 const defaultTheme = `

--- a/src/styles/index.js
+++ b/src/styles/index.js
@@ -1,6 +1,6 @@
 /* @flow */
-
-export { CONTROL_SIZE, NAVBAR_SIZE, REACTION_HEIGHT, REACTION_SPINNER_OFFSET } from './platform';
+export const CONTROL_SIZE = 44;
+export const NAVBAR_SIZE = 52;
 
 export const BRAND_COLOR = 'rgba(82, 194, 175, 1)';
 export const BORDER_COLOR = BRAND_COLOR;

--- a/src/styles/platform.android.js
+++ b/src/styles/platform.android.js
@@ -1,5 +1,0 @@
-/* @flow */
-export const CONTROL_SIZE = 44;
-export const NAVBAR_SIZE = 52;
-export const REACTION_HEIGHT = 30;
-export const REACTION_SPINNER_OFFSET = REACTION_HEIGHT - 2;

--- a/src/styles/platform.ios.js
+++ b/src/styles/platform.ios.js
@@ -1,5 +1,0 @@
-/* @flow */
-export const CONTROL_SIZE = 44;
-export const NAVBAR_SIZE = 52;
-export const REACTION_HEIGHT = 30;
-export const REACTION_SPINNER_OFFSET = REACTION_HEIGHT;


### PR DESCRIPTION
We no longer use 2 of the constants and the other two are not
different between the platforms. Moved to a single place for simplicity.