### PR TITLE
Added types MapSateToProps and AnimatedValue

### DIFF
--- a/src/types.js
+++ b/src/types.js
@@ -7,7 +7,7 @@ import type { AppStyles } from './styles/theme';
 
 export type { ChildrenArray } from 'react';
 
-export type AnimatedValue = any; // { AnimatedValue } from 'react-native';
+export type { AnimatedValue } from 'react-native';
 export type { MapStateToProps } from 'react-redux';
 
 export type * from './actionTypes';

--- a/src/types.js
+++ b/src/types.js
@@ -8,7 +8,7 @@ import type { AppStyles } from './styles/theme';
 export type { ChildrenArray } from 'react';
 
 export type AnimatedValue = any; // { AnimatedValue } from 'react-native';
-export type MapStateToProps = any; // { MapStateToProps } from 'react-redux';
+export type { MapStateToProps } from 'react-redux';
 
 export type * from './actionTypes';
 export type * from './api/apiTypes';


### PR DESCRIPTION
With respect to [issue #2052](https://github.com/zulip/zulip-mobile/issues/2052), types.js contained two type definition as `any` with a more detailed comment next to it. The types were replaced with their static types and were tested with Flow which indicated no errors. The code was formatted with `yarn prettier` after going through the [CONTRIBUTING.md](https://github.com/zulip/zulip-mobile/blob/master/CONTRIBUTING.md). 

The two changes were made with separate commits and i had trouble with flow resolving `react-native`. Once everything was good, the second commit was made.

I hope the changes made lives up to the standards of the organization (^_^) 