### PR TITLE
flow: Define Style type correctly

### DIFF
--- a/src/animation/AnimatedComponent.js
+++ b/src/animation/AnimatedComponent.js
@@ -3,11 +3,11 @@ import React, { PureComponent } from 'react';
 import type { ChildrenArray } from 'react';
 import { Animated, Easing } from 'react-native';
 
-import type { StyleObj } from '../types';
+import type { Style } from '../types';
 
 type Props = {
   children: ChildrenArray<*>,
-  style?: StyleObj,
+  style?: Style,
   visible: boolean,
   property: string,
   useNativeDriver: boolean,

--- a/src/animation/AnimatedRotateComponent.js
+++ b/src/animation/AnimatedRotateComponent.js
@@ -3,10 +3,10 @@ import React, { PureComponent } from 'react';
 import type { ChildrenArray } from 'react';
 import { Animated, Easing } from 'react-native';
 
-import type { StyleObj } from '../types';
+import type { Style } from '../types';
 
 type Props = {
-  style?: StyleObj,
+  style?: Style,
   children: ChildrenArray<*>,
 };
 

--- a/src/animation/AnimatedScaleComponent.js
+++ b/src/animation/AnimatedScaleComponent.js
@@ -3,12 +3,12 @@ import React, { PureComponent } from 'react';
 import type { ChildrenArray } from 'react';
 import { Animated, Easing } from 'react-native';
 
-import type { StyleObj } from '../types';
+import type { Style } from '../types';
 
 type Props = {
   children: ChildrenArray<*>,
   visible: boolean,
-  style?: StyleObj,
+  style?: Style,
 };
 
 type State = {

--- a/src/common/Centerer.js
+++ b/src/common/Centerer.js
@@ -2,7 +2,7 @@
 import React, { PureComponent } from 'react';
 import { StyleSheet, View } from 'react-native';
 
-import type { ChildrenArray, StyleObj } from '../types';
+import type { ChildrenArray, Style } from '../types';
 
 const componentStyles = StyleSheet.create({
   centerer: {
@@ -18,7 +18,7 @@ const componentStyles = StyleSheet.create({
 });
 
 type Props = {
-  style?: StyleObj,
+  style?: Style,
   children: ChildrenArray<*>,
   padding: boolean,
 };

--- a/src/common/ComponentWithOverlay.js
+++ b/src/common/ComponentWithOverlay.js
@@ -3,7 +3,7 @@
 import React, { PureComponent } from 'react';
 import { StyleSheet, View } from 'react-native';
 
-import type { ChildrenArray, StyleObj } from '../types';
+import type { ChildrenArray, Style } from '../types';
 import { BRAND_COLOR } from '../styles';
 import { Touchable } from '../common';
 
@@ -42,7 +42,7 @@ type Props = {
   overlaySize: number,
   overlayColor: string,
   overlayPosition: 'top-right' | 'top-left' | 'bottom-right' | 'bottom-left',
-  style?: StyleObj,
+  style?: Style,
   onPress?: () => void,
 };
 

--- a/src/common/FlexView.js
+++ b/src/common/FlexView.js
@@ -3,10 +3,10 @@ import React, { PureComponent } from 'react';
 import type { ChildrenArray } from 'react';
 import { View } from 'react-native';
 
-import type { StyleObj } from '../types';
+import type { Style } from '../types';
 
 type Props = {
-  style?: StyleObj,
+  style?: Style,
   children: ChildrenArray<*>,
 };
 

--- a/src/common/FloatingActionButton.js
+++ b/src/common/FloatingActionButton.js
@@ -2,7 +2,7 @@
 import React, { PureComponent } from 'react';
 import { StyleSheet, View } from 'react-native';
 
-import type { StyleObj } from '../types';
+import type { Style } from '../types';
 import { BRAND_COLOR } from '../styles';
 import { Touchable } from '../common';
 
@@ -16,7 +16,7 @@ const styles = StyleSheet.create({
 });
 
 type Props = {
-  style?: StyleObj,
+  style?: Style,
   disabled: boolean,
   size: number,
   Icon: any,

--- a/src/common/Input.js
+++ b/src/common/Input.js
@@ -3,12 +3,12 @@ import React, { PureComponent } from 'react';
 import { TextInput } from 'react-native';
 import { FormattedMessage } from 'react-intl';
 
-import type { LocalizableText, StyleObj } from '../types';
+import type { LocalizableText, Style } from '../types';
 import { nullFunction } from '../nullObjects';
 import { HALF_COLOR } from '../styles';
 
 type Props = {
-  style?: StyleObj,
+  style?: Style,
   placeholder: LocalizableText,
   clearButton: boolean,
   onChangeText: (text: string) => void,

--- a/src/common/Label.js
+++ b/src/common/Label.js
@@ -3,11 +3,11 @@ import React, { PureComponent } from 'react';
 import { Text } from 'react-native';
 import { FormattedMessage } from 'react-intl';
 
-import type { LocalizableText, StyleObj } from '../types';
+import type { LocalizableText, Style } from '../types';
 
 type Props = {
   text: LocalizableText,
-  style?: StyleObj,
+  style?: Style,
 };
 
 export default class Label extends PureComponent<Props> {

--- a/src/common/MultilineInput.js
+++ b/src/common/MultilineInput.js
@@ -2,12 +2,12 @@
 import React, { PureComponent } from 'react';
 import { TextInput } from 'react-native';
 
-import type { LocalizableText, StyleObj } from '../types';
+import type { LocalizableText, Style } from '../types';
 import { Input } from '../common';
 
 type Props = {
   value: string,
-  style?: StyleObj,
+  style?: Style,
   placeholder?: LocalizableText,
   onChange?: (text: string) => void,
   onBlur?: () => void,

--- a/src/common/OptionRow.js
+++ b/src/common/OptionRow.js
@@ -3,13 +3,13 @@ import React, { PureComponent } from 'react';
 import { View } from 'react-native';
 
 import { Label, ZulipSwitch } from '../common';
-import type { StyleObj } from '../types';
+import type { Style } from '../types';
 
 type Props = {
   Icon?: Object,
   label: string,
   defaultValue: boolean,
-  style?: StyleObj,
+  style?: Style,
   onValueChange: (newValue: boolean) => void,
 };
 

--- a/src/common/PasswordInput.js
+++ b/src/common/PasswordInput.js
@@ -2,12 +2,12 @@
 import React, { PureComponent } from 'react';
 import { View, TextInput } from 'react-native';
 
-import type { LocalizableText } from '../types';
+import type { LocalizableText, Style } from '../types';
 import Input from './Input';
 import { Label, Touchable } from '../common';
 
 type Props = {
-  style?: StyleObj,
+  style?: Style,
   placeholder: LocalizableText,
 };
 

--- a/src/common/RawLabel.js
+++ b/src/common/RawLabel.js
@@ -2,11 +2,11 @@
 import React, { PureComponent } from 'react';
 import { Text } from 'react-native';
 
-import type { StyleObj } from '../types';
+import type { Style } from '../types';
 
 type Props = {
   text: string,
-  style?: StyleObj,
+  style?: Style,
 };
 
 export default class RawLabel extends PureComponent<Props> {

--- a/src/common/Screen.js
+++ b/src/common/Screen.js
@@ -2,7 +2,7 @@
 import React, { PureComponent } from 'react';
 import { StyleSheet, View, ScrollView } from 'react-native';
 
-import type { ChildrenArray, Dimensions, LocalizableText, StyleObj } from '../types';
+import type { ChildrenArray, Dimensions, LocalizableText, Style } from '../types';
 import { connectWithActionsPreserveOnBack } from '../connectWithActions';
 import { KeyboardAvoider, ZulipStatusBar } from '../common';
 import { getSession } from '../selectors';
@@ -33,7 +33,7 @@ type Props = {
   padding?: boolean,
   search?: boolean,
   title?: LocalizableText,
-  style?: StyleObj,
+  style?: Style,
   searchBarOnChange?: (text: string) => void,
 };
 

--- a/src/common/SlideAnimationView.js
+++ b/src/common/SlideAnimationView.js
@@ -2,10 +2,10 @@
 import React, { PureComponent } from 'react';
 import { Animated } from 'react-native';
 
-import type { AnimatedValue, ChildrenArray, StyleObj } from '../types';
+import type { AnimatedValue, ChildrenArray, Style } from '../types';
 
 type Props = {
-  style: StyleObj,
+  style: Style,
   children: ChildrenArray<*>,
   from: number,
   to: number,

--- a/src/common/SmartUrlInput.js
+++ b/src/common/SmartUrlInput.js
@@ -2,7 +2,7 @@
 import React, { PureComponent } from 'react';
 import { StyleSheet, TextInput, TouchableWithoutFeedback, View } from 'react-native';
 
-import type { StyleObj } from '../types';
+import type { Style } from '../types';
 import { autocompleteUrl, fixRealmUrl, hasProtocol } from '../utils/url';
 import RawLabel from './RawLabel';
 
@@ -20,7 +20,7 @@ type Props = {
   append: string,
   navigation: Object,
   shortAppend: string,
-  style?: StyleObj,
+  style?: Style,
   onChange: (value: string) => void,
   onSubmitEditing: () => Promise<void>,
   enablesReturnKeyAutomatically: boolean,

--- a/src/common/Touchable.android.js
+++ b/src/common/Touchable.android.js
@@ -2,7 +2,7 @@
 import React from 'react';
 import { TouchableNativeFeedback, Platform, View } from 'react-native';
 
-import type { ChildrenArray, StyleObj } from '../types';
+import type { ChildrenArray, Style } from '../types';
 import { HIGHLIGHT_COLOR } from '../styles';
 
 const background =
@@ -13,7 +13,7 @@ const background =
 type Props = {
   onPress?: () => void | Promise<any>,
   onLongPress?: () => void,
-  style?: StyleObj,
+  style?: Style,
   children?: ChildrenArray<*>,
 };
 

--- a/src/common/Touchable.ios.js
+++ b/src/common/Touchable.ios.js
@@ -2,13 +2,13 @@
 import React from 'react';
 import { TouchableHighlight, View } from 'react-native';
 
-import type { ChildrenArray, StyleObj } from '../types';
+import type { ChildrenArray, Style } from '../types';
 import { HIGHLIGHT_COLOR } from '../styles';
 
 type Props = {
   onPress?: () => void | Promise<any>,
   onLongPress?: () => void,
-  style?: StyleObj,
+  style?: Style,
   children?: ChildrenArray<*>,
 };
 

--- a/src/common/UnreadCount.js
+++ b/src/common/UnreadCount.js
@@ -2,7 +2,7 @@
 import React, { PureComponent } from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 
-import type { StyleObj } from '../types';
+import type { Style } from '../types';
 import { BRAND_COLOR } from '../styles';
 import { unreadToLimitedCount } from '../utils/unread';
 import { foregroundColorFromBackground } from '../utils/color';
@@ -33,7 +33,7 @@ const styles = StyleSheet.create({
 });
 
 type Props = {
-  style?: StyleObj,
+  style?: Style,
   borderRadius: number,
   color: string,
   count: number,

--- a/src/common/UserStatusIndicator.js
+++ b/src/common/UserStatusIndicator.js
@@ -3,7 +3,7 @@
 import React, { PureComponent } from 'react';
 import { StyleSheet, View } from 'react-native';
 
-import type { StyleObj, Presence } from '../types';
+import type { Style, Presence } from '../types';
 import { statusFromPresence } from '../utils/presence';
 
 const styles = StyleSheet.create({
@@ -26,7 +26,7 @@ const styles = StyleSheet.create({
 });
 
 type Props = {
-  style: StyleObj,
+  style: Style,
   presence?: Presence,
 };
 

--- a/src/common/ZulipButton.js
+++ b/src/common/ZulipButton.js
@@ -3,7 +3,7 @@ import React, { PureComponent } from 'react';
 import { StyleSheet, Text, View, ActivityIndicator } from 'react-native';
 import { FormattedMessage } from 'react-intl';
 
-import type { StyleObj } from '../types';
+import type { Style } from '../types';
 import { BRAND_COLOR } from '../styles';
 import Touchable from './Touchable';
 
@@ -63,7 +63,7 @@ const styles = StyleSheet.create({
 });
 
 type ButtonInProgressProps = {
-  frameStyle: StyleObj,
+  frameStyle: Style,
 };
 
 const ButtonInProgress = ({ frameStyle }: ButtonInProgressProps) => (
@@ -73,11 +73,11 @@ const ButtonInProgress = ({ frameStyle }: ButtonInProgressProps) => (
 );
 
 type ButtonNormalProps = {
-  frameStyle: StyleObj,
-  touchTargetStyle: StyleObj,
-  textStyle: StyleObj,
+  frameStyle: Style,
+  touchTargetStyle: Style,
+  textStyle: Style,
   text: string,
-  iconStyle: StyleObj,
+  iconStyle: Style,
   Icon?: Object,
   onPress?: () => void | Promise<any>,
 };
@@ -104,7 +104,7 @@ const ButtonNormal = ({
 );
 
 type Props = {
-  style?: StyleObj,
+  style?: Style,
   progress?: boolean,
   disabled: boolean,
   Icon?: Object,

--- a/src/lightbox/AnimatedLightboxFooter.js
+++ b/src/lightbox/AnimatedLightboxFooter.js
@@ -1,12 +1,12 @@
 /* @flow */
 import React, { PureComponent } from 'react';
 
-import type { StyleObj } from '../types';
+import type { Style } from '../types';
 import { SlideAnimationView } from '../common';
 import LightboxFooter from './LightboxFooter';
 
 type Props = {
-  style: StyleObj,
+  style: Style,
   displayMessage: string,
   from: number,
   to: number,

--- a/src/lightbox/AnimatedLightboxHeader.js
+++ b/src/lightbox/AnimatedLightboxHeader.js
@@ -1,7 +1,7 @@
 /* @flow */
 import React, { PureComponent } from 'react';
 
-import type { Action, StyleObj } from '../types';
+import type { Action, Style } from '../types';
 import { SlideAnimationView } from '../common';
 import { shortTime, humanDate } from '../utils/date';
 import LightboxHeader from './LightboxHeader';
@@ -11,7 +11,7 @@ type Props = {
   timestamp: number,
   from: number,
   to: number,
-  style: StyleObj,
+  style: Style,
   avatarUrl: string,
   realm: string,
   onPressBack: () => Action,

--- a/src/lightbox/LightboxFooter.js
+++ b/src/lightbox/LightboxFooter.js
@@ -2,7 +2,7 @@
 import React, { PureComponent } from 'react';
 import { Text, StyleSheet, View } from 'react-native';
 
-import type { StyleObj } from '../types';
+import type { Style } from '../types';
 import NavButton from '../nav/NavButton';
 
 const styles = StyleSheet.create({
@@ -25,7 +25,7 @@ const styles = StyleSheet.create({
 });
 
 type Props = {
-  style?: StyleObj,
+  style?: Style,
   displayMessage: string,
   onOptionsPress: () => void,
 };

--- a/src/lightbox/LightboxHeader.js
+++ b/src/lightbox/LightboxHeader.js
@@ -2,7 +2,7 @@
 import React, { PureComponent } from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 
-import type { Action, StyleObj } from '../types';
+import type { Action, Style } from '../types';
 import { Avatar, Touchable } from '../common';
 import Icon from '../common/Icons';
 
@@ -45,7 +45,7 @@ type Props = {
   timestamp: number,
   from: number,
   to: number,
-  style: StyleObj,
+  style: Style,
   avatarUrl: string,
   realm: string,
   onPressBack: () => Action,

--- a/src/nav/ModalNavBar.js
+++ b/src/nav/ModalNavBar.js
@@ -3,7 +3,7 @@ import React, { PureComponent } from 'react';
 import { View } from 'react-native';
 import type { ChildrenArray } from 'react';
 
-import type { Actions, LocalizableText, StyleObj } from '../types';
+import type { Actions, LocalizableText, Style } from '../types';
 import { connectWithActionsPreserveOnBack } from '../connectWithActions';
 import { NAVBAR_SIZE } from '../styles';
 import { Label, ViewPlaceholder } from '../common';
@@ -17,9 +17,9 @@ type Props = {
   titleColor?: string,
   itemsColor: string,
   rightItem?: Object,
-  style: StyleObj,
+  style: Style,
   children?: ChildrenArray<*>,
-  childrenStyle?: StyleObj,
+  childrenStyle?: Style,
 };
 
 class ModalNavBar extends PureComponent<Props> {

--- a/src/nav/NavButton.js
+++ b/src/nav/NavButton.js
@@ -2,7 +2,7 @@
 import React, { PureComponent } from 'react';
 import { StyleSheet } from 'react-native';
 
-import type { StyleObj } from '../types';
+import type { Style } from '../types';
 import { BRAND_COLOR, NAVBAR_SIZE } from '../styles';
 import { ComponentWithOverlay, UnreadCount } from '../common';
 import Icon from '../common/Icons';
@@ -22,7 +22,7 @@ const styles = StyleSheet.create({
 
 type Props = {
   color: string,
-  style?: StyleObj,
+  style?: Style,
   name?: string,
   unreadCount: number,
   onPress: () => any,

--- a/src/streams/StreamIcon.js
+++ b/src/streams/StreamIcon.js
@@ -2,14 +2,14 @@
 import React from 'react';
 
 import { IconMute, IconStream, IconPrivate } from '../common/Icons';
-import type { StyleObj } from '../types';
+import type { Style } from '../types';
 
 type Props = {
   color?: string,
   isPrivate?: boolean,
   isMuted?: boolean,
   size: number,
-  style?: StyleObj,
+  style?: Style,
 };
 
 export default ({ color, style, isPrivate, isMuted, size }: Props) => {

--- a/src/types.js
+++ b/src/types.js
@@ -10,7 +10,7 @@ export type MapStateToProps = any; // { MapStateToProps } from 'react-redux';
 export type * from './actionTypes';
 export type * from './api/apiTypes';
 
-export type StyleObj = any;
+export type Style = boolean | number | Array<Style> | ?{ [string]: any };
 export type Dispatch = any;
 // export type { Dispatch } from 'redux';
 

--- a/src/users/UserList.js
+++ b/src/users/UserList.js
@@ -2,7 +2,7 @@
 import React, { PureComponent } from 'react';
 import { StyleSheet, SectionList } from 'react-native';
 
-import type { PresenceState, StyleObj, User } from '../types';
+import type { PresenceState, Style, User } from '../types';
 import { SectionHeader, SearchEmptyState } from '../common';
 import UserItem from './UserItem';
 import { sortUserList, filterUserList, groupUsersByStatus } from '../users/userHelpers';
@@ -14,7 +14,7 @@ const styles = StyleSheet.create({
 });
 
 type Props = {
-  style?: StyleObj,
+  style?: Style,
   filter: string,
   users: User[],
   selected: User[],


### PR DESCRIPTION
StyleObj used to be imported directly from `react-native`.
They removed it and converted the styling to `__internal*` naming
indicating they are not to be used elsewhere.

* rename from StyleObj to Style to better represent the type
* now a union
* can be boolean - just ignored (results of conditionals)
* can be number - a 'compiled' style represented as index
* can be an object
* can be an array of styles