### PR TITLE
flow: Define Navigation state `params` properly

### DIFF
--- a/src/types.js
+++ b/src/types.js
@@ -293,9 +293,7 @@ export type NavigationState = {
     title: string,
     routeName: string,
     /** The fields in `params` vary by route; see `navActions.js`. */
-    params: {
-      narrow?: Narrow,
-    },
+    params: Object,
   }>,
 };
 


### PR DESCRIPTION
`params` is an object and can contain anything. It is exacly as
Component's `props` but for navigation data.

It can contain:
 * narrow
 * email
 * streamId
 * serverSettings
 * realm
and more in future.