### PR TITLE
refactor: Move message.length check inside sendMessages

### DIFF
--- a/src/webview/MessageListWeb.js
+++ b/src/webview/MessageListWeb.js
@@ -23,9 +23,9 @@ export default class MessageListWeb extends Component<Props> {
     console.error(event); // eslint-disable-line
   };
 
-  sendMessages = (msg: WebviewInputMessage[]): void => {
-    if (this.webview) {
-      this.webview.postMessage(JSON.stringify(msg), '*');
+  sendMessages = (messages: WebviewInputMessage[]): void => {
+    if (this.webview && messages.length > 0) {
+      this.webview.postMessage(JSON.stringify(messages), '*');
     }
   };
 

--- a/src/webview/webViewHandleUpdates.js
+++ b/src/webview/webViewHandleUpdates.js
@@ -84,8 +84,5 @@ export default (
   sendMessages: (msg: WebviewInputMessage[]) => void,
 ) => {
   const messages = getInputMessages(prevProps, nextProps);
-
-  if (messages.length > 0) {
-    sendMessages(messages);
-  }
+  sendMessages(messages);
 };


### PR DESCRIPTION
When the list of messages to send are an empty list we do not send
anything. Move this check from webViewHandleUpdates to the function
sendMessages so we can have the check run if called from elsewhere.