### PR TITLE
android: Fix label of intent filter.

### DIFF
--- a/android/app/src/debug/res/values/strings.xml
+++ b/android/app/src/debug/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="app_name">Zulip (debug)</string>
+</resources>

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -42,7 +42,7 @@
             <action android:name="android.intent.action.MAIN" />
             <category android:name="android.intent.category.LAUNCHER" />
         </intent-filter>
-        <intent-filter android:label="filter_react_native">
+        <intent-filter>
             <action android:name="android.intent.action.VIEW" />
             <category android:name="android.intent.category.DEFAULT" />
             <category android:name="android.intent.category.BROWSABLE" />


### PR DESCRIPTION
What is this label?
> the one set by the parent component, is used when the component is
> presented to the user as having the capability described by the
> filter.

(https://developer.android.com/guide/topics/manifest/intent-filter-element#label)

Currently this intent filter is only used in the oAuth functionality.
So after selecting account in the browser, user is redirected to the
app with this intent. If multiple app are capable of taking this
intent (like in our case when both release and debug builds are
installed in the phone), then a pop up is shown by the phone OS,
letting user to select with which app he wants to procced. And this
label is used in this pop up. `filter_react_native` is totally
irrelevant, so change it to something relevant, which can be used
to differentiate both the apps in the phone.