### PR TITLE
Remove sent messages from outbox on initial fetch

### DIFF
--- a/src/outbox/__tests__/outboxReducer-test.js
+++ b/src/outbox/__tests__/outboxReducer-test.js
@@ -1,10 +1,34 @@
 import deepFreeze from 'deep-freeze';
 
 import outboxReducers from '../outboxReducers';
-import { MESSAGE_SEND_START, EVENT_NEW_MESSAGE } from '../../actionConstants';
+import {
+  INITIAL_FETCH_COMPLETE,
+  MESSAGE_SEND_START,
+  EVENT_NEW_MESSAGE,
+} from '../../actionConstants';
 import { streamNarrow } from '../../utils/narrow';
 
 describe('outboxReducers', () => {
+  describe(INITIAL_FETCH_COMPLETE, () => {
+    test('filters out isSent', () => {
+      const initialState = deepFreeze([
+        { content: 'New one' },
+        { content: 'Another one' },
+        { content: 'Message already sent', isSent: true },
+      ]);
+
+      const action = deepFreeze({
+        type: INITIAL_FETCH_COMPLETE,
+      });
+
+      const expectedState = [{ content: 'New one' }, { content: 'Another one' }];
+
+      const actualState = outboxReducers(initialState, action);
+
+      expect(actualState).toEqual(expectedState);
+    });
+  });
+
   describe(MESSAGE_SEND_START, () => {
     test('add a new message to outbox', () => {
       const initialState = deepFreeze([]);

--- a/src/outbox/outboxReducers.js
+++ b/src/outbox/outboxReducers.js
@@ -1,11 +1,11 @@
 /* @flow strict-local */
 import type {
   OutboxState,
+  InitialFetchCompleteAction,
   MessageSendStartAction,
   MessageSendCompleteAction,
   OutboxAction,
   Outbox,
-  InitialFetchStartAction,
 } from '../types';
 import {
   INITIAL_FETCH_COMPLETE,
@@ -21,8 +21,10 @@ import { filterArray } from '../utils/immutability';
 
 const initialState = NULL_ARRAY;
 
-const initialFetchComplete = (state: OutboxState, action: InitialFetchStartAction): OutboxState =>
-  filterArray(state, (outbox: Outbox) => !outbox.isSent);
+const initialFetchComplete = (
+  state: OutboxState,
+  action: InitialFetchCompleteAction,
+): OutboxState => filterArray(state, (outbox: Outbox) => !outbox.isSent);
 
 const messageSendStart = (state: OutboxState, action: MessageSendStartAction): OutboxState => {
   const message = state.find(item => item.timestamp === action.outbox.timestamp);

--- a/src/outbox/outboxReducers.js
+++ b/src/outbox/outboxReducers.js
@@ -4,8 +4,11 @@ import type {
   MessageSendStartAction,
   MessageSendCompleteAction,
   OutboxAction,
+  Outbox,
+  InitialFetchStartAction,
 } from '../types';
 import {
+  INITIAL_FETCH_COMPLETE,
   MESSAGE_SEND_START,
   EVENT_NEW_MESSAGE,
   LOGOUT,
@@ -17,6 +20,9 @@ import { NULL_ARRAY } from '../nullObjects';
 import { filterArray } from '../utils/immutability';
 
 const initialState = NULL_ARRAY;
+
+const initialFetchComplete = (state: OutboxState, action: InitialFetchStartAction): OutboxState =>
+  filterArray(state, (outbox: Outbox) => !outbox.isSent);
 
 const messageSendStart = (state: OutboxState, action: MessageSendStartAction): OutboxState => {
   const message = state.find(item => item.timestamp === action.outbox.timestamp);
@@ -36,6 +42,9 @@ const deleteOutboxMessage = (
 
 export default (state: OutboxState = initialState, action: OutboxAction): OutboxState => {
   switch (action.type) {
+    case INITIAL_FETCH_COMPLETE:
+      return initialFetchComplete(state, action);
+
     case MESSAGE_SEND_START:
       return messageSendStart(state, action);
 


### PR DESCRIPTION
Fixes #3203

We do not delete sent messsages from outbox immediately on a
successful sending, but keep them in the outbox until we receive
the message from the server via our event queue.

There are two cases where this is a problem:
 * the queue dies / gets stuck and we do not reveive that message
 * the user quits the app before the response

The second option should be rare but totally possible. The first
option should be rare but currenlty is more frequent than optimal.

Removing the sent messages on initial fetch is a very safe and
conservative behavior. We might decide to do this more aggressively
in future but that might also lead to behavior confusing to the
user like "Where did my message disappear?"