### PR TITLE
refactor: Rename `GroupScreen` to `CreateGroupScreen`.

### DIFF
--- a/src/nav/AppNavigator.js
+++ b/src/nav/AppNavigator.js
@@ -23,7 +23,7 @@ import TimingScreen from '../diagnostics/TimingScreen';
 import NotificationDiagScreen from '../diagnostics/NotificationDiagScreen';
 import StorageScreen from '../diagnostics/StorageScreen';
 import LightboxScreen from '../lightbox/LightboxScreen';
-import GroupScreen from '../user-groups/GroupScreen';
+import CreateGroupScreen from '../user-groups/CreateGroupScreen';
 import InviteUsersScreen from '../streams/InviteUsersScreen';
 import StreamScreen from '../streams/StreamScreen';
 import CreateStreamScreen from '../streams/CreateStreamScreen';
@@ -54,7 +54,7 @@ export default StackNavigator(
     settings: { screen: SettingsScreen },
     language: { screen: LanguageScreen },
     lightbox: { screen: LightboxScreen },
-    group: { screen: GroupScreen },
+    group: { screen: CreateGroupScreen },
     'invite-users': { screen: InviteUsersScreen },
     diagnostics: { screen: DiagnosticsScreen },
     variables: { screen: VariablesScreen },

--- a/src/user-groups/CreateGroupScreen.js
+++ b/src/user-groups/CreateGroupScreen.js
@@ -16,7 +16,7 @@ type State = {
   filter: string,
 };
 
-class GroupScreen extends PureComponent<Props, State> {
+class CreateGroupScreen extends PureComponent<Props, State> {
   props: Props;
   state: State = {
     filter: '',
@@ -42,4 +42,4 @@ class GroupScreen extends PureComponent<Props, State> {
   }
 }
 
-export default connect()(GroupScreen);
+export default connect()(CreateGroupScreen);


### PR DESCRIPTION
GroupScreen is more aligned to screen about group,
it has nothing to say about creating a group (which it is for).
GroupScreen looks too ambiguous here. So rename it to
`CreateGroupScreen` which conveys more details.