### PR TITLE
Altering and Adding Flow types in types.js

### DIFF
--- a/src/types.js
+++ b/src/types.js
@@ -638,7 +638,7 @@ export type MatchResult = Array<string> & { index: number, input: string };
 
 export type GetState = () => GlobalState;
 
-export type LocalizableText = string | Object;
+export type LocalizableText = any; // string | { text: string, values: Object };
 
 export type RenderedTimeDescriptor = {
   type: 'time',

--- a/src/types.js
+++ b/src/types.js
@@ -638,7 +638,7 @@ export type MatchResult = Array<string> & { index: number, input: string };
 
 export type GetState = () => GlobalState;
 
-export type LocalizableText = any; // string | { text: string, values: Object };
+export type LocalizableText = string | { text: string, values: Object };
 
 export type RenderedTimeDescriptor = {
   type: 'time',

--- a/src/types.js
+++ b/src/types.js
@@ -414,10 +414,10 @@ export type NavigationState = {
   index: number,
   isTransitioning: boolean,
   key: string,
-  routes: Array<any> /* <{
+  routes: Array<{
     key: string,
     title: string,
-  }>, */,
+  }>,
 };
 
 export type RealmFilter = [string, string, number];

--- a/src/types.js
+++ b/src/types.js
@@ -693,7 +693,7 @@ export type UnreadStream = {
 export type NotificationCommon = {
   alert: string,
   content: string,
-  content_truncated: string, // boolean
+  content_truncated: boolean,
   'google.message_id': string,
   'google.sent_time': number,
   'google.ttl': number,

--- a/src/types.js
+++ b/src/types.js
@@ -415,7 +415,9 @@ export type NavigationState = {
     key: string,
     title: string,
     routeName: string,
-    params: Object,
+    params: {
+      narrow: Narrow,
+    },
   }>,
 };
 

--- a/src/types.js
+++ b/src/types.js
@@ -140,9 +140,6 @@ export type Message = {
   match_content?: string,
   match_subject?: string,
 
-  /** Obsolete? Gone in server commit 1.6.0~1758 . */
-  sender_domain: string,
-
   /** The rest are believed to really appear in `message` events. */
   avatar_url: ?string,
   client: string,

--- a/src/types.js
+++ b/src/types.js
@@ -71,7 +71,7 @@ export type EventReaction = {
   emoji_code: string,
   emoji_name: string,
   reaction_type: string,
-  user: any,
+  user: string,
 };
 
 /** An aggregate of all the reactions with one emoji to one message. */

--- a/src/types.js
+++ b/src/types.js
@@ -417,6 +417,8 @@ export type NavigationState = {
   routes: Array<{
     key: string,
     title: string,
+    routeName: string,
+    params: Object,
   }>,
 };
 

--- a/src/types.js
+++ b/src/types.js
@@ -638,7 +638,7 @@ export type MatchResult = Array<string> & { index: number, input: string };
 
 export type GetState = () => GlobalState;
 
-export type LocalizableText = string | { text: string, values: Object };
+export type LocalizableText = string | Object;
 
 export type RenderedTimeDescriptor = {
   type: 'time',


### PR DESCRIPTION
With reference to issue #2052 ,the following changes were made to types.js
* Flow types were added to `routes` in `NavigationState`
* Flow type of `NotificationCommon.content_truncated` was changed from `string` to `boolean`
* Obsolete code referring to `sender_domain` had been removed.
* Added Flow type to `EventReaction.user`
* Changed Flow type of `params` in `NavigationState`