### PR TITLE
Fix: Compose menu icons are visible even in unexpanded state.

### DIFF
--- a/src/styles/composeBoxStyles.js
+++ b/src/styles/composeBoxStyles.js
@@ -67,6 +67,9 @@ export default ({ color, backgroundColor, borderColor }: Props) => ({
   composeMenu: {
     flexDirection: 'row',
     overflow: 'hidden',
+    // this backgroundColor style is a test and try hack to fix #2979,
+    // so it's hard to explain the behaviour
+    backgroundColor: 'transparent',
   },
   expandButton: {
     padding: 12,


### PR DESCRIPTION
Fix: #2979