### PR TITLE
Add unread and muted information to getTopicsInScreen

### DIFF
--- a/src/topics/__tests__/topicsSelectors-test.js
+++ b/src/topics/__tests__/topicsSelectors-test.js
@@ -63,7 +63,12 @@ describe('getTopicsInScreen', () => {
           },
         ],
       },
+      streams: [],
       topics: {},
+      mute: [],
+      unread: {
+        streams: [],
+      },
     });
 
     const topics = getTopicsInScreen(state);
@@ -82,13 +87,68 @@ describe('getTopicsInScreen', () => {
           },
         ],
       },
+      streams: [],
       topics: {
         123: [{ name: 'topic', max_id: 456 }],
+      },
+      mute: [],
+      unread: {
+        streams: [],
       },
     });
 
     const topics = getTopicsInScreen(state);
 
-    expect(topics).toEqual([{ name: 'topic', max_id: 456 }]);
+    expect(topics).toEqual([{ name: 'topic', max_id: 456, isMuted: false, unreadCount: 0 }]);
+  });
+
+  test('TODO', () => {
+    const state = deepFreeze({
+      nav: {
+        index: 0,
+        routes: [
+          {
+            routeName: 'topics',
+            params: { streamId: 1 },
+          },
+        ],
+      },
+      streams: [{ stream_id: 1, name: 'stream 1' }],
+      topics: {
+        1: [
+          { name: 'topic 1', max_id: 5 },
+          { name: 'topic 2', max_id: 6 },
+          { name: 'topic 3', max_id: 7 },
+          { name: 'topic 4', max_id: 8 },
+          { name: 'topic 5', max_id: 9 },
+        ],
+      },
+      mute: [['stream 1', 'topic 1'], ['stream 1', 'topic 3'], ['stream 2', 'topic 2']],
+      unread: {
+        streams: [
+          {
+            stream_id: 1,
+            topic: 'topic 2',
+            unread_message_ids: [1, 5, 6],
+          },
+          {
+            stream_id: 1,
+            topic: 'topic 4',
+            unread_message_ids: [7, 8],
+          },
+        ],
+      },
+    });
+    const expected = [
+      { name: 'topic 1', max_id: 5, isMuted: true, unreadCount: 0 },
+      { name: 'topic 2', max_id: 6, isMuted: false, unreadCount: 3 },
+      { name: 'topic 3', max_id: 7, isMuted: true, unreadCount: 0 },
+      { name: 'topic 4', max_id: 8, isMuted: false, unreadCount: 2 },
+      { name: 'topic 5', max_id: 9, isMuted: false, unreadCount: 0 },
+    ];
+
+    const topics = getTopicsInScreen(state);
+
+    expect(topics).toEqual(expected);
   });
 });


### PR DESCRIPTION
Instead of providing jut the basic topic list to the Topic screen,
get unread data from unreadStreams and isMuted from 'mute' state.