### PR TITLE
fetch: Revert "Remove unused message fetch code".

### DIFF
--- a/src/message/fetchActions.js
+++ b/src/message/fetchActions.js
@@ -19,6 +19,7 @@ import {
   getLastMessageId,
   getCaughtUpForActiveNarrow,
   getFetchingForActiveNarrow,
+  getTopMostNarrow,
 } from '../selectors';
 import config from '../config';
 import {
@@ -171,6 +172,15 @@ export const fetchStreams = () => async (dispatch: Dispatch, getState: GetState)
   dispatch(initStreams(streams));
 };
 
+const fetchTopMostNarrow = () => async (dispatch: Dispatch, getState: GetState) => {
+  // only fetch messages if chat screen is at the top of stack
+  // get narrow of top most chat screen in the stack
+  const narrow = getTopMostNarrow(getState());
+  if (narrow) {
+    dispatch(fetchMessagesInNarrow(narrow));
+  }
+};
+
 export const fetchInitialData = () => async (dispatch: Dispatch, getState: GetState) => {
   dispatch(initialFetchStart());
   const auth = getAuth(getState());
@@ -185,6 +195,7 @@ export const fetchInitialData = () => async (dispatch: Dispatch, getState: GetSt
   );
 
   dispatch(realmInit(initData));
+  dispatch(fetchTopMostNarrow());
   dispatch(initialFetchComplete());
   dispatch(startEventPolling(initData.queue_id, initData.last_event_id));
 

--- a/src/nav/__tests__/navSelectors-test.js
+++ b/src/nav/__tests__/navSelectors-test.js
@@ -1,9 +1,11 @@
 import deepFreeze from 'deep-freeze';
 
+import { streamNarrow } from '../../utils/narrow';
 import {
   getCurrentRouteName,
   getCurrentRouteParams,
   getChatScreenParams,
+  getTopMostNarrow,
   getCanGoBack,
   getSameRoutesCount,
 } from '../navSelectors';
@@ -68,6 +70,44 @@ describe('getChatScreenParams', () => {
     const actualResult = getChatScreenParams(state);
 
     expect(actualResult).toBeDefined();
+  });
+});
+
+describe('getTopMostNarrow', () => {
+  test('return undefined if no chat screen are in stack', () => {
+    const state = deepFreeze({
+      nav: {
+        index: 0,
+        routes: [{ routeName: 'main' }],
+      },
+    });
+    expect(getTopMostNarrow(state)).toBe(undefined);
+  });
+
+  test('return narrow of first chat screen from top', () => {
+    const narrow = streamNarrow('all');
+    const state = deepFreeze({
+      nav: {
+        index: 1,
+        routes: [{ routeName: 'main' }, { routeName: 'chat', params: { narrow } }],
+      },
+    });
+    expect(getTopMostNarrow(state)).toEqual(narrow);
+  });
+
+  test('iterate over stack to get first chat screen', () => {
+    const narrow = streamNarrow('all');
+    const state = deepFreeze({
+      nav: {
+        index: 2,
+        routes: [
+          { routeName: 'main' },
+          { routeName: 'chat', params: { narrow } },
+          { routeName: 'account' },
+        ],
+      },
+    });
+    expect(getTopMostNarrow(state)).toEqual(narrow);
   });
 });
 

--- a/src/nav/navSelectors.js
+++ b/src/nav/navSelectors.js
@@ -23,6 +23,18 @@ export const getChatScreenParams = createSelector(
   params => params || { narrow: undefined },
 );
 
+export const getTopMostNarrow = createSelector(getNav, nav => {
+  const { routes } = nav;
+  let { index } = nav;
+  while (index >= 0) {
+    if (routes[index].routeName === 'chat') {
+      return routes[index].params.narrow;
+    }
+    index--;
+  }
+  return undefined;
+});
+
 export const getCanGoBack = (state: GlobalState) => state.nav.index > 0;
 
 export const getSameRoutesCount = createSelector(getNav, nav => {


### PR DESCRIPTION
This reverts commit
  1d05ecdb8 fetch: Remove unused message fetch code in fetchEssentialInitialData.

The reasoning in that commit was mistaken in a couple of ways.
This still isn't the right design for handling this, but it
works for now, fixing the serious bug #3284 ; we'll sort it out better later.