### PR TITLE
Add documentation on debugging WebView issues

### DIFF
--- a/docs/howto/debugging.md
+++ b/docs/howto/debugging.md
@@ -87,10 +87,6 @@ come through.  To quit, hit Ctrl-C.
 
 ### Debugging message rendering
 
-For debugging some issues, it helps to view in a browser the HTML and CSS we
-generate for the WebView.  See `MessageListWeb#render` for instructions, with a
-`console.log(html)` call you can uncomment.
-
 
 ## Troubleshooting
 

--- a/docs/howto/debugging.md
+++ b/docs/howto/debugging.md
@@ -85,7 +85,37 @@ happened), and then it keeps running, printing any new log messages that
 come through.  To quit, hit Ctrl-C.
 
 
-### Debugging message rendering
+## Debugging message rendering and interactions
+
+We render the message list using a native WebView component. Anything
+related to the rendering of messages, the behavior of the message list, or
+bugs inside it, you can debug with familiar tools.
+
+Debugging is available both for Android and iOS, and on an emulator or
+a physical device via a browser's developer tools.
+
+### Debug WebView on iOS
+
+1. Enable debugging on the device
+
+To debug on your physical iOS device, go to `Settings > Safari > Advanced`
+and make sure `Web Inspector` is on.
+
+For iOS Simulator you can skip this step, as it is already enabled.
+
+2. Connect to the device
+
+* Run Safari (even if your browser of choice is something else).
+* If you have not done so already, enable the developer tools by going to
+ Safari’s menu, `Preferences > Advanced`, check the `Show Develop menu in the menu bar` checkbox.
+* In the app you are debugging, make sure you have navigated to a screen that
+ is showing a message list
+* In the `Develop` menu, find your device and select it.
+
+3. Debug
+
+You now have access to the rich developer tools you might be familiar with.
+You can inspect HTML elements, CSS styles and examine console.log output.
 
 
 ## Troubleshooting

--- a/docs/howto/debugging.md
+++ b/docs/howto/debugging.md
@@ -65,6 +65,22 @@ call to `createLogger` in `src/boot/middleware.js`.
   doc](https://github.com/evgenyrodionov/redux-logger#options).
 
 
+### Reactotron
+
+We have integrated [Reactotron](https://github.com/infinitered/reactotron) with the project.
+
+It can be used instead of together with the 'Chrome Developer Tools'.
+Some areas in which Reactotron is better are:
+
+* track Async Storage updates
+* show API requests & responses
+* subscribe to parts of your application state
+* dispatch custom Redux actions
+
+Note: Make sure to enable the "Debug JS Remotely" option from inside of your app.
+
+Refer to the [docs](https://github.com/infinitered/reactotron/blob/master/readme.md) for further details.
+
 ### `adb logcat`
 
 When running on Android, either in the emulator or on a physical device, you

--- a/docs/howto/debugging.md
+++ b/docs/howto/debugging.md
@@ -117,6 +117,27 @@ For iOS Simulator you can skip this step, as it is already enabled.
 You now have access to the rich developer tools you might be familiar with.
 You can inspect HTML elements, CSS styles and examine console.log output.
 
+### Debug WebView on Android
+
+1. Enable debugging on the device
+
+To debug on your physical Android device, go to `Settings > About phone`.
+Next, tap the `Build number` panel seven times. You will get a notice that
+now you are a developer. Go back to the main Settings screen. Go to the new 
+`Developer` options menu and enable the `USB debugging` checkbox.
+
+For Android Emulator you can skip this step, as it is already enabled.
+
+2. Connect to the device
+
+* Run Chrome.
+* Navigate to `about:inspect`.
+* Check the `Discover USB devices` and the app will appear.
+
+3. Debug
+
+You now have access to the rich developer tools you might be familiar with.
+You can inspect HTML elements, CSS styles and examine console.log output.
 
 ## Troubleshooting
 

--- a/src/webview/MessageListWeb.js
+++ b/src/webview/MessageListWeb.js
@@ -84,10 +84,6 @@ export default class MessageListWeb extends Component<Props> {
       showMessagePlaceholders,
     });
 
-    // For debugging issues in our HTML and CSS: Uncomment this line,
-    // copy-paste the output to a file, and open in a browser.
-    // console.log(html);
-
     return (
       <WebView
         source={{


### PR DESCRIPTION
Removes the old naive instructions on debugging WebView in favor of in-depth instructions that allow debugging with the browser's dev tools.