### PR TITLE
Display !avatar images in message list

### DIFF
--- a/src/webview/js/generatedEs3.js
+++ b/src/webview/js/generatedEs3.js
@@ -316,7 +316,7 @@ var appendAuthToImages = function appendAuthToImages(auth) {
 
     var srcPath = img.src.substring(auth.realm.length);
 
-    if (!(srcPath.startsWith('/user_uploads/') || srcPath.startsWith('/thumbnail?'))) {
+    if (!(srcPath.startsWith('/user_uploads/') || srcPath.startsWith('/thumbnail?') || srcPath.startsWith('/avatar/'))) {
       return;
     }
 

--- a/src/webview/js/js.js
+++ b/src/webview/js/js.js
@@ -439,7 +439,13 @@ const appendAuthToImages = auth => {
     // for a small number of routes.  Rather than append the API key to all
     // kinds of URLs on the server, do so only for those routes.
     const srcPath = img.src.substring(auth.realm.length);
-    if (!(srcPath.startsWith('/user_uploads/') || srcPath.startsWith('/thumbnail?'))) {
+    if (
+      !(
+        srcPath.startsWith('/user_uploads/')
+        || srcPath.startsWith('/thumbnail?')
+        || srcPath.startsWith('/avatar/')
+      )
+    ) {
       return;
     }
 


### PR DESCRIPTION
Fixes #3044

Avatars included in a message in the form of

```
!avatar(email@example.com)
```

are not being shown.

They are hosted at `/avatar/` and we do not provide auth for this
path. Fixing this is as simple as adding a check for these urls to
the `appendAuthToImages` function.