### PR TITLE
flow: Add types for API focusPing (presence POST)

### DIFF
--- a/src/api/apiTypes.js
+++ b/src/api/apiTypes.js
@@ -1,4 +1,16 @@
 /* @flow */
+import type { PresenceState } from '../types';
+
+export type ApiResponse = {
+  result: string,
+  msg: string,
+};
+
+export type ApiResponseWithPresence = ApiResponse & {
+  server_timestamp: number,
+  presences: PresenceState,
+};
+
 export type ApiUser = {
   avatar_url: string,
   bot_type?: number,

--- a/src/api/focusPing.js
+++ b/src/api/focusPing.js
@@ -1,12 +1,12 @@
 /* @flow */
-import type { PresenceState, Auth } from '../types';
+import type { ApiResponseWithPresence, Auth } from '../types';
 import { apiPost } from './apiFetch';
 
 export default (
   auth: Auth,
   hasFocus: boolean = true,
   newUserInput: boolean = false,
-): PresenceState =>
+): Promise<ApiResponseWithPresence> =>
   apiPost(auth, 'users/me/presence', res => res, {
     status: hasFocus ? 'active' : 'idle',
     new_user_input: newUserInput,

--- a/src/types.js
+++ b/src/types.js
@@ -199,11 +199,6 @@ export type NarrowElement = {
 
 export type Narrow = NarrowElement[];
 
-export type ApiResponse = {
-  result: string,
-  msg: string,
-};
-
 export type EditMessage = {
   id: number,
   content: string,


### PR DESCRIPTION
Fixes the previously incorrectly typed call.

This is a special case for types, as usually we return not the
response but a property inside the response. In this case though
we both need the `presence` and `server_timestamp` thus we return
the whole response object.