### PR TITLE
Fix jerkiness in message list

### DIFF
--- a/src/animation/AnimatedComponent.js
+++ b/src/animation/AnimatedComponent.js
@@ -28,7 +28,7 @@ export default class AnimatedComponent extends PureComponent<Props> {
       toValue: this.props.visible ? this.props[this.props.property] : 0,
       duration: 300,
       useNativeDriver: this.props.useNativeDriver,
-      easing: this.props.visible ? Easing.elastic() : Easing.back(2),
+      easing: Easing.out(Easing.poly(4)),
     }).start();
   }
 


### PR DESCRIPTION
Now the `composeMenu` doesn't overshoot before coming back to the intended width, and thus prevents text or placeholders from resizing due to this.
https://chat.zulip.org/user_uploads/2/e0/LAA4D-H2hTQ500VnsDgO4Vz5/easing.mp4
Fixes #2572