### PR TITLE
apiTypes: Extract items of `Stream` type to `StreamOptions`.

### DIFF
--- a/src/api/apiTypes.js
+++ b/src/api/apiTypes.js
@@ -182,13 +182,17 @@ export type RealmEmojiState = $ReadOnly<{
 
 export type RealmFilter = [string, string, number];
 
-export type Stream = {|
-  stream_id: number,
+export type StreamOptions = {|
   description: string,
   name: string,
   invite_only: boolean,
   is_announcement_only: boolean,
   history_public_to_subscribers: boolean,
+|};
+
+export type Stream = {|
+  ...$Exact<StreamOptions>,
+  stream_id: number,
 |};
 
 export type Subscription = {|


### PR DESCRIPTION
As this list of streamOptions (name, description, inviteOnly,
isAnnouncementOnly, history_public_to_subscribers) will keep on
increase as we make streams more customizable. So it is good to have a
separate type for stream options.