### PR TITLE
compose: Make input value updates more consistent

### DIFF
--- a/src/compose/ComposeBox.js
+++ b/src/compose/ComposeBox.js
@@ -233,21 +233,19 @@ class ComposeBox extends PureComponent<Props, State> {
         isStreamNarrow(nextProps.narrow) && nextProps.editMessage
           ? nextProps.editMessage.topic
           : '';
-      this.setState({
-        message: nextProps.editMessage ? nextProps.editMessage.content : '',
-        topic,
-      });
+      this.handleMessageChange(nextProps.editMessage ? nextProps.editMessage.content : '');
+      this.handleTopicChange(topic);
       if (this.messageInput) {
         this.messageInput.focus();
       }
     } else if (!isEqual(nextProps.narrow, this.props.narrow)) {
       this.tryUpdateDraft();
 
-      if (nextProps.draft) {
-        this.setState({ message: nextProps.draft });
-      } else {
+      if (!nextProps.draft) {
         this.clearMessageInput();
       }
+
+      this.handleMessageChange(nextProps.draft);
     }
   }
 

--- a/src/compose/ComposeBox.js
+++ b/src/compose/ComposeBox.js
@@ -131,12 +131,15 @@ class ComposeBox extends PureComponent<Props, State> {
   };
 
   handleMessageFocus = () => {
+    const { topic } = this.state;
     const { lastMessageTopic } = this.props;
-    this.setState(({ topic }) => ({
+    this.setState({
       isMessageFocused: true,
       isMenuExpanded: false,
-      topic: topic || lastMessageTopic,
-    }));
+    });
+    setTimeout(() => {
+      this.handleTopicChange(topic || lastMessageTopic);
+    }, 200); // wait, to hope the component is shown
   };
 
   handleMessageBlur = () => {


### PR DESCRIPTION
Use `handleMessageChange` and `handleTopicChange` in
`componentWillReceiveProps` to change `message` and `topic` input
values instead of setting the state manually.

This ensures consistency with other functions in the same component.

This changes the behavior slightly:
 * for topic, we collapse the compose buttons
 * for message, we do the same plus we send a 'typing' event to the
server