### PR TITLE
Handle API errors and network errors differently

### DIFF
--- a/src/api/apiFetch.js
+++ b/src/api/apiFetch.js
@@ -44,13 +44,12 @@ export const apiCall = async (
 
     if (!response.ok || json.result !== 'success') {
       console.log('Bad response for:', { auth, route, params, response }); // eslint-disable-line
-      throw Error(
-        JSON.stringify({
-          status: response.status,
-          statusText: response.statusText,
-          code: json.code,
-        }),
-      );
+      const error = new Error('API');
+      // $FlowFixMe
+      error.response = response;
+      // $FlowFixMe
+      error.code = json.code;
+      throw error;
     }
 
     return resFunc(json);

--- a/src/events/eventActions.js
+++ b/src/events/eventActions.js
@@ -61,11 +61,13 @@ export const startEventPolling = (queueId: number, eventId: number) => async (
     } catch (e) {
       // protection from inadvertent DDOS
       await sleep(5000);
-      const error = JSON.parse(e.message);
-      // The event queue is too old or has been garbage collected
-      if (error.status === 400 && error.code === 'BAD_EVENT_QUEUE_ID') {
-        dispatch(appRefresh());
-        break;
+
+      if (e.message === 'API') {
+        // The event queue is too old or has been garbage collected
+        if (e.response.status === 400 && e.code === 'BAD_EVENT_QUEUE_ID') {
+          dispatch(appRefresh());
+          break;
+        }
       }
     }
   }


### PR DESCRIPTION
Fixes #2392

The error arises from trying to parse non JSON error message.

Implementing a true custom error class to throw seems quite tricky
since Babel does not support it (there are unreliable workarounds)

Instead, the Error message becomes 'API' and the response and code
are passed as properties of the thrown error object.