### PR TITLE
AccountDetailsScreen: Adding flow type and updating to strict-local

### DIFF
--- a/src/account-info/AccountDetailsScreen.js
+++ b/src/account-info/AccountDetailsScreen.js
@@ -1,8 +1,9 @@
-/* @flow */
+/* @flow strict-local */
 import { connect } from 'react-redux';
 
 import React, { PureComponent } from 'react';
 
+import type { NavigationScreenProp } from 'react-navigation';
 import type { Dispatch, GlobalState, User, PresenceState } from '../types';
 import { getAccountDetailsUserFromEmail, getPresence } from '../selectors';
 import { Screen } from '../common';
@@ -33,7 +34,17 @@ class AccountDetailsScreen extends PureComponent<Props> {
   }
 }
 
-export default connect((state: GlobalState, props: Object) => ({
+type ConnectorProps = {|
+  navigation: NavigationScreenProp<*> & {
+    state: {
+      params: {
+        email: string,
+      },
+    },
+  },
+|};
+
+export default connect((state: GlobalState, props: ConnectorProps) => ({
   user: getAccountDetailsUserFromEmail(props.navigation.state.params.email)(state),
   presence: getPresence(state),
 }))(AccountDetailsScreen);


### PR DESCRIPTION
Removed weakly typed reference and added `ConnnectorProps` type to `AccountDetailsScreen.js`. The file was updated with the tag `strict-local`.

Clarifications Required:
* Given `Props` was already being used as a type in the same document, I had to name the new type as `ConnectorProps`. If this can be improved, please let me know and I'll take care of it in a jiffy (^_^)