### PR TITLE
webview: Prevent scroll events in Android while messages loading

### DIFF
--- a/src/webview/css/css.js
+++ b/src/webview/css/css.js
@@ -385,7 +385,7 @@ ul {
   height: 20px;
 }
 #message-loading {
-  position: absolute;
+  position: fixed;
   width: 100%;
   opacity: 0.25;
 }


### PR DESCRIPTION
While 'absolute' position was enough in iOS, Android still sends
scroll events. 'fixed' fixes this.