### PR TITLE
keyboard: Do not 'swallow' first taps in avatar list.

### DIFF
--- a/src/group/AvatarList.js
+++ b/src/group/AvatarList.js
@@ -25,6 +25,7 @@ export default class AvatarList extends PureComponent<Props> {
       <FlatList
         style={styles.list}
         horizontal
+        keyboardShouldPersistTaps="always"
         showsHorizontalScrollIndicator={false}
         initialNumToRender={20}
         data={users}


### PR DESCRIPTION
We open Create group screen with a keyboard open. That is OK.
But then tapping on a avatar (in horizontal list at top) as a
first action hides the keyboard but does not deselect the user.

Instead, tapping the avatar now deselect that user, and tapping outside the
avatar list will hide the keyboard.