### PR TITLE
webview: Disable scroll events while 'loading' shown

### DIFF
--- a/src/render-html/generatedEs3.js
+++ b/src/render-html/generatedEs3.js
@@ -191,6 +191,7 @@ var handleMessageContent = function handleMessageContent(msg) {
 };
 
 var handleMessageFetching = function handleMessageFetching(msg) {
+  scrollEventsDisabled = !msg.showMessagePlaceholders;
   toggleElementHidden('message-loading', !msg.showMessagePlaceholders);
   toggleElementHidden('spinner-older', !msg.fetchingOlder);
   toggleElementHidden('spinner-newer', !msg.fetchingNewer);

--- a/src/render-html/js.js
+++ b/src/render-html/js.js
@@ -184,6 +184,7 @@ const handleMessageContent = (msg: MessageInputContent) => {
 };
 
 const handleMessageFetching = (msg: MessageInputFetching) => {
+  scrollEventsDisabled = !msg.showMessagePlaceholders;
   toggleElementHidden('message-loading', !msg.showMessagePlaceholders);
   toggleElementHidden('spinner-older', !msg.fetchingOlder);
   toggleElementHidden('spinner-newer', !msg.fetchingNewer);


### PR DESCRIPTION
Do not send scroll events while the 'loading' messages are shown
in webview. We just disable the scrolling and it is again enabled
when content is updated.

This fixes an issue marking messages as read even before they
are loaded (default of 0 to MAX_SAFE_INTEGER is sent)