### PR TITLE
notifications: Fix narrow-to-message position

### DIFF
--- a/src/utils/notifications.android.js
+++ b/src/utils/notifications.android.js
@@ -1,7 +1,7 @@
 /* @flow */
 import { NotificationsAndroid, PendingNotifications } from 'react-native-notifications';
 
-import type { Auth, Actions, Dispatch, UserIdMap } from '../types';
+import type { Auth, Dispatch, UserIdMap, SaveTokenPushActionCreator } from '../types';
 import config from '../config';
 import { registerPush } from '../api';
 import { logErrorRemotely } from '../utils/logging';
@@ -16,7 +16,7 @@ export const removeNotificationListener = (
   notificationHandler: (notification: Object) => void,
 ) => {};
 
-export const initializeNotifications = (auth: Auth, saveTokenPush: Actions.saveTokenPush) => {
+export const initializeNotifications = (auth: Auth, saveTokenPush: SaveTokenPushActionCreator) => {
   NotificationsAndroid.setRegistrationTokenUpdateListener(async deviceToken => {
     try {
       const result = await registerPush(auth, deviceToken);

--- a/src/utils/notifications.android.js
+++ b/src/utils/notifications.android.js
@@ -43,7 +43,7 @@ export const handlePendingNotifications = (
   const data = notificationData.getData();
   config.startup.notification = data;
   if (data) {
-    dispatch(doNarrow(getNarrowFromNotificationData(data, usersById), data.zulip_message_id));
+    dispatch(doNarrow(getNarrowFromNotificationData(data, usersById)));
   }
 };
 

--- a/src/utils/notifications.ios.js
+++ b/src/utils/notifications.ios.js
@@ -2,7 +2,7 @@
 import NotificationsIOS from 'react-native-notifications';
 import { PushNotificationIOS } from 'react-native';
 
-import type { Auth, Dispatch, UserIdMap } from '../types';
+import type { Auth, Dispatch, UserIdMap, SaveTokenPushActionCreator } from '../types';
 import config from '../config';
 import { registerPush } from '../api';
 import { logErrorRemotely } from './logging';
@@ -12,7 +12,7 @@ import { doNarrow } from '../actions';
 const onPushRegistered = async (
   auth: Auth,
   deviceToken: string,
-  saveTokenPush: any /* Actions.saveTokenPush */,
+  saveTokenPush: SaveTokenPushActionCreator,
 ) => {
   const result = await registerPush(auth, deviceToken);
   saveTokenPush(deviceToken, result.msg, result.result);
@@ -26,10 +26,7 @@ export const removeNotificationListener = (notificationHandler: (notification: O
   NotificationsIOS.removeEventListener('notificationOpened', notificationHandler);
 };
 
-export const initializeNotifications = (
-  auth: Auth,
-  saveTokenPush: any /* Actions.saveTokenPush */,
-) => {
+export const initializeNotifications = (auth: Auth, saveTokenPush: SaveTokenPushActionCreator) => {
   NotificationsIOS.addEventListener('remoteNotificationsRegistered', deviceToken =>
     onPushRegistered(auth, deviceToken, saveTokenPush),
   );


### PR DESCRIPTION
Fixes #2699

Narrowing to a notification on Android does try to position the
list at the message of the notification.

When running the app from a 'suspended' or 'not running' state
this does not work correctly as we are not anticipating that case
in `getMessageUpdateStrategy`.

Luckily, the fix is simple - according to discussions with Tim,
we want to focus on the first unread message.

Not passing a message Id to the `doNarrow` function does that.

If in future we decide to change the behavior back, we will
need to address this use-case and also make the behavior consistent
with iOS (which does not do that).