### PR TITLE
 compose: Fix image fileName from uri for HEIC image files.

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -124,4 +124,4 @@ rules:
       const, wildcard, reactotron, camelcase, hydrator, perf, stacktrace, Dir, fs,
       avoider, octicons, centerer, ldap, gravatar, identicon, blueimp, filename, wildcards,
       jpeg, jpg, tif, mov, notif, diag, bmp, viewport, scalable, polyfill, rect, touchstart,
-      touchend, touchmove, remoteuser, sso, submessages, nbsp, args, px, na]
+      touchend, touchmove, remoteuser, sso, submessages, nbsp, args, px, na, heic]

--- a/src/compose/ComposeMenu.js
+++ b/src/compose/ComposeMenu.js
@@ -20,22 +20,29 @@ type Props = {
 };
 
 /**
- * Adjust the fileName to reflect the real file format, according to uri.
+ * Adjust `fileName` to one with the right extension for the file format.
  *
- * Photos in an iPhone's camera roll (taken since iOS 11) are typically in
- * HEIF format and have filenames with the extension `.HEIC`.  When the user
- * selects one of these photos through the image picker, the file gets
- * automatically converted to JPEG format... but the `fileName` property in
- * the react-native-image-picker response still has the `.HEIC` extension.
+ * Sometimes we get an image whose filename reflects one format (what it's
+ * stored as in the camera roll), but the actual image has been converted
+ * already to another format for interoperability.
  *
  * The Zulip server will infer the file format from the filename's
- * extension, so we need to adjust the extension to match the format. The
- * clue we get in the image-picker response is the extension found in `uri`.
+ * extension, so in this case we need to adjust the extension to match the
+ * actual format.  The clue we get in the image-picker response is the extension
+ * found in `uri`.
  */
-export const fixFileNameFromUri = (uri: string, fileName: string): string => {
+export const chooseUploadImageFilename = (uri: string, fileName: string): string => {
+  /*
+  * Photos in an iPhone's camera roll (taken since iOS 11) are typically in
+  * HEIF format and have filenames with the extension `.HEIC`.  When the user
+  * selects one of these photos through the image picker, the file gets
+  * automatically converted to JPEG format... but the `fileName` property in
+  * the react-native-image-picker response still has the `.HEIC` extension.
+  */
   if (/\.jpe?g$/i.test(uri)) {
     return fileName.replace(/\.heic$/i, '.jpeg');
   }
+
   return fileName;
 };
 
@@ -59,7 +66,7 @@ class ComposeMenu extends PureComponent<Props> {
 
     const { dispatch, narrow } = this.props;
     dispatch(
-      uploadImage(narrow, response.uri, fixFileNameFromUri(response.uri, response.fileName)),
+      uploadImage(narrow, response.uri, chooseUploadImageFilename(response.uri, response.fileName)),
     );
   };
 

--- a/src/compose/ComposeMenu.js
+++ b/src/compose/ComposeMenu.js
@@ -19,6 +19,26 @@ type Props = {
   onExpandContract: () => void,
 };
 
+/**
+ * In 2017, Apple adopted a new standard image format, HEIF, which stands
+ * for High Efficiency File Format; Apple photos are named with the '.heic'
+ * extension. When an image file with the extension '.heic' is uploaded to the
+ * server,the image becomes unviewable within a message list. Interestingly,
+ * the `file` command line utility reports that images saved under this format
+ * are JPEG files, so there's likely some pecularity with how the server handles
+ * file uploads based on the extension.
+ *
+ * If an image file name has the '.heic' extension, and the uri of the image on a
+ * mobile device has an extension for the JPEG format, fixFileNameFromUri replaces
+ * that extension with '.jpeg'.
+ */
+export const fixFileNameFromUri = (uri: string, fileName: string): string => {
+  if (/\.jpe?g$/i.test(uri)) {
+    return fileName.replace(/\.heic$/i, '.jpeg');
+  }
+  return fileName;
+};
+
 class ComposeMenu extends PureComponent<Props> {
   context: Context;
   props: Props;
@@ -38,8 +58,9 @@ class ComposeMenu extends PureComponent<Props> {
     }
 
     const { dispatch, narrow } = this.props;
-
-    dispatch(uploadImage(narrow, response.uri, response.fileName));
+    dispatch(
+      uploadImage(narrow, response.uri, fixFileNameFromUri(response.uri, response.fileName)),
+    );
   };
 
   handleImageUpload = () => {

--- a/src/compose/ComposeMenu.js
+++ b/src/compose/ComposeMenu.js
@@ -20,17 +20,17 @@ type Props = {
 };
 
 /**
- * In 2017, Apple adopted a new standard image format, HEIF, which stands
- * for High Efficiency File Format; Apple photos are named with the '.heic'
- * extension. When an image file with the extension '.heic' is uploaded to the
- * server,the image becomes unviewable within a message list. Interestingly,
- * the `file` command line utility reports that images saved under this format
- * are JPEG files, so there's likely some pecularity with how the server handles
- * file uploads based on the extension.
+ * Adjust the fileName to reflect the real file format, according to uri.
  *
- * If an image file name has the '.heic' extension, and the uri of the image on a
- * mobile device has an extension for the JPEG format, fixFileNameFromUri replaces
- * that extension with '.jpeg'.
+ * Photos in an iPhone's camera roll (taken since iOS 11) are typically in
+ * HEIF format and have filenames with the extension `.HEIC`.  When the user
+ * selects one of these photos through the image picker, the file gets
+ * automatically converted to JPEG format... but the `fileName` property in
+ * the react-native-image-picker response still has the `.HEIC` extension.
+ *
+ * The Zulip server will infer the file format from the filename's
+ * extension, so we need to adjust the extension to match the format. The
+ * clue we get in the image-picker response is the extension found in `uri`.
  */
 export const fixFileNameFromUri = (uri: string, fileName: string): string => {
   if (/\.jpe?g$/i.test(uri)) {

--- a/src/compose/__tests__/ComposeMenu-test.js
+++ b/src/compose/__tests__/ComposeMenu-test.js
@@ -1,8 +1,8 @@
-import { fixFileNameFromUri } from '../ComposeMenu';
+import { chooseUploadImageFilename } from '../ComposeMenu';
 
-describe('fixFileNameFromUri', () => {
+describe('chooseUploadImageFilename', () => {
   test('Does nothing if the image uri does not end with an extension for the JPEG format', () => {
-    expect(fixFileNameFromUri('foo', 'foo')).toBe('foo');
+    expect(chooseUploadImageFilename('foo', 'foo')).toBe('foo');
   });
 
   test(
@@ -11,7 +11,7 @@ describe('fixFileNameFromUri', () => {
     () => {
       const fileNameWithoutExtension = 'foo';
       expect(
-        fixFileNameFromUri('some/path/something.jpg', `${fileNameWithoutExtension}.heic`),
+        chooseUploadImageFilename('some/path/something.jpg', `${fileNameWithoutExtension}.heic`),
       ).toBe(`${fileNameWithoutExtension}.jpeg`);
     },
   );

--- a/src/compose/__tests__/ComposeMenu-test.js
+++ b/src/compose/__tests__/ComposeMenu-test.js
@@ -1,0 +1,18 @@
+import { fixFileNameFromUri } from '../ComposeMenu';
+
+describe('fixFileNameFromUri', () => {
+  test('Does nothing if the image uri does not end with an extension for the JPEG format', () => {
+    expect(fixFileNameFromUri('foo', 'foo')).toBe('foo');
+  });
+
+  test(
+    'Replaces any extension for the HEIC format with an extension for the JPEG format '
+      + 'if the file name does end with an extension for the JPEG format',
+    () => {
+      const fileNameWithoutExtension = 'foo';
+      expect(
+        fixFileNameFromUri('some/path/something.jpg', `${fileNameWithoutExtension}.heic`),
+      ).toBe(`${fileNameWithoutExtension}.jpeg`);
+    },
+  );
+});


### PR DESCRIPTION
Copying the jsdoc comment I've written for `fixFileNameFromUri`:

```js
/**
 * In 2017, Apple adopted a new standard image format, HEIF, which stands
 * for High Efficiency File Format; Apple photos are named with the '.heic'
 * extension. When an image file with the extension '.heic' is uploaded to the
 * server,the image becomes unviewable within a message list. Interestingly,
 * the `file` command line utility reports that images saved under this format
 * are JPEG files, so there's likely some pecularity with how the server handles
 * file uploads based on the extension.
 *
 * If an image file name has the '.heic' extension, and the uri of the image on a
 * mobile device has an extension for the JPEG format, fixFileNameFromUri replaces
 * that extension with '.jpeg'.
 */
```

This resolves #2178.
@gnprice 