### PR TITLE
 Move action button fom UserPickerCard to AvatarList

### DIFF
--- a/src/user-picker/AvatarList.js
+++ b/src/user-picker/AvatarList.js
@@ -1,48 +1,63 @@
 /* @flow */
 import React, { PureComponent } from 'react';
-import { FlatList, StyleSheet } from 'react-native';
+import { View, FlatList, StyleSheet } from 'react-native';
 
 import type { User } from '../types';
 import AvatarItem from './AvatarItem';
+import { FloatingActionButton } from '../common';
+import AnimatedScaleComponent from '../animation/AnimatedScaleComponent';
+import { IconDone } from '../common/Icons';
 
 const styles = StyleSheet.create({
   list: {},
+  wrapper: {
+    flexDirection: 'row',
+  },
+  button: {
+    margin: 8,
+  },
 });
 
 type Props = {
   users: User[],
   listRef: (component: any) => void,
   onPress: (email: string) => void,
+  onButtonPress: () => void,
 };
 
 export default class AvatarList extends PureComponent<Props> {
   props: Props;
 
   render() {
-    const { listRef, users, onPress } = this.props;
+    const { listRef, users, onPress, onButtonPress } = this.props;
 
     return (
-      <FlatList
-        style={styles.list}
-        horizontal
-        showsHorizontalScrollIndicator={false}
-        initialNumToRender={20}
-        data={users}
-        ref={(component: any) => {
-          if (listRef) {
-            listRef(component);
-          }
-        }}
-        keyExtractor={item => item.email}
-        renderItem={({ item }) => (
-          <AvatarItem
-            email={item.email}
-            avatarUrl={item.avatar_url}
-            fullName={item.full_name}
-            onPress={onPress}
-          />
-        )}
-      />
+      <View style={styles.wrapper}>
+        <FlatList
+          style={styles.list}
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          initialNumToRender={20}
+          data={users}
+          ref={(component: any) => {
+            if (listRef) {
+              listRef(component);
+            }
+          }}
+          keyExtractor={item => item.email}
+          renderItem={({ item }) => (
+            <AvatarItem
+              email={item.email}
+              avatarUrl={item.avatar_url}
+              fullName={item.full_name}
+              onPress={onPress}
+            />
+          )}
+        />
+        <AnimatedScaleComponent style={styles.button} visible>
+          <FloatingActionButton Icon={IconDone} size={50} onPress={onButtonPress} disabled={false} />
+        </AnimatedScaleComponent>
+      </View>
     );
   }
 }

--- a/src/user-picker/UserPickerCard.js
+++ b/src/user-picker/UserPickerCard.js
@@ -4,8 +4,7 @@ import { StyleSheet, View } from 'react-native';
 import { connect } from 'react-redux';
 
 import type { User, PresenceState } from '../types';
-import { FloatingActionButton, LineSeparator } from '../common';
-import { IconDone } from '../common/Icons';
+import { LineSeparator } from '../common';
 import UserList from '../users/UserList';
 import AvatarList from './AvatarList';
 import AnimatedScaleComponent from '../animation/AnimatedScaleComponent';
@@ -17,11 +16,6 @@ const styles = StyleSheet.create({
   },
   list: {
     flex: 1,
-  },
-  button: {
-    position: 'absolute',
-    bottom: 10,
-    right: 10,
   },
 });
 
@@ -70,6 +64,7 @@ class UserPickerCard extends PureComponent<Props, State> {
   };
 
   handleUserDeselect = (email: string) => {
+    console.log('PRESSED');
     const { selected } = this.state;
 
     this.setState({
@@ -78,6 +73,7 @@ class UserPickerCard extends PureComponent<Props, State> {
   };
 
   handleComplete = () => {
+    console.log('COMPLETED');
     const { onComplete } = this.props;
     const { selected } = this.state;
     onComplete(selected);
@@ -101,6 +97,7 @@ class UserPickerCard extends PureComponent<Props, State> {
             }}
             users={selected}
             onPress={this.handleUserDeselect}
+            onButtonPress={this.handleComplete}
           />
         </AnimatedScaleComponent>
         {selected.length > 0 && <LineSeparator />}
@@ -113,14 +110,6 @@ class UserPickerCard extends PureComponent<Props, State> {
           selected={selected}
           onPress={this.handleUserPress}
         />
-        <AnimatedScaleComponent style={styles.button} visible={selected.length > 0}>
-          <FloatingActionButton
-            Icon={IconDone}
-            size={50}
-            disabled={selected.length === 0}
-            onPress={this.handleComplete}
-          />
-        </AnimatedScaleComponent>
       </View>
     );
   }


### PR DESCRIPTION
The floating action button to create the group/invite users in UserPickerCard was aligned to be on the bottom of the scroll view.
This caused problems when the list was large as the user had to scroll all the way to the bottom to find the button.
The button is now moved to the AvatarList component which appears at the top and appears on the right end of this component.

![float_after](https://user-images.githubusercontent.com/22353313/41817573-5a263028-77bb-11e8-80ba-727e9b370d39.png)

This is not a perfect solution, but it's still better then being nearly not able to create groups.

Also removed the logic on `visible` attribute of `AnimatedScaleComponent` wrapper and `disabled` attribute of `FloatingActionButton` since `AvatarList` is only displayed when `selected.length > 0` and it's not shown when `selected.length ===  0` so there is no reason for the button to be disabled if it's not shown at all.

Fixes #2709 