### PR TITLE
Update zulip-markdown-parser to support the new emoji parsing

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "string.fromcodepoint": "^0.2.1",
     "url-parse": "^1.4.0",
     "url-regex": "^4.1.1",
-    "zulip-markdown-parser": "^1.0.4"
+    "zulip-markdown-parser": "^1.0.5"
   },
   "devDependencies": {
     "babel-core": "^6.26.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7626,9 +7626,9 @@ yargs@~3.10.0:
     decamelize "^1.0.0"
     window-size "0.1.0"
 
-zulip-markdown-parser@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/zulip-markdown-parser/-/zulip-markdown-parser-1.0.4.tgz#b45ec4fa3c8ae79ddeb1c946fddee64dfbe4c28a"
+zulip-markdown-parser@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/zulip-markdown-parser/-/zulip-markdown-parser-1.0.5.tgz#1be5286bc161677a8b1a73c011fc2f093d488503"
   dependencies:
     jest-cli "^20.0.4"
     katex "^0.7.1"


### PR DESCRIPTION
Modified the code and test cases in the parser repo here https://github.com/kunall17/zulip-markdown-parser/commit/e3cb658179dc14d1f117989abc3eb6cbf9560404 
Also added a CI to this repo.

This new update will generate HTML with the span tag's rather than img tag's as in the new updated markdown from the server (https://github.com/zulip/zulip/commit/5b5bcce0985f5b478a70b4b4bca4ea23e197d123) 

(Only changes regarding the emoji's and the other newer commits aren't updated in the parser repo!)