### PR TITLE
Fix message loading indicators not showing

### DIFF
--- a/src/message/__tests__/messageActions-test.js
+++ b/src/message/__tests__/messageActions-test.js
@@ -33,9 +33,9 @@ describe('messageActions', () => {
 
       expect(actions).toHaveLength(3);
       expect(actions[0].type).toBe('FETCH_STATE_RESET');
-      expect(actions[1].type).toBe('Navigation/NAVIGATE');
-      expect(actions[2].type).toBe('MESSAGE_FETCH_START');
-      expect(actions[2].narrow).toEqual(streamNarrowObj);
+      expect(actions[1].type).toBe('MESSAGE_FETCH_START');
+      expect(actions[1].narrow).toEqual(streamNarrowObj);
+      expect(actions[2].type).toBe('Navigation/NAVIGATE');
     });
 
     test('when no messages in new narrow but caught up, only switch to narrow, do not fetch', () => {
@@ -96,9 +96,9 @@ describe('messageActions', () => {
 
       expect(actions).toHaveLength(3);
       expect(actions[0].type).toBe('FETCH_STATE_RESET');
-      expect(actions[1].type).toBe('Navigation/NAVIGATE');
-      expect(actions[2].type).toBe('MESSAGE_FETCH_START');
-      expect(actions[2].narrow).toEqual(streamNarrowObj);
+      expect(actions[1].type).toBe('MESSAGE_FETCH_START');
+      expect(actions[1].narrow).toEqual(streamNarrowObj);
+      expect(actions[2].type).toBe('Navigation/NAVIGATE');
     });
 
     test('if new narrow stream is not valid, do nothing', () => {

--- a/src/message/messagesActions.js
+++ b/src/message/messagesActions.js
@@ -22,7 +22,6 @@ export const doNarrow = (narrow: Narrow, anchor: number = FIRST_UNREAD_ANCHOR) =
   }
 
   dispatch({ type: FETCH_STATE_RESET });
-  dispatch(navigateToChat(narrow));
 
   const allNarrows = getAllNarrows(state);
   const messages = getMessages(state);
@@ -39,6 +38,8 @@ export const doNarrow = (narrow: Narrow, anchor: number = FIRST_UNREAD_ANCHOR) =
   } else if (anchor !== FIRST_UNREAD_ANCHOR) {
     dispatch(fetchMessagesAroundAnchor(narrow, anchor));
   }
+
+  dispatch(navigateToChat(narrow));
 };
 
 export const messageLinkPress = (href: string) => (dispatch: Dispatch, getState: GetState) => {


### PR DESCRIPTION
When we navigate to a new narrow if there are three cases regarding
the existance of messages:
 * there are no messages
 * there are messages
 * there are currently no messages but fetching

In case of 3) we are showing a 'message loading indicator'.

Currently though, we are showing it quite rarely. This is caused
by us first navigating to the narrow and then staring to load new
messages (the logic is 'show if no messages but fetching').

We are smart enough to update that state even if the order is
navigation then loading, but it takes some time. Our new handshake
algorithm slows things down a bit too. Thus it seems we no longer
show the loading indicator in many cases.

The solution is simple and effective. First do the fetching, then
do the actual navigation to the narrow.