### PR TITLE
Fix: Incorrectly calculated unread mentions

### DIFF
--- a/src/api/apiTypes.js
+++ b/src/api/apiTypes.js
@@ -75,9 +75,14 @@ export type Message = {
   sender_domain: string,
 
   /**
-   * This is (always?) present in a `message` event; but we leave it out of
-   * the `messages` subtree of the Redux state, moving the information to
-   * the separate `flags` subtree.
+   * The `flags` story is a bit complicated:
+   *  * Absent in the `message` property of a `message` event... but instead
+   *    (confusingly) a `.flags` appears directly on the event.
+   *  * Present in the `EVENT_NEW_MESSAGE` Redux action for such an event.
+   *  * Present in the server's response to a `/messages` request (our
+   *    `getMessages`), and our `MESSAGE_FETCH_COMPLETE` action.
+   *  * Absent in the `messages` subtree of the Redux state; we move the
+   *    information to the separate `flags` subtree.
    */
   flags?: string[],
 

--- a/src/api/apiTypes.js
+++ b/src/api/apiTypes.js
@@ -45,6 +45,13 @@ export type MessageEdit = {
  * complex; this is naturally a place where a large fraction of all the
  * features of Zulip have to appear.
  *
+ * Major appearances of this type include
+ *  * `message: Message` on a server event of type `message`, and our
+ *    `EVENT_NEW_MESSAGE` Redux action for the event;
+ *  * `messages: Message[]` in a `/messages` (our `getMessages`) response,
+ *    and our resulting `MESSAGE_FETCH_COMPLETE` Redux action;
+ *  * `messages: { [id]: Message }` in our global Redux state.
+ *
  * References include:
  *  * the two example events at https://zulipchat.com/api/get-events-from-queue
  *  * `process_message_event` in zerver/tornado/event_queue.py; the call
@@ -65,8 +72,8 @@ export type Message = {
   isOutbox: false,
 
   /**
-   * These don't appear in `message` events, but they appear in GET
-   * requests for messages in a narrow when a search is involved.
+   * These don't appear in `message` events, but they appear in a `/message`
+   * response when a search is involved.
    */
   match_content?: string,
   match_subject?: string,
@@ -76,13 +83,13 @@ export type Message = {
 
   /**
    * The `flags` story is a bit complicated:
-   *  * Absent in the `message` property of a `message` event... but instead
-   *    (confusingly) a `.flags` appears directly on the event.
-   *  * Present in the `EVENT_NEW_MESSAGE` Redux action for such an event.
-   *  * Present in the server's response to a `/messages` request (our
-   *    `getMessages`), and our `MESSAGE_FETCH_COMPLETE` action.
-   *  * Absent in the `messages` subtree of the Redux state; we move the
-   *    information to the separate `flags` subtree.
+   *  * Absent in `event.message` for a `message` event... but instead
+   *    (confusingly) there is an `event.flags`.
+   *  * Present under `EVENT_NEW_MESSAGE`.
+   *  * Present under `MESSAGE_FETCH_COMPLETE`, and in the server `/message`
+   *    response that action is based on.
+   *  * Absent in the Redux `state.messages`; we move the information to a
+   *    separate subtree `state.flags`.
    */
   flags?: string[],
 

--- a/src/events/__tests__/eventMiddleware-test.js
+++ b/src/events/__tests__/eventMiddleware-test.js
@@ -1,0 +1,28 @@
+/* @flow */
+import deepFreeze from 'deep-freeze';
+
+import eventMiddleware from '../eventMiddleware';
+
+describe('eventMiddleware', () => {
+  test('if `event.flags` key exist, move it to `event.message.flags`', () => {
+    const state = { session: {} };
+    const event = {
+      type: 'message',
+      flags: ['mentioned'],
+      message: {},
+    };
+    eventMiddleware(state, event);
+
+    expect(event.flags).not.toBeDefined();
+    expect(event.message.flags).toEqual(['mentioned']);
+  });
+
+  test('if `event.flags` do not exist, do not mutate event', () => {
+    const state = { session: {} };
+    const event = deepFreeze({
+      type: 'message',
+      message: {},
+    });
+    expect(() => eventMiddleware(state, event)).not.toThrow();
+  });
+});

--- a/src/events/eventMiddleware.js
+++ b/src/events/eventMiddleware.js
@@ -9,9 +9,16 @@ import { playMessageSound } from '../utils/sound';
 export default (state: GlobalState, event: Object) => {
   switch (event.type) {
     case 'message': {
+      // move `flags` key from `event` to `event.message` for consistency
+      if (event.flags && !event.message.flags) {
+        event.message.flags = event.flags;
+        delete event.flags;
+      }
+
       const isActive = getIsActive(state);
       const isPrivateMessage = Array.isArray(event.message.display_recipient);
-      if (!isActive || (!isPrivateMessage && event.flags.indexOf('mentioned') === -1)) {
+      const isMentioned = event.message.flags && event.message.flags.includes('mentioned');
+      if (!isActive || !(isPrivateMessage || isMentioned)) {
         break;
       }
 

--- a/src/unread/__tests__/unreadMentionsReducers-test.js
+++ b/src/unread/__tests__/unreadMentionsReducers-test.js
@@ -52,13 +52,14 @@ describe('unreadMentionsReducers', () => {
   });
 
   describe('EVENT_NEW_MESSAGE', () => {
-    test('if message does not contain is_mentioned, do not mutate state', () => {
+    test('if message does not contain "mentioned" flag, do not mutate state', () => {
       const initialState = deepFreeze([]);
 
       const action = deepFreeze({
         type: EVENT_NEW_MESSAGE,
         message: {
           id: 2,
+          flags: [],
         },
       });
 
@@ -74,7 +75,7 @@ describe('unreadMentionsReducers', () => {
         type: EVENT_NEW_MESSAGE,
         message: {
           id: 2,
-          is_mentioned: true,
+          flags: ['mentioned'],
         },
       });
 
@@ -83,14 +84,14 @@ describe('unreadMentionsReducers', () => {
       expect(actualState).toBe(initialState);
     });
 
-    test('if is_mentioned is true and message id does not exist, append to state', () => {
+    test('if "mentioned" flag is set and message id does not exist, append to state', () => {
       const initialState = deepFreeze([1, 2]);
 
       const action = deepFreeze({
         type: EVENT_NEW_MESSAGE,
         message: {
           id: 3,
-          is_mentioned: true,
+          flags: ['mentioned'],
         },
       });
 

--- a/src/unread/unreadMentionsReducers.js
+++ b/src/unread/unreadMentionsReducers.js
@@ -28,7 +28,9 @@ const eventNewMessage = (
   state: UnreadMentionsState,
   action: EventNewMessageAction,
 ): UnreadMentionsState =>
-  action.message.is_mentioned && !state.includes(action.message.id)
+  action.message.flags
+  && action.message.flags.includes('mentioned')
+  && !state.includes(action.message.id)
     ? addItemsToArray(state, [action.message.id])
     : state;
 


### PR DESCRIPTION
We are calculating the unread mentions to be used in the UI but
are currently not used (should do that soon)

Due to not exposing this we have not caught an issue - the logic to
determine if the current user was mentioned in an upcomming  message
was incorrect. In fact, there is no `is_mentioned` key on the `message`
object, but the data is passed via a `flags` array.

This logic is already used correctly in `eventMiddleware.js`.

This PR replaces the incorrect code and fixes the tests.