### PR TITLE
Added flow types to some Selectors in narrowSelectors

### DIFF
--- a/src/chat/narrowsSelectors.js
+++ b/src/chat/narrowsSelectors.js
@@ -75,19 +75,19 @@ export const getShownMessagesForNarrow = (
       messagesForNarrow.filter(item => !shouldBeMuted(item, narrow, subscriptions, mute)),
   );
 
-export const getFirstMessageId = (narrow: Narrow) =>
+export const getFirstMessageId = (narrow: Narrow): Selector<?number> =>
   createSelector(
     getFetchedMessagesForNarrow(narrow),
     messages => (messages.length > 0 ? messages[0].id : undefined),
   );
 
-export const getLastMessageId = (narrow: Narrow) =>
+export const getLastMessageId = (narrow: Narrow): Selector<?number> =>
   createSelector(
     getFetchedMessagesForNarrow(narrow),
     messages => (messages.length > 0 ? messages[messages.length - 1].id : undefined),
   );
 
-export const getLastTopicForNarrow = (narrow: Narrow) =>
+export const getLastTopicForNarrow = (narrow: Narrow): Selector<string> =>
   createSelector(getMessagesForNarrow(narrow), messages => {
     for (let i = messages.length - 1; i >= 0; i--) {
       if (messages[i].subject) {


### PR DESCRIPTION
Issue in focus: #2971 
Referred to f99bc35 for insight
Added flow types to getFirstMessageId, getLastMessageId, getLastTopicFromNarrow after going through their return value and their types mentioned in `zulip-mobile/src/types.js`

Tests Ran:
* [x] npm run test:flow
* [x] npm run test
* [x] npm run test:full

This is my first contribution to your organization and I have enforced everything I have read in CONTRIBUTION.md. I would like to apologize in case of any mistake i have made.