### PR TITLE
docs: Add debugging tip for viewing Redux state diffs.

### DIFF
--- a/docs/howto/debugging.md
+++ b/docs/howto/debugging.md
@@ -61,19 +61,34 @@ generate for the WebView.  See `MessageListWeb#render` for instructions, with a
 
 ### redux-logger: deeper info on Redux events
 
-We utilize [redux-logger](https://github.com/evgenyrodionov/redux-logger)
-middleware, which logs the previous state and next state of every action
-that is dispatched. In `middleware.js`, you can pass the `diff` boolean
-option into `createLogger`, which will use the
-[deep-diff](https://github.com/flitbit/diff#simple-examples) package to log
-the diff between states in debugger console.
+One extremely useful kind of information for debugging many kinds of issues
+-- as well as for getting to understand how the app works! -- is to see the
+Redux state, and a log of the Redux actions.
 
-For example, the log output for the action `SWITCH_NARROW` can look like this:
+We have exactly that information logged to the console (in the Chrome
+Developer Tools; see above), thanks to the middleware
+[`redux-logger`](https://github.com/evgenyrodionov/redux-logger).
 
-![image](https://user-images.githubusercontent.com/12771126/42355493-3a24885e-8082-11e8-96d9-fc7c59e0d1d0.png)
+By default, it logs the previous state and next state of every action that
+is dispatched.  You can control its behavior in more detail by editing the
+call to `createLogger` in `src/boot/middleware.js`.
 
-For debugging reducers, or for new contributors learning the app's data flow,
-it helps to view a clear diff between states for each action!
+* `diff: true` will compute the diff (using
+  [`deep-diff`](https://github.com/flitbit/diff#simple-examples)) between the
+  old and new states.  For example, the log output for the action
+  `SWITCH_NARROW` can look like this:
+
+  ![image](https://user-images.githubusercontent.com/12771126/42355493-3a24885e-8082-11e8-96d9-fc7c59e0d1d0.png)
+
+  This can be especially helpful for seeing what each action really does.
+
+* `predicate` can be used to filter which actions cause a log message.  By
+  default, all actions are logged; when looking at a long log, this option
+  can help you cut noise and focus on actions relevant to what you're
+  studying.
+
+* Many other options exist!  See [the
+  doc](https://github.com/evgenyrodionov/redux-logger#options).
 
 
 ## Troubleshooting

--- a/docs/howto/debugging.md
+++ b/docs/howto/debugging.md
@@ -6,7 +6,7 @@ debug your app][react-debugging].
 
 ## Tools and setup
 
-### Chrome Developer Tools
+### Chrome Developer Tools / "Debug JS remotely"
 
 React Native supports debugging the app using Chrome's developer tools, in
 much the same way you would a web app.  This provides you with prettily
@@ -24,7 +24,11 @@ that you can debug the app with statements like
 ```js
 console.debug(foobar)
 ```
+
 Additionally, all Redux events are automatically logged to the console.
+See discussion of `redux-logger` below.
+
+See also the "Troubleshooting" section below.
 
 [chrome-devtools-device]: https://facebook.github.io/react-native/docs/debugging.html#debugging-on-a-device-with-chrome-developer-tools
 
@@ -48,9 +52,33 @@ happened), and then it keeps running, printing any new log messages that
 come through.  To quit, hit Ctrl-C.
 
 
-### Common issues
+### Debugging message rendering
 
-#### "Debug JS remotely" opens a webpage that never loads.
+For debugging some issues, it helps to view in a browser the HTML and CSS we
+generate for the WebView.  See `MessageListWeb#render` for instructions, with a
+`console.log(html)` call you can uncomment.
+
+
+### redux-logger: deeper info on Redux events
+
+We utilize [redux-logger](https://github.com/evgenyrodionov/redux-logger)
+middleware, which logs the previous state and next state of every action
+that is dispatched. In `middleware.js`, you can pass the `diff` boolean
+option into `createLogger`, which will use the
+[deep-diff](https://github.com/flitbit/diff#simple-examples) package to log
+the diff between states in debugger console.
+
+For example, the log output for the action `SWITCH_NARROW` can look like this:
+
+![image](https://user-images.githubusercontent.com/12771126/42355493-3a24885e-8082-11e8-96d9-fc7c59e0d1d0.png)
+
+For debugging reducers, or for new contributors learning the app's data flow,
+it helps to view a clear diff between states for each action!
+
+
+## Troubleshooting
+
+### "Debug JS remotely" opens a webpage that never loads.
 
 For some reason, React Native may try to open a browser tab for you at
 http://10.0.2.2:8081/debugger-ui .
@@ -67,29 +95,3 @@ if it works.
 
 [dev-menu]: https://facebook.github.io/react-native/docs/debugging.html#accessing-the-in-app-developer-menu
 [react-debugging]: https://facebook.github.io/react-native/docs/debugging.html
-
-
-## Miscellaneous tips
-
-### Message rendering
-
-For debugging some issues, it helps to view in a browser the HTML and CSS we
-generate for the WebView.  See `MessageListWeb#render` for instructions, with a
-`console.log(html)` call you can uncomment.
-
-
-### Redux state diffs
-
-We utilize [redux-logger](https://github.com/evgenyrodionov/redux-logger)
-middleware, which logs the previous state and next state of every action
-that is dispatched. In `middleware.js`, you can pass the `diff` boolean
-option into `createLogger`, which will use the
-[deep-diff](https://github.com/flitbit/diff#simple-examples) package to log
-the diff between states in debugger console.
-
-For example, the log output for the action `SWITCH_NARROW` can look like this:
-
-![image](https://user-images.githubusercontent.com/12771126/42355493-3a24885e-8082-11e8-96d9-fc7c59e0d1d0.png)
-
-For debugging reducers, or for new contributors learning the app's data flow,
-it helps to view a clear diff between states for each action!

--- a/docs/howto/debugging.md
+++ b/docs/howto/debugging.md
@@ -77,3 +77,19 @@ For debugging some issues, it helps to view in a browser the HTML and CSS we
 generate for the WebView.  See `MessageListWeb#render` for instructions, with a
 `console.log(html)` call you can uncomment.
 
+
+### Redux state diffs
+
+We utilize [redux-logger](https://github.com/evgenyrodionov/redux-logger)
+middleware, which logs the previous state and next state of every action
+that is dispatched. In `middleware.js`, you can pass the `diff` boolean
+option into `createLogger`, which will use the
+[deep-diff](https://github.com/flitbit/diff#simple-examples) package to log
+the diff between states in debugger console.
+
+For example, the log output for the action `SWITCH_NARROW` can look like this:
+
+![image](https://user-images.githubusercontent.com/12771126/42355493-3a24885e-8082-11e8-96d9-fc7c59e0d1d0.png)
+
+For debugging reducers, or for new contributors learning the app's data flow,
+it helps to view a clear diff between states for each action!

--- a/docs/howto/debugging.md
+++ b/docs/howto/debugging.md
@@ -32,32 +32,6 @@ See also the "Troubleshooting" section below.
 
 [chrome-devtools-device]: https://facebook.github.io/react-native/docs/debugging.html#debugging-on-a-device-with-chrome-developer-tools
 
-### `adb logcat`
-
-When running on Android, either in the emulator or on a physical device, you
-can use ADB (the Android debugger) to fetch or watch the device's logs.
-This will include any messages that you print with a statement like
-```js
-console.debug(foobar)
-```
-
-To see the logs, run `adb logcat`.  A helpful form for this command is
-```
-adb logcat -T 100 | grep ReactNativeJS
-```
-This filters out logs unrelated to the app, but includes anything you print
-with `console.debug`.  It starts with the last 100 log lines from before you
-run the command (so it can be helpful for seeing something that just
-happened), and then it keeps running, printing any new log messages that
-come through.  To quit, hit Ctrl-C.
-
-
-### Debugging message rendering
-
-For debugging some issues, it helps to view in a browser the HTML and CSS we
-generate for the WebView.  See `MessageListWeb#render` for instructions, with a
-`console.log(html)` call you can uncomment.
-
 
 ### redux-logger: deeper info on Redux events
 
@@ -89,6 +63,33 @@ call to `createLogger` in `src/boot/middleware.js`.
 
 * Many other options exist!  See [the
   doc](https://github.com/evgenyrodionov/redux-logger#options).
+
+
+### `adb logcat`
+
+When running on Android, either in the emulator or on a physical device, you
+can use ADB (the Android debugger) to fetch or watch the device's logs.
+This will include any messages that you print with a statement like
+```js
+console.debug(foobar)
+```
+
+To see the logs, run `adb logcat`.  A helpful form for this command is
+```
+adb logcat -T 100 | grep ReactNativeJS
+```
+This filters out logs unrelated to the app, but includes anything you print
+with `console.debug`.  It starts with the last 100 log lines from before you
+run the command (so it can be helpful for seeing something that just
+happened), and then it keeps running, printing any new log messages that
+come through.  To quit, hit Ctrl-C.
+
+
+### Debugging message rendering
+
+For debugging some issues, it helps to view in a browser the HTML and CSS we
+generate for the WebView.  See `MessageListWeb#render` for instructions, with a
+`console.log(html)` call you can uncomment.
 
 
 ## Troubleshooting

--- a/src/boot/middleware.js
+++ b/src/boot/middleware.js
@@ -15,6 +15,7 @@ if (config.enableReduxLogging) {
   middleware.push(
     createLogger({
       duration: true,
+      // diff: true,
       // predicate: (getState, action) => action.type === 'MESSAGE_FETCH_COMPLETE',
     }),
   );


### PR DESCRIPTION
As discussed in chat [here](https://chat.zulip.org/#narrow/stream/243-mobile-team/subject/meeting/near/608506).

@gnprice 