### PR TITLE
Add GIF support for Android

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -174,6 +174,7 @@ dependencies {
     compile "com.android.support:appcompat-v7:23.0.1"
     compile "me.leolin:ShortcutBadger:1.1.16@aar"
     compile "com.facebook.react:react-native:+"  // From node_modules
+    compile 'com.facebook.fresco:animated-gif:1.3.0' // For animated GIF support
     compile 'com.android.support:customtabs:23.0.1'
 
 }


### PR DESCRIPTION
Enables facebook/fresco which supports animated GIFs in Android.
React Native supports the library by default but does not include
it without us enabling it in the build.