### PR TITLE
messageEditDialog: Fix error message is not shown.

### DIFF
--- a/src/compose/ComposeBox.js
+++ b/src/compose/ComposeBox.js
@@ -233,7 +233,7 @@ class ComposeBox extends PureComponent<Props, State> {
     const subject = topic !== editMessage.topic ? topic : undefined;
     if (content || subject) {
       updateMessage(auth, { content, subject }, editMessage.id).catch(error => {
-        showErrorAlert(error.message, 'Failed to edit message');
+        showErrorAlert(error.data && error.data.msg, 'Failed to edit message');
       });
     }
     dispatch(cancelEditMessage());


### PR DESCRIPTION
We get error message as a result from api call. In apiFetch if any
request fails, we are throwing and error where `error.data` contains
response data.

So get error msg from this data object and show it to the user.