### PR TITLE
Stop using the same icon for two different buttons on the main screen.

### DIFF
--- a/src/common/Icons.js
+++ b/src/common/Icons.js
@@ -20,7 +20,7 @@ export const Icon: ComponentType<{| ...IconProps, name: string |}> = Feather;
 
 export type IconType = ComponentType<IconProps>;
 
-export const IconHome: IconType = props => <Feather name="home" {...props} />;
+export const IconInbox: IconType = props => <Feather name="inbox" {...props} />;
 export const IconStar: IconType = props => <Feather name="star" {...props} />;
 export const IconMention: IconType = props => <Feather name="at-sign" {...props} />;
 export const IconSearch: IconType = props => <Feather name="search" {...props} />;

--- a/src/main/HomeTab.js
+++ b/src/main/HomeTab.js
@@ -33,7 +33,7 @@ class HomeTab extends PureComponent<Props> {
       <View style={styles.wrapper}>
         <View style={styles.iconList}>
           <NavButton
-            name="home"
+            name="globe"
             onPress={() => {
               dispatch(doNarrow(HOME_NARROW));
             }}

--- a/src/main/MainTabs.js
+++ b/src/main/MainTabs.js
@@ -9,7 +9,7 @@ import HomeTab from './HomeTab';
 import StreamTabs from './StreamTabs';
 import PmConversationsCard from '../pm-conversations/PmConversationsCard';
 import SettingsCard from '../settings/SettingsCard';
-import { IconHome, IconSettings, IconStream } from '../common/Icons';
+import { IconInbox, IconSettings, IconStream } from '../common/Icons';
 import { OwnAvatar } from '../common';
 import IconUnreadConversations from '../nav/IconUnreadConversations';
 import ProfileCard from '../account-info/ProfileCard';
@@ -21,7 +21,7 @@ export default TabNavigator(
       navigationOptions: {
         tabBarLabel: 'Home',
         tabBarIcon: (props: TabNavigationOptionsPropsType) => (
-          <IconHome size={24} color={props.tintColor} />
+          <IconInbox size={24} color={props.tintColor} />
         ),
       },
     },

--- a/src/title/TitleSpecial.js
+++ b/src/title/TitleSpecial.js
@@ -8,7 +8,7 @@ import { Icon } from '../common/Icons';
 import styles from '../styles';
 
 const specials = {
-  home: { name: 'All messages', icon: 'home' },
+  home: { name: 'All messages', icon: 'globe' },
   private: { name: 'Private messages', icon: 'mail' },
   starred: { name: 'Starred', icon: 'star' },
   mentioned: { name: 'Mentions', icon: 'at-sign' },


### PR DESCRIPTION
This is a proposal for a quick resolution to #3063, discussed with and suggested by @gnprice.

Before:

<img src="https://user-images.githubusercontent.com/12771126/50362212-bd517980-051b-11e9-8f41-a08ac3c061d0.png" width="300" />

After:

<img src="https://user-images.githubusercontent.com/12771126/50362168-8f6c3500-051b-11e9-85fc-0378990e0904.png" width="300" />