### PR TITLE
Reduce use of Redux with React Navigation

### DIFF
--- a/src/nav/__tests__/navSelectors-test.js
+++ b/src/nav/__tests__/navSelectors-test.js
@@ -1,11 +1,9 @@
 import deepFreeze from 'deep-freeze';
 
-import { streamNarrow } from '../../utils/narrow';
 import {
   getCurrentRoute,
   getCurrentRouteParams,
   getChatScreenParams,
-  getTopMostNarrow,
   getCanGoBack,
   getSameRoutesCount,
 } from '../navSelectors';
@@ -70,44 +68,6 @@ describe('getChatScreenParams', () => {
     const actualResult = getChatScreenParams(state);
 
     expect(actualResult).toBeDefined();
-  });
-});
-
-describe('getTopMostNarrow', () => {
-  test('return undefined if no chat screen are in stack', () => {
-    const state = deepFreeze({
-      nav: {
-        index: 0,
-        routes: [{ routeName: 'main' }],
-      },
-    });
-    expect(getTopMostNarrow(state)).toBe(undefined);
-  });
-
-  test('return narrow of first chat screen from top', () => {
-    const narrow = streamNarrow('all');
-    const state = deepFreeze({
-      nav: {
-        index: 1,
-        routes: [{ routeName: 'main' }, { routeName: 'chat', params: { narrow } }],
-      },
-    });
-    expect(getTopMostNarrow(state)).toEqual(narrow);
-  });
-
-  test('iterate over stack to get first chat screen', () => {
-    const narrow = streamNarrow('all');
-    const state = deepFreeze({
-      nav: {
-        index: 2,
-        routes: [
-          { routeName: 'main' },
-          { routeName: 'chat', params: { narrow } },
-          { routeName: 'account' },
-        ],
-      },
-    });
-    expect(getTopMostNarrow(state)).toEqual(narrow);
   });
 });
 

--- a/src/nav/navSelectors.js
+++ b/src/nav/navSelectors.js
@@ -28,18 +28,6 @@ export const getChatScreenParams = createSelector(
   params => params || { narrow: undefined },
 );
 
-export const getTopMostNarrow = createSelector(getNav, nav => {
-  const { routes } = nav;
-  let { index } = nav;
-  while (index >= 0) {
-    if (routes[index].routeName === 'chat') {
-      return routes[index].params.narrow;
-    }
-    index--;
-  }
-  return undefined;
-});
-
 export const getCanGoBack = (state: GlobalState) => state.nav.index > 0;
 
 export const getSameRoutesCount = createSelector(getNav, nav => {


### PR DESCRIPTION
Based on RN2 branch.

These are the first steps to remove React Navigation's dependency on Redux.
Some of them are a no-brainer. Some future ones would be a good idea too.
It is not yet clear if 100% Redux-less approach is ideal. 