### PR TITLE
Add Autocomplete support for user groups

### DIFF
--- a/src/autocomplete/PeopleAutocomplete.js
+++ b/src/autocomplete/PeopleAutocomplete.js
@@ -41,7 +41,7 @@ class PeopleAutocomplete extends PureComponent<Props> {
             key={item.name}
             name={item.name}
             description={item.description}
-            onPress={() => onAutocomplete(item.name)}
+            onPress={() => onAutocomplete(`*${item.name}*`)}
           />
         ),
       },
@@ -54,7 +54,7 @@ class PeopleAutocomplete extends PureComponent<Props> {
             avatarUrl={item.avatar_url}
             email={item.email}
             showEmail
-            onPress={() => onAutocomplete(item.full_name)}
+            onPress={() => onAutocomplete(`**${item.full_name}**`)}
           />
         ),
       },

--- a/src/autocomplete/StreamAutocomplete.js
+++ b/src/autocomplete/StreamAutocomplete.js
@@ -41,7 +41,7 @@ class StreamAutocomplete extends PureComponent<Props> {
               isPrivate={item.invite_only}
               iconSize={12}
               color={item.color}
-              onPress={() => onAutocomplete(item.name)}
+              onPress={() => onAutocomplete(`**${item.name}**`)}
             />
           )}
         />

--- a/src/autocomplete/__tests__/getAutocompletedText-test.js
+++ b/src/autocomplete/__tests__/getAutocompletedText-test.js
@@ -4,11 +4,15 @@ import getAutocompletedText from '../getAutocompletedText';
 describe('getAutocompletedText', () => {
   let selection = { start: 3, end: 3 };
   test('can autocomplete users', () => {
-    expect(getAutocompletedText('@ab', 'abcd', selection)).toEqual('@**abcd** ');
+    expect(getAutocompletedText('@ab', '**abcd**', selection)).toEqual('@**abcd** ');
+  });
+
+  test('can autocomplete user groups', () => {
+    expect(getAutocompletedText('@ab', '*abcd*', selection)).toEqual('@*abcd* ');
   });
 
   test('can autocomple streams', () => {
-    expect(getAutocompletedText('#ab', 'abcd', selection)).toEqual('#**abcd** ');
+    expect(getAutocompletedText('#ab', '**abcd**', selection)).toEqual('#**abcd** ');
   });
 
   test('can autocomplete emojis', () => {
@@ -17,7 +21,7 @@ describe('getAutocompletedText', () => {
 
   test('can autocomplete more complicated text', () => {
     selection = { start: 12, end: 12 };
-    expect(getAutocompletedText('@**word** @w', 'word word', selection)).toEqual(
+    expect(getAutocompletedText('@**word** @w', '**word word**', selection)).toEqual(
       '@**word** @**word word** ',
     );
 

--- a/src/autocomplete/getAutocompletedText.js
+++ b/src/autocomplete/getAutocompletedText.js
@@ -3,10 +3,10 @@ import type { InputSelectionType } from '../types';
 
 export default (text: string, autocompleteText: string, selection: InputSelectionType) => {
   const { start, end } = selection;
-  let residue = '';
+  let remainder = '';
   if (start === end && start !== text.length) {
     // new letter is typed
-    residue = text.substring(start, text.length);
+    remainder = text.substring(start, text.length);
     text = text.substring(0, start);
   }
   const lastIndex: number = Math.max(
@@ -14,7 +14,9 @@ export default (text: string, autocompleteText: string, selection: InputSelectio
     text.lastIndexOf('#'),
     text.lastIndexOf('@'),
   );
-  const prefix = text[lastIndex] === ':' ? ':' : `${text[lastIndex]}**`;
-  const suffix = text[lastIndex] === ':' ? ':' : '**';
-  return `${text.substring(0, lastIndex)}${prefix}${autocompleteText}${suffix} ${residue}`;
+
+  const prefix = text[lastIndex] === ':' ? ':' : `${text[lastIndex]}`;
+  const suffix = text[lastIndex] === ':' ? ':' : '';
+
+  return `${text.substring(0, lastIndex)}${prefix}${autocompleteText}${suffix} ${remainder}`;
 };

--- a/src/user-groups/UserGroupItem.js
+++ b/src/user-groups/UserGroupItem.js
@@ -1,0 +1,67 @@
+/* @flow */
+import React, { PureComponent } from 'react';
+import { StyleSheet, View } from 'react-native';
+
+import type { Context } from '../types';
+import { IconPeople } from '../common/Icons';
+import { RawLabel, Touchable } from '../common';
+
+const componentStyles = StyleSheet.create({
+  text: {
+    marginLeft: 8,
+  },
+  textEmail: {
+    fontSize: 10,
+    color: '#999',
+  },
+  textWrapper: {
+    flex: 1,
+  },
+});
+
+type Props = {
+  name: string,
+  description: string,
+  onPress: (name: string) => void,
+};
+
+export default class UserGroupItem extends PureComponent<Props> {
+  context: Context;
+  props: Props;
+
+  static contextTypes = {
+    styles: () => null,
+  };
+
+  handlePress = () => {
+    const { name, onPress } = this.props;
+    onPress(name);
+  };
+
+  render() {
+    const { styles } = this.context;
+    const { name, description } = this.props;
+
+    return (
+      <Touchable onPress={this.handlePress}>
+        <View style={styles.listItem}>
+          <IconPeople size={32} />
+          <View style={componentStyles.textWrapper}>
+            <RawLabel
+              style={[componentStyles.text]}
+              text={name}
+              numberOfLines={1}
+              ellipsizeMode="tail"
+            />
+            <RawLabel
+              style={[componentStyles.text, componentStyles.textEmail]}
+              text={description}
+              numberOfLines={1}
+              ellipsizeMode="tail"
+            />
+          </View>
+        </View>
+      </Touchable>
+    );
+  }
+}

--- a/src/users/__tests__/userHelpers-test.js
+++ b/src/users/__tests__/userHelpers-test.js
@@ -4,6 +4,7 @@ import {
   sortUserList,
   filterUserList,
   getAutocompleteSuggestion,
+  getAutocompleteUserGroupSuggestions,
   groupUsersByInitials,
   sortAlphabetically,
   filterUserStartWith,
@@ -133,6 +134,32 @@ describe('getAutocompleteSuggestion', () => {
       { full_name: 'Example', email: 'match@example.com' }, // email contains 'ma'
     ];
     const filteredUsers = getAutocompleteSuggestion(allUsers, 'ma');
+    expect(filteredUsers).toEqual(shouldMatch);
+  });
+});
+
+describe('getAutocompleteUserGroupSuggestions', () => {
+  test('empty input results in empty list', () => {
+    const userGroups = deepFreeze([]);
+
+    const filteredUserGroups = getAutocompleteUserGroupSuggestions(userGroups, 'some filter');
+
+    expect(filteredUserGroups).toEqual(userGroups);
+  });
+
+  test('searches in name and description, case-insensitive', () => {
+    const userGroups = deepFreeze([
+      { name: 'some user group', description: '' },
+      { name: 'another one', description: '' },
+      { name: 'last one', description: 'This is a Group' },
+    ]);
+    const shouldMatch = [
+      { name: 'some user group', description: '' },
+      { name: 'last one', description: 'This is a Group' },
+    ];
+
+    const filteredUsers = getAutocompleteUserGroupSuggestions(userGroups, 'group');
+
     expect(filteredUsers).toEqual(shouldMatch);
   });
 });

--- a/src/users/__tests__/userSelectors-test.js
+++ b/src/users/__tests__/userSelectors-test.js
@@ -6,6 +6,7 @@ import {
   getUsersStatusActive,
   getUsersStatusIdle,
   getUsersStatusOffline,
+  getActiveUsersAndBots,
   getAllUsersAndBots,
   getAllUsersAndBotsByEmail,
   getUsersById,
@@ -169,6 +170,23 @@ describe('getUsersStatusOffline', () => {
     const actualUser = getUsersStatusOffline(state);
 
     expect(actualUser).toEqual(expectedUsers);
+  });
+});
+
+describe('getActiveUsersAndBots', () => {
+  test('return users, bots, does not include inactive users', () => {
+    const state = deepFreeze({
+      users: [{ email: 'abc@example.com' }],
+      realm: {
+        crossRealmBots: [{ email: 'def@example.com' }],
+        nonActiveUsers: [{ email: 'xyz@example.com' }],
+      },
+    });
+    const expectedResult = [{ email: 'abc@example.com' }, { email: 'def@example.com' }];
+
+    const result = getActiveUsersAndBots(state);
+
+    expect(result).toEqual(expectedResult);
   });
 });
 

--- a/src/users/userHelpers.js
+++ b/src/users/userHelpers.js
@@ -1,7 +1,7 @@
 /* @flow */
 import uniqby from 'lodash.uniqby';
 
-import type { Presence, User, PresenceState } from '../types';
+import type { Presence, User, UserGroup, PresenceState } from '../types';
 import { NULL_USER } from '../nullObjects';
 import { statusFromPresence } from '../utils/presence';
 
@@ -127,3 +127,13 @@ export const getAutocompleteSuggestion = (
   const matchesEmail = filterUserMatchesEmail(users, filter, ownEmail);
   return getUniqueUsers([...startWith, ...initials, ...contains, ...matchesEmail]);
 };
+
+export const getAutocompleteUserGroupSuggestions = (
+  userGroups: UserGroup[],
+  filter: string = '',
+): UserGroup[] =>
+  userGroups.filter(
+    userGroup =>
+      userGroup.name.toLowerCase().includes(filter.toLowerCase())
+      || userGroup.description.toLowerCase().includes(filter.toLowerCase()),
+  );

--- a/src/users/userSelectors.js
+++ b/src/users/userSelectors.js
@@ -36,6 +36,12 @@ export const getUsersStatusOffline = createSelector(
     ),
 );
 
+export const getActiveUsersAndBots = createSelector(
+  getUsers,
+  getCrossRealmBots,
+  (users = [], crossRealmBots = []) => [...users, ...crossRealmBots],
+);
+
 export const getAllUsersAndBots = createSelector(
   getUsers,
   getNonActiveUsers,


### PR DESCRIPTION
Implements #2596

* bots are also listed when autocompleting users
* user groups matching the filter are shown on top
* rework of the autocompleting functions to differentiate between user and user groups
