### PR TITLE
webView, css, dark mode: Add BG color for message containing mention.

### DIFF
--- a/src/webview/css/css.js
+++ b/src/webview/css/css.js
@@ -455,6 +455,9 @@ body {
 .highlight {
   background-color: hsla(51, 100%, 64%, 0.42);
 }
+[data-mentioned="true"], [data-wildcard_mentioned="true"] {
+  background: hsla(8, 78%, 43%, 0.15);
+}
 `;
 
 export default (theme: ThemeName, highlightUnreadMessages: boolean) => `


### PR DESCRIPTION
Background color is same as web app is using i.e `hsla(8, 78%, 43%, 0.15)`.

https://github.com/zulip/zulip/blob/master/static/styles/night_mode.scss#L348

Before
![image](https://user-images.githubusercontent.com/18511177/49695927-045c7800-fbc8-11e8-8cbc-b5464976feb6.png)


After
![image](https://user-images.githubusercontent.com/18511177/49695893-9748e280-fbc7-11e8-9ef2-51eed0684acf.png)
