### PR TITLE
updateExistingStream: Reduce api calls on changing stream details.

### DIFF
--- a/src/api/streams/updateStream.js
+++ b/src/api/streams/updateStream.js
@@ -2,7 +2,8 @@
 import type { ApiResponse, Auth } from '../apiTypes';
 import { apiPatch } from '../apiFetch';
 
-export default (auth: Auth, id: number, property: string, value: string): Promise<ApiResponse> =>
-  apiPatch(auth, `streams/${id}`, {
-    [property]: value,
-  });
+export default (
+  auth: Auth,
+  id: number,
+  newValues: { [string]: string | boolean | number },
+): Promise<ApiResponse> => apiPatch(auth, `streams/${id}`, { ...newValues });

--- a/src/utils/__tests__/misc-test.js
+++ b/src/utils/__tests__/misc-test.js
@@ -1,5 +1,11 @@
 /* @flow strict */
-import { initialsFromName, isValidEmailFormat, numberWithSeparators, deeperMerge } from '../misc';
+import {
+  initialsFromName,
+  isValidEmailFormat,
+  numberWithSeparators,
+  deeperMerge,
+  getChangedValues,
+} from '../misc';
 
 describe('numberWithSeparators', () => {
   test('do not change a small number', () => {
@@ -109,5 +115,13 @@ describe('isValidEmail', () => {
     expect(isValidEmailFormat('@a.com')).toBe(false);
     expect(isValidEmailFormat('a@b')).toBe(false);
     expect(isValidEmailFormat('a@.com')).toBe(false);
+  });
+});
+
+describe('getChangedValues', () => {
+  test('return a new object which has only changed data', () => {
+    expect(getChangedValues({ key: 2 }, { key: 1 })).toEqual({ key: 2 });
+    expect(getChangedValues({ key: 1 }, { key: 1 })).toEqual({});
+    expect(getChangedValues({ key: 1 }, { key2: 2 })).toEqual({ key: 1 });
   });
 });

--- a/src/utils/misc.js
+++ b/src/utils/misc.js
@@ -29,3 +29,13 @@ export function groupItemsById<T: { id: number }>(items: T[]): { [id: number]: T
 }
 
 export const isValidEmailFormat = (email: string = ''): boolean => /\S+@\S+\.\S+/.test(email);
+
+export const getChangedValues = (newObj: {}, oldObj: {}) => {
+  const obj: {} = {};
+  Object.keys(newObj).forEach(key => {
+    if (newObj[key] !== oldObj[key]) {
+      obj[key] = newObj[key];
+    }
+  });
+  return obj;
+};


### PR DESCRIPTION
Before inidividual api calls were made for each stream property which
is changed. But on server, this api is capable of handeling multiple
propery at a time. So just call api once with all the properties which
are changed.

Fixes: #3222