### PR TITLE
Simplify Screen component, use only ScrollView 

### DIFF
--- a/src/common/Screen.js
+++ b/src/common/Screen.js
@@ -112,20 +112,17 @@ class Screen extends PureComponent<Props> {
           style={[componentStyles.wrapper, padding && styles.padding]}
           contentContainerStyle={[padding && styles.padding]}
         >
-          {scrollEnabled ? (
-            <ScrollView
-              contentContainerStyle={
-                /* $FlowFixMe wants ViewStyleProp */
-                [centerContent && componentStyles.content, style]
-              }
-              style={componentStyles.childrenWrapper}
-              keyboardShouldPersistTaps={keyboardShouldPersistTaps}
-            >
-              {children}
-            </ScrollView>
-          ) : (
-            <View style={componentStyles.childrenWrapper}>{children}</View>
-          )}
+          <ScrollView
+            contentContainerStyle={
+              /* $FlowFixMe wants ViewStyleProp */
+              [centerContent && componentStyles.content, style]
+            }
+            style={componentStyles.childrenWrapper}
+            keyboardShouldPersistTaps={keyboardShouldPersistTaps}
+            scrollEnabled={scrollEnabled}
+          >
+            {children}
+          </ScrollView>
         </KeyboardAvoider>
       </View>
     );

--- a/src/common/Screen.js
+++ b/src/common/Screen.js
@@ -43,7 +43,7 @@ type Props = {
   padding?: boolean,
   search?: boolean,
   title?: LocalizableText,
-  scrollableContent?: boolean,
+  scrollEnabled?: boolean,
   style?: Style,
   searchBarOnChange?: (text: string) => void,
 };
@@ -78,7 +78,7 @@ class Screen extends PureComponent<Props> {
     autoFocus: false,
     centerContent: false,
     keyboardShouldPersistTaps: 'handled',
-    scrollableContent: true,
+    scrollEnabled: true,
   };
 
   render() {
@@ -89,7 +89,7 @@ class Screen extends PureComponent<Props> {
       keyboardShouldPersistTaps,
       padding,
       safeAreaInsets,
-      scrollableContent,
+      scrollEnabled,
       search,
       searchBarOnChange,
       style,
@@ -112,7 +112,7 @@ class Screen extends PureComponent<Props> {
           style={[componentStyles.wrapper, padding && styles.padding]}
           contentContainerStyle={[padding && styles.padding]}
         >
-          {scrollableContent ? (
+          {scrollEnabled ? (
             <ScrollView
               contentContainerStyle={
                 /* $FlowFixMe wants ViewStyleProp */

--- a/src/streams/InviteUsersScreen.js
+++ b/src/streams/InviteUsersScreen.js
@@ -38,7 +38,7 @@ class InviteUsersScreen extends PureComponent<Props, State> {
   render() {
     const { filter } = this.state;
     return (
-      <Screen search scrollableContent={false} searchBarOnChange={this.handleFilterChange}>
+      <Screen search scrollEnabled={false} searchBarOnChange={this.handleFilterChange}>
         <UserPickerCard filter={filter} onComplete={this.handleInviteUsers} />
       </Screen>
     );

--- a/src/user-groups/GroupScreen.js
+++ b/src/user-groups/GroupScreen.js
@@ -35,7 +35,7 @@ class GroupScreen extends PureComponent<Props, State> {
   render() {
     const { filter } = this.state;
     return (
-      <Screen search scrollableContent={false} searchBarOnChange={this.handleFilterChange}>
+      <Screen search scrollEnabled={false} searchBarOnChange={this.handleFilterChange}>
         <UserPickerCard filter={filter} onComplete={this.handleCreateGroup} />
       </Screen>
     );


### PR DESCRIPTION
When initially writing the Screen component, I was not aware of
the `scrollEnabled` property of `ScrollView`.

Replace the switching between a `ScrollView` and a `View` with
just setting the `scrollEnabled` to the correct value.