### PR TITLE
refactor: Remove mapApiToStateUser

### DIFF
--- a/src/account-info/AccountDetailsScreen.js
+++ b/src/account-info/AccountDetailsScreen.js
@@ -23,7 +23,7 @@ class AccountDetailsScreen extends PureComponent<Props> {
     const title = {
       text: '{_}',
       values: {
-        _: user.fullName || ' ',
+        _: user.full_name || ' ',
       },
     };
 
@@ -32,9 +32,9 @@ class AccountDetailsScreen extends PureComponent<Props> {
         <AccountDetails
           auth={auth}
           actions={actions}
-          fullName={user.fullName}
+          fullName={user.full_name}
           email={user.email}
-          avatarUrl={user.avatarUrl}
+          avatarUrl={user.avatar_url}
           presence={presence[user.email]}
           orientation={orientation}
         />

--- a/src/actionTypes.js
+++ b/src/actionTypes.js
@@ -7,7 +7,6 @@ import type {
   Message,
   Narrow,
   ApiServerSettings,
-  ApiUser,
   User,
   InitialData,
   RealmFilter,
@@ -551,7 +550,7 @@ export type SendFocusPingActionCreator = (hasFocus?: boolean, newUserInput?: boo
 
 export type InitUsersAction = {
   type: 'INIT_USERS',
-  users: ApiUser[],
+  users: User[],
 };
 
 export type InitUsersActionCreator = (users: User[]) => InitUsersAction;

--- a/src/api/apiTypes.js
+++ b/src/api/apiTypes.js
@@ -11,20 +11,6 @@ export type ApiResponseWithPresence = ApiResponse & {
   presences: PresenceState,
 };
 
-export type ApiUser = {
-  avatar_url: string,
-  bot_type?: number,
-  bot_owner?: string,
-  email: string,
-  full_name: string,
-  is_admin: boolean,
-  is_active: boolean,
-  is_bot: boolean,
-  profile_data?: Object,
-  timezone: string,
-  user_id: 5584,
-};
-
 export type AuthenticationMethods = {
   dev: boolean,
   email: boolean,

--- a/src/api/users/getUsers.js
+++ b/src/api/users/getUsers.js
@@ -1,6 +1,6 @@
 /* @flow */
-import type { Auth, ApiUser } from '../../types';
+import type { Auth, User } from '../../types';
 import { apiGet } from '../apiFetch';
 
-export default (auth: Auth): Promise<ApiUser[]> =>
+export default (auth: Auth): Promise<User[]> =>
   apiGet(auth, 'users', res => res.members, { client_gravatar: true });

--- a/src/autocomplete/PeopleAutocomplete.js
+++ b/src/autocomplete/PeopleAutocomplete.js
@@ -34,11 +34,11 @@ class PeopleAutocomplete extends PureComponent<Props> {
           keyExtractor={item => item.email}
           renderItem={({ item }) => (
             <UserItem
-              fullName={item.fullName}
-              avatarUrl={item.avatarUrl}
+              fullName={item.full_name}
+              avatarUrl={item.avatar_url}
               email={item.email}
               showEmail
-              onPress={() => onAutocomplete(item.fullName)}
+              onPress={() => onAutocomplete(item.full_name)}
             />
           )}
         />

--- a/src/chat/GroupDetailsScreen.js
+++ b/src/chat/GroupDetailsScreen.js
@@ -54,8 +54,8 @@ class GroupDetailsScreen extends PureComponent<Props> {
             renderItem={({ item }) => (
               <UserItem
                 key={item.email}
-                fullName={item.fullName}
-                avatarUrl={item.avatarUrl}
+                fullName={item.full_name}
+                avatarUrl={item.avatar_url}
                 email={item.email}
                 showEmail
                 onPress={() => this.handlePress(item.email)}

--- a/src/compose/__tests__/getComposeInputPlaceholder-test.js
+++ b/src/compose/__tests__/getComposeInputPlaceholder-test.js
@@ -13,12 +13,12 @@ describe('getComposeInputPlaceholder', () => {
       {
         id: 23,
         email: 'abc@zulip.com',
-        fullName: 'ABC',
+        full_name: 'ABC',
       },
       {
         id: 22,
         email: 'xyz@zulip.com',
-        fullName: 'XYZ',
+        full_name: 'XYZ',
       },
     ]);
 

--- a/src/compose/getComposeInputPlaceholder.js
+++ b/src/compose/getComposeInputPlaceholder.js
@@ -19,7 +19,7 @@ export default (narrow: Narrow, ownEmail: string, users: User[]): LocalizableTex
     const user = users.find(u => u.email === narrow[0].operand) || {};
     return {
       text: 'Message {recipient}',
-      values: { recipient: `@${user.fullName}` },
+      values: { recipient: `@${user.full_name}` },
     };
   }
 

--- a/src/conversations/ConversationGroup.js
+++ b/src/conversations/ConversationGroup.js
@@ -37,7 +37,7 @@ export default class ConversationGroup extends PureComponent<Props> {
     const { email, usersByEmail, unreadCount } = this.props;
     const allNames = email
       .split(',')
-      .map(e => (usersByEmail[e] || NULL_USER).fullName)
+      .map(e => (usersByEmail[e] || NULL_USER).full_name)
       .join(', ');
 
     return (

--- a/src/conversations/ConversationList.js
+++ b/src/conversations/ConversationList.js
@@ -46,8 +46,8 @@ export default class ConversationList extends PureComponent<Props> {
             return (
               <UserItem
                 email={user.email}
-                fullName={user.fullName}
-                avatarUrl={user.avatarUrl}
+                fullName={user.full_name}
+                avatarUrl={user.avatar_url}
                 presence={presences[user.email]}
                 unreadCount={item.unread}
                 onPress={this.handleUserNarrow}

--- a/src/group/AvatarList.js
+++ b/src/group/AvatarList.js
@@ -32,7 +32,14 @@ export default class AvatarList extends PureComponent<Props> {
           if (listRef) listRef(component);
         }}
         keyExtractor={item => item.email}
-        renderItem={({ item }) => <AvatarItem {...item} onPress={onPress} />}
+        renderItem={({ item }) => (
+          <AvatarItem
+            email={item.email}
+            avatarUrl={item.avatar_url}
+            fullName={item.full_name}
+            onPress={onPress}
+          />
+        )}
       />
     );
   }

--- a/src/nullObjects.js
+++ b/src/nullObjects.js
@@ -25,13 +25,14 @@ export const NULL_ACCOUNT: Account = {
 };
 
 export const NULL_USER: User = {
-  avatarUrl: '',
+  avatar_url: '',
   email: '',
-  fullName: '',
-  id: -1,
-  isActive: false,
-  isAdmin: false,
-  isBot: false,
+  full_name: '',
+  is_active: false,
+  is_admin: false,
+  is_bot: false,
+  timezone: '',
+  user_id: -1,
 };
 
 export const NULL_STREAM: Stream = {

--- a/src/outbox/outboxActions.js
+++ b/src/outbox/outboxActions.js
@@ -75,15 +75,15 @@ const mapEmailsToUsers = (users, narrow, selfDetail) =>
     .split(',')
     .map(item => {
       const user = getUserByEmail(users, item);
-      return { email: item, id: user.id, full_name: user.fullName };
+      return { email: item, id: user.user_id, full_name: user.full_name };
     })
-    .concat({ email: selfDetail.email, id: selfDetail.id, full_name: selfDetail.fullName });
+    .concat({ email: selfDetail.email, id: selfDetail.user_id, full_name: selfDetail.full_name });
 
 // TODO type: `string | NamedUser[]` is a bit confusing.
 const extractTypeToAndSubjectFromNarrow = (
   narrow: Narrow,
   users: User[],
-  selfDetail: { email: string, id: number, fullName: string },
+  selfDetail: { email: string, user_id: number, full_name: string },
 ): { type: 'private' | 'stream', display_recipient: string | NamedUser[], subject: string } => {
   if (isPrivateOrGroupNarrow(narrow)) {
     return {
@@ -122,9 +122,9 @@ export const addToOutbox = (narrow: Narrow, content: string) => async (
       content: html,
       timestamp: localTime,
       id: localTime,
-      sender_full_name: userDetail.fullName,
+      sender_full_name: userDetail.full_name,
       email: userDetail.email,
-      avatar_url: userDetail.avatarUrl,
+      avatar_url: userDetail.avatar_url,
       isOutbox: true,
     }),
   );

--- a/src/title/TitleGroup.js
+++ b/src/title/TitleGroup.js
@@ -27,8 +27,8 @@ export default class TitleGroup extends PureComponent<Props> {
           <View key={user.email} style={styles.titleAvatar}>
             <Avatar
               size={32}
-              name={user.fullName}
-              avatarUrl={user.avatarUrl}
+              name={user.full_name}
+              avatarUrl={user.avatar_url}
               email={user.email}
               presence={presence[user.email]}
             />

--- a/src/title/TitlePrivate.js
+++ b/src/title/TitlePrivate.js
@@ -22,23 +22,22 @@ export default class TitlePrivate extends PureComponent<Props> {
   render() {
     const { styles } = this.context;
     const { user, color, presence } = this.props;
-    const { fullName, avatarUrl, email } = user;
 
     return (
       <View style={styles.navWrapper}>
         <Avatar
           size={32}
-          name={fullName}
-          email={email}
-          avatarUrl={avatarUrl}
-          presence={presence[email]}
+          name={user.full_name}
+          email={user.email}
+          avatarUrl={user.avatar_url}
+          presence={presence[user.email]}
         />
         <ViewPlaceholder width={8} />
         <View>
           <Text style={[styles.navTitle, { color }]} numberOfLines={1} ellipsizeMode="tail">
-            {fullName}
+            {user.full_name}
           </Text>
-          <ActivityText style={styles.navSubtitle} color={color} email={email} />
+          <ActivityText style={styles.navSubtitle} color={color} email={user.email} />
         </View>
       </View>
     );

--- a/src/types.js
+++ b/src/types.js
@@ -1,6 +1,5 @@
 /* @flow */
 import type { Action } from './actionTypes';
-import type { ApiUser } from './api/apiTypes';
 
 export type { ChildrenArray } from 'react';
 
@@ -89,13 +88,17 @@ export type MessageState = {
 export type UserStatus = 'active' | 'idle' | 'offline';
 
 export type User = {
-  avatarUrl: string,
+  avatar_url: string,
+  bot_type?: number,
+  bot_owner?: string,
   email: string,
-  fullName: string,
-  id: number,
-  isActive: boolean,
-  isAdmin: boolean,
-  isBot: boolean,
+  full_name: string,
+  is_admin: boolean,
+  is_active: boolean,
+  is_bot: boolean,
+  profile_data?: Object,
+  timezone: string,
+  user_id: number,
 };
 
 export type UserIdMap = {
@@ -613,8 +616,8 @@ export type InitialDataRealmUser = {
   enter_sends: boolean,
   full_name: string,
   is_admin: boolean,
-  realm_non_active_users: ApiUser[],
-  realm_users: ApiUser[],
+  realm_non_active_users: User[],
+  realm_users: User[],
   user_id: number,
 };
 

--- a/src/typing/__tests__/typingSelectors-test.js
+++ b/src/typing/__tests__/typingSelectors-test.js
@@ -17,10 +17,10 @@ describe('getCurrentTypingUsers', () => {
 
   test('when in private narrow and the same user is typing return details', () => {
     const expectedUser = {
-      id: 1,
+      user_id: 1,
       email: 'john@example.com',
-      avatarUrl: 'http://example.com/avatar.png',
-      fullName: 'John Doe',
+      avatar_url: 'http://example.com/avatar.png',
+      full_name: 'John Doe',
     };
     const state = deepFreeze({
       accounts: [{ email: 'me@example.com' }],
@@ -37,16 +37,16 @@ describe('getCurrentTypingUsers', () => {
 
   test('when two people are typing, return details for all of them', () => {
     const user1 = {
-      id: 1,
+      user_id: 1,
       email: 'john@example.com',
-      avatarUrl: 'http://example.com/avatar1.png',
-      fullName: 'John Doe',
+      avatar_url: 'http://example.com/avatar1.png',
+      full_name: 'John Doe',
     };
     const user2 = {
-      id: 2,
+      user_id: 2,
       email: 'mark@example.com',
-      avatarUrl: 'http://example.com/avatar2.png',
-      fullName: 'Mark Dark',
+      avatar_url: 'http://example.com/avatar2.png',
+      full_name: 'Mark Dark',
     };
     const state = deepFreeze({
       accounts: [{ email: 'me@example.com' }],
@@ -78,10 +78,10 @@ describe('getCurrentTypingUsers', () => {
 
   test('when in group narrow and someone is typing in that narrow return details', () => {
     const expectedUser = {
-      id: 1,
+      user_id: 1,
       email: 'john@example.com',
-      avatarUrl: 'http://example.com/avatar.png',
-      fullName: 'John Doe',
+      avatar_url: 'http://example.com/avatar.png',
+      full_name: 'John Doe',
     };
     const state = deepFreeze({
       accounts: [{ email: 'me@example.com' }],

--- a/src/unread/unreadSelectors.js
+++ b/src/unread/unreadSelectors.js
@@ -212,7 +212,7 @@ export const getUnreadCountForNarrow = (narrow: Narrow) =>
 
       if (isGroupNarrow(narrow)) {
         const userIds = [...narrow[0].operand.split(','), ownEmail]
-          .map(email => (users.find(user => user.email === email) || NULL_USER).id)
+          .map(email => (users.find(user => user.email === email) || NULL_USER).user_id)
           .sort((a, b) => a - b)
           .join(',');
         const unread = unreadHuddles.find(x => x.user_ids_string === userIds);
@@ -224,7 +224,7 @@ export const getUnreadCountForNarrow = (narrow: Narrow) =>
         if (!sender) {
           return 0;
         }
-        const unread = unreadPms.find(x => x.sender_id === sender.id);
+        const unread = unreadPms.find(x => x.sender_id === sender.user_id);
         return unread ? unread.unread_message_ids.length : 0;
       }
 

--- a/src/users/UserList.js
+++ b/src/users/UserList.js
@@ -59,12 +59,12 @@ export default class UserList extends PureComponent<Props> {
         renderItem={({ item }) => (
           <UserItem
             key={item.email}
-            fullName={item.fullName}
-            avatarUrl={item.avatarUrl}
+            fullName={item.full_name}
+            avatarUrl={item.avatar_url}
             email={item.email}
             presence={presences[item.email]}
             onPress={onPress}
-            isSelected={!!selected.find(user => user.id === item.id)}
+            isSelected={!!selected.find(user => user.user_id === item.id)}
           />
         )}
         renderSectionHeader={({ section }) =>

--- a/src/users/__tests__/userHelpers-test.js
+++ b/src/users/__tests__/userHelpers-test.js
@@ -39,18 +39,18 @@ describe('filterUserList', () => {
 
   test('searches in name, email and is case insensitive', () => {
     const allUsers = deepFreeze([
-      { fullName: 'match', email: 'any@example.com' },
-      { fullName: 'partial match', email: 'any@example.com' },
-      { fullName: 'Case Insensitive MaTcH', email: 'any@example.com' },
-      { fullName: 'Any Name', email: 'match@example.com' },
-      { fullName: 'some name', email: 'another@example.com' },
+      { full_name: 'match', email: 'any@example.com' },
+      { full_name: 'partial match', email: 'any@example.com' },
+      { full_name: 'Case Insensitive MaTcH', email: 'any@example.com' },
+      { full_name: 'Any Name', email: 'match@example.com' },
+      { full_name: 'some name', email: 'another@example.com' },
     ]);
 
     const shouldMatch = [
-      { fullName: 'match', email: 'any@example.com' },
-      { fullName: 'partial match', email: 'any@example.com' },
-      { fullName: 'Case Insensitive MaTcH', email: 'any@example.com' },
-      { fullName: 'Any Name', email: 'match@example.com' },
+      { full_name: 'match', email: 'any@example.com' },
+      { full_name: 'partial match', email: 'any@example.com' },
+      { full_name: 'Case Insensitive MaTcH', email: 'any@example.com' },
+      { full_name: 'Any Name', email: 'match@example.com' },
     ];
     const filteredUsers = filterUserList(allUsers, 'match');
     expect(filteredUsers).toEqual(shouldMatch);
@@ -67,21 +67,22 @@ describe('getAutocompleteSuggestion', () => {
 
   test("filters out user's own entry", () => {
     const users = deepFreeze([
-      { email: 'email@example.com', fullName: 'Some Guy' },
-      { email: 'my@example.com', fullName: 'Me' },
+      { email: 'email@example.com', full_name: 'Some Guy' },
+      { email: 'my@example.com', full_name: 'Me' },
     ]);
 
     const shouldMatch = [
       {
-        fullName: 'all',
+        full_name: 'all',
         email: '(Notify everyone)',
-        id: -1,
-        avatarUrl: '',
-        isActive: false,
-        isAdmin: false,
-        isBot: false,
+        user_id: -1,
+        avatar_url: '',
+        timezone: '',
+        is_active: false,
+        is_admin: false,
+        is_bot: false,
       },
-      { email: 'email@example.com', fullName: 'Some Guy' },
+      { email: 'email@example.com', full_name: 'Some Guy' },
     ];
     const filteredUsers = getAutocompleteSuggestion(users, '', 'my@example.com');
     expect(filteredUsers).toEqual(shouldMatch);
@@ -89,18 +90,18 @@ describe('getAutocompleteSuggestion', () => {
 
   test('searches in name, email and is case insensitive', () => {
     const allUsers = deepFreeze([
-      { fullName: 'match', email: 'any1@example.com' },
-      { fullName: 'match this', email: 'any2@example.com' },
-      { fullName: 'MaTcH Case Insensitive', email: 'any3@example.com' },
-      { fullName: 'some name', email: 'another@example.com' },
-      { fullName: 'Example', email: 'match@example.com' },
+      { full_name: 'match', email: 'any1@example.com' },
+      { full_name: 'match this', email: 'any2@example.com' },
+      { full_name: 'MaTcH Case Insensitive', email: 'any3@example.com' },
+      { full_name: 'some name', email: 'another@example.com' },
+      { full_name: 'Example', email: 'match@example.com' },
     ]);
 
     const shouldMatch = [
-      { fullName: 'match', email: 'any1@example.com' },
-      { fullName: 'match this', email: 'any2@example.com' },
-      { fullName: 'MaTcH Case Insensitive', email: 'any3@example.com' },
-      { fullName: 'Example', email: 'match@example.com' },
+      { full_name: 'match', email: 'any1@example.com' },
+      { full_name: 'match this', email: 'any2@example.com' },
+      { full_name: 'MaTcH Case Insensitive', email: 'any3@example.com' },
+      { full_name: 'Example', email: 'match@example.com' },
     ];
     const filteredUsers = getAutocompleteSuggestion(allUsers, 'match');
     expect(filteredUsers).toEqual(shouldMatch);
@@ -108,28 +109,28 @@ describe('getAutocompleteSuggestion', () => {
 
   test('result should be in priority of startsWith, initials, contains in name, matches in email', () => {
     const allUsers = deepFreeze([
-      { fullName: 'M Apple', email: 'any1@example.com' }, // satisfy initials condition
-      { fullName: 'Normal boy', email: 'any2@example.com' }, // satisfy fullName contains condition
-      { fullName: 'example', email: 'example@example.com' }, // random entry
-      { fullName: 'Example', email: 'match@example.com' }, // satisfy email match condition
-      { fullName: 'match', email: 'any@example.com' }, // satisfy fullName starts with condition
-      { fullName: 'match', email: 'normal@example.com' }, // satisfy starts with and email condition
-      { fullName: 'Match App Normal', email: 'any3@example.com' }, // satisfy all conditions
-      { fullName: 'match', email: 'any@example.com' }, // duplicate
-      { fullName: 'Laptop', email: 'laptop@example.com' }, // random entry
-      { fullName: 'Mobile App', email: 'any@match.com' }, // satisfy initials and email condition
-      { fullName: 'Normal', email: 'match2@example.com' }, // satisfy contains in name and matches in email condition
+      { full_name: 'M Apple', email: 'any1@example.com' }, // satisfy initials condition
+      { full_name: 'Normal boy', email: 'any2@example.com' }, // satisfy full_name contains condition
+      { full_name: 'example', email: 'example@example.com' }, // random entry
+      { full_name: 'Example', email: 'match@example.com' }, // satisfy email match condition
+      { full_name: 'match', email: 'any@example.com' }, // satisfy full_name starts with condition
+      { full_name: 'match', email: 'normal@example.com' }, // satisfy starts with and email condition
+      { full_name: 'Match App Normal', email: 'any3@example.com' }, // satisfy all conditions
+      { full_name: 'match', email: 'any@example.com' }, // duplicate
+      { full_name: 'Laptop', email: 'laptop@example.com' }, // random entry
+      { full_name: 'Mobile App', email: 'any@match.com' }, // satisfy initials and email condition
+      { full_name: 'Normal', email: 'match2@example.com' }, // satisfy contains in name and matches in email condition
     ]);
 
     const shouldMatch = [
-      { fullName: 'match', email: 'any@example.com' }, // name starts with 'ma'
-      { fullName: 'match', email: 'normal@example.com' }, // have priority as starts with 'ma'
-      { fullName: 'Match App Normal', email: 'any3@example.com' }, // have priority as starts with 'ma'
-      { fullName: 'M Apple', email: 'any1@example.com' }, // initials 'MA'
-      { fullName: 'Mobile App', email: 'any@match.com' }, // have priority because of initials condition
-      { fullName: 'Normal boy', email: 'any2@example.com' }, // name contains in 'ma'
-      { fullName: 'Normal', email: 'match2@example.com' }, // have priority because of 'ma' contains in name
-      { fullName: 'Example', email: 'match@example.com' }, // email contains 'ma'
+      { full_name: 'match', email: 'any@example.com' }, // name starts with 'ma'
+      { full_name: 'match', email: 'normal@example.com' }, // have priority as starts with 'ma'
+      { full_name: 'Match App Normal', email: 'any3@example.com' }, // have priority as starts with 'ma'
+      { full_name: 'M Apple', email: 'any1@example.com' }, // initials 'MA'
+      { full_name: 'Mobile App', email: 'any@match.com' }, // have priority because of initials condition
+      { full_name: 'Normal boy', email: 'any2@example.com' }, // name contains in 'ma'
+      { full_name: 'Normal', email: 'match2@example.com' }, // have priority because of 'ma' contains in name
+      { full_name: 'Example', email: 'match@example.com' }, // email contains 'ma'
     ];
     const filteredUsers = getAutocompleteSuggestion(allUsers, 'ma');
     expect(filteredUsers).toEqual(shouldMatch);
@@ -138,9 +139,9 @@ describe('getAutocompleteSuggestion', () => {
 
 describe('sortUserList', () => {
   test('sorts list by name', () => {
-    const users = deepFreeze([{ fullName: 'abc' }, { fullName: 'xyz' }, { fullName: 'jkl' }]);
+    const users = deepFreeze([{ full_name: 'abc' }, { full_name: 'xyz' }, { full_name: 'jkl' }]);
     const presences = {};
-    const shouldMatch = [{ fullName: 'abc' }, { fullName: 'jkl' }, { fullName: 'xyz' }];
+    const shouldMatch = [{ full_name: 'abc' }, { full_name: 'jkl' }, { full_name: 'xyz' }];
 
     const sortedUsers = sortUserList(users, presences);
 
@@ -149,10 +150,10 @@ describe('sortUserList', () => {
 
   test('prioritizes status', () => {
     const users = deepFreeze([
-      { fullName: 'Mark', email: 'mark@example.com' },
-      { fullName: 'John', email: 'john@example.com' },
-      { fullName: 'Bob', email: 'bob@example.com' },
-      { fullName: 'Rick', email: 'rick@example.com' },
+      { full_name: 'Mark', email: 'mark@example.com' },
+      { full_name: 'John', email: 'john@example.com' },
+      { full_name: 'Bob', email: 'bob@example.com' },
+      { full_name: 'Rick', email: 'rick@example.com' },
     ]);
     const presences = {
       'mark@example.com': { aggregated: { status: 'offline' } },
@@ -163,10 +164,10 @@ describe('sortUserList', () => {
       'rick@example.com': { aggregated: { status: 'active', timestamp: Date.now() / 1000 } },
     };
     const shouldMatch = [
-      { fullName: 'Rick', email: 'rick@example.com' },
-      { fullName: 'Bob', email: 'bob@example.com' },
-      { fullName: 'John', email: 'john@example.com' },
-      { fullName: 'Mark', email: 'mark@example.com' },
+      { full_name: 'Rick', email: 'rick@example.com' },
+      { full_name: 'Bob', email: 'bob@example.com' },
+      { full_name: 'John', email: 'john@example.com' },
+      { full_name: 'Mark', email: 'mark@example.com' },
     ];
 
     const sortedUsers = sortUserList(users, presences);
@@ -185,39 +186,39 @@ describe('groupUsersByInitials', () => {
 
   test('empty input results in empty list', () => {
     const users = deepFreeze([
-      { fullName: 'Allen' },
-      { fullName: 'Bob Tester' },
-      { fullName: 'bob bob' },
+      { full_name: 'Allen' },
+      { full_name: 'Bob Tester' },
+      { full_name: 'bob bob' },
     ]);
 
     const groupedUsers = groupUsersByInitials(users);
     expect(groupedUsers).toEqual({
-      A: [{ fullName: 'Allen' }],
-      B: [{ fullName: 'Bob Tester' }, { fullName: 'bob bob' }],
+      A: [{ full_name: 'Allen' }],
+      B: [{ full_name: 'Bob Tester' }, { full_name: 'bob bob' }],
     });
   });
 });
 
 describe('sortAlphabetically', () => {
-  test('alphabetically sort user list by fullName', () => {
+  test('alphabetically sort user list by full_name', () => {
     const users = deepFreeze([
-      { fullName: 'zoe', email: 'allen@example.com' },
-      { fullName: 'Ring', email: 'got@example.com' },
-      { fullName: 'watch', email: 'see@example.com' },
-      { fullName: 'mobile', email: 'phone@example.com' },
-      { fullName: 'Ring', email: 'got@example.com' },
-      { fullName: 'hardware', email: 'software@example.com' },
-      { fullName: 'Bob', email: 'tester@example.com' },
+      { full_name: 'zoe', email: 'allen@example.com' },
+      { full_name: 'Ring', email: 'got@example.com' },
+      { full_name: 'watch', email: 'see@example.com' },
+      { full_name: 'mobile', email: 'phone@example.com' },
+      { full_name: 'Ring', email: 'got@example.com' },
+      { full_name: 'hardware', email: 'software@example.com' },
+      { full_name: 'Bob', email: 'tester@example.com' },
     ]);
 
     const expectedUsers = [
-      { fullName: 'Bob', email: 'tester@example.com' },
-      { fullName: 'hardware', email: 'software@example.com' },
-      { fullName: 'mobile', email: 'phone@example.com' },
-      { fullName: 'Ring', email: 'got@example.com' },
-      { fullName: 'Ring', email: 'got@example.com' },
-      { fullName: 'watch', email: 'see@example.com' },
-      { fullName: 'zoe', email: 'allen@example.com' },
+      { full_name: 'Bob', email: 'tester@example.com' },
+      { full_name: 'hardware', email: 'software@example.com' },
+      { full_name: 'mobile', email: 'phone@example.com' },
+      { full_name: 'Ring', email: 'got@example.com' },
+      { full_name: 'Ring', email: 'got@example.com' },
+      { full_name: 'watch', email: 'see@example.com' },
+      { full_name: 'zoe', email: 'allen@example.com' },
     ];
     expect(sortAlphabetically(users)).toEqual(expectedUsers);
   });
@@ -226,37 +227,37 @@ describe('sortAlphabetically', () => {
 describe('filterUserStartWith', () => {
   test('returns users whose name starts with filter excluding self', () => {
     const users = deepFreeze([
-      { fullName: 'Apple', email: 'a@example.com' },
-      { fullName: 'bob', email: 'f@app.com' },
-      { fullName: 'app', email: 'p@p.com' },
-      { fullName: 'Mobile app', email: 'p3@p.com' },
-      { fullName: 'Mac App', email: 'p@p2.com' },
-      { fullName: 'app', email: 'own@example.com' },
+      { full_name: 'Apple', email: 'a@example.com' },
+      { full_name: 'bob', email: 'f@app.com' },
+      { full_name: 'app', email: 'p@p.com' },
+      { full_name: 'Mobile app', email: 'p3@p.com' },
+      { full_name: 'Mac App', email: 'p@p2.com' },
+      { full_name: 'app', email: 'own@example.com' },
     ]);
 
     const expectedUsers = [
-      { fullName: 'Apple', email: 'a@example.com' },
-      { fullName: 'app', email: 'p@p.com' },
+      { full_name: 'Apple', email: 'a@example.com' },
+      { full_name: 'app', email: 'p@p.com' },
     ];
     expect(filterUserStartWith(users, 'app', 'own@example.com')).toEqual(expectedUsers);
   });
 });
 
 describe('filterUserByInitials', () => {
-  test('returns users whose fullName initials matches filter excluding self', () => {
+  test('returns users whose full_name initials matches filter excluding self', () => {
     const users = deepFreeze([
-      { fullName: 'Apple', email: 'a@example.com' },
-      { fullName: 'mam', email: 'f@app.com' },
-      { fullName: 'app', email: 'p@p.com' },
-      { fullName: 'Mobile Application', email: 'p3@p.com' },
-      { fullName: 'Mac App', email: 'p@p2.com' },
-      { fullName: 'app', email: 'p@p.com' },
-      { fullName: 'app', email: 'own@example.com' },
+      { full_name: 'Apple', email: 'a@example.com' },
+      { full_name: 'mam', email: 'f@app.com' },
+      { full_name: 'app', email: 'p@p.com' },
+      { full_name: 'Mobile Application', email: 'p3@p.com' },
+      { full_name: 'Mac App', email: 'p@p2.com' },
+      { full_name: 'app', email: 'p@p.com' },
+      { full_name: 'app', email: 'own@example.com' },
     ]);
 
     const expectedUsers = [
-      { fullName: 'Mobile Application', email: 'p3@p.com' },
-      { fullName: 'Mac App', email: 'p@p2.com' },
+      { full_name: 'Mobile Application', email: 'p3@p.com' },
+      { full_name: 'Mac App', email: 'p@p2.com' },
     ];
     expect(filterUserByInitials(users, 'ma', 'own@example.com')).toEqual(expectedUsers);
   });
@@ -295,20 +296,20 @@ describe('groupUsersByStatus', () => {
 });
 
 describe('filterUserThatContains', () => {
-  test('returns users whose fullName contains filter excluding self', () => {
+  test('returns users whose full_name contains filter excluding self', () => {
     const users = deepFreeze([
-      { fullName: 'Apple', email: 'a@example.com' },
-      { fullName: 'mam', email: 'f@app.com' },
-      { fullName: 'app', email: 'p@p.com' },
-      { fullName: 'Mobile app', email: 'p3@p.com' },
-      { fullName: 'Mac App', email: 'p@p2.com' },
-      { fullName: 'app', email: 'p@p.com' },
-      { fullName: 'app', email: 'own@example.com' },
+      { full_name: 'Apple', email: 'a@example.com' },
+      { full_name: 'mam', email: 'f@app.com' },
+      { full_name: 'app', email: 'p@p.com' },
+      { full_name: 'Mobile app', email: 'p3@p.com' },
+      { full_name: 'Mac App', email: 'p@p2.com' },
+      { full_name: 'app', email: 'p@p.com' },
+      { full_name: 'app', email: 'own@example.com' },
     ]);
 
     const expectedUsers = [
-      { fullName: 'mam', email: 'f@app.com' },
-      { fullName: 'Mac App', email: 'p@p2.com' },
+      { full_name: 'mam', email: 'f@app.com' },
+      { full_name: 'Mac App', email: 'p@p2.com' },
     ];
     expect(filterUserThatContains(users, 'ma', 'own@example.com')).toEqual(expectedUsers);
   });
@@ -317,16 +318,16 @@ describe('filterUserThatContains', () => {
 describe('filterUserMatchesEmail', () => {
   test('returns users whose email matches filter excluding self', () => {
     const users = deepFreeze([
-      { fullName: 'Apple', email: 'a@example.com' },
-      { fullName: 'mam', email: 'f@app.com' },
-      { fullName: 'app', email: 'p@p.com' },
-      { fullName: 'Mobile app', email: 'p3@p.com' },
-      { fullName: 'Mac App', email: 'p@p2.com' },
-      { fullName: 'app', email: 'p@p.com' },
-      { fullName: 'app', email: 'own@example.com' },
+      { full_name: 'Apple', email: 'a@example.com' },
+      { full_name: 'mam', email: 'f@app.com' },
+      { full_name: 'app', email: 'p@p.com' },
+      { full_name: 'Mobile app', email: 'p3@p.com' },
+      { full_name: 'Mac App', email: 'p@p2.com' },
+      { full_name: 'app', email: 'p@p.com' },
+      { full_name: 'app', email: 'own@example.com' },
     ]);
 
-    const expectedUsers = [{ fullName: 'Apple', email: 'a@example.com' }];
+    const expectedUsers = [{ full_name: 'Apple', email: 'a@example.com' }];
     expect(filterUserMatchesEmail(users, 'example', 'own@example.com')).toEqual(expectedUsers);
   });
 });
@@ -334,21 +335,21 @@ describe('filterUserMatchesEmail', () => {
 describe('getUniqueUsers', () => {
   test('returns unique users check by email', () => {
     const users = deepFreeze([
-      { fullName: 'Apple', email: 'a@example.com' },
-      { fullName: 'Apple', email: 'a@example.com' },
-      { fullName: 'app', email: 'p@p.com' },
-      { fullName: 'app', email: 'p@p.com' },
-      { fullName: 'Mac App', email: 'p@p2.com' },
-      { fullName: 'Mac App', email: 'p@p2.com' },
-      { fullName: 'Mac App 2', email: 'p@p2.com' },
-      { fullName: 'app', email: 'own@example.com' },
+      { full_name: 'Apple', email: 'a@example.com' },
+      { full_name: 'Apple', email: 'a@example.com' },
+      { full_name: 'app', email: 'p@p.com' },
+      { full_name: 'app', email: 'p@p.com' },
+      { full_name: 'Mac App', email: 'p@p2.com' },
+      { full_name: 'Mac App', email: 'p@p2.com' },
+      { full_name: 'Mac App 2', email: 'p@p2.com' },
+      { full_name: 'app', email: 'own@example.com' },
     ]);
 
     const expectedUsers = [
-      { fullName: 'Apple', email: 'a@example.com' },
-      { fullName: 'app', email: 'p@p.com' },
-      { fullName: 'Mac App', email: 'p@p2.com' },
-      { fullName: 'app', email: 'own@example.com' },
+      { full_name: 'Apple', email: 'a@example.com' },
+      { full_name: 'app', email: 'p@p.com' },
+      { full_name: 'Mac App', email: 'p@p2.com' },
+      { full_name: 'app', email: 'own@example.com' },
     ];
     expect(getUniqueUsers(users)).toEqual(expectedUsers);
   });

--- a/src/users/__tests__/userSelectors-test.js
+++ b/src/users/__tests__/userSelectors-test.js
@@ -40,12 +40,13 @@ describe('getAccountDetailsUser', () => {
     });
     const expectedUser = {
       email: 'b@a.com',
-      fullName: 'b@a.com',
-      avatarUrl: '',
-      id: -1,
-      isActive: false,
-      isAdmin: false,
-      isBot: false,
+      full_name: 'b@a.com',
+      avatar_url: '',
+      timezone: '',
+      user_id: -1,
+      is_active: false,
+      is_admin: false,
+      is_bot: false,
     };
 
     const actualUser = getAccountDetailsUser(state);
@@ -58,14 +59,14 @@ describe('getActiveUsers', () => {
   test('return all active users from state', () => {
     const state = deepFreeze({
       users: [
-        { fullName: 'Abc', isActive: true },
-        { fullName: 'Def', isActive: false },
-        { fullName: 'Xyz', isActive: true },
+        { full_name: 'Abc', is_active: true },
+        { full_name: 'Def', is_active: false },
+        { full_name: 'Xyz', is_active: true },
       ],
     });
     const expectedUsers = [
-      { fullName: 'Abc', isActive: true },
-      { fullName: 'Xyz', isActive: true },
+      { full_name: 'Abc', is_active: true },
+      { full_name: 'Xyz', is_active: true },
     ];
 
     const actualUser = getActiveUsers(state);
@@ -78,9 +79,9 @@ describe('getUsersStatusActive', () => {
   test('returns users with presence status set as "active"', () => {
     const state = deepFreeze({
       users: [
-        { email: 'abc@example.com', isActive: true },
-        { email: 'def@example.com', isActive: true },
-        { email: 'xyz@example.com', isActive: true },
+        { email: 'abc@example.com', is_active: true },
+        { email: 'def@example.com', is_active: true },
+        { email: 'xyz@example.com', is_active: true },
       ],
       presence: {
         'abc@example.com': {
@@ -90,7 +91,7 @@ describe('getUsersStatusActive', () => {
         },
       },
     });
-    const expectedUsers = [{ email: 'abc@example.com', isActive: true }];
+    const expectedUsers = [{ email: 'abc@example.com', is_active: true }];
 
     const actualUser = getUsersStatusActive(state);
 
@@ -102,9 +103,9 @@ describe('getUsersStatusIdle', () => {
   test('returns users with presence status set as "idle"', () => {
     const state = deepFreeze({
       users: [
-        { email: 'abc@example.com', isActive: true },
-        { email: 'def@example.com', isActive: true },
-        { email: 'xyz@example.com', isActive: true },
+        { email: 'abc@example.com', is_active: true },
+        { email: 'def@example.com', is_active: true },
+        { email: 'xyz@example.com', is_active: true },
       ],
       presence: {
         'abc@example.com': {
@@ -120,8 +121,8 @@ describe('getUsersStatusIdle', () => {
       },
     });
     const expectedUsers = [
-      { email: 'abc@example.com', isActive: true },
-      { email: 'def@example.com', isActive: true },
+      { email: 'abc@example.com', is_active: true },
+      { email: 'def@example.com', is_active: true },
     ];
 
     const actualUser = getUsersStatusIdle(state);
@@ -134,9 +135,9 @@ describe('getUsersStatusOffline', () => {
   test('returns users with presence status set as "offline"', () => {
     const state = deepFreeze({
       users: [
-        { email: 'abc@example.com', isActive: true },
-        { email: 'def@example.com', isActive: true },
-        { email: 'xyz@example.com', isActive: true },
+        { email: 'abc@example.com', is_active: true },
+        { email: 'def@example.com', is_active: true },
+        { email: 'xyz@example.com', is_active: true },
       ],
       presence: {
         'abc@example.com': {
@@ -157,9 +158,9 @@ describe('getUsersStatusOffline', () => {
       },
     });
     const expectedUsers = [
-      { email: 'abc@example.com', isActive: true },
-      { email: 'def@example.com', isActive: true },
-      { email: 'xyz@example.com', isActive: true },
+      { email: 'abc@example.com', is_active: true },
+      { email: 'def@example.com', is_active: true },
+      { email: 'xyz@example.com', is_active: true },
     ];
 
     const actualUser = getUsersStatusOffline(state);
@@ -193,15 +194,15 @@ describe('getUsersById', () => {
   test('return users mapped by their Id', () => {
     const state = deepFreeze({
       users: [
-        { id: 1, email: 'abc@example.com' },
-        { id: 2, email: 'def@example.com' },
-        { id: 3, email: 'xyz@example.com' },
+        { user_id: 1, email: 'abc@example.com' },
+        { user_id: 2, email: 'def@example.com' },
+        { user_id: 3, email: 'xyz@example.com' },
       ],
     });
     const expectedResult = {
-      1: { id: 1, email: 'abc@example.com' },
-      2: { id: 2, email: 'def@example.com' },
-      3: { id: 3, email: 'xyz@example.com' },
+      1: { user_id: 1, email: 'abc@example.com' },
+      2: { user_id: 2, email: 'def@example.com' },
+      3: { user_id: 3, email: 'xyz@example.com' },
     };
 
     const result = getUsersById(state);

--- a/src/users/__tests__/usersReducers-test.js
+++ b/src/users/__tests__/usersReducers-test.js
@@ -51,9 +51,9 @@ describe('usersReducers', () => {
 
       const expectedState = [
         {
-          id: 1,
+          user_id: 1,
           email: 'john@example.com',
-          fullName: 'John Doe',
+          full_name: 'John Doe',
         },
       ];
 

--- a/src/users/userHelpers.js
+++ b/src/users/userHelpers.js
@@ -9,11 +9,11 @@ export const getUserByEmail = (users: User[], userEmail: string): User =>
   users.find(user => user.email === userEmail) || NULL_USER;
 
 export const getUserById = (users: User[], userId: number): User =>
-  users.find(user => user.id === userId) || NULL_USER;
+  users.find(user => user.user_id === userId) || NULL_USER;
 
 export const groupUsersByInitials = (users: User[]): Object =>
   users.reduce((accounts, x) => {
-    const firstLetter = x.fullName[0].toUpperCase();
+    const firstLetter = x.full_name[0].toUpperCase();
     if (!accounts[firstLetter]) {
       accounts[firstLetter] = []; // eslint-disable-line
     }
@@ -49,7 +49,7 @@ export const sortUserList = (users: any[], presences: PresenceState): User[] =>
   [...users].sort(
     (x1, x2) =>
       statusOrder(presences[x1.email]) - statusOrder(presences[x2.email]) ||
-      x1.fullName.toLowerCase().localeCompare(x2.fullName.toLowerCase()),
+      x1.full_name.toLowerCase().localeCompare(x2.full_name.toLowerCase()),
   );
 
 export const filterUserList = (users: User[], filter: string = '', ownEmail: ?string): User[] =>
@@ -58,17 +58,18 @@ export const filterUserList = (users: User[], filter: string = '', ownEmail: ?st
         user =>
           user.email !== ownEmail &&
           (filter === '' ||
-            user.fullName.toLowerCase().includes(filter.toLowerCase()) ||
+            user.full_name.toLowerCase().includes(filter.toLowerCase()) ||
             user.email.toLowerCase().includes(filter.toLowerCase())),
       )
     : users;
 
 export const sortAlphabetically = (users: User[]): User[] =>
-  [...users].sort((x1, x2) => x1.fullName.toLowerCase().localeCompare(x2.fullName.toLowerCase()));
+  [...users].sort((x1, x2) => x1.full_name.toLowerCase().localeCompare(x2.full_name.toLowerCase()));
 
 export const filterUserStartWith = (users: User[], filter: string = '', ownEmail: string): User[] =>
   users.filter(
-    user => user.email !== ownEmail && user.fullName.toLowerCase().startsWith(filter.toLowerCase()),
+    user =>
+      user.email !== ownEmail && user.full_name.toLowerCase().startsWith(filter.toLowerCase()),
   );
 
 export const filterUserByInitials = (
@@ -79,7 +80,7 @@ export const filterUserByInitials = (
   users.filter(
     user =>
       user.email !== ownEmail &&
-      user.fullName
+      user.full_name
         .replace(/(\s|[a-z])/g, '')
         .toLowerCase()
         .startsWith(filter.toLowerCase()),
@@ -91,7 +92,7 @@ export const filterUserThatContains = (
   ownEmail: string,
 ): User[] =>
   users.filter(
-    user => user.email !== ownEmail && user.fullName.toLowerCase().includes(filter.toLowerCase()),
+    user => user.email !== ownEmail && user.full_name.toLowerCase().includes(filter.toLowerCase()),
   );
 
 export const filterUserMatchesEmail = (
@@ -106,8 +107,8 @@ export const filterUserMatchesEmail = (
 export const getUniqueUsers = (users: User[]): User[] => uniqby(users, 'email');
 
 export const getUsersAndWildcards = (users: User[]) => [
-  { ...NULL_USER, fullName: 'all', email: '(Notify everyone)' },
-  { ...NULL_USER, fullName: 'everyone', email: '(Notify everyone)' },
+  { ...NULL_USER, full_name: 'all', email: '(Notify everyone)' },
+  { ...NULL_USER, full_name: 'everyone', email: '(Notify everyone)' },
   ...users,
 ];
 

--- a/src/users/userSelectors.js
+++ b/src/users/userSelectors.js
@@ -18,7 +18,7 @@ export const getAccountDetailsUser = createSelector(
       allUsers.find(x => x.email === params.email) || {
         ...NULL_USER,
         email: params.email,
-        fullName: params.email,
+        full_name: params.email,
       }
     );
   },
@@ -29,11 +29,11 @@ export const getSelfUserDetail = createSelector(getUsers, getOwnEmail, (users, o
 );
 
 export const getActiveUsers = createSelector(getUsers, users =>
-  users.filter(user => user.isActive),
+  users.filter(user => user.is_active),
 );
 
 export const getSortedUsers = createSelector(getUsers, users =>
-  [...users].sort((x1, x2) => x1.fullName.toLowerCase().localeCompare(x2.fullName.toLowerCase())),
+  [...users].sort((x1, x2) => x1.full_name.toLowerCase().localeCompare(x2.full_name.toLowerCase())),
 );
 
 export const getUsersStatusActive = createSelector(getActiveUsers, getPresence, (users, presence) =>
@@ -62,7 +62,7 @@ export const getUsersByEmail = createSelector(getUsers, users =>
 
 export const getUsersById = createSelector(getUsers, (users = []) =>
   users.reduce((usersById, user) => {
-    usersById[user.id] = user;
+    usersById[user.user_id] = user;
     return usersById;
   }, {}),
 );

--- a/src/users/usersActions.js
+++ b/src/users/usersActions.js
@@ -1,7 +1,7 @@
 /* @flow */
 import differenceInSeconds from 'date-fns/difference_in_seconds';
 
-import type { Dispatch, GetState, Narrow, ApiUser, InitUsersAction } from '../types';
+import type { Dispatch, GetState, Narrow, User, InitUsersAction } from '../types';
 import { focusPing, getUsers, typing } from '../api';
 import { INIT_USERS, PRESENCE_RESPONSE } from '../actionConstants';
 import { getAuth } from '../selectors';
@@ -33,7 +33,7 @@ export const sendFocusPing = (hasFocus: boolean = true, newUserInput: boolean = 
   });
 };
 
-export const initUsers = (users: ApiUser[]): InitUsersAction => ({
+export const initUsers = (users: User[]): InitUsersAction => ({
   type: INIT_USERS,
   users,
 });

--- a/src/users/usersReducers.js
+++ b/src/users/usersReducers.js
@@ -1,7 +1,5 @@
 /* @flow */
 import type {
-  User,
-  ApiUser,
   UsersState,
   UsersAction,
   InitUsersAction,
@@ -20,27 +18,16 @@ import {
 } from '../actionConstants';
 import { NULL_ARRAY } from '../nullObjects';
 
-const mapApiToStateUser = (user: ApiUser): User => ({
-  id: user.user_id,
-  email: user.email,
-  fullName: user.full_name,
-  avatarUrl: user.avatar_url,
-  isActive: user.is_active,
-  isAdmin: user.is_admin,
-  isBot: user.is_bot,
-});
-
 const initialState: UsersState = NULL_ARRAY;
 
-const initUsers = (state: UsersState, action: InitUsersAction): UsersState =>
-  action.users.map(mapApiToStateUser);
+const initUsers = (state: UsersState, action: InitUsersAction): UsersState => action.users;
 
 const realmInit = (state: UsersState, action: RealmInitAction): UsersState =>
-  action.data.realm_users.map(mapApiToStateUser);
+  action.data.realm_users;
 
 const eventUserAdd = (state: UsersState, action: EventUserAddAction): UsersState => [
   ...state,
-  mapApiToStateUser(action.person),
+  action.person,
 ];
 
 export default (state: UsersState = initialState, action: UsersAction): UsersState => {

--- a/src/utils/__tests__/url-test.js
+++ b/src/utils/__tests__/url-test.js
@@ -270,9 +270,9 @@ describe('getEmojiUrl', () => {
 
 describe('getNarrowFromLink', () => {
   const users = [
-    { email: 'abc@example.com', id: 1 },
-    { email: 'xyz@example.com', id: 2 },
-    { email: 'def@example.com', id: 3 },
+    { email: 'abc@example.com', user_id: 1 },
+    { email: 'xyz@example.com', user_id: 2 },
+    { email: 'def@example.com', user_id: 3 },
   ];
 
   test('when link is not in-app link, return default homeNarrow', () => {

--- a/src/webview/html/messageTypingAsHtml.js
+++ b/src/webview/html/messageTypingAsHtml.js
@@ -8,7 +8,9 @@ const typingAvatar = (realm: string, user: User): string => `
   <img
     class="avatar-img"
     data-email="${user.email}"
-    src="${user.avatarUrl ? getFullUrl(user.avatarUrl, realm) : getGravatarFromEmail(user.email)}">
+    src="${
+      user.avatar_url ? getFullUrl(user.avatar_url, realm) : getGravatarFromEmail(user.email)
+    }">
 </div>
 `;
 


### PR DESCRIPTION
We started using this concept in the beginning, matching the
API response to an internal more JavaScript-friendly format, that
was optionally could contain more data and be less API-dependent.

This turned out to be too much work, for too little benefit,
especially with the use of selectors.

The use of this remained for the users data structure and for
nothing else (we had User and ApiUser types)

* merge User and ApiUser into a single type
* do not map from ApiUser to User but keep data as-is
* replace all use of camelCase to snake_case