### PR TITLE
autocomplete popup: Fix maximum height.

### DIFF
--- a/src/common/Popup.js
+++ b/src/common/Popup.js
@@ -13,6 +13,7 @@ const styles = StyleSheet.create({
     shadowOpacity: 0.5,
     shadowRadius: 16,
     elevation: 3,
+    maxHeight: 250,
   },
 });
 


### PR DESCRIPTION
This is a quick fix to #2997. Set the height to 250 logical pixels, which is high enough to display about 5 list items.

Before:

![autocomplete-popup-quick-fix-before](https://user-images.githubusercontent.com/12771126/46701138-9a2d5400-cbd3-11e8-950e-0bf1798c02f4.gif)

After:

![autocomplete-popup-quick-fix-after](https://user-images.githubusercontent.com/12771126/46701273-0d36ca80-cbd4-11e8-8e7b-cb7c46dfcfe2.gif)
