### PR TITLE
Fix "No recent conversations" not showing up

### DIFF
--- a/src/conversations/ConversationsCard.js
+++ b/src/conversations/ConversationsCard.js
@@ -66,7 +66,7 @@ export default class ConversationsCard extends PureComponent<Props> {
             onPress={actions.navigateToUsersScreen}
           />
         </View>
-        {conversations.length === 0 ? (
+        {conversations.length <= 1 ? (
           <Label style={componentStyles.emptySlate} text="No recent conversations" />
         ) : (
           <ConversationList


### PR DESCRIPTION
The first commit just centers the "No recent conversations" text and makes it smaller to be consistent with the rest of the app.

The second commit attempts to solve #2521 by making "No recent conversations" show when there is <=1 conversations instead of 0 conversations since a conversation with welcome-bot (which shouldn't be there) is always returned.