### PR TITLE
ui: Use cached data for conversations tab.

### DIFF
--- a/src/pm-conversations/PmConversationsCard.js
+++ b/src/pm-conversations/PmConversationsCard.js
@@ -58,7 +58,7 @@ class PmConversationsCard extends PureComponent<Props> {
     const { styles } = this.context;
     const { dispatch, conversations, isLoading, presences, usersByEmail } = this.props;
 
-    if (isLoading) {
+    if (isLoading && conversations.length === 0) {
       return <LoadingIndicator size={40} />;
     }
 


### PR DESCRIPTION
Fixes #2725

Previously we incorrectly showed a loading spinner if users data
was loading regardless of wether we had user data already.

For better user experience and to be consistent with the rest of
the app's behavior, show the cached data while updating the user
data. Show spinner only if no data is cached.