### PR TITLE
refactor: Remove color from unreadView streamItem.

### DIFF
--- a/src/streams/StreamIcon.js
+++ b/src/streams/StreamIcon.js
@@ -5,7 +5,7 @@ import { IconMute, IconStream, IconPrivate } from '../common/Icons';
 import type { StyleObj } from '../types';
 
 type Props = {
-  color: string,
+  color?: string,
   isPrivate?: boolean,
   isMuted?: boolean,
   size: number,

--- a/src/streams/StreamItem.js
+++ b/src/streams/StreamItem.js
@@ -39,7 +39,7 @@ type Props = {
   isPrivate?: boolean,
   isSelected?: boolean,
   showSwitch?: boolean,
-  color: string,
+  color?: string,
   backgroundColor?: string,
   isSwitchedOn?: boolean,
   unreadCount?: number,

--- a/src/unread/UnreadCards.js
+++ b/src/unread/UnreadCards.js
@@ -67,7 +67,6 @@ export default class UnreadCards extends PureComponent<Props> {
               iconSize={16}
               isMuted={section.isMuted}
               isPrivate={section.isPrivate}
-              color={section.color}
               backgroundColor={section.color}
               unreadCount={section.unread}
               onPress={this.handleStreamPress}


### PR DESCRIPTION
As we are already sending stream color via backgroundColor
prop. And we want text, icon color to be decided from the
background color.

This removes the confusion in stream item that text and
icon color should be taken either from color or backgroundColor.