### PR TITLE
Add Flow for all selectors

### DIFF
--- a/src/chat/__tests__/narrowsSelectors-test.js
+++ b/src/chat/__tests__/narrowsSelectors-test.js
@@ -4,6 +4,7 @@ import {
   getFirstMessageId,
   getLastMessageId,
   getLastTopicForNarrow,
+  getRecipientsInGroupNarrow,
   getMessagesForNarrow,
   getStreamInNarrow,
   isNarrowValid,
@@ -260,6 +261,27 @@ describe('getLastTopicForNarrow', () => {
     const actualLastTopic = getLastTopicForNarrow(narrow)(state);
 
     expect(actualLastTopic).toEqual('Some subject');
+  });
+});
+
+describe('getRecipientsInGroupNarrow', () => {
+  test('returns recipients in group narrow skipping non-existing users', () => {
+    const state = deepFreeze({
+      narrows: {},
+      users: [
+        {
+          email: 'john@example.com',
+        },
+      ],
+      realm: {
+        nonActiveUsers: [],
+      },
+    });
+    const narrow = groupNarrow(['john@example.com', 'nonexisting@example.com']);
+
+    const actualRecipients = getRecipientsInGroupNarrow(narrow)(state);
+
+    expect(actualRecipients).toEqual([{ email: 'john@example.com' }]);
   });
 });
 

--- a/src/chat/narrowsSelectors.js
+++ b/src/chat/narrowsSelectors.js
@@ -100,7 +100,9 @@ export const getLastTopicForNarrow = (narrow: Narrow): Selector<string> =>
 
 export const getRecipientsInGroupNarrow = (narrow: Narrow) =>
   createSelector(getAllUsers, allUsers =>
-    emailsOfGroupNarrow(narrow).map(r => allUsers.find(x => x.email === r) || []),
+    emailsOfGroupNarrow(narrow)
+      .map(r => allUsers.find(x => x.email === r))
+      .filter(user => user),
   );
 
 export const getStreamInNarrow = (narrow: Narrow) =>

--- a/src/chat/narrowsSelectors.js
+++ b/src/chat/narrowsSelectors.js
@@ -1,7 +1,7 @@
 /* @flow strict-local */
 import { createSelector } from 'reselect';
 
-import type { Message, Narrow, Outbox, Selector } from '../types';
+import type { Message, Narrow, Outbox, RealmBot, Selector, Stream, User } from '../types';
 import {
   getAllNarrows,
   getSubscriptions,
@@ -98,14 +98,14 @@ export const getLastTopicForNarrow = (narrow: Narrow): Selector<string> =>
     return '';
   });
 
-export const getRecipientsInGroupNarrow = (narrow: Narrow) =>
+export const getRecipientsInGroupNarrow = (narrow: Narrow): Selector<Array<User | RealmBot>> =>
   createSelector(getAllUsersByEmail, allUsersByEmail =>
     emailsOfGroupNarrow(narrow)
       .map(email => allUsersByEmail[email])
       .filter(user => user),
   );
 
-export const getStreamInNarrow = (narrow: Narrow) =>
+export const getStreamInNarrow = (narrow: Narrow): Selector<Stream> =>
   createSelector(getSubscriptions, getStreams, (subscriptions, streams) => {
     if (!isStreamOrTopicNarrow(narrow)) {
       return NULL_SUBSCRIPTION;
@@ -127,19 +127,19 @@ export const getStreamInNarrow = (narrow: Narrow) =>
     return NULL_SUBSCRIPTION;
   });
 
-export const getIfNoMessages = (narrow: Narrow) =>
+export const getIfNoMessages = (narrow: Narrow): Selector<boolean> =>
   createSelector(getShownMessagesForNarrow(narrow), messages => messages && messages.length === 0);
 
-export const getShowMessagePlaceholders = (narrow: Narrow) =>
+export const getShowMessagePlaceholders = (narrow: Narrow): Selector<boolean> =>
   createSelector(
     getIfNoMessages(narrow),
     getIsFetching(narrow),
     (noMessages, isFetching) => isFetching && noMessages,
   );
 
-export const canSendToActiveNarrow = (narrow: Narrow) => canSendToNarrow(narrow);
+export const canSendToActiveNarrow = (narrow: Narrow): boolean => canSendToNarrow(narrow);
 
-export const isNarrowValid = (narrow: Narrow) =>
+export const isNarrowValid = (narrow: Narrow): Selector<boolean> =>
   createSelector(getStreams, getAllUsers, (streams, allUsers) => {
     if (isStreamOrTopicNarrow(narrow)) {
       return streams.find(s => s.name === narrow[0].operand) !== undefined;

--- a/src/chat/narrowsSelectors.js
+++ b/src/chat/narrowsSelectors.js
@@ -11,7 +11,7 @@ import {
   getOutbox,
 } from '../directSelectors';
 import { getCaughtUpForActiveNarrow } from '../caughtup/caughtUpSelectors';
-import { getAllUsers } from '../users/userSelectors';
+import { getAllUsers, getAllUsersByEmail } from '../users/userSelectors';
 import { getIsFetching } from './fetchingSelectors';
 import {
   isAllPrivateNarrow,
@@ -99,9 +99,9 @@ export const getLastTopicForNarrow = (narrow: Narrow): Selector<string> =>
   });
 
 export const getRecipientsInGroupNarrow = (narrow: Narrow) =>
-  createSelector(getAllUsers, allUsers =>
+  createSelector(getAllUsersByEmail, allUsersByEmail =>
     emailsOfGroupNarrow(narrow)
-      .map(r => allUsers.find(x => x.email === r))
+      .map(email => allUsersByEmail[email])
       .filter(user => user),
   );
 

--- a/src/nav/navSelectors.js
+++ b/src/nav/navSelectors.js
@@ -1,7 +1,7 @@
 /* @flow */
 import { createSelector } from 'reselect';
 
-import type { GlobalState, NavigationState } from '../types';
+import type { GlobalState, Narrow, NavigationState, Selector } from '../types';
 import config from '../config';
 import { navigateToChat } from './navActions';
 import { getUsersById } from '../users/userSelectors';
@@ -17,20 +17,20 @@ const getNavigationIndex = (state: GlobalState): number => state.nav.index;
 export const getCurrentRouteName = (state: GlobalState): string =>
   state.nav.routes[state.nav.index].routeName;
 
-export const getCurrentRouteParams = createSelector(
+export const getCurrentRouteParams: Selector<Object> = createSelector(
   getNavigationRoutes,
   getNavigationIndex,
   (routes, index) => routes && routes[index] && routes[index].params,
 );
 
-export const getChatScreenParams = createSelector(
+export const getChatScreenParams: Selector<{ narrow: Narrow }> = createSelector(
   getCurrentRouteParams,
   params => params || { narrow: undefined },
 );
 
-export const getCanGoBack = (state: GlobalState) => state.nav.index > 0;
+export const getCanGoBack = (state: GlobalState): boolean => state.nav.index > 0;
 
-export const getSameRoutesCount = createSelector(getNav, nav => {
+export const getSameRoutesCount: Selector<number> = createSelector(getNav, nav => {
   let i = nav.routes.length - 1;
   while (i >= 0) {
     if (nav.routes[i].routeName !== nav.routes[nav.routes.length - 1].routeName) {
@@ -41,21 +41,25 @@ export const getSameRoutesCount = createSelector(getNav, nav => {
   return nav.routes.length - i - 1;
 });
 
-export const getStateForRoute = (route: string, params?: Object) => {
+export const getStateForRoute = (route: string, params?: Object): ?NavigationState => {
   const action = AppNavigator.router.getActionForPathAndParams(route, params);
   return action != null ? AppNavigator.router.getStateForAction(action) : null;
 };
 
-export const getInitialNavState = createSelector(getNav, getUsersById, (nav, usersById) => {
-  const state =
-    !nav || (nav.routes.length === 1 && nav.routes[0].routeName === 'loading')
-      ? getStateForRoute('main')
-      : nav;
+export const getInitialNavState: Selector<?NavigationState> = createSelector(
+  getNav,
+  getUsersById,
+  (nav, usersById) => {
+    const state =
+      !nav || (nav.routes.length === 1 && nav.routes[0].routeName === 'loading')
+        ? getStateForRoute('main')
+        : nav;
 
-  if (!config.startup.notification) {
-    return state;
-  }
+    if (!config.startup.notification) {
+      return state;
+    }
 
-  const narrow = getNarrowFromNotificationData(config.startup.notification, usersById);
-  return AppNavigator.router.getStateForAction(navigateToChat(narrow), state);
-});
+    const narrow = getNarrowFromNotificationData(config.startup.notification, usersById);
+    return AppNavigator.router.getStateForAction(navigateToChat(narrow), state);
+  },
+);

--- a/src/users/userSelectors.js
+++ b/src/users/userSelectors.js
@@ -34,11 +34,13 @@ export const getAllUsers: Selector<(User | RealmBot)[]> = createSelector(
   ],
 );
 
-export const getAllUsersByEmail = createSelector(getAllUsers, allUsers =>
-  allUsers.reduce((usersByEmail, user) => {
-    usersByEmail[user.email] = user;
-    return usersByEmail;
-  }, {}),
+export const getAllUsersByEmail: Selector<{ [string]: User }> = createSelector(
+  getAllUsers,
+  allUsers =>
+    allUsers.reduce((usersByEmail, user) => {
+      usersByEmail[user.email] = user;
+      return usersByEmail;
+    }, {}),
 );
 
 export const getUsersById: Selector<UserIdMap> = createSelector(getUsers, (users = []) =>
@@ -54,7 +56,8 @@ export const getUsersSansMe: Selector<User[]> = createSelector(
   (users, ownEmail) => users.filter(user => user.email !== ownEmail),
 );
 
-export const getAccountDetailsUserFromEmail = (email: string) =>
+// $FlowFixMe
+export const getAccountDetailsUserFromEmail = (email: string): Selector<User | RealmBot> =>
   createSelector(getAllUsers, allUsers => {
     if (!email) {
       return NULL_USER;


### PR DESCRIPTION
Selectors are one of the most important parts of the app that are still not typed. So do that for:
* accountsSelectors
* caughtUpSelectors
* fetchingSelectors
* narrowsSelectors
* messageSelectors
* pmConversationsSelectors
* subscriptionSelectors
* topicSelectors
* typingSelectors
* unreadSelectors
* userSelectors

`navSelectors` are intentionally nov covered as we are trying to get rid of them.