### PR TITLE
Do not include empty values in API calls

### DIFF
--- a/src/api/apiFetch.js
+++ b/src/api/apiFetch.js
@@ -54,6 +54,8 @@ export const apiCall = async (
     if (response.ok && json !== undefined) {
       return resFunc(json);
     }
+    // eslint-disable-next-line no-console
+    console.error({ route, params, response });
     throw makeApiError(response.status, json);
   } finally {
     networkActivityStop(isSilent);

--- a/src/api/apiFetch.js
+++ b/src/api/apiFetch.js
@@ -1,6 +1,6 @@
 /* @flow */
 import type { Auth, ResponseExtractionFunc } from '../types';
-import { getAuthHeader, encodeAsURI, isValidUrl } from '../utils/url';
+import { getAuthHeader, encodeAsUriNoEmptyValues, isValidUrl } from '../utils/url';
 import userAgent from '../utils/userAgent';
 import { networkActivityStart, networkActivityStop } from '../utils/networkActivity';
 
@@ -71,7 +71,7 @@ export const apiGet = async (
 ) =>
   apiCall(
     auth,
-    `${route}?${encodeAsURI(params)}`,
+    `${route}?${encodeAsUriNoEmptyValues(params)}`,
     {
       method: 'get',
     },
@@ -90,7 +90,7 @@ export const apiPost = async (
     route,
     {
       method: 'post',
-      body: encodeAsURI(params),
+      body: encodeAsUriNoEmptyValues(params),
     },
     resFunc,
   );
@@ -122,7 +122,7 @@ export const apiPut = async (
     route,
     {
       method: 'put',
-      body: encodeAsURI(params),
+      body: encodeAsUriNoEmptyValues(params),
     },
     resFunc,
   );
@@ -138,7 +138,7 @@ export const apiDelete = async (
     route,
     {
       method: 'delete',
-      body: encodeAsURI(params),
+      body: encodeAsUriNoEmptyValues(params),
     },
     resFunc,
   );
@@ -154,7 +154,7 @@ export const apiPatch = async (
     route,
     {
       method: 'patch',
-      body: encodeAsURI(params),
+      body: encodeAsUriNoEmptyValues(params),
     },
     resFunc,
   );
@@ -167,7 +167,7 @@ export const apiHead = async (
 ) =>
   apiCall(
     auth,
-    `${route}?${encodeAsURI(params)}`,
+    `${route}?${encodeAsUriNoEmptyValues(params)}`,
     {
       method: 'head',
     },

--- a/src/api/messages/updateMessage.js
+++ b/src/api/messages/updateMessage.js
@@ -1,7 +1,6 @@
 /* @flow */
 import type { ApiResponse, Auth } from '../../types';
 import { apiPatch } from '../apiFetch';
-import { removeEmptyValues } from '../../utils/misc';
 
 export default async (auth: Auth, content: Object, id: number): Promise<ApiResponse> =>
-  apiPatch(auth, `messages/${id}`, res => res, removeEmptyValues(content));
+  apiPatch(auth, `messages/${id}`, res => res, content);

--- a/src/utils/url.js
+++ b/src/utils/url.js
@@ -4,6 +4,7 @@ import urlRegex from 'url-regex';
 
 import type { Auth, Narrow, User } from '../types';
 import { HOME_NARROW, topicNarrow, streamNarrow, groupNarrow, specialNarrow } from './narrow';
+import { removeEmptyValues } from './misc';
 import { getUserById } from '../users/userHelpers';
 import { transformToEncodedURI } from './string';
 
@@ -29,6 +30,9 @@ export const encodeAsURI = (params: { [key: string]: any }): string =>
   Object.keys(params)
     .map((key: string) => `${encodeURIComponent(key)}=${encodeURIComponent(params[key])}`)
     .join('&');
+
+export const encodeAsUriNoEmptyValues = (params: { [key: string]: any }): string =>
+  encodeAsURI(removeEmptyValues(params));
 
 export const getFullUrl = (url: string = '', realm: string): string =>
   !url.startsWith('http') ? `${realm}${url.startsWith('/') ? '' : '/'}${url}` : url;


### PR DESCRIPTION
Introduces a new function `encodeAsUriNoEmptyValues` and replaces the `encodeAsURI` used previously.

Now we do not pass empty values to the back-end API.

Also, fixes #2889