### PR TITLE
fix: StreamItem fails to render when no unread data is loaded

### DIFF
--- a/src/streams/StreamItem.js
+++ b/src/streams/StreamItem.js
@@ -111,9 +111,7 @@ export default class StreamItem extends PureComponent<Props> {
               />
             )}
           </View>
-          {unreadCount && (
-            <UnreadCount color={iconColor} count={unreadCount} inverse={isSelected} />
-          )}
+          <UnreadCount color={iconColor} count={unreadCount} inverse={isSelected} />
           {showSwitch && (
             <ZulipSwitch
               defaultValue={!!isSwitchedOn}


### PR DESCRIPTION
Remove the `unreadCount &&` check that is not even needed as
<UnreadCount /> component handles empty values by not rendering.