### PR TITLE
Fix PasswordInput not passing onChangeText prop to Input

### DIFF
--- a/src/common/PasswordInput.js
+++ b/src/common/PasswordInput.js
@@ -50,12 +50,13 @@ export default class PasswordInput extends PureComponent<Props, State> {
   };
 
   render() {
-    const { placeholder } = this.props;
+    const { placeholder, onChangeText } = this.props;
     const { isHidden } = this.state;
 
     return (
       <View>
         <Input
+          onChangeText={onChangeText}
           placeholder={placeholder}
           secureTextEntry={isHidden}
           autoCorrect={false}


### PR DESCRIPTION
In 4dd4752d8 which made the props passed down to Input from `PasswordInput` explicit, `onChangeText` was not passed down.

This commit fixes this by passing down `onChangeText` from `PasswordInput` to `Input`.

Reported in chat [here](https://chat.zulip.org/#narrow/stream/48-mobile/subject/new.20login.20screen/near/669460).