### PR TITLE
flow: Specify `connect` parameter type

### DIFF
--- a/src/streams/StreamScreen.js
+++ b/src/streams/StreamScreen.js
@@ -12,7 +12,6 @@ import {
   doToggleMuteStream,
   doTogglePinStream,
   navigateToEditStream,
-  navigateToTopicList,
   toggleStreamNotification,
   navigateToStreamSubscribers,
 } from '../actions';
@@ -40,11 +39,6 @@ class StreamScreen extends PureComponent<Props> {
   handleToggleMuteStream = (newValue: boolean) => {
     const { dispatch, stream } = this.props;
     dispatch(doToggleMuteStream(stream.stream_id, newValue));
-  };
-
-  handleTopics = () => {
-    const { dispatch, stream } = this.props;
-    dispatch(navigateToTopicList(stream.stream_id));
   };
 
   handleEdit = () => {
@@ -87,7 +81,6 @@ class StreamScreen extends PureComponent<Props> {
         />
         <OptionDivider />
         <View style={styles.padding}>
-          <ZulipButton text="Topics" onPress={() => delay(this.handleTopics)} />
           {isAdmin && (
             <ZulipButton
               style={styles.marginTop}


### PR DESCRIPTION
The state parameter of the `connect` function is of type `GlobalState`.
It is annotated only in part of the calls we do. This makes sure it is
annotated everywhere.