### PR TITLE
Only show the notification with an event message

### DIFF
--- a/android/app/src/main/java/com/zulipmobile/MainApplication.java
+++ b/android/app/src/main/java/com/zulipmobile/MainApplication.java
@@ -85,11 +85,12 @@ public class MainApplication extends Application implements ReactApplication, IN
             clearConversations(conversations);
             NotificationManager nMgr = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
             nMgr.cancelAll();
-            return null;
         } else {
             PushNotificationsProp prop = new PushNotificationsProp(bundle);
-            addConversationToMap(prop, conversations);
-            return new GCMPushNotifications(context, bundle, defaultFacade, defaultAppLaunchHelper, new JsIOHelper(), conversations);
+            if (prop.getEvent().equals("message")) {
+                addConversationToMap(prop, conversations);
+            }
         }
+        return new GCMPushNotifications(context, bundle, defaultFacade, defaultAppLaunchHelper, new JsIOHelper(), conversations);
     }
 }

--- a/android/app/src/main/java/com/zulipmobile/notifications/GCMPushNotifications.java
+++ b/android/app/src/main/java/com/zulipmobile/notifications/GCMPushNotifications.java
@@ -90,6 +90,10 @@ public class GCMPushNotifications extends PushNotification {
         // First, get a builder initialized with defaults from the core class.
         final Notification.Builder builder = super.getNotificationBuilder(intent);
 
+        if (!getProps().getEvent().equals("message")) {
+            return builder;
+        }
+
         String type = getProps().getRecipientType();
         String content = getProps().getContent();
         String senderFullName = getProps().getSenderFullName();
@@ -189,5 +193,13 @@ public class GCMPushNotifications extends PushNotification {
     @Override
     protected int createNotificationId(Notification notification) {
         return NOTIFICATION_ID;
+    }
+
+    @Override
+    public void onReceived() throws InvalidNotificationException {
+        if (!getProps().getEvent().equals("message")) {
+            throw new InvalidNotificationException("Cannot handle this notification.");
+        }
+        super.onReceived();
     }
 }

--- a/android/app/src/main/java/com/zulipmobile/notifications/PushNotificationsProp.java
+++ b/android/app/src/main/java/com/zulipmobile/notifications/PushNotificationsProp.java
@@ -71,4 +71,8 @@ public class PushNotificationsProp extends PushNotificationProps {
     public int getZulipMessageId() {
         return Integer.parseInt(mBundle.getString("zulip_message_id"));
     }
+
+    public Object getEvent() {
+        return mBundle.getString("event");
+    }
 }


### PR DESCRIPTION
Fixes a bug in which previously the notification was trying to show
messages with event remove which was showing up as `null:null` as it
didn't have any payload for the narrow and the content