### PR TITLE
docs: Remove support for iOS 8.0.

### DIFF
--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -1,6 +1,6 @@
 # Developer guide
 
-We target operating systems >= Android 4.4 (API 19) and >= iOS 8.1.
+We target operating systems >= Android 4.4 (API 19) and >= iOS 9.0.
 
 ## Why React Native?
 

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -1,6 +1,6 @@
 # Developer guide
 
-We target operating systems >= Android 4.4 (API 19) and >= iOS 8.0.
+We target operating systems >= Android 4.4 (API 19) and >= iOS 8.1.
 
 ## Why React Native?
 


### PR DESCRIPTION
XCode (I'm using 9.4.1 at the time of this commit) doesn't provide a simulator for iOS 8.0, and the vast majority of our iOS users stay updated to the latest OS, so the impact of this should be trivial.
