### PR TITLE
cleanup: Remove unused drafts-related code

### DIFF
--- a/src/compose/ComposeBox.android.js
+++ b/src/compose/ComposeBox.android.js
@@ -3,7 +3,6 @@ import React, { PureComponent } from 'react';
 import { View, TextInput, findNodeHandle } from 'react-native';
 import { connect } from 'react-redux';
 import TextInputReset from 'react-native-text-input-reset';
-import isEqual from 'lodash.isequal';
 
 import type {
   Auth,
@@ -279,10 +278,6 @@ class ComposeBox extends PureComponent<Props, State> {
       if (this.messageInput) {
         this.messageInput.focus();
       }
-    } else if (!isEqual(nextProps.narrow, this.props.narrow)) {
-      this.tryUpdateDraft();
-
-      this.setMessageInputValue(nextProps.draft);
     }
   }
 

--- a/src/compose/ComposeBox.ios.js
+++ b/src/compose/ComposeBox.ios.js
@@ -3,7 +3,6 @@ import React, { PureComponent } from 'react';
 import { View, TextInput, findNodeHandle } from 'react-native';
 import { connect } from 'react-redux';
 import TextInputReset from 'react-native-text-input-reset';
-import isEqual from 'lodash.isequal';
 
 import type {
   Auth,
@@ -246,14 +245,6 @@ class ComposeBox extends PureComponent<Props, State> {
       if (this.messageInput) {
         this.messageInput.focus();
       }
-    } else if (!isEqual(nextProps.narrow, this.props.narrow)) {
-      this.tryUpdateDraft();
-
-      if (!nextProps.draft) {
-        this.clearMessageInput();
-      }
-
-      this.handleMessageChange(nextProps.draft);
     }
   }
 


### PR DESCRIPTION
Using `componentWillReceiveProps` the way we did should not be
considered a best practice, and should not be used if better
options are available (there are other lifesycle events too).

We still need the `editMessage` comparison, though future rework
will make it not needed.

We don't need the `narrow` comparison though. It can never be true.
It used to be usable before, not anymore.

We get the prop down from several components. The hierarchy is:
ChatScreen > Chat > ComposeBox

ChatScreen gets the `narrow` value from the React Navigation's
`navigation.state.params`. This value does change only when a new
screen is created. So the same instance of the same screen will
never receive a different value. This comparison will always produce
`false`. Removing it!

This was confirmed both theoretically by analysing the code thoroughly
and pracitally by putting a `console.log` and navigating between many
different narrows in different ways.