### PR TITLE
composeBox: Limit maxHeight to 110.

### DIFF
--- a/src/styles/composeBoxStyles.js
+++ b/src/styles/composeBoxStyles.js
@@ -52,6 +52,7 @@ export default ({ color, backgroundColor, borderColor }: Props) => ({
     backgroundColor,
     color,
     fontSize: 15,
+    maxHeight: 110,
     ...inputMarginPadding,
   },
   topicInput: {


### PR DESCRIPTION
Most chat apps limit the height of composeBox, and then text box
becomes scrollable on further entering text. FB messenger and WhatsApp
limit to 6 lines of text. Following the same pattern, limit the max
height of message input.

Fixes: #3048

<img width="490" alt="screen shot 2018-10-13 at 1 04 07 pm" src="https://user-images.githubusercontent.com/18511177/46903658-8f393300-cef5-11e8-969f-ab7fa35173a5.png">

<img width="388" alt="image" src="https://user-images.githubusercontent.com/18511177/46903665-ab3cd480-cef5-11e8-8075-370ce786b05a.png">
