### PR TITLE
[WIP] Show grouped notifications using messaging style 

### DIFF
--- a/android/app/src/main/java/com/zulipmobile/notifications/MessageInfo.java
+++ b/android/app/src/main/java/com/zulipmobile/notifications/MessageInfo.java
@@ -3,10 +3,16 @@ package com.zulipmobile.notifications;
 public class MessageInfo {
     private String content;
     private int messageId;
+    private long timestamp;
 
-    public MessageInfo(String content, int messageId) {
+    public MessageInfo(String content, int messageId, long timestamp) {
         this.content = content;
         this.messageId = messageId;
+        this.timestamp = timestamp;
+    }
+
+    public long getTimestamp() {
+        return timestamp;
     }
 
     public String getContent() {

--- a/android/app/src/main/java/com/zulipmobile/notifications/NotificationHelper.java
+++ b/android/app/src/main/java/com/zulipmobile/notifications/NotificationHelper.java
@@ -123,6 +123,14 @@ public class NotificationHelper {
         return names;
     }
 
+    private static String extractStreamName(String key) {
+        return key.split(":")[1];
+    }
+
+    private static String getTypeFromKey(String key) {
+        return key.substring(key.lastIndexOf(':') + 1, key.length());
+    }
+
     public static void addConversationToMap(PushNotificationsProp prop, ConversationMap conversations) {
         String key = buildKeyString(prop);
         List<MessageInfo> messages = conversations.get(key);

--- a/android/app/src/main/java/com/zulipmobile/notifications/NotificationHelper.java
+++ b/android/app/src/main/java/com/zulipmobile/notifications/NotificationHelper.java
@@ -105,6 +105,8 @@ public class NotificationHelper {
         if (type.equals("stream")) {
             String displayTopic = extractStreamName(key);
             builder.setSubText("Message on " + displayTopic);
+        } else if (type.equals("group")) {
+            builder.setSubText("Message on group conversation");
         }
         return builder;
     }

--- a/android/app/src/main/java/com/zulipmobile/notifications/NotificationHelper.java
+++ b/android/app/src/main/java/com/zulipmobile/notifications/NotificationHelper.java
@@ -134,7 +134,7 @@ public class NotificationHelper {
     public static void addConversationToMap(PushNotificationsProp prop, ConversationMap conversations) {
         String key = buildKeyString(prop);
         List<MessageInfo> messages = conversations.get(key);
-        MessageInfo messageInfo = new MessageInfo(prop.getContent(), prop.getZulipMessageId());
+        MessageInfo messageInfo = new MessageInfo(prop.getContent(), prop.getZulipMessageId(), prop.getTimeInMilliSeconds());
         if (messages == null) {
             messages = new ArrayList<>();
         }

--- a/android/app/src/main/java/com/zulipmobile/notifications/PushNotificationsProp.java
+++ b/android/app/src/main/java/com/zulipmobile/notifications/PushNotificationsProp.java
@@ -48,6 +48,10 @@ public class PushNotificationsProp {
         return mBundle.getString("time");
     }
 
+    public Long getTimeInMilliSeconds() {
+        return Long.parseLong(getTime()) * 1000;
+    }
+
     protected PushNotificationsProp copy() {
         return new PushNotificationsProp((Bundle) mBundle.clone());
     }

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,6 +1,5 @@
 <resources>
     <string name="app_name">Zulip</string>
-    <string name="notification_channel_name">Notifications</string>
     <string name="gcm_id">835904834568\</string>
     <string name="no_browser_found">No Browser Found</string>
     <plurals name="messages">
@@ -8,4 +7,7 @@
         <item quantity="other">&#160;(%d messages)</item>
     </plurals>
     <string name="send_to">Share To</string>
+    <string name="notification_channel_stream_name">Stream notifications</string>
+    <string name="notification_channel_huddle_name">Group notifications</string>
+    <string name="notification_channel_private_name">Private notifications</string>
 </resources>


### PR DESCRIPTION
This changes the way notifications are displayed, previously only the last message content was being displayed in a summarised format.
This changes to a grouped notification and now each notification is being separately notified in a messaging style format. This adds the possibility of narrowing to that particular notification, action events (replies or cancellation) of each narrow. 
Now it shows all the messages of a narrow saved in our data structure.

**Screenshots:** 
Expanded
![expanded](https://user-images.githubusercontent.com/12700799/50467996-bf0fb700-09cb-11e9-9790-387a70ea8ae8.png)
In collapsed way
![device-2018-12-27-113238](https://user-images.githubusercontent.com/12700799/50467997-bf0fb700-09cb-11e9-90ea-1be943e62baf.png)

The titles can be discussed and changed as per discussion.

The code is mostly taken from the android docs
For grouping the notifications: https://developer.android.com/training/notify-user/group
For Messaging style notifications: https://developer.android.com/training/notify-user/expanded#message-style