### PR TITLE
searchInput: Fix style issue.

### DIFF
--- a/src/common/InputWithClearButton.js
+++ b/src/common/InputWithClearButton.js
@@ -62,10 +62,12 @@ export default class InputWithClearButton extends PureComponent<Props, State> {
   render() {
     const { styles } = this.context;
     const { canBeCleared, text } = this.state;
+    const { style } = this.props;
 
     return (
       <View style={styles.row}>
         <Input
+          style={style}
           placeholder={this.props.placeholder}
           textInputRef={textInput => {
             this.textInput = textInput;


### PR DESCRIPTION
By default our Input component have border styles for iOS, which needs
to be overridden for search input to remove border styles. So pass
input style from SearchInput to `InputWithClearButton` which are then
applied to Input.

Before
![image](https://user-images.githubusercontent.com/18511177/49696552-18f13e00-fbd1-11e8-9426-ae12ec8aadf9.png)


After
![image](https://user-images.githubusercontent.com/18511177/49696546-02e37d80-fbd1-11e8-890d-1d9aab1c3aaf.png)
