### PR TITLE
WIP: Added WelcomeScreen and WelcomeHelpScreen to help new users

### DIFF
--- a/src/actionTypes.js
+++ b/src/actionTypes.js
@@ -656,6 +656,8 @@ export type Actions = {
   navigateToCreateStream: NavigateActionCreator,
   navigateToEditStream: NavigateToStreamActionCreator,
   navigateToNotifications: NavigateActionCreator,
+  navigateToWelcomeHelp: NavigateActionCreator,
+  navigateToWelcomeScreen: NavigateActionCreator,
 
   // accountActions
   switchAccount: AccountSwitchActionCreator,

--- a/src/nav/AppNavigator.js
+++ b/src/nav/AppNavigator.js
@@ -29,6 +29,8 @@ import CreateStreamScreen from '../streams/CreateStreamScreen';
 import EditStreamScreen from '../streams/EditStreamScreen';
 import NotificationsScreen from '../settings/NotificationsScreen';
 import TopicListScreen from '../topics/TopicListScreen';
+import WelcomeHelpScreen from '../start/WelcomeHelpScreen';
+import WelcomeScreen from '../start/WelcomeScreen';
 
 export default StackNavigator(
   {
@@ -60,6 +62,8 @@ export default StackNavigator(
     topics: { screen: TopicListScreen },
     notifDiag: { screen: NotificationDiagScreen },
     notifications: { screen: NotificationsScreen },
+    welcomehelp: { screen: WelcomeHelpScreen },
+    welcomescreen: { screen: WelcomeScreen },
   },
   {
     initialRouteName: 'main',

--- a/src/nav/__tests__/navSelectors-test.js
+++ b/src/nav/__tests__/navSelectors-test.js
@@ -56,7 +56,7 @@ describe('getInitialNavState', () => {
     expect(nav.routes[1].routeName).toEqual('route2');
   });
 
-  test('if not logged in, and no previous accounts, show realm screen', () => {
+  test('if not logged in, and no previous accounts, show welcome screen', () => {
     const state = deepFreeze({
       accounts: [],
       users: [],
@@ -68,7 +68,7 @@ describe('getInitialNavState', () => {
     const nav = getInitialNavState(state);
 
     expect(nav.routes.length).toBe(1);
-    expect(nav.routes[0].routeName).toEqual('realm');
+    expect(nav.routes[0].routeName).toEqual('welcomescreen');
   });
 
   test('if more than one account and no active account, display account list', () => {
@@ -86,7 +86,7 @@ describe('getInitialNavState', () => {
     expect(nav.routes[0].routeName).toEqual('account');
   });
 
-  test('when only a single account and no other properties, redirect to realm', () => {
+  test('when only a single account and no other properties, redirect to welcome screen', () => {
     const state = deepFreeze({
       accounts: [{ realm: 'https://example.com' }],
       users: [],
@@ -98,7 +98,7 @@ describe('getInitialNavState', () => {
     const nav = getInitialNavState(state);
 
     expect(nav.routes.length).toBe(1);
-    expect(nav.routes[0].routeName).toEqual('realm');
+    expect(nav.routes[0].routeName).toEqual('welcomescreen');
   });
 
   test('when multiple accounts and default one has realm and email, show account list', () => {
@@ -119,7 +119,7 @@ describe('getInitialNavState', () => {
     expect(nav.routes[0].routeName).toEqual('account');
   });
 
-  test('when default account has server and email set, redirect to realm screen', () => {
+  test('when default account has server and email set, redirect to welcome screen', () => {
     const state = deepFreeze({
       accounts: [{ realm: 'https://example.com', email: 'johndoe@example.com' }],
       users: [],
@@ -131,7 +131,7 @@ describe('getInitialNavState', () => {
     const nav = getInitialNavState(state);
 
     expect(nav.routes.length).toBe(1);
-    expect(nav.routes[0].routeName).toEqual('realm');
+    expect(nav.routes[0].routeName).toEqual('welcomescreen');
   });
 });
 

--- a/src/nav/navActions.js
+++ b/src/nav/navActions.js
@@ -58,6 +58,12 @@ export const navigateToCreateGroup = (): NavigateAction =>
 export const navigateToDiagnostics = (): NavigateAction =>
   NavigationActions.navigate({ routeName: 'diagnostics' });
 
+export const navigateToWelcomeHelp = (): NavigateAction =>
+  NavigationActions.navigate({ routeName: 'welcomehelp' });
+
+export const navigateToWelcomeScreen = (): NavigateAction =>
+  NavigationActions.navigate({ routeName: 'welcomescreen' });
+
 export const navigateToVariables = (): NavigateAction =>
   NavigationActions.navigate({ routeName: 'variables' });
 

--- a/src/nav/navSelectors.js
+++ b/src/nav/navSelectors.js
@@ -76,7 +76,7 @@ export const getInitialNavState = createSelector(
   getUsersById,
   (nav, accounts, auth, usersById) => {
     if (!auth.apiKey) {
-      return getStateForRoute(accounts && accounts.length > 1 ? 'account' : 'realm');
+      return getStateForRoute(accounts && accounts.length > 1 ? 'account' : 'welcomescreen');
     }
 
     const state =

--- a/src/start/WelcomeHelpScreen.js
+++ b/src/start/WelcomeHelpScreen.js
@@ -1,0 +1,20 @@
+/* @flow */
+import React, { PureComponent } from 'react';
+
+import { Screen, RawLabel, Centerer } from '../common';
+
+export default class WelcomeHelpScreen extends PureComponent<{}> {
+  render() {
+    return (
+      <Screen title="Help" padding>
+        <Centerer>
+          <RawLabel
+            text={
+              "Zulip combines the immediacy of Slack with an email threading model. With Zulip, you can catch up on important conversations while ignoring irrelevant ones.\n\nNew to Zulip? You'll need to first create an account from your computer.\n\nIf you're not sure where to start, go to zulipchat.com from your web browser.\n\nHope to see you back here soon!"
+            }
+          />
+        </Centerer>
+      </Screen>
+    );
+  }
+}

--- a/src/start/WelcomeScreen.js
+++ b/src/start/WelcomeScreen.js
@@ -1,0 +1,44 @@
+/* @flow */
+import React, { PureComponent } from 'react';
+import { View, StyleSheet } from 'react-native';
+
+import connectWithActions from '../connectWithActions';
+import type { Actions } from '../types';
+import { Screen, Centerer, ZulipButton } from '../common';
+
+const componentStyles = StyleSheet.create({
+  divider: {
+    height: 20,
+  },
+});
+
+type Props = {
+  actions: Actions,
+};
+
+class WelcomeScreen extends PureComponent<Props> {
+  props: Props;
+
+  render() {
+    const { actions } = this.props;
+    return (
+      <Screen title="Welcome!" centerContent padding>
+        <Centerer>
+          <ZulipButton
+            secondary
+            text="I have a Zulip account"
+            onPress={() => actions.navigateToAddNewAccount('')}
+          />
+          <View style={componentStyles.divider} />
+          <ZulipButton
+            secondary
+            text="I am new to Zulip"
+            onPress={() => actions.navigateToWelcomeHelp()}
+          />
+        </Centerer>
+      </Screen>
+    );
+  }
+}
+
+export default connectWithActions(props => ({}))(WelcomeScreen);


### PR DESCRIPTION
Now the app goes to the `WelcomeHelpScreen` when the user has no account and has not logged in. 

The screen presents the user with two options as shown below:
![screenshot_20180508-211123](https://user-images.githubusercontent.com/22353313/39767762-1f50e798-5305-11e8-92dd-bd039202f5cd.png)

"I have a Zulip account" goes to the `RealmScreen`. "I am new to Zulip" goes to a dedicated help screen:
![screenshot_20180508-211118](https://user-images.githubusercontent.com/22353313/39767765-21a30760-5305-11e8-852d-d180f1718a92.png)

I've modified the tests so none fails, but it's probably not the right way to do things. Need to understand why some tests that seemingly shouldn't go to the realm screen seem to be going to it.