### PR TITLE
PR #3231 follow-up. settings: Build a better UI for choosing language.

### DIFF
--- a/src/settings/LanguagePicker.js
+++ b/src/settings/LanguagePicker.js
@@ -52,7 +52,7 @@ export default class LanguagePicker extends PureComponent<Props> {
     return (
       <FlatList
         ItemSeparatorComponent={OptionDivider}
-        initialNumToRender={languages.length}
+        initialNumToRender={15}
         data={data}
         keyboardShouldPersistTaps="always"
         keyExtractor={item => item.tag}


### PR DESCRIPTION
- Let's sort the languages, by locale, rather than put English first and the rest in English alpha order.
- When I search, then try to make a choice, it seems to take two taps -- one to dismiss the keyboard, the next to actually choose it. Let's make it take just one tap.