### PR TITLE
More robust caughtUp logic

### DIFF
--- a/src/actionTypes.js
+++ b/src/actionTypes.js
@@ -222,8 +222,8 @@ type MessageFetchCompleteAction = {|
   anchor: number,
   numBefore: number,
   numAfter: number,
-  foundNewest: ?boolean,
-  foundOldest: ?boolean,
+  foundNewest: boolean | void,
+  foundOldest: boolean | void,
 |};
 
 type InitialFetchStartAction = {|

--- a/src/actionTypes.js
+++ b/src/actionTypes.js
@@ -222,6 +222,8 @@ type MessageFetchCompleteAction = {|
   anchor: number,
   numBefore: number,
   numAfter: number,
+  foundNewest: ?boolean,
+  foundOldest: ?boolean,
 |};
 
 type InitialFetchStartAction = {|

--- a/src/api/messages/getMessages.js
+++ b/src/api/messages/getMessages.js
@@ -5,13 +5,20 @@ import { apiGet } from '../apiFetch';
 type ApiResponseMessages = {|
   ...ApiResponseSuccess,
   anchor: number,
-  found_anchor: boolean,
-  found_newest: boolean,
-  found_oldest: boolean,
+  found_anchor?: boolean,
+  found_newest?: boolean,
+  found_oldest?: boolean,
   messages: Message[],
 |};
 
-/** See https://zulipchat.com/api/get-messages */
+/**
+ * See https://zulipchat.com/api/get-messages
+ *
+ * These values exist only in Zulip 1.8 or newer:
+ *   * found_anchor
+ *   * found_newest
+ *   * found_oldest
+ */
 export default async (
   auth: Auth,
   narrow: Narrow,

--- a/src/caughtup/__tests__/caughtUpReducers-test.js
+++ b/src/caughtup/__tests__/caughtUpReducers-test.js
@@ -364,4 +364,30 @@ describe('caughtUpReducers', () => {
       expect(newState).toEqual(expectedState);
     });
   });
+
+  test('if `foundNewest` and `foundOldest` are provided use them', () => {
+    const initialState = deepFreeze({});
+
+    const action = deepFreeze({
+      type: MESSAGE_FETCH_COMPLETE,
+      narrow: HOME_NARROW,
+      anchor: 3,
+      messages: [],
+      numBefore: 2,
+      numAfter: 2,
+      foundNewest: true,
+      foundOldest: true,
+    });
+
+    const expectedState = {
+      [HOME_NARROW_STR]: {
+        older: true,
+        newer: true,
+      },
+    };
+
+    const newState = caughtUpReducers(initialState, action);
+
+    expect(newState).toEqual(expectedState);
+  });
 });

--- a/src/caughtup/__tests__/caughtUpReducers-test.js
+++ b/src/caughtup/__tests__/caughtUpReducers-test.js
@@ -50,6 +50,8 @@ describe('caughtUpReducers', () => {
         messages: [{ id: 1 }, { id: 2 }, { id: 3 }],
         numBefore: 5,
         numAfter: 5,
+        foundNewest: undefined,
+        foundOldest: undefined,
       });
 
       const expectedState = {
@@ -81,6 +83,8 @@ describe('caughtUpReducers', () => {
       messages: [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }, { id: 5 }],
       numBefore: 2,
       numAfter: 2,
+      foundNewest: undefined,
+      foundOldest: undefined,
     });
 
     const expectedState = {
@@ -111,6 +115,8 @@ describe('caughtUpReducers', () => {
       messages: [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }, { id: 5 }],
       numBefore: 2,
       numAfter: 2,
+      foundNewest: undefined,
+      foundOldest: undefined,
     });
 
     const expectedState = {
@@ -264,6 +270,8 @@ describe('caughtUpReducers', () => {
       messages: [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }, { id: 5 }],
       numBefore: 10,
       numAfter: 0,
+      foundNewest: undefined,
+      foundOldest: undefined,
     });
 
     const expectedState = {

--- a/src/caughtup/caughtUpReducers.js
+++ b/src/caughtup/caughtUpReducers.js
@@ -16,6 +16,7 @@ const messageFetchComplete = (state, action) => {
   const key = JSON.stringify(action.narrow);
 
   if (action.foundNewest !== undefined && action.foundOldest !== undefined) {
+    /* This should always be the case for Zulip Server v1.8 or newer. */
     return {
       ...state,
       [key]: {
@@ -24,6 +25,8 @@ const messageFetchComplete = (state, action) => {
       },
     };
   }
+
+  /* A legacy server.  Try to infer the caught-up state ourselves. */
 
   if (action.anchor === LAST_MESSAGE_ANCHOR) {
     return {

--- a/src/caughtup/caughtUpReducers.js
+++ b/src/caughtup/caughtUpReducers.js
@@ -15,6 +15,16 @@ const initialState: CaughtUpState = NULL_OBJECT;
 const messageFetchComplete = (state, action) => {
   const key = JSON.stringify(action.narrow);
 
+  if (action.foundNewest !== undefined && action.foundOldest !== undefined) {
+    return {
+      ...state,
+      [key]: {
+        older: action.foundOldest,
+        newer: action.foundNewest,
+      },
+    };
+  }
+
   if (action.anchor === LAST_MESSAGE_ANCHOR) {
     return {
       ...state,

--- a/src/chat/__tests__/fetchingReducers-test.js
+++ b/src/chat/__tests__/fetchingReducers-test.js
@@ -84,6 +84,8 @@ describe('fetchingReducers', () => {
         anchor: 0,
         numBefore: 10,
         numAfter: 0,
+        foundNewest: undefined,
+        foundOldest: undefined,
       });
 
       const expectedState = {

--- a/src/message/fetchActions.js
+++ b/src/message/fetchActions.js
@@ -41,6 +41,8 @@ const messageFetchComplete = (
   anchor: number,
   numBefore: number,
   numAfter: number,
+  foundNewest: ?boolean,
+  foundOldest: ?boolean,
 ): Action => ({
   type: MESSAGE_FETCH_COMPLETE,
   messages,
@@ -48,6 +50,8 @@ const messageFetchComplete = (
   anchor,
   numBefore,
   numAfter,
+  foundNewest,
+  foundOldest,
 });
 
 export const fetchMessages = (
@@ -58,7 +62,7 @@ export const fetchMessages = (
   useFirstUnread: boolean = false,
 ) => async (dispatch: Dispatch, getState: GetState) => {
   dispatch(messageFetchStart(narrow, numBefore, numAfter));
-  const { messages } = await getMessages(
+  const { messages, found_newest, found_oldest } = await getMessages(
     getAuth(getState()),
     narrow,
     anchor,
@@ -66,7 +70,9 @@ export const fetchMessages = (
     numAfter,
     useFirstUnread,
   );
-  dispatch(messageFetchComplete(messages, narrow, anchor, numBefore, numAfter));
+  dispatch(
+    messageFetchComplete(messages, narrow, anchor, numBefore, numAfter, found_newest, found_oldest),
+  );
 };
 
 const fetchMessagesAroundAnchor = (narrow: Narrow, anchor: number) =>
@@ -139,10 +145,20 @@ export const fetchMessagesInNarrow = (
 
 const fetchPrivateMessages = () => async (dispatch: Dispatch, getState: GetState) => {
   const auth = getAuth(getState());
-  const { messages } = await tryUntilSuccessful(() =>
+  const { messages, found_newest, found_oldest } = await tryUntilSuccessful(() =>
     getMessages(auth, ALL_PRIVATE_NARROW, LAST_MESSAGE_ANCHOR, 100, 0),
   );
-  dispatch(messageFetchComplete(messages, ALL_PRIVATE_NARROW, LAST_MESSAGE_ANCHOR, 100, 0));
+  dispatch(
+    messageFetchComplete(
+      messages,
+      ALL_PRIVATE_NARROW,
+      LAST_MESSAGE_ANCHOR,
+      100,
+      0,
+      found_newest,
+      found_oldest,
+    ),
+  );
 };
 
 const fetchStreams = () => async (dispatch: Dispatch, getState: GetState) => {

--- a/src/message/fetchActions.js
+++ b/src/message/fetchActions.js
@@ -41,8 +41,8 @@ const messageFetchComplete = (
   anchor: number,
   numBefore: number,
   numAfter: number,
-  foundNewest: ?boolean,
-  foundOldest: ?boolean,
+  foundNewest?: boolean,
+  foundOldest?: boolean,
 ): Action => ({
   type: MESSAGE_FETCH_COMPLETE,
   messages,


### PR DESCRIPTION
Fixes #3338

Previously we had to use custom caught-up logic to determine if we
have loaded the oldest or newest messages in a narrow.

Back-end now gives us that data while older versions do not.

Keep the old logic when the `found_newest` and `found_oldest`
values are not provided but use them directly if present.