### PR TITLE
Remove unused string "New group chat".

### DIFF
--- a/src/i18n/translations/messages_ar.json
+++ b/src/i18n/translations/messages_ar.json
@@ -78,7 +78,6 @@
   "Subscribed": "Subscribed",
   "No users found": "No users found",
   "No streams found": "No streams found",
-  "New group chat": "New group chat",
   "Diagnostics": "Diagnostics",
   "Toggle compose tools": "Toggle compose tools",
   "Terms of service": "Terms of service",

--- a/src/i18n/translations/messages_bg.json
+++ b/src/i18n/translations/messages_bg.json
@@ -78,7 +78,6 @@
   "Subscribed": "Абонирани",
   "No users found": "Няма намерени потребители",
   "No streams found": "Няма намерени канали",
-  "New group chat": "Няма намерени групови разговори",
   "Diagnostics": "Диагностика",
   "Toggle compose tools": "Превключи инструменти за редакция",
   "Terms of service": "Условия за ползване",

--- a/src/i18n/translations/messages_ca.json
+++ b/src/i18n/translations/messages_ca.json
@@ -78,7 +78,6 @@
   "Subscribed": "Subscribed",
   "No users found": "No users found",
   "No streams found": "No streams found",
-  "New group chat": "Nou xat de grup",
   "Diagnostics": "Diagnostics",
   "Toggle compose tools": "Toggle compose tools",
   "Terms of service": "Terms of service",

--- a/src/i18n/translations/messages_cs.json
+++ b/src/i18n/translations/messages_cs.json
@@ -78,7 +78,6 @@
   "Subscribed": "Odebíráno",
   "No users found": "Nenalezeni žádní uživatelé",
   "No streams found": "Nenalezeny žádné skupiny",
-  "New group chat": "Nový skupinový rozhovor",
   "Diagnostics": "Diagnóza",
   "Toggle compose tools": "Přepnout nástroje pro skládání",
   "Terms of service": "Podmínky užití",

--- a/src/i18n/translations/messages_da.json
+++ b/src/i18n/translations/messages_da.json
@@ -78,7 +78,6 @@
   "Subscribed": "Subscribed",
   "No users found": "No users found",
   "No streams found": "No streams found",
-  "New group chat": "New group chat",
   "Diagnostics": "Diagnostics",
   "Toggle compose tools": "Toggle compose tools",
   "Terms of service": "Terms of service",

--- a/src/i18n/translations/messages_de.json
+++ b/src/i18n/translations/messages_de.json
@@ -78,7 +78,6 @@
   "Subscribed": "Abonniert",
   "No users found": "Keine Nutzer gefunden",
   "No streams found": "Keine Streams gefunden",
-  "New group chat": "Neuer Gruppenchat",
   "Diagnostics": "Diagnose",
   "Toggle compose tools": "Nachrichtenbox umschalten",
   "Terms of service": "Nutzungsbedingungen",

--- a/src/i18n/translations/messages_en.json
+++ b/src/i18n/translations/messages_en.json
@@ -78,7 +78,6 @@
   "Subscribed": "Subscribed",
   "No users found": "No users found",
   "No streams found": "No streams found",
-  "New group chat": "New group chat",
   "Diagnostics": "Diagnostics",
   "Toggle compose tools": "Toggle compose tools",
   "Terms of service": "Terms of service",

--- a/src/i18n/translations/messages_es.json
+++ b/src/i18n/translations/messages_es.json
@@ -78,7 +78,6 @@
   "Subscribed": "Suscrito",
   "No users found": "No se han encontrado usuarios",
   "No streams found": "No se encontraron canales",
-  "New group chat": "Nuevo chat de grupo",
   "Diagnostics": "Diagnósticos",
   "Toggle compose tools": "Abrir las herramientas de redacción",
   "Terms of service": "Términos de servicio",

--- a/src/i18n/translations/messages_fa.json
+++ b/src/i18n/translations/messages_fa.json
@@ -78,7 +78,6 @@
   "Subscribed": "Subscribed",
   "No users found": "No users found",
   "No streams found": "No streams found",
-  "New group chat": "New group chat",
   "Diagnostics": "Diagnostics",
   "Toggle compose tools": "Toggle compose tools",
   "Terms of service": "Terms of service",

--- a/src/i18n/translations/messages_fi.json
+++ b/src/i18n/translations/messages_fi.json
@@ -78,7 +78,6 @@
   "Subscribed": "Tilattu",
   "No users found": "Käyttäjiä ei löydy",
   "No streams found": "Kanavia ei löydy",
-  "New group chat": "Uusi ryhmächatti",
   "Diagnostics": "Diagnostiikka",
   "Toggle compose tools": "Vaihtele kirjoitustyökaluja",
   "Terms of service": "Käyttöehdot",

--- a/src/i18n/translations/messages_fr.json
+++ b/src/i18n/translations/messages_fr.json
@@ -78,7 +78,6 @@
   "Subscribed": "Abonné",
   "No users found": "Aucun utilisateur trouvé",
   "No streams found": "Aucun canal trouvé",
-  "New group chat": "Nouveau groupe de chat",
   "Diagnostics": "Diagnostiques",
   "Toggle compose tools": "Basculer les outils de composition",
   "Terms of service": "Conditions d'utilisation",

--- a/src/i18n/translations/messages_gl.json
+++ b/src/i18n/translations/messages_gl.json
@@ -78,7 +78,6 @@
   "Subscribed": "Subscrito",
   "No users found": "Non se atoparon usuarios",
   "No streams found": "Non se atoparon fíos",
-  "New group chat": "Novo grupo de conversas",
   "Diagnostics": "Diagnóstico",
   "Toggle compose tools": "Mudar de ferramenta de edición",
   "Terms of service": "Condicións de servizo",

--- a/src/i18n/translations/messages_hi.json
+++ b/src/i18n/translations/messages_hi.json
@@ -78,7 +78,6 @@
   "Subscribed": "सदस्यता लिया",
   "No users found": "कोई सदस्य नहीं मिले",
   "No streams found": "कोई धारा नहीं मिला",
-  "New group chat": "नया समूह चर्चा",
   "Diagnostics": "निदान",
   "Toggle compose tools": "बदले लेख साधन",
   "Terms of service": "सेवा की शर्तें",

--- a/src/i18n/translations/messages_hr.json
+++ b/src/i18n/translations/messages_hr.json
@@ -78,7 +78,6 @@
   "Subscribed": "Subscribed",
   "No users found": "No users found",
   "No streams found": "No streams found",
-  "New group chat": "New group chat",
   "Diagnostics": "Diagnostics",
   "Toggle compose tools": "Toggle compose tools",
   "Terms of service": "Terms of service",

--- a/src/i18n/translations/messages_hu.json
+++ b/src/i18n/translations/messages_hu.json
@@ -78,7 +78,6 @@
   "Subscribed": "Feliratkozva",
   "No users found": "Nincsenek felhasználók",
   "No streams found": "Nincseke üzenetfolyamok",
-  "New group chat": "Új csoportos csevegés",
   "Diagnostics": "Diagnosztika",
   "Toggle compose tools": "Szerkesztőeszközök kapcsolása",
   "Terms of service": "Szolgáltatási feltételek",

--- a/src/i18n/translations/messages_id_ID.json
+++ b/src/i18n/translations/messages_id_ID.json
@@ -78,7 +78,6 @@
   "Subscribed": "Berlangganan",
   "No users found": "Pengguna tidak ditemukan",
   "No streams found": "Stream tidak ditemukan",
-  "New group chat": "Grup chat baru",
   "Diagnostics": "Diagnosis",
   "Toggle compose tools": "Ubah alat penyusun",
   "Terms of service": "Ketentuan layanan",

--- a/src/i18n/translations/messages_it.json
+++ b/src/i18n/translations/messages_it.json
@@ -78,7 +78,6 @@
   "Subscribed": "Subscribed",
   "No users found": "No users found",
   "No streams found": "No streams found",
-  "New group chat": "New group chat",
   "Diagnostics": "Diagnostics",
   "Toggle compose tools": "Toggle compose tools",
   "Terms of service": "Terms of service",

--- a/src/i18n/translations/messages_ja.json
+++ b/src/i18n/translations/messages_ja.json
@@ -78,7 +78,6 @@
   "Subscribed": "購読済み",
   "No users found": "ユーザーが見つかりません",
   "No streams found": "ストリームが見つかりません",
-  "New group chat": "新しいグループチャット",
   "Diagnostics": "診断",
   "Toggle compose tools": "作成ツールを切り替え",
   "Terms of service": "サービス利用規約",

--- a/src/i18n/translations/messages_ko.json
+++ b/src/i18n/translations/messages_ko.json
@@ -78,7 +78,6 @@
   "Subscribed": "구독됨",
   "No users found": "사용자가 발견되지 않음.",
   "No streams found": "스트림이 발견되지 않음.",
-  "New group chat": "새 그룹 대화",
   "Diagnostics": "진단",
   "Toggle compose tools": "작성툴 토글",
   "Terms of service": "서비스 약관",

--- a/src/i18n/translations/messages_ml.json
+++ b/src/i18n/translations/messages_ml.json
@@ -78,7 +78,6 @@
   "Subscribed": "വരിക്കാരനായി",
   "No users found": "No users found",
   "No streams found": "No streams found",
-  "New group chat": "New group chat",
   "Diagnostics": "Diagnostics",
   "Toggle compose tools": "Toggle compose tools",
   "Terms of service": "Terms of service",

--- a/src/i18n/translations/messages_nl.json
+++ b/src/i18n/translations/messages_nl.json
@@ -78,7 +78,6 @@
   "Subscribed": "Geabonneerd",
   "No users found": "Geen gebruikers gevonden",
   "No streams found": "Geen kanalen gevonden",
-  "New group chat": "Nieuw groepsgesprek",
   "Diagnostics": "Diagnostische informatie",
   "Toggle compose tools": "Berichttools omschakelen",
   "Terms of service": "Gebruiksvoorwaarden",

--- a/src/i18n/translations/messages_pl.json
+++ b/src/i18n/translations/messages_pl.json
@@ -78,7 +78,6 @@
   "Subscribed": "Subskrybujesz",
   "No users found": "Nie znaleziono użytkownika",
   "No streams found": "Nie znaleziono kanału",
-  "New group chat": "Nowa grupa czatu",
   "Diagnostics": "Diagnostyka",
   "Toggle compose tools": "Przełącz narzędzia do tworzenia",
   "Terms of service": "Warunki korzystania z usługi",

--- a/src/i18n/translations/messages_pt.json
+++ b/src/i18n/translations/messages_pt.json
@@ -78,7 +78,6 @@
   "Subscribed": "Inscrito",
   "No users found": "Usuários não encontrados",
   "No streams found": "Fluxos não encontrados",
-  "New group chat": "Novo bate-papo de grupo",
   "Diagnostics": "Diagnósticos",
   "Toggle compose tools": "Alternar ferramentas de composição",
   "Terms of service": "Termos de serviço",

--- a/src/i18n/translations/messages_ro.json
+++ b/src/i18n/translations/messages_ro.json
@@ -78,7 +78,6 @@
   "Subscribed": "Subscribed",
   "No users found": "No users found",
   "No streams found": "No streams found",
-  "New group chat": "New group chat",
   "Diagnostics": "Diagnostics",
   "Toggle compose tools": "Toggle compose tools",
   "Terms of service": "Terms of service",

--- a/src/i18n/translations/messages_ru.json
+++ b/src/i18n/translations/messages_ru.json
@@ -78,7 +78,6 @@
   "Subscribed": "Подписан",
   "No users found": "Пользователи не найдены",
   "No streams found": "Каналы не найдены",
-  "New group chat": "Новый групповой чат",
   "Diagnostics": "Диагностика",
   "Toggle compose tools": "Переключить инструменты компоновки",
   "Terms of service": "Условия использования",

--- a/src/i18n/translations/messages_sr.json
+++ b/src/i18n/translations/messages_sr.json
@@ -78,7 +78,6 @@
   "Subscribed": "Subscribed",
   "No users found": "No users found",
   "No streams found": "No streams found",
-  "New group chat": "New group chat",
   "Diagnostics": "Diagnostics",
   "Toggle compose tools": "Toggle compose tools",
   "Terms of service": "Terms of service",

--- a/src/i18n/translations/messages_sv.json
+++ b/src/i18n/translations/messages_sv.json
@@ -78,7 +78,6 @@
   "Subscribed": "Subscribed",
   "No users found": "No users found",
   "No streams found": "No streams found",
-  "New group chat": "New group chat",
   "Diagnostics": "Diagnostics",
   "Toggle compose tools": "Toggle compose tools",
   "Terms of service": "Terms of service",

--- a/src/i18n/translations/messages_ta.json
+++ b/src/i18n/translations/messages_ta.json
@@ -78,7 +78,6 @@
   "Subscribed": "சேர்ந்துள்ளார்",
   "No users found": "No users found",
   "No streams found": "No streams found",
-  "New group chat": "New group chat",
   "Diagnostics": "Diagnostics",
   "Toggle compose tools": "Toggle compose tools",
   "Terms of service": "Terms of service",

--- a/src/i18n/translations/messages_tr.json
+++ b/src/i18n/translations/messages_tr.json
@@ -78,7 +78,6 @@
   "Subscribed": "Abone olunan kanallar",
   "No users found": "Kullanıcı bulunamadı",
   "No streams found": "Kanal bulunmadı",
-  "New group chat": "Yeni grup sohbet",
   "Diagnostics": "Arıza Tespit",
   "Toggle compose tools": "Metin araçlarını aç/kapa",
   "Terms of service": "Hizmet koşulları",

--- a/src/i18n/translations/messages_uk.json
+++ b/src/i18n/translations/messages_uk.json
@@ -78,7 +78,6 @@
   "Subscribed": "Підписано",
   "No users found": "Користувачів не знайдено",
   "No streams found": "Не знайдено каналів",
-  "New group chat": "Новий груповий чат",
   "Diagnostics": "Діагностика",
   "Toggle compose tools": "Включити інструменти створення",
   "Terms of service": "Умови використання",

--- a/src/i18n/translations/messages_uz.json
+++ b/src/i18n/translations/messages_uz.json
@@ -78,7 +78,6 @@
   "Subscribed": "Subscribed",
   "No users found": "No users found",
   "No streams found": "No streams found",
-  "New group chat": "New group chat",
   "Diagnostics": "Diagnostics",
   "Toggle compose tools": "Toggle compose tools",
   "Terms of service": "Terms of service",

--- a/src/i18n/translations/messages_zh-Hans.json
+++ b/src/i18n/translations/messages_zh-Hans.json
@@ -78,7 +78,6 @@
   "Subscribed": "已订阅",
   "No users found": "未找到用户",
   "No streams found": "频道不存在",
-  "New group chat": "新聊天群组",
   "Diagnostics": "诊断",
   "Toggle compose tools": "切换组合工具",
   "Terms of service": "服务协议",

--- a/src/i18n/translations/messages_zh-Hant.json
+++ b/src/i18n/translations/messages_zh-Hant.json
@@ -78,7 +78,6 @@
   "Subscribed": "Subscribed",
   "No users found": "No users found",
   "No streams found": "No streams found",
-  "New group chat": "New group chat",
   "Diagnostics": "Diagnostics",
   "Toggle compose tools": "Toggle compose tools",
   "Terms of service": "Terms of service",


### PR DESCRIPTION
The string "New group chat" only appears in the translations files, which means that it isn't being displayed anywhere on the UI.

See https://github.com/zulip/zulip-mobile/issues/2694#issuecomment-432430078.