### PR TITLE
Do not display 'Why not start the conversation?' for specialNarrow and searchNarrow

### DIFF
--- a/src/message/NoMessages.js
+++ b/src/message/NoMessages.js
@@ -15,6 +15,7 @@ import {
   isStreamNarrow,
   isTopicNarrow,
   isSearchNarrow,
+  canSendToNarrow,
 } from '../utils/narrow';
 
 const styles = StyleSheet.create({
@@ -64,7 +65,7 @@ class NoMessages extends PureComponent<Props> {
     return (
       <View style={styles.container}>
         <Label style={styles.text} text={message.text} />
-        <Label text="Why not start the conversation?" />
+        {canSendToNarrow(narrow) ? <Label text="Why not start the conversation?" /> : null}
       </View>
     );
   }


### PR DESCRIPTION
This subtitle does not seem to make sense for specialNarrow and searchNarrow as one cannot start a conversation directly from these.