### PR TITLE
Fix, add a test, improve `getRecipientsInGroupNarrow`

### DIFF
--- a/src/chat/__tests__/narrowsSelectors-test.js
+++ b/src/chat/__tests__/narrowsSelectors-test.js
@@ -4,6 +4,7 @@ import {
   getFirstMessageId,
   getLastMessageId,
   getLastTopicForNarrow,
+  getRecipientsInGroupNarrow,
   getMessagesForNarrow,
   getStreamInNarrow,
   isNarrowValid,
@@ -260,6 +261,27 @@ describe('getLastTopicForNarrow', () => {
     const actualLastTopic = getLastTopicForNarrow(narrow)(state);
 
     expect(actualLastTopic).toEqual('Some subject');
+  });
+});
+
+describe('getRecipientsInGroupNarrow', () => {
+  test('returns recipients in group narrow skipping non-existing users', () => {
+    const state = deepFreeze({
+      narrows: {},
+      users: [
+        {
+          email: 'john@example.com',
+        },
+      ],
+      realm: {
+        nonActiveUsers: [],
+      },
+    });
+    const narrow = groupNarrow(['john@example.com', 'nonexisting@example.com']);
+
+    const actualRecipients = getRecipientsInGroupNarrow(narrow)(state);
+
+    expect(actualRecipients).toEqual([{ email: 'john@example.com' }]);
   });
 });
 

--- a/src/chat/narrowsSelectors.js
+++ b/src/chat/narrowsSelectors.js
@@ -100,7 +100,9 @@ export const getLastTopicForNarrow = (narrow: Narrow): Selector<string> =>
 
 export const getRecipientsInGroupNarrow = (narrow: Narrow) =>
   createSelector(getAllUsers, allUsers =>
-    emailsOfGroupNarrow(narrow).map(r => allUsers.find(x => x.email === r) || []),
+    emailsOfGroupNarrow(narrow)
+      .map(r => allUsers.find(x => x.email === r))
+      .filter(user => user),
   );
 
 export const getStreamInNarrow = (narrow: Narrow) =>

--- a/src/chat/narrowsSelectors.js
+++ b/src/chat/narrowsSelectors.js
@@ -11,7 +11,7 @@ import {
   getOutbox,
 } from '../directSelectors';
 import { getCaughtUpForActiveNarrow } from '../caughtup/caughtUpSelectors';
-import { getAllUsers } from '../users/userSelectors';
+import { getAllUsers, getAllUsersByEmail } from '../users/userSelectors';
 import { getIsFetching } from './fetchingSelectors';
 import {
   isAllPrivateNarrow,
@@ -99,9 +99,9 @@ export const getLastTopicForNarrow = (narrow: Narrow): Selector<string> =>
   });
 
 export const getRecipientsInGroupNarrow = (narrow: Narrow) =>
-  createSelector(getAllUsers, allUsers =>
+  createSelector(getAllUsersByEmail, allUsersByEmail =>
     emailsOfGroupNarrow(narrow)
-      .map(r => allUsers.find(x => x.email === r))
+      .map(email => allUsersByEmail[email])
       .filter(user => user),
   );
 


### PR DESCRIPTION
While adding Flow types, I found a bug in `getRecipientsInGroupNarrow`.
If a user is not found by the `allUsers.find` call, it is replaced with
an empty array `[]`. This was likely intended to be an empty object.

Funnily, doing a `user.email` returns an `undefined` regardless if
`user` is an object or an array. Neither will satisfy a strictly
typing object as a `User` type. This is a good argument in favor of
the `NULL_USER` constant. For that reason, I do not fully agree with
deprecating it.

Instead of adding a dummy/null object we can filter the user out.
So do that, and add a test to confirm this works.