### PR TITLE
android: Enforce user to enter pin/fingerprint on launch.

### DIFF
--- a/android/app/src/main/java/com/zulipmobile/MainActivity.java
+++ b/android/app/src/main/java/com/zulipmobile/MainActivity.java
@@ -1,11 +1,49 @@
 package com.zulipmobile;
 
+import android.app.KeyguardManager;
 import android.content.Intent;
 import android.content.res.Configuration;
+import android.os.Bundle;
+import android.widget.Toast;
 
 import com.facebook.react.ReactActivity;
 
 public class MainActivity extends ReactActivity {
+
+    private static final int REQUEST_CODE = 1337;
+    private KeyguardManager keyguardManager;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        Intent i = null;
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.LOLLIPOP) {
+            keyguardManager=(KeyguardManager)getSystemService(KEYGUARD_SERVICE);
+            i = keyguardManager.createConfirmDeviceCredentialIntent(
+                    "Zulip secure", "Authenticate to access Zulip ");
+
+
+            if (i == null) {
+                Toast.makeText(this, "No authentication required!", Toast.LENGTH_SHORT).show();
+            } else {
+                startActivityForResult(i, REQUEST_CODE);
+            }
+        }
+    }
+
+    @Override
+    public void onActivityResult(int requestCode, int resultCode,
+                                    Intent data) {
+        if (requestCode==REQUEST_CODE) {
+            if (resultCode==RESULT_OK) {
+                Toast.makeText(this, "Authenticated!", Toast.LENGTH_SHORT).show();
+            }
+            else {
+                finish();
+            }
+        }
+    }
 
     /**
      * Returns the name of the main component registered from JavaScript.


### PR DESCRIPTION
For Android API >= 21 lollipop, it is very easy to do with the help of
`createConfirmDeviceCredentialIntent`

On launching Zulip app, it will show default lock screen and ask user
to enter pin/pattern/fingerprint (kinda System login required)
https://cl.ly/43036b22ab01

If user can not enter, then the Zulip app can not be accessed (means
user can not bypass this lock) https://cl.ly/b413379f4581

Fixes: #3216

References: https://developer.android.com/reference/android/app/KeyguardManager#createConfirmDeviceCredentialIntent(java.lang.CharSequence,%20java.lang.CharSequence)