### PR TITLE
api: Handle differences in failed response and json

### DIFF
--- a/src/api/apiFetch.js
+++ b/src/api/apiFetch.js
@@ -40,9 +40,18 @@ export const apiCall = async (
     networkActivityStart(isSilent);
     const response = await apiFetch(auth, route, params);
 
+    if (!response.ok) {
+      console.log('Bad response for:', { auth, route, params, response }); // eslint-disable-line
+      const error = new Error('API');
+      // $FlowFixMe
+      error.response = response;
+      // $FlowFixMe
+      throw error;
+    }
+
     const json = await response.json();
 
-    if (!response.ok || json.result !== 'success') {
+    if (json.result !== 'success') {
       console.log('Bad response for:', { auth, route, params, response }); // eslint-disable-line
       const error = new Error('API');
       // $FlowFixMe


### PR DESCRIPTION
Handle differently the cases where the server returns a 'not ok'
response (404, 500 etc.) vs successful response but with an error
code in the json.

This fixes a misleading exception where we try to JSON-parse an
HTML response from server.