### PR TITLE
ui: Fix Account List spacing on Android

### DIFF
--- a/src/account/AccountItem.js
+++ b/src/account/AccountItem.js
@@ -8,7 +8,6 @@ import { IconDone, IconTrash } from '../common/Icons';
 
 const styles = StyleSheet.create({
   wrapper: {
-    marginBottom: 8,
     justifyContent: 'space-between',
   },
   accountItem: {

--- a/src/account/AccountList.js
+++ b/src/account/AccountList.js
@@ -3,6 +3,7 @@ import React, { PureComponent } from 'react';
 import { View, FlatList } from 'react-native';
 
 import type { Auth, Account } from '../types';
+import { ViewPlaceholder } from '../common';
 import AccountItem from './AccountItem';
 
 type Props = {
@@ -23,6 +24,7 @@ export default class AccountList extends PureComponent<Props> {
         <FlatList
           data={accounts}
           keyExtractor={item => `${item.email}${item.realm}`}
+          ItemSeparatorComponent={() => <ViewPlaceholder height={8} />}
           renderItem={({ item, index }) => (
             <AccountItem
               index={index}

--- a/src/account/AccountPickScreen.js
+++ b/src/account/AccountPickScreen.js
@@ -2,19 +2,12 @@
 import { connect } from 'react-redux';
 
 import React, { PureComponent } from 'react';
-import { StyleSheet } from 'react-native';
 
 import type { Auth, Account, Dispatch, GlobalState } from '../types';
 import { getAuth, getAccounts } from '../selectors';
-import { Centerer, ZulipButton, Logo, Screen } from '../common';
+import { Centerer, ZulipButton, Logo, Screen, ViewPlaceholder } from '../common';
 import AccountList from './AccountList';
 import { navigateToAddNewAccount, switchAccount, removeAccount } from '../actions';
-
-const styles = StyleSheet.create({
-  button: {
-    marginTop: 8,
-  },
-});
 
 type Props = {
   auth: Auth,
@@ -52,9 +45,9 @@ class AccountPickScreen extends PureComponent<Props> {
             onAccountRemove={this.handleAccountRemove}
             auth={auth}
           />
+          <ViewPlaceholder height={16} />
           <ZulipButton
             text="Add new account"
-            style={styles.button}
             onPress={() => {
               dispatch(navigateToAddNewAccount(''));
             }}


### PR DESCRIPTION
This fixes the 'no spacing between account list items' issue. #2982

No visual changes to the iOS version, but Android now also matches it.

Also, more importantly, it makes the styling more clean and logical.

Now:
 * the AccountItem does not have a 'margin' by default, that didn't
make sense as it is not its job to provide that styling
 * the spacing is logically implemented via `ItemSeparatorComponent`