### PR TITLE
avatar: Fix rounded corners not used for group chat icon

### DIFF
--- a/src/common/ImageAvatar.js
+++ b/src/common/ImageAvatar.js
@@ -27,6 +27,7 @@ export default class ImageAvatar extends PureComponent<Props> {
   props: Props;
 
   static defaultProps = {
+    shape: 'rounded',
     onPress: nullFunction,
   };
 

--- a/src/common/TextAvatar.js
+++ b/src/common/TextAvatar.js
@@ -22,7 +22,7 @@ const styles = StyleSheet.create({
 type Props = {
   name: string,
   size: number,
-  shape?: string,
+  shape: string,
   children?: ChildrenArray<*>,
   onPress?: () => void,
 };
@@ -39,6 +39,10 @@ type Props = {
  */
 export default class TextAvatar extends PureComponent<Props> {
   props: Props;
+
+  static defaultProps = {
+    shape: 'rounded',
+  };
 
   render() {
     const { children, name, size, shape, onPress } = this.props;


### PR DESCRIPTION
The `TextAvatar` component is used for the avatar of group chats.
It did not show the same rounded corners as the single PMs.

This is supported and the issue was that we are not passing a `shape`
prop thus accidentally defaulting the value to `square`.

Set the default value for `shape` to `rounded` for both avatar
components to fix the issue and to better reflect our intent.