### PR TITLE
TopicAutocomplete: Use simple string match for topic filtering

### DIFF
--- a/src/autocomplete/TopicAutocomplete.js
+++ b/src/autocomplete/TopicAutocomplete.js
@@ -32,7 +32,9 @@ class TopicAutocomplete extends PureComponent<Props> {
       return null;
     }
 
-    const topicsToSuggest = topics.filter(x => x && x !== text && x.match(new RegExp(text, 'i')));
+    const topicsToSuggest = topics.filter(
+      x => x && x !== text && x.toLowerCase().indexOf(text.toLowerCase()) > -1,
+    );
 
     return (
       <AnimatedScaleComponent visible={topicsToSuggest.length > 0}>


### PR DESCRIPTION
Using a RegExp on user input crashes the app on invalid inputs like entering a
single `(`. The search seems to have been using a RegExp search only for
enabling case-insensitive search. This has now been switched to a simple
sub-string test using lower-cased strings.

Fixes #2857