### PR TITLE
WIP: Handle image redirect in Lightbox

### DIFF
--- a/src/lightbox/LightboxContainer.js
+++ b/src/lightbox/LightboxContainer.js
@@ -4,10 +4,11 @@ import { View, StyleSheet, Dimensions, Easing } from 'react-native';
 import PhotoView from 'react-native-photo-view';
 import { connectActionSheet } from '@expo/react-native-action-sheet';
 
+import { fetchWithAuth } from '../api/apiFetch';
 import type { Actions, Auth, Message } from '../types';
 import connectWithActions from '../connectWithActions';
 import { getAuth } from '../selectors';
-import { getResource } from '../utils/url';
+import { getResource, getFullUrl } from '../utils/url';
 import AnimatedLightboxHeader from './AnimatedLightboxHeader';
 import AnimatedLightboxFooter from './AnimatedLightboxFooter';
 import { constructActionSheetButtons, executeActionSheetAction } from './LightboxActionSheet';
@@ -90,11 +91,19 @@ class LightboxContainer extends PureComponent<Props, State> {
     movement: this.state.movement,
   });
 
+  componentDidMount() {
+    const { src, auth } = this.props;
+    fetchWithAuth(auth, getFullUrl(src, auth.realm)).then(response =>
+      this.setState({ redirectedUrl: response.url }),
+    );
+  }
+
   render() {
     const { src, message, auth } = this.props;
+    const { redirectedUrl } = this.state;
     const footerMessage =
       message.type === 'stream' ? `Shared in #${message.display_recipient}` : 'Shared with you';
-    const resource = getResource(src, auth);
+    const resource = redirectedUrl ? { uri: redirectedUrl } : getResource(src, auth);
     const { width, height } = Dimensions.get('window');
 
     return (


### PR DESCRIPTION
This is code intended to be discussed and while it works is not intended for merging!

On `zulipchat.com` we do a 302 redirect to AWS where we host the user-uploaded images.
This is not supported by the React Native's `Image` component, nor by the `PhotoView` component we use.

We need to handle this ourselves. The challenge is that we do not want to request extra data (or at least much more extra data).

If we do a `GET` on the URL, we will get the image data that can be huge. There is no effective way to pass huge amounts of data to `Image` - it is explicitly recommended we do not use the BASE64 formatted image data to the component for anything larger than a thumbnail or icon.

Using the `HEAD` method to request images returns 'method not supported'. If enabling this is an option, this sounds like a reasonable solution.