### PR TITLE
webview: Content update always as last message

### DIFF
--- a/src/render-html/webViewHandleUpdates.js
+++ b/src/render-html/webViewHandleUpdates.js
@@ -64,10 +64,6 @@ export default (
 ) => {
   const messages = [];
 
-  if (!isEqual(prevProps.renderedMessages, nextProps.renderedMessages)) {
-    messages.push(updateContent(prevProps, nextProps));
-  }
-
   if (
     !isEqual(prevProps.fetching, nextProps.fetching) ||
     prevProps.showMessagePlaceholders !== nextProps.showMessagePlaceholders
@@ -77,6 +73,10 @@ export default (
 
   if (!isEqual(prevProps.typingUsers, nextProps.typingUsers)) {
     messages.push(updateTyping(prevProps, nextProps));
+  }
+
+  if (!isEqual(prevProps.renderedMessages, nextProps.renderedMessages)) {
+    messages.push(updateContent(prevProps, nextProps));
   }
 
   if (messages.length > 0) {


### PR DESCRIPTION
Move content update mssage to the end of the list.
This makes poisitioning more precise if another message happens
(since they hide/show elements)