### PR TITLE
webView: Recursively find last message visible on screen. Fix: #2988

### DIFF
--- a/src/webview/js/generatedEs3.js
+++ b/src/webview/js/generatedEs3.js
@@ -122,17 +122,25 @@ window.addEventListener('resize', function (event) {
   height = documentBody.clientHeight;
 });
 
-var isMessageNode = function isMessageNode(node) {
-  return !!node && node.getAttribute && node.hasAttribute('data-msg-id');
+var getLastVisibleMsgIdOnScreen = function getLastVisibleMsgIdOnScreen() {
+  var x = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : 200;
+  var y = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : window.innerHeight - 20;
+
+  if (x < 0 || y < 0) {
+    return 0;
+  }
+  var endNode = getMessageNode(document.elementFromPoint(x, y));
+  var msgId = getMessageIdFromNode(endNode, 0);
+  return msgId !== 0 ? msgId : getLastVisibleMsgIdOnScreen(x, y - 20);
 };
 
 var getStartAndEndNodes = function getStartAndEndNodes() {
   var startNode = getMessageNode(document.elementFromPoint(200, 20));
-  var endNode = getMessageNode(document.elementFromPoint(200, window.innerHeight - 20));
+  var endNodeId = getLastVisibleMsgIdOnScreen();
 
   return {
-    start: isMessageNode(startNode) ? startNode.getAttribute('data-msg-id') : Number.MAX_SAFE_INTEGER,
-    end: isMessageNode(endNode) ? endNode.getAttribute('data-msg-id') : 0
+    start: getMessageIdFromNode(startNode, Number.MAX_SAFE_INTEGER),
+    end: endNodeId
   };
 };
 

--- a/src/webview/js/js.js
+++ b/src/webview/js/js.js
@@ -141,13 +141,25 @@ window.addEventListener('resize', event => {
   height = documentBody.clientHeight;
 });
 
+const getLastVisibleMsgIdOnScreen = (
+  x: number = 200,
+  y: number = window.innerHeight - 20,
+): number => {
+  if (x < 0 || y < 0) {
+    return 0;
+  }
+  const endNode = getMessageNode(document.elementFromPoint(x, y));
+  const msgId = getMessageIdFromNode(endNode, 0);
+  return msgId !== 0 ? msgId : getLastVisibleMsgIdOnScreen(x, y - 20);
+};
+
 const getStartAndEndNodes = (): { start: number, end: number } => {
   const startNode = getMessageNode(document.elementFromPoint(200, 20));
-  const endNode = getMessageNode(document.elementFromPoint(200, window.innerHeight - 20));
+  const endNodeId = getLastVisibleMsgIdOnScreen();
 
   return {
     start: getMessageIdFromNode(startNode, Number.MAX_SAFE_INTEGER),
-    end: getMessageIdFromNode(endNode, 0),
+    end: endNodeId,
   };
 };
 


### PR DESCRIPTION
Before: Cordinate (200, window.innerHeight - 20) was used to find last
visible message on the screen (with current scroll position) and it's
id was passed to find messages which needs to be mark as read. But
what if list is small and there is no message node at
`window.innerHeight - 20` as y cordinate. Then `0` as message id was
passed, which is not making any sense (as now start msg id > end msg
id, see `msg.id >= fromId && msg.id <= toId` in
`filterUnreadMessagesInRange`).

After: Now recursively find last visible message node on screen with
current scroll position, i.e first find message node at (200,
window.innerHeight - 20), then (200, window.innerHeight - 40), then
(200, window.innerHeight - 60) and so on until y cordinate becomes
negative or message node is found.

Fix: #2988

Approach 2