### PR TITLE
Fix Autocomplete sometimes not responding to touch

### DIFF
--- a/src/compose/ComposeBox.js
+++ b/src/compose/ComposeBox.js
@@ -284,7 +284,7 @@ class ComposeBox extends PureComponent<Props, State> {
     const placeholder = getComposeInputPlaceholder(narrow, auth.email, users);
     const style = {
       marginBottom: safeAreaInsets.bottom,
-      ...(canSend ? {} : { opacity: 0, position: 'absolute' }),
+      ...(canSend ? {} : { display: 'none' }),
     };
 
     return (


### PR DESCRIPTION
Fixes #3209

Back in #3065 we did introduce a new behavior for `ComposeBox` to
not unmount when one can't write to a narrow. I would not call it
a 'hack' as this approach should have worked fine (and would on web)
Seemingly it is throwing React Native off and showing the Autocomplete
visually above the WebView but below in the stack of 'touchable' targets.

Luckily, a better, less hacky approach is possible. Just use a familiar
style from the web: `display: 'none'`