### PR TITLE
migrations: Fix regression introduced in `2` migration.

### DIFF
--- a/src/redux-persist-migrate/index.js
+++ b/src/redux-persist-migrate/index.js
@@ -49,11 +49,10 @@ export default function createMigration(manifest, versionSelector, versionSetter
   const migrationDispatch = next => action => {
     if (action.type === REHYDRATE) {
       const incomingState = action.payload;
-      let incomingVersion = parseInt(versionSelector(incomingState), 10);
+      const incomingVersion = parseInt(versionSelector(incomingState), 10);
       if (Number.isNaN(incomingVersion)) {
-        incomingVersion = null;
-        // first launch after install, so initial state is empty object
-        // migration not required, just update verion
+        // first launch after install, so incoming state is empty object
+        // migration not required, just update version
         action.payload = versionSetter(incomingState, currentVersion);
         return next(action);
       }

--- a/src/redux-persist-migrate/index.js
+++ b/src/redux-persist-migrate/index.js
@@ -52,6 +52,10 @@ export default function createMigration(manifest, versionSelector, versionSetter
       let incomingVersion = parseInt(versionSelector(incomingState), 10);
       if (Number.isNaN(incomingVersion)) {
         incomingVersion = null;
+        // first launch after install, so initial state is empty object
+        // migration not required, just update verion
+        action.payload = versionSetter(incomingState, currentVersion);
+        return next(action);
       }
 
       if (incomingVersion !== currentVersion) {


### PR DESCRIPTION
In `2` migration (c2ed78e7e6c9b46ed4c1cf0d0b66ae87b2b0ce40), we
dropped `result` & `msg` from the `state.relam.pushToken`. But now if
someone freshly installs the app, then there is not any initilization
of `realm` state, so it will throw undefined (as at the time of
applying `2` migration there is only `messages` & `narrows` in the
`state`, which are initialized in `1` migration). So make sure realm
state is present before accessing `state.realm.pushToken.token`.