### PR TITLE
Reuse the destination narrow logic when uploading images

### DIFF
--- a/src/compose/ComposeBox.js
+++ b/src/compose/ComposeBox.js
@@ -212,15 +212,17 @@ class ComposeBox extends PureComponent<Props, State> {
     this.setState({ isMenuExpanded: false });
   };
 
+  getDestinationNarrow = (): Narrow => {
+    const { narrow } = this.props;
+    const { topic } = this.state;
+    return isStreamNarrow(narrow) ? topicNarrow(narrow[0].operand, topic || '(no topic)') : narrow;
+  };
+
   handleSend = () => {
-    const { dispatch, narrow } = this.props;
-    const { topic, message } = this.state;
+    const { dispatch } = this.props;
+    const { message } = this.state;
 
-    const destinationNarrow = isStreamNarrow(narrow)
-      ? topicNarrow(narrow[0].operand, topic || '(no topic)')
-      : narrow;
-
-    dispatch(addToOutbox(destinationNarrow, message));
+    dispatch(addToOutbox(this.getDestinationNarrow(), message));
 
     this.setMessageInputValue('');
   };
@@ -302,7 +304,7 @@ class ComposeBox extends PureComponent<Props, State> {
         <View style={styles.composeBox} onLayout={this.handleLayoutChange}>
           <View style={styles.alignBottom}>
             <ComposeMenu
-              narrow={narrow}
+              destinationNarrow={this.getDestinationNarrow()}
               expanded={isMenuExpanded}
               onExpandContract={this.handleComposeMenuToggle}
             />

--- a/src/compose/ComposeMenu.js
+++ b/src/compose/ComposeMenu.js
@@ -15,7 +15,7 @@ import { getNarrowToSendTo } from '../selectors';
 type Props = {
   dispatch: Dispatch,
   expanded: boolean,
-  narrow: Narrow,
+  destinationNarrow: Narrow,
   onExpandContract: () => void,
 };
 
@@ -64,9 +64,13 @@ class ComposeMenu extends PureComponent<Props> {
       return;
     }
 
-    const { dispatch, narrow } = this.props;
+    const { dispatch, destinationNarrow } = this.props;
     dispatch(
-      uploadImage(narrow, response.uri, chooseUploadImageFilename(response.uri, response.fileName)),
+      uploadImage(
+        destinationNarrow,
+        response.uri,
+        chooseUploadImageFilename(response.uri, response.fileName),
+      ),
     );
   };
 
@@ -127,5 +131,5 @@ class ComposeMenu extends PureComponent<Props> {
 }
 
 export default connect((state, props) => ({
-  narrow: getNarrowToSendTo(props.narrow)(state),
+  destinationNarrow: getNarrowToSendTo(props.narrow)(state),
 }))(ComposeMenu);

--- a/src/compose/ComposeMenu.js
+++ b/src/compose/ComposeMenu.js
@@ -10,7 +10,6 @@ import { showErrorAlert } from '../utils/info';
 import { IconPlus, IconLeft, IconPeople, IconImage, IconCamera } from '../common/Icons';
 import AnimatedComponent from '../animation/AnimatedComponent';
 import { navigateToCreateGroup, uploadImage } from '../actions';
-import { getNarrowToSendTo } from '../selectors';
 
 type Props = {
   dispatch: Dispatch,
@@ -130,6 +129,4 @@ class ComposeMenu extends PureComponent<Props> {
   }
 }
 
-export default connect((state, props) => ({
-  destinationNarrow: getNarrowToSendTo(props.narrow)(state),
-}))(ComposeMenu);
+export default connect()(ComposeMenu);

--- a/src/topics/topicSelectors.js
+++ b/src/topics/topicSelectors.js
@@ -14,7 +14,7 @@ import { getMute, getStreams, getTopics, getUnreadStreams } from '../directSelec
 import { getShownMessagesForNarrow } from '../chat/narrowsSelectors';
 import { getStreamsById } from '../subscriptions/subscriptionSelectors';
 import { NULL_ARRAY } from '../nullObjects';
-import { isStreamNarrow, topicNarrow } from '../utils/narrow';
+import { isStreamNarrow } from '../utils/narrow';
 
 export const getTopicsForNarrow = (narrow: Narrow): Selector<string[]> =>
   createSelector(getTopics, getStreams, (topics: TopicsState, streams: StreamsState) => {
@@ -64,10 +64,4 @@ export const getLastMessageTopic = (narrow: Narrow): Selector<string> =>
   createSelector(
     getShownMessagesForNarrow(narrow),
     messages => (messages.length === 0 ? '' : messages[messages.length - 1].subject),
-  );
-
-export const getNarrowToSendTo = (narrow: Narrow): Selector<Narrow> =>
-  createSelector(
-    getLastMessageTopic(narrow),
-    lastTopic => (isStreamNarrow(narrow) ? topicNarrow(narrow[0].operand, lastTopic) : narrow),
   );


### PR DESCRIPTION
Fixes #3130

Extract the code in `ComposeBox => handleSend()` that determines
the destination narrow to `getDestinationNarrow()`. Use this function
to pass the narrow to `ComposeMenu` which then uses that value when
uploading an image.