### PR TITLE
Fix prettier error and run prettier locally

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "build:ios": "cd ios && xcodebuild -scheme ZulipMobile archivexcodebuild -scheme ZulipMobile archive",
     "build:ios-release": "detox build --configuration ios.sim.release",
 
-    "test": "yarn run test:lint && yarn run jest && yarn run test:flow",
+    "test": "yarn run test:flow && yarn run test:lint && yarn run jest && yarn run test:prettier",
     "test:full": "yarn run test:flow && yarn run test:lint && yarn run test:coveralls && yarn run test:prettier",
 
     "test:lint": "eslint --max-warnings=0 src/",

--- a/src/chat/__tests__/fetchingReducers-test.js
+++ b/src/chat/__tests__/fetchingReducers-test.js
@@ -3,11 +3,7 @@ import deepFreeze from 'deep-freeze';
 
 import fetchingReducers from '../fetchingReducers';
 import { HOME_NARROW_STR, streamNarrow } from '../../utils/narrow';
-import {
-  DO_NARROW,
-  MESSAGE_FETCH_START,
-  MESSAGE_FETCH_COMPLETE,
-} from '../../actionConstants';
+import { DO_NARROW, MESSAGE_FETCH_START, MESSAGE_FETCH_COMPLETE } from '../../actionConstants';
 
 describe('fetchingReducers', () => {
   describe('DO_NARROW', () => {


### PR DESCRIPTION
* Run `yarn prettier` to fix formatting
* Include `prettier` test in `yarn test`

Include the `yarn run test:prettier` test when running tests locally
with the default `yarn test`. This will help reduce the commits with
incorrect formatting (for these who run the command)

The order of the command is changed to be consistent with the
`test:full` command that is run on the CI server with the only
the difference is we are not running Coveralls locally.