### PR TITLE
layout: Align show button to right in PasswordInput on Android API 28.

### DIFF
--- a/src/common/PasswordInput.js
+++ b/src/common/PasswordInput.js
@@ -8,6 +8,10 @@ import { BRAND_COLOR } from '../styles';
 import { Label, Touchable } from '../common';
 
 const componentStyles = StyleSheet.create({
+  wrapper: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
   passwordInput: {
     flex: 1,
     flexDirection: 'row',
@@ -60,7 +64,7 @@ export default class PasswordInput extends PureComponent<Props, State> {
     const { isHidden } = this.state;
 
     return (
-      <View style={style}>
+      <View style={[componentStyles.wrapper, style]}>
         <Input
           {...this.props}
           style={componentStyles.passwordInput}


### PR DESCRIPTION
Fixes: #2814.

Now

<img width="292" alt="screen shot 2018-07-14 at 8 53 00 pm" src="https://user-images.githubusercontent.com/18511177/42726004-16703c84-87ab-11e8-85b0-c7976d176c93.png">
