### PR TITLE
Display a lower-res image while the bigger image is still loading

### DIFF
--- a/src/account-info/AccountDetails.js
+++ b/src/account-info/AccountDetails.js
@@ -1,6 +1,6 @@
 /* @flow */
 import React, { PureComponent } from 'react';
-import { View, Dimensions } from 'react-native';
+import { View, Dimensions, Image, StyleSheet } from 'react-native';
 
 import type { Auth, Dispatch, Context, Presence, User } from '../types';
 import { Avatar, ComponentList, RawLabel, ZulipButton } from '../common';
@@ -8,7 +8,8 @@ import { IconPrivateChat } from '../common/Icons';
 import { privateNarrow } from '../utils/narrow';
 import UserStatusIndicator from '../common/UserStatusIndicator';
 import ActivityText from '../title/ActivityText';
-import { getMediumAvatar } from '../utils/avatar';
+import { getMediumAvatar, getGravatarFromEmail } from '../utils/avatar';
+import { getFullUrl } from '../utils/url';
 import { nowInTimeZone } from '../utils/date';
 import { doNarrow } from '../actions';
 
@@ -18,6 +19,15 @@ type Props = {
   user: User,
   presence: Presence,
 };
+
+const screenWidth = Dimensions.get('window').width;
+
+const componentStyles = StyleSheet.create({
+  imageDimensions: {
+    width: screenWidth,
+    height: screenWidth,
+  },
+});
 
 export default class AccountDetails extends PureComponent<Props, void> {
   context: Context;
@@ -35,17 +45,23 @@ export default class AccountDetails extends PureComponent<Props, void> {
   render() {
     const { styles } = this.context;
     const { user, auth, presence } = this.props;
-    const screenWidth = Dimensions.get('window').width;
+    const { avatar_url, email } = user;
+    const mediumAvatarUrl = avatar_url ? getMediumAvatar(avatar_url) : null;
+    const fullMediumAvatarUrl = mediumAvatarUrl
+      ? getFullUrl(mediumAvatarUrl, auth.realm)
+      : getGravatarFromEmail(email);
+    const fullAvatarUrl = avatar_url
+      ? getFullUrl(avatar_url, auth.realm)
+      : getGravatarFromEmail(email);
+    console.log(fullMediumAvatarUrl);
+    console.log(fullAvatarUrl);
 
     return (
       <View>
-        <Avatar
-          avatarUrl={user.avatar_url ? getMediumAvatar(user.avatar_url) : null}
-          name={user.full_name}
-          email={user.email}
-          size={screenWidth}
-          realm={auth.realm}
-          shape="square"
+        <Image
+          source={{ uri: fullMediumAvatarUrl }}
+          loadingIndicatorSource={{ uri: fullAvatarUrl }}
+          style={componentStyles.imageDimensions}
         />
         <ComponentList outerSpacing itemStyle={[styles.row, styles.center]}>
           <View>

--- a/src/account-info/AccountDetails.js
+++ b/src/account-info/AccountDetails.js
@@ -26,6 +26,7 @@ const componentStyles = StyleSheet.create({
   imageDimensions: {
     width: screenWidth,
     height: screenWidth,
+    alignSelf: 'center',
   },
 });
 


### PR DESCRIPTION
Makes use of loadingIndicatorSource to display a lower res image that will be faster to load while the main image is loading to avoid a blank screen for several seconds.

Fixes issue #1958 