### PR TITLE
Replace broken dev_get_emails endpoint with dev_list_users.

### DIFF
--- a/src/api/devGetEmails.js
+++ b/src/api/devGetEmails.js
@@ -1,6 +1,0 @@
-/* @flow */
-import type { Auth } from '../types';
-import { apiGet } from './apiFetch';
-
-export default (auth: Auth): Promise<[string[], string[]]> =>
-  apiGet(auth, 'dev_get_emails', res => [res.direct_admins, res.direct_users]);

--- a/src/api/devListUsers.js
+++ b/src/api/devListUsers.js
@@ -1,0 +1,6 @@
+/* @flow */
+import type { Auth, DevUser } from '../types';
+import { apiGet } from './apiFetch';
+
+export default (auth: Auth): Promise<[DevUser[], DevUser[]]> =>
+  apiGet(auth, 'dev_list_users', res => [res.direct_admins, res.direct_users]);

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -2,7 +2,7 @@
 export { default as queueMarkAsRead } from './queueMarkAsRead';
 export { default as checkCompatibility } from './checkCompatibility';
 export { default as devFetchApiKey } from './devFetchApiKey';
-export { default as devGetEmails } from './devGetEmails';
+export { default as devListUsers } from './devListUsers';
 export { default as fetchApiKey } from './fetchApiKey';
 export { default as focusPing } from './focusPing';
 export { default as getTopics } from './getTopics';

--- a/src/start/DevAuthScreen.js
+++ b/src/start/DevAuthScreen.js
@@ -2,10 +2,10 @@
 import React, { PureComponent } from 'react';
 import { ActivityIndicator, View, StyleSheet, FlatList } from 'react-native';
 
-import type { Actions, Auth, Context } from '../types';
+import type { Actions, Auth, Context, DevUser } from '../types';
 import connectWithActions from '../connectWithActions';
 import { ErrorMsg, Label, Screen, ZulipButton } from '../common';
-import { devGetEmails, devFetchApiKey } from '../api';
+import { devListUsers, devFetchApiKey } from '../api';
 import { getAuth } from '../selectors';
 
 const inlineStyles = StyleSheet.create({
@@ -20,8 +20,8 @@ type Props = {
 
 type State = {
   progress: boolean,
-  directAdmins: string[],
-  directUsers: string[],
+  directAdmins: DevUser[],
+  directUsers: DevUser[],
   error: string,
 };
 
@@ -45,7 +45,7 @@ class DevAuthScreen extends PureComponent<Props, State> {
 
     (async () => {
       try {
-        const [directAdmins, directUsers] = await devGetEmails(auth);
+        const [directAdmins, directUsers] = await devListUsers(auth);
 
         this.setState({ directAdmins, directUsers, progress: false });
       } catch (err) {
@@ -83,15 +83,19 @@ class DevAuthScreen extends PureComponent<Props, State> {
             style={[styles.field, styles.heading2, inlineStyles.heading]}
             text="Administrators"
           />
-          {directAdmins.map(email => (
-            <ZulipButton key={email} text={email} onPress={() => this.tryDevLogin(email)} />
+          {directAdmins.map(admin => (
+            <ZulipButton
+              key={admin.email}
+              text={admin.email}
+              onPress={() => this.tryDevLogin(admin.email)}
+            />
           ))}
           <Label
             style={[styles.field, styles.heading2, inlineStyles.heading]}
             text="Normal users"
           />
           <FlatList
-            data={directUsers}
+            data={directUsers.map(user => user.email)}
             keyExtractor={(item, index) => item}
             ItemSeparatorComponent={() => <View style={inlineStyles.accountItem} />}
             renderItem={({ item }) => (

--- a/src/types.js
+++ b/src/types.js
@@ -157,6 +157,11 @@ export type UserGroup = {
   name: string,
 };
 
+export type DevUser = {
+  realm_uri: string,
+  email: string,
+};
+
 export type PresenceAggregated = {
   client: string,
   status: UserStatus,


### PR DESCRIPTION
The dev_get_emails Zulip server endpoint has been renamed
to dev_list_users in zulip/zulip:73c3c94. The sole purpose
of this endpoint was to supply the frontend with a list of
users in the dev environment. Because it got renamed, the
mobile app dev login view broke.
This commit uses the new endpoint and also addresses changes
in the data structure returned by the endpoint.


I think `devListUsers.js` is not a great name. I chse it because I think it's best if it matches the API endpoint it is used for.
