### PR TITLE
Improve topic screen.

### DIFF
--- a/src/__tests__/baseSelectors-test.js
+++ b/src/__tests__/baseSelectors-test.js
@@ -3,7 +3,6 @@ import deepFreeze from 'deep-freeze';
 import {
   getCurrentRoute,
   getCurrentRouteParams,
-  getTopicListScreenParams,
   getAccountDetailsScreenParams,
   getEditStreamScreenParams,
   getChatScreenParams,
@@ -56,21 +55,6 @@ describe('getCurrentRouteParams', () => {
     const actualResult = getCurrentRouteParams(state);
 
     expect(actualResult).toEqual(expectedResult);
-  });
-});
-
-describe('getTopicListScreenParams', () => {
-  test('even when no params are passed do not return "undefined"', () => {
-    const state = deepFreeze({
-      nav: {
-        index: 0,
-        routes: [{ routeName: 'topics' }],
-      },
-    });
-
-    const actualResult = getTopicListScreenParams(state);
-
-    expect(actualResult).toBeDefined();
   });
 });
 

--- a/src/baseSelectors.js
+++ b/src/baseSelectors.js
@@ -20,11 +20,6 @@ export const getCurrentRouteParams = createSelector(
   (routes, index) => routes && routes[index] && routes[index].params,
 );
 
-export const getTopicListScreenParams = createSelector(
-  getCurrentRouteParams,
-  params => params || { streamId: -1 },
-);
-
 export const getAccountDetailsScreenParams = createSelector(
   getCurrentRouteParams,
   params => params || { email: '' },

--- a/src/topics/TopicListScreen.js
+++ b/src/topics/TopicListScreen.js
@@ -2,7 +2,7 @@
 import React, { PureComponent } from 'react';
 
 import type { Actions, Stream, TopicExtended } from '../types';
-import connectWithActions from '../connectWithActions';
+import { connectWithActionsPreserveOnBack } from '../connectWithActions';
 import { Screen } from '../common';
 import { topicNarrow } from '../utils/narrow';
 import { getTopicsInStream } from '../selectors';
@@ -52,7 +52,7 @@ class TopicListScreen extends PureComponent<Props, State> {
   }
 }
 
-export default connectWithActions((state, props) => ({
+export default connectWithActionsPreserveOnBack((state, props) => ({
   stream: getStreamEditInitialValues(state),
   topics: getTopicsInStream(props.navigation.state.params.streamId)(state),
 }))(TopicListScreen);

--- a/src/topics/TopicListScreen.js
+++ b/src/topics/TopicListScreen.js
@@ -5,7 +5,7 @@ import type { Actions, Stream, TopicExtended } from '../types';
 import connectWithActions from '../connectWithActions';
 import { Screen } from '../common';
 import { topicNarrow } from '../utils/narrow';
-import { getTopicsInScreen } from '../selectors';
+import { getTopicsInStream } from '../selectors';
 import { getStreamEditInitialValues } from '../subscriptions/subscriptionSelectors';
 import TopicList from './TopicList';
 
@@ -52,7 +52,7 @@ class TopicListScreen extends PureComponent<Props, State> {
   }
 }
 
-export default connectWithActions(state => ({
+export default connectWithActions((state, props) => ({
   stream: getStreamEditInitialValues(state),
-  topics: getTopicsInScreen(state),
+  topics: getTopicsInStream(props.navigation.state.params.streamId)(state),
 }))(TopicListScreen);

--- a/src/topics/__tests__/topicsSelectors-test.js
+++ b/src/topics/__tests__/topicsSelectors-test.js
@@ -1,6 +1,6 @@
 import deepFreeze from 'deep-freeze';
 
-import { getTopicsForNarrow, getLastMessageTopic, getTopicsInScreen } from '../topicSelectors';
+import { getTopicsForNarrow, getLastMessageTopic, getTopicsInStream } from '../topicSelectors';
 import { homeNarrow, streamNarrow } from '../../utils/narrow';
 
 describe('getTopicsForNarrow', () => {
@@ -51,18 +51,9 @@ describe('getLastMessageTopic', () => {
   });
 });
 
-describe('getTopicsInScreen', () => {
+describe('getTopicsInStream', () => {
   test('when no topics loaded for given stream return undefined', () => {
     const state = deepFreeze({
-      nav: {
-        index: 0,
-        routes: [
-          {
-            routeName: 'topics',
-            params: { streamId: 123 },
-          },
-        ],
-      },
       streams: [],
       topics: {},
       mute: [],
@@ -71,22 +62,13 @@ describe('getTopicsInScreen', () => {
       },
     });
 
-    const topics = getTopicsInScreen(state);
+    const topics = getTopicsInStream(123)(state);
 
     expect(topics).toEqual(undefined);
   });
 
   test('when topics loaded for given stream return them', () => {
     const state = deepFreeze({
-      nav: {
-        index: 0,
-        routes: [
-          {
-            routeName: 'topics',
-            params: { streamId: 123 },
-          },
-        ],
-      },
       streams: [],
       topics: {
         123: [{ name: 'topic', max_id: 456 }],
@@ -97,22 +79,13 @@ describe('getTopicsInScreen', () => {
       },
     });
 
-    const topics = getTopicsInScreen(state);
+    const topics = getTopicsInStream(123)(state);
 
     expect(topics).toEqual([{ name: 'topic', max_id: 456, isMuted: false, unreadCount: 0 }]);
   });
 
   test('TODO', () => {
     const state = deepFreeze({
-      nav: {
-        index: 0,
-        routes: [
-          {
-            routeName: 'topics',
-            params: { streamId: 1 },
-          },
-        ],
-      },
       streams: [{ stream_id: 1, name: 'stream 1' }],
       topics: {
         1: [
@@ -147,7 +120,7 @@ describe('getTopicsInScreen', () => {
       { name: 'topic 5', max_id: 9, isMuted: false, unreadCount: 0 },
     ];
 
-    const topics = getTopicsInScreen(state);
+    const topics = getTopicsInStream(1)(state);
 
     expect(topics).toEqual(expected);
   });

--- a/src/topics/topicSelectors.js
+++ b/src/topics/topicSelectors.js
@@ -3,7 +3,6 @@ import { createSelector } from 'reselect';
 
 import type { MuteState, Narrow, StreamsState, StreamUnreadItem, TopicsState } from '../types';
 import { getMute, getStreams, getTopics, getUnreadStreams } from '../directSelectors';
-import { getTopicListScreenParams } from '../baseSelectors';
 import { getShownMessagesForNarrow } from '../chat/chatSelectors';
 import { getStreamsById } from '../subscriptions/subscriptionSelectors';
 import { NULL_ARRAY } from '../nullObjects';
@@ -23,41 +22,35 @@ export const getTopicsForNarrow = (narrow: Narrow) =>
     return topics[stream.stream_id].map(x => x.name);
   });
 
-export const getTopicsInScreen = createSelector(
-  getTopicListScreenParams,
-  getTopics,
-  getMute,
-  getStreamsById,
-  getUnreadStreams,
-  (
-    params,
-    topics: TopicsState,
-    mute: MuteState,
-    streamsById,
-    unreadStreams: StreamUnreadItem[],
-  ) => {
-    const topicList = topics[params.streamId];
+export const getTopicsInStream = (streamId: number) =>
+  createSelector(
+    getTopics,
+    getMute,
+    getStreamsById,
+    getUnreadStreams,
+    (topics: TopicsState, mute: MuteState, streamsById, unreadStreams: StreamUnreadItem[]) => {
+      const topicList = topics[streamId];
 
-    if (!topicList) {
-      return undefined;
-    }
+      if (!topicList) {
+        return undefined;
+      }
 
-    const stream = streamsById[params.streamId];
+      const stream = streamsById[streamId];
 
-    return topicList.map(({ name, max_id }) => {
-      const isMuted = !!mute.find(x => x[0] === stream.name && x[1] === name);
-      const unreadStream = unreadStreams.find(
-        x => x.stream_id === stream.stream_id && x.topic === name,
-      );
-      return {
-        name,
-        max_id,
-        isMuted,
-        unreadCount: unreadStream ? unreadStream.unread_message_ids.length : 0,
-      };
-    });
-  },
-);
+      return topicList.map(({ name, max_id }) => {
+        const isMuted = !!mute.find(x => x[0] === stream.name && x[1] === name);
+        const unreadStream = unreadStreams.find(
+          x => x.stream_id === stream.stream_id && x.topic === name,
+        );
+        return {
+          name,
+          max_id,
+          isMuted,
+          unreadCount: unreadStream ? unreadStream.unread_message_ids.length : 0,
+        };
+      });
+    },
+  );
 
 export const getLastMessageTopic = (narrow: Narrow) =>
   createSelector(


### PR DESCRIPTION

* topic-screen: Pass streamId from props to selector.  08ce417
Before streamId was taken from getCurrentRouteParams, as on push/pop
current route params changes, resulting in re-render of screen.
Which is redundant.

* topic-screen: Connect to store with connectWithActionsPreserveOnBack. eae118f
So that it doesn't repaints when nav isTransitioning or going back.