### PR TITLE
Fix incorrectly calculating caughtUp

### DIFF
--- a/src/caughtup/__tests__/caughtUpReducers-test.js
+++ b/src/caughtup/__tests__/caughtUpReducers-test.js
@@ -119,6 +119,130 @@ describe('caughtUpReducers', () => {
     expect(newState).toEqual(expectedState);
   });
 
+  test('when at first unread and before and after messages are as many as requested not yet caught up', () => {
+    const initialState = deepFreeze({});
+
+    const action = deepFreeze({
+      type: MESSAGE_FETCH_COMPLETE,
+      narrow: homeNarrow,
+      anchor: 0,
+      messages: [
+        { id: 1, flags: ['read'] },
+        { id: 2, flags: ['read'] },
+        { id: 3, flags: ['read'] },
+        { id: 4, flags: [] },
+        { id: 5, flags: [] },
+        { id: 6, flags: [] },
+        { id: 7, flags: [] },
+      ],
+      numBefore: 3,
+      numAfter: 3,
+    });
+
+    const expectedState = {
+      [homeNarrowStr]: {
+        older: false,
+        newer: false,
+      },
+    };
+
+    const newState = caughtUpReducers(initialState, action);
+
+    expect(newState).toEqual(expectedState);
+  });
+
+  test('when at first unread and before messages are less than requested older is caught up', () => {
+    const initialState = deepFreeze({});
+
+    const action = deepFreeze({
+      type: MESSAGE_FETCH_COMPLETE,
+      narrow: homeNarrow,
+      anchor: 0,
+      messages: [
+        { id: 1, flags: ['read'] },
+        { id: 2, flags: ['read'] },
+        { id: 3, flags: [] },
+        { id: 4, flags: [] },
+        { id: 5, flags: [] },
+        { id: 6, flags: [] },
+      ],
+      numBefore: 3,
+      numAfter: 4,
+    });
+
+    const expectedState = {
+      [homeNarrowStr]: {
+        older: true,
+        newer: false,
+      },
+    };
+
+    const newState = caughtUpReducers(initialState, action);
+
+    expect(newState).toEqual(expectedState);
+  });
+
+  test('when at first unread and after messages are less than requested newer is caught up', () => {
+    const initialState = deepFreeze({});
+
+    const action = deepFreeze({
+      type: MESSAGE_FETCH_COMPLETE,
+      narrow: homeNarrow,
+      anchor: 0,
+      messages: [
+        { id: 1, flags: ['read'] },
+        { id: 2, flags: ['read'] },
+        { id: 3, flags: ['read'] },
+        { id: 4, flags: [] },
+        { id: 5, flags: [] },
+        { id: 6, flags: [] },
+      ],
+      numBefore: 3,
+      numAfter: 4,
+    });
+
+    const expectedState = {
+      [homeNarrowStr]: {
+        older: false,
+        newer: true,
+      },
+    };
+
+    const newState = caughtUpReducers(initialState, action);
+
+    expect(newState).toEqual(expectedState);
+  });
+
+  test('when at first unread and both before and after messages are less than requested older and newer are caught up', () => {
+    const initialState = deepFreeze({});
+
+    const action = deepFreeze({
+      type: MESSAGE_FETCH_COMPLETE,
+      narrow: homeNarrow,
+      anchor: 0,
+      messages: [
+        { id: 1, flags: ['read'] },
+        { id: 2, flags: ['read'] },
+        { id: 3, flags: [] },
+        { id: 4, flags: [] },
+        { id: 5, flags: [] },
+      ],
+      numBefore: 3,
+      numAfter: 4,
+    });
+
+    const expectedState = {
+      [homeNarrowStr]: {
+        older: true,
+        newer: true,
+      },
+    };
+
+    const newState = caughtUpReducers(initialState, action);
+
+    expect(newState).toEqual(expectedState);
+  });
+
   test('if requesting latest messages always newer is caught up', () => {
     const initialState = deepFreeze({});
 

--- a/src/caughtup/caughtUpReducers.js
+++ b/src/caughtup/caughtUpReducers.js
@@ -27,11 +27,18 @@ const messageFetchComplete = (
     };
   }
 
-  // Find the anchor in the results (or set it past the end of the list)
-  let anchorIdx = action.messages.findIndex(msg => msg.id === action.anchor);
+  let anchorIdx = -1;
+
+  if (action.anchor === 0) {
+    anchorIdx = action.messages.findIndex(msg => msg.flags.indexOf('read') === -1);
+  } else {
+    anchorIdx = action.messages.findIndex(msg => msg.id === action.anchor);
+  }
+
   if (anchorIdx === -1) {
     anchorIdx = action.messages.length;
   }
+
   const totalMessagesRequested = action.numBefore + action.numAfter;
   // If we're requesting messages before the anchor, the server
   // returns one less than we expect (to avoid duplicating the anchor)
@@ -41,7 +48,7 @@ const messageFetchComplete = (
       ? -(action.messages.length - totalMessagesRequested)
       : 0;
 
-  const caughtUpOlder = anchorIdx + 1 < action.numBefore;
+  const caughtUpOlder = anchorIdx < action.numBefore;
   const caughtUpNewer = action.messages.length - anchorIdx + adjustment < action.numAfter;
 
   const prevState = state[key] || NULL_CAUGHTUP;

--- a/src/unread/unreadSelectors.js
+++ b/src/unread/unreadSelectors.js
@@ -1,7 +1,7 @@
 /* @flow */
 import { createSelector } from 'reselect';
 
-import type { Narrow, UnreadStreamData } from '../types';
+import type { Narrow } from '../types';
 import { caseInsensitiveCompareObjFunc } from '../utils/misc';
 import {
   getMute,


### PR DESCRIPTION
We were not handling correctly the case where anchor is 0.
It is 0 when we request the messages around the first unread one.

Added tests to confirm it works for any case of incoming messages.