### PR TITLE
Added flow type in actionTypes.js

### DIFF
--- a/src/actionTypes.js
+++ b/src/actionTypes.js
@@ -86,6 +86,7 @@ import type {
   PresenceState,
   Presence,
   RealmEmojiState,
+  SettingsState,
   CaughtUpState,
   MuteState,
   AlertWordsState,
@@ -515,8 +516,7 @@ export type FlagsAction =
 
 export type SettingsChangeAction = {
   type: typeof SETTINGS_CHANGE,
-  key: string,
-  value: boolean | string,
+  update: $Shape<SettingsState>,
 };
 
 export type DraftUpdateAction = {

--- a/src/actionTypes.js
+++ b/src/actionTypes.js
@@ -516,7 +516,7 @@ export type FlagsAction =
 export type SettingsChangeAction = {
   type: typeof SETTINGS_CHANGE,
   key: string,
-  value: any,
+  value: boolean | string,
 };
 
 export type DraftUpdateAction = {

--- a/src/settings/LanguageScreen.js
+++ b/src/settings/LanguageScreen.js
@@ -19,7 +19,7 @@ class LanguageScreen extends PureComponent<Props> {
 
   handleLocaleChange = (value: string) => {
     const { dispatch } = this.props;
-    dispatch(settingsChange('locale', value));
+    dispatch(settingsChange({ locale: value }));
   };
 
   render() {

--- a/src/settings/NotificationsScreen.js
+++ b/src/settings/NotificationsScreen.js
@@ -27,7 +27,7 @@ class NotificationsScreen extends PureComponent<Props> {
       opp: 'offline_notification_change',
       value: !offlineNotification,
     });
-    dispatch(settingsChange('offlineNotification', !offlineNotification));
+    dispatch(settingsChange({ offlineNotification: !offlineNotification }));
   };
 
   handleOnlineNotificationChange = () => {
@@ -37,7 +37,7 @@ class NotificationsScreen extends PureComponent<Props> {
       opp: 'online_notification_change',
       value: !onlineNotification,
     });
-    dispatch(settingsChange('onlineNotification', !onlineNotification));
+    dispatch(settingsChange({ onlineNotification: !onlineNotification }));
   };
 
   handleStreamNotificationChange = () => {
@@ -47,7 +47,7 @@ class NotificationsScreen extends PureComponent<Props> {
       opp: 'stream_notification_change',
       value: !streamNotification,
     });
-    dispatch(settingsChange('streamNotification', !streamNotification));
+    dispatch(settingsChange({ streamNotification: !streamNotification }));
   };
 
   render() {

--- a/src/settings/SettingsCard.js
+++ b/src/settings/SettingsCard.js
@@ -51,7 +51,7 @@ class SettingsCard extends PureComponent<Props> {
 
   handleThemeChange = () => {
     const { dispatch, theme } = this.props;
-    dispatch(settingsChange('theme', theme === 'default' ? 'night' : 'default'));
+    dispatch(settingsChange({ theme: theme === 'default' ? 'night' : 'default' }));
   };
 
   render() {

--- a/src/settings/__tests__/settingsReducers-test.js
+++ b/src/settings/__tests__/settingsReducers-test.js
@@ -10,12 +10,11 @@ describe('settingsReducers', () => {
 
       const action = deepFreeze({
         type: SETTINGS_CHANGE,
-        key: 'key',
-        value: 123,
+        update: { theme: 'default' },
       });
 
       const expectedState = {
-        key: 123,
+        theme: 'default',
       };
 
       const actualState = settingsReducers(prevState, action);
@@ -25,17 +24,16 @@ describe('settingsReducers', () => {
 
     test('changes value of an existing key', () => {
       const prevState = deepFreeze({
-        key: 123,
+        theme: 'night',
       });
 
       const action = deepFreeze({
         type: SETTINGS_CHANGE,
-        key: 'key',
-        value: 456,
+        update: { theme: 'default' },
       });
 
       const expectedState = {
-        key: 456,
+        theme: 'default',
       };
 
       const actualState = settingsReducers(prevState, action);

--- a/src/settings/settingsActions.js
+++ b/src/settings/settingsActions.js
@@ -1,9 +1,8 @@
 /* @flow */
-import type { SettingsChangeAction } from '../types';
+import type { SettingsChangeAction, SettingsState } from '../types';
 import { SETTINGS_CHANGE } from '../actionConstants';
 
-export const settingsChange = (key: string, value: boolean | string): SettingsChangeAction => ({
+export const settingsChange = (update: $Shape<SettingsState>): SettingsChangeAction => ({
   type: SETTINGS_CHANGE,
-  key,
-  value,
+  update,
 });

--- a/src/settings/settingsActions.js
+++ b/src/settings/settingsActions.js
@@ -2,7 +2,7 @@
 import type { SettingsChangeAction } from '../types';
 import { SETTINGS_CHANGE } from '../actionConstants';
 
-export const settingsChange = (key: string, value: any): SettingsChangeAction => ({
+export const settingsChange = (key: string, value: boolean | string): SettingsChangeAction => ({
   type: SETTINGS_CHANGE,
   key,
   value,

--- a/src/settings/settingsReducers.js
+++ b/src/settings/settingsReducers.js
@@ -29,7 +29,7 @@ const realmInit = (state: SettingsState, action: RealmInitAction): SettingsState
 
 const settingsChange = (state: SettingsState, action: SettingsChangeAction): SettingsState => ({
   ...state,
-  [action.key]: action.value,
+  ...action.update,
 });
 
 const eventUpdateGlobalNotificationsSettings = (


### PR DESCRIPTION
Added flow type to `FetchMessageAction` and `EventAlertWordsAction`.

For `FetchMessageAction`:
`FetchMessageAction` in a function that is used to invoke Redux dispatch. This function is defined in both synchronous and asynchronous sense in `fetchActions.js`: [async](https://github.com/zulip/zulip-mobile/blob/08f1bfdd0b4dcb2aaf734ef590e6a78ca386618a/src/message/fetchActions.js#L75) and [sync](https://github.com/zulip/zulip-mobile/blob/08f1bfdd0b4dcb2aaf734ef590e6a78ca386618a/src/message/fetchActions.js#L88)

Tests Ran:
* [x] npm run test:flow
* [x] npm run test:lint
* [x] npm run test:full

Issue in focus: #2052 