### PR TITLE
webview: Fix search result in topic headers render as literal HTML.

### DIFF
--- a/src/webview/html/messageHeaderAsHtml.js
+++ b/src/webview/html/messageHeaderAsHtml.js
@@ -59,7 +59,7 @@ export default ({
     # ${item.display_recipient}
   </div>
   <div class="header topic-text" data-narrow="${topicNarrowStr}">
-    ${item.match_subject || item.subject}
+    $!${item.match_subject || item.subject}
   </div>
 </div>
     `;


### PR DESCRIPTION
Add `$!` before topic while generating header HTML, to include a literal.

Fix: #2845

Before
<img width="315" alt="screen shot 2018-07-30 at 10 35 11 am" src="https://user-images.githubusercontent.com/18511177/43378551-42028cc6-93e5-11e8-8420-29de28052945.png">

After
<img width="317" alt="screen shot 2018-07-30 at 10 34 39 am" src="https://user-images.githubusercontent.com/18511177/43378549-41dc4944-93e5-11e8-9333-cb76898cf4f5.png">
