### PR TITLE
action-sheet: Update `react-native-action-sheet` to `^1.1.0`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "update-snapshots": "yarn run test:unit -- -u"
   },
   "dependencies": {
-    "@expo/react-native-action-sheet": "1.0.2",
+    "@expo/react-native-action-sheet": "^1.1.0",
     "@remobile/react-native-toast": "^1.0.7",
     "base-64": "^0.1.0",
     "blueimp-md5": "^2.10.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -454,9 +454,9 @@
     lodash "^4.2.0"
     to-fast-properties "^2.0.0"
 
-"@expo/react-native-action-sheet@1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@expo/react-native-action-sheet/-/react-native-action-sheet-1.0.2.tgz#abdfb21cbefec6147c6ee8b8fb725287cbd2e696"
+"@expo/react-native-action-sheet@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@expo/react-native-action-sheet/-/react-native-action-sheet-1.1.0.tgz#637583fd6367fb8261cda2510260678c3784ed5d"
   dependencies:
     hoist-non-react-statics "^2.2.2"
     prop-types "^15.5.10"


### PR DESCRIPTION
This fixes the long pending issue of text in options being cut on One
Plus and Oppo phones.

Fix: #2365

Before
![5720633322116342657](https://user-images.githubusercontent.com/18511177/44464900-9f413e80-a639-11e8-9ee1-cc58b5e1623b.jpg)

After
![945001061173431406](https://user-images.githubusercontent.com/18511177/44464899-9ea8a800-a639-11e8-88e0-37f7deafb2ea.jpg)
