### PR TITLE
draftsSelectors: Flow typed selector

### DIFF
--- a/src/drafts/draftsSelectors.js
+++ b/src/drafts/draftsSelectors.js
@@ -2,7 +2,7 @@
 import { createSelector } from 'reselect';
 
 import { getDrafts } from '../directSelectors';
-import type { Narrow } from '../types';
+import type { Narrow, Selector } from '../types';
 
-export const getDraftForActiveNarrow = (narrow: Narrow) =>
+export const getDraftForActiveNarrow = (narrow: Narrow): Selector<string> =>
   createSelector(getDrafts, drafts => drafts[JSON.stringify(narrow)] || '');


### PR DESCRIPTION
Issue in focus: #2971 

I'm aware of the PR #3166, but `draftsSelectors` wasn't a part of original PR message. I went through the discussion and didn't find any mention of removing this entirely so I went ahead and typed the selector present in `draftsSelectors.js`.

Tests ran:
* [x] npm run test:flow
* [x] npm run test:lint