### PR TITLE
fix: Improve focus ping

### DIFF
--- a/src/users/usersActions.js
+++ b/src/users/usersActions.js
@@ -11,7 +11,7 @@ import { isPrivateOrGroupNarrow } from '../utils/narrow';
 let lastReportPresence = new Date();
 let lastTypingStart = new Date();
 
-export const reportPresence = (hasFocus: boolean = true, newUserInput: boolean = false) => async (
+export const reportPresence = (hasFocus: boolean = true) => async (
   dispatch: Dispatch,
   getState: GetState,
 ) => {
@@ -26,7 +26,7 @@ export const reportPresence = (hasFocus: boolean = true, newUserInput: boolean =
 
   lastReportPresence = new Date();
 
-  const response = await api.reportPresence(auth, hasFocus, newUserInput);
+  const response = await api.reportPresence(auth, hasFocus);
   dispatch({
     type: PRESENCE_RESPONSE,
     presence: response.presences,


### PR DESCRIPTION
Pass `new_user_input` as `true` instead of `false`.
I had incorrectly assumed before that this has something to do
with the user putting in new 'input' (typing)

The ditermination of wether it should be `true` or `false` is made
on the web if the user has actually interacted with the app.

On mobile we do not have a long running browser tab that might be
in the background, thus we should pass `true` always.

As discussed here:
https://chat.zulip.org/#narrow/stream/3-backend/topic/presence.20update.20fields