### PR TITLE
topicListScreen: Remove `connectPreserveOnBackOption` from connect params.

### DIFF
--- a/src/account-info/AccountDetailsScreen.js
+++ b/src/account-info/AccountDetailsScreen.js
@@ -7,7 +7,6 @@ import type { Auth, Dispatch, GlobalState, Orientation, User, PresenceState } fr
 import { getAuth, getSession, getAccountDetailsUserFromEmail, getPresence } from '../selectors';
 import { Screen } from '../common';
 import AccountDetails from './AccountDetails';
-import { connectPreserveOnBackOption } from '../utils/redux';
 
 type Props = {
   auth: Auth,
@@ -44,14 +43,9 @@ class AccountDetailsScreen extends PureComponent<Props> {
   }
 }
 
-export default connect(
-  (state: GlobalState, props: Object) => ({
-    auth: getAuth(state),
-    user: getAccountDetailsUserFromEmail(props.navigation.state.params.email)(state),
-    orientation: getSession(state).orientation,
-    presence: getPresence(state),
-  }),
-  null,
-  null,
-  connectPreserveOnBackOption,
-)(AccountDetailsScreen);
+export default connect((state: GlobalState, props: Object) => ({
+  auth: getAuth(state),
+  user: getAccountDetailsUserFromEmail(props.navigation.state.params.email)(state),
+  orientation: getSession(state).orientation,
+  presence: getPresence(state),
+}))(AccountDetailsScreen);

--- a/src/common/Screen.js
+++ b/src/common/Screen.js
@@ -16,7 +16,6 @@ import { KeyboardAvoider, OfflineNotice, ZulipStatusBar } from '../common';
 import { getSession } from '../selectors';
 import ModalNavBar from '../nav/ModalNavBar';
 import ModalSearchNavBar from '../nav/ModalSearchNavBar';
-import { connectPreserveOnBackOption } from '../utils/redux';
 
 const componentStyles = StyleSheet.create({
   wrapper: {
@@ -120,11 +119,6 @@ class Screen extends PureComponent<Props> {
   }
 }
 
-export default connect(
-  (state: GlobalState) => ({
-    safeAreaInsets: getSession(state).safeAreaInsets,
-  }),
-  null,
-  null,
-  connectPreserveOnBackOption,
-)(Screen);
+export default connect((state: GlobalState) => ({
+  safeAreaInsets: getSession(state).safeAreaInsets,
+}))(Screen);

--- a/src/topics/TopicListScreen.js
+++ b/src/topics/TopicListScreen.js
@@ -10,7 +10,6 @@ import { getTopicsForStream } from '../selectors';
 import { getStreamFromId } from '../subscriptions/subscriptionSelectors';
 import TopicList from './TopicList';
 import { fetchTopics, doNarrow } from '../actions';
-import { connectPreserveOnBackOption } from '../utils/redux';
 
 type Props = {
   dispatch: Dispatch,
@@ -55,12 +54,7 @@ class TopicListScreen extends PureComponent<Props, State> {
   }
 }
 
-export default connect(
-  (state: GlobalState, props: Object) => ({
-    stream: getStreamFromId(props.navigation.state.params.streamId)(state),
-    topics: getTopicsForStream(props.navigation.state.params.streamId)(state),
-  }),
-  null,
-  null,
-  connectPreserveOnBackOption,
-)(TopicListScreen);
+export default connect((state: GlobalState, props: Object) => ({
+  stream: getStreamFromId(props.navigation.state.params.streamId)(state),
+  topics: getTopicsForStream(props.navigation.state.params.streamId)(state),
+}))(TopicListScreen);


### PR DESCRIPTION
Why this is removed? Because it was acting over smartly. This was
added to save redundant re-renders which were caused by nav state
change on pushing/popping route. But what if topics got fetched while
navigation is in a state of `isTransitioning`. It will ignore that
event and will not get re-rendered.

Also `topicListScreen` is not depended on the nav state, so even if

 ```
cur.nav.routes.length < prev.nav.routes.length
```

is removed then also there is no problem. As the prop supllied to
`topicListScreen` will not change and `shouldComponentUpdate` (as
`PureComonent` is used) will return false and save re-render.

Instead of using `connectPreserveOnBackOption`, we should make our
selector not to listen to nav state change (#2810). Which is a better
alternative for `connectPreserveOnBackOption`.

Fix: #2808

Next will go through all other instances where
`connectPreserveOnBackOption` is used and check whether it is really
required or not.