### PR TITLE
types: Remove ImageResource type.

### DIFF
--- a/src/lightbox/LightboxContainer.js
+++ b/src/lightbox/LightboxContainer.js
@@ -4,7 +4,7 @@ import { View, StyleSheet, Dimensions, Easing } from 'react-native';
 import PhotoView from 'react-native-photo-view';
 import { connectActionSheet } from '@expo/react-native-action-sheet';
 
-import type { Actions, Auth, Message, ImageResource } from '../types';
+import type { Actions, Auth, Message } from '../types';
 import connectWithActions from '../connectWithActions';
 import { getAuth } from '../selectors';
 import { getResource } from '../utils/url';
@@ -36,7 +36,7 @@ const styles = StyleSheet.create({
 type Props = {
   auth: Auth,
   actions: Actions,
-  src: ImageResource,
+  src: string,
   message: Message,
   handleImagePress: (movement: string) => void,
   showActionSheetWithOptions: (Object, (number) => void) => void,

--- a/src/lightbox/LightboxScreen.js
+++ b/src/lightbox/LightboxScreen.js
@@ -6,7 +6,7 @@ import { ActionSheetProvider } from '@expo/react-native-action-sheet';
 
 import { ZulipStatusBar } from '../common';
 import LightboxContainer from './LightboxContainer';
-import type { Message, ImageResource } from '../types';
+import type { Message } from '../types';
 
 const styles = StyleSheet.create({
   screen: {
@@ -21,7 +21,7 @@ type Props = {
   navigation: NavigationScreenProp<*> & {
     state: {
       params: {
-        src: ImageResource,
+        src: string,
         message: Message,
       },
     },

--- a/src/types.js
+++ b/src/types.js
@@ -45,8 +45,6 @@ export type InputSelectionType = {
 
 export type Account = Auth;
 
-export type ImageResource = string;
-
 export type ReactionType = any; /* {
   emoji_name: string,
   user: any,


### PR DESCRIPTION
The `ImageResource` type was just an alias for `string`.
Therefore, we can just assign the `string` type directly
instead of `ImageResource`.

See #2561 for further discussion.