### PR TITLE
fix: Show loading when narrowing from notification

### DIFF
--- a/src/message/__tests__/fetchActions-test.js
+++ b/src/message/__tests__/fetchActions-test.js
@@ -1,12 +1,6 @@
 import mockStore from 'redux-mock-store'; // eslint-disable-line
 
-import {
-  backgroundFetchMessages,
-  fetchMessages,
-  fetchMessagesAtFirstUnread,
-  fetchOlder,
-  fetchNewer,
-} from '../fetchActions';
+import { fetchMessages, fetchMessagesAtFirstUnread, fetchOlder, fetchNewer } from '../fetchActions';
 import { streamNarrow, homeNarrow, homeNarrowStr } from '../../utils/narrow';
 import { navStateWithNarrow } from '../../utils/testHelpers';
 
@@ -20,7 +14,7 @@ describe('fetchActions', () => {
     fetch.reset();
   });
 
-  describe('backgroundFetchMessages', () => {
+  describe('fetchMessages', () => {
     test('message fetch success action is dispatched after successful fetch', async () => {
       const store = mockStore({
         ...navStateWithNarrow(homeNarrow),
@@ -36,15 +30,14 @@ describe('fetchActions', () => {
       const response = { messages: [{ id: 1 }, { id: 2 }, { id: 3 }], result: 'success' };
       fetch.mockResponseSuccess(JSON.stringify(response));
 
-      await store.dispatch(backgroundFetchMessages(homeNarrow, 0, 1, 1, true));
+      await store.dispatch(fetchMessages(homeNarrow, 0, 1, 1, true));
       const actions = store.getActions();
 
-      expect(actions).toHaveLength(1);
-      expect(actions[0].type).toBe('MESSAGE_FETCH_COMPLETE');
+      expect(actions).toHaveLength(2);
+      expect(actions[0].type).toBe('MESSAGE_FETCH_START');
+      expect(actions[1].type).toBe('MESSAGE_FETCH_COMPLETE');
     });
-  });
 
-  describe('fetchMessages', () => {
     test('when messages to be fetched both before and after anchor, fetchingOlder and fetchingNewer is true', () => {
       const store = mockStore({
         ...navStateWithNarrow(homeNarrow),

--- a/src/message/fetchActions.js
+++ b/src/message/fetchActions.js
@@ -153,6 +153,9 @@ export const fetchEssentialInitialData = () => async (dispatch: Dispatch, getSta
   // only fetch messages if chat scrren is at the top of stack
   // get narrow of top most chat screen in the stack
   const narrow = getTopMostNarrow(getState());
+  if (narrow) {
+    dispatch(messageFetchStart(narrow, halfCount, halfCount));
+  }
   const [initData, messages] = await Promise.all([
     await tryUntilSuccessful(() => registerForEvents(auth)),
     narrow

--- a/src/message/fetchActions.js
+++ b/src/message/fetchActions.js
@@ -70,13 +70,14 @@ export const messageFetchComplete = (
   numAfter,
 });
 
-export const backgroundFetchMessages = (
+export const fetchMessages = (
   narrow: Narrow,
   anchor: number,
   numBefore: number,
   numAfter: number,
   useFirstUnread: boolean = false,
-) => async (dispatch: Dispatch, getState: GetState) => {
+): FetchMessagesAction => async (dispatch: Dispatch, getState: GetState) => {
+  dispatch(messageFetchStart(narrow, numBefore, numAfter));
   const messages = await getMessages(
     getAuth(getState()),
     narrow,
@@ -85,19 +86,7 @@ export const backgroundFetchMessages = (
     numAfter,
     useFirstUnread,
   );
-
   dispatch(messageFetchComplete(messages, narrow, anchor, numBefore, numAfter));
-};
-
-export const fetchMessages = (
-  narrow: Narrow,
-  anchor: number,
-  numBefore: number,
-  numAfter: number,
-  useFirstUnread: boolean = false,
-): FetchMessagesAction => async (dispatch: Dispatch) => {
-  dispatch(messageFetchStart(narrow, numBefore, numAfter));
-  dispatch(backgroundFetchMessages(narrow, anchor, numBefore, numAfter, useFirstUnread));
 };
 
 export const fetchMessagesAroundAnchor = (narrow: Narrow, anchor: number): FetchMessagesAction =>


### PR DESCRIPTION
Fixes #2714

Narrowing from a notification is a special case, where we load
messages for the message narrow on startup.

We were not setting correctly the 'fetching' state and we were
displaying 'No messages' while actually loading new messages.