### PR TITLE
android notification: Use different icon for debug build.

### DIFF
--- a/android/app/src/main/java/com/zulipmobile/notifications/GCMPushNotifications.java
+++ b/android/app/src/main/java/com/zulipmobile/notifications/GCMPushNotifications.java
@@ -18,6 +18,7 @@ import com.wix.reactnativenotifications.core.InitialNotificationHolder;
 import com.wix.reactnativenotifications.core.JsIOHelper;
 import com.wix.reactnativenotifications.core.ProxyService;
 import com.wix.reactnativenotifications.core.notification.PushNotification;
+import com.zulipmobile.BuildConfig;
 import com.zulipmobile.R;
 
 import java.io.IOException;
@@ -112,7 +113,11 @@ public class GCMPushNotifications extends PushNotification {
         String baseURL = getProps().getBaseURL();
         int totalMessagesCount = extractTotalMessagesCount(conversations);
 
-        builder.setSmallIcon(R.drawable.zulip_notification);
+        if (BuildConfig.DEBUG) {
+            builder.setSmallIcon(R.mipmap.ic_launcher);
+        } else {
+            builder.setSmallIcon(R.drawable.zulip_notification);
+        }
         builder.setAutoCancel(true);
         builder.setContentText(content);
 


### PR DESCRIPTION
Before both debug and release build were having same icon and both
build can coexist at the same time in the phone. So it was hard to
figure out from which build notification is generated.

For now reusing the laucher icon of debug build as notification icon
of debug build. As this icon is not as per notification icon pattern,
it looks quite odd. But it saves extra overhead of new icon. Only
contributors will be having debug build, so this can be compromissed.

Also next we should try not to include debug launcher icon in release
APK.

Fix: #2863