### PR TITLE
Remove all 'response extraction' code

### DIFF
--- a/src/api/apiFetch.js
+++ b/src/api/apiFetch.js
@@ -7,10 +7,6 @@ import { networkActivityStart, networkActivityStop } from '../utils/networkActiv
 
 const apiVersion = 'api/v1';
 
-type ResponseExtractionFunc = (response: Object) => any;
-
-const defaultResFunc: ResponseExtractionFunc = res => res;
-
 export const getFetchParams = (auth: Auth, params: Object = {}) => {
   const contentType =
     params.body instanceof FormData
@@ -51,7 +47,6 @@ export const apiCall = async (
   auth: Auth,
   route: string,
   params: Object = {},
-  resFunc: ResponseExtractionFunc = defaultResFunc,
   isSilent: boolean = false,
 ) => {
   try {
@@ -59,7 +54,7 @@ export const apiCall = async (
     const response = await apiFetch(auth, route, params);
     const json = await response.json().catch(() => undefined);
     if (response.ok && json !== undefined) {
-      return resFunc(json);
+      return json;
     }
     // eslint-disable-next-line no-console
     console.log({ route, params, httpStatus: response.status, json });
@@ -72,7 +67,6 @@ export const apiCall = async (
 export const apiGet = async (
   auth: Auth,
   route: string,
-  resFunc: ResponseExtractionFunc = defaultResFunc,
   params: UrlParams = {},
   isSilent: boolean = false,
 ) =>
@@ -82,101 +76,40 @@ export const apiGet = async (
     {
       method: 'get',
     },
-    resFunc,
     isSilent,
   );
 
-export const apiPost = async (
-  auth: Auth,
-  route: string,
-  resFunc: ResponseExtractionFunc = defaultResFunc,
-  params: UrlParams = {},
-) =>
-  apiCall(
-    auth,
-    route,
-    {
-      method: 'post',
-      body: encodeParamsForUrl(params),
-    },
-    resFunc,
-  );
+export const apiPost = async (auth: Auth, route: string, params: UrlParams = {}) =>
+  apiCall(auth, route, {
+    method: 'post',
+    body: encodeParamsForUrl(params),
+  });
 
-export const apiFile = async (
-  auth: Auth,
-  route: string,
-  resFunc: ResponseExtractionFunc = defaultResFunc,
-  body: FormData,
-) =>
-  apiCall(
-    auth,
-    route,
-    {
-      method: 'post',
-      body,
-    },
-    resFunc,
-  );
+export const apiFile = async (auth: Auth, route: string, body: FormData) =>
+  apiCall(auth, route, {
+    method: 'post',
+    body,
+  });
 
-export const apiPut = async (
-  auth: Auth,
-  route: string,
-  resFunc: ResponseExtractionFunc = defaultResFunc,
-  params: UrlParams = {},
-) =>
-  apiCall(
-    auth,
-    route,
-    {
-      method: 'put',
-      body: encodeParamsForUrl(params),
-    },
-    resFunc,
-  );
+export const apiPut = async (auth: Auth, route: string, params: UrlParams = {}) =>
+  apiCall(auth, route, {
+    method: 'put',
+    body: encodeParamsForUrl(params),
+  });
 
-export const apiDelete = async (
-  auth: Auth,
-  route: string,
-  resFunc: ResponseExtractionFunc = defaultResFunc,
-  params: UrlParams = {},
-) =>
-  apiCall(
-    auth,
-    route,
-    {
-      method: 'delete',
-      body: encodeParamsForUrl(params),
-    },
-    resFunc,
-  );
+export const apiDelete = async (auth: Auth, route: string, params: UrlParams = {}) =>
+  apiCall(auth, route, {
+    method: 'delete',
+    body: encodeParamsForUrl(params),
+  });
 
-export const apiPatch = async (
-  auth: Auth,
-  route: string,
-  resFunc: ResponseExtractionFunc = defaultResFunc,
-  params: UrlParams = {},
-) =>
-  apiCall(
-    auth,
-    route,
-    {
-      method: 'patch',
-      body: encodeParamsForUrl(params),
-    },
-    resFunc,
-  );
+export const apiPatch = async (auth: Auth, route: string, params: UrlParams = {}) =>
+  apiCall(auth, route, {
+    method: 'patch',
+    body: encodeParamsForUrl(params),
+  });
 
-export const apiHead = async (
-  auth: Auth,
-  route: string,
-  resFunc: ResponseExtractionFunc = defaultResFunc,
-  params: UrlParams = {},
-) =>
-  apiCall(
-    auth,
-    `${route}?${encodeParamsForUrl(params)}`,
-    {
-      method: 'head',
-    },
-    resFunc,
-  );
+export const apiHead = async (auth: Auth, route: string, params: UrlParams = {}) =>
+  apiCall(auth, `${route}?${encodeParamsForUrl(params)}`, {
+    method: 'head',
+  });

--- a/src/api/devFetchApiKey.js
+++ b/src/api/devFetchApiKey.js
@@ -2,5 +2,9 @@
 import type { Auth } from './apiTypes';
 import { apiPost } from './apiFetch';
 
-export default (auth: Auth, email: string) =>
-  apiPost(auth, 'dev_fetch_api_key', res => res.api_key, { username: email });
+type ApiResponseDevFetchApiKey = ApiResponseSuccess & {
+  api_key: string,
+};
+
+export default (auth: Auth, email: string): Promise<ApiResponseDevFetchApiKey> =>
+  apiPost(auth, 'dev_fetch_api_key', { username: email });

--- a/src/api/emoji_reactions/emojiReactionAdd.js
+++ b/src/api/emoji_reactions/emojiReactionAdd.js
@@ -9,7 +9,7 @@ export default (
   emojiCode: string,
   emojiName: string,
 ): Promise<ApiResponse> =>
-  apiPost(auth, `messages/${messageId}/reactions`, res => res, {
+  apiPost(auth, `messages/${messageId}/reactions`, {
     reaction_type: reactionType,
     emoji_code: emojiCode,
     emoji_name: emojiName,

--- a/src/api/emoji_reactions/emojiReactionRemove.js
+++ b/src/api/emoji_reactions/emojiReactionRemove.js
@@ -9,7 +9,7 @@ export default (
   emojiCode: string,
   emojiName: string,
 ): Promise<ApiResponse> =>
-  apiDelete(auth, `messages/${messageId}/reactions`, res => res, {
+  apiDelete(auth, `messages/${messageId}/reactions`, {
     reaction_type: reactionType,
     emoji_code: emojiCode,
     emoji_name: emojiName,

--- a/src/api/fetchApiKey.js
+++ b/src/api/fetchApiKey.js
@@ -8,4 +8,4 @@ type ApiResponseFetchApiKey = ApiResponseSuccess & {
 };
 
 export default (auth: Auth, email: string, password: string): Promise<ApiResponseFetchApiKey> =>
-  apiPost(auth, 'fetch_api_key', res => res, { username: email, password });
+  apiPost(auth, 'fetch_api_key', { username: email, password });

--- a/src/api/mark_as_read/markStreamAsRead.js
+++ b/src/api/mark_as_read/markStreamAsRead.js
@@ -3,6 +3,6 @@ import type { ApiResponse, Auth } from '../apiTypes';
 import { apiPost } from '../apiFetch';
 
 export default async (auth: Auth, streamId: number): Promise<ApiResponse> =>
-  apiPost(auth, 'mark_stream_as_read', res => res, {
+  apiPost(auth, 'mark_stream_as_read', {
     stream_id: streamId,
   });

--- a/src/api/mark_as_read/markTopicAsRead.js
+++ b/src/api/mark_as_read/markTopicAsRead.js
@@ -3,7 +3,7 @@ import type { ApiResponse, Auth } from '../apiTypes';
 import { apiPost } from '../apiFetch';
 
 export default async (auth: Auth, streamId: number, topic: string): Promise<ApiResponse> =>
-  apiPost(auth, 'mark_topic_as_read', res => res, {
+  apiPost(auth, 'mark_topic_as_read', {
     stream_id: streamId,
     topic_name: topic,
   });

--- a/src/api/messages/getMessages.js
+++ b/src/api/messages/getMessages.js
@@ -9,8 +9,9 @@ export default async (
   numBefore: number,
   numAfter: number,
   useFirstUnread: boolean = false,
-): Promise<Message[]> =>
-  apiGet(auth, 'messages', res => res.messages, {
+  applyMarkdown: boolean = true,
+): Promise<ApiResponseMessages> =>
+  apiGet(auth, 'messages', {
     narrow: JSON.stringify(narrow),
     anchor,
     num_before: numBefore,

--- a/src/api/messages/messagesFlags.js
+++ b/src/api/messages/messagesFlags.js
@@ -3,4 +3,4 @@ import type { ApiResponse, Auth } from '../apiTypes';
 import { apiPost } from '../apiFetch';
 
 export default (auth: Auth, messages: number[], op: string, flag: string): Promise<ApiResponse> =>
-  apiPost(auth, 'messages/flags', res => res, { messages: JSON.stringify(messages), flag, op });
+  apiPost(auth, 'messages/flags', { messages: JSON.stringify(messages), flag, op });

--- a/src/api/messages/sendMessage.js
+++ b/src/api/messages/sendMessage.js
@@ -12,7 +12,7 @@ export default async (
   localId: number,
   eventQueueId: number,
 ): Promise<ApiResponse> =>
-  apiPost(auth, 'messages', res => res, {
+  apiPost(auth, 'messages', {
     type,
     to,
     subject,

--- a/src/api/messages/updateMessage.js
+++ b/src/api/messages/updateMessage.js
@@ -3,4 +3,4 @@ import type { ApiResponse, Auth } from '../apiTypes';
 import { apiPatch } from '../apiFetch';
 
 export default async (auth: Auth, content: Object, id: number): Promise<ApiResponse> =>
-  apiPatch(auth, `messages/${id}`, res => res, content);
+  apiPatch(auth, `messages/${id}`, content);

--- a/src/api/notifications/registerPush.android.js
+++ b/src/api/notifications/registerPush.android.js
@@ -3,6 +3,6 @@ import type { Auth } from '../apiTypes';
 import { apiPost } from '../apiFetch';
 
 export default async (auth: Auth, token: string) =>
-  apiPost(auth, 'users/me/android_gcm_reg_id', res => res, {
+  apiPost(auth, 'users/me/android_gcm_reg_id', {
     token,
   });

--- a/src/api/notifications/registerPush.ios.js
+++ b/src/api/notifications/registerPush.ios.js
@@ -3,7 +3,7 @@ import type { Auth } from '../apiTypes';
 import { apiPost } from '../apiFetch';
 
 export default async (auth: Auth, token: string): Object =>
-  apiPost(auth, 'users/me/apns_device_token', res => res, {
+  apiPost(auth, 'users/me/apns_device_token', {
     token,
     appid: 'org.zulip.Zulip',
   });

--- a/src/api/notifications/unregisterPush.android.js
+++ b/src/api/notifications/unregisterPush.android.js
@@ -3,4 +3,4 @@ import type { Auth } from '../apiTypes';
 import { apiDelete } from '../apiFetch';
 
 export default (auth: Auth, token: string) =>
-  apiDelete(auth, 'users/me/android_gcm_reg_id', res => res, { token });
+  apiDelete(auth, 'users/me/android_gcm_reg_id', { token });

--- a/src/api/notifications/unregisterPush.ios.js
+++ b/src/api/notifications/unregisterPush.ios.js
@@ -3,4 +3,4 @@ import type { Auth } from '../apiTypes';
 import { apiDelete } from '../apiFetch';
 
 export default (auth: Auth, token: string) =>
-  apiDelete(auth, 'users/me/apns_device_token', res => res, { token });
+  apiDelete(auth, 'users/me/apns_device_token', { token });

--- a/src/api/reportPresence.js
+++ b/src/api/reportPresence.js
@@ -8,7 +8,7 @@ export default (
   hasFocus: boolean = true,
   newUserInput: boolean = false,
 ): Promise<ApiResponseWithPresence> =>
-  apiPost(auth, 'users/me/presence', res => res, {
+  apiPost(auth, 'users/me/presence', {
     status: hasFocus ? 'active' : 'idle',
     new_user_input: newUserInput,
   });

--- a/src/api/settings/toggleMobilePushSettings.js
+++ b/src/api/settings/toggleMobilePushSettings.js
@@ -23,6 +23,6 @@ export default async ({
   opp: string,
   value: boolean,
 }): Promise<ApiResponse> =>
-  apiPatch(auth, 'settings/notifications', res => res, {
+  apiPatch(auth, 'settings/notifications', {
     ...getRequestBody(opp, value),
   });

--- a/src/api/streams/createStream.js
+++ b/src/api/streams/createStream.js
@@ -10,7 +10,7 @@ export default (
   inviteOnly?: boolean = false,
   announce?: boolean = false,
 ): Promise<ApiResponse> =>
-  apiPost(auth, 'users/me/subscriptions', res => res, {
+  apiPost(auth, 'users/me/subscriptions', {
     subscriptions: JSON.stringify([{ name, description }]),
     principals: JSON.stringify(principals),
     invite_only: inviteOnly,

--- a/src/api/streams/updateStream.js
+++ b/src/api/streams/updateStream.js
@@ -3,6 +3,6 @@ import type { ApiResponse, Auth } from '../apiTypes';
 import { apiPatch } from '../apiFetch';
 
 export default (auth: Auth, id: number, property: string, value: string): Promise<ApiResponse> =>
-  apiPatch(auth, `streams/${id}`, res => res, {
+  apiPatch(auth, `streams/${id}`, {
     [property]: value,
   });

--- a/src/api/subscriptions/muteStream.js
+++ b/src/api/subscriptions/muteStream.js
@@ -3,7 +3,7 @@ import type { ApiResponse, Auth } from '../apiTypes';
 import { apiPost } from '../apiFetch';
 
 export default async (auth: Auth, streamId: number): Promise<ApiResponse> =>
-  apiPost(auth, 'users/me/subscriptions/properties', res => res, {
+  apiPost(auth, 'users/me/subscriptions/properties', {
     subscription_data: JSON.stringify([
       {
         property: 'in_home_view',

--- a/src/api/subscriptions/muteTopic.js
+++ b/src/api/subscriptions/muteTopic.js
@@ -3,7 +3,7 @@ import type { ApiResponse, Auth } from '../apiTypes';
 import { apiPatch } from '../apiFetch';
 
 export default async (auth: Auth, stream: string, topic: string): Promise<ApiResponse> =>
-  apiPatch(auth, 'users/me/subscriptions/muted_topics', res => res, {
+  apiPatch(auth, 'users/me/subscriptions/muted_topics', {
     stream,
     topic,
     op: 'add',

--- a/src/api/subscriptions/subscriptionAdd.js
+++ b/src/api/subscriptions/subscriptionAdd.js
@@ -11,7 +11,7 @@ export default (
   subscriptions: SubscriptionObj[],
   principals?: string[],
 ): Promise<ApiResponse> =>
-  apiPost(auth, 'users/me/subscriptions', res => res, {
+  apiPost(auth, 'users/me/subscriptions', {
     subscriptions: JSON.stringify(subscriptions),
     principals: JSON.stringify(principals),
   });

--- a/src/api/subscriptions/subscriptionRemove.js
+++ b/src/api/subscriptions/subscriptionRemove.js
@@ -3,7 +3,7 @@ import type { ApiResponse, Auth } from '../apiTypes';
 import { apiDelete } from '../apiFetch';
 
 export default (auth: Auth, subscriptions: string[], principals?: string[]): Promise<ApiResponse> =>
-  apiDelete(auth, 'users/me/subscriptions', res => res, {
+  apiDelete(auth, 'users/me/subscriptions', {
     subscriptions: JSON.stringify(subscriptions),
     principals: JSON.stringify(principals),
   });

--- a/src/api/subscriptions/toggleMuteStream.js
+++ b/src/api/subscriptions/toggleMuteStream.js
@@ -3,7 +3,7 @@ import type { ApiResponse, Auth } from '../apiTypes';
 import { apiPost } from '../apiFetch';
 
 export default async (auth: Auth, streamId: number, value: boolean): Promise<ApiResponse> =>
-  apiPost(auth, 'users/me/subscriptions/properties', res => res, {
+  apiPost(auth, 'users/me/subscriptions/properties', {
     subscription_data: JSON.stringify([
       {
         property: 'in_home_view',

--- a/src/api/subscriptions/togglePinStream.js
+++ b/src/api/subscriptions/togglePinStream.js
@@ -3,7 +3,7 @@ import type { ApiResponse, Auth } from '../apiTypes';
 import { apiPost } from '../apiFetch';
 
 export default async (auth: Auth, streamId: number, value: boolean): Promise<ApiResponse> =>
-  apiPost(auth, 'users/me/subscriptions/properties', res => res, {
+  apiPost(auth, 'users/me/subscriptions/properties', {
     subscription_data: JSON.stringify([
       {
         property: 'pin_to_top',

--- a/src/api/subscriptions/toggleStreamNotifications.js
+++ b/src/api/subscriptions/toggleStreamNotifications.js
@@ -3,7 +3,7 @@ import type { ApiResponse, Auth } from '../apiTypes';
 import { apiPost } from '../apiFetch';
 
 export default async (auth: Auth, streamId: number, value: boolean): Promise<ApiResponse> =>
-  apiPost(auth, 'users/me/subscriptions/properties', res => res, {
+  apiPost(auth, 'users/me/subscriptions/properties', {
     subscription_data: JSON.stringify([
       {
         property: 'push_notifications',

--- a/src/api/subscriptions/unmuteTopic.js
+++ b/src/api/subscriptions/unmuteTopic.js
@@ -3,7 +3,7 @@ import type { ApiResponse, Auth } from '../apiTypes';
 import { apiPatch } from '../apiFetch';
 
 export default async (auth: Auth, stream: string, topic: string): Promise<ApiResponse> =>
-  apiPatch(auth, 'users/me/subscriptions/muted_topics', res => res, {
+  apiPatch(auth, 'users/me/subscriptions/muted_topics', {
     stream,
     topic,
     op: 'remove',

--- a/src/api/typing.js
+++ b/src/api/typing.js
@@ -3,7 +3,7 @@ import type { ApiResponse, Auth, TypingOperation } from './apiTypes';
 import { apiPost } from './apiFetch';
 
 export default (auth: Auth, recipients: string, operation: TypingOperation): Promise<ApiResponse> =>
-  apiPost(auth, 'typing', res => res, {
+  apiPost(auth, 'typing', {
     to: recipients,
     op: operation,
   });

--- a/src/api/uploadFile.js
+++ b/src/api/uploadFile.js
@@ -9,5 +9,5 @@ export default (auth: Auth, uri: string, name: string) => {
   const type = getMimeTypeFromFileExtension(extension);
   // $FlowFixMe
   formData.append('file', { uri, name, type, extension });
-  return apiFile(auth, 'user_uploads', res => res.uri, formData);
+  return apiFile(auth, 'user_uploads', formData);
 };

--- a/src/api/users/getUsers.js
+++ b/src/api/users/getUsers.js
@@ -2,5 +2,13 @@
 import type { Auth, User } from '../apiTypes';
 import { apiGet } from '../apiFetch';
 
-export default (auth: Auth): Promise<User[]> =>
-  apiGet(auth, 'users', res => res.members, { client_gravatar: true });
+/** See https://zulipchat.com/api/get-all-users */
+
+type ApiResponseUsers = ApiResponseSuccess & {
+  members: User[],
+};
+
+export default (auth: Auth, clientGravatar: boolean = true): Promise<ApiResponseUsers> =>
+  apiGet(auth, 'users', {
+    client_gravatar: clientGravatar,
+  });


### PR DESCRIPTION
Based on the API PR.

At this point, no function does use the response extraction concept and all use the `res => res` default null function.
    
Removing this is simple and risk-free.
    
    * remove any Flow types associated with this
    * remove the parameter from all core API functions
    * remove the parameter from all specific API functions