### PR TITLE
Use standard Redux dispatch to replace most `connectWithActions`.

### DIFF
--- a/src/account-info/LogoutButton.js
+++ b/src/account-info/LogoutButton.js
@@ -1,13 +1,16 @@
 /* @flow */
+import { connect } from 'react-redux';
+
 import React, { PureComponent } from 'react';
 import { StyleSheet } from 'react-native';
 
-import type { Actions, Auth } from '../types';
-import connectWithActions from '../connectWithActions';
+import type { Auth, Dispatch } from '../types';
 import { ZulipButton } from '../common';
 import { unregisterPush } from '../api';
 import { getAuth, getPushToken } from '../selectors';
 import { logErrorRemotely } from '../utils/logging';
+import { logout } from '../account/accountActions';
+import { deleteTokenPush } from '../realm/realmActions';
 
 const styles = StyleSheet.create({
   logoutButton: {
@@ -19,28 +22,28 @@ const styles = StyleSheet.create({
 type Props = {
   auth: Auth,
   pushToken: string,
-  actions: Actions,
+  dispatch: Dispatch,
 };
 
 class LogoutButton extends PureComponent<Props> {
   props: Props;
 
   shutdownPUSH = async () => {
-    const { auth, actions, pushToken } = this.props;
+    const { auth, dispatch, pushToken } = this.props;
     if (pushToken !== '') {
       try {
         await unregisterPush(auth, pushToken);
       } catch (e) {
         logErrorRemotely(e, 'failed to unregister Push token');
       }
-      actions.deleteTokenPush();
+      dispatch(deleteTokenPush());
     }
   };
 
   logout = () => {
-    const { actions } = this.props;
+    const { dispatch } = this.props;
     this.shutdownPUSH();
-    actions.logout();
+    dispatch(logout());
   };
 
   render() {
@@ -50,7 +53,7 @@ class LogoutButton extends PureComponent<Props> {
   }
 }
 
-export default connectWithActions(state => ({
+export default connect(state => ({
   auth: getAuth(state),
   pushToken: getPushToken(state),
 }))(LogoutButton);

--- a/src/account-info/SwitchAccountButton.js
+++ b/src/account-info/SwitchAccountButton.js
@@ -1,13 +1,16 @@
 /* @flow */
+import { connect } from 'react-redux';
+
 import React, { PureComponent } from 'react';
 import { StyleSheet } from 'react-native';
 
-import type { Auth, Actions } from '../types';
-import connectWithActions from '../connectWithActions';
+import type { Auth, Dispatch } from '../types';
 import { ZulipButton } from '../common';
 import { getAuth, getAccounts, getPushToken } from '../selectors';
 import { unregisterPush } from '../api';
 import { logErrorRemotely } from '../utils/logging';
+import { navigateToAccountPicker } from '../nav/navActions';
+import { deleteTokenPush } from '../realm/realmActions';
 
 const styles = StyleSheet.create({
   button: {
@@ -18,7 +21,7 @@ const styles = StyleSheet.create({
 
 type Props = {
   auth: Auth,
-  actions: Actions,
+  dispatch: Dispatch,
   pushToken: string,
 };
 
@@ -26,20 +29,21 @@ class SwitchAccountButton extends PureComponent<Props> {
   props: Props;
 
   shutdownPUSH = async () => {
-    const { auth, actions, pushToken } = this.props;
+    const { auth, dispatch, pushToken } = this.props;
     if (pushToken !== '') {
       try {
         await unregisterPush(auth, pushToken);
       } catch (e) {
         logErrorRemotely(e, 'failed to unregister Push token');
       }
-      actions.deleteTokenPush();
+      dispatch(deleteTokenPush());
     }
   };
 
   switchAccount = () => {
+    const { dispatch } = this.props;
     this.shutdownPUSH();
-    this.props.actions.navigateToAccountPicker();
+    dispatch(navigateToAccountPicker());
   };
 
   render() {
@@ -49,7 +53,7 @@ class SwitchAccountButton extends PureComponent<Props> {
   }
 }
 
-export default connectWithActions(state => ({
+export default connect(state => ({
   auth: getAuth(state),
   accounts: getAccounts(state),
   pushToken: getPushToken(state),

--- a/src/account/AccountPickScreen.js
+++ b/src/account/AccountPickScreen.js
@@ -1,12 +1,15 @@
 /* @flow */
+import { connect } from 'react-redux';
+
 import React, { PureComponent } from 'react';
 import { StyleSheet } from 'react-native';
 
-import type { Auth, Actions, Account } from '../types';
-import connectWithActions from '../connectWithActions';
+import type { Auth, Account, Dispatch } from '../types';
 import { getAuth, getAccounts } from '../selectors';
 import { Centerer, ZulipButton, Logo, Screen } from '../common';
 import AccountList from './AccountList';
+import { switchAccount, removeAccount } from '../account/accountActions';
+import { navigateToAddNewAccount } from '../nav/navActions';
 
 const styles = StyleSheet.create({
   button: {
@@ -17,28 +20,28 @@ const styles = StyleSheet.create({
 type Props = {
   auth: Auth,
   accounts: Account[],
-  actions: Actions,
+  dispatch: Dispatch,
 };
 
 class AccountPickScreen extends PureComponent<Props> {
   props: Props;
 
   handleAccountSelect = (index: number) => {
-    const { accounts, actions } = this.props;
+    const { accounts, dispatch } = this.props;
     const { realm, apiKey } = accounts[index];
     if (apiKey) {
       setTimeout(() => {
-        actions.switchAccount(index);
+        dispatch(switchAccount(index));
       });
     } else {
-      actions.navigateToAddNewAccount(realm);
+      dispatch(navigateToAddNewAccount(realm));
     }
   };
 
-  handleAccountRemove = (index: number) => this.props.actions.removeAccount(index);
+  handleAccountRemove = (index: number) => this.props.dispatch(removeAccount(index));
 
   render() {
-    const { accounts, actions, auth } = this.props;
+    const { accounts, dispatch, auth } = this.props;
 
     return (
       <Screen title="Pick account" centerContent padding>
@@ -53,7 +56,9 @@ class AccountPickScreen extends PureComponent<Props> {
           <ZulipButton
             text="Add new account"
             style={styles.button}
-            onPress={() => actions.navigateToAddNewAccount('')}
+            onPress={() => {
+              dispatch(navigateToAddNewAccount(''));
+            }}
           />
         </Centerer>
       </Screen>
@@ -61,7 +66,7 @@ class AccountPickScreen extends PureComponent<Props> {
   }
 }
 
-export default connectWithActions(state => ({
+export default connect(state => ({
   auth: getAuth(state),
   accounts: getAccounts(state),
 }))(AccountPickScreen);

--- a/src/autocomplete/EmojiAutocomplete.js
+++ b/src/autocomplete/EmojiAutocomplete.js
@@ -1,8 +1,9 @@
 /* @flow */
+import { connect } from 'react-redux';
+
 import React, { PureComponent } from 'react';
 import { FlatList } from 'react-native';
 
-import connectWithActions from '../connectWithActions';
 import { Popup } from '../common';
 import EmojiRow from '../emoji/EmojiRow';
 import getFilteredEmojiList from '../emoji/getFilteredEmojiList';
@@ -46,6 +47,6 @@ class EmojiAutocomplete extends PureComponent<Props> {
   }
 }
 
-export default connectWithActions((state: GlobalState) => ({
+export default connect((state: GlobalState) => ({
   realmEmoji: getActiveRealmEmoji(state),
 }))(EmojiAutocomplete);

--- a/src/autocomplete/PeopleAutocomplete.js
+++ b/src/autocomplete/PeopleAutocomplete.js
@@ -1,9 +1,10 @@
 /* @flow */
+import { connect } from 'react-redux';
+
 import React, { PureComponent } from 'react';
 import { SectionList } from 'react-native';
 
 import type { User, UserGroup, GlobalState } from '../types';
-import connectWithActions from '../connectWithActions';
 import { getOwnEmail, getSortedUsers, getUserGroups } from '../selectors';
 import {
   getAutocompleteSuggestion,
@@ -72,7 +73,7 @@ class PeopleAutocomplete extends PureComponent<Props> {
   }
 }
 
-export default connectWithActions((state: GlobalState) => ({
+export default connect((state: GlobalState) => ({
   ownEmail: getOwnEmail(state),
   users: getSortedUsers(state),
   userGroups: getUserGroups(state),

--- a/src/autocomplete/StreamAutocomplete.js
+++ b/src/autocomplete/StreamAutocomplete.js
@@ -1,9 +1,10 @@
 /* @flow */
+import { connect } from 'react-redux';
+
 import React, { PureComponent } from 'react';
 import { FlatList } from 'react-native';
 
 import type { GlobalState, SubscriptionsState } from '../types';
-import connectWithActions from '../connectWithActions';
 import { Popup } from '../common';
 import { getSubscribedStreams } from '../subscriptions/subscriptionSelectors';
 import StreamItem from '../streams/StreamItem';
@@ -50,6 +51,6 @@ class StreamAutocomplete extends PureComponent<Props> {
   }
 }
 
-export default connectWithActions((state: GlobalState) => ({
+export default connect((state: GlobalState) => ({
   subscriptions: getSubscribedStreams(state),
 }))(StreamAutocomplete);

--- a/src/autocomplete/TopicAutocomplete.js
+++ b/src/autocomplete/TopicAutocomplete.js
@@ -1,9 +1,10 @@
 /* @flow */
+import { connect } from 'react-redux';
+
 import React, { PureComponent } from 'react';
 import { FlatList, StyleSheet } from 'react-native';
 
 import type { GlobalState } from '../types';
-import connectWithActions from '../connectWithActions';
 import { getTopicsForNarrow } from '../selectors';
 import { Popup, RawLabel, Touchable } from '../common';
 import AnimatedScaleComponent from '../animation/AnimatedScaleComponent';
@@ -53,6 +54,6 @@ class TopicAutocomplete extends PureComponent<Props> {
   }
 }
 
-export default connectWithActions((state: GlobalState, props) => ({
+export default connect((state: GlobalState, props) => ({
   topics: getTopicsForNarrow(props.narrow)(state),
 }))(TopicAutocomplete);

--- a/src/boot/AppDataFetcher.js
+++ b/src/boot/AppDataFetcher.js
@@ -1,13 +1,15 @@
 /* @flow */
+import { connect } from 'react-redux';
+
 import { PureComponent } from 'react';
 
-import type { Actions, ChildrenArray } from '../types';
-import connectWithActions from '../connectWithActions';
+import type { ChildrenArray, Dispatch } from '../types';
 import { getSession } from '../directSelectors';
+import { doInitialFetch } from '../message/fetchActions';
 
 type Props = {
   needsInitialFetch: boolean,
-  actions: Actions,
+  dispatch: Dispatch,
   children?: ChildrenArray<*>,
 };
 
@@ -15,10 +17,10 @@ class AppDataFetcher extends PureComponent<Props> {
   props: Props;
 
   componentDidUpdate = () => {
-    const { actions, needsInitialFetch } = this.props;
+    const { dispatch, needsInitialFetch } = this.props;
 
     if (needsInitialFetch) {
-      actions.doInitialFetch();
+      dispatch(doInitialFetch());
     }
   };
 
@@ -27,6 +29,6 @@ class AppDataFetcher extends PureComponent<Props> {
   }
 }
 
-export default connectWithActions(state => ({
+export default connect(state => ({
   needsInitialFetch: getSession(state).needsInitialFetch,
 }))(AppDataFetcher);

--- a/src/compose/ComposeMenu.js
+++ b/src/compose/ComposeMenu.js
@@ -4,13 +4,15 @@ import { View } from 'react-native';
 // $FlowFixMe
 import ImagePicker from 'react-native-image-picker';
 
-import type { Actions, Context, Narrow } from '../types';
+import type { Context, Dispatch, Narrow } from '../types';
 import { showErrorAlert } from '../utils/info';
 import { IconPlus, IconLeft, IconPeople, IconImage, IconCamera } from '../common/Icons';
 import AnimatedComponent from '../animation/AnimatedComponent';
+import { uploadImage } from '../message/fetchActions';
+import { navigateToCreateGroup } from '../nav/navActions';
 
 type Props = {
-  actions: Actions,
+  dispatch: Dispatch,
   expanded: boolean,
   narrow: Narrow,
   onExpandContract: () => void,
@@ -34,9 +36,9 @@ export default class ComposeMenu extends Component<Props> {
       return;
     }
 
-    const { actions, narrow } = this.props;
+    const { dispatch, narrow } = this.props;
 
-    actions.uploadImage(narrow, response.uri, response.fileName);
+    dispatch(uploadImage(narrow, response.uri, response.fileName));
   };
 
   handleImageUpload = () => {
@@ -59,8 +61,7 @@ export default class ComposeMenu extends Component<Props> {
 
   render() {
     const { styles } = this.context;
-    const { actions, expanded, onExpandContract } = this.props;
-
+    const { dispatch, expanded, onExpandContract } = this.props;
     return (
       <View style={styles.composeMenu}>
         <AnimatedComponent property="width" useNativeDriver={false} visible={expanded} width={120}>
@@ -68,7 +69,7 @@ export default class ComposeMenu extends Component<Props> {
             <IconPeople
               style={styles.composeMenuButton}
               size={24}
-              onPress={actions.navigateToCreateGroup}
+              onPress={() => dispatch(navigateToCreateGroup())}
             />
             <IconImage
               style={styles.composeMenuButton}

--- a/src/compose/ComposeMenuContainer.js
+++ b/src/compose/ComposeMenuContainer.js
@@ -1,8 +1,9 @@
 /* @flow */
-import connectWithActions from '../connectWithActions';
+import { connect } from 'react-redux';
+
 import ComposeMenu from './ComposeMenu';
 import { getNarrowToSendTo } from '../selectors';
 
-export default connectWithActions((state, props) => ({
+export default connect((state, props) => ({
   narrow: getNarrowToSendTo(props.narrow)(state),
 }))(ComposeMenu);


### PR DESCRIPTION
This cuts `connectWithActions` for:
* compose menu
* logout button
* switch account button