### PR TITLE
Support new stream format for internal links

### DIFF
--- a/src/utils/__tests__/url-test.js
+++ b/src/utils/__tests__/url-test.js
@@ -163,32 +163,14 @@ describe('isGroupLink', () => {
 });
 
 describe('isSpecialLink', () => {
-  test('only in-app link containing "is" is a special link', () => {
-    expect(
-      isSpecialLink('https://example.com/#narrow/stream/jest/topic/test', 'https://example.com'),
-    ).toBe(false);
-
-    expect(isSpecialLink('https://example.com/#narrow/is/private', 'https://example.com')).toBe(
-      true,
-    );
-
-    expect(isSpecialLink('https://example.com/#narrow/is/starred', 'https://example.com')).toBe(
-      true,
-    );
-
-    expect(isSpecialLink('https://example.com/#narrow/is/mentioned', 'https://example.com')).toBe(
-      true,
-    );
-
-    expect(isSpecialLink('https://example.com/#narrow/is/men', 'https://example.com')).toBe(false);
-
-    expect(isSpecialLink('https://example.com/#narrow/is/men/stream', 'https://example.com')).toBe(
-      false,
-    );
-
-    expect(isSpecialLink('https://example.com/#narrow/are/men/stream', 'https://example.com')).toBe(
-      false,
-    );
+  test('only paths containing "is" is a special link', () => {
+    expect(isSpecialLink(['stream', 'jest', 'topic', 'test'])).toBe(false);
+    expect(isSpecialLink(['is', 'private'])).toBe(true);
+    expect(isSpecialLink(['is', 'starred'])).toBe(true);
+    expect(isSpecialLink(['is', 'mentioned'])).toBe(true);
+    expect(isSpecialLink(['is', 'men'])).toBe(false);
+    expect(isSpecialLink(['is', 'men', 'stream'])).toBe(false);
+    expect(isSpecialLink(['are', 'men', 'stream'])).toBe(false);
   });
 });
 

--- a/src/utils/__tests__/url-test.js
+++ b/src/utils/__tests__/url-test.js
@@ -142,57 +142,20 @@ describe('isStreamLink', () => {
 });
 
 describe('isTopicLink', () => {
-  test('when a url is not a topic narrow return false', () => {
-    expect(
-      isTopicLink('https://example.com/#narrow/pm-with/1,2-group', 'https://example.com'),
-    ).toBe(false);
-    expect(isTopicLink('https://example.com/#narrow/stream/jest', 'https://example.com')).toBe(
-      false,
-    );
-
-    expect(
-      isTopicLink(
-        'https://example.com/#narrow/stream/stream/topic/topic/near/',
-        'https://example.com',
-      ),
-    ).toBe(false);
-
-    expect(isTopicLink('https://example.com/#narrow/stream/topic/', 'https://example.com')).toBe(
-      false,
-    );
+  test('when the path is not a topic narrow return false', () => {
+    expect(isTopicLink(['pm-with', '1,2-group'])).toBe(false);
+    expect(isTopicLink(['stream', '243-mobile-team'])).toBe(false);
+    expect(isTopicLink(['stream', 'stream', 'topic', 'topic', 'near'])).toBe(false);
+    expect(isTopicLink(['stream', 'topic'])).toBe(false);
   });
 
-  test('when a url is a topic narrow return true', () => {
-    expect(
-      isTopicLink('https://example.com/#narrow/stream/jest/topic/test', 'https://example.com'),
-    ).toBe(true);
-
-    expect(
-      isTopicLink(
-        'https://example.com/#narrow/stream/mobile/subject/topic/near/378333',
-        'https://example.com',
-      ),
-    ).toBe(true);
-
-    expect(
-      isTopicLink('https://example.com/#narrow/stream/mobile/topic/topic/', 'https://example.com'),
-    ).toBe(true);
-
-    expect(
-      isTopicLink(
-        'https://example.com/#narrow/stream/stream/topic/topic/near/1',
-        'https://example.com',
-      ),
-    ).toBe(true);
-
-    expect(
-      isTopicLink(
-        'https://example.com/#narrow/stream/stream/subject/topic/near/1',
-        'https://example.com',
-      ),
-    ).toBe(true);
-
-    expect(isTopicLink('/#narrow/stream/stream/subject/topic', 'https://example.com')).toBe(true);
+  test('when the path is a topic narrow return true', () => {
+    expect(isTopicLink(['stream', 'jest', 'topic', 'test'])).toBe(true);
+    expect(isTopicLink(['stream', 'test', 'subject', 'topic', 'near', '378333'])).toBe(true);
+    expect(isTopicLink(['stream', 'test', 'topic', 'topic'])).toBe(true);
+    expect(isTopicLink(['stream', 'stream', 'topic', 'topic', 'near', '1'])).toBe(true);
+    expect(isTopicLink(['stream', 'stream', 'subject', 'topic', 'near', '1'])).toBe(true);
+    expect(isTopicLink(['stream', 'stream', 'subject', 'topic'])).toBe(true);
   });
 });
 

--- a/src/utils/__tests__/url-test.js
+++ b/src/utils/__tests__/url-test.js
@@ -197,22 +197,11 @@ describe('isTopicLink', () => {
 });
 
 describe('isGroupLink', () => {
-  test('only in-app link containing "pm-with" is a group link', () => {
-    expect(
-      isGroupLink('https://example.com/#narrow/stream/jest/topic/test', 'https://example.com'),
-    ).toBe(false);
-    expect(
-      isGroupLink('https://example.com/#narrow/pm-with/1,2-group', 'https://example.com'),
-    ).toBe(true);
-    expect(
-      isGroupLink('https://example.com/#narrow/pm-with/1,2-group/near/1', 'https://example.com'),
-    ).toBe(true);
-    expect(
-      isGroupLink(
-        'https://example.com/#narrow/pm-with/a.40b.2Ecom.c.d.2Ecom/near/3',
-        'https://example.com',
-      ),
-    ).toBe(true);
+  test('only paths containing "pm-with" is a group link', () => {
+    expect(isGroupLink(['stream', 'test'])).toBe(false);
+    expect(isGroupLink(['pm-with', '1,2-group'])).toBe(true);
+    expect(isGroupLink(['pm-with', '1,2-group', 'near', '1'])).toBe(true);
+    expect(isGroupLink(['pm-with', 'a.40b.2Ecom.c.d.2Ecom', 'near', '3'])).toBe(true);
   });
 });
 

--- a/src/utils/__tests__/url-test.js
+++ b/src/utils/__tests__/url-test.js
@@ -128,16 +128,10 @@ describe('isMessageLink', () => {
 });
 
 describe('isStreamLink', () => {
-  test('only in-app link containing "stream" is a stream link', () => {
-    expect(
-      isStreamLink('https://example.com/#narrow/pm-with/1,2-group', 'https://example.com'),
-    ).toBe(false);
-    expect(isStreamLink('https://example.com/#narrow/stream/jest', 'https://example.com')).toBe(
-      true,
-    );
-    expect(isStreamLink('https://example.com/#narrow/stream/stream/', 'https://example.com')).toBe(
-      true,
-    );
+  test('only paths containing "stream" is a stream link', () => {
+    expect(isStreamLink(['pm-with', '1,2-group'])).toBe(false);
+    expect(isStreamLink(['stream', 'test'])).toBe(true);
+    expect(isStreamLink(['stream', 'stream'])).toBe(true);
   });
 });
 

--- a/src/utils/url.js
+++ b/src/utils/url.js
@@ -54,15 +54,8 @@ export const isGroupLink = (paths: string[]): boolean =>
 export const isStreamLink = (paths: string[]): boolean =>
   paths.length === 2 && paths[0] === 'stream';
 
-export const isSpecialLink = (url: string, realm: string): boolean => {
-  const paths = getPathsFromUrl(url, realm);
-  return (
-    isUrlInAppLink(url, realm)
-    && paths.length === 2
-    && paths[0] === 'is'
-    && /^(private|starred|mentioned)/i.test(paths[1])
-  );
-};
+export const isSpecialLink = (paths: string[]): boolean =>
+  paths.length === 2 && paths[0] === 'is' && /^(private|starred|mentioned)/i.test(paths[1]);
 
 export const isEmojiUrl = (url: string, realm: string): boolean =>
   isUrlOnRealm(url, realm) && url.includes('/static/generated/emoji/images/emoji/unicode/');

--- a/src/utils/url.js
+++ b/src/utils/url.js
@@ -52,14 +52,9 @@ export const isTopicLink = (url: string, realm: string): boolean => {
   );
 };
 
-export const isGroupLink = (url: string, realm: string): boolean => {
-  const paths = getPathsFromUrl(url, realm);
-  return (
-    isUrlInAppLink(url, realm)
-    && ((paths.length === 2 && paths[0] === 'pm-with')
-      || (paths.length === 4 && paths[0] === 'pm-with' && paths[2] === 'near'))
-  );
-};
+export const isGroupLink = (paths: string[]): boolean =>
+  (paths.length === 2 && paths[0] === 'pm-with')
+  || (paths.length === 4 && paths[0] === 'pm-with' && paths[2] === 'near');
 
 export const isStreamLink = (url: string, realm: string): boolean => {
   const paths = getPathsFromUrl(url, realm);

--- a/src/utils/url.js
+++ b/src/utils/url.js
@@ -83,8 +83,10 @@ export const getEmojiUrl = (unicode: string): string =>
   `/static/generated/emoji/images/emoji/unicode/${unicode}.png`;
 
 export const getNarrowFromLink = (url: string, realm: string, users: User[]): Narrow => {
+  if (isUrlInAppLink(url, realm)) {
+    return HOME_NARROW;
+  }
   const paths = getPathsFromUrl(url, realm);
-
   if (isGroupLink(url, realm)) {
     const recipients = paths[1].split('-')[0].split(',');
     return groupNarrow(
@@ -100,8 +102,6 @@ export const getNarrowFromLink = (url: string, realm: string, users: User[]): Na
   } else if (isSpecialLink(url, realm)) {
     return specialNarrow(paths[1]);
   }
-
-  return HOME_NARROW;
 };
 
 export const getMessageIdFromLink = (url: string, realm: string): number => {

--- a/src/utils/url.js
+++ b/src/utils/url.js
@@ -51,10 +51,8 @@ export const isGroupLink = (paths: string[]): boolean =>
   (paths.length === 2 && paths[0] === 'pm-with')
   || (paths.length === 4 && paths[0] === 'pm-with' && paths[2] === 'near');
 
-export const isStreamLink = (url: string, realm: string): boolean => {
-  const paths = getPathsFromUrl(url, realm);
-  return isUrlInAppLink(url, realm) && paths.length === 2 && paths[0] === 'stream';
-};
+export const isStreamLink = (paths: string[]): boolean =>
+  paths.length === 2 && paths[0] === 'stream';
 
 export const isSpecialLink = (url: string, realm: string): boolean => {
   const paths = getPathsFromUrl(url, realm);

--- a/src/utils/url.js
+++ b/src/utils/url.js
@@ -42,15 +42,10 @@ export const isUrlInAppLink = (url: string, realm: string): boolean =>
 export const isMessageLink = (url: string, realm: string): boolean =>
   isUrlInAppLink(url, realm) && url.includes('near');
 
-export const isTopicLink = (url: string, realm: string): boolean => {
-  const paths = getPathsFromUrl(url, realm);
-  return (
-    isUrlInAppLink(url, realm)
-    && ((paths.length === 4 || paths.length === 6)
-      && paths[0] === 'stream'
-      && (paths[2] === 'subject' || paths[2] === 'topic'))
-  );
-};
+export const isTopicLink = (paths: string[]): boolean =>
+  (paths.length === 4 || paths.length === 6)
+  && paths[0] === 'stream'
+  && (paths[2] === 'subject' || paths[2] === 'topic');
 
 export const isGroupLink = (paths: string[]): boolean =>
   (paths.length === 2 && paths[0] === 'pm-with')

--- a/src/utils/url.js
+++ b/src/utils/url.js
@@ -63,6 +63,13 @@ export const isEmojiUrl = (url: string, realm: string): boolean =>
 export const getEmojiUrl = (unicode: string): string =>
   `/static/generated/emoji/images/emoji/unicode/${unicode}.png`;
 
+export const getStreamNameFromSlug = (slug: string): string => {
+  if (!isNaN(slug.split('-')[0])) {
+    return slug.substring(slug.indexOf('-') + 1);
+  }
+  return slug;
+};
+
 export const getNarrowFromLink = (url: string, realm: string, users: User[]): Narrow => {
   if (isUrlInAppLink(url, realm)) {
     return HOME_NARROW;


### PR DESCRIPTION
The first five commits reworks `isGroupLink`  and similar functions to avoid repetition of `isUrlInAppLink` and `getPathsFromUrl`.

The sixth commit introduces a function called `getStreamNameFromSlug` that removes the stream ID in the case of the new format and returns the stream name, or returns the stream name in the case of the old format.

This covers the case where, let's say a user has a stream named `test` with ID 7 and a stream named `7-test` with ID 8.
If the links are given in the new format, `7-test` will navigate to stream named `test` with ID 7 and `8-7-test` will navigate to stream `7-test` with ID 8, as expected.
If the link to stream `7-test` is given in the old format, it will navigate to stream `test` with ID 7 as the new format is prioritised.

A drawback I see with my own approach here is that the stream matching is still done by stream name and not stream ID. Matching by ID can be introduced by some changes in `isNarrowValid` or in a similar place.

TODO: Add tests for `getStreamNameFromSlug`.

Fixes #2760 