### PR TITLE
ui: Collapse compose menu on message or topic edit

### DIFF
--- a/src/compose/ComposeBox.js
+++ b/src/compose/ComposeBox.js
@@ -91,11 +91,11 @@ export default class ComposeBox extends PureComponent<Props, State> {
   };
 
   handleTopicChange = (topic: string) => {
-    this.setState({ topic });
+    this.setState({ topic, isMenuExpanded: false });
   };
 
   handleMessageChange = (message: string) => {
-    this.setState({ message });
+    this.setState({ message, isMenuExpanded: false });
     const { dispatch, narrow } = this.props;
     dispatch(sendTypingEvent(narrow));
   };


### PR DESCRIPTION
The compose menu is supposed to stay expanded for a short time.
When a users starts editing either the message or the topic we
collapse the menu. This is consistent with FB Messenger's behavior.