### PR TITLE
Add 'ComponentList' component and improve 'AccountDetails'

### DIFF
--- a/src/account-info/AccountDetails.js
+++ b/src/account-info/AccountDetails.js
@@ -3,7 +3,7 @@ import React, { PureComponent } from 'react';
 import { View, Dimensions } from 'react-native';
 
 import type { Auth, Dispatch, Context, Presence, User } from '../types';
-import { Avatar, RawLabel, ZulipButton } from '../common';
+import { Avatar, ComponentList, RawLabel, ZulipButton } from '../common';
 import { IconPrivateChat } from '../common/Icons';
 import { privateNarrow } from '../utils/narrow';
 import UserStatusIndicator from '../common/UserStatusIndicator';
@@ -47,27 +47,28 @@ export default class AccountDetails extends PureComponent<Props, void> {
           realm={auth.realm}
           shape="square"
         />
-        <View style={[styles.row, styles.margin, styles.center]}>
-          <UserStatusIndicator presence={presence} hideIfOffline={false} />
-          <RawLabel style={[styles.largerText, styles.halfMarginLeft]} text={user.email} />
-        </View>
-        <View style={[styles.row, styles.margin, styles.center]}>
-          <ActivityText style={styles.largerText} email={user.email} />
-        </View>
-        {user.timezone ? (
-          <View style={[styles.row, styles.margin, styles.center]}>
-            <RawLabel
-              style={styles.largerText}
-              text={`${nowInTimeZone(user.timezone)} Local time`}
-            />
+        <ComponentList outerSpacing itemStyle={[styles.row, styles.center]}>
+          <View>
+            <UserStatusIndicator presence={presence} hideIfOffline={false} />
+            <RawLabel style={[styles.largerText, styles.halfMarginLeft]} text={user.email} />
           </View>
-        ) : null}
-        <ZulipButton
-          style={styles.marginHorizontal}
-          text="Send private message"
-          onPress={this.handleChatPress}
-          Icon={IconPrivateChat}
-        />
+          <View>
+            <ActivityText style={styles.largerText} email={user.email} />
+          </View>
+          {user.timezone ? (
+            <View>
+              <RawLabel
+                style={styles.largerText}
+                text={`${nowInTimeZone(user.timezone)} Local time`}
+              />
+            </View>
+          ) : null}
+          <ZulipButton
+            text="Send private message"
+            onPress={this.handleChatPress}
+            Icon={IconPrivateChat}
+          />
+        </ComponentList>
       </View>
     );
   }

--- a/src/common/ComponentList.js
+++ b/src/common/ComponentList.js
@@ -1,0 +1,42 @@
+/* @flow */
+import React, { PureComponent } from 'react';
+import type { ChildrenArray } from 'react';
+import { View } from 'react-native';
+
+import type { Style } from '../types';
+
+type Props = {
+  children: ChildrenArray<*>,
+  spacing?: number,
+  outerSpacing?: boolean,
+  style?: Style,
+  itemStyle?: Style,
+};
+
+export default class ComponentList extends PureComponent<Props> {
+  props: Props;
+
+  static defaultProps = {
+    outerSpacing: true,
+    spacing: 16,
+  };
+
+  render() {
+    const { children, itemStyle, spacing, outerSpacing, style } = this.props;
+    const outerStyle = outerSpacing ? { margin: spacing } : {};
+    const marginStyle = { marginBottom: spacing };
+
+    return (
+      <View style={[style, outerStyle]}>
+        {React.Children.map(
+          children,
+          (child, i) =>
+            child
+            && React.cloneElement(child, {
+              style: [child.props.style, i + 1 < children.length ? marginStyle : {}, itemStyle],
+            }),
+        )}
+      </View>
+    );
+  }
+}

--- a/src/common/index.js
+++ b/src/common/index.js
@@ -3,6 +3,7 @@ export { default as Arc } from './Arc';
 export { default as Avatar } from './Avatar';
 export { default as Centerer } from './Centerer';
 export { default as Circle } from './Circle';
+export { default as ComponentList } from './ComponentList';
 export { default as ComponentWithOverlay } from './ComponentWithOverlay';
 export { default as ErrorMsg } from './ErrorMsg';
 export { default as FlexView } from './FlexView';


### PR DESCRIPTION
* Add new layout component `ComponentList` that makes applying layout styles to multiple components easier (either in a row or a column)

* Fixes the inconsistent styling of the spacing in `AccountDetails` using this component, and simplifies it at the same time.

No duplicate margins between the items:

```Before............................................After....................................```
![before-after](https://user-images.githubusercontent.com/867242/41604617-56e1d894-73e8-11e8-910c-25f6fa27c02d.png)
