### PR TITLE
flow: Make `value` property of MultilineInput not required

### DIFF
--- a/src/common/MultilineInput.js
+++ b/src/common/MultilineInput.js
@@ -6,7 +6,7 @@ import type { LocalizableText, Style } from '../types';
 import { Input } from '../common';
 
 type Props = {
-  value: string,
+  value?: string,
   style?: Style,
   placeholder?: LocalizableText,
   onChange?: (text: string) => void,


### PR DESCRIPTION
The component does not require it to function porperly.

We are also moving its only usage (in the compose box) to an
non-controlled component.