### PR TITLE
Change default value of keyboardShouldPersistTaps for Screen

### DIFF
--- a/src/account/AccountList.js
+++ b/src/account/AccountList.js
@@ -21,7 +21,6 @@ export default class AccountList extends PureComponent<Props> {
     return (
       <View>
         <FlatList
-          keyboardShouldPersistTaps="always"
           data={accounts}
           keyExtractor={item => `${item.email}${item.realm}`}
           renderItem={({ item, index }) => (

--- a/src/common/Screen.js
+++ b/src/common/Screen.js
@@ -47,7 +47,7 @@ class Screen extends PureComponent<Props> {
 
   static defaultProps = {
     centerContent: false,
-    keyboardShouldPersistTaps: 'never',
+    keyboardShouldPersistTaps: 'handled',
   };
 
   render() {
@@ -70,7 +70,7 @@ class Screen extends PureComponent<Props> {
         <ModalBar title={title} searchBarOnChange={searchBarOnChange} />
         <KeyboardAvoider
           behavior="padding"
-          keyboardShouldPersistTaps="always"
+          keyboardShouldPersistTaps="handled"
           style={[componentStyles.wrapper, padding && componentStyles.padding]}
           contentContainerStyle={[padding && componentStyles.padding]}
         >

--- a/src/group/AvatarList.js
+++ b/src/group/AvatarList.js
@@ -25,7 +25,6 @@ export default class AvatarList extends PureComponent<Props> {
       <FlatList
         style={styles.list}
         horizontal
-        keyboardShouldPersistTaps="always"
         showsHorizontalScrollIndicator={false}
         initialNumToRender={20}
         data={users}

--- a/src/group/GroupScreen.js
+++ b/src/group/GroupScreen.js
@@ -20,11 +20,7 @@ export default class GroupScreen extends PureComponent<{}, State> {
   render() {
     const { filter } = this.state;
     return (
-      <Screen
-        search
-        keyboardShouldPersistTaps="handled"
-        searchBarOnChange={this.handleFilterChange}
-      >
+      <Screen search searchBarOnChange={this.handleFilterChange}>
         <GroupContainer filter={filter} />
       </Screen>
     );

--- a/src/streams/CreateStreamScreen.js
+++ b/src/streams/CreateStreamScreen.js
@@ -7,7 +7,7 @@ import EditStreamContainer from './EditStreamContainer';
 export default class CreateStreamScreen extends PureComponent<{}> {
   render() {
     return (
-      <Screen title="Create new stream" padding keyboardShouldPersistTaps="handled">
+      <Screen title="Create new stream" padding>
         <EditStreamContainer />
       </Screen>
     );

--- a/src/streams/EditStreamScreen.js
+++ b/src/streams/EditStreamScreen.js
@@ -7,7 +7,7 @@ import EditStreamContainer from './EditStreamContainer';
 export default class EditStreamScreen extends PureComponent<{}> {
   render() {
     return (
-      <Screen title="Edit stream" padding keyboardShouldPersistTaps="handled">
+      <Screen title="Edit stream" padding>
         <EditStreamContainer />
       </Screen>
     );


### PR DESCRIPTION
* the default value of 'never' is rarely a good choice
* the other option 'always' is good when we do not want the user
to be able to hide the keyboard (like on the password and realm screens)
* the one that is 'handled' is great as a default

Here we change the default value to 'handled', remove any property
that was manually setting it to that value, and remove several no
longer needed keyboardShouldPersistTaps in FlatLists.