### PR TITLE
flow, userItem: Make `avatarUrl` optional.

### DIFF
--- a/src/users/UserItem.js
+++ b/src/users/UserItem.js
@@ -28,7 +28,7 @@ const componentStyles = StyleSheet.create({
 type Props = {
   email: string,
   fullName: string,
-  avatarUrl: string,
+  avatarUrl: ?string,
   presence?: Presence,
   isSelected?: boolean,
   showEmail?: boolean,


### PR DESCRIPTION
If user have not set custom (image) avatar then, we are required to
generate gavatar url (hashing email addredd) on the client side. So in
such cases we don't have avatar url. UserItem takes avatarUrl and
passes it to Avatar, in which it can be null/undefined. So make it
optional in UserItem too.