### PR TITLE
Use a trailing slash when doing a SSO login

### DIFF
--- a/src/start/AuthScreen.js
+++ b/src/start/AuthScreen.js
@@ -98,7 +98,7 @@ class AuthScreen extends PureComponent<Props> {
   };
 
   handleSso = () => {
-    this.beginOAuth('accounts/login/sso');
+    this.beginOAuth('accounts/login/sso/');
   };
 
   render() {


### PR DESCRIPTION
Fixes #3126

Adds a trailing slash to the `accounts/login/sso` path when doing
OAuth. The convention for the Zulip webapp is to include trailing
slashes in URLS.

The `accounts/login/social/github` just next to it is left as-is
because it actually does not work with a trailing slash currently.