### PR TITLE
types: Give a real type for ImageResource.

### DIFF
--- a/src/types.js
+++ b/src/types.js
@@ -45,9 +45,7 @@ export type InputSelectionType = {
 
 export type Account = Auth;
 
-export type ImageResource = any; /* {
-  uri: string,
-} */
+export type ImageResource = string;
 
 export type ReactionType = any; /* {
   emoji_name: string,


### PR DESCRIPTION
As it is used in the code, ImageResources are simply
strings that contain a uri. They are not, however, an
object with a uri property, as the type comment suggested.

This is me getting my feet wet with Flow type annotations. I traced the code paths and in all cases, it looks like `ImageResource` is actually just a string. However, I'm wondering if in this case, instead of making it an alias for string, a better solution would be to actually use
```
export type ImageResource = {
  uri: string,
}
```
and change the code to use the `uri` property instead?

Another question I have is if the suggested type definitions in the comments are human or machine generated.