### PR TITLE
topic-screen: Connect to store with connectWithActionsPreserveOnBack.

### DIFF
--- a/src/topics/TopicListScreen.js
+++ b/src/topics/TopicListScreen.js
@@ -2,7 +2,7 @@
 import React, { PureComponent } from 'react';
 
 import type { Actions, Stream, TopicExtended } from '../types';
-import connectWithActions from '../connectWithActions';
+import { connectWithActionsPreserveOnBack } from '../connectWithActions';
 import { Screen } from '../common';
 import { topicNarrow } from '../utils/narrow';
 import { getTopicsInScreen } from '../selectors';
@@ -52,7 +52,7 @@ class TopicListScreen extends PureComponent<Props, State> {
   }
 }
 
-export default connectWithActions(state => ({
+export default connectWithActionsPreserveOnBack(state => ({
   stream: getStreamEditInitialValues(state),
   topics: getTopicsInScreen(state),
 }))(TopicListScreen);


### PR DESCRIPTION
So that it doesn't repaints when nav isTransitioning or going back.

From #2455