### PR TITLE
AccountDetailsScreen: Aded and tested flow typing and updated to strict-local

### DIFF
--- a/src/account-info/AccountDetailsScreen.js
+++ b/src/account-info/AccountDetailsScreen.js
@@ -1,8 +1,9 @@
-/* @flow */
+/* @flow strict-local */
 import { connect } from 'react-redux';
 
 import React, { PureComponent } from 'react';
 
+import type { NavigationScreenProp } from 'react-navigation';
 import type { Dispatch, GlobalState, User, PresenceState } from '../types';
 import { getAccountDetailsUserFromEmail, getPresence } from '../selectors';
 import { Screen } from '../common';
@@ -33,7 +34,15 @@ class AccountDetailsScreen extends PureComponent<Props> {
   }
 }
 
-export default connect((state: GlobalState, props: Object) => ({
+type ConnectorProps = {|
+  navigation: NavigationScreenProp<{
+    params: {
+      email: string,
+    },
+  }>,
+|};
+
+export default connect((state: GlobalState, props: ConnectorProps) => ({
   user: getAccountDetailsUserFromEmail(props.navigation.state.params.email)(state),
   presence: getPresence(state),
 }))(AccountDetailsScreen);

--- a/src/emoji/EmojiPickerScreen.js
+++ b/src/emoji/EmojiPickerScreen.js
@@ -18,13 +18,11 @@ type Props = {|
   activeRealmEmojiByName: RealmEmojiState,
   auth: Auth,
   dispatch: Dispatch,
-  navigation: NavigationScreenProp<*> & {
-    state: {
-      params: {
-        messageId: number,
-      },
+  navigation: NavigationScreenProp<{
+    params: {
+      messageId: number,
     },
-  },
+  }>,
 |};
 
 type State = {|

--- a/src/start/AuthScreen.js
+++ b/src/start/AuthScreen.js
@@ -20,13 +20,11 @@ import { loginSuccess, navigateToDev, navigateToPassword } from '../actions';
 type Props = {|
   dispatch: Dispatch,
   realm: string,
-  navigation: NavigationScreenProp<*> & {
-    state: {
-      params: {
-        serverSettings: ApiServerSettings,
-      },
+  navigation: NavigationScreenProp<{
+    params: {
+      serverSettings: ApiServerSettings,
     },
-  },
+  }>,
 |};
 
 let otp = '';


### PR DESCRIPTION
Previous PR: #3248 
The previous PR was flawed as it fooled flow into believing the code was under flow coverage when it wasn't.
I followed this [comment](https://github.com/react-navigation/react-navigation/issues/912#issuecomment-327032278) in the `react-navigation` repository where the state is passed as the parameter rather than using intersection types in flow. 
This passed flow test and even gave an error when I changes `email` to `emails`, thus proving to an extent the code is covered under flow.
I would love your reviews on this change - I presume it was the using of `&` operator that led to the weird behavior.
I also did some further digging and found out that this problem persists even in `/src/lightbox/LightboxScreen.js` where if we change `params` to `param`, flow will not throw any errors.

If this implementation is fine, I would be more than happy to change the usage of `NavigationScreenProp` throughout the code-base. 
