### PR TITLE
Replace legacy 5dip grid dimensions with Material dimensions

### DIFF
--- a/src/autocomplete/TopicAutocomplete.js
+++ b/src/autocomplete/TopicAutocomplete.js
@@ -11,7 +11,8 @@ import AnimatedScaleComponent from '../animation/AnimatedScaleComponent';
 
 const styles = StyleSheet.create({
   topic: {
-    padding: 10,
+    padding: 12,
+    paddingLeft: 16,
   },
 });
 

--- a/src/common/ErrorMsg.js
+++ b/src/common/ErrorMsg.js
@@ -9,8 +9,7 @@ const styles = StyleSheet.create({
   field: {
     flexDirection: 'row',
     height: CONTROL_SIZE / 2,
-    marginTop: 5,
-    marginBottom: 5,
+    marginVertical: 8,
     justifyContent: 'center',
   },
   error: {

--- a/src/common/Popup.js
+++ b/src/common/Popup.js
@@ -5,8 +5,7 @@ import { View, Dimensions, StyleSheet } from 'react-native';
 
 const styles = StyleSheet.create({
   popup: {
-    marginRight: 20,
-    marginLeft: 20,
+    marginHorizontal: 16,
     marginBottom: 2,
     bottom: 0,
     borderRadius: 5,

--- a/src/common/SectionHeader.js
+++ b/src/common/SectionHeader.js
@@ -6,7 +6,7 @@ import Label from './Label';
 
 const styles = StyleSheet.create({
   header: {
-    padding: 10,
+    padding: 12,
     backgroundColor: 'rgba(127, 127, 127, 0.75)',
   },
 });

--- a/src/common/SectionSeparator.js
+++ b/src/common/SectionSeparator.js
@@ -5,7 +5,6 @@ import { StyleSheet, View } from 'react-native';
 const styles = StyleSheet.create({
   separator: {
     height: 1,
-    margin: 10,
     backgroundColor: 'rgba(127, 127, 127, 0.75)',
   },
 });

--- a/src/message/NoMessages.js
+++ b/src/message/NoMessages.js
@@ -27,7 +27,6 @@ const styles = StyleSheet.create({
   },
   text: {
     fontSize: 20,
-    paddingLeft: 10,
     padding: 8,
   },
 });


### PR DESCRIPTION
Most of the changes are too small to be noticed. I've provided screenshots of some of the more noticeable changes.

`AvatarItem` before:
![avatars_before](https://user-images.githubusercontent.com/22353313/41157365-2ac8a286-6b43-11e8-91bf-8f4256d58a14.png)

`AvatarItem` after:
![avatars_after](https://user-images.githubusercontent.com/22353313/41157375-30fe7306-6b43-11e8-9fa5-08333d23940f.png)

`Popup` and `TopicAutoComplete` before:
![topicauto_before](https://user-images.githubusercontent.com/22353313/41334665-0e05ff94-6f04-11e8-9dfd-6ef4c5db9b4d.png)

`Popup` and `TopicAutoComplete` after:
![topicauto_after](https://user-images.githubusercontent.com/22353313/41334678-15dcef8e-6f04-11e8-9195-f2b99181d55f.png)

`RealmInfo` before:
![realminfo_before](https://user-images.githubusercontent.com/22353313/41334696-2658ae8e-6f04-11e8-8666-d53d72753b83.png)

`RealmInfo` after:
![realminfo_after](https://user-images.githubusercontent.com/22353313/41334706-2d949b22-6f04-11e8-8b40-7e3aea8d116b.png)

`ErrorMsg` before:
![errormsg_before](https://user-images.githubusercontent.com/22353313/41334732-3ce30212-6f04-11e8-8482-bfd67af18e19.png)


`ErrorMsg` after:
![errormsg_after](https://user-images.githubusercontent.com/22353313/41334735-3f8deff4-6f04-11e8-9c0a-f4390ff8c2b5.png)

`SearchEmptyState` before:
![searchempty_before](https://user-images.githubusercontent.com/22353313/41334753-4bf52aa0-6f04-11e8-8796-b27f561ada8f.png)

`SearchEmptyState` after:
![searchempty_after](https://user-images.githubusercontent.com/22353313/41334776-5c9ab262-6f04-11e8-9809-3f39f61d5113.png)

`StreamTabs` before:
![streamtabs_before](https://user-images.githubusercontent.com/22353313/41334791-68185b12-6f04-11e8-8ee1-b2eb468a4131.png)

`StreamTabs` after:
![streamtabs_after](https://user-images.githubusercontent.com/22353313/41334811-778989d6-6f04-11e8-8588-e245bc0b01f0.png)

`NotSubscribed` before:
![notsubbed_before](https://user-images.githubusercontent.com/22353313/41334844-896e556e-6f04-11e8-9108-480b9899eb7f.png)

`NotSubscribed` after:
![notsubbed_after](https://user-images.githubusercontent.com/22353313/41334863-96677228-6f04-11e8-9fe7-bba8c8d91e0b.png)

`LightBoxFooter` and `LightBoxHeader` before:
![lightbox_before](https://user-images.githubusercontent.com/22353313/41334891-a88a8b66-6f04-11e8-9a69-3a053e04af1f.png)

`LightBoxFooter` and `LightBoxHeader` after:
![lightbox_after](https://user-images.githubusercontent.com/22353313/41334903-b0a0d24c-6f04-11e8-8721-c7812950c040.png)

`NoMessages` just removes redundant padding, no visual change.


This PR aims to close #2642 