### PR TITLE
messageListContainer: Return null if no messages are there in narrow.

### DIFF
--- a/src/message/MessageListContainer.js
+++ b/src/message/MessageListContainer.js
@@ -116,6 +116,10 @@ class MessageListContainer extends PureComponent<Props> {
   };
 
   render() {
+    const { messages } = this.props;
+
+    if (messages.length === 0) return null;
+
     return (
       <MessageListWeb
         {...this.props}


### PR DESCRIPTION
If there are no messages, then do not render messsage list
component. This might increase performance. On the other
hand it don't have any disadvantage.

Also fix "No message" text is not in the center of the screen