### PR TITLE
WIP: Add concrete type for EventUpdateMessageAction

### DIFF
--- a/src/actionTypes.js
+++ b/src/actionTypes.js
@@ -380,7 +380,49 @@ export type EventStreamOccupyAction = {
 
 export type EventNewMessageAction = any;
 export type EventMessageDeleteAction = any;
-export type EventUpdateMessageAction = any;
+
+export type EventUpdateMessageCommon = {
+  edit_timestamp: number,
+  flags: string[],
+  message_id: number,
+  message_ids: number[],
+  sender: string,
+  stream_name: string,
+  user_id: number,
+};
+
+export type EventUpdateMessageContentAction = EventUpdateMessageCommon & {
+  type: 'EVENT_UPDATE_MESSAGE',
+  content?: string,
+  is_me_message: boolean,
+  mention_user_ids: number[],
+  orig_content: string,
+  orig_rendered_content: string,
+  presence_idle_user_ids: number[],
+  prev_rendered_content_version: number,
+  prior_mention_user_ids: number[],
+  push_notify_user_ids: number[],
+  rendered_content: string,
+  stream_push_user_ids: number,
+};
+
+export type EventUpdateMessageTopicAction = EventUpdateMessageCommon & {
+  type: 'EVENT_UPDATE_MESSAGE',
+  orig_subject: string,
+  propagate_mode: 'change_one' | 'change_later' | 'change_all',
+  stream_id: number,
+  subject: string,
+  subject_links: string[],
+};
+
+export type EventUpdateMessageContentAndTopicAction = EventUpdateMessageContentAction &
+  EventUpdateMessageTopicAction;
+
+export type EventUpdateMessageAction =
+  | EventUpdateMessageContentAndTopicAction
+  | EventUpdateMessageContentAction
+  | EventUpdateMessageTopicAction;
+
 export type EventReactionAddAction = any;
 export type EventReactionRemoveAction = any;
 export type EventPresenceAction = any;


### PR DESCRIPTION
This is the event fired when a message on the server have been updated.

There are three cases that could cause that:
* message's content have changed
* message's topic have changed
* both content and topic have changed

Curenly we are handling only the content change and partially the
topic change.

We are also not doing anything with the `propagate_mode`.

These types are correct but the tests are failing because the reducer
was not aware of all the incoming data formats (it either changed
since we implemented it, or we implemented it incompletely).

Now thanks to Flow we know what remains to be done.