### PR TITLE
StreamTabs: fix ripple overflow bug

### DIFF
--- a/src/styles/tabs.js
+++ b/src/styles/tabs.js
@@ -28,6 +28,11 @@ export default ({ showLabel, showIcon }: Props) => ({
     },
     style: {
       backgroundColor: 'transparent',
+      // Setting a zero-width border (instead of none) works around an issue
+      // affecting react-navigation's TabNavigator.
+      // github.com/zulip/zulip-mobile/issues/2065
+      borderWidth: 0,
+      elevation: 0,
     },
   },
 });


### PR DESCRIPTION
Setting a border stops the ripple from overflowing. Setting elevation to 0 overrides the default elevation of the tabs to maintain the same aesthetic.

Fixes #2065 

Before:
![ripple_before](https://user-images.githubusercontent.com/22353313/40723652-f91664ec-643c-11e8-88b3-5d9c344f179d.png)

After:
![ripple_after](https://user-images.githubusercontent.com/22353313/40723660-fd2fcc58-643c-11e8-932f-b1b5cdc0ae99.png)
