### PR TITLE
Cache the 'users' state

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -87,7 +87,7 @@ const config: Config = {
     'update_global_notifications',
     'update_message_flags',
   ],
-  storeKeys: ['accounts', 'drafts', 'outbox', 'settings'],
+  storeKeys: ['accounts', 'drafts', 'outbox', 'settings', 'users'],
   cacheKeys: ['messages', 'mute', 'realm', 'subscriptions', 'unread'],
 };
 


### PR DESCRIPTION
Fixes #2591

This is a very simple and effective solution to the issue.
Alternatives were examined and found to be both complex and
have drawbacks. Waiting asynchronously for the users to load
would require a lot of rework and would lengthen the action to
potentially several seconds on mobile network.

Initially we were preserving most of the store keys but then went
for a more lean approach.

The app handles correctly the cases when users might not have yet
loaded on startup. An exception is narrowing to a group narrow.

When pressing a group notifications we get only the users' IDs and
need to map these IDs to users' emails so we can perform the narrow.

A future improvement to the narrowing functionality where we will
narrow by IDs will remove this dependency for us.