### PR TITLE
webView, css: Fix height of message_inline_ref img.

### DIFF
--- a/src/webview/css/css.js
+++ b/src/webview/css/css.js
@@ -252,6 +252,7 @@ hr {
   text-align: center;
 }
 .message_inline_image img,
+.message_inline_ref img,
 .twitter-image img {
   width: 100%;
   height: 30vh;


### PR DESCRIPTION
message_inline_reg images are mostly of preview of videos like dropbox
videos etc. Add same css as of twitter-image and message_inline_image.


On master (07354a3e78750cf3b6efdbc6d5809deea40cdc4b)
<img width="341" alt="image" src="https://user-images.githubusercontent.com/18511177/48366697-a6c23200-e6d4-11e8-90bd-1e5e4adaebbf.png">

<img width="357" alt="image" src="https://user-images.githubusercontent.com/18511177/48366714-ae81d680-e6d4-11e8-88f1-f8b50a3e5957.png">




This PR
<img width="351" alt="image" src="https://user-images.githubusercontent.com/18511177/48366628-77132a00-e6d4-11e8-9db7-ba57dff63e9c.png">

message link: https://chat.zulip.org/#narrow/stream/65-checkins/subject/Lily/near/650332