### PR TITLE
ui: Fix AccountItem delete button alignment

### DIFF
--- a/src/account/AccountItem.js
+++ b/src/account/AccountItem.js
@@ -2,7 +2,7 @@
 import React, { PureComponent } from 'react';
 import { StyleSheet, View } from 'react-native';
 
-import { BRAND_COLOR } from '../styles';
+import { BRAND_COLOR, HALF_SPACING } from '../styles';
 import { RawLabel, Touchable } from '../common';
 import { IconDone, IconTrash } from '../common/Icons';
 
@@ -31,7 +31,8 @@ const styles = StyleSheet.create({
     fontWeight: 'bold',
   },
   icon: {
-    padding: 6,
+    padding: HALF_SPACING,
+    margin: -HALF_SPACING,
   },
 });
 


### PR DESCRIPTION
Make sure that the delete button is aligned vertically.

### Before
![before](https://user-images.githubusercontent.com/867242/40928234-7e75325e-6829-11e8-882b-cb975f9db902.png)

### After
![after](https://user-images.githubusercontent.com/867242/40928236-7e983c18-6829-11e8-8731-e6a4175c7a27.png)


Removing the `padding` style works, but we do this instead:

```js
padding: HALF_SPACING,
margin: -HALF_SPACING,
```

The default button size is too small - 32px (with the minimal
suggested width being 44px, and the larger the better)

Padding increases the touch area (now 32 + 8 + 8 = 48, good enough)
and a negative margin keeps the button at the same place as if it
did not have padding set.