### PR TITLE
Display "No internet connection" banner on every screen.

### DIFF
--- a/src/animation/AnimatedComponent.js
+++ b/src/animation/AnimatedComponent.js
@@ -11,6 +11,7 @@ type Props = {
   visible: boolean,
   property: string,
   useNativeDriver: boolean,
+  delay: number,
 };
 
 export default class AnimatedComponent extends PureComponent<Props> {
@@ -19,6 +20,7 @@ export default class AnimatedComponent extends PureComponent<Props> {
   static defaultProps = {
     visible: true,
     useNativeDriver: true,
+    delay: 0,
   };
 
   animatedValue = new Animated.Value(0);
@@ -26,6 +28,7 @@ export default class AnimatedComponent extends PureComponent<Props> {
   animate() {
     Animated.timing(this.animatedValue, {
       toValue: this.props.visible ? this.props[this.props.property] : 0,
+      delay: this.props.delay,
       duration: 300,
       useNativeDriver: this.props.useNativeDriver,
       easing: Easing.out(Easing.poly(4)),

--- a/src/animation/AnimatedComponent.js
+++ b/src/animation/AnimatedComponent.js
@@ -23,13 +23,21 @@ export default class AnimatedComponent extends PureComponent<Props> {
 
   animatedValue = new Animated.Value(0);
 
-  componentDidUpdate() {
+  animate() {
     Animated.timing(this.animatedValue, {
       toValue: this.props.visible ? this.props[this.props.property] : 0,
       duration: 300,
       useNativeDriver: this.props.useNativeDriver,
       easing: Easing.out(Easing.poly(4)),
     }).start();
+  }
+
+  componentDidMount() {
+    this.animate();
+  }
+
+  componentDidUpdate() {
+    this.animate();
   }
 
   render() {

--- a/src/chat/Chat.js
+++ b/src/chat/Chat.js
@@ -3,7 +3,7 @@ import React, { PureComponent } from 'react';
 import { View } from 'react-native';
 
 import type { Context, Narrow } from '../types';
-import { KeyboardAvoider, OfflineNotice } from '../common';
+import { KeyboardAvoider } from '../common';
 import MessageList from '../message/MessageList';
 import NoMessages from '../message/NoMessages';
 import ComposeBox from '../compose/ComposeBox';
@@ -44,7 +44,6 @@ export default class Chat extends PureComponent<Props> {
     return (
       <KeyboardAvoider style={styles.flexed} behavior="padding">
         <View style={styles.flexed}>
-          <OfflineNotice />
           <UnreadNotice narrow={narrow} />
           <NoMessages narrow={narrow} />
           <MessageList

--- a/src/chat/ChatScreen.js
+++ b/src/chat/ChatScreen.js
@@ -5,7 +5,7 @@ import type { NavigationScreenProp } from 'react-navigation';
 import { ActionSheetProvider } from '@expo/react-native-action-sheet';
 
 import type { Context, Narrow } from '../types';
-import { ZulipStatusBar } from '../common';
+import { OfflineNotice, ZulipStatusBar } from '../common';
 import Chat from '../chat/Chat';
 import MainNavBar from '../nav/MainNavBar';
 
@@ -36,6 +36,7 @@ export default class ChatScreen extends PureComponent<Props> {
         <View style={styles.screen}>
           <ZulipStatusBar narrow={narrow} />
           <MainNavBar narrow={narrow} />
+          <OfflineNotice />
           <Chat narrow={narrow} />
         </View>
       </ActionSheetProvider>

--- a/src/common/OfflineNotice.js
+++ b/src/common/OfflineNotice.js
@@ -2,17 +2,18 @@
 import { connect } from 'react-redux';
 
 import React, { PureComponent } from 'react';
-import { View, StyleSheet } from 'react-native';
+import { StyleSheet } from 'react-native';
 
 import { getSession } from '../selectors';
 import { Label } from '../common';
+
+import AnimatedComponent from '../animation/AnimatedComponent';
 
 const styles = StyleSheet.create({
   block: {
     flexDirection: 'row',
     justifyContent: 'center',
     alignItems: 'center',
-    padding: 8,
     backgroundColor: '#FD3D26',
   },
   text: {
@@ -36,15 +37,17 @@ class OfflineNotice extends PureComponent<Props> {
 
   render() {
     const { isOnline } = this.props;
-
-    if (isOnline) {
-      return null;
-    }
-
     return (
-      <View style={styles.block}>
-        <Label style={styles.text} text="No Internet connection" />
-      </View>
+      <AnimatedComponent
+        property="height"
+        useNativeDriver={false}
+        visible={!isOnline}
+        height={30}
+        style={styles.block}
+        delay={300}
+      >
+        {!isOnline && <Label style={styles.text} text="No Internet connection" />}
+      </AnimatedComponent>
     );
   }
 }

--- a/src/common/Screen.js
+++ b/src/common/Screen.js
@@ -5,7 +5,7 @@ import React, { PureComponent } from 'react';
 import { StyleSheet, View, ScrollView } from 'react-native';
 
 import type { ChildrenArray, Context, Dimensions, LocalizableText, Style } from '../types';
-import { KeyboardAvoider, ZulipStatusBar } from '../common';
+import { KeyboardAvoider, OfflineNotice, ZulipStatusBar } from '../common';
 import { getSession } from '../selectors';
 import ModalNavBar from '../nav/ModalNavBar';
 import ModalSearchNavBar from '../nav/ModalSearchNavBar';
@@ -94,6 +94,7 @@ class Screen extends PureComponent<Props> {
         ) : (
           <ModalNavBar title={title} />
         )}
+        <OfflineNotice />
         <KeyboardAvoider
           behavior="padding"
           style={[componentStyles.wrapper, padding && styles.padding]}

--- a/src/main/MainScreenWithTabs.js
+++ b/src/main/MainScreenWithTabs.js
@@ -3,7 +3,7 @@ import React, { PureComponent } from 'react';
 import { View } from 'react-native';
 
 import type { Context } from '../types';
-import { ZulipStatusBar } from '../common';
+import { OfflineNotice, ZulipStatusBar } from '../common';
 import MainTabs from './MainTabs';
 
 export default class MainScreenWithTabs extends PureComponent<{}> {
@@ -19,6 +19,7 @@ export default class MainScreenWithTabs extends PureComponent<{}> {
     return (
       <View style={[styles.flexed, styles.backgroundColor]}>
         <ZulipStatusBar />
+        <OfflineNotice />
         <MainTabs />
       </View>
     );


### PR DESCRIPTION
Previously, the "No internet connection" banner was only
displayed in a topic narrow. This made it hard to know
if the app isn't loading because of a bug or because it
is disconnected.

Addresses #2721.

This is what the changes look like (animations are a bit laggy because of the screen recording; it looks a little better when going smoothly):

![bug5](https://user-images.githubusercontent.com/7950151/41910639-90019954-794a-11e8-8bc5-d90c38cd4bce.gif)

If we decide to merge this, `OfflineNotice` isn't really a Common component anymore, since it's designed specifically for the position on top of the screen. It's not used anywhere else, so that's fine, but we should move the file somewhere else.