### PR TITLE
Show toast and don't navigate if realm notification different

### DIFF
--- a/src/main/MainScreenWithTabs.js
+++ b/src/main/MainScreenWithTabs.js
@@ -1,17 +1,34 @@
 /* @flow */
 import React, { PureComponent } from 'react';
 import { View } from 'react-native';
+import { connect } from 'react-redux';
 
-import type { Context } from '../types';
+import type { Context, Auth } from '../types';
 import { ZulipStatusBar } from '../common';
 import MainTabs from './MainTabs';
+import { getAuth } from '../selectors';
+import { showToast } from '../utils/info';
+import config from '../config';
 
-export default class MainScreenWithTabs extends PureComponent<{}> {
+type Props = {
+  auth: Auth,
+};
+
+class MainScreenWithTabs extends PureComponent<Props> {
   context: Context;
 
   static contextTypes = {
     styles: () => null,
   };
+
+  componentWillMount() {
+    if (config.startup.notification) {
+      if (this.props.auth.realm.indexOf(config.startup.notification.server) < 0) {
+        showToast('Notification is from a different realm.');
+        config.startup.notification = undefined;
+      }
+    }
+  }
 
   render() {
     const { styles } = this.context;
@@ -24,3 +41,7 @@ export default class MainScreenWithTabs extends PureComponent<{}> {
     );
   }
 }
+
+export default connect(state => ({
+  auth: getAuth(state),
+}))(MainScreenWithTabs);

--- a/src/nav/navSelectors.js
+++ b/src/nav/navSelectors.js
@@ -84,7 +84,10 @@ export const getInitialNavState = createSelector(
         ? getStateForRoute('main')
         : nav;
 
-    if (!config.startup.notification) {
+    if (
+      !config.startup.notification ||
+      auth.realm.indexOf(config.startup.notification.server) < 0
+    ) {
       return state;
     }
 


### PR DESCRIPTION
Shows a toast if the realm of the notification clicked is different and aborts the narrow.

_(This is a quick fix and not the final solution)_

Further discussion is required if
1. We want to show a dialog box and ask the user if they want to switch 
2. Directly switch (Showing the login screen directly) and then narrow

Or something other

Btw, Even receiving notification from different realm is bug as on switching accounts, it has been implemented to call the unregister token API to the server, hence the notification should not have been received in the first place, I checked out the with some random string in the api call and it showed the token is invalid, that's a good sign, I'll check with valid token later on and update here! 

If someone wants to work/test on this simply change the notification object in the config.js as this 
```
    notification: {
      sender_full_name: 'Name',
      sender_avatar_url:
        'https://secure.gravatar.com/avatar/7b82892ab28701cc6bfe7798b3498eb7?d:identicon&version:1',
      content_truncated: 'false',
      zulip_message_id: 225696,
      recipient_type: 'private',
      time: 1497322553,
      user: 'kunall.gupta17@gmail.com',
      alert: 'New private message from Name',
      event: 'message',
      content: 'test',
      sender_email: 'testmailhere@test.com',
      server: 'chat.zulip.org',
    },
```
^ This is basically the notification object which is recieved from the server.