### PR TITLE
compose-box: Fix jerkiness in message list on expanding menu.

### DIFF
--- a/src/animation/AnimatedComponent.js
+++ b/src/animation/AnimatedComponent.js
@@ -11,6 +11,7 @@ type Props = {
   visible: boolean,
   property: string,
   useNativeDriver: boolean,
+  onAnimationCompleted: (visible: boolean) => void,
 };
 
 export default class AnimatedComponent extends PureComponent<Props> {
@@ -24,12 +25,13 @@ export default class AnimatedComponent extends PureComponent<Props> {
   animatedValue = new Animated.Value(0);
 
   componentDidUpdate() {
+    const { onAnimationCompleted, property, visible } = this.props;
     Animated.timing(this.animatedValue, {
-      toValue: this.props.visible ? this.props[this.props.property] : 0,
+      toValue: this.props.visible ? this.props[property] : 0,
       duration: 300,
       useNativeDriver: this.props.useNativeDriver,
       easing: this.props.visible ? Easing.elastic() : Easing.back(2),
-    }).start();
+    }).start(() => onAnimationCompleted(visible));
   }
 
   render() {

--- a/src/compose/ComposeBox.js
+++ b/src/compose/ComposeBox.js
@@ -67,6 +67,11 @@ export default class ComposeBox extends PureComponent<Props, State> {
     height: 20,
     topic: '',
     message: this.props.draft,
+    messageBoxPlaceholder: getComposeInputPlaceholder(
+      this.props.narrow,
+      this.props.auth.email,
+      this.props.users,
+    ),
     selection: { start: 0, end: 0 },
   };
 
@@ -165,6 +170,15 @@ export default class ComposeBox extends PureComponent<Props, State> {
     actions.cancelEditMessage();
   };
 
+  onComposeMenuAnimationCompleted = isVisible => {
+    const { auth, narrow, users } = this.props;
+    this.setState({
+      messageBoxPlaceholder: isVisible
+        ? 'Message'
+        : getComposeInputPlaceholder(narrow, auth.email, users),
+    });
+  };
+
   tryUpdateDraft = () => {
     const { actions, draft, narrow } = this.props;
     const { message } = this.state;
@@ -216,14 +230,14 @@ export default class ComposeBox extends PureComponent<Props, State> {
       isMenuExpanded,
       height,
       message,
+      messageBoxPlaceholder,
       topic,
       selection,
     } = this.state;
     const {
-      auth,
       canSend,
       narrow,
-      users,
+
       editMessage,
       safeAreaInsets,
       messageInputRef,
@@ -239,7 +253,6 @@ export default class ComposeBox extends PureComponent<Props, State> {
     }
 
     const canSelectTopic = (isMessageFocused || isTopicFocused) && isStreamNarrow(narrow);
-    const placeholder = isMenuExpanded ? 'Message' : getComposeInputPlaceholder(narrow, auth.email, users);
 
     return (
       <View style={{ marginBottom: safeAreaInsets.bottom }}>
@@ -256,6 +269,7 @@ export default class ComposeBox extends PureComponent<Props, State> {
         <View style={styles.composeBox} onLayout={this.handleLayoutChange}>
           <View style={styles.alignBottom}>
             <ComposeMenuContainer
+              onAnimationCompleted={this.onComposeMenuAnimationCompleted}
               narrow={narrow}
               expanded={isMenuExpanded}
               onExpandContract={this.handleComposeMenuToggle}
@@ -279,7 +293,7 @@ export default class ComposeBox extends PureComponent<Props, State> {
             )}
             <MultilineInput
               style={styles.composeTextInput}
-              placeholder={placeholder}
+              placeholder={messageBoxPlaceholder}
               textInputRef={component => {
                 if (component) {
                   this.messageInput = component;

--- a/src/compose/ComposeBox.js
+++ b/src/compose/ComposeBox.js
@@ -44,6 +44,7 @@ type State = {
   isMenuExpanded: boolean,
   topic: string,
   message: string,
+  messageBoxPlaceholder: string,
   height: number,
   selection: InputSelectionType,
 };
@@ -170,7 +171,7 @@ export default class ComposeBox extends PureComponent<Props, State> {
     actions.cancelEditMessage();
   };
 
-  onComposeMenuAnimationCompleted = isVisible => {
+  onComposeMenuAnimationCompleted = (isVisible: boolean) => {
     const { auth, narrow, users } = this.props;
     this.setState({
       messageBoxPlaceholder: isVisible
@@ -237,7 +238,6 @@ export default class ComposeBox extends PureComponent<Props, State> {
     const {
       canSend,
       narrow,
-
       editMessage,
       safeAreaInsets,
       messageInputRef,
@@ -253,6 +253,7 @@ export default class ComposeBox extends PureComponent<Props, State> {
     }
 
     const canSelectTopic = (isMessageFocused || isTopicFocused) && isStreamNarrow(narrow);
+    const placeholder = isMenuExpanded ? 'Message' : messageBoxPlaceholder;
 
     return (
       <View style={{ marginBottom: safeAreaInsets.bottom }}>
@@ -293,7 +294,7 @@ export default class ComposeBox extends PureComponent<Props, State> {
             )}
             <MultilineInput
               style={styles.composeTextInput}
-              placeholder={messageBoxPlaceholder}
+              placeholder={placeholder}
               textInputRef={component => {
                 if (component) {
                   this.messageInput = component;

--- a/src/compose/ComposeBox.js
+++ b/src/compose/ComposeBox.js
@@ -239,7 +239,7 @@ export default class ComposeBox extends PureComponent<Props, State> {
     }
 
     const canSelectTopic = (isMessageFocused || isTopicFocused) && isStreamNarrow(narrow);
-    const placeholder = getComposeInputPlaceholder(narrow, auth.email, users);
+    const placeholder = isMenuExpanded ? 'Message' : getComposeInputPlaceholder(narrow, auth.email, users);
 
     return (
       <View style={{ marginBottom: safeAreaInsets.bottom }}>

--- a/src/compose/ComposeMenu.js
+++ b/src/compose/ComposeMenu.js
@@ -13,6 +13,7 @@ type Props = {
   actions: Actions,
   expanded: boolean,
   narrow: Narrow,
+  onAnimationCompleted: (visible: boolean) => void,
   onExpandContract: () => void,
 };
 
@@ -59,11 +60,17 @@ export default class ComposeMenu extends Component<Props> {
 
   render() {
     const { styles } = this.context;
-    const { actions, expanded, onExpandContract } = this.props;
+    const { actions, expanded, onAnimationCompleted, onExpandContract } = this.props;
 
     return (
       <View style={styles.composeMenu}>
-        <AnimatedComponent property="width" useNativeDriver={false} visible={expanded} width={120}>
+        <AnimatedComponent
+          property="width"
+          useNativeDriver={false}
+          onAnimationCompleted={onAnimationCompleted}
+          visible={expanded}
+          width={120}
+        >
           <View style={styles.composeMenu}>
             <IconPeople
               style={styles.composeMenuButton}


### PR DESCRIPTION
* compose-box: Set message input as 'Message' when menu is expanded.  d556dd6
When menu is expanded it's width is reduced, so use smaller
placeholder. So that scroll in message list is maintained.
d556dd6


* animation: Add animation complete callback prop. 78f349b
  * Update compose box message placeholder on animation
completed.
  * Store placeholder in the state.


* compose-box: Fix jerkiness in message list on expanding menu. 8f272e5
  * When it is expanded, update placeholder instantly.
  * When it is compressed, update it when animation ends.

Before:
https://chat.zulip.org/user_uploads/2/a1/E2ni2cyBSY-NbdOHLysj4OjF/before-self-narrow.mov
https://chat.zulip.org/user_uploads/2/d7/thaZMo_sTidyhDIxWOBQgONh/before-pm-narrow.mov

After:
https://chat.zulip.org/user_uploads/2/60/6ElE6doB9ONatvQFGHWfDINU/after-pn-narrow.mov
https://chat.zulip.org/user_uploads/2/b9/0jx6pNiNcz2_4HL8yYEKCEwi/after-self-narrow.mov