### PR TITLE
drafts: Fix draftRemove action is always fired when chat screen pops.

### DIFF
--- a/src/compose/ComposeBox.js
+++ b/src/compose/ComposeBox.js
@@ -188,12 +188,13 @@ export default class ComposeBox extends PureComponent<Props, State> {
     const { actions, draft, narrow } = this.props;
     const { message } = this.state;
 
-    if (message.trim().length === 0) {
-      actions.draftRemove(narrow);
+    if (draft.trim() === message.trim()) {
       return;
     }
 
-    if (draft !== message) {
+    if (message.trim().length === 0) {
+      actions.draftRemove(narrow);
+    } else {
       actions.draftAdd(narrow, message);
     }
   };


### PR DESCRIPTION
Only fire event if draft was originally present and new message
effective (message.trim()) length is 0.