### PR TITLE
refactor: Rename `getCurrentRoute` to `getCurrentRouteName`.

### DIFF
--- a/src/nav/__tests__/navSelectors-test.js
+++ b/src/nav/__tests__/navSelectors-test.js
@@ -1,14 +1,14 @@
 import deepFreeze from 'deep-freeze';
 
 import {
-  getCurrentRoute,
+  getCurrentRouteName,
   getCurrentRouteParams,
   getChatScreenParams,
   getCanGoBack,
   getSameRoutesCount,
 } from '../navSelectors';
 
-describe('getCurrentRoute', () => {
+describe('getCurrentRouteName', () => {
   test('return name of the current route', () => {
     const state = deepFreeze({
       nav: {
@@ -21,7 +21,7 @@ describe('getCurrentRoute', () => {
     });
     const expectedResult = 'second';
 
-    const actualResult = getCurrentRoute(state);
+    const actualResult = getCurrentRouteName(state);
 
     expect(actualResult).toEqual(expectedResult);
   });

--- a/src/nav/navSelectors.js
+++ b/src/nav/navSelectors.js
@@ -14,7 +14,7 @@ const getNavigationRoutes = (state: GlobalState): Object[] => state.nav.routes;
 
 const getNavigationIndex = (state: GlobalState): number => state.nav.index;
 
-export const getCurrentRoute = (state: GlobalState): string =>
+export const getCurrentRouteName = (state: GlobalState): string =>
   state.nav.routes[state.nav.index].routeName;
 
 export const getCurrentRouteParams = createSelector(

--- a/src/title/titleSelectors.js
+++ b/src/title/titleSelectors.js
@@ -4,15 +4,15 @@ import { createSelector } from 'reselect';
 import type { Narrow } from '../types';
 import { BRAND_COLOR } from '../styles';
 import { getSubscriptions } from '../directSelectors';
-import { getCurrentRoute } from '../nav/navSelectors';
+import { getCurrentRouteName } from '../nav/navSelectors';
 import { foregroundColorFromBackground } from '../utils/color';
 import { isStreamNarrow, isTopicNarrow } from '../utils/narrow';
 import { NULL_SUBSCRIPTION } from '../nullObjects';
 
 export const getIsInTopicOrStreamNarrow = (narrow: Narrow) =>
   createSelector(
-    getCurrentRoute,
-    route => (route === 'chat' ? isStreamNarrow(narrow) || isTopicNarrow(narrow) : false),
+    getCurrentRouteName,
+    routeName => (routeName === 'chat' ? isStreamNarrow(narrow) || isTopicNarrow(narrow) : false),
   );
 
 export const getTitleBackgroundColor = (narrow: Narrow) =>


### PR DESCRIPTION
As this selector, returns `routeName`, instead of route (which also
contains other route details too like route params). So definately
`getCurrentRouteName` is more appropiate name for this, it's give more
clarity of what's it returns.

Pulling this commit out from #2807.