### PR TITLE
NotificationDiagScreen: Remove padding prop from screen component

### DIFF
--- a/src/diagnostics/NotificationDiagScreen.js
+++ b/src/diagnostics/NotificationDiagScreen.js
@@ -22,7 +22,7 @@ class NotificationDiagScreen extends PureComponent<Props> {
       'Initial notification': JSON.stringify(config.startup.notification),
     };
     return (
-      <Screen title="Notification Diagnostics" padding>
+      <Screen title="Notification Diagnostics">
         <FlatList
           data={Object.keys(variables)}
           keyExtractor={item => item}


### PR DESCRIPTION
Just a quick fix.

Before:
![diagbefore](https://user-images.githubusercontent.com/22353313/42033197-b44f4c56-7af9-11e8-8c50-1fe06d448039.png)

After:
![diagafter](https://user-images.githubusercontent.com/22353313/42033205-b94726a2-7af9-11e8-8517-83a65ae6ffb8.png)
