### PR TITLE
api: Return whole response from post/patch API calls

### DIFF
--- a/src/api/emoji_reactions/emojiReactionAdd.js
+++ b/src/api/emoji_reactions/emojiReactionAdd.js
@@ -9,7 +9,7 @@ export default (
   emojiCode: string,
   emojiName: string,
 ): PresenceState =>
-  apiPost(auth, `messages/${messageId}/reactions`, res => res.presences, {
+  apiPost(auth, `messages/${messageId}/reactions`, res => res, {
     reaction_type: reactionType,
     emoji_code: emojiCode,
     emoji_name: emojiName,

--- a/src/api/emoji_reactions/emojiReactionRemove.js
+++ b/src/api/emoji_reactions/emojiReactionRemove.js
@@ -9,7 +9,7 @@ export default (
   emojiCode: string,
   emojiName: string,
 ): PresenceState =>
-  apiDelete(auth, `messages/${messageId}/reactions`, res => res.presences, {
+  apiDelete(auth, `messages/${messageId}/reactions`, res => res, {
     reaction_type: reactionType,
     emoji_code: emojiCode,
     emoji_name: emojiName,

--- a/src/api/messages/sendMessage.js
+++ b/src/api/messages/sendMessage.js
@@ -13,7 +13,7 @@ export default async (
   localId: number,
   eventQueueId: number,
 ) =>
-  apiPost(auth, 'messages', res => res.messages, {
+  apiPost(auth, 'messages', res => res, {
     type,
     to,
     subject,

--- a/src/api/messages/updateMessage.js
+++ b/src/api/messages/updateMessage.js
@@ -4,4 +4,4 @@ import { apiPatch } from '../apiFetch';
 import { removeEmptyValues } from '../../utils/misc';
 
 export default async (auth: Auth, content: Object, id: number) =>
-  apiPatch(auth, `messages/${id}`, res => res.raw_content, removeEmptyValues(content));
+  apiPatch(auth, `messages/${id}`, res => res, removeEmptyValues(content));

--- a/src/api/notifications/unregisterPush.android.js
+++ b/src/api/notifications/unregisterPush.android.js
@@ -3,4 +3,4 @@ import type { Auth } from '../../types';
 import { apiDelete } from '../apiFetch';
 
 export default (auth: Auth, token: string) =>
-  apiDelete(auth, 'users/me/android_gcm_reg_id', res => res.api_key, { token });
+  apiDelete(auth, 'users/me/android_gcm_reg_id', res => res, { token });

--- a/src/api/notifications/unregisterPush.ios.js
+++ b/src/api/notifications/unregisterPush.ios.js
@@ -3,4 +3,4 @@ import type { Auth } from '../../types';
 import { apiDelete } from '../apiFetch';
 
 export default (auth: Auth, token: string) =>
-  apiDelete(auth, 'users/me/apns_device_token', res => res.api_key, { token });
+  apiDelete(auth, 'users/me/apns_device_token', res => res, { token });


### PR DESCRIPTION
We do not use any of the responses from the post/patch API calls
currently. Yet we have specified (wrongly) some extraction
functions. This is likely caused by copy-pasting, as all of these
are wrong (but since unused not causing bugs).

Return the whole response for all these calls. Upcoming Flow types
for these calls will ensure proper use of these.