### PR TITLE
apiFetch: Fix regression in using `console.warn`.

### DIFF
--- a/src/api/apiFetch.js
+++ b/src/api/apiFetch.js
@@ -62,7 +62,7 @@ export const apiCall = async (
       return resFunc(json);
     }
     // eslint-disable-next-line no-console
-    console.warn({ route, params, httpStatus: response.status, json });
+    console.log({ route, params, httpStatus: response.status, json });
     throw makeApiError(response.status, json);
   } finally {
     networkActivityStop(isSilent);


### PR DESCRIPTION
`console.warn` takes string as parameter, not a object. Before we were
passing object, which again raised an exception and it was direclty
going to catch, instead of creating and throwing an error from
`makeApiError.`