### PR TITLE
fix: Resolve layout issues with Touchable on Android

### DIFF
--- a/src/common/Touchable.js
+++ b/src/common/Touchable.js
@@ -62,12 +62,11 @@ export default class Touchable extends PureComponent<Props> {
     return (
       <TouchableNativeFeedback
         accessibilityLabel={accessibilityLabel}
-        style={style}
         background={androidBackground}
         onPress={onPress}
         onLongPress={onLongPress}
       >
-        <View>{children}</View>
+        <View style={style}>{children}</View>
       </TouchableNativeFeedback>
     );
   }


### PR DESCRIPTION
`TouchableNativeFeedback` that we use on Android does not receive
any `style` props, that is quite inconsistent with `TouchableHighlight`
which we use on iOS.

Trying to set style props on a Touchable component does not have an
effect on Android, thus layout issues were introduced for Android-only in:
* AccountItem
* PasswordInput
* ZulipButton