### PR TITLE
SwitchAccountButton: Remove unused prop `accounts`.

### DIFF
--- a/src/account-info/SwitchAccountButton.js
+++ b/src/account-info/SwitchAccountButton.js
@@ -6,7 +6,7 @@ import { StyleSheet } from 'react-native';
 
 import type { Auth, Dispatch, GlobalState } from '../types';
 import { ZulipButton } from '../common';
-import { getAuth, getAccounts, getPushToken } from '../selectors';
+import { getAuth, getPushToken } from '../selectors';
 import { unregisterPush } from '../api';
 import { logErrorRemotely } from '../utils/logging';
 import { deleteTokenPush, navigateToAccountPicker } from '../actions';
@@ -54,6 +54,5 @@ class SwitchAccountButton extends PureComponent<Props> {
 
 export default connect((state: GlobalState) => ({
   auth: getAuth(state),
-  accounts: getAccounts(state),
   pushToken: getPushToken(state),
 }))(SwitchAccountButton);


### PR DESCRIPTION
This is a silent type error that seems to have been introduced via https://github.com/zulip/zulip-mobile/commit/b37352ade06779ad77f334c091300c2370cd9ce2#diff-73a6ef41677e3bf406fce93366e99735.