### PR TITLE
mesageEdit: Show topic input even in topic narrow.

### DIFF
--- a/src/compose/ComposeBox.js
+++ b/src/compose/ComposeBox.js
@@ -28,7 +28,7 @@ import { updateMessage } from '../api';
 import { FloatingActionButton, Input, MultilineInput } from '../common';
 import { showErrorAlert } from '../utils/info';
 import { IconDone, IconSend } from '../common/Icons';
-import { isStreamNarrow, topicNarrow } from '../utils/narrow';
+import { isStreamNarrow, isStreamOrTopicNarrow, topicNarrow } from '../utils/narrow';
 import ComposeMenu from './ComposeMenu';
 import AutocompleteViewWrapper from '../autocomplete/AutocompleteViewWrapper';
 import getComposeInputPlaceholder from './getComposeInputPlaceholder';
@@ -93,7 +93,10 @@ class ComposeBox extends PureComponent<Props, State> {
 
   getCanSelectTopic = () => {
     const { isMessageFocused, isTopicFocused } = this.state;
-    const { narrow } = this.props;
+    const { editMessage, narrow } = this.props;
+    if (editMessage) {
+      return isStreamOrTopicNarrow(narrow);
+    }
     if (!isStreamNarrow(narrow)) {
       return false;
     }

--- a/src/compose/ComposeBox.js
+++ b/src/compose/ComposeBox.js
@@ -91,6 +91,15 @@ class ComposeBox extends PureComponent<Props, State> {
     selection: { start: 0, end: 0 },
   };
 
+  getCanSelectTopic = () => {
+    const { isMessageFocused, isTopicFocused } = this.state;
+    const { narrow } = this.props;
+    if (!isStreamNarrow(narrow)) {
+      return false;
+    }
+    return isMessageFocused || isTopicFocused;
+  };
+
   handleComposeMenuToggle = () => {
     this.setState(({ isMenuExpanded }) => ({
       isMenuExpanded: !isMenuExpanded,
@@ -241,15 +250,7 @@ class ComposeBox extends PureComponent<Props, State> {
 
   render() {
     const { styles } = this.context;
-    const {
-      isMessageFocused,
-      isTopicFocused,
-      isMenuExpanded,
-      height,
-      message,
-      topic,
-      selection,
-    } = this.state;
+    const { isTopicFocused, isMenuExpanded, height, message, topic, selection } = this.state;
     const {
       auth,
       canSend,
@@ -269,7 +270,6 @@ class ComposeBox extends PureComponent<Props, State> {
       return <NotSubscribed narrow={narrow} />;
     }
 
-    const canSelectTopic = (isMessageFocused || isTopicFocused) && isStreamNarrow(narrow);
     const placeholder = getComposeInputPlaceholder(narrow, auth.email, usersAndBots);
 
     return (
@@ -293,7 +293,7 @@ class ComposeBox extends PureComponent<Props, State> {
             />
           </View>
           <View style={styles.composeText}>
-            {canSelectTopic && (
+            {this.getCanSelectTopic() && (
               <Input
                 style={styles.topicInput}
                 underlineColorAndroid="transparent"


### PR DESCRIPTION
Sometimes message ref is undefined, so it is not focused. Thus
use editMessage object to check for topic input visibility.