### PR TITLE
Invalidate old messages less abruptly (was: Fixes 'No messages' on queue restart)

### DIFF
--- a/src/actionTypes.js
+++ b/src/actionTypes.js
@@ -212,6 +212,7 @@ export type MessageFetchCompleteAction = {
   anchor: number,
   numBefore: number,
   numAfter: number,
+  replaceExisting: boolean,
 };
 
 export type MarkMessagesReadAction = {

--- a/src/chat/__tests__/flagsReducers-test.js
+++ b/src/chat/__tests__/flagsReducers-test.js
@@ -50,6 +50,32 @@ describe('flagsReducers', () => {
 
       expect(actualState).toBe(initialState);
     });
+
+    test('if `replaceExisting` is `true` replace old state completely', () => {
+      const initialState = deepFreeze({
+        read: {
+          1: true,
+          2: true,
+          3: true,
+        },
+      });
+
+      const expectedState = {
+        read: {
+          3: true,
+        },
+      };
+
+      const action = deepFreeze({
+        type: MESSAGE_FETCH_COMPLETE,
+        messages: [{ id: 3, flags: ['read'] }],
+        replaceExisting: true,
+      });
+
+      const actualState = flagsReducers(initialState, action);
+
+      expect(actualState.read).toEqual(expectedState.read);
+    });
   });
 
   test('flags are added or replace existing flags', () => {

--- a/src/chat/__tests__/narrowsReducers-test.js
+++ b/src/chat/__tests__/narrowsReducers-test.js
@@ -441,6 +441,31 @@ describe('narrowsReducers', () => {
 
       expect(newState).toEqual(expectedState);
     });
+
+    test('replace!', () => {
+      const initialState = deepFreeze({
+        [HOME_NARROW_STR]: [1, 2, 3, 4, 5, 6],
+        [ALL_PRIVATE_NARROW_STR]: [2, 3, 4],
+        [streamNarrowStr]: [4, 5, 6],
+        [JSON.stringify(privateNarrow('mark@example.com'))]: [3, 2],
+      });
+
+      const action = deepFreeze({
+        type: MESSAGE_FETCH_COMPLETE,
+        narrow: streamNarrow('new stream'),
+        messages: [{ id: 4 }, { id: 5 }],
+        replaceExisting: true,
+      });
+
+      const expectedState = {
+        [ALL_PRIVATE_NARROW_STR]: [2, 3, 4],
+        [JSON.stringify(streamNarrow('new stream'))]: [4, 5],
+      };
+
+      const newState = narrowsReducers(initialState, action);
+
+      expect(newState).toEqual(expectedState);
+    });
   });
 
   describe('EVENT_UPDATE_MESSAGE_FLAGS', () => {

--- a/src/chat/flagsReducers.js
+++ b/src/chat/flagsReducers.js
@@ -87,7 +87,7 @@ const processFlagsForMessages = (state: FlagsState, messages: Message[]): FlagsS
 };
 
 const messageFetchComplete = (state: FlagsState, action: MessageFetchCompleteAction): FlagsState =>
-  processFlagsForMessages(state, action.messages);
+  processFlagsForMessages(action.replaceExisting ? initialState : state, action.messages);
 
 const eventNewMessage = (state: FlagsState, action: EventNewMessageAction): FlagsState =>
   addFlagsForMessages(state, [action.message.id], action.message.flags);

--- a/src/chat/flagsReducers.js
+++ b/src/chat/flagsReducers.js
@@ -9,7 +9,6 @@ import type {
   MarkMessagesReadAction,
 } from '../types';
 import {
-  DEAD_QUEUE,
   MESSAGE_FETCH_COMPLETE,
   EVENT_NEW_MESSAGE,
   EVENT_UPDATE_MESSAGE_FLAGS,
@@ -117,7 +116,6 @@ const markMessagesRead = (state: FlagsState, action: MarkMessagesReadAction): Fl
 
 export default (state: FlagsState = initialState, action: FlagsAction): FlagsState => {
   switch (action.type) {
-    case DEAD_QUEUE:
     case ACCOUNT_SWITCH:
       return initialState;
 

--- a/src/chat/narrowsReducers.js
+++ b/src/chat/narrowsReducers.js
@@ -10,7 +10,6 @@ import type {
   EventUpdateMessageFlagsAction,
 } from '../types';
 import {
-  DEAD_QUEUE,
   LOGOUT,
   LOGIN_SUCCESS,
   ACCOUNT_SWITCH,
@@ -102,7 +101,6 @@ const eventUpdateMessageFlags = (
 
 export default (state: NarrowsState = initialState, action: MessageAction): NarrowsState => {
   switch (action.type) {
-    case DEAD_QUEUE:
     case LOGOUT:
     case LOGIN_SUCCESS:
     case ACCOUNT_SWITCH:

--- a/src/chat/narrowsReducers.js
+++ b/src/chat/narrowsReducers.js
@@ -19,7 +19,7 @@ import {
   EVENT_UPDATE_MESSAGE_FLAGS,
 } from '../actionConstants';
 import { LAST_MESSAGE_ANCHOR, FIRST_UNREAD_ANCHOR } from '../constants';
-import { isMessageInNarrow, STARRED_NARROW_STR } from '../utils/narrow';
+import { isMessageInNarrow, STARRED_NARROW_STR, ALL_PRIVATE_NARROW_STR } from '../utils/narrow';
 import { NULL_OBJECT } from '../nullObjects';
 
 const initialState: NarrowsState = NULL_OBJECT;
@@ -30,6 +30,13 @@ const messageFetchComplete = (
 ): NarrowsState => {
   const key = JSON.stringify(action.narrow);
   const fetchedMessageIds = action.messages.map(message => message.id);
+
+  if (action.replaceExisting) {
+    return {
+      [ALL_PRIVATE_NARROW_STR]: state[ALL_PRIVATE_NARROW_STR],
+      [key]: fetchedMessageIds,
+    };
+  }
 
   // We are not reading older or newer messages but trying to read 'fresh' information
   // at a position that makes sense (last unread or a specific ID). Replace old messages.

--- a/src/chat/narrowsReducers.js
+++ b/src/chat/narrowsReducers.js
@@ -30,13 +30,20 @@ const messageFetchComplete = (
 ): NarrowsState => {
   const key = JSON.stringify(action.narrow);
   const fetchedMessageIds = action.messages.map(message => message.id);
-  const replaceExisting =
-    action.anchor === FIRST_UNREAD_ANCHOR || action.anchor === LAST_MESSAGE_ANCHOR;
+
+  // We are not reading older or newer messages but trying to read 'fresh' information
+  // at a position that makes sense (last unread or a specific ID). Replace old messages.
+  if (action.anchor === FIRST_UNREAD_ANCHOR || action.anchor === LAST_MESSAGE_ANCHOR) {
+    return {
+      ...state,
+      [key]: fetchedMessageIds,
+    };
+  }
+
+  // Merge messages in state with the newly coming messages
   return {
     ...state,
-    [key]: replaceExisting
-      ? fetchedMessageIds
-      : union(state[key], fetchedMessageIds).sort((a, b) => a - b),
+    [key]: union(state[key], fetchedMessageIds).sort((a, b) => a - b),
   };
 };
 

--- a/src/message/__tests__/messagesReducers-test.js
+++ b/src/message/__tests__/messagesReducers-test.js
@@ -306,6 +306,27 @@ describe('messagesReducers', () => {
       expect(newState).toEqual(expectedState);
     });
 
+    test('if `replaceExisting` is `true` completely replace previous state', () => {
+      const initialState = deepFreeze({
+        1: { id: 1 },
+        2: { id: 2 },
+        3: { id: 3 },
+        4: { id: 4 },
+        5: { id: 5 },
+      });
+      const action = deepFreeze({
+        type: MESSAGE_FETCH_COMPLETE,
+        messages: [{ id: 3 }, { id: 4 }],
+        replaceExisting: true,
+      });
+      const expectedState = {
+        3: { id: 3 },
+        4: { id: 4 },
+      };
+      const newState = messagesReducers(initialState, action);
+      expect(newState).toEqual(expectedState);
+    });
+
     test('when anchor is FIRST_UNREAD_ANCHOR common messages are not replaced', () => {
       const commonMessages = { 2: { id: 2, timestamp: 4 }, 3: { id: 3, timestamp: 5 } };
       const initialState = deepFreeze({

--- a/src/message/messagesActions.js
+++ b/src/message/messagesActions.js
@@ -19,7 +19,7 @@ export const doNarrow = (narrow: Narrow, anchor: number = FIRST_UNREAD_ANCHOR) =
   }
 
   dispatch({ type: DO_NARROW, narrow });
-  dispatch(fetchMessagesInNarrow(narrow, anchor));
+  dispatch(fetchMessagesInNarrow(narrow, anchor, false));
   dispatch(navigateToChat(narrow));
 };
 

--- a/src/message/messagesReducers.js
+++ b/src/message/messagesReducers.js
@@ -12,7 +12,6 @@ import type {
   EventUpdateMessageAction,
 } from '../types';
 import {
-  DEAD_QUEUE,
   LOGOUT,
   LOGIN_SUCCESS,
   ACCOUNT_SWITCH,
@@ -141,7 +140,6 @@ const eventUpdateMessage = (
 
 export default (state: MessagesState = initialState, action: MessageAction): MessagesState => {
   switch (action.type) {
-    case DEAD_QUEUE:
     case LOGOUT:
     case LOGIN_SUCCESS:
     case ACCOUNT_SWITCH:

--- a/src/message/messagesReducers.js
+++ b/src/message/messagesReducers.js
@@ -31,7 +31,7 @@ const messageFetchComplete = (
   state: MessagesState,
   action: MessageFetchCompleteAction,
 ): MessagesState => ({
-  ...state,
+  ...(action.replaceExisting ? initialState : state),
   ...groupItemsById(action.messages.map(message => omit(message, 'flags'))),
 });
 


### PR DESCRIPTION
Not yet ready, but I consider it a P0 bug fix and I will finish up first thing next week.