### PR TITLE
webview: Add a 'default' update strategy

### DIFF
--- a/src/message/messageUpdates.js
+++ b/src/message/messageUpdates.js
@@ -14,6 +14,7 @@ type TransitionProps = {
 };
 
 export type UpdateStrategy =
+  | 'default'
   | 'replace'
   | 'preserve-position'
   | 'scroll-to-anchor'
@@ -66,5 +67,5 @@ export const getMessageUpdateStrategy = (transitionProps: TransitionProps): Upda
     return 'scroll-to-bottom-if-near-bottom';
   }
 
-  return 'preserve-position';
+  return 'default';
 };

--- a/src/render-html/generatedEs3.js
+++ b/src/render-html/generatedEs3.js
@@ -175,6 +175,7 @@ var updateContentAndScrollToBottomIfNearBottom = function updateContentAndScroll
 
 var updateFunctions = {
   replace: replaceContent,
+  default: updateContentAndPreservePosition,
   'preserve-position': updateContentAndPreservePosition,
   'scroll-to-anchor': updateContentAndScrollToAnchor,
   'scroll-to-bottom': updateContentAndScrollToBottom,

--- a/src/render-html/js.js
+++ b/src/render-html/js.js
@@ -170,6 +170,7 @@ const updateContentAndScrollToBottomIfNearBottom = msg => {
 
 const updateFunctions = {
   replace: replaceContent,
+  default: updateContentAndPreservePosition,
   'preserve-position': updateContentAndPreservePosition,
   'scroll-to-anchor': updateContentAndScrollToAnchor,
   'scroll-to-bottom': updateContentAndScrollToBottom,


### PR DESCRIPTION
When we can not determine any concrete update strategy we used to
default to 'preserve position'. Keep the same behavior but name this
'default'. This will help differentiate when debugging if we
intentionally want to preserve position or just because we did not
match any other strategy.