### PR TITLE
VS Code: Fix jsconfig.json.

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,6 +1,5 @@
 {
     "compilerOptions": {
-        "allowJs": true,
         "allowSyntheticDefaultImports": true
     },
     "exclude": [


### PR DESCRIPTION
`jsconfig.json` tells VS Code that a project
is a js project and allows to configure
VS Code's settings for js projects.
The "allowJS" attribute is only relevant for
tsconfig.js files, but not jsconfig.js (where
it is automatically set to true). Previously,
our jsconfig.json still had a
`"allowJs": true` line, which VS Code complained
about. Thus it's safe and helpful to remove the line.