### PR TITLE
Upgrade `flow-coverage-report` version

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "eslint-plugin-react-native": "^3.2.1",
     "eslint-plugin-spellcheck": "0.0.6",
     "flow-bin": "^0.67.0",
-    "flow-coverage-report": "^0.5.0",
+    "flow-coverage-report": "^0.6.0",
     "flow-typed": "^2.4.0",
     "jest": "^22.4.4",
     "jest-cli": "^22.4.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2803,9 +2803,9 @@ flat-cache@^1.2.1:
     graceful-fs "^4.1.2"
     write "^0.2.1"
 
-flow-annotation-check@1.8.0:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/flow-annotation-check/-/flow-annotation-check-1.8.0.tgz#49a97d2ddd7d0f91c2addc4b95d1e89ec5eea6ad"
+flow-annotation-check@1.8.1:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/flow-annotation-check/-/flow-annotation-check-1.8.1.tgz#41ed407a79e56f5ea71b8f4edc55853c66799e3f"
   dependencies:
     argparse "^1.0.9"
     babel-plugin-transform-object-rest-spread "^6.20.2"
@@ -2816,14 +2816,14 @@ flow-bin@^0.67.0:
   version "0.67.1"
   resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.67.1.tgz#eabb7197cce870ac9442cfd04251c7ddc30377db"
 
-flow-coverage-report@^0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/flow-coverage-report/-/flow-coverage-report-0.5.0.tgz#adbcecb5bf9a068d3d66f8881b0d7b96cb82c5f2"
+flow-coverage-report@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/flow-coverage-report/-/flow-coverage-report-0.6.0.tgz#3bab30921f14ef798d709902048205bd7611ec43"
   dependencies:
     array.prototype.find "2.0.4"
     babel-runtime "6.23.0"
     badge-up "2.3.0"
-    flow-annotation-check "1.8.0"
+    flow-annotation-check "1.8.1"
     glob "7.1.1"
     minimatch "3.0.4"
     mkdirp "0.5.1"


### PR DESCRIPTION
Fixes `yarn test:flow-coverage` not working.

`flow-coverage-report` 0.5.0 does not support the `flow-strict`
annotation and fails to run the coverage. 0.6.0 fixes that.