### PR TITLE
composebox: Do not unmount Input on hide

### DIFF
--- a/src/compose/ComposeBox.js
+++ b/src/compose/ComposeBox.js
@@ -277,10 +277,6 @@ class ComposeBox extends PureComponent<Props, State> {
       isSubscribed,
     } = this.props;
 
-    if (!canSend) {
-      return null;
-    }
-
     if (!isSubscribed) {
       return <NotSubscribed narrow={narrow} />;
     } else if (isAnnouncementOnly && !isAdmin) {
@@ -288,9 +284,13 @@ class ComposeBox extends PureComponent<Props, State> {
     }
 
     const placeholder = getComposeInputPlaceholder(narrow, auth.email, users);
+    const style = {
+      marginBottom: safeAreaInsets.bottom,
+      ...(canSend ? {} : { opacity: 0, position: 'absolute' }),
+    };
 
     return (
-      <View style={{ marginBottom: safeAreaInsets.bottom }}>
+      <View style={style}>
         <AutocompleteViewWrapper
           composeText={message}
           isTopicFocused={isTopicFocused}


### PR DESCRIPTION

When `canSend` property is `false` we hide the ComposeBox component.
Then after it appears again the contents of both topic and message
Inputs are missing.

This issue exists only with our uncontrolled Input.

The cause is quite curious. We correctly initialize the components
on `componentDidMount`. So the component is working correctly on
initial render. What is messing it up is that if `canSend` becomes
`false` we do render a `null` (so nothing). This happens when we
are refreshing the state, on `APP_REFRESH` called on broken queues,
but can happen in other cases too (any case that makes `canSend` be
`false`).

When we show the component again, since we handle the show/no show
logic inside the component, the lifecycle event `componentDidMount`
is not called again. Thus we do not initialize he values of the
Inputs that were unmounted.

There are several approaches to fixing this:
 * take the `canSend` logic ouside of the component. On each change
the whole component will get unmounted and the `componentDidMount`
will be called again - not a bad solution
 * handle the `false` to `true` transition of the value inside the
`componentWillReceiveProps` - would work, but we are trying to get
rid of this funcion, and also makes the logic too convoluted
 * do not unmount the Inputs when hiding - the chosen solution

When we need to hide the component, instead of not rendering it at
all, we just hide it - setting the `opacity` to 0 does that.
We also set `position` to `absolute` so it does not take up space
visually.

Tested both on iOS and Android and works well.