### PR TITLE
Fix Webview extra scroll event never fired

### DIFF
--- a/src/webview/js/generatedEs3.js
+++ b/src/webview/js/generatedEs3.js
@@ -142,7 +142,7 @@ var sendScrollMessage = function sendScrollMessage() {
 };
 
 var sendScrollMessageIfListShort = function sendScrollMessageIfListShort() {
-  if (documentBody.scrollHeight < documentBody.clientHeight) {
+  if (documentBody.scrollHeight === documentBody.clientHeight) {
     sendScrollMessage();
   }
 };

--- a/src/webview/js/js.js
+++ b/src/webview/js/js.js
@@ -146,7 +146,7 @@ const sendScrollMessage = () => {
 // If the message list is too short to scroll, fake a scroll event
 // in order to cause the messages to be marked as read.
 const sendScrollMessageIfListShort = () => {
-  if (documentBody.scrollHeight < documentBody.clientHeight) {
+  if (documentBody.scrollHeight === documentBody.clientHeight) {
     sendScrollMessage();
   }
 };


### PR DESCRIPTION
If the message list is too short no scroll event is ever fired.
That is why we manually send a scroll event in these cases.
Our logic is wrong though, `documentBody.scrollHeight` is never
smaller than `documentBody.clientHeight`, it is equal or greater.

The correct check is `===`.