### PR TITLE
fix: Do not render group conversation with missing data

### DIFF
--- a/src/pm-conversations/GroupPmConversationItem.js
+++ b/src/pm-conversations/GroupPmConversationItem.js
@@ -40,10 +40,15 @@ export default class GroupPmConversationItem extends PureComponent<Props> {
   render() {
     const { styles } = this.context;
     const { email, usersByEmail, unreadCount } = this.props;
-    const allNames = email
-      .split(',')
-      .map(e => (usersByEmail[e] || NULL_USER).full_name)
-      .join(', ');
+    const allUsers = email.split(',').map(e => usersByEmail[e]);
+
+    const allUsersFound = allUsers.every(user => user);
+
+    if (!allUsersFound) {
+      return null;
+    }
+
+    const allNames = allUsers.map(user => user.full_name).join(', ');
 
     return (
       <Touchable onPress={this.handlePress}>


### PR DESCRIPTION
This is consistent with how we do it for 1:1 PM conversations.

Previously `GroupPmConversationItem` we try to retrieve all recipients
from the `usersByEmail` data. If not found we did substitute them
with a `NULL_USER`. This resulted in empty names.

Now, we first search for all users. If any of the users is not found
we do not render the component at all.

This has two benefits:
 * a component with missing names looks broken
 * even if we deduce the names from existing data we do not want to
render this, as we can not narrow to this conversation