### PR TITLE
Update Android Studio components.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,11 +28,13 @@ android:
     - build-tools-26.0.1
     - build-tools-27.0.3
     - build-tools-27.1.1
+    - build-tools-28.0.3
     - android-23
     - android-24
     - android-25
     - android-26
     - android-27
+    - android-28
     - extra-google-m2repository
     - extra-android-m2repository
     - extra-google-android-support

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -92,7 +92,6 @@ def enableProguardInReleaseBuilds = false
 
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
-    buildToolsVersion rootProject.ext.buildToolsVersion
 
     defaultConfig {
         applicationId "com.zulipmobile"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -15,7 +15,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.4'
+        classpath 'com.android.tools.build:gradle:3.2.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         targetSdkVersion = 26
         compileSdkVersion = 27
 
-        buildToolsVersion = "27.0.3"
+        buildToolsVersion = "28.0.3"
 
         supportLibVersion = "27.1.1"
     }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -6,8 +6,6 @@ buildscript {
         targetSdkVersion = 26
         compileSdkVersion = 27
 
-        buildToolsVersion = "28.0.3"
-
         supportLibVersion = "27.1.1"
     }
     repositories {

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Oct 11 00:38:59 PDT 2018
+#Wed Oct 31 17:41:38 PDT 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip


### PR DESCRIPTION
The debug build is working as expected (hurray!) with JDK 11 and API 28.

With these updates, I think the adjustment in #3079 is no longer necessary.

(@zulipbot add "area: Android")

