### PR TITLE
WIP: Improvement to Input behaviour on opening/closing composeMenu

### DIFF
--- a/src/animation/AnimatedComponent.js
+++ b/src/animation/AnimatedComponent.js
@@ -11,6 +11,7 @@ type Props = {
   visible: boolean,
   property: string,
   useNativeDriver: boolean,
+  onAnimationCompleted: () => void,
 };
 
 export default class AnimatedComponent extends PureComponent<Props> {
@@ -24,12 +25,13 @@ export default class AnimatedComponent extends PureComponent<Props> {
   animatedValue = new Animated.Value(0);
 
   componentDidUpdate() {
+    const { onAnimationCompleted } = this.props;
     Animated.timing(this.animatedValue, {
       toValue: this.props.visible ? this.props[this.props.property] : 0,
       duration: 300,
       useNativeDriver: this.props.useNativeDriver,
       easing: this.props.visible ? Easing.elastic() : Easing.back(2),
-    }).start();
+    }).start(() => onAnimationCompleted());
   }
 
   render() {

--- a/src/compose/ComposeBox.js
+++ b/src/compose/ComposeBox.js
@@ -50,6 +50,7 @@ type State = {
   isMessageFocused: boolean,
   isTopicFocused: boolean,
   isMenuExpanded: boolean,
+  showFullMessage: boolean,
   topic: string,
   message: string,
   height: number,
@@ -72,6 +73,7 @@ export default class ComposeBox extends PureComponent<Props, State> {
     isMessageFocused: false,
     isTopicFocused: false,
     isMenuExpanded: false,
+    showFullMessage: true,
     height: 20,
     topic: '',
     message: this.props.draft,
@@ -79,8 +81,15 @@ export default class ComposeBox extends PureComponent<Props, State> {
   };
 
   handleComposeMenuToggle = () => {
-    this.setState(({ isMenuExpanded }) => ({
+    this.setState(({ isMenuExpanded, showFullMessage }) => ({
+      showFullMessage: false,
       isMenuExpanded: !isMenuExpanded,
+    }));
+  };
+
+  onComposeMenuAnimationCompleted = () => {
+    this.setState(({ isMenuExpanded, showFullMessage }) => ({
+      showFullMessage: isMenuExpanded ? false : true,
     }));
   };
 
@@ -232,6 +241,7 @@ export default class ComposeBox extends PureComponent<Props, State> {
       isMessageFocused,
       isTopicFocused,
       isMenuExpanded,
+      showFullMessage,
       height,
       message,
       topic,
@@ -277,6 +287,7 @@ export default class ComposeBox extends PureComponent<Props, State> {
               narrow={narrow}
               expanded={isMenuExpanded}
               onExpandContract={this.handleComposeMenuToggle}
+              onAnimationCompleted={this.onComposeMenuAnimationCompleted}
             />
           </View>
           <View style={styles.composeText}>
@@ -297,7 +308,12 @@ export default class ComposeBox extends PureComponent<Props, State> {
               />
             )}
             <MultilineInput
-              style={styles.composeTextInput}
+              style={[
+                styles.composeTextInput,
+                showFullMessage
+                  ? styles.composeTextInputShowFullText
+                  : styles.composeTextInputShowOneLine,
+              ]}
               placeholder={placeholder}
               textInputRef={component => {
                 if (component) {

--- a/src/compose/ComposeMenu.js
+++ b/src/compose/ComposeMenu.js
@@ -14,6 +14,7 @@ type Props = {
   expanded: boolean,
   narrow: Narrow,
   onExpandContract: () => void,
+  onAnimationCompleted: () => void,
 };
 
 export default class ComposeMenu extends Component<Props> {
@@ -59,11 +60,17 @@ export default class ComposeMenu extends Component<Props> {
 
   render() {
     const { styles } = this.context;
-    const { actions, expanded, onExpandContract } = this.props;
+    const { actions, expanded, onExpandContract, onAnimationCompleted } = this.props;
 
     return (
       <View style={styles.composeMenu}>
-        <AnimatedComponent property="width" useNativeDriver={false} visible={expanded} width={120}>
+        <AnimatedComponent
+          property="width"
+          useNativeDriver={false}
+          visible={expanded}
+          width={120}
+          onAnimationCompleted={onAnimationCompleted}
+        >
           <View style={styles.composeMenu}>
             <IconPeople
               style={styles.composeMenuButton}

--- a/src/styles/composeBoxStyles.js
+++ b/src/styles/composeBoxStyles.js
@@ -51,6 +51,12 @@ export default ({ color, backgroundColor, borderColor }: Props) => ({
     fontSize: 15,
     ...inputMarginPadding,
   },
+  composeTextInputShowFullText: {
+    height: 'auto',
+  },
+  composeTextInputShowOneLine: {
+    height: 30,
+  },
   topicInput: {
     borderWidth: 0,
     borderRadius: 5,


### PR DESCRIPTION
Now composebox functions similar to FB Messenger's input box:

* On tapping the menu expand button, the height of input box is immediately reduced to a fixed value.
* On closing the menu, the height remains fixed until the animation is complete and then is replaced by `height: 'auto' `

This also serves to de-emphasize the input when the menu is open.

(Accidentally captured some background music in the screen recordings, sorry for that)
Before: https://chat.zulip.org/user_uploads/2/f9/_Deoxhl-b9RC1yemRCL9jFdE/composebox_before.mp4

After: https://chat.zulip.org/user_uploads/2/3b/rdB45oSZsbEO8VFmP93wfSLV/compose_heightChange_after.mp4

This PR attempts to fix #2572 