### PR TITLE
Improve reducers' handling of `REALM_INIT`

### DIFF
--- a/src/alertWords/__tests__/alertWordsReducer-test.js
+++ b/src/alertWords/__tests__/alertWordsReducer-test.js
@@ -20,16 +20,17 @@ describe('alertWordsReducer', () => {
       expect(actualState).toEqual(expectedState);
     });
 
-    test('when no `alert_words` data is given do not mutate state', () => {
+    test('when no `alert_words` data is given reset state', () => {
       const initialState = deepFreeze(['word']);
       const action = deepFreeze({
         type: REALM_INIT,
         data: {},
       });
+      const expectedState = [];
 
       const actualState = alertWordsReducer(initialState, action);
 
-      expect(actualState).toBe(initialState);
+      expect(actualState).toEqual(expectedState);
     });
   });
 

--- a/src/alertWords/alertWordsReducer.js
+++ b/src/alertWords/alertWordsReducer.js
@@ -11,10 +11,10 @@ import { NULL_ARRAY } from '../nullObjects';
 const initialState = NULL_ARRAY;
 
 const realmInit = (state: AlertWordsState, action: RealmInitAction): AlertWordsState =>
-  action.data.alert_words || state;
+  action.data.alert_words || initialState;
 
 const initAlertWords = (state: AlertWordsState, action: EventAlertWordsAction): AlertWordsState =>
-  action.alertWords || state;
+  action.alertWords || initialState;
 
 export default (
   state: AlertWordsState = initialState,

--- a/src/mute/__tests__/muteReducers-test.js
+++ b/src/mute/__tests__/muteReducers-test.js
@@ -5,9 +5,8 @@ import { ACCOUNT_SWITCH, EVENT_MUTED_TOPICS, REALM_INIT } from '../../actionCons
 
 describe('muteReducers', () => {
   describe('REALM_INIT', () => {
-    test('when same muted topics exists in state, do not change state', () => {
-      const initialState = deepFreeze([['stream'], ['topic']]);
-
+    test('when `mute` data is provided init state with it', () => {
+      const initialState = deepFreeze([]);
       const action = deepFreeze({
         type: REALM_INIT,
         data: {
@@ -16,7 +15,21 @@ describe('muteReducers', () => {
       });
 
       const actualState = muteReducers(initialState, action);
-      expect(actualState).toBe(initialState);
+
+      expect(actualState).toEqual([['stream'], ['topic']]);
+    });
+
+    test('when no `mute` data is given reset state', () => {
+      const initialState = deepFreeze([['stream'], ['topic']]);
+      const action = deepFreeze({
+        type: REALM_INIT,
+        data: {},
+      });
+      const expectedState = [];
+
+      const actualState = muteReducers(initialState, action);
+
+      expect(actualState).toEqual(expectedState);
     });
   });
 

--- a/src/mute/muteReducers.js
+++ b/src/mute/muteReducers.js
@@ -1,6 +1,4 @@
 /* @flow */
-import isEqual from 'lodash.isequal';
-
 import type { MuteState, MuteAction, RealmInitAction, EventMutedTopicsAction } from '../types';
 import { REALM_INIT, ACCOUNT_SWITCH, EVENT_MUTED_TOPICS } from '../actionConstants';
 import { NULL_ARRAY } from '../nullObjects';
@@ -8,7 +6,7 @@ import { NULL_ARRAY } from '../nullObjects';
 const initialState: MuteState = NULL_ARRAY;
 
 const realmInit = (state: MuteState, action: RealmInitAction): MuteState =>
-  isEqual(action.data.muted_topics, state) ? state : action.data.muted_topics;
+  action.data.muted_topics || initialState;
 
 const eventMutedTopics = (state: MuteState, action: EventMutedTopicsAction): MuteState =>
   action.muted_topics;

--- a/src/presence/__tests__/presenceReducers-test.js
+++ b/src/presence/__tests__/presenceReducers-test.js
@@ -1,7 +1,12 @@
 /* @flow */
 import deepFreeze from 'deep-freeze';
 
-import { PRESENCE_RESPONSE, EVENT_PRESENCE, ACCOUNT_SWITCH } from '../../actionConstants';
+import {
+  REALM_INIT,
+  PRESENCE_RESPONSE,
+  EVENT_PRESENCE,
+  ACCOUNT_SWITCH,
+} from '../../actionConstants';
 import presenceReducers from '../presenceReducers';
 
 const currentTimestamp = Date.now() / 1000;
@@ -17,6 +22,52 @@ describe('presenceReducers', () => {
 
     const newState = presenceReducers(prevState, {});
     expect(newState).toBe(prevState);
+  });
+
+  describe('REALM_INIT', () => {
+    test('when `presence` data is provided init state with it', () => {
+      const presenceData = {
+        'email@example.com': {
+          aggregated: {
+            client: 'website',
+            status: 'active',
+            timestamp: 123,
+          },
+        },
+      };
+      const initialState = deepFreeze({});
+      const action = deepFreeze({
+        type: REALM_INIT,
+        data: {
+          presences: presenceData,
+        },
+      });
+
+      const actualState = presenceReducers(initialState, action);
+
+      expect(actualState).toEqual(presenceData);
+    });
+
+    test('when no `presence` data is given reset state', () => {
+      const initialState = deepFreeze({
+        'email@example.com': {
+          aggregated: {
+            client: 'website',
+            status: 'active',
+            timestamp: 123,
+          },
+        },
+      });
+      const action = deepFreeze({
+        type: REALM_INIT,
+        data: {},
+      });
+      const expectedState = {};
+
+      const actualState = presenceReducers(initialState, action);
+
+      expect(actualState).toEqual(expectedState);
+    });
   });
 
   describe('PRESENCE_RESPONSE', () => {

--- a/src/presence/presenceReducers.js
+++ b/src/presence/presenceReducers.js
@@ -20,7 +20,7 @@ import { getAggregatedPresence } from '../utils/presence';
 const initialState: PresenceState = NULL_OBJECT;
 
 const realmInit = (state: PresenceState, action: RealmInitAction): PresenceState =>
-  action.data.presences;
+  action.data.presences || initialState;
 
 const presenceResponse = (state: PresenceState, action: PresenceResponseAction): PresenceState => ({
   ...state,

--- a/src/subscriptions/__tests__/subscriptionsReducers-test.js
+++ b/src/subscriptions/__tests__/subscriptionsReducers-test.js
@@ -1,6 +1,7 @@
 import deepFreeze from 'deep-freeze';
 
 import {
+  REALM_INIT,
   EVENT_SUBSCRIPTION_ADD,
   EVENT_SUBSCRIPTION_REMOVE,
   // EVENT_SUBSCRIPTION_PEER_ADD,
@@ -12,6 +13,50 @@ import {
 import subscriptionsReducers from '../subscriptionsReducers';
 
 describe('subscriptionsReducers', () => {
+  describe('REALM_INIT', () => {
+    test('when `subscriptions` data is provided init state with it', () => {
+      const initialState = deepFreeze([]);
+      const action = deepFreeze({
+        type: REALM_INIT,
+        data: {
+          subscriptions: [
+            {
+              name: 'some stream',
+              stream_id: 1,
+            },
+          ],
+        },
+      });
+
+      const actualState = subscriptionsReducers(initialState, action);
+
+      expect(actualState).toEqual([
+        {
+          name: 'some stream',
+          stream_id: 1,
+        },
+      ]);
+    });
+
+    test('when no `subscriptions` data is given reset state', () => {
+      const initialState = deepFreeze([
+        {
+          name: 'some stream',
+          stream_id: 1,
+        },
+      ]);
+      const action = deepFreeze({
+        type: REALM_INIT,
+        data: {},
+      });
+      const expectedState = [];
+
+      const actualState = subscriptionsReducers(initialState, action);
+
+      expect(actualState).toEqual(expectedState);
+    });
+  });
+
   describe('INIT_SUBSCRIPTIONS', () => {
     test('when subscriptions are same in state as initialized', () => {
       const prevState = deepFreeze([

--- a/src/subscriptions/subscriptionsReducers.js
+++ b/src/subscriptions/subscriptionsReducers.js
@@ -29,7 +29,7 @@ import { filterArray } from '../utils/immutability';
 const initialState: SubscriptionsState = NULL_ARRAY;
 
 const realmInit = (state: SubscriptionsState, action: RealmInitAction): SubscriptionsState =>
-  isEqual(action.data.subscriptions, state) ? state : action.data.subscriptions;
+  action.data.subscriptions || initialState;
 
 const initSubscriptions = (
   state: SubscriptionsState,

--- a/src/unread/unreadHuddlesReducers.js
+++ b/src/unread/unreadHuddlesReducers.js
@@ -23,7 +23,7 @@ import { NULL_ARRAY } from '../nullObjects';
 const initialState: UnreadHuddlesState = NULL_ARRAY;
 
 const realmInit = (state: UnreadHuddlesState, action: RealmInitAction): UnreadHuddlesState =>
-  (action.data.unread_msgs && action.data.unread_msgs.huddles) || NULL_ARRAY;
+  (action.data.unread_msgs && action.data.unread_msgs.huddles) || initialState;
 
 const eventNewMessage = (
   state: UnreadHuddlesState,

--- a/src/unread/unreadMentionsReducers.js
+++ b/src/unread/unreadMentionsReducers.js
@@ -22,7 +22,7 @@ import { NULL_ARRAY } from '../nullObjects';
 const initialState: UnreadMentionsState = NULL_ARRAY;
 
 const realmInit = (state: UnreadMentionsState, action: RealmInitAction): UnreadMentionsState =>
-  (action.data.unread_msgs && action.data.unread_msgs.mentions) || NULL_ARRAY;
+  (action.data.unread_msgs && action.data.unread_msgs.mentions) || initialState;
 
 const eventNewMessage = (
   state: UnreadMentionsState,

--- a/src/unread/unreadPmsReducers.js
+++ b/src/unread/unreadPmsReducers.js
@@ -22,7 +22,7 @@ import { NULL_ARRAY } from '../nullObjects';
 const initialState: UnreadPmsState = NULL_ARRAY;
 
 const realmInit = (state: UnreadPmsState, action: RealmInitAction): UnreadPmsState =>
-  (action.data.unread_msgs && action.data.unread_msgs.pms) || NULL_ARRAY;
+  (action.data.unread_msgs && action.data.unread_msgs.pms) || initialState;
 
 const eventNewMessage = (state: UnreadPmsState, action: EventNewMessageAction): UnreadPmsState => {
   if (action.message.type !== 'private') {

--- a/src/unread/unreadStreamsReducers.js
+++ b/src/unread/unreadStreamsReducers.js
@@ -22,7 +22,7 @@ import { NULL_ARRAY } from '../nullObjects';
 const initialState: UnreadStreamsState = NULL_ARRAY;
 
 const realmInit = (state: UnreadStreamsState, action: RealmInitAction): UnreadStreamsState =>
-  (action.data.unread_msgs && action.data.unread_msgs.streams) || NULL_ARRAY;
+  (action.data.unread_msgs && action.data.unread_msgs.streams) || initialState;
 
 const eventNewMessage = (
   state: UnreadStreamsState,

--- a/src/user-groups/__tests__/userGroupsReducers-test.js
+++ b/src/user-groups/__tests__/userGroupsReducers-test.js
@@ -1,6 +1,7 @@
 import deepFreeze from 'deep-freeze';
 
 import {
+  REALM_INIT,
   ACCOUNT_SWITCH,
   EVENT_USER_GROUP_ADD,
   EVENT_USER_GROUP_REMOVE,
@@ -18,6 +19,47 @@ describe('userGroupsReducers', () => {
 
     const newState = userGroupsReducers(initialState, action);
     expect(newState).toBeDefined();
+  });
+
+  describe('REALM_INIT', () => {
+    test('when data is provided init state with it', () => {
+      const initialState = deepFreeze([]);
+      const action = deepFreeze({
+        type: REALM_INIT,
+        data: {
+          realm_user_groups: [
+            {
+              id: 1,
+              name: 'Some user group',
+              members: [],
+            },
+          ],
+        },
+      });
+
+      const actualState = userGroupsReducers(initialState, action);
+
+      expect(actualState).toEqual([
+        {
+          id: 1,
+          name: 'Some user group',
+          members: [],
+        },
+      ]);
+    });
+
+    test('when no data is given reset state', () => {
+      const initialState = deepFreeze([['stream'], ['topic']]);
+      const action = deepFreeze({
+        type: REALM_INIT,
+        data: {},
+      });
+      const expectedState = [];
+
+      const actualState = userGroupsReducers(initialState, action);
+
+      expect(actualState).toEqual(expectedState);
+    });
   });
 
   describe('ACCOUNT_SWITCH', () => {

--- a/src/user-groups/userGroupsReducers.js
+++ b/src/user-groups/userGroupsReducers.js
@@ -25,7 +25,7 @@ import { NULL_ARRAY } from '../nullObjects';
 const initialState: UserGroupsState = NULL_ARRAY;
 
 const realmInit = (state: UserGroupsState, action: RealmInitAction): UserGroupsState =>
-  action.data.realm_user_groups;
+  action.data.realm_user_groups || initialState;
 
 const eventUserGroupAdd = (
   state: UserGroupsState,

--- a/src/users/__tests__/usersReducers-test.js
+++ b/src/users/__tests__/usersReducers-test.js
@@ -1,6 +1,6 @@
 import deepFreeze from 'deep-freeze';
 
-import { EVENT_USER_ADD, ACCOUNT_SWITCH } from '../../actionConstants';
+import { REALM_INIT, EVENT_USER_ADD, ACCOUNT_SWITCH } from '../../actionConstants';
 import usersReducers from '../usersReducers';
 
 describe('usersReducers', () => {
@@ -20,6 +20,53 @@ describe('usersReducers', () => {
 
     const newState = usersReducers(initialState, action);
     expect(newState).toBe(initialState);
+  });
+
+  describe('REALM_INIT', () => {
+    test('when `users` data is provided init state with it', () => {
+      const initialState = deepFreeze([]);
+      const action = deepFreeze({
+        type: REALM_INIT,
+        data: {
+          realm_users: [
+            {
+              user_id: 1,
+              email: 'john@example.com',
+              full_name: 'John Doe',
+            },
+          ],
+        },
+      });
+
+      const actualState = usersReducers(initialState, action);
+
+      expect(actualState).toEqual([
+        {
+          user_id: 1,
+          email: 'john@example.com',
+          full_name: 'John Doe',
+        },
+      ]);
+    });
+
+    test('when no `users` data is given reset state', () => {
+      const initialState = deepFreeze([
+        {
+          user_id: 1,
+          email: 'john@example.com',
+          full_name: 'John Doe',
+        },
+      ]);
+      const action = deepFreeze({
+        type: REALM_INIT,
+        data: {},
+      });
+      const expectedState = [];
+
+      const actualState = usersReducers(initialState, action);
+
+      expect(actualState).toEqual(expectedState);
+    });
   });
 
   describe('EVENT_USER_ADD', () => {

--- a/src/users/usersReducers.js
+++ b/src/users/usersReducers.js
@@ -14,7 +14,7 @@ import { NULL_ARRAY } from '../nullObjects';
 const initialState: UsersState = NULL_ARRAY;
 
 const realmInit = (state: UsersState, action: RealmInitAction): UsersState =>
-  action.data.realm_users;
+  action.data.realm_users || initialState;
 
 const eventUserAdd = (state: UsersState, action: EventUserAddAction): UsersState => [
   ...state,


### PR DESCRIPTION
Fixes #2859

The current behavior of reducers differs slightly. This PR makes sure all reducers behave consistently and predictably.

The `REALM_INIT` action is called when we receive data from the `register` API call. Most reducers do reset the state if they do not receive any data. Some don't. This PR makes sure that:
 * a reducer does not leave the reducer with invalid data (`undefined`)
 * does not preserve state but resets it