### PR TITLE
compose box: Pilot extraction of `connect` mapStateToProps argument.

### DIFF
--- a/src/compose/ComposeBox.js
+++ b/src/compose/ComposeBox.js
@@ -341,7 +341,7 @@ class ComposeBox extends PureComponent<Props, State> {
   }
 }
 
-export default connect((state: GlobalState, props) => ({
+const mapStateToProps = (state: GlobalState, props) => ({
   auth: getAuth(state),
   users: getUsers(state),
   safeAreaInsets: getSession(state).safeAreaInsets,
@@ -350,4 +350,5 @@ export default connect((state: GlobalState, props) => ({
   editMessage: getSession(state).editMessage,
   draft: getDraftForActiveNarrow(props.narrow)(state),
   lastMessageTopic: getLastMessageTopic(props.narrow)(state),
-}))(ComposeBox);
+});
+export default connect(mapStateToProps)(ComposeBox);


### PR DESCRIPTION
This extracts the mapStateToProps argument from the `connect`
function. It makes the code easier to read and matches the
Redux `connect` argument terminology.

@gnprice this is part of the change to the `connect` function I've been talking about yesterday. I think it's much cleaner for someone who is new to the project but familiar with Redux terminology. Not sure if it's worth changing everywhere, though. The other part, namely adding a second `mapDispatchToProps` argument, turned out to only make sense if we were calling `connect` in a separate file, so I didn't  include an example commit for it.