### PR TITLE
Fix 'edit message' API call failing

### DIFF
--- a/src/api/messages/updateMessage.js
+++ b/src/api/messages/updateMessage.js
@@ -3,5 +3,10 @@ import type { ApiResponse, Auth } from '../../types';
 import { apiPatch } from '../apiFetch';
 import { removeEmptyValues } from '../../utils/misc';
 
-export default async (auth: Auth, content: Object, id: number): Promise<ApiResponse> =>
-  apiPatch(auth, `messages/${id}`, res => res, removeEmptyValues(content));
+export default async (
+  auth: Auth,
+  messageId: number,
+  content: ?string,
+  topic: ?string,
+): Promise<ApiResponse> =>
+  apiPatch(auth, `messages/${messageId}`, res => res, removeEmptyValues({ content, topic }));

--- a/src/compose/ComposeBox.js
+++ b/src/compose/ComposeBox.js
@@ -176,7 +176,7 @@ export default class ComposeBox extends PureComponent<Props, State> {
     const content = editMessage.content !== message ? message : undefined;
     const subject = topic !== editMessage.topic ? topic : undefined;
     if (content || subject) {
-      updateMessage(auth, { content, subject }, editMessage.id).catch(error => {
+      updateMessage(auth, editMessage.id, content, subject).catch(error => {
         showErrorAlert(error.message, 'Failed to edit message');
       });
     }


### PR DESCRIPTION
The API call `messages/${messageId}` now expects a `topic` parameter
instead of `subject`.

The function call signature changes:
* `messageId` is now the first parameter (after `auth`)
* instead of object, accepts the only two possible values as separate
and concretely-typed parameters