### PR TITLE
flow: Remove handleImagePress from Lightbox props.

### DIFF
--- a/src/lightbox/Lightbox.js
+++ b/src/lightbox/Lightbox.js
@@ -40,7 +40,6 @@ type Props = {
   dispatch: Dispatch,
   src: string,
   message: Message,
-  handleImagePress: (movement: string) => void,
   showActionSheetWithOptions: (Object, (number) => void) => void,
 };
 


### PR DESCRIPTION
There is no `handleImagePress` prop that is passed to Lightbox. At the time of this commit, `handleImagePress` is a prototype method that updates local state.