### PR TITLE
Fix `sendFocusPing` not actually working

### DIFF
--- a/src/message/fetchActions.js
+++ b/src/message/fetchActions.js
@@ -202,7 +202,7 @@ export const doInitialFetch = () => async (dispatch: Dispatch, getState: GetStat
 
   dispatch(initNotifications());
   dispatch(sendFocusPing());
-  setInterval(() => sendFocusPing(), 60 * 1000);
+  setInterval(() => dispatch(sendFocusPing()), 60 * 1000);
 };
 
 export const uploadImage = (narrow: Narrow, uri: string, name: string) => async (


### PR DESCRIPTION
Calling `sendFocusPing` without a `dispatch` does not work as
intended. All it does is return an action creator. Called as-is
there is no effect.

We need to dispatch this properly. A simple and effective fix.

Thanks to Marc who reported the issue:
https://chat.zulip.org/#narrow/stream/48-mobile/topic/sendFocusPing.20Interval