### PR TITLE
Make components extend 'PureComponent'

### DIFF
--- a/src/compose/ComposeMenu.js
+++ b/src/compose/ComposeMenu.js
@@ -1,5 +1,5 @@
 /* @flow */
-import React, { Component } from 'react';
+import React, { PureComponent } from 'react';
 import { View } from 'react-native';
 // $FlowFixMe
 import ImagePicker from 'react-native-image-picker';
@@ -19,7 +19,7 @@ type Props = {
   onExpandContract: () => void,
 };
 
-class ComposeMenu extends Component<Props> {
+class ComposeMenu extends PureComponent<Props> {
   context: Context;
   props: Props;
 

--- a/src/emoji/EmojiPickerScreen.js
+++ b/src/emoji/EmojiPickerScreen.js
@@ -1,7 +1,7 @@
 /* @flow */
 import { connect } from 'react-redux';
 
-import React, { Component } from 'react';
+import React, { PureComponent } from 'react';
 import { FlatList } from 'react-native';
 import type { NavigationScreenProp } from 'react-navigation';
 
@@ -31,7 +31,7 @@ type State = {
   filter: string,
 };
 
-class EmojiPickerScreen extends Component<Props, State> {
+class EmojiPickerScreen extends PureComponent<Props, State> {
   props: Props;
   state: State;
 

--- a/src/emoji/EmojiRow.js
+++ b/src/emoji/EmojiRow.js
@@ -1,5 +1,5 @@
 /* @flow */
-import React, { Component } from 'react';
+import React, { PureComponent } from 'react';
 import { StyleSheet, View } from 'react-native';
 
 import { RawLabel, Touchable } from '../common';
@@ -21,7 +21,7 @@ type Props = {
   onPress: () => void,
 };
 
-export default class EmojiRow extends Component<Props> {
+export default class EmojiRow extends PureComponent<Props> {
   props: Props;
 
   render() {

--- a/src/start/AuthButton.js
+++ b/src/start/AuthButton.js
@@ -1,5 +1,5 @@
 /* @flow */
-import React, { Component } from 'react';
+import React, { PureComponent } from 'react';
 
 import type { Context } from '../types';
 import { ZulipButton } from '../common';
@@ -10,7 +10,7 @@ type Props = {
   onPress: () => void,
 };
 
-export default class AuthButton extends Component<Props> {
+export default class AuthButton extends PureComponent<Props> {
   context: Context;
   props: Props;
 


### PR DESCRIPTION
This is for consistency with the rest of the project's components.
They were not set to extend `Component` intentionally but by mistake.

The only remaining and intentional component not extending `PureComponent`
is `MessageListWeb` that implements a custom `shouldComponentUpdate`.