### PR TITLE
streamScreen: Show 'Add subscribers' to all users.

### DIFF
--- a/src/streams/StreamScreen.js
+++ b/src/streams/StreamScreen.js
@@ -95,13 +95,11 @@ class StreamScreen extends PureComponent<Props> {
               onPress={() => delay(this.handleEdit)}
             />
           )}
-          {isAdmin && (
-            <ZulipButton
-              style={styles.marginTop}
-              text="Add subscribers"
-              onPress={() => delay(this.handleEditSubscribers)}
-            />
-          )}
+          <ZulipButton
+            style={styles.marginTop}
+            text="Add subscribers"
+            onPress={() => delay(this.handleEditSubscribers)}
+          />
         </View>
       </Screen>
     );


### PR DESCRIPTION
Before it was only shown to admin. Checked on web app, anyone can add
anybody in the stream visible to him.

This makes behaviour consistent on web app and mobile app.

Fix: #2840