### PR TITLE
webview: Fix webview exceptions details not sent to Sentry

### DIFF
--- a/src/webview/webViewEventHandlers.js
+++ b/src/webview/webViewEventHandlers.js
@@ -169,5 +169,5 @@ export const handleDebug = (props: Props, event: MessageListEventDebug) => {
 };
 
 export const handleError = (props: Props, event: MessageListEventError) => {
-  logErrorRemotely(new Error(event.details), 'WebView Exception');
+  logErrorRemotely(new Error(JSON.stringify(event.details)), 'WebView Exception');
 };


### PR DESCRIPTION
It seems the thrown Error object expects a string.
With the previous implementation we are getting `[object Object]`
Now we stringify the details so we can receive them.