### PR TITLE
edit-stream-screen: Pass stream id from navigation props.

### DIFF
--- a/src/streams/EditStreamContainer.js
+++ b/src/streams/EditStreamContainer.js
@@ -1,11 +1,11 @@
 /* @flow */
 import connectWithActions from '../connectWithActions';
-import { getEditStreamScreenParams, getOwnEmail } from '../selectors';
+import { getOwnEmail } from '../selectors';
 import { getStreamEditInitialValues } from '../subscriptions/subscriptionSelectors';
 import EditStreamCard from './EditStreamCard';
 
-export default connectWithActions(state => ({
+export default connectWithActions((state, props) => ({
   ownEmail: getOwnEmail(state),
-  streamId: getEditStreamScreenParams(state).streamId,
-  initialValues: getStreamEditInitialValues(state),
+  streamId: props.streamId || -1,
+  initialValues: getStreamEditInitialValues(props.streamId)(state),
 }))(EditStreamCard);

--- a/src/streams/EditStreamScreen.js
+++ b/src/streams/EditStreamScreen.js
@@ -1,14 +1,25 @@
 /* @flow */
 import React, { PureComponent } from 'react';
+import type { NavigationScreenProp } from 'react-navigation';
 
 import { Screen } from '../common';
 import EditStreamContainer from './EditStreamContainer';
 
-export default class EditStreamScreen extends PureComponent<{}> {
+type Props = {
+  navigation: NavigationScreenProp<*> & {
+    state: {
+      params: {
+        streamId: number,
+      },
+    },
+  },
+};
+
+export default class EditStreamScreen extends PureComponent<Props> {
   render() {
     return (
       <Screen title="Edit stream" padding>
-        <EditStreamContainer />
+        <EditStreamContainer streamId={this.props.navigation.state.params.streamId} />
       </Screen>
     );
   }

--- a/src/subscriptions/subscriptionSelectors.js
+++ b/src/subscriptions/subscriptionSelectors.js
@@ -5,7 +5,6 @@ import type { Narrow } from '../types';
 import { NULL_STREAM } from '../nullObjects';
 import { isStreamOrTopicNarrow } from '../utils/narrow';
 import { getSubscriptions, getStreams } from '../directSelectors';
-import { getEditStreamScreenParams } from '../baseSelectors';
 
 export const getStreamsById = createSelector(getStreams, streams =>
   streams.reduce((streamsById, stream) => {
@@ -40,7 +39,8 @@ export const getSubscribedStreams = createSelector(
     })),
 );
 
-export const getStreamEditInitialValues = createSelector(
-  [getStreams, getEditStreamScreenParams],
-  (streams, params) => streams.find(x => x.stream_id === params.streamId) || NULL_STREAM,
-);
+export const getStreamEditInitialValues = (streamId: number) =>
+  createSelector(
+    [getStreams],
+    streams => streams.find(x => x.stream_id === streamId) || NULL_STREAM,
+  );


### PR DESCRIPTION
Before it was taken from getCurrentRouteParams, which changes
on screen push/pop resulting in redundant repaints.