### PR TITLE
Fix isFetching selector logic

### DIFF
--- a/src/chat/__tests__/fetchingSelectors-test.js
+++ b/src/chat/__tests__/fetchingSelectors-test.js
@@ -32,7 +32,6 @@ describe('getFetchingForActiveNarrow', () => {
 describe('getIsFetching', () => {
   test('when no initial fetching required and fetching is empty returns false', () => {
     const state = deepFreeze({
-      session: {},
       fetching: {},
     });
 
@@ -41,22 +40,8 @@ describe('getIsFetching', () => {
     expect(result).toEqual(false);
   });
 
-  test('when initial fetching required regardless of fetching state returns true', () => {
-    const state = deepFreeze({
-      session: {
-        needsInitialFetch: true,
-      },
-      fetching: {},
-    });
-
-    const result = getIsFetching(homeNarrow)(state);
-
-    expect(result).toEqual(true);
-  });
-
   test('if fetching older for current narrow returns true', () => {
     const state = deepFreeze({
-      session: {},
       fetching: {
         [homeNarrowStr]: { older: true, newer: false },
       },
@@ -69,7 +54,6 @@ describe('getIsFetching', () => {
 
   test('if fetching newer for current narrow returns true', () => {
     const state = deepFreeze({
-      session: {},
       fetching: {
         [homeNarrowStr]: { older: false, newer: true },
       },

--- a/src/chat/fetchingSelectors.js
+++ b/src/chat/fetchingSelectors.js
@@ -1,8 +1,8 @@
 /* @flow */
 import { createSelector } from 'reselect';
 
-import type { Narrow } from '../types';
-import { getSession, getFetching } from '../directSelectors';
+import type { Fetching, Narrow } from '../types';
+import { getFetching } from '../directSelectors';
 import { NULL_FETCHING } from '../nullObjects';
 
 export const getFetchingForActiveNarrow = (narrow: Narrow) =>
@@ -10,7 +10,6 @@ export const getFetchingForActiveNarrow = (narrow: Narrow) =>
 
 export const getIsFetching = (narrow: Narrow) =>
   createSelector(
-    getSession,
     getFetchingForActiveNarrow(narrow),
-    (session, fetching) => session.needsInitialFetch || fetching.older || fetching.newer,
+    (fetching: Fetching): boolean => fetching.older || fetching.newer,
   );


### PR DESCRIPTION
'needsInitialFetch' is a flag used to determine if we should fetch
data (via fetchEssentialInitialData and fetchRestOfInitialData)

The logic of 'isFetching' might have been correct in the past but now we
are using it differently. Remove the 'needsInitialFetch' flag from the
selector and keep only the fetching older & newer for current narrow.