### PR TITLE
Webview: Fix over strict type check on click handler.

### DIFF
--- a/src/webview/js/generatedEs3.js
+++ b/src/webview/js/generatedEs3.js
@@ -277,7 +277,8 @@ documentBody.addEventListener('click', function (e) {
 
   var target = e.target;
 
-  if (!(target instanceof HTMLElement || target instanceof SVGElement)) {
+
+  if (!(target instanceof Element)) {
     return;
   }
 

--- a/src/webview/js/generatedEs3.js
+++ b/src/webview/js/generatedEs3.js
@@ -277,8 +277,7 @@ documentBody.addEventListener('click', function (e) {
 
   var target = e.target;
 
-
-  if (!(target instanceof HTMLElement)) {
+  if (!(target instanceof HTMLElement || target instanceof SVGElement)) {
     return;
   }
 

--- a/src/webview/js/js.js
+++ b/src/webview/js/js.js
@@ -357,8 +357,7 @@ documentBody.addEventListener('click', (e: MouseEvent) => {
 
   const { target } = e;
 
-  // $FlowFixMe - Flow doesn't have the SVGElement type declaration yet
-  if (!(target instanceof HTMLElement || target instanceof SVGElement)) {
+  if (!(target instanceof Element)) {
     return;
   }
 

--- a/src/webview/js/js.js
+++ b/src/webview/js/js.js
@@ -357,7 +357,8 @@ documentBody.addEventListener('click', (e: MouseEvent) => {
 
   const { target } = e;
 
-  if (!(target instanceof HTMLElement)) {
+  // $FlowFixMe - Flow doesn't have the SVGElement type declaration yet
+  if (!(target instanceof HTMLElement || target instanceof SVGElement)) {
     return;
   }
 


### PR DESCRIPTION
This commit fixes a change introduced in d8352d where we're falsely
returning early if the element is not an instanceof HTMLElement.
Some elements like the down arrow are svg elements so we add
that condition for the return statement.