### PR TITLE
Improve getMessageTransitionProps to detect replaced messages

### DIFF
--- a/src/message/__tests__/messageUpdates-test.js
+++ b/src/message/__tests__/messageUpdates-test.js
@@ -21,6 +21,7 @@ describe('getMessageTransitionProps', () => {
       oldMessagesAdded: false,
       onlyOneNewMessage: false,
       sameNarrow: true,
+      messagesReplaced: false,
     });
   });
 
@@ -44,6 +45,7 @@ describe('getMessageTransitionProps', () => {
       oldMessagesAdded: true,
       onlyOneNewMessage: false,
       sameNarrow: true,
+      messagesReplaced: false,
     });
   });
 
@@ -67,6 +69,7 @@ describe('getMessageTransitionProps', () => {
       oldMessagesAdded: false,
       onlyOneNewMessage: false,
       sameNarrow: true,
+      messagesReplaced: false,
     });
   });
 
@@ -90,6 +93,7 @@ describe('getMessageTransitionProps', () => {
       oldMessagesAdded: false,
       onlyOneNewMessage: true,
       sameNarrow: true,
+      messagesReplaced: false,
     });
   });
 
@@ -113,6 +117,7 @@ describe('getMessageTransitionProps', () => {
       oldMessagesAdded: false,
       onlyOneNewMessage: false,
       sameNarrow: false,
+      messagesReplaced: false,
     });
   });
 
@@ -136,6 +141,31 @@ describe('getMessageTransitionProps', () => {
       oldMessagesAdded: false,
       onlyOneNewMessage: false,
       sameNarrow: true,
+      messagesReplaced: false,
+    });
+  });
+
+  test('recognize when messages are invalidated and replaced', () => {
+    const prevProps = {
+      messages: [{ id: 1 }, { id: 2 }],
+      narrow: 'some narrow',
+    };
+    const nextProps = {
+      messages: [{ id: 4 }, { id: 5 }, { id: 6 }],
+      narrow: 'some narrow',
+    };
+
+    const result = getMessageTransitionProps(prevProps, nextProps);
+
+    expect(result).toEqual({
+      newMessagesAdded: true,
+      noMessages: false,
+      noNewMessages: false,
+      allNewMessages: false,
+      oldMessagesAdded: false,
+      onlyOneNewMessage: false,
+      sameNarrow: true,
+      messagesReplaced: true,
     });
   });
 });

--- a/src/message/messageUpdates.js
+++ b/src/message/messageUpdates.js
@@ -11,6 +11,7 @@ type TransitionProps = {
   onlyOneNewMessage: boolean,
   oldMessagesAdded: boolean,
   newMessagesAdded: boolean,
+  messagesReplaced: boolean,
 };
 
 export type UpdateStrategy =
@@ -44,6 +45,11 @@ export const getMessageTransitionProps = (prevProps: Props, nextProps: Props): T
     nextProps.messages.length > 1 &&
     prevProps.messages[prevProps.messages.length - 1].id ===
       nextProps.messages[nextProps.messages.length - 2].id;
+  const messagesReplaced =
+    sameNarrow &&
+    prevProps.messages.length > 0 &&
+    nextProps.messages.length > 0 &&
+    prevProps.messages[prevProps.messages.length - 1].id < nextProps.messages[0].id;
 
   return {
     sameNarrow,
@@ -53,6 +59,7 @@ export const getMessageTransitionProps = (prevProps: Props, nextProps: Props): T
     onlyOneNewMessage,
     oldMessagesAdded,
     newMessagesAdded,
+    messagesReplaced,
   };
 };
 


### PR DESCRIPTION
Previously we missed to discriminate the case when old messages
are invalidated and replaced with completely new ones.

If previous messages last message ID is older than the new messages
first message ID then the messages were completely replaced.