### PR TITLE
createStreamScreen: Add `keyboardShouldPersistTaps="always"` to Screen.

### DIFF
--- a/src/streams/CreateStreamScreen.js
+++ b/src/streams/CreateStreamScreen.js
@@ -25,7 +25,7 @@ class CreateStreamScreen extends PureComponent<Props> {
 
   render() {
     return (
-      <Screen title="Create new stream" padding>
+      <Screen title="Create new stream" padding keyboardShouldPersistTaps="always">
         <EditStreamCard
           isNewStream
           initialValues={{ name: '', description: '', invite_only: false }}


### PR DESCRIPTION
Let's take an example, user just pushed create stream screen, now as
the details/fields are empty, button is disabled and on clicking
button keybaord is dismissed. Which is totally unexpected.

Basically as the button is disabled, so onPress is undefined and View
is rendered in the Touchable. So this touch gets propogated to
ScrollView, which dismisses the keyboard.

This improves the user exprience.