### PR TITLE
Replace `require()` with `import` where possible.

### DIFF
--- a/src/ZulipMobile.js
+++ b/src/ZulipMobile.js
@@ -11,8 +11,8 @@ import AppDataFetcher from './boot/AppDataFetcher';
 import BackNavigationHandler from './nav/BackNavigationHandler';
 import AppWithNavigation from './nav/AppWithNavigation';
 
-require('./i18n/locale');
-require('./sentry');
+import './i18n/locale';
+import './sentry';
 
 // $FlowFixMe
 console.disableYellowBox = true; // eslint-disable-line

--- a/src/boot/TranslationProvider.js
+++ b/src/boot/TranslationProvider.js
@@ -10,7 +10,7 @@ import { getSettings } from '../selectors';
 import '../../vendor/intl/intl';
 import messages from '../i18n/messages';
 
-require('../i18n/locale');
+import '../i18n/locale';
 
 type Props = {
   locale: string,


### PR DESCRIPTION
The `import` command from `ES6` gets transpiled by Babel to `require()`.
Babel is enabled for the src/ directory. Since we use `import` wherever
Babel is enabled, replace the few stray instances of `require()` in src/.