### PR TITLE
webview: Message loading state does not cause 'scroll'

### DIFF
--- a/src/webview/css/css.js
+++ b/src/webview/css/css.js
@@ -385,6 +385,8 @@ ul {
   height: 20px;
 }
 #message-loading {
+  position: absolute;
+  width: 100%;
   opacity: 0.25;
 }
 #js-error {


### PR DESCRIPTION
Sets 'absolute' position to the 'message loading' element so it
does not cause 'scroll' events to fire.

This improves on previous behavior by:
* not showing the 'scroll to bottom' button
* not sending extra 'scroll' events to messageListWeb component