### PR TITLE
image-picker: Set storageOptions.cameraRoll and storageOptions.waitUntilSaved.

### DIFF
--- a/src/compose/ComposeMenu.js
+++ b/src/compose/ComposeMenu.js
@@ -57,7 +57,14 @@ class ComposeMenu extends PureComponent<Props> {
   };
 
   handleCameraCapture = () => {
-    ImagePicker.launchCamera({}, this.handleImagePickerResponse);
+    const options = {
+      storageOptions: {
+        cameraRoll: true,
+        waitUntilSaved: true,
+      },
+    };
+
+    ImagePicker.launchCamera(options, this.handleImagePickerResponse);
   };
 
   render() {


### PR DESCRIPTION
See the documentation: https://github.com/react-community/react-native-image-picker#options

Prior to this fix, it was impossible to send an image taken after directly launching the camera. There was no `fileName` property on the `response` object passed to `ComposeMenu.handleImagePickerResponse`.

In the React Native Remote Debugger, this manifested as a console warning that String.prototype.split was being invoked on an undefined value in `getFileExtension`.

On iOS, when sending a message via directly taking an image from the camera for the first time, iOS will ask for 3 permissions via modal - first, to access the camera, second, *after taking the image*, to add to the photo library, and third, to access the photo library (read and write). The first time  after granting these permissions, the taken image will not send, which is a bug.

To prevent this bug in the future, those permissions can be granted when the application starts and can be checked whenever the UI for directly launching is used.

@gnprice 