### PR TITLE
Handle no data in storage for flagsReducers

### DIFF
--- a/src/chat/__tests__/flagsReducers-test.js
+++ b/src/chat/__tests__/flagsReducers-test.js
@@ -14,6 +14,21 @@ import { NULL_OBJECT } from '../../nullObjects';
 
 describe('flagsReducers', () => {
   describe('REHYDRATE', () => {
+    test('handles no input data', () => {
+      const initialState = NULL_OBJECT;
+
+      const action = deepFreeze({
+        type: REHYDRATE,
+        payload: {},
+      });
+
+      const expectedState = {};
+
+      const actualState = flagsReducers(initialState, action);
+
+      expect(actualState).toEqual(expectedState);
+    });
+
     test('flags from all messages are extracted and stored by id', () => {
       const initialState = NULL_OBJECT;
 

--- a/src/chat/flagsReducers.js
+++ b/src/chat/flagsReducers.js
@@ -92,8 +92,9 @@ const processFlagsForMessages = (state: FlagsState, messages: Message[]): FlagsS
 
 const rehydrate = (state: FlagsState, action: RehydrateAction): FlagsState => {
   // $FlowFixMe
-  const allMessages: Message[] = Array.prototype.concat(...Object.values(action.payload.messages));
-  return processFlagsForMessages(state, allMessages);
+  const arrayOfMessageArrays: Array<Message[]> = Object.values(action.payload.messages || {});
+  const flattenedMessages: Message[] = Array.prototype.concat(...arrayOfMessageArrays);
+  return processFlagsForMessages(state, flattenedMessages);
 };
 
 const messageFetchComplete = (state: FlagsState, action: MessageFetchCompleteAction): FlagsState =>


### PR DESCRIPTION
This happens only on first app startup.

I had incorrectly assumed that `action.payload` will have the
form of an empty initial state object, but it is actually an
empty object, thus `payload.messages` is `undefined`.