### PR TITLE
Fix ESlint warning

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -125,4 +125,4 @@ rules:
       const, wildcard, reactotron, camelcase, hydrator, perf, stacktrace, Dir, fs,
       avoider, octicons, centerer, ldap, gravatar, identicon, blueimp, filename, wildcards,
       jpeg, jpg, tif, mov, notif, diag, bmp, viewport, scalable, polyfill, rect, touchstart,
-      touchend, touchmove, remoteuser, sso, submessage]
+      touchend, touchmove, remoteuser, sso, submessages]


### PR DESCRIPTION
`eslint-plugin-spellcheck` does a strict check on `submessage` and
fails for the plural form.