### PR TITLE
keyboard: Do not 'swallow' first taps in users screen.

### DIFF
--- a/src/users/UsersScreen.js
+++ b/src/users/UsersScreen.js
@@ -23,7 +23,7 @@ export default class UsersScreen extends PureComponent<Props, State> {
     const { filter } = this.state;
 
     return (
-      <Screen search searchBarOnChange={this.handleFilterChange}>
+      <Screen search searchBarOnChange={this.handleFilterChange} keyboardShouldPersistTaps="always">
         <UsersContainer filter={filter} />
       </Screen>
     );


### PR DESCRIPTION
We open Users screen with a keyboard open. That is OK.
But then tapping on a user as a first action hides the keyboard
but does not narrow to the user.

Instead, tapping the user now narrow to that user, and tapping outside the
user list will hide the keyboard.