### PR TITLE
Altered types in NotificationCommon & EventReaction

### DIFF
--- a/src/types.js
+++ b/src/types.js
@@ -65,7 +65,7 @@ export type EventReaction = {
   emoji_code: string,
   emoji_name: string,
   reaction_type: string,
-  user: any,
+  user: string,
 };
 
 /** An aggregate of all the reactions with one emoji to one message. */
@@ -553,7 +553,7 @@ export type UnreadStream = {
 export type NotificationCommon = {
   alert: string,
   content: string,
-  content_truncated: string, // boolean
+  content_truncated: boolean,
   'google.message_id': string,
   'google.sent_time': number,
   'google.ttl': number,


### PR DESCRIPTION
Issue in focus: #2052 
Type of content_truncated which was previously defined as `string` was changed to `boolean` as commented out next to it which proved to be iccurate.
Changed type of EventReaction.user from any to string.