### PR TITLE
Make progressiveTimeout test less flaky

### DIFF
--- a/src/utils/__tests__/progressiveTimeout-test.js
+++ b/src/utils/__tests__/progressiveTimeout-test.js
@@ -5,11 +5,11 @@ describe('progressiveTimeout', () => {
     const start = Date.now();
     await progressiveTimeout();
     const duration = Date.now() - start;
-    expect(duration < 50).toBeTruthy();
+    expect(duration < 100).toBeTruthy();
 
     const start2 = Date.now();
     await progressiveTimeout();
     const duration2 = Date.now() - start2;
-    expect(duration2 > 2000 && duration2 < 2050).toBeTruthy();
+    expect(duration2 > 1900).toBeTruthy();
   });
 });


### PR DESCRIPTION
This test deals with async timing, for which I had some reservations.
It seems I was right. This seems to fail from time to time when run
on CI. I did relax the checks and removed one of the upper limit ones
(< 2050).

If this version fails even once, we should remove the test.