### PR TITLE
AccountDetails: wrapped timezone display in a conditional.

### DIFF
--- a/src/account-info/AccountDetails.js
+++ b/src/account-info/AccountDetails.js
@@ -52,14 +52,14 @@ export default class AccountDetails extends PureComponent<Props, void> {
         <View style={[styles.row, styles.margin, styles.center]}>
           <ActivityText style={styles.largerText} email={user.email} />
         </View>
-        {user.timezone && (
+        {user.timezone ? (
           <View style={[styles.row, styles.margin, styles.center]}>
             <RawLabel
               style={styles.largerText}
               text={`${nowInTimeZone(user.timezone)} Local time`}
             />
           </View>
-        )}
+        ) : null}
         <ZulipButton
           style={styles.marginLeftRight}
           text="Send private message"


### PR DESCRIPTION
This prevents crashes when user.timezone is equal to `''` and not `null`.

When timezone is not set, `user.timezone` is `''`.
While `null && true` returns `null`, `'' && true` returns `''` which causes the crash.

This condition has been replaced with a conditional, which should continue to work as expected even if the backend was changed to return `null` sometime in the future.

Closes issue #2534