### PR TITLE
Adding Flow types to NavigationState.routes()

### DIFF
--- a/src/types.js
+++ b/src/types.js
@@ -288,10 +288,14 @@ export type NavigationState = {
   index: number,
   isTransitioning: boolean,
   key: string,
-  routes: Array<any> /* <{
+  routes: Array<{
     key: string,
     title: string,
-  }>, */,
+    routeName: string,
+    params: {
+      narrow: Narrow,
+    },
+  }>,
 };
 
 export type RealmBot = {

--- a/src/types.js
+++ b/src/types.js
@@ -292,8 +292,9 @@ export type NavigationState = {
     key: string,
     title: string,
     routeName: string,
+    /** The fields in `params` vary by route; see `navActions.js`. */
     params: {
-      narrow: Narrow,
+      narrow?: Narrow,
     },
   }>,
 };


### PR DESCRIPTION
Issue in focus: #2052 
The commented out code replaced the previous type `any`.
On the way, it was found a couple of things were missing - routeName and params which was added along with their accurate types.