### PR TITLE
test: Relax progressiveTimeout test criteria

### DIFF
--- a/src/utils/__tests__/progressiveTimeout-test.js
+++ b/src/utils/__tests__/progressiveTimeout-test.js
@@ -5,7 +5,7 @@ describe('progressiveTimeout', () => {
     const start = Date.now();
     await progressiveTimeout();
     const duration = Date.now() - start;
-    expect(duration < 100).toBeTruthy();
+    expect(duration < 1000).toBeTruthy();
 
     const start2 = Date.now();
     await progressiveTimeout();


### PR DESCRIPTION
From time to time this test case fails, as it takes more than 100
msecs to run on CI. This change relaxes the check to be 'less than
1sec' and does not change the meaning of the test.