### PR TITLE
Fixed input box looking like it's disabled

### DIFF
--- a/src/compose/ComposeBox.js
+++ b/src/compose/ComposeBox.js
@@ -37,7 +37,8 @@ const componentStyles = StyleSheet.create({
     justifyContent: 'center',
   },
   topicInput: {
-    padding: 4,
+    padding: 2,
+    paddingLeft: 8,
     borderColor: 'rgba(127, 127, 127, 0.5)',
     borderWidth: 1,
     borderRadius: 3,

--- a/src/styles/theme.js
+++ b/src/styles/theme.js
@@ -193,8 +193,9 @@ export default ({ color, backgroundColor, borderColor, cardColor, dividerColor }
   },
   composeBox: {
     flexDirection: 'row',
-    backgroundColor: 'rgba(127, 127, 127, 0.1)',
     borderTopColor: borderColor,
+    borderTopWidth: 1,
+    padding: 4,
   },
   subheader: {
     flex: 1,


### PR DESCRIPTION
Styling changes to make the input box more like one would expect an enabled input box to look like. Also fixed the topic input box being too tall.
Input box before:
![screenshot_20180425-145128](https://user-images.githubusercontent.com/22353313/39237902-77bab9b0-489a-11e8-85e8-e610bd62a6a3.png)

Input box after:
![screenshot_20180425-145056](https://user-images.githubusercontent.com/22353313/39237910-80b8537e-489a-11e8-9781-540e9da110ff.png)

Topic input before:
![screenshot_20180425-150325](https://user-images.githubusercontent.com/22353313/39237968-ae2730aa-489a-11e8-8aa4-7cc056571c43.png)

Topic input after:
![screenshot_20180425-150305](https://user-images.githubusercontent.com/22353313/39237974-b5011e4a-489a-11e8-96c4-b73d39c53bcb.png)
