### PR TITLE
Ignore Flow checks for `react-native-safe-area`

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -30,6 +30,7 @@
 .*/node_modules/react-native-notifications/.*
 .*/node_modules/react-native-tab-view/.*
 .*/node_modules/react-navigation-redux-helpers/.*
+.*/node_modules/react-native-safe-area/.*
 
 
 [include]


### PR DESCRIPTION
This is to fix Flow checks failing.
We don't actually need this component anymore as the recently added
SafeAreaView in React Native.