### PR TITLE
message_edit: Fix error is not shown on msg edit if any.

### DIFF
--- a/src/compose/ComposeBox.js
+++ b/src/compose/ComposeBox.js
@@ -159,7 +159,12 @@ export default class ComposeBox extends PureComponent<Props, State> {
     const subject = topic !== editMessage.topic ? topic : undefined;
     if (content || subject) {
       updateMessage(auth, { content, subject }, editMessage.id).catch(error => {
-        showErrorAlert(error.message, 'Failed to edit message');
+        const { response } = error;
+        try {
+          response.json().then(obj => showErrorAlert(obj.msg, 'Failed to edit message'));
+        } catch (e) {
+          showErrorAlert('', 'Failed to edit message');
+        }
       });
     }
     actions.cancelEditMessage();


### PR DESCRIPTION
* First check for json result then response.ok.
* Add msg in error is json result is not 'success'.

Before

<img width="234" alt="screen shot 2018-05-20 at 11 47 49 pm" src="https://user-images.githubusercontent.com/18511177/40282148-59a64744-5c88-11e8-8519-8fb720578f11.png">


After
<img width="285" alt="screen shot 2018-05-20 at 11 41 47 pm" src="https://user-images.githubusercontent.com/18511177/40282147-597855aa-5c88-11e8-8805-78f460c70e62.png">