### PR TITLE
ModalNavBar: Add marginLeft to title text if there is no back button.

### DIFF
--- a/src/nav/ModalNavBar.js
+++ b/src/nav/ModalNavBar.js
@@ -5,7 +5,7 @@ import type { ChildrenArray } from 'react';
 
 import type { Actions, Context, LocalizableText, Style } from '../types';
 import { connectWithActionsPreserveOnBack } from '../connectWithActions';
-import { NAVBAR_SIZE } from '../styles';
+import { NAVBAR_SIZE, SPACING } from '../styles';
 import { Label } from '../common';
 import { getCanGoBack } from '../selectors';
 import NavButton from './NavButton';
@@ -44,7 +44,7 @@ class ModalNavBar extends PureComponent<Props> {
     } = this.props;
     const textStyle = [
       styles.navTitle,
-      canGoBack && { marginRight: NAVBAR_SIZE },
+      canGoBack ? { marginRight: NAVBAR_SIZE } : { marginLeft: SPACING },
       rightItem ? { marginLeft: NAVBAR_SIZE } : {},
       titleColor ? { color: titleColor } : {},
     ];


### PR DESCRIPTION
Before:
![screenshot_20180528-135718](https://user-images.githubusercontent.com/22353313/40606854-5afb99ee-6284-11e8-995e-4048223175db.png)

After:
![screenshot_20180528-142743](https://user-images.githubusercontent.com/22353313/40606874-63c89ba8-6284-11e8-8c80-303566c8b829.png)
