### PR TITLE
Make sure stream created is public by default

### DIFF
--- a/src/nullObjects.js
+++ b/src/nullObjects.js
@@ -39,7 +39,7 @@ export const NULL_STREAM: Stream = {
   stream_id: 0,
   description: '',
   name: '',
-  invite_only: true,
+  invite_only: false,
   in_home_view: false,
   pin_to_top: false,
   color: 'green',


### PR DESCRIPTION
This makes the behavior consistent with the web app.

The change affects two concepts that both benefit from it:

* the nullObject should have had `invite_only` set to `false` anyway
* new streams will now be created as 'public'