### PR TITLE
refactor: Simplify `needsInitialFetch` logic

### DIFF
--- a/src/session/__tests__/sessionReducers-test.js
+++ b/src/session/__tests__/sessionReducers-test.js
@@ -1,9 +1,14 @@
 import deepFreeze from 'deep-freeze';
 
-import { ACCOUNT_SWITCH, CANCEL_EDIT_MESSAGE, START_EDIT_MESSAGE } from '../../actionConstants';
+import {
+  ACCOUNT_SWITCH,
+  CANCEL_EDIT_MESSAGE,
+  START_EDIT_MESSAGE,
+  LOGIN_SUCCESS,
+} from '../../actionConstants';
 import sessionReducers from '../sessionReducers';
 
-describe('appReducers', () => {
+describe('sessionReducers', () => {
   describe('ACCOUNT_SWITCH', () => {
     test('reissues initial fetch', () => {
       const prevState = deepFreeze({});
@@ -78,6 +83,20 @@ describe('appReducers', () => {
       const newState = sessionReducers(prevState, action);
 
       expect(newState).toEqual(expectedState);
+    });
+  });
+
+  describe('LOGIN_SUCCESS', () => {
+    test('reissues initial fetch', () => {
+      const prevState = deepFreeze({});
+
+      const action = deepFreeze({
+        type: LOGIN_SUCCESS,
+      });
+
+      const newState = sessionReducers(prevState, action);
+
+      expect(newState.needsInitialFetch).toBe(true);
     });
   });
 });


### PR DESCRIPTION
On `loginSuccess` we set `needsInitialFetch` to `true`.
This was introduced in:
https://github.com/zulip/zulip-mobile/commit/8edbf8562481d759a0a16daf0fac028ca54b6114

The code was `needsInitialFetch: !!action.apiKey` which might
suggest that more is going on, but not really. `apiKey` is always
a non empty value if login succeeds.

This PR replaces the code to `true` to make it simpler and more
clear, but no behavior is changed.

Also, adds a test for `sessionReducers\LOGIN_SUCCESS`.