### PR TITLE
flow: Make the `Actions` type work + various cleanups

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
 **/flow-typed/**
+**/__flow-tests__/**

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "prettier": "prettier --write --loglevel=warn 'src/**/*.js' ; eslint --no-eslintrc -c tools/formatting.eslintrc.yaml --fix src/",
     "test:prettier": "prettier-eslint --list-different --eslint-config-path ./tools/formatting.eslintrc.yaml 'src/**/*.js'",
     "test:lint": "eslint src/",
-    "test:flow": "flow",
+    "test:flow": "flow --max-warnings 0",
     "test:flow-todo": "eslint --no-eslintrc -c tools/flow-todo.eslintrc.yaml src/",
     "test:flow-coverage": "flow-coverage-report -i 'src/**/*.js' -x '**/__tests__/**' -t html",
     "test:unit": "jest src/ --maxWorkers=2",

--- a/src/__flow-tests__/types-test.js
+++ b/src/__flow-tests__/types-test.js
@@ -1,0 +1,9 @@
+/* @flow */
+import type { Action } from '../types';
+
+// Assert that Action does not allow arbitrary objects.
+{
+  const foo = { nonexistent_key: 'bar' };
+  // $FlowExpectedError
+  const bar: Action = foo;
+}

--- a/src/session/sessionActions.js
+++ b/src/session/sessionActions.js
@@ -27,7 +27,6 @@ import { getAuth, getIsOnline, getIsActive } from '../selectors';
 export const appOnline = (isOnline: boolean) => (
   dispatch: Dispatch,
   getState: GetState,
-  // $FlowFixMe: `dispatch` at caller has the wrong type
 ): ?AppOnlineAction => {
   if (isOnline !== getIsOnline(getState())) {
     dispatch({
@@ -40,7 +39,6 @@ export const appOnline = (isOnline: boolean) => (
 export const appState = (isActive: boolean) => (
   dispatch: Dispatch,
   getState: GetState,
-  // $FlowFixMe: `dispatch` at caller has the wrong type
 ): ?AppStateAction => {
   if (isActive !== getIsActive(getState())) {
     dispatch({
@@ -62,7 +60,6 @@ export const initSafeAreaInsets = (safeAreaInsets: Dimensions): InitSafeAreaInse
 export const appOrientation = (orientation: string) => (
   dispatch: Dispatch,
   getState: GetState,
-  // $FlowFixMe: `dispatch` at caller has the wrong type
 ): ?AppOrientationAction => {
   if (orientation !== getState().session.orientation) {
     dispatch({

--- a/src/streams/StreamScreen.js
+++ b/src/streams/StreamScreen.js
@@ -58,7 +58,6 @@ class StreamScreen extends PureComponent<Props> {
 
   toggleStreamPushNotification = () => {
     const { dispatch, subscription, stream } = this.props;
-    // $FlowFixMe: `dispatch` has the wrong type
     dispatch(toggleStreamNotification(stream.stream_id, !subscription.push_notifications));
   };
 

--- a/src/types.js
+++ b/src/types.js
@@ -13,8 +13,9 @@ export type MapStateToProps = any; // { MapStateToProps } from 'react-redux';
 export type * from './actionTypes';
 export type * from './api/apiTypes';
 
-export type Thunk<A> = ((Dispatch, GetState) => Promise<void> | void) => A;
-export type Dispatch = ReduxDispatch<Action> & Thunk<Action>;
+export type ThunkDispatch<T> = ((Dispatch, GetState) => T) => T;
+
+export type Dispatch = ReduxDispatch<Action> & ThunkDispatch<*>;
 
 export type Style = boolean | number | Array<Style> | ?{ [string]: any };
 


### PR DESCRIPTION
Originally, this set out to get flow into a state where it will complain about bugs like the one fixed in https://github.com/zulip/zulip-mobile/commit/d5e6a0bb2c66b793155d05a6b10be57bcdeb6a5a.
The issue here was the following `dispatch` call:
```js
dispatch(navigateToCreateStream);
```
`navigateToCreateStream` is an action creator, so it needs to be called before it can be dispatched. The correct `dispatch` call is
```js
dispatch(navigateToCreateStream());
```

I only succeeded partially. The dispatch bug described above seems to be in fact undetectable with the current implementation of Flow. On the other hand, the commits in this PR make Flow detect some other potential regression candidates, among some other things.

Why can't Flow detect the dispatch bug described above?

I tried to approach the bug by looking at the type of `dispatch`. It's probably too permissive, since it accepts an action creator, even though it should only accept actions. The type of `dispatch` is `Dispatch`:
```js
export type Thunk<A> = ((Dispatch, GetState) => Promise<any> | void) => A;
export type Dispatch = ReduxDispatch<Action> & Thunk<Action>;
```
`ReduxDispatch<Action>` is `Action` object.  With this PR, the `Action` type works properly (and doesn't accept anything anymore), so there must  be another issue.  The issue lies with `Thunk<A>`: This allows actions to be functions, and not just objects. In particular, an action can be the `(Dispatch, GetState) => Promise<any> | void`. Now,  `navigateToCreateStream` has an arity of 0, whereas Flow should expect a function of arity 2, right? Nope! In Flow, the type of a function that accepts only a subset of the parameters of another function is a subtype of the type of that function; see the [Flow function subtyping rules](https://flow.org/en/docs/lang/subtypes/#toc-subtypes-of-functions).

This is very annoying, and there is no way to work around this by e.g. declaring "exact functions" that require a certain arity. The workaround I can think of is very annoying as well: We could split the Dispatch type, but that wouldn't reflect reality and create a ton of new boilerplate annotations.

I guess for this case our best bet is living with this annoyance, but adding a linter rule so that the specific dispatch regression would be caught.