### PR TITLE
account-details: Pass email from props to selector.

### DIFF
--- a/src/__tests__/baseSelectors-test.js
+++ b/src/__tests__/baseSelectors-test.js
@@ -4,7 +4,6 @@ import {
   getCurrentRoute,
   getCurrentRouteParams,
   getTopicListScreenParams,
-  getAccountDetailsScreenParams,
   getEditStreamScreenParams,
   getChatScreenParams,
   getTopMostNarrow,
@@ -69,21 +68,6 @@ describe('getTopicListScreenParams', () => {
     });
 
     const actualResult = getTopicListScreenParams(state);
-
-    expect(actualResult).toBeDefined();
-  });
-});
-
-describe('getAccountDetailsScreenParams', () => {
-  test('even when no params are passed do not return "undefined"', () => {
-    const state = deepFreeze({
-      nav: {
-        index: 0,
-        routes: [{ routeName: 'account-details' }],
-      },
-    });
-
-    const actualResult = getAccountDetailsScreenParams(state);
 
     expect(actualResult).toBeDefined();
   });

--- a/src/account-info/AccountDetailsScreen.js
+++ b/src/account-info/AccountDetailsScreen.js
@@ -41,9 +41,9 @@ class AccountDetailsScreen extends PureComponent<Props> {
   }
 }
 
-export default connectWithActionsPreserveOnBack(state => ({
+export default connectWithActionsPreserveOnBack((state, props) => ({
   auth: getAuth(state),
-  user: getAccountDetailsUser(state),
+  user: getAccountDetailsUser(props.navigation.state.params.email)(state),
   orientation: getSession(state).orientation,
   presence: getPresence(state),
 }))(AccountDetailsScreen);

--- a/src/baseSelectors.js
+++ b/src/baseSelectors.js
@@ -25,11 +25,6 @@ export const getTopicListScreenParams = createSelector(
   params => params || { streamId: -1 },
 );
 
-export const getAccountDetailsScreenParams = createSelector(
-  getCurrentRouteParams,
-  params => params || { email: '' },
-);
-
 export const getEditStreamScreenParams = createSelector(
   getCurrentRouteParams,
   params => params || { streamId: -1 },

--- a/src/users/__tests__/userSelectors-test.js
+++ b/src/users/__tests__/userSelectors-test.js
@@ -10,32 +10,29 @@ import {
   getUsersById,
   getUsersSansMe,
 } from '../userSelectors';
+import { NULL_USER } from '../../nullObjects';
 
 describe('getAccountDetailsUser', () => {
+  test('if email is undefined return NULL_USER', () => {
+    const state = deepFreeze({
+      users: [],
+    });
+    expect(getAccountDetailsUser(undefined)(state)).toEqual(NULL_USER);
+  });
+
   test('return user for the account details screen', () => {
     const state = deepFreeze({
-      nav: {
-        index: 1,
-        routes: [{ routeName: 'first' }, { routeName: 'second', params: { email: 'b@a.com' } }],
-      },
       users: [{ firstName: 'a', email: 'a@a.com' }, { firstName: 'b', email: 'b@a.com' }],
     });
     const expectedUser = { firstName: 'b', email: 'b@a.com' };
 
-    const actualUser = getAccountDetailsUser(state);
+    const actualUser = getAccountDetailsUser('b@a.com')(state);
 
     expect(actualUser).toEqual(expectedUser);
   });
 
   test('if user does not exist return a user with the same email and no details', () => {
     const state = deepFreeze({
-      nav: {
-        index: 1,
-        routes: [
-          { routeName: 'first', params: { email: 'a@a.com' } },
-          { routeName: 'second', params: { email: 'b@a.com' } },
-        ],
-      },
       users: [],
     });
     const expectedUser = {
@@ -49,7 +46,7 @@ describe('getAccountDetailsUser', () => {
       is_bot: false,
     };
 
-    const actualUser = getAccountDetailsUser(state);
+    const actualUser = getAccountDetailsUser('b@a.com')(state);
 
     expect(actualUser).toEqual(expectedUser);
   });

--- a/src/users/userSelectors.js
+++ b/src/users/userSelectors.js
@@ -3,26 +3,23 @@ import { createSelector } from 'reselect';
 
 import { NULL_USER } from '../nullObjects';
 import { getPresence, getUsers } from '../directSelectors';
-import { getAccountDetailsScreenParams } from '../baseSelectors';
 import { getOwnEmail } from '../account/accountSelectors';
 import { getUserByEmail } from './userHelpers';
 
-export const getAccountDetailsUser = createSelector(
-  [getUsers, getAccountDetailsScreenParams],
-  (allUsers, params) => {
-    if (!params.email) {
+export const getAccountDetailsUser = (email: string) =>
+  createSelector([getUsers], allUsers => {
+    if (!email) {
       return NULL_USER;
     }
 
     return (
-      allUsers.find(x => x.email === params.email) || {
+      allUsers.find(x => x.email === email) || {
         ...NULL_USER,
-        email: params.email,
-        full_name: params.email,
+        email,
+        full_name: email,
       }
     );
-  },
-);
+  });
 
 export const getSelfUserDetail = createSelector(getUsers, getOwnEmail, (users, ownEmail) =>
   getUserByEmail(users, ownEmail),


### PR DESCRIPTION
Before email was taken from getCurrentRouteParams, as on push/pop
current route params changes, resulting in re-render of screen.
Which is redundant.

Fix: sudden change in avatar from null user gavatar to actual avatar
on navigating back to account-details screen.