### PR TITLE
Update max iOS version to run on

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "ios": "react-native run-ios",
     "ios-min": "react-native run-ios --simulator 'iPhone 5s'",
     "ios-mid": "react-native run-ios --simulator 'iPhone 8 Plus'",
-    "ios-max": "react-native run-ios --simulator 'iPhone X'",
+    "ios-max": "react-native run-ios --simulator 'iPhone XS Max'",
     "ipad": "react-native run-ios --simulator 'iPad Air'",
     "ios-device": "react-native run-ios --device",
     "android": "react-native run-android",


### PR DESCRIPTION
With the new iOS and device releases, update the 'max' version
of iPhone (newest, largest) to be 'iPhone XS Max'.