### PR TITLE
Smarter smart url input. Fixes #2415

### DIFF
--- a/src/common/SmartUrlInput.js
+++ b/src/common/SmartUrlInput.js
@@ -19,7 +19,6 @@ type Props = {
   protocol: string,
   append: string,
   navigation: Object,
-  shortAppend: string,
   style?: Style,
   onChange: (value: string) => void,
   onSubmitEditing: () => Promise<void>,
@@ -56,8 +55,8 @@ export default class SmartUrlInput extends PureComponent<Props, State> {
   handleChange = (value: string) => {
     this.setState({ value });
 
-    const { append, shortAppend, protocol, onChange } = this.props;
-    onChange(fixRealmUrl(autocompleteUrl(value, protocol, append, shortAppend)));
+    const { append, protocol, onChange } = this.props;
+    onChange(fixRealmUrl(autocompleteUrl(value, protocol, append)));
   };
 
   urlPress = () => {
@@ -80,17 +79,15 @@ export default class SmartUrlInput extends PureComponent<Props, State> {
       defaultOrganization,
       protocol,
       append,
-      shortAppend,
       defaultValue,
       style,
       onSubmitEditing,
       enablesReturnKeyAutomatically,
     } = this.props;
     let { value } = this.state;
-    let showAnyAppend = !value.match(/.+\..+\.+./g); // at least two dots
-    const useFullAppend = value.indexOf('.') === -1;
+    let showAppend = value.indexOf('.') === -1;
     if (defaultValue && value.length === 0) {
-      showAnyAppend = false;
+      showAppend = false;
       value = defaultValue;
     }
 
@@ -115,7 +112,7 @@ export default class SmartUrlInput extends PureComponent<Props, State> {
           }}
         />
         {value.length === 0 && this.renderPlaceholderPart(defaultOrganization)}
-        {showAnyAppend && this.renderPlaceholderPart(useFullAppend ? append : shortAppend)}
+        {showAppend && this.renderPlaceholderPart(append)}
       </View>
     );
   }

--- a/src/start/RealmScreen.js
+++ b/src/start/RealmScreen.js
@@ -84,7 +84,6 @@ class RealmScreen extends PureComponent<Props, State> {
           defaultOrganization="your-org"
           protocol="https://"
           append=".zulipchat.com"
-          shortAppend=".com"
           defaultValue={initialRealm}
           onChange={this.handleRealmChange}
           onSubmitEditing={this.tryRealm}

--- a/src/utils/__tests__/url-test.js
+++ b/src/utils/__tests__/url-test.js
@@ -491,28 +491,28 @@ describe('fixRealmUrl', () => {
 
 describe('autocompleteUrl', () => {
   test('when no value is entered return empty string', () => {
-    const result = autocompleteUrl('', 'https://', '.zulipchat.com', '');
+    const result = autocompleteUrl('', 'https://', '.zulipchat.com');
     expect(result).toEqual('');
   });
 
   test('when an protocol is provided use it', () => {
-    const result = autocompleteUrl('http://example', 'https://', '.zulipchat.com', '');
+    const result = autocompleteUrl('http://example', 'https://', '.zulipchat.com');
     expect(result).toEqual('http://example.zulipchat.com');
   });
 
   test('do not use any other protocol than http and https', () => {
-    const result = autocompleteUrl('ftp://example', 'https://', '.zulipchat.com', '');
+    const result = autocompleteUrl('ftp://example', 'https://', '.zulipchat.com');
     expect(result).toEqual('https://ftp://example.zulipchat.com');
   });
 
-  test('if one dot in the input use the short append instead', () => {
-    const result = autocompleteUrl('subdomain.mydomain', 'https://', '.zulipchat.com', '.com');
-    expect(result).toEqual('https://subdomain.mydomain.com');
+  test('if more than one dots in input do not use any append', () => {
+    const result = autocompleteUrl('subdomain.mydomain.org', 'https://', '.zulipchat.com');
+    expect(result).toEqual('https://subdomain.mydomain.org');
   });
 
-  test('if more than one dots in input do not use any append', () => {
-    const result = autocompleteUrl('subdomain.mydomain.org', 'https://', '.zulipchat.com', '.com');
-    expect(result).toEqual('https://subdomain.mydomain.org');
+  test('when no subdomain entered do not append top-level domain', () => {
+    const result = autocompleteUrl('mydomain.org', 'https://', '.zulipchat.com');
+    expect(result).toEqual('https://mydomain.org');
   });
 });
 

--- a/src/utils/url.js
+++ b/src/utils/url.js
@@ -147,15 +147,10 @@ const mimes = {
 export const getMimeTypeFromFileExtension = (extension: string): string =>
   mimes[extension.toLowerCase()] || 'application/octet-stream';
 
-export const autocompleteUrl = (
-  value: string = '',
-  protocol: string,
-  append: string,
-  shortAppend: string,
-): string =>
+export const autocompleteUrl = (value: string = '', protocol: string, append: string): string =>
   value.length > 0
     ? `${hasProtocol(value) ? '' : protocol}${value || 'your-org'}${
-        value.indexOf('.') === -1 ? append : !value.match(/.+\..+\.+./g) ? shortAppend : ''
+        value.indexOf('.') === -1 ? append : ''
       }`
     : '';
 


### PR DESCRIPTION
This fixes an issue reported twice... we are being 'too smart'. 
The previous way to input a realm URL always tried to append a `.com` at the end of `something.something` assuming that it is an incomplete url in the form of `subdomain.domain.tld`.

Users hosting their Zulip server on `domain.com` could not enter their URL correctly.

This simplifies the logic and removes the code to append the extra `.com`