### PR TITLE
Fix scroll in `Screen` when `scrollEnabled={false}`

### DIFF
--- a/src/common/Screen.js
+++ b/src/common/Screen.js
@@ -115,7 +115,7 @@ class Screen extends PureComponent<Props> {
           <ScrollView
             contentContainerStyle={
               /* $FlowFixMe wants ViewStyleProp */
-              [centerContent && componentStyles.content, style]
+              [styles.flexed, centerContent && componentStyles.content, style]
             }
             style={componentStyles.childrenWrapper}
             keyboardShouldPersistTaps={keyboardShouldPersistTaps}


### PR DESCRIPTION
A change in how `Screen` component works when not scrollable in:
https://github.com/zulip/zulip-mobile/commit/026814edd7f4a3a19b9486bd3c01b20f91c52cd0
and a fix to not render the whole `FlatList`s and `ScrollList`s:
https://github.com/zulip/zulip-mobile/commit/b0730a0636862f09d195c33be09d47776e449080
have revealed a bug - the `ScrollView` used inside the `Screen`
is not allowing its content to be scrolled.

To fix that, adding `flex: 1` is enough.

Tested all screens with `ScrollEnabled={false}` on both iOS and Android.