### PR TITLE
Handle narrow from group notifications when missing users

### DIFF
--- a/src/utils/__tests__/notificationsCommon-test.js
+++ b/src/utils/__tests__/notificationsCommon-test.js
@@ -43,4 +43,16 @@ describe('getNarrowFromNotificationData', () => {
 
     expect(narrow).toEqual(expectedNarrow);
   });
+
+  test('do not throw when users are not found; return a home narrow', () => {
+    const notification = {
+      recipient_type: 'private',
+      pm_users: '1,2,4',
+    };
+    const usersById = {};
+
+    const narrow = getNarrowFromNotificationData(notification, usersById);
+
+    expect(narrow).toEqual(homeNarrow);
+  });
 });

--- a/src/utils/notificationsCommon.js
+++ b/src/utils/notificationsCommon.js
@@ -4,8 +4,10 @@ import { homeNarrow, topicNarrow, privateNarrow, groupNarrow } from '../utils/na
 
 const getGroupNarrowFromNotificationData = (data: NotificationGroup, usersById: UserIdMap = {}) => {
   const userIds = data.pm_users.split(',');
-  const userEmails = userIds.map(x => usersById[x].email);
-  return groupNarrow(userEmails);
+  const users = userIds.map(id => usersById[id]);
+  const doAllUsersExist = users.every(user => user);
+
+  return doAllUsersExist ? groupNarrow(users.map(user => user.email)) : homeNarrow;
 };
 
 export const getNarrowFromNotificationData = (data: Notification, usersById: UserIdMap = {}) => {


### PR DESCRIPTION
To do the group narrow, we get ids as input. We need to access the
users state to get these users emails. If a user does not exist
(disabled, deleted, just added but we haven't read that data yet?)
instead of throwing an error narrow to Home narrow.