### PR TITLE
refactor: Dump logic to message action sheet.

### DIFF
--- a/src/message/MessageListContainer.js
+++ b/src/message/MessageListContainer.js
@@ -15,11 +15,7 @@ import type {
   User,
 } from '../types';
 import connectWithActions from '../connectWithActions';
-import {
-  constructActionButtons,
-  constructHeaderActionButtons,
-  executeActionSheetAction,
-} from './messageActionSheet';
+import { constructActionButtons, executeActionSheetAction } from './messageActionSheet';
 import MessageListWeb from '../webview/MessageListWeb';
 import {
   getAuth,
@@ -74,14 +70,11 @@ class MessageListContainer extends PureComponent<Props> {
     if (!message) return;
 
     const getString = value => this.context.intl.formatMessage({ id: value });
-    const options =
-      target === 'message'
-        ? constructActionButtons({
-            ...this.props,
-            message,
-            getString,
-          })
-        : constructHeaderActionButtons({ ...this.props, message, getString });
+    const options = constructActionButtons(target)({
+      ...this.props,
+      message,
+      getString,
+    });
 
     const callback = buttonIndex => {
       executeActionSheetAction({

--- a/src/message/__tests__/messageActionSheet-test.js
+++ b/src/message/__tests__/messageActionSheet-test.js
@@ -28,7 +28,7 @@ describe('constructActionButtons', () => {
       id: 3,
     });
 
-    const buttons = constructActionButtons({
+    const buttons = constructActionButtons('message')({
       message,
       auth,
       narrow,
@@ -46,7 +46,7 @@ describe('constructActionButtons', () => {
       id: 1,
     });
 
-    const buttons = constructActionButtons({
+    const buttons = constructActionButtons('message')({
       message,
       auth,
       narrow,

--- a/src/message/messageActionSheet.js
+++ b/src/message/messageActionSheet.js
@@ -197,7 +197,7 @@ const actionSheetButtons: ActionSheetButtonType[] = [
     onlyIf: ({ message, auth, narrow }) =>
       resolveMultiple(message, auth, narrow, [isSentMessage, isSentBySelf, isNotDeleted]),
   },
-  // If skip then covered in constructActionButtons
+  // If skip then covered in constructMessageActionButtons
   { title: 'Star message', onPress: starMessage, onlyIf: skip },
   { title: 'Unstar message', onPress: unstarMessage, onlyIf: skip },
   { title: 'Cancel', onPress: skip, onlyIf: skip },
@@ -238,7 +238,7 @@ export const constructHeaderActionButtons = ({
   return buttons;
 };
 
-export const constructActionButtons = ({
+export const constructMessageActionButtons = ({
   message,
   auth,
   narrow,
@@ -279,6 +279,9 @@ export const executeActionSheetAction = ({
     }
   }
 };
+
+export const constructActionButtons = (target: string) =>
+  target === 'header' ? constructHeaderActionButtons : constructMessageActionButtons;
 
 export type ShowActionSheetTypes = {
   options: Array<any>,


### PR DESCRIPTION
There are two set of options, one for message and another one for header.
Moved this logic to show respective options on message & header longPress
to messageActionSheet. Thus making render layer only responsible for
calling methods and rendering.