### PR TITLE
ui: Remove background from topic items

### DIFF
--- a/src/streams/TopicItem.js
+++ b/src/streams/TopicItem.js
@@ -10,7 +10,6 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     padding: 8,
-    backgroundColor: 'rgba(127, 127, 127, 0.25)',
   },
   selectedRow: {
     backgroundColor: BRAND_COLOR,


### PR DESCRIPTION
Initially the background color was set to copy the same background
of the topic header in the message list, but seems no one is making
the connection and instead it looks weird. Just remove this background.