### PR TITLE
flow: Define a base ServerEvent type

### DIFF
--- a/src/actionTypes.js
+++ b/src/actionTypes.js
@@ -329,7 +329,7 @@ export type EventNewMessageAction = ServerEvent & {
   ownEmail: string,
 };
 
-export type EventMessageDeleteAction = {
+export type EventMessageDeleteAction = ServerEvent & {
   type: typeof EVENT_MESSAGE_DELETE,
   messageId: number,
 };

--- a/src/events/eventToAction.js
+++ b/src/events/eventToAction.js
@@ -109,6 +109,7 @@ const newMessage = (state: GlobalState, event: Object): EventNewMessageAction =>
 });
 
 const deleteMessage = (state: GlobalState, event: Object): EventMessageDeleteAction => ({
+  ...event,
   type: EVENT_MESSAGE_DELETE,
   messageId: event.message_id,
 });


### PR DESCRIPTION
Server events do contain an `id` prop that is not really used by
the reducers (it is a incremental id set by the server)

Base all `Event*` types on `ServerEvent` and remove `id` from
the individual types.