### PR TITLE
Update is:starred narrow on EVENT_UPDATE_MESSAGE_FLAGS.

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -124,7 +124,8 @@ rules:
       const, wildcard, reactotron, camelcase, hydrator, perf, stacktrace, Dir, fs,
       avoider, octicons, centerer, ldap, gravatar, identicon, blueimp, filename, wildcards,
       jpeg, jpg, tif, mov, notif, diag, bmp, viewport, scalable, polyfill, rect, touchstart,
-      touchend, touchmove, remoteuser, sso, submessages, nbsp, args, px, na, heic]
+      touchend, touchmove, remoteuser, sso, submessages, nbsp, args, px, na, heic,
+      unstarred]
 overrides:
   - files:
       - generatedEs3.js

--- a/src/utils/narrow.js
+++ b/src/utils/narrow.js
@@ -58,6 +58,8 @@ export const isSpecialNarrow = (narrow: Narrow): boolean =>
 
 export const STARRED_NARROW = specialNarrow('starred');
 
+export const STARRED_NARROW_STR = JSON.stringify(STARRED_NARROW);
+
 export const MENTIONED_NARROW = specialNarrow('mentioned');
 
 export const ALL_PRIVATE_NARROW = specialNarrow('private');


### PR DESCRIPTION
Fixes #2677.

In the screenshot below, #2676 is still unresolved.

<p align="center">
<img alt="fix-2677-update-starred-list" src="https://user-images.githubusercontent.com/12771126/45987569-231a8c00-c027-11e8-9af5-716dc0ba95af.gif" />
</p>

I would label this with "bug" and "area: redux".