### PR TITLE
Fix outbox message avatar (if gravatar)

### DIFF
--- a/src/outbox/outboxActions.js
+++ b/src/outbox/outboxActions.js
@@ -123,7 +123,7 @@ export const addToOutbox = (narrow: Narrow, content: string) => async (
       timestamp: localTime,
       id: localTime,
       sender_full_name: userDetail.full_name,
-      email: userDetail.email,
+      sender_email: userDetail.email,
       avatar_url: userDetail.avatar_url,
       isOutbox: true,
     }),


### PR DESCRIPTION
We were passing the incorrect field `email` instead of `sender_email`.
It is used to determine the user's avatar if avatar_url is `null`.