### PR TITLE
refactor: Remove componentWillReceiveProps from AnimatedComponent

### DIFF
--- a/src/animation/AnimatedComponent.js
+++ b/src/animation/AnimatedComponent.js
@@ -23,12 +23,12 @@ export default class AnimatedComponent extends PureComponent<Props> {
 
   animatedValue = new Animated.Value(0);
 
-  componentWillReceiveProps(nextProps: Props) {
+  componentDidUpdate() {
     Animated.timing(this.animatedValue, {
-      toValue: nextProps.visible ? nextProps[nextProps.property] : 0,
+      toValue: this.props.visible ? this.props[this.props.property] : 0,
       duration: 300,
-      useNativeDriver: nextProps.useNativeDriver,
-      easing: nextProps.visible ? Easing.elastic() : Easing.back(2),
+      useNativeDriver: this.props.useNativeDriver,
+      easing: this.props.visible ? Easing.elastic() : Easing.back(2),
     }).start();
   }
 


### PR DESCRIPTION
The function is being deprecated.
* keep the same functionality
* do the work in a different lifecycle event