### PR TITLE
Update message state on EVENT_UPDATE_MESSAGE_FLAGS.

### DIFF
--- a/src/chat/__tests__/chatSelectors-test.js
+++ b/src/chat/__tests__/chatSelectors-test.js
@@ -14,7 +14,7 @@ import {
   privateNarrow,
   streamNarrow,
   topicNarrow,
-  specialNarrow,
+  STARRED_NARROW,
   groupNarrow,
 } from '../../utils/narrow';
 import { NULL_SUBSCRIPTION } from '../../nullObjects';
@@ -265,7 +265,7 @@ describe('isNarrowValid', () => {
     const state = {
       realm: {},
     };
-    const narrow = specialNarrow('starred');
+    const narrow = STARRED_NARROW;
 
     const result = isNarrowValid(narrow)(state);
 

--- a/src/main/HomeTab.js
+++ b/src/main/HomeTab.js
@@ -5,7 +5,7 @@ import React, { PureComponent } from 'react';
 import { StyleSheet, View } from 'react-native';
 
 import type { Dispatch } from '../types';
-import { HOME_NARROW, specialNarrow, STARRED_NARROW } from '../utils/narrow';
+import { HOME_NARROW, MENTIONED_NARROW, STARRED_NARROW } from '../utils/narrow';
 import NavButton from '../nav/NavButton';
 import UnreadCards from '../unread/UnreadCards';
 import { doNarrow, navigateToSearch } from '../actions';
@@ -47,7 +47,7 @@ class HomeTab extends PureComponent<Props> {
           <NavButton
             name="at-sign"
             onPress={() => {
-              dispatch(doNarrow(specialNarrow('mentioned')));
+              dispatch(doNarrow(MENTIONED_NARROW));
             }}
           />
           <NavButton

--- a/src/main/HomeTab.js
+++ b/src/main/HomeTab.js
@@ -5,7 +5,7 @@ import React, { PureComponent } from 'react';
 import { StyleSheet, View } from 'react-native';
 
 import type { Dispatch } from '../types';
-import { HOME_NARROW, specialNarrow } from '../utils/narrow';
+import { HOME_NARROW, specialNarrow, STARRED_NARROW } from '../utils/narrow';
 import NavButton from '../nav/NavButton';
 import UnreadCards from '../unread/UnreadCards';
 import { doNarrow, navigateToSearch } from '../actions';
@@ -41,7 +41,7 @@ class HomeTab extends PureComponent<Props> {
           <NavButton
             name="star"
             onPress={() => {
-              dispatch(doNarrow(specialNarrow('starred')));
+              dispatch(doNarrow(STARRED_NARROW));
             }}
           />
           <NavButton

--- a/src/utils/__tests__/getStatusBarColor-test.js
+++ b/src/utils/__tests__/getStatusBarColor-test.js
@@ -6,7 +6,7 @@ import {
   streamNarrow,
   topicNarrow,
   privateNarrow,
-  specialNarrow,
+  MENTIONED_NARROW,
   groupNarrow,
 } from '../narrow';
 import getStatusBarColor from '../getStatusBarColor';
@@ -97,7 +97,7 @@ describe('getStatusBarColor', () => {
       subscriptions,
     });
     expect(
-      getStatusBarColor(getTitleBackgroundColor(specialNarrow('mentioned'))(state), themeDefault),
+      getStatusBarColor(getTitleBackgroundColor(MENTIONED_NARROW)(state), themeDefault),
     ).toEqual('white');
   });
 });

--- a/src/utils/__tests__/narrow-test.js
+++ b/src/utils/__tests__/narrow-test.js
@@ -20,6 +20,7 @@ import {
   isStreamOrTopicNarrow,
   getNarrowFromMessage,
   parseNarrowString,
+  STARRED_NARROW,
 } from '../narrow';
 
 describe('HOME_NARROW', () => {
@@ -136,13 +137,13 @@ describe('isStreamOrTopicNarrow', () => {
     expect(isStreamOrTopicNarrow(groupNarrow(['john@example.com', 'mark@example.com']))).toBe(
       false,
     );
-    expect(isStreamOrTopicNarrow(specialNarrow('starred'))).toBe(false);
+    expect(isStreamOrTopicNarrow(STARRED_NARROW)).toBe(false);
   });
 });
 
 describe('specialNarrow', () => {
   test('produces a narrow with "is" operator', () => {
-    expect(specialNarrow('starred')).toEqual([
+    expect(STARRED_NARROW).toEqual([
       {
         operator: 'is',
         operand: 'starred',
@@ -155,7 +156,7 @@ describe('specialNarrow', () => {
     expect(isSpecialNarrow([])).toBe(false);
     expect(isSearchNarrow([{}, {}])).toBe(false);
     expect(isSpecialNarrow(streamNarrow('some stream'))).toBe(false);
-    expect(isSpecialNarrow(specialNarrow('starred'))).toBe(true);
+    expect(isSpecialNarrow(STARRED_NARROW)).toBe(true);
     expect(isSpecialNarrow([{ operator: 'stream', operand: 'some stream' }])).toBe(false);
     expect(isSpecialNarrow([{ operator: 'is', operand: 'starred' }])).toBe(true);
   });

--- a/src/utils/narrow.js
+++ b/src/utils/narrow.js
@@ -157,3 +157,5 @@ export const isSameNarrow = (narrow1: Narrow, narrow2: Narrow): boolean =>
 export const parseNarrowString = (narrowStr: string): Narrow => JSON.parse(unescape(narrowStr));
 
 export const STARRED_NARROW = specialNarrow('starred');
+
+export const MENTIONED_NARROW = specialNarrow('mentioned');

--- a/src/utils/narrow.js
+++ b/src/utils/narrow.js
@@ -155,3 +155,5 @@ export const isSameNarrow = (narrow1: Narrow, narrow2: Narrow): boolean =>
   Array.isArray(narrow1) && Array.isArray(narrow2) && isEqual(narrow1, narrow2);
 
 export const parseNarrowString = (narrowStr: string): Narrow => JSON.parse(unescape(narrowStr));
+
+export const STARRED_NARROW = specialNarrow('starred');

--- a/src/utils/narrow.js
+++ b/src/utils/narrow.js
@@ -157,5 +157,6 @@ export const isSameNarrow = (narrow1: Narrow, narrow2: Narrow): boolean =>
 export const parseNarrowString = (narrowStr: string): Narrow => JSON.parse(unescape(narrowStr));
 
 export const STARRED_NARROW = specialNarrow('starred');
+export const STARRED_NARROW_STR = JSON.stringify(STARRED_NARROW);
 
 export const MENTIONED_NARROW = specialNarrow('mentioned');


### PR DESCRIPTION
Prior to this commit, dispatching the EVENT_UPDATE_MESSAGE_FLAGS action only updated `state.flags` and did not correspondingly update any fields in `state.messages`.

---

Fix #2676 by linearly searching through all messages in MessagesState, and add or remove the specified flag.

Before:

![starred-messages-bug-2676](https://user-images.githubusercontent.com/12771126/43297757-e9a75e1a-9107-11e8-84c1-d7e7df06e736.gif)

After:

![starred-messages-fixed-2676](https://user-images.githubusercontent.com/12771126/43178704-8711d1d4-8f83-11e8-819c-c1da2ca85bd1.gif)

---

For #2677:

Adding newly starred messages entails:
(1) Caching newly starred messages in the local scope of `eventUpdateMessageFlags` in an `id -> Message` map
(2) Appending newly starred messages to the list of messages for the 'is:starred' narrow
(3) Sorting the 'is:starred' narrow by timestamp to maintain chronological order

Removing starred messages entails filtering out the ids in `action.messages` from the 'is:starred' narrow.

Before:

![starred-list-bug-2677](https://user-images.githubusercontent.com/12771126/43298173-bebcb022-9109-11e8-81f3-4597f7a4cb2e.gif)

After:

![starred-list-fixed-2677](https://user-images.githubusercontent.com/12771126/43298177-c3cbd1ba-9109-11e8-8b75-b9c4bb12d0ef.gif)

---

Resolve #2627.

This logic should be updated with @roberthoenig's [refactor of the message state](https://chat.zulip.org/#narrow/stream/243-mobile-team/subject/message.20state/near/617688).

@gnprice 
@borisyankov 