### PR TITLE
Continue to improve starred messages.

### DIFF
--- a/src/api/apiTypes.js
+++ b/src/api/apiTypes.js
@@ -74,6 +74,13 @@ export type Message = {
   /** Obsolete? Gone in server commit 1.6.0~1758 . */
   sender_domain: string,
 
+  /**
+   * This is (always?) present in a `message` event; but we leave it out of
+   * the `messages` subtree of the Redux state, moving the information to
+   * the separate `flags` subtree.
+   */
+  flags?: string[],
+
   /** The rest are believed to really appear in `message` events. */
   avatar_url: ?string,
   client: string,
@@ -81,7 +88,6 @@ export type Message = {
   content_type: 'text/html' | 'text/markdown',
   display_recipient: $FlowFixMe, // `string` for type stream, else PmRecipientUser[].
   edit_history: MessageEdit[],
-  flags: string[],
   gravatar_hash: string,
   id: number,
   is_me_message: boolean,

--- a/src/caughtup/caughtUpReducers.js
+++ b/src/caughtup/caughtUpReducers.js
@@ -31,7 +31,7 @@ const messageFetchComplete = (
   let anchorIdx = -1;
 
   if (action.anchor === FIRST_UNREAD_ANCHOR) {
-    anchorIdx = action.messages.findIndex(msg => msg.flags.indexOf('read') === -1);
+    anchorIdx = action.messages.findIndex(msg => msg.flags && msg.flags.indexOf('read') === -1);
   } else {
     anchorIdx = action.messages.findIndex(msg => msg.id === action.anchor);
   }

--- a/src/chat/flagsReducers.js
+++ b/src/chat/flagsReducers.js
@@ -36,7 +36,7 @@ const initialState = {
 const addFlagsForMessages = (
   state: FlagsState,
   messages: number[],
-  flags: string[],
+  flags?: string[],
 ): FlagsState => {
   if (!messages || messages.length === 0 || !flags || flags.length === 0) {
     return state;

--- a/src/message/messageReducers.js
+++ b/src/message/messageReducers.js
@@ -33,7 +33,7 @@ const messageFetchComplete = (
   action: MessageFetchCompleteAction,
 ): MessagesState => ({
   ...state,
-  ...groupItemsById(action.messages),
+  ...groupItemsById(action.messages.map(message => omit(message, 'flags'))),
 });
 
 const eventReactionAdd = (state: MessagesState, action: EventReactionAddAction): MessagesState => {
@@ -80,7 +80,7 @@ const eventNewMessage = (state: MessagesState, action: EventNewMessageAction): M
   }
   return {
     ...state,
-    [action.message.id]: action.message,
+    [action.message.id]: omit(action.message, 'flags'),
   };
 };
 

--- a/src/webview/webViewHandleUpdates.js
+++ b/src/webview/webViewHandleUpdates.js
@@ -59,7 +59,16 @@ const updateTyping = (prevProps: Props, nextProps: Props): MessageInputTyping =>
 });
 
 export const getInputMessages = (prevProps: Props, nextProps: Props): WebviewInputMessage[] => {
-  if (prevProps.renderedMessages !== nextProps.renderedMessages) {
+  const allFlagKeys = Array.from(
+    new Set([...Object.keys(prevProps.flags || {}), ...Object.keys(nextProps.flags || {})]),
+  );
+
+  if (
+    prevProps.renderedMessages !== nextProps.renderedMessages
+    || allFlagKeys
+      .filter(key => key !== 'read')
+      .some(key => prevProps.flags[key] !== nextProps.flags[key])
+  ) {
     return [updateContent(prevProps, nextProps)];
   }
 


### PR DESCRIPTION
This continues, and implements the [design discussed](https://github.com/zulip/zulip-mobile/pull/2843#issuecomment-409558352), in #2843.

Merging the first two commits of this pull request will resolve #2676:

Before:

![m2676-take2-before](https://user-images.githubusercontent.com/12771126/44697930-d72df480-aa32-11e8-9375-910954cee4cd.gif)

After:

![m2676-take2-after](https://user-images.githubusercontent.com/12771126/44697963-ed3bb500-aa32-11e8-96c0-b090572647f7.gif)

To remove the `flags` property from messages in `state.messages`, my plan is to update the `flags` attribute for flow type for `Message` from `string[]` to `string[] | void`, and then figure out any necessary tweaks to processing in `caughtUpReducers`, `flagsReducers`, and `chatReducers`.

@gnprice
