### PR TITLE
realmScreen: Fix reg in focus of relam input.

### DIFF
--- a/src/start/RealmScreen.js
+++ b/src/start/RealmScreen.js
@@ -76,7 +76,7 @@ class RealmScreen extends PureComponent<Props, State> {
     const { progress, error, realm } = this.state;
 
     return (
-      <Screen title="Welcome" padding centerContent keyboardShouldPersistTaps="always">
+      <Screen title="Welcome" padding centerContent keyboardShouldPersistTaps="never">
         <Label text="Organization URL" />
         <SmartUrlInput
           style={styles.marginVertical}


### PR DESCRIPTION
Steps to reproduce:
* Open relam screen on Android.
* Observe: Keyboard will be auto focussed on input.
* Tap above/below in the input and button or on the
  placeholder part.
* Observe: Keyboard will first hide and then again
  pops up. This happens continously.

This commit:
* Once you tap outside (or on placeholder), keyboard will hide.
* Again tapping on placeholder or input, keyboard will pop.