### PR TITLE
Added properties on gradle.properties for help in generating release apk

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -20,3 +20,8 @@
 # TODO remove this after RN 0.57 upgrade.
 #      See https://github.com/facebook/react-native/issues/16906 .
 android.enableAapt2=false
+
+MYAPP_RELEASE_STORE_FILE=keystore-file-name.keystore
+MYAPP_RELEASE_KEY_ALIAS=keystore-file-alias
+MYAPP_RELEASE_STORE_PASSWORD=keystore-release-store-password
+MYAPP_RELEASE_KEY_PASSWORD=keystore-release-key-password


### PR DESCRIPTION
The previous edition of the Gradle.properties didn't contain the properties required for generation of apk which sometimes may confuse the developer.