### PR TITLE
accountDetails: Fix layout regression.

### DIFF
--- a/src/account-info/AccountDetails.js
+++ b/src/account-info/AccountDetails.js
@@ -15,7 +15,11 @@ import styles from '../styles';
 
 const componentStyles = StyleSheet.create({
   componentListItem: {
+    alignItems: 'center',
+  },
+  userStatusWrapper: {
     justifyContent: 'center',
+    flexDirection: 'row',
   },
 });
 
@@ -44,8 +48,8 @@ export default class AccountDetails extends PureComponent<Props, void> {
           size={screenWidth}
           shape="square"
         />
-        <ComponentList outerSpacing itemStyle={[styles.row, componentStyles.componentListItem]}>
-          <View>
+        <ComponentList outerSpacing itemStyle={componentStyles.componentListItem}>
+          <View style={componentStyles.userStatusWrapper}>
             <UserStatusIndicator presence={presence} hideIfOffline={false} />
             <RawLabel style={[styles.largerText, styles.halfMarginLeft]} text={user.email} />
           </View>

--- a/src/account-info/AccountDetails.js
+++ b/src/account-info/AccountDetails.js
@@ -1,6 +1,6 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
-import { View, Dimensions } from 'react-native';
+import { View, Dimensions, StyleSheet } from 'react-native';
 
 import type { Dispatch, Presence, User } from '../types';
 import { Avatar, ComponentList, RawLabel, ZulipButton } from '../common';
@@ -12,6 +12,12 @@ import { getMediumAvatar } from '../utils/avatar';
 import { nowInTimeZone } from '../utils/date';
 import { doNarrow } from '../actions';
 import styles from '../styles';
+
+const componentStyles = StyleSheet.create({
+  componentListItem: {
+    justifyContent: 'center',
+  },
+});
 
 type Props = {|
   dispatch: Dispatch,
@@ -38,7 +44,7 @@ export default class AccountDetails extends PureComponent<Props, void> {
           size={screenWidth}
           shape="square"
         />
-        <ComponentList outerSpacing itemStyle={[styles.row, styles.center]}>
+        <ComponentList outerSpacing itemStyle={[styles.row, componentStyles.componentListItem]}>
           <View>
             <UserStatusIndicator presence={presence} hideIfOffline={false} />
             <RawLabel style={[styles.largerText, styles.halfMarginLeft]} text={user.email} />


### PR DESCRIPTION
We are using `ImageBackground`, which uses styles such as `position:
absolute`. Because it is capable of displaying text (/componenets)
over it. So styles such as `alignItems: center, flex: 1` were
resulting items to be present at vertically center of screen instead
of space below image.

By removing this styles and only keeping `justifyContent: center`,
works as expected.

Fix: #3228

![image](https://user-images.githubusercontent.com/18511177/50283771-f1c22880-047c-11e9-9d0f-017830a347c3.png)
