### PR TITLE
Enable client_gravatar for registerEvents

### DIFF
--- a/src/api/registerForEvents.js
+++ b/src/api/registerForEvents.js
@@ -9,4 +9,5 @@ export default (auth: Auth) =>
     event_types: JSON.stringify(config.trackServerEvents),
     fetch_event_types: JSON.stringify(config.serverDataOnStartup),
     include_subscribers: false,
+    client_gravatar: true,
   });


### PR DESCRIPTION
We already support calculating of user gravatars form their emails.
But we had the call to omit this extra data only for explicitly
getting users by `GET /users`. We now read them through the
`registerEvents` call so enable this setting there too.