### PR TITLE
flow: Add types for `alert words`

### DIFF
--- a/src/alertWords/alertWordsActions.js
+++ b/src/alertWords/alertWordsActions.js
@@ -1,12 +1,15 @@
 /* @flow */
-import type { Auth, Dispatch } from '../types';
+import type { Dispatch, GetState } from '../types';
 import { getAlertWords } from '../api';
 import { INIT_ALERT_WORDS } from '../actionConstants';
+import { getAuth } from '../selectors';
 
-export const initAlertWords = (alertWords: Object) => ({
+export const initAlertWords = (alertWords: string[]) => ({
   type: INIT_ALERT_WORDS,
   alertWords,
 });
 
-export const fetchAlertWords = (auth: Auth) => async (dispatch: Dispatch) =>
+export const fetchAlertWords = () => async (dispatch: Dispatch, getState: GetState) => {
+  const auth = getAuth(getState());
   dispatch(initAlertWords(await getAlertWords(auth)));
+};

--- a/src/api/alert_words/getAlertWords.js
+++ b/src/api/alert_words/getAlertWords.js
@@ -2,4 +2,5 @@
 import type { Auth } from '../../types';
 import { apiGet } from '../apiFetch';
 
-export default async (auth: Auth) => apiGet(auth, 'users/me/alert_words', res => res.alert_words);
+export default async (auth: Auth): Promise<string[]> =>
+  apiGet(auth, 'users/me/alert_words', res => res.alert_words);


### PR DESCRIPTION
Also, do not require an auth parameter for the `initAlertWords` call.