### PR TITLE
fix: Show stream is muted correctly

### DIFF
--- a/src/streams/StreamScreen.js
+++ b/src/streams/StreamScreen.js
@@ -70,7 +70,7 @@ class StreamScreen extends PureComponent<Props> {
         />
         <OptionRow
           label="Muted"
-          defaultValue={stream.in_home_view === false}
+          defaultValue={subscription.in_home_view === false}
           onValueChange={this.handleToggleMuteStream}
         />
         <OptionRow


### PR DESCRIPTION
Fixes #2433

We were trying to retrieve the `mute` state from the `stream` value
but it is in the `subscription` one.

This also fixes not being able to change the mute state on muted stream.