### PR TITLE
edit-message: Fix styling issue in 'Edit Message' title text.

### DIFF
--- a/src/title/TitlePlain.js
+++ b/src/title/TitlePlain.js
@@ -20,6 +20,6 @@ export default class TitlePrivate extends PureComponent<Props> {
   render() {
     const { styles } = this.context;
     const { text, color } = this.props;
-    return <Text style={[styles.navBar, { color }]}>{text}</Text>;
+    return <Text style={[styles.navTitle, styles.flexed, { color }]}>{text}</Text>;
   }
 }


### PR DESCRIPTION
Before
<img width="315" alt="screen shot 2018-05-22 at 11 54 28 pm" src="https://user-images.githubusercontent.com/18511177/40382235-87f5b906-5e1b-11e8-9ab0-ba37c72c7a1f.png">
<img width="326" alt="screen shot 2018-05-22 at 11 54 41 pm" src="https://user-images.githubusercontent.com/18511177/40382236-882373b4-5e1b-11e8-923b-2143e3ec3090.png">


This PR
<img width="329" alt="screen shot 2018-05-22 at 11 47 56 pm" src="https://user-images.githubusercontent.com/18511177/40382191-65f68484-5e1b-11e8-85a4-633f9338a0be.png">
<img width="318" alt="screen shot 2018-05-22 at 11 48 40 pm" src="https://user-images.githubusercontent.com/18511177/40382192-66337902-5e1b-11e8-9c39-1096f23c6be3.png">
