### PR TITLE
android: Request WRITE_EXTERNAL_STORAGE permission.

### DIFF
--- a/src/lightbox/LightboxActionSheet.js
+++ b/src/lightbox/LightboxActionSheet.js
@@ -1,6 +1,6 @@
 /* @flow */
 import type { Auth } from '../types';
-import downloadFile from '../api/downloadFile';
+import downloadImage from './downloadImage';
 import share from './share';
 import shareImage from './shareImage';
 import { showToast } from '../utils/info';
@@ -32,9 +32,9 @@ type ButtonType = {
   onPress: (props: ButtonProps) => void | boolean | Promise<any>,
 };
 
-const downloadImage = async ({ src, auth }: DownloadImageType) => {
+const tryToDownloadImage = async ({ src, auth }: DownloadImageType) => {
   try {
-    await downloadFile(src, auth);
+    await downloadImage(src, auth);
     showToast('Download complete');
   } catch (error) {
     showToast('Can not download');
@@ -50,7 +50,7 @@ const shareImageDirectly = ({ src, auth }: DownloadImageType) => {
 };
 
 const actionSheetButtons: ButtonType[] = [
-  { title: 'Download image', onPress: downloadImage },
+  { title: 'Download image', onPress: tryToDownloadImage },
   { title: 'Share image', onPress: shareImageDirectly },
   { title: 'Share link to image', onPress: shareLink },
   { title: 'Cancel', onPress: () => false },

--- a/src/lightbox/LightboxActionSheet.js
+++ b/src/lightbox/LightboxActionSheet.js
@@ -37,7 +37,7 @@ const tryToDownloadImage = async ({ src, auth }: DownloadImageType) => {
     await downloadImage(src, auth);
     showToast('Download complete');
   } catch (error) {
-    showToast('Can not download');
+    showToast(error.message);
   }
 };
 

--- a/src/lightbox/LightboxActionSheet.js
+++ b/src/lightbox/LightboxActionSheet.js
@@ -50,7 +50,7 @@ const shareImageDirectly = ({ src, auth }: DownloadImageType) => {
 };
 
 const actionSheetButtons: ButtonType[] = [
-  { title: 'Download file', onPress: downloadImage },
+  { title: 'Download image', onPress: downloadImage },
   { title: 'Share image', onPress: shareImageDirectly },
   { title: 'Share link to image', onPress: shareLink },
   { title: 'Cancel', onPress: () => false },

--- a/src/lightbox/downloadImage.js
+++ b/src/lightbox/downloadImage.js
@@ -1,12 +1,12 @@
 /* @flow */
-import { CameraRoll, Platform } from 'react-native';
+import { CameraRoll, Platform, PermissionsAndroid } from 'react-native';
 import RNFetchBlob from 'rn-fetch-blob';
 
 import type { Auth } from '../api/apiTypes';
 import { getAuthHeader, getFullUrl } from '../utils/url';
 import userAgent from '../utils/userAgent';
 
-export default (src: string, auth: Auth) => {
+export default async (src: string, auth: Auth) => {
   const absoluteUrl = getFullUrl(src, auth.realm);
 
   if (Platform.OS === 'ios') {
@@ -14,6 +14,30 @@ export default (src: string, auth: Auth) => {
     const urlWithApiKey = `${absoluteUrl}${delimiter}api_key=${auth.apiKey}`;
     return CameraRoll.saveToCameraRoll(urlWithApiKey);
   }
+
+  // Platform.OS === 'android'
+  const permissionIsGranted = await PermissionsAndroid.check(
+    PermissionsAndroid.PERMISSIONS.WRITE_EXTERNAL_STORAGE,
+  );
+
+  if (!permissionIsGranted) {
+    const permissionRequestResult = await PermissionsAndroid.request(
+      PermissionsAndroid.PERMISSIONS.WRITE_EXTERNAL_STORAGE,
+      {
+        title: 'Zulip Storage Permission',
+        message: 'In order to download images, Zulip needs permission to write to your SD card.',
+      },
+    );
+
+    if (
+      permissionRequestResult === PermissionsAndroid.RESULTS.DENIED
+      || permissionRequestResult === PermissionsAndroid.RESULTS.NEVER_ASK_AGAIN
+    ) {
+      throw new Error('Storage permission denied');
+    }
+  }
+
+  // permissionRequestResult === PermissionsAndroid.RESULTS.GRANTED;
   return RNFetchBlob.config({
     addAndroidDownloads: {
       path: `${RNFetchBlob.fs.dirs.DownloadDir}/${src.split('/').pop()}`,

--- a/src/lightbox/downloadImage.js
+++ b/src/lightbox/downloadImage.js
@@ -8,6 +8,9 @@ import userAgent from '../utils/userAgent';
 
 /**
  * Request permission WRITE_EXTERNAL_STORAGE, or throw if can't get it.
+ *
+ * The error thrown will have a `message` suitable for showing to the user
+ * as a toast.
  */
 const androidEnsureStoragePermission = async (): Promise<void> => {
   // See docs from Android for the underlying interaction with the user:
@@ -20,12 +23,12 @@ const androidEnsureStoragePermission = async (): Promise<void> => {
     return;
   }
   const result = await PermissionsAndroid.request(permission, {
-    title: 'Zulip Storage Permission',
-    message: 'In order to download images, Zulip needs permission to write to your SD card.',
+    title: 'Storage permission needed',
+    message: 'To download images, allow Zulip to store files on your device.',
   });
   const { DENIED, NEVER_ASK_AGAIN /* , GRANTED */ } = PermissionsAndroid.RESULTS;
   if (result === DENIED || result === NEVER_ASK_AGAIN) {
-    throw new Error('Storage permission denied');
+    throw new Error('Storage permission required');
   }
   // result === GRANTED
 };

--- a/src/lightbox/downloadImage.js
+++ b/src/lightbox/downloadImage.js
@@ -2,7 +2,7 @@
 import { CameraRoll, Platform } from 'react-native';
 import RNFetchBlob from 'rn-fetch-blob';
 
-import type { Auth } from './apiTypes';
+import type { Auth } from '../api/apiTypes';
 import { getAuthHeader, getFullUrl } from '../utils/url';
 import userAgent from '../utils/userAgent';
 

--- a/src/lightbox/shareImage.android.js
+++ b/src/lightbox/shareImage.android.js
@@ -1,5 +1,5 @@
 /* @flow */
-import download from '../api/downloadFile';
+import download from './downloadImage';
 import type { Auth } from '../types';
 import ShareImageAndroid from '../nativeModules/ShareImageAndroid';
 

--- a/src/lightbox/shareImage.ios.js
+++ b/src/lightbox/shareImage.ios.js
@@ -2,12 +2,12 @@
 import { Share } from 'react-native';
 
 import type { Auth } from '../types';
-import downloadFile from '../api/downloadFile';
+import downloadImage from './downloadImage';
 import { showToast } from '../utils/info';
 
 export default async (url: string, auth: Auth) => {
   try {
-    const uri = await downloadFile(url, auth);
+    const uri = await downloadImage(url, auth);
     try {
       await Share.share({ url: uri, message: url });
     } catch (error) {


### PR DESCRIPTION
The first time a user attempts to download an image, permission to write to external storage (the SD card) should be requested. If permission is granted by the user, the image should proceed to download.

If permission is denied, the image will not be fetched, and the corresponding text 'Storage permission denied' is shown. Any subsequent time that a user attempts to download an image, a 'rationale' modal will appear with explaining why the app needs permissions, and the permission will once again be requested.

<p align="center">
<img width="320" alt="android-request-permissions-write-external-storage-1" src="https://user-images.githubusercontent.com/12771126/48238278-456e2c00-e37f-11e8-9ddb-9ffe93d086c5.gif" />
</p>

If a user instructs that the permission not be asked for again, then subsequent attempts to download an image will only result in showing the text 'Storage permission denied', though the permission can always be changed via Android Settings.

<p align="center">
<img width="320" alt="android-request-permissions-write-external-storage-2" src="https://user-images.githubusercontent.com/12771126/48238309-5fa80a00-e37f-11e8-86b6-a2389b7d04d3.gif" />
</p>

For reference, see [React Native 0.57's PermissionsAndroid API](https://facebook.github.io/react-native/docs/permissionsandroid) and [Android's developer documentation on requesting permissions](https://developer.android.com/training/permissions/requesting).

This fixes #3115 and progresses #3075.
@gnprice 