### PR TITLE
mention state: Fix state is not updated if mention in new message.

### DIFF
--- a/src/actionTypes.js
+++ b/src/actionTypes.js
@@ -322,6 +322,7 @@ export type EventStreamOccupyAction = ServerEvent & {
 export type EventNewMessageAction = ServerEvent & {
   type: typeof EVENT_NEW_MESSAGE,
   caughtUp: CaughtUpState,
+  flags: [string],
   local_message_id: ?number,
   message: Message,
   ownEmail: string,

--- a/src/unread/__tests__/unreadMentionsReducers-test.js
+++ b/src/unread/__tests__/unreadMentionsReducers-test.js
@@ -52,7 +52,7 @@ describe('unreadMentionsReducers', () => {
   });
 
   describe('EVENT_NEW_MESSAGE', () => {
-    test('if message does not contain is_mentioned, do not mutate state', () => {
+    test('if actions does not contain flags, do not mutate state', () => {
       const initialState = deepFreeze([]);
 
       const action = deepFreeze({
@@ -72,6 +72,24 @@ describe('unreadMentionsReducers', () => {
 
       const action = deepFreeze({
         type: EVENT_NEW_MESSAGE,
+        flags: ['mentioned'],
+        message: {
+          id: 2,
+          is_mentioned: true,
+        },
+      });
+
+      const actualState = unreadMentionsReducers(initialState, action);
+
+      expect(actualState).toBe(initialState);
+    });
+
+    test('if flags does not contain mentioned, do not mutate state', () => {
+      const initialState = deepFreeze([1, 2]);
+
+      const action = deepFreeze({
+        type: EVENT_NEW_MESSAGE,
+        flags: ['read'],
         message: {
           id: 2,
           is_mentioned: true,
@@ -88,6 +106,7 @@ describe('unreadMentionsReducers', () => {
 
       const action = deepFreeze({
         type: EVENT_NEW_MESSAGE,
+        flags: ['mentioned'],
         message: {
           id: 3,
           is_mentioned: true,

--- a/src/unread/unreadMentionsReducers.js
+++ b/src/unread/unreadMentionsReducers.js
@@ -28,7 +28,7 @@ const eventNewMessage = (
   state: UnreadMentionsState,
   action: EventNewMessageAction,
 ): UnreadMentionsState =>
-  action.message.is_mentioned && !state.includes(action.message.id)
+  action.flags && action.flags.indexOf('mentioned') > -1 && !state.includes(action.message.id)
     ? addItemsToArray(state, [action.message.id])
     : state;
 


### PR DESCRIPTION
New mesage event contains flags array which can contain 'mentioned'.
So use this info to update state.

Now server doesn't send `is_mentioned` attribute in the message
object, instead it uses flags for this purpose.