### PR TITLE
Authenticate image downloads by appending an 'api_key' parameter.

### DIFF
--- a/src/api/downloadFile.js
+++ b/src/api/downloadFile.js
@@ -7,10 +7,12 @@ import { getAuthHeader, getFullUrl } from '../utils/url';
 import userAgent from '../utils/userAgent';
 
 export default (src: string, auth: Auth) => {
-  const fullUrlWithAPIKey = `${getFullUrl(src, auth.realm)}?api_key=${auth.apiKey}`;
+  const absoluteUrl = getFullUrl(src, auth.realm);
 
   if (Platform.OS === 'ios') {
-    return CameraRoll.saveToCameraRoll(fullUrlWithAPIKey);
+    const delimiter = absoluteUrl.includes('?') ? '&' : '?';
+    const urlWithApiKey = `${absoluteUrl}${delimiter}api_key=${auth.apiKey}`;
+    return CameraRoll.saveToCameraRoll(urlWithApiKey);
   }
   return RNFetchBlob.config({
     addAndroidDownloads: {
@@ -20,7 +22,7 @@ export default (src: string, auth: Auth) => {
       title: src.split('/').pop(),
       notification: true,
     },
-  }).fetch('GET', getFullUrl(src, auth.realm), {
+  }).fetch('GET', absoluteUrl, {
     'Content-Type': 'application/x-www-form-urlencoded; charset=utf-8',
     'User-Agent': userAgent,
     Authorization: getAuthHeader(auth.email, auth.apiKey),

--- a/src/api/downloadFile.js
+++ b/src/api/downloadFile.js
@@ -7,8 +7,10 @@ import { getAuthHeader, getFullUrl } from '../utils/url';
 import userAgent from '../utils/userAgent';
 
 export default (src: string, auth: Auth) => {
+  const fullUrlWithAPIKey = `${getFullUrl(src, auth.realm)}?api_key=${auth.apiKey}`;
+
   if (Platform.OS === 'ios') {
-    return CameraRoll.saveToCameraRoll(getFullUrl(src, auth.realm));
+    return CameraRoll.saveToCameraRoll(fullUrlWithAPIKey);
   }
   return RNFetchBlob.config({
     addAndroidDownloads: {


### PR DESCRIPTION
Fixes #2618.

The Zulip server generally requires authentication for uploading
and downloading images. Since React Native's webview doesn't support
setting HTTP Authorization headers at the moment, we pass the API key
as a query parameter. See zulip/zulip@5ddf261.

There was previously an `appendAuthToImages` utility method that was
added in cb31986 and then removed in 9e28ef2. However,
`downloadFile.js` is used only for images, so opt to just append the
api_key via string concatenation, which is simple and easy.