### PR TITLE
CSS: Change style of disabled ZulipButton.

### DIFF
--- a/src/common/ZulipButton.js
+++ b/src/common/ZulipButton.js
@@ -58,7 +58,10 @@ const styles = StyleSheet.create({
     color: BRAND_COLOR,
   },
   disabled: {
-    opacity: 0.25,
+    backgroundColor: '#999',
+  },
+  disabledText: {
+    color: '#ddd',
   },
 });
 
@@ -148,7 +151,11 @@ export default class ZulipButton extends PureComponent<Props> {
       disabled && styles.disabled,
       style,
     ];
-    const textStyle = [styles.text, secondary ? styles.secondaryText : styles.primaryText];
+    const textStyle = [
+      styles.text,
+      secondary ? styles.secondaryText : styles.primaryText,
+      disabled && styles.disabledText,
+    ];
     const iconStyle = [styles.icon, secondary ? styles.secondaryIcon : styles.primaryIcon];
 
     if (progress) {


### PR DESCRIPTION
Tweaks the styling of the ZulipButton in its disabled state.
Can be tested on create a stream and when logging in.

Screenshot: 

![Zulip Button Disabled Style](http://g.recordit.co/3BJXgrIz4m.gif)

Fixes #2976