### PR TITLE
docs/push-notifications: Add missing step for setting bouncer url.

### DIFF
--- a/docs/howto/push-notifications.md
+++ b/docs/howto/push-notifications.md
@@ -41,6 +41,11 @@ additional steps:
    python manage.py register_server --agree_to_terms_of_service
    ```
 
+   Registration should be one-time; that is, as long as you're using the
+   same `zproject/dev-secrets.conf` that was generated at provision time, you
+   shouldn't have to run the command again unless you build a new dev
+   environment from scratch.
+
    This is a variation of our [instructions for production
    deployments](https://zulip.readthedocs.io/en/latest/production/mobile-push-notifications.html),
    adapted for the Zulip dev environment.

--- a/docs/howto/push-notifications.md
+++ b/docs/howto/push-notifications.md
@@ -23,27 +23,27 @@ instance of APNs.)
 [Set up the dev server for mobile development](dev-server.md), with two
 additional steps:
 
-* Before you run the server with `tools/run-dev.py`, add the following line
-  to `zproject/dev_settings.py`:
+1. Before you run the server with `tools/run-dev.py`, add the following line
+   to `zproject/dev_settings.py`:
 
-  ```python
-  PUSH_NOTIFICATION_BOUNCER_URL = 'https://push.zulipchat.com'
-  ```
+   ```python
+   PUSH_NOTIFICATION_BOUNCER_URL = 'https://push.zulipchat.com'
+   ```
 
-  For a production build, `PUSH_NOTIFICATION_BOUNCER_URL` is specified in a
-  settings file generated from `zproject/prod_settings_template.py`. This is
-  a workaround for that, and you can keep this around via `git stash`.
+   For a production build, `PUSH_NOTIFICATION_BOUNCER_URL` is specified in a
+   settings file generated from `zproject/prod_settings_template.py`. This is
+   a workaround for that, and you can keep this around via `git stash`.
 
-* Then, register your development server with our production bouncer by 
-  running the following custom Django management command:
+2. Then, register your development server with our production bouncer by 
+   running the following custom Django management command:
 
-  ```
-  python manage.py register_server --agree_to_terms_of_service
-  ```
+   ```
+   python manage.py register_server --agree_to_terms_of_service
+   ```
 
-  This is a variation of our [instructions for production
-  deployments](https://zulip.readthedocs.io/en/latest/production/mobile-push-notifications.html),
-  adapted for the Zulip dev environment.
+   This is a variation of our [instructions for production
+   deployments](https://zulip.readthedocs.io/en/latest/production/mobile-push-notifications.html),
+   adapted for the Zulip dev environment.
 
 Now, follow the instructions in [dev-server.md](dev-server.md) to log into
 the dev server, using a production build of the app -- that is, the Zulip

--- a/docs/howto/push-notifications.md
+++ b/docs/howto/push-notifications.md
@@ -55,9 +55,9 @@ the dev server, using a production build of the app -- that is, the Zulip
 app installed from the App Store or Play Store.
 
 A tip for testing Zulip's push notifications: simulate a private
-conversation between two users, and make sure that you don't have the Zulip
-app open while you're doing so.  For example, if you've logged in as `Iago`
-on your mobile device, log in as `Polonius` via a web browser, and send a PM
-from `Polonius` to `Iago`.
+conversation between two users, and make sure that notifications are toggled
+on in settings and that you don't have the Zulip app open while you're doing
+so. For example, if you've logged in as `Iago` on your mobile device, log in
+as `Polonius` via a web browser, and send a PM from `Polonius` to `Iago`.
 
 You should see a push notification appear on the mobile device!

--- a/docs/howto/push-notifications.md
+++ b/docs/howto/push-notifications.md
@@ -20,12 +20,22 @@ instance of APNs.)
 
 ## Testing server-side changes (iOS or Android)
 
-[Set up the dev server for mobile development](dev-server.md), with one
-additional step:
+[Set up the dev server for mobile development](dev-server.md), with two
+additional steps:
 
-* Before you run the server with `tools/run-dev.py`, register your
-  development server with our production bouncer by running the following
-  custom Django management command:
+* Before you run the server with `tools/run-dev.py`, add the following line
+  to `zproject/dev_settings.py`:
+
+  ```python
+  PUSH_NOTIFICATION_BOUNCER_URL = 'https://push.zulipchat.com'
+  ```
+
+  For a production build, `PUSH_NOTIFICATION_BOUNCER_URL` is specified in a
+  settings file generated from `zproject/prod_settings_template.py`. This is
+  a workaround for that, and you can keep this around via `git stash`.
+
+* Then, register your development server with our production bouncer by 
+  running the following custom Django management command:
 
   ```
   python manage.py register_server --agree_to_terms_of_service


### PR DESCRIPTION
I split the changes into two commits for a cleaner diff.