### PR TITLE
Rework and fix `progressiveTimeout`

### DIFF
--- a/src/utils/__tests__/progressiveTimeout-test.js
+++ b/src/utils/__tests__/progressiveTimeout-test.js
@@ -11,6 +11,6 @@ describe('progressiveTimeout', () => {
     const start2 = Date.now();
     await progressiveTimeout();
     const duration2 = Date.now() - start2;
-    expect(duration2 > 1900).toBeTruthy();
+    expect(duration2 > 240).toBeTruthy();
   });
 });

--- a/src/utils/progressiveTimeout.js
+++ b/src/utils/progressiveTimeout.js
@@ -1,14 +1,21 @@
 /* @flow strict */
 let lastTimeoutTime = 0;
-let lastTimeoutLength = -2;
+let timeoutLength = 0;
 
+/**
+ * Timeout that progressively increases its duration
+ * Starts at 0 (no timeout the first time) and increases by 250 milliseconds
+ * until it reaches 5 secs.
+ * If the last timeout was more than a minute ago reset duration.
+ */
 export default (): Promise<void> => {
-  if (Date.now() - lastTimeoutTime < 5 * 60 * 1000) {
-    lastTimeoutLength = -2;
-    lastTimeoutTime = Date.now();
+  if (Date.now() - lastTimeoutTime > 60 * 1000) {
+    // did the last timeout happen more than a minute ago?
+    timeoutLength = 0;
+  } else if (timeoutLength < 5000) {
+    // increase timeout by 250 milliseconds (only if not already at 5 secs)
+    timeoutLength += 250;
   }
-
-  lastTimeoutLength += lastTimeoutLength < 10 ? 2 : 0;
-
-  return new Promise(resolve => setTimeout(resolve, lastTimeoutLength * 1000));
+  lastTimeoutTime = Date.now();
+  return new Promise(resolve => setTimeout(resolve, timeoutLength));
 };


### PR DESCRIPTION
After a closer look at `progressiveTimeout` with Greg, we found a
piece of logic is wrong, the timeout would not reset if it has
been more than 5 minutes since last timeout instead of the other
way around. Also, the logic was more convoluted than it could be.

This commit does:
 * fix the timeout reset bug
 * simplify the logic
 * tweaks the timing values