### PR TITLE
Add support for new thumbnail format

### DIFF
--- a/src/utils/__tests__/url-test.js
+++ b/src/utils/__tests__/url-test.js
@@ -16,7 +16,6 @@ import {
   hasProtocol,
   fixRealmUrl,
   autocompleteUrl,
-  appendAuthToImages,
 } from '../url';
 
 import { streamNarrow, topicNarrow } from '../narrow';
@@ -513,79 +512,5 @@ describe('autocompleteUrl', () => {
   test('when no subdomain entered do not append top-level domain', () => {
     const result = autocompleteUrl('mydomain.org', 'https://', '.zulipchat.com');
     expect(result).toEqual('https://mydomain.org');
-  });
-});
-
-describe('appendAuthToImages', () => {
-  const auth = {
-    realm: 'https://realm.zulip.com',
-    apiKey: 'some_key',
-    email: 'me@example.com',
-  };
-
-  test('empty string is unchanged', () => {
-    const input = '';
-    const expected = input;
-    expect(appendAuthToImages(input, auth)).toEqual(expected);
-  });
-
-  test('appends the api key to a relative image src url', () => {
-    const input = '<img src="/user_uploads/img.png" />';
-    const expected = '<img src="/user_uploads/img.png?api_key=some_key" />';
-    expect(appendAuthToImages(input, auth)).toEqual(expected);
-  });
-
-  test('appends the api key to an absolute image src if in the same realm', () => {
-    const input = '<img src="https://realm.zulip.com/user_uploads/img.png" />';
-    const expected = '<img src="https://realm.zulip.com/user_uploads/img.png?api_key=some_key" />';
-    expect(appendAuthToImages(input, auth)).toEqual(expected);
-  });
-
-  // The server generates these if the user contains a literal URL pointing to
-  // an uploaded image on the server: e.g. markdown of
-  //   https://realm.zulip.com/user_uploads/1/2/3/foo.png
-  // is rendered as an image element
-  //   <img src="user_uploads/1/2/3/foo.png">
-  test('appends the api key to a path-relative url', () => {
-    const input = '<img src="user_uploads/img.png" />';
-    const expected = '<img src="user_uploads/img.png?api_key=some_key" />';
-    expect(appendAuthToImages(input, auth)).toEqual(expected);
-  });
-
-  test('does not rewrite non-user_uploads urls', () => {
-    const input = '<img src="https://realm.zulip.com/other/img.png">';
-    const expected = input;
-    expect(appendAuthToImages(input, auth)).toEqual(expected);
-  });
-
-  test('does not append anything to images pointing to different domains', () => {
-    const input = '<img src="https://example.com/user_uploads/img.png" />';
-    const expected = input;
-    expect(appendAuthToImages(input, auth)).toEqual(expected);
-  });
-
-  test('does not mistreat the realm name as a regex', () => {
-    const input = '<img src="https://realm-zulip.com/user_uploads/img.png">';
-    const expected = input;
-    expect(appendAuthToImages(input, auth)).toEqual(expected);
-  });
-
-  test('does not replace urls not in images', () => {
-    const input = '<a href="/user_uploads/img.png" />';
-    const expected = input;
-    expect(appendAuthToImages(input, auth)).toEqual(expected);
-  });
-
-  test('replaces urls in images in the whole string', () => {
-    const input = '<img src="/user_uploads/img.png" /><img src="/user_uploads/img.png" />';
-    const expected =
-      '<img src="/user_uploads/img.png?api_key=some_key" /><img src="/user_uploads/img.png?api_key=some_key" />';
-    expect(appendAuthToImages(input, auth)).toEqual(expected);
-  });
-
-  test('does not overrun', () => {
-    const input = '<img src="/user_uploads/img.png">"But soft,"';
-    const expected = '<img src="/user_uploads/img.png?api_key=some_key">"But soft,"';
-    expect(appendAuthToImages(input, auth)).toEqual(expected);
   });
 });

--- a/src/utils/url.js
+++ b/src/utils/url.js
@@ -155,13 +155,3 @@ export const autocompleteUrl = (value: string = '', protocol: string, append: st
     : '';
 
 export const isValidUrl = (url: string): boolean => urlRegex({ exact: true }).test(url);
-
-// This formula borrowed from MDN:
-// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions
-const escapeRegExp = (str: string): string => str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-
-export const appendAuthToImages = (messageStr: string, auth: Auth): string =>
-  messageStr.replace(
-    new RegExp(`<img src="((?:|/|${escapeRegExp(auth.realm)}/)user_uploads/[^"]*)"`, 'g'),
-    `<img src="$1?api_key=${auth.apiKey}"`,
-  );

--- a/src/webview/MessageListWeb.js
+++ b/src/webview/MessageListWeb.js
@@ -11,6 +11,7 @@ import renderMessagesAsHtml from './html/renderMessagesAsHtml';
 import { getInputMessages } from './webViewHandleUpdates';
 import * as webViewEventHandlers from './webViewEventHandlers';
 import { base64Utf8Encode } from '../utils/encoding';
+import { appendAuthToImages } from '../utils/url';
 
 export default class MessageListWeb extends Component<Props> {
   context: Context;
@@ -60,7 +61,7 @@ export default class MessageListWeb extends Component<Props> {
   render() {
     const { styles, theme } = this.context;
     const { anchor, auth, showMessagePlaceholders, debug } = this.props;
-    const html = getHtml(renderMessagesAsHtml(this.props), theme, {
+    const html = getHtml(appendAuthToImages(renderMessagesAsHtml(this.props), auth), theme, {
       anchor,
       highlightUnreadMessages: debug.highlightUnreadMessages,
       showMessagePlaceholders,

--- a/src/webview/MessageListWeb.js
+++ b/src/webview/MessageListWeb.js
@@ -11,7 +11,6 @@ import renderMessagesAsHtml from './html/renderMessagesAsHtml';
 import { getInputMessages } from './webViewHandleUpdates';
 import * as webViewEventHandlers from './webViewEventHandlers';
 import { base64Utf8Encode } from '../utils/encoding';
-import { appendAuthToImages } from '../utils/url';
 
 export default class MessageListWeb extends Component<Props> {
   context: Context;
@@ -61,8 +60,9 @@ export default class MessageListWeb extends Component<Props> {
   render() {
     const { styles, theme } = this.context;
     const { anchor, auth, showMessagePlaceholders, debug } = this.props;
-    const html = getHtml(appendAuthToImages(renderMessagesAsHtml(this.props), auth), theme, {
+    const html = getHtml(renderMessagesAsHtml(this.props), theme, {
       anchor,
+      auth,
       highlightUnreadMessages: debug.highlightUnreadMessages,
       showMessagePlaceholders,
     });

--- a/src/webview/html/html.js
+++ b/src/webview/html/html.js
@@ -1,18 +1,19 @@
 /* @flow */
 import template from './template';
-import type { ThemeType } from '../../types';
+import type { Auth, ThemeType } from '../../types';
 import css from '../css/css';
 import htmlBody from './htmlBody';
 import script from '../js/script';
 
 type InitOptionsType = {
   anchor: number,
+  auth: Auth,
   highlightUnreadMessages: boolean,
   showMessagePlaceholders: boolean,
 };
 
 export default (content: string, theme: ThemeType, initOptions: InitOptionsType) => template`
-$!${script(initOptions.anchor)}
+$!${script(initOptions.anchor, initOptions.auth)}
 $!${css(theme, initOptions.highlightUnreadMessages)}
 
 <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">

--- a/src/webview/html/renderMessagesAsHtml.js
+++ b/src/webview/html/renderMessagesAsHtml.js
@@ -1,7 +1,6 @@
 /* @flow */
 import type { Props } from '../../message/MessageList';
 
-import { appendAuthToImages } from '../../utils/url';
 import messageAsHtml from './messageAsHtml';
 import messageHeaderAsHtml from './messageHeaderAsHtml';
 import timeRowAsHtml from './timeRowAsHtml';
@@ -54,8 +53,4 @@ const renderMessages = ({
     return list; // eslint-disable-next-line
   }, []);
 
-export default (props: Props): string => {
-  const { auth } = props;
-
-  return appendAuthToImages(renderMessages(props).join(''), auth);
-};
+export default (props: Props): string => renderMessages(props).join('');

--- a/src/webview/js/generatedEs3.js
+++ b/src/webview/js/generatedEs3.js
@@ -235,8 +235,9 @@ var handleMessageContent = function handleMessageContent(msg) {
   sendScrollMessageIfListShort();
 };
 
-var handleInitialLoad = function handleInitialLoad(anchor) {
+var handleInitialLoad = function handleInitialLoad(anchor, auth) {
   scrollToAnchor(anchor);
+  appendAuthToImages(auth);
   sendScrollMessageIfListShort();
   scrollEventsDisabled = false;
 };

--- a/src/webview/js/generatedEs3.js
+++ b/src/webview/js/generatedEs3.js
@@ -194,12 +194,17 @@ var scrollToPreserve = function scrollToPreserve(msgId, prevBoundTop) {
 
 var appendAuthToImages = function appendAuthToImages(auth) {
   var imageTags = document.getElementsByTagName('img');
-
   Array.from(imageTags).forEach(function (img) {
-    if (img.src.startsWith(auth.realm)) {
-      var delimiter = img.src.includes('?') ? '&' : '?';
-      img.src += delimiter + 'api_key=' + auth.apiKey;
+    if (!img.src.startsWith(auth.realm)) {
+      return;
     }
+
+    var srcPath = img.src.substring(auth.realm.length);
+    if (!(srcPath.startsWith('/user_uploads/') || srcPath.startsWith('/thumbnail?'))) {
+      return;
+    }
+    var delimiter = img.src.includes('?') ? '&' : '?';
+    img.src += delimiter + 'api_key=' + auth.apiKey;
   });
 };
 

--- a/src/webview/js/generatedEs3.js
+++ b/src/webview/js/generatedEs3.js
@@ -192,6 +192,17 @@ var scrollToPreserve = function scrollToPreserve(msgId, prevBoundTop) {
   window.scrollBy(0, newBoundRect.top - prevBoundTop);
 };
 
+var appendAuthToImages = function appendAuthToImages(auth) {
+  var imageTags = document.getElementsByTagName('img');
+
+  Array.from(imageTags).forEach(function (img) {
+    if (img.src.startsWith(auth.realm)) {
+      var delimiter = img.src.includes('?') ? '&' : '?';
+      img.src += delimiter + 'api_key=' + auth.apiKey;
+    }
+  });
+};
+
 var handleMessageContent = function handleMessageContent(msg) {
   var target = void 0;
   if (msg.updateStrategy === 'replace') {

--- a/src/webview/js/generatedEs3.js
+++ b/src/webview/js/generatedEs3.js
@@ -222,6 +222,8 @@ var handleMessageContent = function handleMessageContent(msg) {
 
   documentBody.innerHTML = msg.content;
 
+  appendAuthToImages(msg.auth);
+
   if (target.type === 'bottom') {
     scrollToBottom();
   } else if (target.type === 'anchor') {

--- a/src/webview/js/js.js
+++ b/src/webview/js/js.js
@@ -255,6 +255,8 @@ const handleMessageContent = (msg: MessageInputContent) => {
 
   documentBody.innerHTML = msg.content;
 
+  appendAuthToImages(msg.auth);
+
   if (target.type === 'bottom') {
     scrollToBottom();
   } else if (target.type === 'anchor') {

--- a/src/webview/js/js.js
+++ b/src/webview/js/js.js
@@ -1,4 +1,5 @@
 /* @flow */
+import type { Auth } from '../../types';
 import type {
   WebviewInputMessage,
   MessageInputContent,
@@ -269,8 +270,9 @@ const handleMessageContent = (msg: MessageInputContent) => {
 };
 
 /** We call this when the webview's content first loads. */
-const handleInitialLoad = /* eslint-disable-line */ (anchor: number) => {
+const handleInitialLoad = /* eslint-disable-line */ (anchor: number, auth: Auth) => {
   scrollToAnchor(anchor);
+  appendAuthToImages(auth);
   sendScrollMessageIfListShort();
   scrollEventsDisabled = false;
 };

--- a/src/webview/js/js.js
+++ b/src/webview/js/js.js
@@ -217,6 +217,17 @@ const scrollToPreserve = (msgId: number, prevBoundTop: number) => {
   window.scrollBy(0, newBoundRect.top - prevBoundTop);
 };
 
+const appendAuthToImages = auth => {
+  const imageTags = document.getElementsByTagName('img');
+
+  Array.from(imageTags).forEach(img => {
+    if (img.src.startsWith(auth.realm)) {
+      const delimiter = img.src.includes('?') ? '&' : '?';
+      img.src += `${delimiter}api_key=${auth.apiKey}`;
+    }
+  });
+};
+
 const handleMessageContent = (msg: MessageInputContent) => {
   let target: ScrollTarget;
   if (msg.updateStrategy === 'replace') {

--- a/src/webview/js/js.js
+++ b/src/webview/js/js.js
@@ -219,12 +219,21 @@ const scrollToPreserve = (msgId: number, prevBoundTop: number) => {
 
 const appendAuthToImages = auth => {
   const imageTags = document.getElementsByTagName('img');
-
   Array.from(imageTags).forEach(img => {
-    if (img.src.startsWith(auth.realm)) {
-      const delimiter = img.src.includes('?') ? '&' : '?';
-      img.src += `${delimiter}api_key=${auth.apiKey}`;
+    if (!img.src.startsWith(auth.realm)) {
+      return;
     }
+
+    // This unusual form of authentication is only accepted by the server
+    // for a small number of routes.  Rather than append the API key to all
+    // kinds of URLs on the server, do so only for those routes.
+    const srcPath = img.src.substring(auth.realm.length);
+    if (!(srcPath.startsWith('/user_uploads/') || srcPath.startsWith('/thumbnail?'))) {
+      return;
+    }
+
+    const delimiter = img.src.includes('?') ? '&' : '?';
+    img.src += `${delimiter}api_key=${auth.apiKey}`;
   });
 };
 

--- a/src/webview/js/script.js
+++ b/src/webview/js/script.js
@@ -1,10 +1,11 @@
 /* @flow */
+import type { Auth } from '../../types';
 import smoothScroll from './smoothScroll.min';
 import matchesPolyfill from './matchesPolyfill';
 import js from './generatedEs3';
 import config from '../../config';
 
-export default (anchor: number): string => `
+export default (anchor: number, auth: Auth): string => `
 <script>
 window.__forceSmoothScrollPolyfill__ = true;
 ${smoothScroll}
@@ -12,7 +13,7 @@ ${matchesPolyfill}
 window.enableWebViewErrorDisplay = ${config.enableWebViewErrorDisplay.toString()};
 document.addEventListener('DOMContentLoaded', function() {
   ${js}
-  handleInitialLoad(${anchor});
+  handleInitialLoad(${anchor}, ${JSON.stringify(auth)});
 });
 </script>
 `;

--- a/src/webview/webViewHandleUpdates.js
+++ b/src/webview/webViewHandleUpdates.js
@@ -1,9 +1,9 @@
 /* @flow */
 import isEqual from 'lodash.isequal';
 
+import type { Auth } from '../types';
 import type { Props } from '../message/MessageList';
 import type { UpdateStrategy } from '../message/messageUpdates';
-import { appendAuthToImages } from '../utils/url';
 import htmlBody from './html/htmlBody';
 import renderMessagesAsHtml from './html/renderMessagesAsHtml';
 import messageTypingAsHtml from './html/messageTypingAsHtml';
@@ -12,6 +12,7 @@ import { getMessageTransitionProps, getMessageUpdateStrategy } from '../message/
 export type MessageInputContent = {
   type: 'content',
   anchor: number,
+  auth: Auth,
   content: string,
   updateStrategy: UpdateStrategy,
 };
@@ -31,17 +32,14 @@ export type MessageInputTyping = {
 export type WebviewInputMessage = MessageInputContent | MessageInputFetching | MessageInputTyping;
 
 const updateContent = (prevProps: Props, nextProps: Props): MessageInputContent => {
-  const { auth } = nextProps;
-  const content = htmlBody(
-    appendAuthToImages(renderMessagesAsHtml(nextProps), auth),
-    nextProps.showMessagePlaceholders,
-  );
+  const content = htmlBody(renderMessagesAsHtml(nextProps), nextProps.showMessagePlaceholders);
   const transitionProps = getMessageTransitionProps(prevProps, nextProps);
   const updateStrategy = getMessageUpdateStrategy(transitionProps);
 
   return {
     type: 'content',
     anchor: nextProps.anchor,
+    auth: nextProps.auth,
     content,
     updateStrategy,
   };

--- a/src/webview/webViewHandleUpdates.js
+++ b/src/webview/webViewHandleUpdates.js
@@ -3,6 +3,7 @@ import isEqual from 'lodash.isequal';
 
 import type { Props } from '../message/MessageList';
 import type { UpdateStrategy } from '../message/messageUpdates';
+import { appendAuthToImages } from '../utils/url';
 import htmlBody from './html/htmlBody';
 import renderMessagesAsHtml from './html/renderMessagesAsHtml';
 import messageTypingAsHtml from './html/messageTypingAsHtml';
@@ -30,7 +31,11 @@ export type MessageInputTyping = {
 export type WebviewInputMessage = MessageInputContent | MessageInputFetching | MessageInputTyping;
 
 const updateContent = (prevProps: Props, nextProps: Props): MessageInputContent => {
-  const content = htmlBody(renderMessagesAsHtml(nextProps), nextProps.showMessagePlaceholders);
+  const { auth } = nextProps;
+  const content = htmlBody(
+    appendAuthToImages(renderMessagesAsHtml(nextProps), auth),
+    nextProps.showMessagePlaceholders,
+  );
   const transitionProps = getMessageTransitionProps(prevProps, nextProps);
   const updateStrategy = getMessageUpdateStrategy(transitionProps);
 


### PR DESCRIPTION
Implements #2876

Our current code works fine with the images in messages used before.
It doesn't work with the new, upcoming thumbnails. The reason is that our `appendAuthToImages` function is too rigid and does not recognize the new `img` tags (which have some extra `data` attributes and the URL is a bit different)

Instead of trying to parse arbitrary HTML or trying to limit what HTML the server renders, we can do the smart thing. This PR moves the functionality inside the WebView. It has quite an unfair advantage - a full-blown browser that perfectly recognizes HTML.