### PR TITLE
TitleSpecial: Added padding left to the label.

### DIFF
--- a/src/title/TitleSpecial.js
+++ b/src/title/TitleSpecial.js
@@ -33,7 +33,7 @@ export default class TitleSpecial extends PureComponent<Props> {
 
     return (
       <View style={styles.navWrapper}>
-        <Icon name={icon} size={20} color={color} />
+        <Icon name={icon} size={20} color={color} style={styles.halfPaddingRight} />
         <Label style={[styles.navTitle, { color }]} text={name} />
       </View>
     );


### PR DESCRIPTION
Add spacing between the icon and the corresponding label.

Before:
![titlespecialbefore](https://user-images.githubusercontent.com/22353313/40495697-85f61f62-5f95-11e8-8bb8-00136963f0b0.png)

After:
![titlespecialafter](https://user-images.githubusercontent.com/22353313/40495692-8173af18-5f95-11e8-81fd-a47eff09490a.png)
