### PR TITLE
Fix Android build error on macOS.

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -11,8 +11,8 @@ buildscript {
         supportLibVersion = "27.1.1"
     }
     repositories {
-        jcenter()
         google()
+        jcenter()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.1.4'
@@ -25,8 +25,8 @@ buildscript {
 allprojects {
     repositories {
         mavenLocal()
-        jcenter()
         google()
+        jcenter()
         maven {
             // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
             url "$rootDir/../node_modules/react-native/android"


### PR DESCRIPTION
This error seems to have been related to dependencies in `jcenter()`.

```
FAILURE: Build failed with an exception.

* What went wrong:
Could not resolve all files for configuration ':app:debugCompileClasspath'.
> Could not find support-vector-drawable.aar (com.android.support:support-vector-drawable:27.1.1).
  Searched in the following locations:
      https://jcenter.bintray.com/com/android/support/support-vector-drawable/27.1.1/support-vector-drawable-27.1.1.aar
> Could not find livedata-core.aar (android.arch.lifecycle:livedata-core:1.1.0).
  Searched in the following locations:
      https://jcenter.bintray.com/android/arch/lifecycle/livedata-core/1.1.0/livedata-core-1.1.0.aar
> Could not find runtime.aar (android.arch.core:runtime:1.1.0).
  Searched in the following locations:
      https://jcenter.bintray.com/android/arch/core/runtime/1.1.0/runtime-1.1.0.aar
> Could not find viewmodel.aar (android.arch.lifecycle:viewmodel:1.1.0).
  Searched in the following locations:
      https://jcenter.bintray.com/android/arch/lifecycle/viewmodel/1.1.0/viewmodel-1.1.0.aar
```

See https://github.com/facebook/react-native/issues/21916.

@gnprice 