### PR TITLE
Clean up type checking related to renderMessages.js.

### DIFF
--- a/src/message/MessageList.js
+++ b/src/message/MessageList.js
@@ -16,6 +16,7 @@ import type {
   RealmEmojiState,
   Subscription,
   User,
+  RenderedSection,
 } from '../types';
 import { constructActionButtons, executeActionSheetAction } from './messageActionSheet';
 import MessageListWeb from '../webview/MessageListWeb';
@@ -48,7 +49,7 @@ export type Props = {
   mute: MuteState,
   narrow: Narrow,
   realmEmoji: RealmEmojiState,
-  renderedMessages: any,
+  renderedMessages: RenderedSection[],
   showMessagePlaceholders: boolean,
   subscriptions: Subscription[],
   typingUsers: User[],

--- a/src/message/__tests__/renderMessages-test.js
+++ b/src/message/__tests__/renderMessages-test.js
@@ -2,13 +2,14 @@ import deepFreeze from 'deep-freeze';
 
 import { homeNarrow } from '../../utils/narrow';
 import renderMessages from '../renderMessages';
+import { NULL_MESSAGE } from '../../nullObjects';
 
 describe('renderMessages', () => {
   const narrow = deepFreeze([]);
 
   test('empty messages results in a single empty section', () => {
     const messageList = renderMessages([], homeNarrow);
-    expect(messageList).toEqual([{ key: 0, message: {}, data: [] }]);
+    expect(messageList).toEqual([{ key: 0, message: NULL_MESSAGE, data: [] }]);
   });
 
   test('renders time, header and message for a single input', () => {

--- a/src/message/renderMessages.js
+++ b/src/message/renderMessages.js
@@ -1,5 +1,6 @@
 /* @flow */
 import type { Message, Narrow, RenderedSectionDescriptor } from '../types';
+import { NULL_MESSAGE } from '../nullObjects';
 import { isTopicNarrow, isPrivateOrGroupNarrow } from '../utils/narrow';
 import { isSameRecipient } from '../utils/message';
 import { isSameDay } from '../utils/date';
@@ -46,6 +47,6 @@ export default (messages: Message[], narrow: Narrow): RenderedSectionDescriptor[
 
       return sections;
     },
-    [{ key: 0, data: [], message: {} }],
+    [{ key: 0, data: [], message: NULL_MESSAGE }],
   );
 };

--- a/src/message/renderMessages.js
+++ b/src/message/renderMessages.js
@@ -1,11 +1,11 @@
 /* @flow */
-import type { Message, Narrow, RenderedSectionDescriptor } from '../types';
+import type { Message, Narrow, RenderedSection } from '../types';
 import { NULL_MESSAGE } from '../nullObjects';
 import { isTopicNarrow, isPrivateOrGroupNarrow } from '../utils/narrow';
 import { isSameRecipient } from '../utils/message';
 import { isSameDay } from '../utils/date';
 
-export default (messages: Message[], narrow: Narrow): RenderedSectionDescriptor[] => {
+export default (messages: Message[], narrow: Narrow): RenderedSection[] => {
   let prevItem;
   const showHeader = !isPrivateOrGroupNarrow(narrow) && !isTopicNarrow(narrow);
 

--- a/src/nullObjects.js
+++ b/src/nullObjects.js
@@ -56,6 +56,7 @@ export const NULL_MESSAGE: Message = {
   id: -1,
   isOutbox: false,
   is_me_message: false,
+  last_edit_timestamp: 0,
   reactions: [],
   recipient_id: -1,
   sender_domain: '',

--- a/src/reactions/aggregateReactions.js
+++ b/src/reactions/aggregateReactions.js
@@ -1,16 +1,17 @@
 /* @flow */
-import type { EventReaction, AggregatedReaction } from '../types';
+import type { SlimEventReaction, AggregatedReaction } from '../types';
+import codePointMap from '../emoji/codePointMap';
 
-export default (reactions: EventReaction[], ownEmail: string): AggregatedReaction[] =>
+export default (reactions: SlimEventReaction[], ownEmail: string): AggregatedReaction[] =>
   Array.from(
     reactions
       .reduce((reactionMap, x) => {
         if (!reactionMap.has(x.emoji_name)) {
           reactionMap.set(x.emoji_name, {
-            code: x.emoji_code,
+            code: codePointMap[x.emoji_name],
             count: 1,
             name: x.emoji_name,
-            type: x.reaction_type,
+            type: 'unicode_emoji',
             selfReacted: false,
           });
         } else {

--- a/src/types.js
+++ b/src/types.js
@@ -492,22 +492,25 @@ export type GetState = () => GlobalState;
 
 export type LocalizableText = any; // string | { text: string, values: Object };
 
-export type RenderedTimeDescriptor = {
+type RenderedTime = {
   type: 'time',
+  key: string,
   timestamp: number,
+  firstMessage: Message,
 };
 
-export type RenderedMessageDescriptor = {
+type RenderedMessage = {
   type: 'message',
-  message: Object,
+  key: number,
+  isBrief: boolean,
+  message: Message,
 };
 
-export type RenderedItemDescriptor = any; // MessageDescriptor | TimeDescriptor;
-
-export type RenderedSectionDescriptor = any; /* {
-  message: Object,
-  data: ItemDescriptor[],
-} */
+export type RenderedSection = {
+  key: 0 | string,
+  message: Message,
+  data: (RenderedTime | RenderedMessage)[],
+};
 
 export type DraftState = {
   [narrow: string]: string,

--- a/src/types.js
+++ b/src/types.js
@@ -66,11 +66,9 @@ export type SlimEventReaction = {
  * See also SlimEventReaction, which contains the minimal subset of these
  * properties needed to compute the rest.
  */
-export type EventReaction = {
+export type EventReaction = SlimEventReaction & {
   emoji_code: string,
-  emoji_name: string,
   reaction_type: string,
-  user: any,
 };
 
 /** An aggregate of all the reactions with one emoji to one message. */

--- a/src/types.js
+++ b/src/types.js
@@ -54,6 +54,11 @@ export type Account = Auth;
  *
  * See also EventReaction, which carries additional properties computed from
  * these.
+ *
+ * To compute emoji_code from emoji_name, use the mapping exported
+ * by `src/emoji/codePointMap`.
+ *
+ * TODO: Add note on how to determine `reaction_type`.
  */
 export type SlimEventReaction = {
   emoji_name: string,

--- a/src/types.js
+++ b/src/types.js
@@ -68,7 +68,7 @@ export type SlimEventReaction = {
  */
 export type EventReaction = SlimEventReaction & {
   emoji_code: string,
-  reaction_type: string,
+  reaction_type: 'unicode_emoji' | 'realm_emoji' | 'zulip_extra_emoji',
 };
 
 /** An aggregate of all the reactions with one emoji to one message. */

--- a/src/types.js
+++ b/src/types.js
@@ -111,6 +111,7 @@ export type Message = {
   id: number,
   isOutbox: boolean,
   is_me_message: boolean,
+  last_edit_timestamp: number,
   match_content?: string,
   match_subject?: string,
   reactions: SlimEventReaction[],

--- a/src/webview/__tests__/webViewHandleUpdates-test.js
+++ b/src/webview/__tests__/webViewHandleUpdates-test.js
@@ -1,4 +1,5 @@
 import { getInputMessages } from '../webViewHandleUpdates';
+import { NULL_MESSAGE } from '../../nullObjects';
 
 describe('getInputMessages', () => {
   test('missing prev and next props returns no messages', () => {
@@ -57,7 +58,7 @@ describe('getInputMessages', () => {
     const prevProps = {
       auth: { realm: '' },
       messages: [],
-      renderedMessages: [{ key: 0, data: [], message: {} }],
+      renderedMessages: [{ key: 0, data: [], message: NULL_MESSAGE }],
     };
     const nextProps = {
       auth: { realm: '' },
@@ -66,7 +67,7 @@ describe('getInputMessages', () => {
         {
           key: 0,
           data: [{ key: 123, type: 'message', isBrief: false, message: { id: 0 } }],
-          message: {},
+          message: NULL_MESSAGE,
         },
       ],
     };
@@ -102,7 +103,7 @@ describe('getInputMessages', () => {
       fetching: { older: false, newer: false },
       typingUsers: [],
       messages: [],
-      renderedMessages: [{ key: 0, data: [], message: {} }],
+      renderedMessages: [{ key: 0, data: [], message: NULL_MESSAGE }],
     };
     const nextProps = {
       auth: { realm: '' },
@@ -113,7 +114,7 @@ describe('getInputMessages', () => {
         {
           key: 0,
           data: [{ key: 123, type: 'message', isBrief: false, message: { id: 0 } }],
-          message: {},
+          message: NULL_MESSAGE,
         },
       ],
     };

--- a/src/webview/html/messageAsHtml.js
+++ b/src/webview/html/messageAsHtml.js
@@ -1,6 +1,6 @@
 /* @flow */
 import template from './template';
-import type { EventReaction, RealmEmojiState } from '../../types';
+import type { SlimEventReaction, RealmEmojiState } from '../../types';
 import { shortTime } from '../../utils/date';
 import messageTagsAsHtml from './messageTagsAsHtml';
 import messageReactionListAsHtml from './messageReactionListAsHtml';
@@ -38,7 +38,7 @@ type BriefMessageProps = {
   id: number,
   isOutbox: boolean,
   ownEmail: string,
-  reactions: EventReaction[],
+  reactions: SlimEventReaction[],
   realmEmoji: RealmEmojiState,
   timeEdited: number,
 };
@@ -70,7 +70,7 @@ const messageBody = ({
   id: number,
   isOutbox: boolean,
   ownEmail: string,
-  reactions: EventReaction[],
+  reactions: SlimEventReaction[],
   realmEmoji: RealmEmojiState,
   timeEdited: number,
 }) => template`

--- a/src/webview/html/messageAsHtml.js
+++ b/src/webview/html/messageAsHtml.js
@@ -40,7 +40,7 @@ type BriefMessageProps = {
   ownEmail: string,
   reactions: EventReaction[],
   realmEmoji: RealmEmojiState,
-  timeEdited: Date,
+  timeEdited: number,
 };
 
 type FullMessageProps = BriefMessageProps & {
@@ -72,7 +72,7 @@ const messageBody = ({
   ownEmail: string,
   reactions: EventReaction[],
   realmEmoji: RealmEmojiState,
-  timeEdited: Date,
+  timeEdited: number,
 }) => template`
 $!${content}
 $!${isOutbox ? '<div class="loading-spinner outbox-spinner"></div>' : ''}

--- a/src/webview/html/messageAsHtml.js
+++ b/src/webview/html/messageAsHtml.js
@@ -1,11 +1,11 @@
 /* @flow */
 import template from './template';
-import type { FlagsState, EventReaction, RealmEmojiState } from '../../types';
+import type { EventReaction, RealmEmojiState } from '../../types';
 import { shortTime } from '../../utils/date';
 import messageTagsAsHtml from './messageTagsAsHtml';
 import messageReactionListAsHtml from './messageReactionListAsHtml';
 
-const messageDiv = (id: number, msgClass: string, flags: Object): string =>
+const messageDiv = (id: number, msgClass: string, flags: string[]): string =>
   template`<div
      class="message ${msgClass}"
      id="msg-${id}"
@@ -34,7 +34,7 @@ const messageSubheader = ({
 
 type BriefMessageProps = {
   content: string,
-  flags: FlagsState,
+  flags: string[],
   id: number,
   isOutbox: boolean,
   ownEmail: string,
@@ -66,7 +66,7 @@ const messageBody = ({
   timeEdited,
 }: {
   content: string,
-  flags: Object,
+  flags: string[],
   id: number,
   isOutbox: boolean,
   ownEmail: string,

--- a/src/webview/html/messageReactionListAsHtml.js
+++ b/src/webview/html/messageReactionListAsHtml.js
@@ -1,11 +1,11 @@
 /* @flow */
-import type { EventReaction, RealmEmojiState } from '../../types';
+import type { SlimEventReaction, RealmEmojiState } from '../../types';
 import aggregateReactions from '../../reactions/aggregateReactions';
 import template from './template';
 import messageReactionAsHtml from './messageReactionAsHtml';
 
 export default (
-  reactions: EventReaction[],
+  reactions: SlimEventReaction[],
   messageId: number,
   ownEmail: string,
   realmEmoji: RealmEmojiState,

--- a/src/webview/html/messageTagsAsHtml.js
+++ b/src/webview/html/messageTagsAsHtml.js
@@ -2,7 +2,7 @@
 import distanceInWordsToNow from 'date-fns/distance_in_words_to_now';
 import template from './template';
 
-export default (flags: Object, timeEdited?: number): string => {
+export default (flags: string[], timeEdited?: number): string => {
   const isStarred = flags.indexOf('starred') > -1;
   if (timeEdited === undefined && !isStarred) {
     return '';


### PR DESCRIPTION
My initial goal was to add a type definition to annotate the `renderedMessages` prop passed from `MessageList` into `MessageListWeb`, which caused a number of flow error messages leading to this series of changes.

The data flow around this area is buggy - see #2627, #2676, and #2677 - so hopefully this elucidates the current structure of the subsystem and provides insight into any possibly unintended behavior.

