### PR TITLE
notifications: Narrow to group narrows

### DIFF
--- a/src/boot/AppEventHandlers.js
+++ b/src/boot/AppEventHandlers.js
@@ -4,9 +4,9 @@ import { AppState, NetInfo, View, StyleSheet, Platform, NativeModules } from 're
 import SafeArea from 'react-native-safe-area';
 import Orientation from 'react-native-orientation';
 
-import type { Actions, ChildrenArray } from '../types';
+import type { Actions, ChildrenArray, UserIdMap } from '../types';
 import connectWithActions from '../connectWithActions';
-import { getSession, getUnreadByHuddlesMentionsAndPMs } from '../selectors';
+import { getSession, getUnreadByHuddlesMentionsAndPMs, getUsersById } from '../selectors';
 import {
   addNotificationListener,
   removeNotificationListener,
@@ -27,6 +27,7 @@ type Props = {
   actions: Actions,
   children?: ChildrenArray<*>,
   unreadCount: number,
+  usersById: UserIdMap,
 };
 
 class AppEventHandlers extends PureComponent<Props> {
@@ -56,8 +57,8 @@ class AppEventHandlers extends PureComponent<Props> {
   };
 
   handleNotificationOpen = (notification: Object) => {
-    const { actions } = this.props;
-    handlePendingNotifications(notification, actions);
+    const { actions, usersById } = this.props;
+    handlePendingNotifications(notification, actions, usersById);
   };
 
   handleMemoryWarning = () => {
@@ -65,8 +66,8 @@ class AppEventHandlers extends PureComponent<Props> {
   };
 
   componentDidMount() {
-    const { actions } = this.props;
-    handleInitialNotification(actions);
+    const { actions, usersById } = this.props;
+    handleInitialNotification(actions, usersById);
 
     NetInfo.addEventListener('connectionChange', this.handleConnectivityChange);
     AppState.addEventListener('change', this.handleAppStateChange);
@@ -93,5 +94,6 @@ class AppEventHandlers extends PureComponent<Props> {
 
 export default connectWithActions(state => ({
   needsInitialFetch: getSession(state).needsInitialFetch,
+  usersById: getUsersById(state),
   unreadCount: getUnreadByHuddlesMentionsAndPMs(state),
 }))(AppEventHandlers);

--- a/src/nav/__tests__/navSelectors-test.js
+++ b/src/nav/__tests__/navSelectors-test.js
@@ -32,6 +32,7 @@ describe('getInitialNavState', () => {
   test('when no previous navigation is given do not throw but return some result', () => {
     const state = deepFreeze({
       accounts: [{ apiKey: '123' }],
+      users: [],
     });
 
     const nav = getInitialNavState(state);
@@ -42,6 +43,7 @@ describe('getInitialNavState', () => {
   test('if logged in, preserve the state', () => {
     const state = deepFreeze({
       accounts: [{ apiKey: '123' }],
+      users: [],
       nav: {
         routes: [{ routeName: 'route1' }, { routeName: 'route2' }],
       },
@@ -57,6 +59,7 @@ describe('getInitialNavState', () => {
   test('if not logged in, and no previous accounts, show realm screen', () => {
     const state = deepFreeze({
       accounts: [],
+      users: [],
       nav: {
         routes: [],
       },
@@ -71,6 +74,7 @@ describe('getInitialNavState', () => {
   test('if more than one account and no active account, display account list', () => {
     const state = deepFreeze({
       accounts: [{}, {}],
+      users: [],
       nav: {
         routes: [],
       },
@@ -85,6 +89,7 @@ describe('getInitialNavState', () => {
   test('when only a single account and no other properties, redirect to realm', () => {
     const state = deepFreeze({
       accounts: [{ realm: 'https://example.com' }],
+      users: [],
       nav: {
         routes: [],
       },
@@ -102,6 +107,7 @@ describe('getInitialNavState', () => {
         { realm: 'https://example.com', email: 'johndoe@example.com' },
         { realm: 'https://example.com', email: 'janedoe@example.com' },
       ],
+      users: [],
       nav: {
         routes: [],
       },
@@ -116,6 +122,7 @@ describe('getInitialNavState', () => {
   test('when default account has server and email set, redirect to realm screen', () => {
     const state = deepFreeze({
       accounts: [{ realm: 'https://example.com', email: 'johndoe@example.com' }],
+      users: [],
       nav: {
         routes: [],
       },

--- a/src/nav/navSelectors.js
+++ b/src/nav/navSelectors.js
@@ -7,6 +7,7 @@ import config from '../config';
 import { getNav, getAccounts } from '../directSelectors';
 import { navigateToChat } from './navActions';
 import { getAuth } from '../account/accountSelectors';
+import { getUsersById } from '../users/userSelectors';
 import AppNavigator from './AppNavigator';
 import { getNarrowFromNotificationData } from '../utils/notificationsCommon';
 
@@ -72,7 +73,8 @@ export const getInitialNavState = createSelector(
   getNav,
   getAccounts,
   getAuth,
-  (nav, accounts, auth) => {
+  getUsersById,
+  (nav, accounts, auth, usersById) => {
     if (!auth.apiKey) {
       return getStateForRoute(accounts && accounts.length > 1 ? 'account' : 'realm');
     }
@@ -86,7 +88,7 @@ export const getInitialNavState = createSelector(
       return state;
     }
 
-    const narrow = getNarrowFromNotificationData(config.startup.notification);
+    const narrow = getNarrowFromNotificationData(config.startup.notification, usersById);
     return AppNavigator.router.getStateForAction(navigateToChat(narrow), state);
   },
 );

--- a/src/users/userSelectors.js
+++ b/src/users/userSelectors.js
@@ -60,7 +60,7 @@ export const getUsersByEmail = createSelector(getUsers, users =>
   }, {}),
 );
 
-export const getUsersById = createSelector(getUsers, users =>
+export const getUsersById = createSelector(getUsers, (users = []) =>
   users.reduce((usersById, user) => {
     usersById[user.id] = user;
     return usersById;

--- a/src/utils/notifications.android.js
+++ b/src/utils/notifications.android.js
@@ -1,7 +1,7 @@
 /* @flow */
 import { NotificationsAndroid, PendingNotifications } from 'react-native-notifications';
 
-import type { Auth, Actions } from '../types';
+import type { Auth, Actions, UserIdMap } from '../types';
 import config from '../config';
 import { registerPush } from '../api';
 import { logErrorRemotely } from '../utils/logging';
@@ -30,7 +30,11 @@ export const refreshNotificationToken = () => {
   NotificationsAndroid.refreshToken();
 };
 
-export const handlePendingNotifications = (notificationData: Object, actions: Actions) => {
+export const handlePendingNotifications = (
+  notificationData: Object,
+  actions: Actions,
+  usersById: UserIdMap,
+) => {
   if (!notificationData || !notificationData.getData) {
     return;
   }
@@ -38,11 +42,11 @@ export const handlePendingNotifications = (notificationData: Object, actions: Ac
   const data = notificationData.getData();
   config.startup.notification = data;
   if (data) {
-    actions.doNarrow(getNarrowFromNotificationData(data), data.zulip_message_id);
+    actions.doNarrow(getNarrowFromNotificationData(data, usersById), data.zulip_message_id);
   }
 };
 
-export const handleInitialNotification = async (actions: Actions) => {
+export const handleInitialNotification = async (actions: Actions, usersById: UserIdMap) => {
   const data = await PendingNotifications.getInitialNotification();
-  handlePendingNotifications(data, actions);
+  handlePendingNotifications(data, actions, usersById);
 };

--- a/src/utils/notifications.ios.js
+++ b/src/utils/notifications.ios.js
@@ -2,7 +2,7 @@
 import NotificationsIOS from 'react-native-notifications';
 import { PushNotificationIOS } from 'react-native';
 
-import type { Auth, Actions } from '../types';
+import type { Auth, Actions, UserIdMap } from '../types';
 import config from '../config';
 import { registerPush } from '../api';
 import { logErrorRemotely } from './logging';
@@ -40,7 +40,11 @@ export const initializeNotifications = (
 
 export const refreshNotificationToken = () => {};
 
-export const handlePendingNotifications = (notificationData: Object, actions: Actions) => {
+export const handlePendingNotifications = (
+  notificationData: Object,
+  actions: Actions,
+  usersById: UserIdMap,
+) => {
   if (!notificationData || !notificationData.getData) {
     return;
   }
@@ -48,11 +52,11 @@ export const handlePendingNotifications = (notificationData: Object, actions: Ac
   const data = notificationData.getData();
   config.startup.notification = data.zulip;
   if (data && data.zulip) {
-    actions.doNarrow(getNarrowFromNotificationData(data)); // , data.message_ids
+    actions.doNarrow(getNarrowFromNotificationData(data, usersById));
   }
 };
 
-export const handleInitialNotification = async (actions: Actions) => {
+export const handleInitialNotification = async (actions: Actions, usersById: UserIdMap) => {
   const data = await PushNotificationIOS.getInitialNotification();
-  handlePendingNotifications(data, actions);
+  handlePendingNotifications(data, actions, usersById);
 };


### PR DESCRIPTION
Pass `usersById` data to the newly updated `getNarrowFromNotificationData`
so it can calculate the correct group narrow.

Add empty `users` state to navSelectors tests as now the function
`getInitialNavState` depends on that data.