### PR TITLE
fix: Correct error validation when logging in with LDAP

### DIFF
--- a/src/start/PasswordAuthScreen.js
+++ b/src/start/PasswordAuthScreen.js
@@ -69,8 +69,10 @@ class PasswordAuthView extends PureComponent<Props, State> {
     const { ldap } = this.props.navigation.state.params;
     const { email, password } = this.state;
 
-    if (!email || (!ldap && !isValidEmailFormat(email))) {
-      this.setState({ error: ldap ? 'Enter a username' : 'Enter a valid email address' });
+    if (ldap && email.length === 0) {
+      this.setState({ error: 'Enter a username' });
+    } else if (!ldap && !isValidEmailFormat(email)) {
+      this.setState({ error: 'Enter a valid email address' });
     } else if (!password) {
       this.setState({ error: 'Enter a password' });
     } else {
@@ -82,7 +84,8 @@ class PasswordAuthView extends PureComponent<Props, State> {
     const { styles } = this.context;
     const { ldap } = this.props.navigation.state.params;
     const { email, password, progress, error } = this.state;
-    const isButtonDisabled = password.length === 0 || !isValidEmailFormat(email);
+    const isButtonDisabled =
+      password.length === 0 || email.length === 0 || (!ldap && !isValidEmailFormat(email));
 
     return (
       <Screen title="Log in" centerContent padding keyboardShouldPersistTaps="always">


### PR DESCRIPTION
Fixes #2488

* make checking for errors in LDAP vs password simpler and less
error-prone
* do not disable 'Log in' button for LDAP if input is not email
(as it will not be, it will be a user name)