### PR TITLE
autocompleteView: Return null if prefix is neither :,@ nor #.

### DIFF
--- a/src/autocomplete/AutocompleteView.js
+++ b/src/autocomplete/AutocompleteView.js
@@ -34,10 +34,16 @@ export default class AutocompleteView extends PureComponent<Props> {
     const { text, selection } = this.props;
     const result = getAutocompleteFilter(text, selection);
 
-    const AutocompleteComponent = prefixToComponent[result.lastWordPrefix];
+    const { filter, lastWordPrefix } = result;
+
+    if (lastWordPrefix.length === 0) {
+      return null;
+    }
+
+    const AutocompleteComponent = prefixToComponent[lastWordPrefix];
 
     return (
-      <AnimatedScaleComponent visible={result.filter.length > 0}>
+      <AnimatedScaleComponent visible={filter.length > 0}>
         {AutocompleteComponent && (
           <AutocompleteComponent filter={result.filter} onAutocomplete={this.handleAutocomplete} />
         )}

--- a/src/autocomplete/AutocompleteView.js
+++ b/src/autocomplete/AutocompleteView.js
@@ -36,7 +36,7 @@ export default class AutocompleteView extends PureComponent<Props> {
 
     const { filter, lastWordPrefix } = result;
 
-    if (lastWordPrefix.length === 0) {
+    if (lastWordPrefix.length === 0 || filter.length === 0) {
       return null;
     }
 


### PR DESCRIPTION
`getAutocompleteFilter` returns `lastWordPrefix` as either `:`, `@`,
`#` or ''. If it is a empty string that means user have entered normal
text, for which we are not interested and don't want to show
autocomplete popup. So return null from the component and render
nothing.

Fix: #2791