### PR TITLE
flow: Add annotation for `is_incompatible` to type ApiServerSettings.

### DIFF
--- a/src/api/apiTypes.js
+++ b/src/api/apiTypes.js
@@ -278,6 +278,7 @@ export type AuthenticationMethods = {
 export type ApiServerSettings = {
   authentication_methods: AuthenticationMethods,
   email_auth_enabled: boolean,
+  is_incompatible: boolean,
   msg: string,
   push_notifications_enabled: boolean,
   realm_description: string,


### PR DESCRIPTION
This matches the API update introduced with https://github.com/zulip/zulip/commit/be9b6a6deefe90949dc2fec32b919f44b6b9e2a6 via https://github.com/zulip/zulip/pull/10971.