### PR TITLE
Canonicalize user email before producing gravatar

### DIFF
--- a/src/utils/__tests__/avatar-test.js
+++ b/src/utils/__tests__/avatar-test.js
@@ -29,6 +29,12 @@ describe('getGravatarFromEmail', () => {
     );
   });
 
+  test('given a case-sensitive email canonize and return gravatar url', () => {
+    expect(getGravatarFromEmail('Test@example.com')).toEqual(
+      'https://secure.gravatar.com/avatar/55502f40dc8b7c769880b10874abc9d0?d=identicon&s=80',
+    );
+  });
+
   test('given an email and a size return gravatar url for that size', () => {
     expect(getGravatarFromEmail('test@example.com', 200)).toEqual(
       'https://secure.gravatar.com/avatar/55502f40dc8b7c769880b10874abc9d0?d=identicon&s=200',

--- a/src/utils/avatar.js
+++ b/src/utils/avatar.js
@@ -7,5 +7,5 @@ export const getMediumAvatar = (avatarUrl: string): string => {
   return matches ? avatarUrl.replace(matches[0], `${matches[1]}-medium.png`) : avatarUrl;
 };
 
-export const getGravatarFromEmail = (email: string, size: number = 80): string =>
-  `https://secure.gravatar.com/avatar/${md5(email)}?d=identicon&s=${size}`;
+export const getGravatarFromEmail = (email: string = '', size: number = 80): string =>
+  `https://secure.gravatar.com/avatar/${md5(email.toLowerCase())}?d=identicon&s=${size}`;


### PR DESCRIPTION
Fixes #2493

Pass lower case emails to the gravatar hasing function

See http://en.gravatar.com/site/implement/hash/ for the specification

Related issue zulip/zulip@4abbfe9