### PR TITLE
cleanup: Cleanup unused 'shouldTimeout' API parameter

### DIFF
--- a/src/api/apiFetch.js
+++ b/src/api/apiFetch.js
@@ -34,7 +34,6 @@ export const apiCall = async (
   params: Object = {},
   resFunc: ResponseExtractionFunc = res => res,
   isSilent: boolean = false,
-  shouldTimeout: boolean = true,
 ) => {
   try {
     networkActivityStart(isSilent);
@@ -73,7 +72,6 @@ export const apiGet = async (
   resFunc: ResponseExtractionFunc,
   params: Object = {},
   isSilent: boolean = false,
-  shouldTimeout: boolean = true,
 ) =>
   apiCall(
     auth,
@@ -83,7 +81,6 @@ export const apiGet = async (
     },
     resFunc,
     isSilent,
-    shouldTimeout,
   );
 
 export const apiPost = async (

--- a/src/api/pollForEvents.js
+++ b/src/api/pollForEvents.js
@@ -12,5 +12,4 @@ export default (auth: Auth, queueId: number, lastEventId: number) =>
       last_event_id: lastEventId,
     },
     true,
-    false,
   );


### PR DESCRIPTION
We used to have a (not functioning well) timeout mechanism.
This parameter is a leftover of this feature, but is currently unused.