### PR TITLE
outbox: Fix not being able to delete unsent messages

### DIFF
--- a/src/message/messageActionSheet.js
+++ b/src/message/messageActionSheet.js
@@ -134,7 +134,7 @@ const actionSheetButtons: MessageButtonType[] = [
   {
     title: 'Delete message',
     onPress: doDeleteMessage,
-    onlyIf: allOf([isSentMessage, isSentBySelf, isNotDeleted]),
+    onlyIf: allOf([isSentBySelf, isNotDeleted]),
   },
   // If skip then covered in constructMessageActionButtons
   { title: 'Star message', onPress: starMessage, onlyIf: skip },


### PR DESCRIPTION
As pointed in #3186 sometimes our unsent messages might get stuck
and not get sent. Also they can not be deleted.

The cause for the messages getting stuck is yet unknown but is
important to figure out).

Not being able to delete the messages has a simple fix though.
In fact, we already support that but incorrectly determine the
visibility of that opiton.

Remove the `isSentMessage` as a requirement for the 'Delete' option
and allow deletion of the outbox messages.