### PR TITLE
ui: Allow UI to give feedback to user on account switching

### DIFF
--- a/src/account/AccountPickScreen.js
+++ b/src/account/AccountPickScreen.js
@@ -27,7 +27,9 @@ class AccountPickScreen extends PureComponent<Props> {
     const { accounts, actions } = this.props;
     const { realm, apiKey } = accounts[index];
     if (apiKey) {
-      actions.switchAccount(index);
+      setTimeout(() => {
+        actions.switchAccount(index);
+      });
     } else {
       actions.navigateToAddNewAccount(realm);
     }


### PR DESCRIPTION
Calling `switchAccount` action takes long and the user is not given
any indiction immediately. Use `setTimeout` to allow the UI to first
respond (the button will give feedback) and then call the action.