### PR TITLE
Add a polyfill for Element.matches

### DIFF
--- a/src/webview/js/matchesPolyfill.js
+++ b/src/webview/js/matchesPolyfill.js
@@ -1,0 +1,19 @@
+/* eslint-disable */
+// Official MDN polyfill for Element.matches
+// Source: https://developer.mozilla.org/en-US/docs/Web/API/Element/matches
+export default `
+if (!Element.prototype.matches) {
+  Element.prototype.matches =
+    Element.prototype.matchesSelector ||
+    Element.prototype.mozMatchesSelector ||
+    Element.prototype.msMatchesSelector ||
+    Element.prototype.oMatchesSelector ||
+    Element.prototype.webkitMatchesSelector ||
+    function(s) {
+      var matches = (this.document || this.ownerDocument).querySelectorAll(s),
+        i = matches.length;
+      while (--i >= 0 && matches.item(i) !== this) {}
+      return i > -1;
+    };
+}
+`;

--- a/src/webview/js/script.js
+++ b/src/webview/js/script.js
@@ -1,5 +1,6 @@
 /* @flow */
 import smoothScroll from './smoothScroll.min';
+import matchesPolyfill from './matchesPolyfill';
 import js from './generatedEs3';
 import config from '../../config';
 
@@ -7,6 +8,7 @@ export default (anchor: number): string => `
 <script>
 window.__forceSmoothScrollPolyfill__ = true;
 ${smoothScroll}
+${matchesPolyfill}
 window.enableWebViewErrorDisplay = ${config.enableWebViewErrorDisplay.toString()};
 document.addEventListener('DOMContentLoaded', function() {
   ${js}


### PR DESCRIPTION
Fixes #2540

The Element.matches function is not supported on Android 4.4 causing
many interactions inside the webview to throw an exception.