### PR TITLE
message edit: Fix error msg is not shown when msg edit fails.

### DIFF
--- a/src/compose/ComposeBox.js
+++ b/src/compose/ComposeBox.js
@@ -24,7 +24,7 @@ import {
 } from '../actions';
 import { updateMessage } from '../api';
 import { FloatingActionButton, Input } from '../common';
-import { showErrorAlert } from '../utils/info';
+import { showErrorFromException } from '../utils/info';
 import { IconDone, IconSend } from '../common/Icons';
 import { isStreamNarrow, isStreamOrTopicNarrow, topicNarrow } from '../utils/narrow';
 import ComposeMenu from './ComposeMenu';
@@ -240,7 +240,7 @@ class ComposeBox extends PureComponent<Props, State> {
     const subject = topic !== editMessage.topic ? topic : undefined;
     if ((content !== undefined && content !== '') || (subject !== undefined && subject !== '')) {
       updateMessage(auth, { content, subject }, editMessage.id).catch(error => {
-        showErrorAlert(error.message, 'Failed to edit message');
+        showErrorFromException(error, 'Failed to edit message');
       });
     }
     dispatch(cancelEditMessage());

--- a/src/utils/info.js
+++ b/src/utils/info.js
@@ -2,14 +2,14 @@
 import { Alert } from 'react-native';
 import Toast from '@remobile/react-native-toast';
 
-export const showToast = (message: string) => {
+export const showToast = (message: string): void => {
   Toast.show(message, Toast.SHORT);
 };
 
-export const showErrorAlert = (message: string, title: string) =>
+export const showErrorAlert = (message: string, title: string): void =>
   Alert.alert(title, message, [{ text: 'OK', onPress: () => {} }], { cancelable: true });
 
-export const showErrorFromException = (error: Error, title: string) =>
+export const showErrorFromException = (error: Error, title: string): void =>
   // $FlowFixMe
   Alert.alert(title, error && error.data && error.data.msg, [{ text: 'OK', onPress: () => {} }], {
     cancelable: true,

--- a/src/utils/info.js
+++ b/src/utils/info.js
@@ -8,3 +8,9 @@ export const showToast = (message: string) => {
 
 export const showErrorAlert = (message: string, title: string) =>
   Alert.alert(title, message, [{ text: 'OK', onPress: () => {} }], { cancelable: true });
+
+export const showErrorFromException = (error: Error, title: string) =>
+  // $FlowFixMe
+  Alert.alert(title, error && error.data && error.data.msg, [{ text: 'OK', onPress: () => {} }], {
+    cancelable: true,
+  });


### PR DESCRIPTION
After a0cc3dc, it became quite easier to handle api fail. In this
commit, just get the correct object from error which contains error
message.

Fix: #2870