### PR TITLE
android: Make the minimal platform we support 4.4 (API 19)

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -96,7 +96,7 @@ android {
 
     defaultConfig {
         applicationId "com.zulipmobile"
-        minSdkVersion 16
+        minSdkVersion 19
         targetSdkVersion 22
         versionCode 13
         versionName "1.0.13"


### PR DESCRIPTION
Useful information on Android versions can be found here:
https://en.wikipedia.org/wiki/Android_version_history

React Native allows us to support Android 4.1 and newer (API 16+)

We were claiming we support 4.1 but we haven't tested the app on
that platform version. Also, in our documentation we say we support
version 4.4

Now, making this official, we set the API support to 19.
Once published to the Play Store this will ensure users only on
supported versions can download the app.