### PR TITLE
webview: Do not use Array.from in WebView

### DIFF
--- a/src/webview/js/generatedEs3.js
+++ b/src/webview/js/generatedEs3.js
@@ -9,6 +9,10 @@ export default `
 'use strict';
 
 
+var arrayFrom = function arrayFrom(arrayLike) {
+  return Array.prototype.slice.call(arrayLike);
+};
+
 var documentBody = document.body;
 if (!documentBody) {
   throw new Error('No document.body element!');
@@ -185,7 +189,7 @@ var scrollToPreserve = function scrollToPreserve(msgId, prevBoundTop) {
 
 var appendAuthToImages = function appendAuthToImages(auth) {
   var imageTags = document.getElementsByTagName('img');
-  Array.from(imageTags).forEach(function (img) {
+  arrayFrom(imageTags).forEach(function (img) {
     if (!img.src.startsWith(auth.realm)) {
       return;
     }

--- a/src/webview/js/js.js
+++ b/src/webview/js/js.js
@@ -7,6 +7,10 @@ import type {
   MessageInputTyping,
 } from '../webViewHandleUpdates';
 
+// Converts an array-like object to an actual array
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/slice#Array-like_objects
+const arrayFrom = arrayLike => Array.prototype.slice.call(arrayLike);
+
 // We pull out document.body in one place, and check it's not null, in order
 // to provide that assertion to the type-checker.
 const documentBody = document.body;
@@ -241,7 +245,7 @@ const scrollToPreserve = (msgId: number, prevBoundTop: number) => {
 
 const appendAuthToImages = auth => {
   const imageTags = document.getElementsByTagName('img');
-  Array.from(imageTags).forEach(img => {
+  arrayFrom(imageTags).forEach(img => {
     if (!img.src.startsWith(auth.realm)) {
       return;
     }

--- a/src/webview/js/js.js
+++ b/src/webview/js/js.js
@@ -7,7 +7,12 @@ import type {
   MessageInputTyping,
 } from '../webViewHandleUpdates';
 
-// Converts an array-like object to an actual array
+/**
+ * Convert an array-like object to an actual array.
+ *
+ * A substitute for `Array.from`, which doesn't exist in the WebViews of some
+ * of our supported platforms.
+ */
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/slice#Array-like_objects
 const arrayFrom = arrayLike => Array.prototype.slice.call(arrayLike);
 


### PR DESCRIPTION
Fixes #2905

`Array.from` is not available on all platform's WebViews we support.
One way to do this is to include a polyfill like this one:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/from#Polyfill

Instead we'll use a simlper and sufficient approach - using `Array`'s `slice`
method called on the imageTags array-like object.