### PR TITLE
activityText: Reuse RawLabel instead of Text.

### DIFF
--- a/src/title/ActivityText.js
+++ b/src/title/ActivityText.js
@@ -1,15 +1,15 @@
 /* @flow */
 import React, { PureComponent } from 'react';
-import { Text } from 'react-native';
 
 import type { PresenceState, Style } from '../types';
 import connectWithActions from '../connectWithActions';
 import { getPresence } from '../selectors';
 import { presenceToHumanTime } from '../utils/presence';
+import { RawLabel } from '../common';
 
 type Props = {
   email: string,
-  color: string,
+  color?: string,
   presences: PresenceState,
   style: Style,
 };
@@ -30,10 +30,12 @@ class ActivityText extends PureComponent<Props> {
 
     const activity = presenceToHumanTime(presences[email]);
 
-    return <Text style={[style, { color }]}>Active {activity}</Text>;
+    return (
+      <RawLabel style={[style, color !== undefined && { color }]} text={`Active ${activity}`} />
+    );
   }
 }
 
-export default connectWithActions((state, props) => ({
+export default connectWithActions((state, props: Props) => ({
   presences: getPresence(state),
 }))(ActivityText);


### PR DESCRIPTION
*So that default text color is applied, i.e
according to theme if color passed in props is
undefined.

*Ideally we need to translate text, in both
activity text and message list (last edit timestamp).
Will be doing it in another PR.

Before
<img width="294" alt="screen shot 2018-05-18 at 2 27 27 am" src="https://user-images.githubusercontent.com/18511177/40203583-491ed4a0-5a43-11e8-91ab-359fa1ef41a0.png">


After
<img width="324" alt="screen shot 2018-05-18 at 2 16 04 am" src="https://user-images.githubusercontent.com/18511177/40203582-48a66376-5a43-11e8-8b73-4a071dd3d57a.png">
