### PR TITLE
 webView,css:Fix scroll got disturbed when viewport height changes.

### DIFF
--- a/src/webview/css/css.js
+++ b/src/webview/css/css.js
@@ -294,7 +294,7 @@ hr {
 .message_inline_ref img,
 .twitter-image img {
   width: 100%;
-  height: 30vh;
+  height: 160px;
   object-fit: contain;
 }
 blockquote {


### PR DESCRIPTION
Before `img` height was in `vh`. So when viewport height changes,
`img` height also gets changed. Thus scroll position gets affected.

Now provide `img` height in `px`, so that it doesn't change on
viewport height change.

Note: on unread notice/keyboard show/hide, webView viewport height
changes.

References: https://developer.mozilla.org/en-US/docs/Web/CSS/length

Fix: #3264