### PR TITLE
tests: Make eslint error on warnings.

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "generate-webview-js": "node tools/generate-webview-js",
     "prettier": "prettier --write --loglevel=warn 'src/**/*.js' ; eslint --no-eslintrc -c tools/formatting.eslintrc.yaml --fix src/",
     "test:prettier": "prettier-eslint --list-different --eslint-config-path ./tools/formatting.eslintrc.yaml 'src/**/*.js'",
-    "test:lint": "eslint src/",
+    "test:lint": "eslint --max-warnings=0 src/",
     "test:flow": "flow --max-warnings 0",
     "test:flow-todo": "eslint --no-eslintrc -c tools/flow-todo.eslintrc.yaml src/",
     "test:flow-coverage": "flow-coverage-report -i 'src/**/*.js' -x '**/__tests__/**' -t html",


### PR DESCRIPTION
Do this to make the CI fail on improperly formatted code, straying
`console.log()`s, etc. that might not be detected by test:prettier.