### PR TITLE
ui: Replace component padding styles with utility ones

### DIFF
--- a/src/common/Centerer.js
+++ b/src/common/Centerer.js
@@ -4,15 +4,12 @@ import { StyleSheet, View } from 'react-native';
 
 import type { ChildrenArray, StyleObj } from '../types';
 
-const styles = StyleSheet.create({
+const componentStyles = StyleSheet.create({
   centerer: {
     flex: 1,
     flexDirection: 'row',
     justifyContent: 'space-around',
     alignItems: 'center',
-  },
-  padding: {
-    padding: 20,
   },
   inner: {
     width: '100%',
@@ -29,16 +26,21 @@ type Props = {
 export default class Centerer extends PureComponent<Props> {
   props: Props;
 
+  static contextTypes = {
+    styles: () => null,
+  };
+
   static defaultProps = {
     padding: false,
   };
 
   render() {
-    const { children, style, padding } = this.props;
+    const { styles } = this.context;
+    const { children, padding, style } = this.props;
 
     return (
-      <View style={[styles.centerer, padding && styles.padding, style]}>
-        <View style={styles.inner}>{children}</View>
+      <View style={[componentStyles.centerer, padding && styles.padding, style]}>
+        <View style={componentStyles.inner}>{children}</View>
       </View>
     );
   }

--- a/src/common/Screen.js
+++ b/src/common/Screen.js
@@ -22,9 +22,6 @@ const componentStyles = StyleSheet.create({
     flexGrow: 1,
     justifyContent: 'center',
   },
-  padding: {
-    padding: 10,
-  },
 });
 
 type Props = {
@@ -77,8 +74,8 @@ class Screen extends PureComponent<Props> {
         <KeyboardAvoider
           behavior="padding"
           keyboardShouldPersistTaps="handled"
-          style={[componentStyles.wrapper, padding && componentStyles.padding]}
-          contentContainerStyle={[padding && componentStyles.padding]}
+          style={[componentStyles.wrapper, padding && styles.padding]}
+          contentContainerStyle={[padding && styles.padding]}
         >
           <ScrollView
             contentContainerStyle={[

--- a/src/settings/SettingsCard.js
+++ b/src/settings/SettingsCard.js
@@ -10,12 +10,9 @@ import SwitchAccountButton from '../account-info/SwitchAccountButton';
 import LogoutButton from '../account-info/LogoutButton';
 import { IconDiagnostics, IconNotifications, IconNight, IconLanguage } from '../common/Icons';
 
-const styles = StyleSheet.create({
+const componentStyles = StyleSheet.create({
   optionWrapper: {
     flex: 1,
-  },
-  padding: {
-    padding: 16,
   },
   accountButtons: {
     flex: 1,
@@ -32,16 +29,21 @@ type Props = {
 class SettingsCard extends PureComponent<Props> {
   props: Props;
 
+  static contextTypes = {
+    styles: () => null,
+  };
+
   handleThemeChange = () => {
     const { actions, theme } = this.props;
     actions.settingsChange('theme', theme === 'default' ? 'night' : 'default');
   };
 
   render() {
+    const { styles } = this.context;
     const { theme, actions } = this.props;
 
     return (
-      <ScrollView style={styles.optionWrapper}>
+      <ScrollView style={componentStyles.optionWrapper}>
         <OptionRow
           Icon={IconNight}
           label="Night mode"
@@ -64,7 +66,7 @@ class SettingsCard extends PureComponent<Props> {
           <WebLink label="Terms of service" href="/terms/" />
           <WebLink label="Privacy policy" href="/privacy/" />
         </View>
-        <View style={styles.accountButtons}>
+        <View style={componentStyles.accountButtons}>
           <SwitchAccountButton />
           <LogoutButton />
         </View>

--- a/src/streams/StreamCard.js
+++ b/src/streams/StreamCard.js
@@ -7,7 +7,7 @@ import { RawLabel } from '../common';
 import StreamIcon from '../streams/StreamIcon';
 import { NULL_SUBSCRIPTION } from '../nullObjects';
 
-const styles = StyleSheet.create({
+const componentStyles = StyleSheet.create({
   streamRow: {
     flexDirection: 'row',
     alignItems: 'center',
@@ -17,9 +17,6 @@ const styles = StyleSheet.create({
   },
   descriptionText: {
     opacity: 0.8,
-  },
-  padding: {
-    padding: 16,
   },
 });
 
@@ -31,7 +28,12 @@ type Props = {
 export default class StreamCard extends PureComponent<Props> {
   props: Props;
 
+  static contextTypes = {
+    styles: () => null,
+  };
+
   render() {
+    const { styles } = this.context;
     const { stream, subscription } = this.props;
 
     const name = subscription.name || stream.name;
@@ -39,16 +41,21 @@ export default class StreamCard extends PureComponent<Props> {
 
     return (
       <View style={styles.padding}>
-        <View style={styles.streamRow}>
+        <View style={componentStyles.streamRow}>
           <StreamIcon
             size={20}
             color={subscription.color || NULL_SUBSCRIPTION.color}
             isMuted={subscription ? !subscription.in_home_view : false}
             isPrivate={stream && stream.invite_only}
           />
-          <RawLabel style={styles.streamText} text={name} numberOfLines={1} ellipsizeMode="tail" />
+          <RawLabel
+            style={componentStyles.streamText}
+            text={name}
+            numberOfLines={1}
+            ellipsizeMode="tail"
+          />
         </View>
-        <RawLabel style={styles.descriptionText} text={description} />
+        <RawLabel style={componentStyles.descriptionText} text={description} />
       </View>
     );
   }


### PR DESCRIPTION
Any specific style that is of the form `padding: {}` is replaced
with the utility styles introduced earlier.