### PR TITLE
Improve outbox handling

### DIFF
--- a/src/outbox/outboxActions.js
+++ b/src/outbox/outboxActions.js
@@ -54,7 +54,8 @@ export const trySendMessages = () => (dispatch: Dispatch, getState: GetState) =>
   }
   dispatch(toggleOutboxSending(true));
   const auth = getAuth(state);
-  state.outbox.forEach(async item => {
+  const outboxToSend = state.outbox.filter(outbox => !outbox.isSent);
+  outboxToSend.forEach(async item => {
     try {
       await sendMessage(
         auth,
@@ -126,6 +127,7 @@ export const addToOutbox = (narrow: Narrow, content: string) => async (
   dispatch(
     messageSendStart({
       narrow,
+      isSent: false,
       ...extractTypeToAndSubjectFromNarrow(narrow, state.users, userDetail),
       markdownContent: content,
       content: getContentPreview(content, state),

--- a/src/outbox/outboxReducers.js
+++ b/src/outbox/outboxReducers.js
@@ -1,5 +1,10 @@
 /* @flow */
-import type { OutboxState, MessageSendStartAction, OutboxAction } from '../types';
+import type {
+  OutboxState,
+  MessageSendStartAction,
+  MessageSendCompleteAction,
+  OutboxAction,
+} from '../types';
 import {
   MESSAGE_SEND_START,
   EVENT_NEW_MESSAGE,
@@ -21,7 +26,10 @@ const messageSendStart = (state: OutboxState, action: MessageSendStartAction): O
   return [...state, { ...action.outbox }];
 };
 
-const messageSendComplete = (
+const messageSendComplete = (state: OutboxState, action: MessageSendCompleteAction): OutboxState =>
+  state.map(item => (item.id !== action.local_message_id ? item : { ...item, isSent: true }));
+
+const deleteOutboxMessage = (
   state: OutboxState,
   action: { local_message_id: number },
 ): OutboxState => filterArray(state, item => item && item.timestamp !== +action.local_message_id);
@@ -32,9 +40,11 @@ export default (state: OutboxState = initialState, action: OutboxAction): Outbox
       return messageSendStart(state, action);
 
     case MESSAGE_SEND_COMPLETE:
+      return messageSendComplete(state, action);
+
     case DELETE_OUTBOX_MESSAGE:
     case EVENT_NEW_MESSAGE:
-      return messageSendComplete(state, action);
+      return deleteOutboxMessage(state, action);
 
     case ACCOUNT_SWITCH:
     case LOGOUT:

--- a/src/types.js
+++ b/src/types.js
@@ -386,6 +386,7 @@ export type TypingState = {
  */
 export type Outbox = {
   isOutbox: true,
+  isSent: boolean,
 
   markdownContent: string,
   narrow: Narrow,


### PR DESCRIPTION
Changes one of the intermediate steps when sending messages.
Fixes message list jumping and 'messages disappearing for a while'.

Our current outbox flow is:
1. Add outbox item and render it
2. Outbox item is sent and removed from outbox
3. New message given back by a server and we render

The problem is that at step 2 the message disappears.
On a fast network, this appears as a fast jump in the message list,
not ideal. On a slow network, this appears as a prolonged and buggy
looking 'message disappears after sending'.

Now we:
1. Add outbox item and render it
2. Send but do not remove from the list, instead mark as `isSent` to
prevent a duplicate if sending needs to be restarted
3. New message received, remove from outbox