### PR TITLE
flow: Add missing 'Context' types

### DIFF
--- a/src/animation/AnimatedScaleComponent.js
+++ b/src/animation/AnimatedScaleComponent.js
@@ -17,9 +17,7 @@ type State = {
 
 export default class AnimatedScaleComponent extends PureComponent<Props, State> {
   props: Props;
-  state: State;
-
-  state = {
+  state: State = {
     visible: this.props.visible,
   };
 

--- a/src/autocomplete/AutocompleteViewWrapper.js
+++ b/src/autocomplete/AutocompleteViewWrapper.js
@@ -26,6 +26,8 @@ type Props = {
 };
 
 export default class AutocompleteViewWrapper extends PureComponent<Props> {
+  props: Props;
+
   render() {
     const {
       composeText,

--- a/src/boot/CompatibilityChecker.js
+++ b/src/boot/CompatibilityChecker.js
@@ -15,9 +15,7 @@ type State = {
 
 export default class CompatibilityChecker extends PureComponent<Props, State> {
   props: Props;
-  state: State;
-
-  state = {
+  state: State = {
     compatibilityCheckFail: false,
   };
 

--- a/src/boot/StoreProvider.js
+++ b/src/boot/StoreProvider.js
@@ -11,6 +11,8 @@ type Props = {
 };
 
 export default class StoreHydrator extends PureComponent<Props> {
+  props: Props;
+
   componentDidMount() {
     timing.start('Store hydration');
     restore(() => {

--- a/src/boot/TranslationProvider.js
+++ b/src/boot/TranslationProvider.js
@@ -18,6 +18,8 @@ type Props = {
 };
 
 class TranslationProvider extends PureComponent<Props> {
+  props: Props;
+
   render() {
     const { locale, children } = this.props;
 

--- a/src/chat/GroupDetailsScreen.js
+++ b/src/chat/GroupDetailsScreen.js
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 import React, { PureComponent } from 'react';
 import { FlatList } from 'react-native';
 
-import type { Dispatch } from '../types';
+import type { Context, Dispatch } from '../types';
 import { Screen } from '../common';
 import UserItem from '../users/UserItem';
 import { navigateToAccountDetails } from '../actions';
@@ -14,6 +14,8 @@ type Props = {
 };
 
 class GroupDetailsScreen extends PureComponent<Props> {
+  context: Context;
+
   static contextTypes = {
     styles: () => null,
   };

--- a/src/chat/GroupDetailsScreen.js
+++ b/src/chat/GroupDetailsScreen.js
@@ -15,6 +15,7 @@ type Props = {
 
 class GroupDetailsScreen extends PureComponent<Props> {
   context: Context;
+  props: Props;
 
   static contextTypes = {
     styles: () => null,

--- a/src/chat/UnreadNotice.js
+++ b/src/chat/UnreadNotice.js
@@ -4,7 +4,7 @@ import { connect } from 'react-redux';
 import React, { PureComponent } from 'react';
 import { StyleSheet, View } from 'react-native';
 
-import type { Narrow } from '../types';
+import type { Context, Narrow } from '../types';
 import { getUnreadCountForNarrow } from '../selectors';
 import { Label, RawLabel } from '../common';
 import { unreadToLimitedCount } from '../utils/unread';
@@ -37,6 +37,7 @@ type Props = {
 };
 
 class UnreadNotice extends PureComponent<Props> {
+  context: Context;
   props: Props;
 
   static defaultProps = {

--- a/src/common/Input.js
+++ b/src/common/Input.js
@@ -33,7 +33,9 @@ type State = {
 export default class Input extends PureComponent<Props, State> {
   context: Context;
   props: Props;
-  state: State;
+  state: State = {
+    isFocused: false,
+  };
   textInput: TextInput;
 
   static contextTypes = {
@@ -48,10 +50,6 @@ export default class Input extends PureComponent<Props, State> {
     restProps: [],
     onChangeText: nullFunction,
     textInputRef: nullFunction,
-  };
-
-  state = {
-    isFocused: false,
   };
 
   handleClear = () => {

--- a/src/common/Input.js
+++ b/src/common/Input.js
@@ -44,9 +44,6 @@ export default class Input extends PureComponent<Props, State> {
 
   static defaultProps = {
     placeholder: {},
-  };
-
-  static defaultProps = {
     restProps: [],
     onChangeText: nullFunction,
     textInputRef: nullFunction,

--- a/src/common/InputWithClearButton.js
+++ b/src/common/InputWithClearButton.js
@@ -41,16 +41,14 @@ type State = {
 export default class InputWithClearButton extends PureComponent<Props, State> {
   context: Context;
   props: Props;
-  state: State;
+  state: State = {
+    canBeCleared: false,
+    text: '',
+  };
   textInput: TextInput;
 
   static contextTypes = {
     styles: () => null,
-  };
-
-  state = {
-    canBeCleared: false,
-    text: '',
   };
 
   handleChangeText = (text: string) => {

--- a/src/common/LineSeparator.js
+++ b/src/common/LineSeparator.js
@@ -2,7 +2,11 @@
 import React, { PureComponent } from 'react';
 import { View } from 'react-native';
 
+import type { Context } from '../types';
+
 export default class LineSeparator extends PureComponent<{}> {
+  context: Context;
+
   static contextTypes = {
     styles: () => null,
   };

--- a/src/common/PasswordInput.js
+++ b/src/common/PasswordInput.js
@@ -42,12 +42,10 @@ type State = {
 export default class PasswordInput extends PureComponent<Props, State> {
   context: Context;
   props: Props;
-  state: State;
-  textInput: TextInput;
-
-  state = {
+  state: State = {
     isHidden: true,
   };
+  textInput: TextInput;
 
   handleShow = () => {
     this.setState(({ isHidden }) => ({

--- a/src/common/Popup.js
+++ b/src/common/Popup.js
@@ -3,6 +3,8 @@ import React, { PureComponent } from 'react';
 import type { ChildrenArray } from 'react';
 import { View, StyleSheet } from 'react-native';
 
+import type { Context } from '../types';
+
 const styles = StyleSheet.create({
   popup: {
     marginRight: 20,
@@ -20,6 +22,7 @@ type Props = {
 };
 
 export default class Popup extends PureComponent<Props> {
+  context: Context;
   props: Props;
 
   static contextTypes = {

--- a/src/common/RawLabel.js
+++ b/src/common/RawLabel.js
@@ -2,7 +2,7 @@
 import React, { PureComponent } from 'react';
 import { Text } from 'react-native';
 
-import type { Style } from '../types';
+import type { Context, Style } from '../types';
 
 type Props = {
   text: string,
@@ -18,6 +18,8 @@ type Props = {
  * @prop [style] - Style object applied to the Text component.
  */
 export default class RawLabel extends PureComponent<Props> {
+  context: Context;
+
   static contextTypes = {
     styles: () => null,
   };

--- a/src/common/RawLabel.js
+++ b/src/common/RawLabel.js
@@ -19,12 +19,11 @@ type Props = {
  */
 export default class RawLabel extends PureComponent<Props> {
   context: Context;
+  props: Props;
 
   static contextTypes = {
     styles: () => null,
   };
-
-  props: Props;
 
   render() {
     const styles = this.context.styles || {};

--- a/src/common/SectionHeader.js
+++ b/src/common/SectionHeader.js
@@ -2,6 +2,7 @@
 import React, { PureComponent } from 'react';
 import { StyleSheet, View } from 'react-native';
 
+import type { Context } from '../types';
 import Label from './Label';
 
 const styles = StyleSheet.create({
@@ -16,6 +17,7 @@ type Props = {
 };
 
 export default class SectionHeader extends PureComponent<Props> {
+  context: Context;
   props: Props;
 
   static contextTypes = {

--- a/src/common/SlideAnimationView.js
+++ b/src/common/SlideAnimationView.js
@@ -20,15 +20,13 @@ type State = {
 };
 
 export default class SlideAnimationView extends PureComponent<Props, State> {
-  state: State;
+  state: State = {
+    animationIndex: new Animated.Value(0),
+  };
 
   static defaultProps = {
     duration: 300,
     movement: 'out',
-  };
-
-  state = {
-    animationIndex: new Animated.Value(0),
   };
 
   animate() {

--- a/src/common/ZulipStatusBar.js
+++ b/src/common/ZulipStatusBar.js
@@ -29,10 +29,6 @@ type Props = {
  * @prop [narrow] - Currently active narrow.
  */
 class ZulipStatusBar extends PureComponent<Props> {
-  static contextTypes = {
-    styles: () => null,
-  };
-
   props: Props;
 
   static defaultProps = {

--- a/src/common/ZulipSwitch.js
+++ b/src/common/ZulipSwitch.js
@@ -26,16 +26,14 @@ type State = {
  */
 export default class ZulipSwitch extends PureComponent<Props, State> {
   props: Props;
-  state: State;
+  state: State = {
+    valueControlled: this.props.defaultValue,
+  };
 
   static defaultProps = {
     value: false,
     disabled: false,
     defaultValue: false,
-  };
-
-  state = {
-    valueControlled: this.props.defaultValue,
   };
 
   handleValueChange = (newValue: boolean) => {

--- a/src/compose/ComposeBox.ios.js
+++ b/src/compose/ComposeBox.ios.js
@@ -79,16 +79,7 @@ type State = {
 class ComposeBox extends PureComponent<Props, State> {
   context: Context;
   props: Props;
-  state: State;
-
-  messageInput: TextInput = null;
-  topicInput: TextInput = null;
-
-  static contextTypes = {
-    styles: () => null,
-  };
-
-  state = {
+  state: State = {
     isMessageFocused: false,
     isTopicFocused: false,
     isMenuExpanded: false,
@@ -96,6 +87,13 @@ class ComposeBox extends PureComponent<Props, State> {
     topic: '',
     message: this.props.draft,
     selection: { start: 0, end: 0 },
+  };
+
+  messageInput: TextInput = null;
+  topicInput: TextInput = null;
+
+  static contextTypes = {
+    styles: () => null,
   };
 
   getCanSelectTopic = () => {

--- a/src/diagnostics/NotificationDiagScreen.js
+++ b/src/diagnostics/NotificationDiagScreen.js
@@ -14,6 +14,8 @@ type Props = {
 };
 
 class NotificationDiagScreen extends PureComponent<Props> {
+  props: Props;
+
   render() {
     const { pushToken } = this.props;
     const variables = {

--- a/src/lightbox/AnimatedLightboxFooter.js
+++ b/src/lightbox/AnimatedLightboxFooter.js
@@ -14,6 +14,8 @@ type Props = {
 };
 
 export default class AnimatedLightboxFooter extends PureComponent<Props> {
+  props: Props;
+
   render() {
     const { displayMessage, onOptionsPress, style, ...restProps } = this.props;
     return (

--- a/src/lightbox/AnimatedLightboxHeader.js
+++ b/src/lightbox/AnimatedLightboxHeader.js
@@ -18,6 +18,8 @@ type Props = {
 };
 
 export default class AnimatedLightboxHeader extends PureComponent<Props> {
+  props: Props;
+
   render() {
     const { onPressBack, senderName, timestamp, ...restProps } = this.props;
     const displayDate = humanDate(new Date(timestamp * 1000));

--- a/src/lightbox/Lightbox.js
+++ b/src/lightbox/Lightbox.js
@@ -50,9 +50,7 @@ type State = {
 
 class Lightbox extends PureComponent<Props, State> {
   props: Props;
-  state: State;
-
-  state = {
+  state: State = {
     movement: 'out',
   };
 

--- a/src/lightbox/LightboxFooter.js
+++ b/src/lightbox/LightboxFooter.js
@@ -31,6 +31,8 @@ type Props = {
 };
 
 export default class LightboxFooter extends PureComponent<Props> {
+  props: Props;
+
   render() {
     const { displayMessage, onOptionsPress, style } = this.props;
     return (

--- a/src/lightbox/LightboxHeader.js
+++ b/src/lightbox/LightboxHeader.js
@@ -50,10 +50,6 @@ type Props = {
 };
 
 export default class LightboxHeader extends PureComponent<Props> {
-  static contextTypes = {
-    styles: () => null,
-  };
-
   render() {
     const { onPressBack, senderName, subheader, ...restProps } = this.props;
 

--- a/src/lightbox/LightboxHeader.js
+++ b/src/lightbox/LightboxHeader.js
@@ -50,6 +50,8 @@ type Props = {
 };
 
 export default class LightboxHeader extends PureComponent<Props> {
+  props: Props;
+
   render() {
     const { onPressBack, senderName, subheader, ...restProps } = this.props;
 

--- a/src/main/HomeTab.js
+++ b/src/main/HomeTab.js
@@ -26,6 +26,8 @@ type Props = {
 };
 
 class HomeTab extends PureComponent<Props> {
+  props: Props;
+
   render() {
     const { dispatch } = this.props;
 

--- a/src/message/MessageList.js
+++ b/src/message/MessageList.js
@@ -6,6 +6,7 @@ import { connectActionSheet } from '@expo/react-native-action-sheet';
 
 import type {
   Auth,
+  Context,
   Debug,
   Dispatch,
   Fetching,
@@ -61,6 +62,7 @@ export type Props = {
 };
 
 class MessageList extends PureComponent<Props> {
+  context: Context;
   props: Props;
 
   static contextTypes = {

--- a/src/nav/AppWithNavigation.js
+++ b/src/nav/AppWithNavigation.js
@@ -15,6 +15,8 @@ type Props = {
 };
 
 class AppWithNavigation extends PureComponent<Props> {
+  props: Props;
+
   render() {
     const { dispatch, nav } = this.props;
     const addListener = createReduxBoundAddListener('root');

--- a/src/nav/IconUnreadConversations.js
+++ b/src/nav/IconUnreadConversations.js
@@ -21,6 +21,8 @@ type Props = {
 };
 
 class IconUnreadConversations extends PureComponent<Props> {
+  props: Props;
+
   render() {
     const { unreadHuddlesTotal, unreadPmsTotal, color } = this.props;
     const unreadCount = unreadHuddlesTotal + unreadPmsTotal;

--- a/src/nav/ModalSearchNavBar.js
+++ b/src/nav/ModalSearchNavBar.js
@@ -35,14 +35,12 @@ type State = {
 class ModalSearchNavBar extends PureComponent<Props, State> {
   context: Context;
   props: Props;
-  state: State;
+  state: State = {
+    isSearchActive: false,
+  };
 
   static contextTypes = {
     styles: () => null,
-  };
-
-  state = {
-    isSearchActive: false,
   };
 
   enableSearchActiveState = () => {

--- a/src/search/SearchMessagesCard.js
+++ b/src/search/SearchMessagesCard.js
@@ -35,9 +35,7 @@ type State = {
 
 class SearchMessagesCard extends PureComponent<Props, State> {
   props: Props;
-  state: State;
-
-  state = {
+  state: State = {
     messages: [],
     isFetching: false,
   };

--- a/src/search/SearchMessagesScreen.js
+++ b/src/search/SearchMessagesScreen.js
@@ -14,9 +14,7 @@ type State = {
 export default class SearchMessagesScreen extends PureComponent<Props, State> {
   context: Context;
   props: Props;
-  state: State;
-
-  state = {
+  state: State = {
     query: '',
   };
 

--- a/src/start/RealmScreen.js
+++ b/src/start/RealmScreen.js
@@ -25,17 +25,16 @@ type State = {
 class RealmScreen extends PureComponent<Props, State> {
   context: Context;
   props: Props;
-  state: State;
+  state: State = {
+    progress: false,
+    realm: this.props.initialRealm,
+    error: undefined,
+  };
+
   scrollView: ScrollView;
 
   static contextTypes = {
     styles: () => null,
-  };
-
-  state = {
-    progress: false,
-    realm: this.props.initialRealm,
-    error: undefined,
   };
 
   tryRealm = async () => {

--- a/src/streams/EditStreamCard.js
+++ b/src/streams/EditStreamCard.js
@@ -2,6 +2,7 @@
 import React, { PureComponent } from 'react';
 import { View } from 'react-native';
 
+import type { Context } from '../types';
 import { Input, Label, OptionRow, ZulipButton } from '../common';
 
 type Props = {
@@ -21,6 +22,7 @@ type State = {
 };
 
 export default class EditStreamCard extends PureComponent<Props, State> {
+  context: Context;
   props: Props;
   state: State;
 

--- a/src/streams/EditStreamCard.js
+++ b/src/streams/EditStreamCard.js
@@ -24,16 +24,14 @@ type State = {
 export default class EditStreamCard extends PureComponent<Props, State> {
   context: Context;
   props: Props;
-  state: State;
-
-  static contextTypes = {
-    styles: () => null,
-  };
-
-  state = {
+  state: State = {
     name: this.props.initialValues.name,
     description: this.props.initialValues.description,
     isPrivate: this.props.initialValues.invite_only,
+  };
+
+  static contextTypes = {
+    styles: () => null,
   };
 
   handlePerformAction = () => {

--- a/src/streams/StreamScreen.js
+++ b/src/streams/StreamScreen.js
@@ -31,6 +31,7 @@ class StreamScreen extends PureComponent<Props> {
   static contextTypes = {
     styles: () => null,
   };
+
   handleTogglePinStream = (newValue: boolean) => {
     const { dispatch, stream } = this.props;
     dispatch(doTogglePinStream(stream.stream_id, newValue));

--- a/src/subscriptions/StreamListCard.js
+++ b/src/subscriptions/StreamListCard.js
@@ -36,10 +36,7 @@ type State = {
 
 class StreamListCard extends PureComponent<Props, State> {
   props: Props;
-
-  state: State;
-
-  state = {
+  state: State = {
     filter: '',
   };
 

--- a/src/title/ActivityText.js
+++ b/src/title/ActivityText.js
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 
 import React, { PureComponent } from 'react';
 
-import type { PresenceState, Style } from '../types';
+import type { Context, PresenceState, Style } from '../types';
 import { getPresence } from '../selectors';
 import { presenceToHumanTime } from '../utils/presence';
 import { RawLabel } from '../common';
@@ -16,6 +16,7 @@ type Props = {
 };
 
 class ActivityText extends PureComponent<Props> {
+  context: Context;
   props: Props;
 
   static contextTypes = {

--- a/src/title/TitleHome.js
+++ b/src/title/TitleHome.js
@@ -1,5 +1,7 @@
 /* @flow */
 import React, { PureComponent } from 'react';
+
+import type { Context } from '../types';
 import TitleSpecial from './TitleSpecial';
 
 type Props = {
@@ -7,6 +9,7 @@ type Props = {
 };
 
 export default class TitleHome extends PureComponent<Props> {
+  context: Context;
   props: Props;
 
   static contextTypes = {

--- a/src/user-picker/UserPickerCard.js
+++ b/src/user-picker/UserPickerCard.js
@@ -38,14 +38,12 @@ type State = {
 };
 
 class UserPickerCard extends PureComponent<Props, State> {
-  listRef: (component: any) => void;
-
   props: Props;
-  state: State;
-
-  state = {
+  state: State = {
     selected: [],
   };
+
+  listRef: (component: any) => void;
 
   handleUserSelect = (email: string) => {
     const { users } = this.props;

--- a/src/users/UserList.js
+++ b/src/users/UserList.js
@@ -24,12 +24,11 @@ type Props = {
 
 export default class UserList extends PureComponent<Props> {
   context: Context;
+  props: Props;
 
   static contextTypes = {
     styles: () => null,
   };
-
-  props: Props;
 
   static defaultProps = {
     selected: [],

--- a/src/users/UserList.js
+++ b/src/users/UserList.js
@@ -2,7 +2,7 @@
 import React, { PureComponent } from 'react';
 import { StyleSheet, SectionList } from 'react-native';
 
-import type { PresenceState, Style, User } from '../types';
+import type { Context, PresenceState, Style, User } from '../types';
 import { SectionHeader, SearchEmptyState } from '../common';
 import UserItem from './UserItem';
 import { sortUserList, filterUserList, groupUsersByStatus } from '../users/userHelpers';
@@ -23,6 +23,8 @@ type Props = {
 };
 
 export default class UserList extends PureComponent<Props> {
+  context: Context;
+
   static contextTypes = {
     styles: () => null,
   };

--- a/src/users/UsersScreen.js
+++ b/src/users/UsersScreen.js
@@ -11,9 +11,7 @@ type State = {
 };
 
 export default class UsersScreen extends PureComponent<Props, State> {
-  state: State;
-
-  state = {
+  state: State = {
     filter: '',
   };
 


### PR DESCRIPTION
Components with `static contextTypes` get injected the context
object (of type `Context`).

Some components had this injected but the types were missing.
This adds `context: Context` to all such components.