### PR TITLE
Add 1em of spacing between paragraphs in the same message.

### DIFF
--- a/src/webview/css/css.js
+++ b/src/webview/css/css.js
@@ -107,6 +107,9 @@ hr {
 .message-brief {
   padding: 0 1em 1em 4em;
 }
+.message p + p {
+  margin-top: 1em;
+}
 .avatar {
   min-width: 2em;
   width: 2em;


### PR DESCRIPTION
Select for any paragraph tag directly after another paragraph
tag using the adjacent sibling combinator, and add 1em of margin
above.

We use 1em in accordance with Material Design guidelines for
readability (see 'Paragraph spacing'):
https://material.io/design/typography/understanding-typography.html#readability

Fixes #2607.