### PR TITLE
webview: Replace UIWebView with WKWebView

### DIFF
--- a/src/webview/MessageListWeb.js
+++ b/src/webview/MessageListWeb.js
@@ -90,6 +90,7 @@ export default class MessageListWeb extends Component<Props> {
 
     return (
       <WebView
+        useWebKit
         source={{
           baseUrl: auth.realm,
           html,


### PR DESCRIPTION
React Native 0.57+ supports the new `WKWebView` iOS component in
`WebView` instead of the legacy `UIWebView`..

The UIWebView component is deprecated since iOS 12
https://developer.apple.com/documentation/uikit/uiwebview

WKWebView is supported on iOS 8 and newer so that is not a concern.
https://developer.apple.com/documentation/webkit/wkwebview

An article on the `WKWebView` support in React Native here:
http://facebook.github.io/react-native/blog/2018/08/27/wkwebview

The change code-wise is trivial, but this needs thorough manual testing.