### PR TITLE
Added type MapStateToProps in types.js

### DIFF
--- a/src/types.js
+++ b/src/types.js
@@ -7,7 +7,7 @@ import type { AppStyles } from './styles/theme';
 
 export type { ChildrenArray } from 'react';
 
-export type AnimatedValue = any; // { AnimatedValue } from 'react-native';
+export type { AnimatedValue } from 'react-native';
 export type { MapStateToProps } from 'react-redux';
 
 export type * from './actionTypes';

--- a/src/types.js
+++ b/src/types.js
@@ -7,7 +7,7 @@ import type { AppStyles } from './styles/theme';
 
 export type { ChildrenArray } from 'react';
 
-export type { AnimatedValue } from 'react-native';
+export type AnimatedValue = any; // { AnimatedValue } from 'react-native';
 export type { MapStateToProps } from 'react-redux';
 
 export type * from './actionTypes';

--- a/src/types.js
+++ b/src/types.js
@@ -8,7 +8,7 @@ import type { AppStyles } from './styles/theme';
 export type { ChildrenArray } from 'react';
 
 export type AnimatedValue = any; // { AnimatedValue } from 'react-native';
-export type MapStateToProps = any; // { MapStateToProps } from 'react-redux';
+export type { MapStateToProps } from 'react-redux';
 
 export type * from './actionTypes';
 export type * from './api/apiTypes';


### PR DESCRIPTION
With respect to issue #2052, types.js contained two type definition as any with a more detailed comment next to it. One of the types were replaced with their static types and were tested with Flow which indicated no errors. The code was formatted with `yarn prettier` after going through the CONTRIBUTING.md.

The Travis CI build failed for AnimatedValue type after 2 minutes. I apologise for overlooking it. The MapState ToProps passed and hence can be added without any problems. Again I would like to apologise for the inconveniences caused with the AnimatedValue type commit.

I hope the changes made lives up to the standards of the organization (^_^)