### PR TITLE
Change the data structure for saving notifications data

### DIFF
--- a/android/app/src/main/java/com/zulipmobile/MainApplication.java
+++ b/android/app/src/main/java/com/zulipmobile/MainApplication.java
@@ -4,7 +4,6 @@ import android.app.Application;
 import android.app.NotificationManager;
 import android.content.Context;
 import android.os.Bundle;
-import android.util.Pair;
 
 import com.RNFetchBlob.RNFetchBlobPackage;
 import com.facebook.react.ReactApplication;
@@ -26,6 +25,7 @@ import com.wix.reactnativenotifications.core.notification.INotificationsApplicat
 import com.wix.reactnativenotifications.core.notification.IPushNotification;
 import com.zmxv.RNSound.RNSoundPackage;
 import com.zulipmobile.notifications.GCMPushNotifications;
+import com.zulipmobile.notifications.MessageInfo;
 import com.zulipmobile.notifications.PushNotificationsProp;
 import com.zulipmobile.RNSecureRandom;
 
@@ -40,7 +40,7 @@ import static com.zulipmobile.notifications.NotificationHelper.addConversationTo
 import static com.zulipmobile.notifications.NotificationHelper.clearConversations;
 
 public class MainApplication extends Application implements ReactApplication, INotificationsApplication {
-    private LinkedHashMap<String, Pair<String, Integer>> conversations;
+    private LinkedHashMap<String, List<MessageInfo>> conversations;
 
     private final ReactNativeHost mReactNativeHost = new ReactNativeHost(this) {
         @Override

--- a/android/app/src/main/java/com/zulipmobile/notifications/GCMPushNotifications.java
+++ b/android/app/src/main/java/com/zulipmobile/notifications/GCMPushNotifications.java
@@ -39,9 +39,12 @@ public class GCMPushNotifications extends PushNotification {
     public static final String ACTION_NOTIFICATIONS_DISMISS = "ACTION_NOTIFICATIONS_DISMISS";
 
     /**
-     * {@link LinkedHashMap} is for holding the message notifications data and group them according to their narrow collection that contains.
-     * {@link String} for the narrow key of the message.
-     * {@link List<MessageInfo>} for the list of messages received in that narrow.
+     * The Zulip messages we're showing as a notification, grouped by conversation.
+     *
+     * Each key identifies a conversation; see @{link buildKeyString}.
+     *
+     * Each value is the messages in the conversation, in the order we
+     * received them.
      */
     private LinkedHashMap<String, List<MessageInfo>> conversations;
 

--- a/android/app/src/main/java/com/zulipmobile/notifications/GCMPushNotifications.java
+++ b/android/app/src/main/java/com/zulipmobile/notifications/GCMPushNotifications.java
@@ -11,7 +11,6 @@ import android.os.Build;
 import android.os.Bundle;
 import android.text.TextUtils;
 import android.util.Log;
-import android.util.Pair;
 
 import com.wix.reactnativenotifications.core.AppLaunchHelper;
 import com.wix.reactnativenotifications.core.AppLifecycleFacade;
@@ -24,6 +23,7 @@ import com.zulipmobile.R;
 import java.io.IOException;
 import java.net.URL;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Locale;
 
 import me.leolin.shortcutbadger.ShortcutBadger;
@@ -37,14 +37,20 @@ public class GCMPushNotifications extends PushNotification {
 
     public static final int NOTIFICATION_ID = 435;
     public static final String ACTION_NOTIFICATIONS_DISMISS = "ACTION_NOTIFICATIONS_DISMISS";
-    private LinkedHashMap<String, Pair<String, Integer>> conversations;
+
+    /**
+     * {@link LinkedHashMap} is for holding the message notifications data and group them according to their narrow collection that contains.
+     * {@link String} for the narrow key of the message.
+     * {@link List<MessageInfo>} for the list of messages received in that narrow.
+     */
+    private LinkedHashMap<String, List<MessageInfo>> conversations;
 
     /**
      * Same as {@link com.wix.reactnativenotifications.core.NotificationIntentAdapter#PUSH_NOTIFICATION_EXTRA_NAME}
      */
     private static final String PUSH_NOTIFICATION_EXTRA_NAME = "pushNotification";
 
-    public GCMPushNotifications(Context context, Bundle bundle, AppLifecycleFacade appLifecycleFacade, AppLaunchHelper appLaunchHelper, JsIOHelper jsIoHelper, LinkedHashMap<String, Pair<String, Integer>> conversations) {
+    public GCMPushNotifications(Context context, Bundle bundle, AppLifecycleFacade appLifecycleFacade, AppLaunchHelper appLaunchHelper, JsIOHelper jsIoHelper, LinkedHashMap<String, List<MessageInfo>> conversations) {
         super(context, bundle, appLifecycleFacade, appLaunchHelper, jsIoHelper);
         this.conversations = conversations;
     }

--- a/android/app/src/main/java/com/zulipmobile/notifications/MessageInfo.java
+++ b/android/app/src/main/java/com/zulipmobile/notifications/MessageInfo.java
@@ -1,0 +1,19 @@
+package com.zulipmobile.notifications;
+
+public class MessageInfo {
+    private String content;
+    private int messageId;
+
+    public MessageInfo(String content, int messageId) {
+        this.content = content;
+        this.messageId = messageId;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public int getMessageId() {
+        return messageId;
+    }
+}

--- a/android/app/src/main/java/com/zulipmobile/notifications/PushNotificationsProp.java
+++ b/android/app/src/main/java/com/zulipmobile/notifications/PushNotificationsProp.java
@@ -67,4 +67,8 @@ public class PushNotificationsProp extends PushNotificationProps {
     public String getGroupRecipientString() {
         return Arrays.toString(getPmUsers());
     }
+
+    public int getZulipMessageId() {
+        return Integer.parseInt(mBundle.getString("zulip_message_id"));
+    }
 }


### PR DESCRIPTION
Previously it was saved as

```
LinkedHashMap<String, Pair<String, Integer>> conversations;
```

Now it is saved as

```
LinkedHashMap<String, List<MessageInfo>> conversations;
```

MessageInfo contains the content and the message id.
This commit does no visual changes, only changes the underlaying data structure and functions related to it.