### PR TITLE
webview: On messages replaced position at anchor

### DIFF
--- a/src/message/__tests__/messageUpdates-test.js
+++ b/src/message/__tests__/messageUpdates-test.js
@@ -215,6 +215,21 @@ describe('getMessageUpdateStrategy', () => {
     expect(result).toEqual('replace');
   });
 
+  test('when messages replaced go to anchor', () => {
+    const prevProps = {
+      messages: [{ id: 1 }, { id: 2 }, { id: 3 }],
+      narrow: 'some narrow',
+    };
+    const nextProps = {
+      messages: [{ id: 5 }, { id: 6 }, { id: 7 }],
+      narrow: 'some narrow',
+    };
+
+    const result = getMessageUpdateStrategy(getMessageTransitionProps(prevProps, nextProps));
+
+    expect(result).toEqual('scroll-to-anchor');
+  });
+
   test('when older messages loaded preserve scroll position', () => {
     const prevProps = {
       messages: [{ id: 4 }, { id: 5 }, { id: 6 }],

--- a/src/message/messageUpdates.js
+++ b/src/message/messageUpdates.js
@@ -67,13 +67,17 @@ export const getMessageUpdateStrategy = (transitionProps: TransitionProps): Upda
   if (transitionProps.noMessages) {
     return 'replace';
   } else if (
+    !transitionProps.sameNarrow ||
+    transitionProps.allNewMessages ||
+    transitionProps.messagesReplaced
+  ) {
+    return 'scroll-to-anchor';
+  } else if (
     transitionProps.noNewMessages ||
     transitionProps.oldMessagesAdded ||
     (transitionProps.newMessagesAdded && !transitionProps.onlyOneNewMessage)
   ) {
     return 'preserve-position';
-  } else if (!transitionProps.sameNarrow || transitionProps.allNewMessages) {
-    return 'scroll-to-anchor';
   } else if (transitionProps.onlyOneNewMessage) {
     return 'scroll-to-bottom-if-near-bottom';
   }


### PR DESCRIPTION
Fixes #2339

If we detect stale cache we replace messages completely.
Previously we did not properly catch this specific case and used
'preserve-position' strategy.

Instead, now we detect this case and position at anchor.