### PR TITLE
Set backBehavior of MainTabs to initialRoute

### DIFF
--- a/src/main/MainTabs.js
+++ b/src/main/MainTabs.js
@@ -52,7 +52,6 @@ export default TabNavigator(
     },
   },
   {
-    backBehavior: 'none',
     tabBarComponent: TabBarBottom,
     tabBarPosition: 'bottom',
     ...tabsOptions({


### PR DESCRIPTION
`backBehavior` was set to none, which caused the app to close unexpectedly when back was pressed from the tabs other than the `HomeTab`.

This removes this, and as `backBehavior` defaults to `initialRoute`, pressing back on any other tab returns to the `HomeTab` and pressing back again exits the app.