### PR TITLE
Make VSCode recommend extensions we recommend

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,8 @@
+{
+	"recommendations": [
+		"vsmobile.vscode-react-native",
+		"flowtype.flow-for-vscode",
+		"dbaeumer.vscode-eslint",
+		"esbenp.prettier-vscode"	
+	]
+}


### PR DESCRIPTION
We do recommend seveal VS Code extensions in our documentation:
https://github.com/zulip/zulip-mobile/blob/32795a8ba71e290efabc1ef36a27e654d3daf3a1/docs/howto/editor.md

It turns out VS Code supports an automatic recommendation of these
extensions if we specify them in `.vscode/extensions.json` file.