### PR TITLE
Add support for realm emoji

### DIFF
--- a/src/api/emoji_reactions/emojiReactionAdd.js
+++ b/src/api/emoji_reactions/emojiReactionAdd.js
@@ -6,7 +6,7 @@ export default (
   auth: Auth,
   messageId: number,
   reactionType: string,
-  emojiCode: string,
+  emojiCode: string | number,
   emojiName: string,
 ): Promise<ApiResponse> =>
   apiPost(auth, `messages/${messageId}/reactions`, res => res, {

--- a/src/autocomplete/EmojiAutocomplete.js
+++ b/src/autocomplete/EmojiAutocomplete.js
@@ -8,11 +8,11 @@ import { Popup } from '../common';
 import EmojiRow from '../emoji/EmojiRow';
 import getFilteredEmojiList from '../emoji/getFilteredEmojiList';
 import type { GlobalState, RealmEmojiState } from '../types';
-import { getActiveRealmEmojiById } from '../selectors';
+import { getActiveRealmEmojiByName } from '../selectors';
 
 type Props = {
   filter: string,
-  realmEmoji: RealmEmojiState,
+  activeRealmEmojiByName: RealmEmojiState,
   onAutocomplete: (name: string) => void,
 };
 
@@ -20,8 +20,8 @@ class EmojiAutocomplete extends PureComponent<Props> {
   props: Props;
 
   render() {
-    const { filter, realmEmoji, onAutocomplete } = this.props;
-    const emojis = getFilteredEmojiList(filter, realmEmoji);
+    const { filter, activeRealmEmojiByName, onAutocomplete } = this.props;
+    const emojis = getFilteredEmojiList(filter, activeRealmEmojiByName);
 
     if (emojis.length === 0) {
       return null;
@@ -34,7 +34,13 @@ class EmojiAutocomplete extends PureComponent<Props> {
           initialNumToRender={12}
           data={emojis}
           keyExtractor={item => item}
-          renderItem={({ item }) => <EmojiRow name={item} onPress={() => onAutocomplete(item)} />}
+          renderItem={({ item }) => (
+            <EmojiRow
+              realmEmoji={activeRealmEmojiByName[item]}
+              name={item}
+              onPress={() => onAutocomplete(item)}
+            />
+          )}
         />
       </Popup>
     );
@@ -42,5 +48,5 @@ class EmojiAutocomplete extends PureComponent<Props> {
 }
 
 export default connect((state: GlobalState) => ({
-  realmEmoji: getActiveRealmEmojiById(state),
+  activeRealmEmojiByName: getActiveRealmEmojiByName(state),
 }))(EmojiAutocomplete);

--- a/src/emoji/EmojiRow.js
+++ b/src/emoji/EmojiRow.js
@@ -4,6 +4,8 @@ import { StyleSheet, View } from 'react-native';
 
 import { RawLabel, Touchable } from '../common';
 import Emoji from '../emoji/Emoji';
+import RealmEmoji from './RealmEmoji';
+import type { RealmEmojiType } from '../types';
 
 const styles = StyleSheet.create({
   emojiRow: {
@@ -18,6 +20,7 @@ const styles = StyleSheet.create({
 
 type Props = {
   name: string,
+  realmEmoji: RealmEmojiType,
   onPress: () => void,
 };
 
@@ -25,14 +28,12 @@ export default class EmojiRow extends PureComponent<Props> {
   props: Props;
 
   render() {
-    const { name, onPress } = this.props;
+    const { name, realmEmoji, onPress } = this.props;
 
-    // TODO: this only handles Unicode emoji (shipped with the app),
-    // not realm emoji or Zulip extra emoji.  See our issue #2846.
     return (
       <Touchable onPress={onPress}>
         <View style={styles.emojiRow}>
-          <Emoji name={name} size={20} />
+          {realmEmoji ? <RealmEmoji name={name} /> : <Emoji name={name} size={20} />}
           <RawLabel style={styles.text} text={name} />
         </View>
       </Touchable>

--- a/src/emoji/__tests__/emojiSelectors-test.js
+++ b/src/emoji/__tests__/emojiSelectors-test.js
@@ -140,3 +140,67 @@ describe('getActiveRealmEmojiByName', () => {
     expect(getActiveRealmEmojiByName(deepFreeze(state))).toEqual(expectedResult);
   });
 });
+
+describe('getAllRealmEmojiByName', () => {
+  test('get realm emoji object with emoji names as the keys', () => {
+    const state = {
+      accounts: [{ realm: 'https://example.com' }],
+      realm: {
+        emoji: {
+          1: {
+            name: 'smile',
+            source_url: 'https://example.com/static/user_upload/smile.png',
+          },
+          2: {
+            name: 'laugh',
+            source_url: 'https://example.com/static/user_upload/laugh.png',
+          },
+        },
+      },
+    };
+
+    const expectedResult = {
+      smile: {
+        name: 'smile',
+        source_url: 'https://example.com/static/user_upload/smile.png',
+      },
+      laugh: {
+        name: 'laugh',
+        source_url: 'https://example.com/static/user_upload/laugh.png',
+      },
+    };
+    expect(getAllRealmEmojiByName(deepFreeze(state))).toEqual(expectedResult);
+  });
+});
+
+describe('getActiveRealmEmojiByName', () => {
+  test('get realm emoji object with emoji names as the keys', () => {
+    const state = {
+      accounts: [{ realm: 'https://example.com' }],
+      realm: {
+        emoji: {
+          1: {
+            name: 'smile',
+            source_url: 'https://example.com/static/user_upload/smile.png',
+          },
+          2: {
+            name: 'laugh',
+            source_url: 'https://example.com/static/user_upload/laugh.png',
+          },
+        },
+      },
+    };
+
+    const expectedResult = {
+      smile: {
+        name: 'smile',
+        source_url: 'https://example.com/static/user_upload/smile.png',
+      },
+      laugh: {
+        name: 'laugh',
+        source_url: 'https://example.com/static/user_upload/laugh.png',
+      },
+    };
+    expect(getActiveRealmEmojiByName(deepFreeze(state))).toEqual(expectedResult);
+  });
+});

--- a/src/emoji/__tests__/getFilteredEmojiList-test.js
+++ b/src/emoji/__tests__/getFilteredEmojiList-test.js
@@ -16,8 +16,7 @@ describe('getFilteredEmojiList', () => {
     expect(list).toEqual(['goal_net', 'goat', 'goblin', 'golf', 'golfer', 'gorilla']);
   });
 
-  // skip: #2846
-  test.skip('search in realm emojis as well', () => {
+  test('search in realm emojis as well', () => {
     const list = getFilteredEmojiList('don', {
       done: { source_url: '/user_avatars/2/emoji/done.png' },
     });
@@ -31,8 +30,7 @@ describe('getFilteredEmojiList', () => {
     expect(list).toEqual(['dog', 'dog2', 'dog_face']);
   });
 
-  // skip: #2846
-  test.skip('return realm emojis which includes filter ', () => {
+  test('return realm emojis which includes filter ', () => {
     const list = getFilteredEmojiList('all', {
       small: { source_url: '/user_avatars/2/emoji/small.png' },
     });

--- a/src/emoji/emojiSelectors.js
+++ b/src/emoji/emojiSelectors.js
@@ -43,3 +43,17 @@ export const getActiveRealmEmojiByName: Selector<{ [string]: RealmEmojiType }> =
       return result;
     }, {}),
 );
+
+export const getAllRealmEmojiByName = createSelector(getAllRealmEmoji, emojis =>
+  Object.keys(emojis).reduce((list, key) => {
+    list[emojis[key].name] = emojis[key];
+    return list;
+  }, {}),
+);
+
+export const getActiveRealmEmojiByName = createSelector(getActiveRealmEmoji, emojis =>
+  Object.keys(emojis).reduce((list, key) => {
+    list[emojis[key].name] = emojis[key];
+    return list;
+  }, {}),
+);

--- a/src/emoji/getFilteredEmojiList.js
+++ b/src/emoji/getFilteredEmojiList.js
@@ -3,11 +3,12 @@ import emojiMap from './emojiMap';
 import type { RealmEmojiType } from '../types';
 
 export default (query: string, realmEmoji: { [string]: RealmEmojiType }) =>
-  // TODO: this doesn't actually handle realm emoji.  See our issue #2846.
   Array.from(
     new Set([
       ...Object.keys(emojiMap)
         .filter(x => x.indexOf(query) === 0)
         .sort(),
+      ...Object.keys(realmEmoji).filter(emoji => emoji.startsWith(query)),
+      ...Object.keys(realmEmoji).filter(emoji => emoji.includes(query)),
     ]),
   );

--- a/src/emoji/getFilteredEmojiList.js
+++ b/src/emoji/getFilteredEmojiList.js
@@ -2,13 +2,13 @@
 import emojiMap from './emojiMap';
 import type { RealmEmojiType } from '../types';
 
-export default (query: string, realmEmoji: { [string]: RealmEmojiType }) =>
+export default (query: string, activeRealmEmojiByName: { [string]: RealmEmojiType }) =>
   Array.from(
     new Set([
       ...Object.keys(emojiMap)
         .filter(x => x.indexOf(query) === 0)
         .sort(),
-      ...Object.keys(realmEmoji).filter(emoji => emoji.startsWith(query)),
-      ...Object.keys(realmEmoji).filter(emoji => emoji.includes(query)),
+      ...Object.keys(activeRealmEmojiByName).filter(emoji => emoji.startsWith(query)),
+      ...Object.keys(activeRealmEmojiByName).filter(emoji => emoji.includes(query)),
     ]),
   );

--- a/src/message/MessageList.js
+++ b/src/message/MessageList.js
@@ -24,7 +24,7 @@ import { constructActionButtons, executeActionSheetAction } from './messageActio
 import MessageListWeb from '../webview/MessageListWeb';
 import {
   getAuth,
-  getAllRealmEmojiById,
+  getAllRealmEmojiByName,
   getCurrentTypingUsers,
   getDebug,
   getRenderedMessages,
@@ -61,7 +61,7 @@ export type Props = {
   isFetching: boolean,
   messages: Message[],
   narrow: Narrow,
-  realmEmoji: RealmEmojiState,
+  allRealmEmojiByName: RealmEmojiState,
   renderedMessages: RenderedSectionDescriptor[],
   showMessagePlaceholders: boolean,
   subscriptions: Subscription[],
@@ -135,7 +135,7 @@ export default connect((state: GlobalState, props: OuterProps) => ({
   flags: getFlags(state),
   isFetching: props.isFetching || getIsFetching(props.narrow)(state),
   messages: props.messages || getShownMessagesForNarrow(props.narrow)(state),
-  realmEmoji: getAllRealmEmojiById(state),
+  allRealmEmojiByName: getAllRealmEmojiByName(state),
   twentyFourHourTime: getRealm(state).twentyFourHourTime,
   renderedMessages: props.renderedMessages || getRenderedMessages(props.narrow)(state),
   showMessagePlaceholders:

--- a/src/search/SearchMessagesCard.js
+++ b/src/search/SearchMessagesCard.js
@@ -13,8 +13,7 @@ import MessageList from '../message/MessageList';
 import { getMessages } from '../api';
 import renderMessages from '../message/renderMessages';
 import { NULL_ARRAY, NULL_FETCHING } from '../nullObjects';
-import { getAllRealmEmojiById, getAuth, getSubscriptions } from '../selectors';
-import { LAST_MESSAGE_ANCHOR } from '../constants';
+import { getAllRealmEmojiByName, getAuth, getSubscriptions } from '../selectors';
 
 const styles = StyleSheet.create({
   results: {
@@ -104,5 +103,11 @@ class SearchMessagesCard extends PureComponent<Props, State> {
 export default connect((state: GlobalState) => ({
   auth: getAuth(state),
   subscriptions: getSubscriptions(state),
+<<<<<<< HEAD
   realmEmoji: getAllRealmEmojiById(state),
+||||||| merged common ancestors
+  realmEmoji: getAllRealmEmoji(state),
+=======
+  allRealmEmojiByName: getAllRealmEmojiByName(state),
+>>>>>>> SearchMessagesCard: Use new emoji selector
 }))(SearchMessagesCard);

--- a/src/webview/html/messageAsHtml.js
+++ b/src/webview/html/messageAsHtml.js
@@ -44,7 +44,7 @@ type BriefMessageProps = {
   isOutbox: boolean,
   ownEmail: string,
   reactions: EventReaction[],
-  realmEmoji: RealmEmojiState,
+  allRealmEmojiByName: RealmEmojiState,
   timeEdited: ?number,
 };
 
@@ -67,7 +67,7 @@ const messageBody = ({
   isOutbox,
   ownEmail,
   reactions,
-  realmEmoji,
+  allRealmEmojiByName,
   timeEdited,
 }: {
   content: string,
@@ -76,13 +76,13 @@ const messageBody = ({
   isOutbox: boolean,
   ownEmail: string,
   reactions: EventReaction[],
-  realmEmoji: RealmEmojiState,
+  allRealmEmojiByName: RealmEmojiState,
   timeEdited: ?number,
 }) => template`
 $!${content}
 $!${isOutbox ? '<div class="loading-spinner outbox-spinner"></div>' : ''}
 $!${messageTagsAsHtml(!!flags.starred[id], timeEdited)}
-$!${messageReactionListAsHtml(reactions, id, ownEmail, realmEmoji)}
+$!${messageReactionListAsHtml(reactions, id, ownEmail, allRealmEmojiByName)}
 `;
 
 const briefMessageAsHtml = ({
@@ -92,12 +92,21 @@ const briefMessageAsHtml = ({
   isOutbox,
   ownEmail,
   reactions,
-  realmEmoji,
+  allRealmEmojiByName,
   timeEdited,
 }: BriefMessageProps) => template`
 $!${messageDiv(id, 'message-brief', flags)}
   <div class="content">
-    $!${messageBody({ content, flags, id, isOutbox, ownEmail, reactions, realmEmoji, timeEdited })}
+    $!${messageBody({
+      content,
+      flags,
+      id,
+      isOutbox,
+      ownEmail,
+      reactions,
+      allRealmEmojiByName,
+      timeEdited,
+    })}
   </div>
 </div>
 `;
@@ -115,7 +124,7 @@ const fullMessageAsHtml = ({
   isOutbox,
   reactions,
   ownEmail,
-  realmEmoji,
+  allRealmEmojiByName,
 }: FullMessageProps) => template`
 $!${messageDiv(id, 'message-full', flags)}
   <div class="avatar">
@@ -123,7 +132,16 @@ $!${messageDiv(id, 'message-full', flags)}
   </div>
   <div class="content">
     $!${messageSubheader({ fromName, timestamp, twentyFourHourTime })}
-    $!${messageBody({ content, flags, id, isOutbox, ownEmail, reactions, realmEmoji, timeEdited })}
+    $!${messageBody({
+      content,
+      flags,
+      id,
+      isOutbox,
+      ownEmail,
+      reactions,
+      allRealmEmojiByName,
+      timeEdited,
+    })}
   </div>
 </div>
 `;

--- a/src/webview/html/messageReactionAsHtml.js
+++ b/src/webview/html/messageReactionAsHtml.js
@@ -10,14 +10,14 @@ const getRealmEmojiHtml = (realmEmoji: RealmEmojiType): string =>
 export default (
   messageId: number,
   reaction: AggregatedReaction,
-  realmEmoji: RealmEmojiState,
+  allRealmEmojiByName: RealmEmojiState,
 ): string =>
   template`<span onClick="" class="reaction${reaction.selfReacted ? ' self-voted' : ''}"
         data-name="${reaction.name}"
         data-code="${reaction.code}"
         data-type="${reaction.type}">$!${
-    realmEmoji[reaction.name]
-      ? getRealmEmojiHtml(realmEmoji[reaction.name])
+    allRealmEmojiByName[reaction.name]
+      ? getRealmEmojiHtml(allRealmEmojiByName[reaction.name])
       : emojiMap[reaction.name]
   }&nbsp;${reaction.count}
 </span>`;

--- a/src/webview/html/messageReactionListAsHtml.js
+++ b/src/webview/html/messageReactionListAsHtml.js
@@ -8,7 +8,7 @@ export default (
   reactions: EventReaction[],
   messageId: number,
   ownEmail: string,
-  realmEmoji: RealmEmojiState,
+  allRealmEmojiByName: RealmEmojiState,
 ): string => {
   if (!reactions || reactions.length === 0) {
     return '';
@@ -18,7 +18,7 @@ export default (
 
   return template`
     <div class="reaction-list">
-      $!${aggregated.map(r => messageReactionAsHtml(messageId, r, realmEmoji)).join('')}
+      $!${aggregated.map(r => messageReactionAsHtml(messageId, r, allRealmEmojiByName)).join('')}
     </div>
   `;
 };

--- a/src/webview/html/renderMessagesAsHtml.js
+++ b/src/webview/html/renderMessagesAsHtml.js
@@ -9,7 +9,7 @@ import { getGravatarFromEmail } from '../../utils/avatar';
 export default ({
   auth,
   subscriptions,
-  realmEmoji,
+  allRealmEmojiByName,
   flags,
   renderedMessages,
   narrow,
@@ -43,10 +43,9 @@ export default ({
               avatarUrl: message.avatar_url || getGravatarFromEmail(message.sender_email),
               timeEdited: message.last_edit_timestamp,
               isOutbox: message.isOutbox,
-              // $FlowFixMe: EventReaction vs. SlimEventReaction
               reactions: message.reactions,
               ownEmail: auth.email,
-              realmEmoji,
+              allRealmEmojiByName,
               twentyFourHourTime,
             }),
           );


### PR DESCRIPTION
Created new selectors `getAllRealmEmojiByName` and `getActiveRealmEmojiByName` that returns the correct object structure expected by the rest of the application for the `realmEmoji` object.

Also added realm emoji support to  `EmojiPickerScreen`, `EmojiAutocomplete` and `EmojiRow` which was removed in 0c2d40f797c02a4cbd11515a3a99adc469fe2fc8

Fixes #2129 and partially #2846 (Zulip extra emoji is not yet supported)

The build is failing right now because the argument `emojiCode`  for `emojiReactionAdd()` and `emojiReactionRemove()` is expected to be a string, but in the case of realm emoji, the emoji ID is passed as `emojiCode` and this is a number.