### PR TITLE
peopleAutocomplete: Use `user_id` as key for each item in list.

### DIFF
--- a/src/autocomplete/PeopleAutocomplete.js
+++ b/src/autocomplete/PeopleAutocomplete.js
@@ -50,7 +50,7 @@ class PeopleAutocomplete extends PureComponent<Props> {
         data: filteredUsers,
         renderItem: ({ item }) => (
           <UserItem
-            key={item.full_name}
+            key={item.user_id}
             fullName={item.full_name}
             avatarUrl={item.avatar_url}
             email={item.email}


### PR DESCRIPTION
Two user might have same name, but can't have same `user_id`. So use
id as key for each item of the list which is unique.