### PR TITLE
refactor: Create a common method that should be called on stream, people, emoji onAutocomplete. Eliminate new function creation for every item of list.

### DIFF
--- a/src/autocomplete/EmojiAutocomplete.js
+++ b/src/autocomplete/EmojiAutocomplete.js
@@ -21,8 +21,12 @@ const MAX_CHOICES = 30;
 class EmojiAutocomplete extends PureComponent<Props> {
   props: Props;
 
+  onAutocomplete = (name: string): void => {
+    this.props.onAutocomplete(name);
+  };
+
   render() {
-    const { filter, realmEmoji, onAutocomplete } = this.props;
+    const { filter, realmEmoji } = this.props;
     const emojis = getFilteredEmojiList(filter, realmEmoji);
 
     if (emojis.length === 0) {
@@ -36,7 +40,7 @@ class EmojiAutocomplete extends PureComponent<Props> {
           initialNumToRender={12}
           data={emojis.slice(0, MAX_CHOICES)}
           keyExtractor={item => item}
-          renderItem={({ item }) => <EmojiRow name={item} onPress={() => onAutocomplete(item)} />}
+          renderItem={({ item }) => <EmojiRow name={item} onPress={this.onAutocomplete} />}
         />
       </Popup>
     );

--- a/src/autocomplete/PeopleAutocomplete.js
+++ b/src/autocomplete/PeopleAutocomplete.js
@@ -25,8 +25,16 @@ type Props = {
 class PeopleAutocomplete extends PureComponent<Props> {
   props: Props;
 
+  handleUserGroupItemAutocomplete = (name: string): void => {
+    this.props.onAutocomplete(`*${name}*`);
+  };
+
+  handleUserItemAutocomplete = ({ fullName }): void => {
+    this.props.onAutocomplete(`**${fullName}**`);
+  };
+
   render() {
-    const { filter, ownEmail, users, userGroups, onAutocomplete } = this.props;
+    const { filter, ownEmail, users, userGroups } = this.props;
     const filteredUserGroups = getAutocompleteUserGroupSuggestions(userGroups, filter);
     const filteredUsers: User[] = getAutocompleteSuggestion(users, filter, ownEmail);
 
@@ -42,7 +50,7 @@ class PeopleAutocomplete extends PureComponent<Props> {
             key={item.name}
             name={item.name}
             description={item.description}
-            onPress={() => onAutocomplete(`*${item.name}*`)}
+            onPress={this.handleUserGroupItemAutocomplete}
           />
         ),
       },
@@ -55,7 +63,7 @@ class PeopleAutocomplete extends PureComponent<Props> {
             avatarUrl={item.avatar_url}
             email={item.email}
             showEmail
-            onPress={() => onAutocomplete(`**${item.full_name}**`)}
+            onPress={this.handleUserItemAutocomplete}
           />
         ),
       },

--- a/src/autocomplete/StreamAutocomplete.js
+++ b/src/autocomplete/StreamAutocomplete.js
@@ -18,8 +18,12 @@ type Props = {
 class StreamAutocomplete extends PureComponent<Props> {
   props: Props;
 
+  onAutocomplete = (name: string): void => {
+    this.props.onAutocomplete(`**${name}**`);
+  };
+
   render() {
-    const { filter, subscriptions, onAutocomplete } = this.props;
+    const { filter, subscriptions } = this.props;
     const streams = subscriptions.filter(x =>
       x.name.toLowerCase().startsWith(filter.toLowerCase()),
     );
@@ -42,7 +46,7 @@ class StreamAutocomplete extends PureComponent<Props> {
               isPrivate={item.invite_only}
               iconSize={12}
               color={item.color}
-              onPress={() => onAutocomplete(`**${item.name}**`)}
+              onPress={this.onAutocomplete}
             />
           )}
         />

--- a/src/chat/GroupDetailsScreen.js
+++ b/src/chat/GroupDetailsScreen.js
@@ -21,17 +21,12 @@ class GroupDetailsScreen extends PureComponent<Props> {
     styles: () => null,
   };
 
-  props: Props;
-
   handlePress = ({ email }) => {
-    const { dispatch } = this.props;
-    dispatch(navigateToAccountDetails(email));
+    this.props.dispatch(navigateToAccountDetails(email));
   };
 
   render() {
-    const { navigation } = this.props;
-    const { recipients } = navigation.state.params;
-
+    const { recipients } = this.props.navigation.state.params;
     return (
       <Screen title="Recipients" scrollEnabled={false}>
         <FlatList

--- a/src/chat/GroupDetailsScreen.js
+++ b/src/chat/GroupDetailsScreen.js
@@ -45,7 +45,7 @@ class GroupDetailsScreen extends PureComponent<Props> {
               avatarUrl={item.avatar_url}
               email={item.email}
               showEmail
-              onPress={() => this.handlePress(item.email)}
+              onPress={this.handlePress}
             />
           )}
         />

--- a/src/chat/GroupDetailsScreen.js
+++ b/src/chat/GroupDetailsScreen.js
@@ -23,7 +23,7 @@ class GroupDetailsScreen extends PureComponent<Props> {
 
   props: Props;
 
-  handlePress = (email: string) => {
+  handlePress = ({ email }) => {
     const { dispatch } = this.props;
     dispatch(navigateToAccountDetails(email));
   };

--- a/src/emoji/EmojiPickerScreen.js
+++ b/src/emoji/EmojiPickerScreen.js
@@ -65,14 +65,7 @@ class EmojiPickerScreen extends PureComponent<Props, State> {
           initialNumToRender={20}
           data={emojis}
           keyExtractor={item => item}
-          renderItem={({ item }) => (
-            <EmojiRow
-              name={item}
-              onPress={() => {
-                this.addReaction(item);
-              }}
-            />
-          )}
+          renderItem={({ item }) => <EmojiRow name={item} onPress={this.addReaction} />}
         />
       </Screen>
     );

--- a/src/emoji/EmojiRow.js
+++ b/src/emoji/EmojiRow.js
@@ -18,19 +18,24 @@ const styles = StyleSheet.create({
 
 type Props = {
   name: string,
-  onPress: () => void,
+  onPress: (name: string) => void,
 };
 
 export default class EmojiRow extends PureComponent<Props> {
   props: Props;
 
-  render() {
+  handlePress = () => {
     const { name, onPress } = this.props;
+    onPress(name);
+  };
+
+  render() {
+    const { name } = this.props;
 
     // TODO: this only handles Unicode emoji (shipped with the app),
     // not realm emoji or Zulip extra emoji.  See our issue #2846.
     return (
-      <Touchable onPress={onPress}>
+      <Touchable onPress={this.handlePress}>
         <View style={styles.emojiRow}>
           <Emoji name={name} size={20} />
           <RawLabel style={styles.text} text={name} />

--- a/src/pm-conversations/PmConversationList.js
+++ b/src/pm-conversations/PmConversationList.js
@@ -28,8 +28,8 @@ type Props = {
 export default class PmConversationList extends PureComponent<Props> {
   props: Props;
 
-  handleUserNarrow = (email: string) => {
-    this.props.dispatch(doNarrow(privateNarrow(email)));
+  handleUserNarrow = (params: { email: string }) => {
+    this.props.dispatch(doNarrow(privateNarrow(params.email)));
   };
 
   handleGroupNarrow = (email: string) => {

--- a/src/user-picker/UserPickerCard.js
+++ b/src/user-picker/UserPickerCard.js
@@ -57,7 +57,7 @@ class UserPickerCard extends PureComponent<Props, State> {
     }
   };
 
-  handleUserPress = (email: string) => {
+  handleUserPress = ({ email }) => {
     const { selected } = this.state;
 
     if (selected.find(x => x.email === email)) {

--- a/src/users/UserItem.js
+++ b/src/users/UserItem.js
@@ -33,7 +33,7 @@ type Props = {
   isSelected?: boolean,
   showEmail?: boolean,
   unreadCount?: number,
-  onPress: (email: string) => void,
+  onPress: ({ email: string, fullName: string }) => void,
 };
 
 export default class UserItem extends PureComponent<Props> {
@@ -45,9 +45,9 @@ export default class UserItem extends PureComponent<Props> {
   };
 
   handlePress = () => {
-    const { email, onPress } = this.props;
-    if (email && onPress) {
-      onPress(email);
+    const { email, fullName, onPress } = this.props;
+    if (email && fullName && onPress) {
+      onPress({ email, fullName });
     }
   };
 

--- a/src/users/UserList.js
+++ b/src/users/UserList.js
@@ -19,7 +19,7 @@ type Props = {
   users: User[],
   selected: User[],
   presences: PresenceState,
-  onPress: (email: string) => void,
+  onPress: ({ email: string, fullName: string }) => void,
 };
 
 export default class UserList extends PureComponent<Props> {

--- a/src/users/UsersCard.js
+++ b/src/users/UsersCard.js
@@ -20,7 +20,7 @@ type Props = {
 class UsersCard extends PureComponent<Props> {
   props: Props;
 
-  handleUserNarrow = (email: string) => {
+  handleUserNarrow = ({ email }) => {
     const { dispatch } = this.props;
     dispatch(navigateBack());
     dispatch(doNarrow(privateNarrow(email)));


### PR DESCRIPTION
StreamItem calls `onPress` with the stream name as parameter, so fit
that paramter in the common function which can be used for all stream
item autocomplete. Before, for every item a new function was created
at the time of rendering.

Create a function inside render should be avoided.
(https://codeburst.io/6-simple-ways-to-speed-up-your-react-native-app-d5b775ab3f16)

This is a expriemental change, if it goes goods then we should do this
at other similiar places too.