### PR TITLE
stream screen: Remove "Topics" button

### DIFF
--- a/src/streams/StreamScreen.js
+++ b/src/streams/StreamScreen.js
@@ -12,7 +12,6 @@ import {
   doToggleMuteStream,
   doTogglePinStream,
   navigateToEditStream,
-  navigateToTopicList,
   toggleStreamNotification,
   navigateToStreamSubscribers,
 } from '../actions';
@@ -40,11 +39,6 @@ class StreamScreen extends PureComponent<Props> {
   handleToggleMuteStream = (newValue: boolean) => {
     const { dispatch, stream } = this.props;
     dispatch(doToggleMuteStream(stream.stream_id, newValue));
-  };
-
-  handleTopics = () => {
-    const { dispatch, stream } = this.props;
-    dispatch(navigateToTopicList(stream.stream_id));
   };
 
   handleEdit = () => {
@@ -87,7 +81,6 @@ class StreamScreen extends PureComponent<Props> {
         />
         <OptionDivider />
         <View style={styles.padding}>
-          <ZulipButton text="Topics" onPress={() => delay(this.handleTopics)} />
           {isAdmin && (
             <ZulipButton
               style={styles.marginTop}


### PR DESCRIPTION
Now that we have the topics button in the navigation bar, this
button is not useful and is just extra noise. Remove it!

![screenshot_1541179788](https://user-images.githubusercontent.com/867242/47931030-db3f1e00-de8a-11e8-9fe1-322322e98bd3.png)
