### PR TITLE
WIP: Input redesign

### DIFF
--- a/src/compose/ComposeBox.js
+++ b/src/compose/ComposeBox.js
@@ -29,6 +29,9 @@ const componentStyles = StyleSheet.create({
     flexDirection: 'column',
     justifyContent: 'flex-end',
   },
+  composeOptions: {
+    flexDirection: 'row',
+  },
   composeText: {
     flex: 1,
     justifyContent: 'center',
@@ -273,28 +276,28 @@ export default class ComposeBox extends PureComponent<Props, State> {
           onTopicAutocomplete={this.handleTopicChange}
         />
         <View style={styles.composeBox} onLayout={this.handleLayoutChange}>
-          <View style={componentStyles.bottom}>
-            <ComposeMenuContainer
-              narrow={narrow}
-              expanded={isMenuExpanded}
-              onExpandContract={this.handleComposeMenuToggle}
-            />
-          </View>
           <View style={componentStyles.composeText}>
             {canSelectTopic && (
-              <Input
-                style={styles.topicInput}
-                underlineColorAndroid="transparent"
-                placeholder="Topic"
-                selectTextOnFocus
-                textInputRef={component => {
-                  this.topicInput = component;
-                }}
-                onChangeText={this.handleTopicChange}
-                onFocus={this.handleTopicFocus}
-                onBlur={this.handleTopicBlur}
-                value={topic}
-              />
+              <View style={componentStyles.composeOptions}>
+                <ComposeMenuContainer
+                  narrow={narrow}
+                  expanded={isMenuExpanded}
+                  onExpandContract={this.handleComposeMenuToggle}
+                />
+                <Input
+                  style={styles.topicInput}
+                  underlineColorAndroid="transparent"
+                  placeholder="Topic"
+                  selectTextOnFocus
+                  textInputRef={component => {
+                    this.topicInput = component;
+                  }}
+                  onChangeText={this.handleTopicChange}
+                  onFocus={this.handleTopicFocus}
+                  onBlur={this.handleTopicBlur}
+                  value={topic}
+                />
+              </View>
             )}
             <MultilineInput
               style={styles.composeTextInput}

--- a/src/styles/theme.js
+++ b/src/styles/theme.js
@@ -1,6 +1,6 @@
 /* @flow */
 import { Platform } from 'react-native';
-import { BORDER_COLOR, BRAND_COLOR, CONTROL_SIZE, NAVBAR_SIZE, SPACING, HALF_SPACING } from './';
+import { BORDER_COLOR, BRAND_COLOR, CONTROL_SIZE, NAVBAR_SIZE, SPACING, HALF_SPACING, HALF_COLOR } from './';
 import utilityStyles from './utilityStyles';
 
 type Props = {
@@ -49,21 +49,22 @@ export default ({ color, backgroundColor, borderColor, cardColor, dividerColor }
     width: 1,
   },
   topicInput: {
-    borderWidth: 0,
+    borderWidth: 1,
     borderRadius: 5,
+    borderColor,
     backgroundColor,
     marginTop: 5,
     padding: 5,
+    flex: 1,
   },
   composeTextInput: {
-    borderWidth: 0,
-    borderRadius: 5,
     backgroundColor,
     color,
     fontSize: 15,
     marginTop: 5,
     marginBottom: 5,
     padding: 5,
+    paddingLeft: SPACING,
   },
   background: {
     backgroundColor,
@@ -198,7 +199,7 @@ export default ({ color, backgroundColor, borderColor, cardColor, dividerColor }
   },
   composeBox: {
     flexDirection: 'row',
-    backgroundColor: 'rgba(127, 127, 127, 0.1)',
+    borderTopWidth: 1,
     borderTopColor: borderColor,
   },
   subheader: {


### PR DESCRIPTION
Trying out a new design for the Input, the objective is to increase the comfort of a user to write longer messages and paragraphs.

This maximizes the width of the Input and removes it's visible borders. The compose menu is moved to the top row alongside topic input.

Before:
![composetext_before](https://user-images.githubusercontent.com/22353313/39537063-09bd2a4e-4e56-11e8-9940-ba9437823563.png)

After:
![composetext_after](https://user-images.githubusercontent.com/22353313/39537067-0d7e034c-4e56-11e8-915c-aac4291e0cdb.png)
