### PR TITLE
languagePicker, search: Fix language is not selected on single tap.

### DIFF
--- a/src/settings/LanguagePicker.js
+++ b/src/settings/LanguagePicker.js
@@ -60,6 +60,7 @@ export default class LanguagePicker extends PureComponent<Props> {
         ItemSeparatorComponent={() => <View style={styles.separator} />}
         initialNumToRender={languages.length}
         data={data}
+        keyboardShouldPersistTaps="always"
         keyExtractor={item => item.locale}
         renderItem={({ item }) => (
           <LanguagePickerItem


### PR DESCRIPTION
List was capturing first tap to hide keyboard. So set
`keyboardShouldPersistTaps` as `always` in `FlatList`, to avoid
capturing of tap event by list.

References:
https://facebook.github.io/react-native/docs/scrollview#keyboardshouldpersisttaps