### PR TITLE
webview: Fix getMessageTransitionProps detecting new message

### DIFF
--- a/src/message/__tests__/messageUpdates-test.js
+++ b/src/message/__tests__/messageUpdates-test.js
@@ -93,6 +93,29 @@ describe('getMessageTransitionProps', () => {
     });
   });
 
+  test('when different narrows do not consider new message', () => {
+    const prevProps = {
+      messages: [{ id: 2 }, { id: 3 }, { id: 4 }],
+      narrow: 'some narrow',
+    };
+    const nextProps = {
+      messages: [{ id: 2 }, { id: 3 }, { id: 4 }, { id: 5 }],
+      narrow: 'another narrow',
+    };
+
+    const result = getMessageTransitionProps(prevProps, nextProps);
+
+    expect(result).toEqual({
+      newMessagesAdded: false,
+      noMessages: false,
+      noNewMessages: false,
+      allNewMessages: false,
+      oldMessagesAdded: false,
+      onlyOneNewMessage: false,
+      sameNarrow: false,
+    });
+  });
+
   test('recognize when all messages are loaded', () => {
     const prevProps = {
       messages: [],

--- a/src/message/messageUpdates.js
+++ b/src/message/messageUpdates.js
@@ -38,6 +38,7 @@ export const getMessageTransitionProps = (prevProps: Props, nextProps: Props): T
     prevProps.messages[prevProps.messages.length - 1].id <
       nextProps.messages[nextProps.messages.length - 1].id;
   const onlyOneNewMessage =
+    sameNarrow &&
     prevProps.messages.length > 0 &&
     nextProps.messages.length > 1 &&
     prevProps.messages[prevProps.messages.length - 1].id ===


### PR DESCRIPTION
When determining if a new message wa loaded in getMessageTransitionProps
only consider true if the narrow remained the same.