### PR TITLE
Fix Nav bar color changes to white on going back to stream/topic narrow from stream/topic info screen.

### DIFF
--- a/src/title/__tests__/titleSelectors-test.js
+++ b/src/title/__tests__/titleSelectors-test.js
@@ -2,20 +2,20 @@
 import deepFreeze from 'deep-freeze';
 
 import { getTitleBackgroundColor, getTitleTextColor } from '../titleSelectors';
-import { streamNarrow, privateNarrow } from '../../utils/narrow';
+import { groupNarrow, streamNarrow, privateNarrow } from '../../utils/narrow';
 import { BRAND_COLOR } from '../../styles';
 import { defaultNav, otherNav } from '../../utils/testHelpers';
 
 const subscriptions = [{ name: 'all', color: '#fff' }, { name: 'announce', color: '#000' }];
 
 describe('getTitleBackgroundColor', () => {
-  test('return transparent color for account', () => {
+  test('return transparent color for screens other than chat, i.e narrow is undefined', () => {
     const state = deepFreeze({
       nav: otherNav,
       subscriptions,
     });
 
-    expect(getTitleBackgroundColor(streamNarrow('all'))(state)).toEqual('transparent');
+    expect(getTitleBackgroundColor(undefined)(state)).toEqual('transparent');
   });
 
   test('return stream color for stream and topic narrow', () => {
@@ -36,27 +36,30 @@ describe('getTitleBackgroundColor', () => {
     expect(getTitleBackgroundColor(streamNarrow('feedback'))(state)).toEqual('gray');
   });
 
-  test('return transparent for other narrow and screens', () => {
+  test('return transparent for non topic/stream narrow', () => {
     const state = deepFreeze({
       nav: defaultNav,
       subscriptions,
     });
 
     expect(getTitleBackgroundColor(privateNarrow('abc@zulip.com'))(state)).toEqual('transparent');
+    expect(getTitleBackgroundColor(groupNarrow(['abc@zulip.com', 'def@zulip.com']))(state)).toEqual(
+      'transparent',
+    );
   });
 });
 
 describe('getTitleTextColor', () => {
-  test('for account nav get use foregroundColorFromBackground', () => {
+  test('for account screen and non chat screen use foregroundColorFromBackground, with default title background color ', () => {
     const state = deepFreeze({
       nav: otherNav,
       subscriptions,
     });
 
-    expect(getTitleTextColor(streamNarrow('all'))(state)).toEqual('rgba(82, 194, 175, 1)');
+    expect(getTitleTextColor(undefined)(state)).toEqual('rgba(82, 194, 175, 1)');
   });
 
-  test('for stream and topic narrow get use foregroundColorFromBackground', () => {
+  test('for stream and topic narrow get use foregroundColorFromBackground, with stream color', () => {
     const state = deepFreeze({
       nav: defaultNav,
       subscriptions,

--- a/src/title/titleSelectors.js
+++ b/src/title/titleSelectors.js
@@ -15,17 +15,22 @@ export const getIsInTopicOrStreamNarrow = (narrow?: Narrow) =>
     routeName => (routeName === 'chat' ? isStreamNarrow(narrow) || isTopicNarrow(narrow) : false),
   );
 
-export const getTitleBackgroundColor = (narrow: Narrow) =>
+/** (If `narrow` omitted, returns 'transparent'.) */
+export const getTitleBackgroundColor = (narrow?: Narrow) =>
   createSelector(
     getSubscriptions,
     getIsInTopicOrStreamNarrow(narrow),
     (subscriptions, isInTopicOrStreamNarrow) =>
       isInTopicOrStreamNarrow
-        ? (subscriptions.find(sub => narrow[0].operand === sub.name) || NULL_SUBSCRIPTION).color
+        ? (
+            subscriptions.find(sub => Array.isArray(narrow) && narrow[0].operand === sub.name)
+            || NULL_SUBSCRIPTION
+          ).color
         : 'transparent',
   );
 
-export const getTitleTextColor = (narrow: Narrow) =>
+/** (If `narrow` omitted, returns BRAND_COLOR.) */
+export const getTitleTextColor = (narrow?: Narrow) =>
   createSelector(
     getTitleBackgroundColor(narrow),
     getIsInTopicOrStreamNarrow(narrow),

--- a/src/title/titleSelectors.js
+++ b/src/title/titleSelectors.js
@@ -4,16 +4,9 @@ import { createSelector } from 'reselect';
 import type { Narrow } from '../types';
 import { BRAND_COLOR } from '../styles';
 import { getSubscriptions } from '../directSelectors';
-import { getCurrentRouteName } from '../nav/navSelectors';
 import { foregroundColorFromBackground } from '../utils/color';
-import { isStreamNarrow, isTopicNarrow, isStreamOrTopicNarrow } from '../utils/narrow';
+import { isStreamOrTopicNarrow } from '../utils/narrow';
 import { NULL_SUBSCRIPTION } from '../nullObjects';
-
-export const getIsInTopicOrStreamNarrow = (narrow?: Narrow) =>
-  createSelector(
-    getCurrentRouteName,
-    routeName => (routeName === 'chat' ? isStreamNarrow(narrow) || isTopicNarrow(narrow) : false),
-  );
 
 /** (If `narrow` omitted, returns 'transparent'.) */
 export const getTitleBackgroundColor = (narrow?: Narrow) =>

--- a/src/title/titleSelectors.js
+++ b/src/title/titleSelectors.js
@@ -9,19 +9,10 @@ import { isStreamOrTopicNarrow } from '../utils/narrow';
 import { NULL_SUBSCRIPTION } from '../nullObjects';
 
 /**
- * This selectors can be called from any screen/component to
- * get background/text color of the title (in the nav bar).
+ * Background color to use for the app bar in narrow `narrow`.
  *
- * If narrow is undefined, i.e not a chat screen then return default values
- * (in that case isStreamOrTopicNarrow will return false)
- * else return color according to the stream.
- *
- * Note: here selectors are not subscribed to nav state change
- * to get narrow in the current/chat screen, if that would have done
- * this selectors results will change when new screen is pushed over a chatscreen
- * and might cause re-render to screen which are not at the top of the stack
- *
- * @param narrow - Narrow of the screen, if is is chat screen else undefined
+ * If `narrow` is a stream or topic narrow, this is based on the stream color.
+ * Otherwise, it takes a default value.
  */
 export const getTitleBackgroundColor = (narrow?: Narrow) =>
   createSelector(
@@ -35,7 +26,9 @@ export const getTitleBackgroundColor = (narrow?: Narrow) =>
         : 'transparent',
   );
 
-/** See getTitleBackgroundColor; this is the foreground. */
+/**
+ * Text color to use for the app bar over `getTitleBackgroundColor(narrow)`.
+ */
 export const getTitleTextColor = (narrow?: Narrow) =>
   createSelector(
     getTitleBackgroundColor(narrow),

--- a/src/title/titleSelectors.js
+++ b/src/title/titleSelectors.js
@@ -6,7 +6,7 @@ import { BRAND_COLOR } from '../styles';
 import { getSubscriptions } from '../directSelectors';
 import { getCurrentRouteName } from '../nav/navSelectors';
 import { foregroundColorFromBackground } from '../utils/color';
-import { isStreamNarrow, isTopicNarrow } from '../utils/narrow';
+import { isStreamNarrow, isTopicNarrow, isStreamOrTopicNarrow } from '../utils/narrow';
 import { NULL_SUBSCRIPTION } from '../nullObjects';
 
 export const getIsInTopicOrStreamNarrow = (narrow?: Narrow) =>
@@ -19,9 +19,8 @@ export const getIsInTopicOrStreamNarrow = (narrow?: Narrow) =>
 export const getTitleBackgroundColor = (narrow?: Narrow) =>
   createSelector(
     getSubscriptions,
-    getIsInTopicOrStreamNarrow(narrow),
-    (subscriptions, isInTopicOrStreamNarrow) =>
-      isInTopicOrStreamNarrow
+    subscriptions =>
+      isStreamOrTopicNarrow(narrow)
         ? (
             subscriptions.find(sub => Array.isArray(narrow) && narrow[0].operand === sub.name)
             || NULL_SUBSCRIPTION
@@ -33,9 +32,8 @@ export const getTitleBackgroundColor = (narrow?: Narrow) =>
 export const getTitleTextColor = (narrow?: Narrow) =>
   createSelector(
     getTitleBackgroundColor(narrow),
-    getIsInTopicOrStreamNarrow(narrow),
-    (backgroundColor, isInTopicOrStreamNarrow) =>
-      backgroundColor && isInTopicOrStreamNarrow
+    backgroundColor =>
+      backgroundColor && isStreamOrTopicNarrow(narrow)
         ? foregroundColorFromBackground(backgroundColor)
         : BRAND_COLOR,
   );

--- a/src/title/titleSelectors.js
+++ b/src/title/titleSelectors.js
@@ -8,7 +8,21 @@ import { foregroundColorFromBackground } from '../utils/color';
 import { isStreamOrTopicNarrow } from '../utils/narrow';
 import { NULL_SUBSCRIPTION } from '../nullObjects';
 
-/** (If `narrow` omitted, returns 'transparent'.) */
+/**
+ * This selectors can be called from any screen/component to
+ * get background/text color of the title (in the nav bar).
+ *
+ * If narrow is undefined, i.e not a chat screen then return default values
+ * (in that case isStreamOrTopicNarrow will return false)
+ * else return color according to the stream.
+ *
+ * Note: here selectors are not subscribed to nav state change
+ * to get narrow in the current/chat screen, if that would have done
+ * this selectors results will change when new screen is pushed over a chatscreen
+ * and might cause re-render to screen which are not at the top of the stack
+ *
+ * @param narrow - Narrow of the screen, if is is chat screen else undefined
+ */
 export const getTitleBackgroundColor = (narrow?: Narrow) =>
   createSelector(
     getSubscriptions,
@@ -21,7 +35,7 @@ export const getTitleBackgroundColor = (narrow?: Narrow) =>
         : 'transparent',
   );
 
-/** (If `narrow` omitted, returns BRAND_COLOR.) */
+/** See getTitleBackgroundColor; this is the foreground. */
 export const getTitleTextColor = (narrow?: Narrow) =>
   createSelector(
     getTitleBackgroundColor(narrow),

--- a/src/title/titleSelectors.js
+++ b/src/title/titleSelectors.js
@@ -9,7 +9,7 @@ import { foregroundColorFromBackground } from '../utils/color';
 import { isStreamNarrow, isTopicNarrow } from '../utils/narrow';
 import { NULL_SUBSCRIPTION } from '../nullObjects';
 
-export const getIsInTopicOrStreamNarrow = (narrow: Narrow) =>
+export const getIsInTopicOrStreamNarrow = (narrow?: Narrow) =>
   createSelector(
     getCurrentRouteName,
     routeName => (routeName === 'chat' ? isStreamNarrow(narrow) || isTopicNarrow(narrow) : false),

--- a/src/utils/narrow.js
+++ b/src/utils/narrow.js
@@ -76,7 +76,7 @@ export const streamNarrow = (stream: string): Narrow => [
   },
 ];
 
-export const isStreamNarrow = (narrow: Narrow): boolean =>
+export const isStreamNarrow = (narrow?: Narrow): boolean =>
   Array.isArray(narrow) && narrow.length === 1 && narrow[0].operator === 'stream';
 
 export const topicNarrow = (stream: string, topic: string): Narrow => [
@@ -90,10 +90,10 @@ export const topicNarrow = (stream: string, topic: string): Narrow => [
   },
 ];
 
-export const isTopicNarrow = (narrow: Narrow): boolean =>
+export const isTopicNarrow = (narrow?: Narrow): boolean =>
   Array.isArray(narrow) && narrow.length === 2 && narrow[1].operator === 'topic';
 
-export const isStreamOrTopicNarrow = (narrow: Narrow): boolean =>
+export const isStreamOrTopicNarrow = (narrow?: Narrow): boolean =>
   Array.isArray(narrow) && narrow.length >= 1 && narrow[0].operator === 'stream';
 
 export const SEARCH_NARROW = (query: string): Narrow => [


### PR DESCRIPTION
Fix #2797


* selector: Do not depend on selector to check narrow `isStreamOrTopic`.  ad77e44
Before we were depended on `getIsInTopicOrStreamNarrow` to check if
narrow is stream or topic in `getTitleBackgroundColor`. Which was
causing problem described here:
#2797 (comment)
Problem was: as soon as event arrives, it changes state. For very
minute time period the store data is invalid. And in this time
`getIsInTopicOrStreamNarrow` was called which returned false.
Also on going back, if nav bar backgound color becomes white and after
some time any event arrives, nav bar retrives back it's color.
For chat screen narrow will be defined so return color accordingly but
for other screens narrow will bot be defined and
`isStreamOrTopicNarrow` will return false. So there is no need to
consider current route (which `getIsInTopicOrStreamNarrow` was using)
in getting color.
Now simple function `isStreamOrTopicNarrow` is used to check whether
narrow is stream or topic or not.
Fixes the part of #2797


* selector: Do not depend on selector to check narrow `isStreamOrTopic`, part 2. 2ed6607
In the previous commit `getTitleBackgroundColor` became independent
from the `getIsInTopicOrStreamNarrow`. Now extending that pattern to
make `getTitleTextColor` independent, for the same reason.
Fixes the part of #2797


* cleanup: Remove unused `getIsInTopicOrStreamNarrow` method.  7cbde68
See previous two commits for why it became unused.