### PR TITLE
webview: Make WebView friendly error red

### DIFF
--- a/src/webview/css/css.js
+++ b/src/webview/css/css.js
@@ -404,7 +404,7 @@ blockquote {
 #js-error-plain, #js-error-plain-dummy {
   z-index: 1000;
   width: 100%;
-  background: #555;
+  background: red;
   color: white;
   font-size: 15px;
   padding: 4px;


### PR DESCRIPTION
Currently the 'friendly error' we show in production can easily
be mistaken for a normal header because of its background color.

Make the background red instead.

| Before | After |
| ---| --- |
| ![simulator screen shot - iphone 8 plus - 2018-08-19 at 21 52 03](https://user-images.githubusercontent.com/867242/44312573-49835100-a403-11e8-990f-bb1ab360e481.png) | ![simulator screen shot - iphone 8 plus - 2018-08-19 at 22 42 58](https://user-images.githubusercontent.com/867242/44312578-556f1300-a403-11e8-9426-2358381ceda8.png) |