### PR TITLE
webview: Send a 'ready' message from webview js

### DIFF
--- a/src/webview/js/generatedEs3.js
+++ b/src/webview/js/generatedEs3.js
@@ -337,4 +337,13 @@ documentBody.addEventListener('touchmove', function (e) {
 documentBody.addEventListener('drag', function (e) {
   lastTouchEventTimestamp = 0;
 });
+
+var waitForBridge = function waitForBridge() {
+  if (window.postMessage.length === 1) {
+    sendMessage({ type: 'ready' });
+  } else {
+    setTimeout(waitForBridge, 10);
+  }
+};
+waitForBridge();
 `;

--- a/src/webview/js/js.js
+++ b/src/webview/js/js.js
@@ -338,3 +338,12 @@ documentBody.addEventListener('touchmove', e => {
 documentBody.addEventListener('drag', e => {
   lastTouchEventTimestamp = 0;
 });
+
+const waitForBridge = () => {
+  if (window.postMessage.length === 1) {
+    sendMessage({ type: 'ready' });
+  } else {
+    setTimeout(waitForBridge, 10);
+  }
+};
+waitForBridge();

--- a/src/webview/webViewEventHandlers.js
+++ b/src/webview/webViewEventHandlers.js
@@ -7,6 +7,10 @@ import { logErrorRemotely } from '../utils/logging';
 import { filterUnreadMessagesInRange } from '../utils/unread';
 import { parseNarrowString } from '../utils/narrow';
 
+type MessageListEventReady = {
+  type: 'ready',
+};
+
 type MessageListEventScroll = {
   type: 'scroll',
   innerHeight: number,
@@ -70,6 +74,7 @@ type MessageListEventError = {
 };
 
 export type MessageListEvent =
+  | MessageListEventReady
   | MessageListEventScroll
   | MessageListEventAvatar
   | MessageListEventNarrow
@@ -88,6 +93,10 @@ type Props = {
   messages: Message[],
   narrow: Narrow,
   onLongPress: (messageId: number, target: string) => void,
+};
+
+export const handleReady = (props: Props, event: MessageListEventReady) => {
+  console.log('Ready to send events'); // eslint-disable-line
 };
 
 export const handleScroll = (props: Props, event: MessageListEventScroll) => {

--- a/src/webview/webViewEventHandlers.js
+++ b/src/webview/webViewEventHandlers.js
@@ -95,10 +95,6 @@ type Props = {
   onLongPress: (messageId: number, target: string) => void,
 };
 
-export const handleReady = (props: Props, event: MessageListEventReady) => {
-  console.log('Ready to send events'); // eslint-disable-line
-};
-
 export const handleScroll = (props: Props, event: MessageListEventScroll) => {
   const { innerHeight, offsetHeight, scrollY, startMessageId, endMessageId } = event;
   const { actions, narrow } = props;

--- a/src/webview/webViewHandleUpdates.js
+++ b/src/webview/webViewHandleUpdates.js
@@ -77,12 +77,3 @@ export const getInputMessages = (prevProps: Props, nextProps: Props): WebviewInp
 
   return messages;
 };
-
-export default (
-  prevProps: Props,
-  nextProps: Props,
-  sendMessages: (msg: WebviewInputMessage[]) => void,
-) => {
-  const messages = getInputMessages(prevProps, nextProps);
-  sendMessages(messages);
-};


### PR DESCRIPTION
We use postMessage to send messages to and from the webview.
Custom versions of that standard functions are injected by the
WebView component.

Sometimes, on Android (and seemingly not on iOS) it takes some time
for this custom JS to get injected, and we send our initial message
to the webview before it is ready. Thus the first message is not
delivered and often results in the 'infamous loading messages bug'

By checking for the function parameter count (window.postMessage.length === 1)
we can differentiate if the custom function is injected already or not.
Then we send a custom message back to our component.