### PR TITLE
people autocomplete: Fix it doesn't pop if `@` entered in new line.

### DIFF
--- a/src/autocomplete/__tests__/getAutocompleteFilter-test.js
+++ b/src/autocomplete/__tests__/getAutocompleteFilter-test.js
@@ -27,6 +27,18 @@ describe('getAutocompleteFilter', () => {
     });
   });
 
+  test('get respective lastWordPrefix even when keyword is entered in new line', () => {
+    selection = { start: 1, end: 1 };
+    expect(getAutocompleteFilter('\n@', selection)).toEqual({ filter: '', lastWordPrefix: '' });
+    expect(getAutocompleteFilter('\n#', selection)).toEqual({ filter: '', lastWordPrefix: '' });
+    expect(getAutocompleteFilter('\n:', selection)).toEqual({ filter: '', lastWordPrefix: '' });
+
+    selection = { start: 2, end: 2 };
+    expect(getAutocompleteFilter('\n@', selection)).toEqual({ filter: '', lastWordPrefix: '@' });
+    expect(getAutocompleteFilter('\n#', selection)).toEqual({ filter: '', lastWordPrefix: '#' });
+    expect(getAutocompleteFilter('\n:', selection)).toEqual({ filter: '', lastWordPrefix: ':' });
+  });
+
   test('get #streams filters', () => {
     selection = { start: 1, end: 1 };
     expect(getAutocompleteFilter('#', selection)).toEqual({ filter: '', lastWordPrefix: '#' });

--- a/src/autocomplete/getAutocompleteFilter.js
+++ b/src/autocomplete/getAutocompleteFilter.js
@@ -10,14 +10,14 @@ export default (text: string, selection: InputSelectionType) => {
   const lastIndex: number = Math.max(
     text.lastIndexOf(':'),
     text.lastIndexOf('#'),
-    [' ', '#', ':'].includes(text[text.lastIndexOf('@') - 1]) || text.lastIndexOf('@') === 0 // to make sure `@` is not the part of email
+    ['\n', ' ', '#', ':'].includes(text[text.lastIndexOf('@') - 1]) || text.lastIndexOf('@') === 0 // to make sure `@` is not the part of email
       ? text.lastIndexOf('@')
       : -1,
   );
 
   const lastWordPrefix: string = lastIndex !== -1 ? text[lastIndex] : '';
   const filter: string =
-    text.length > lastIndex + 1 && text[lastIndex + 1] !== ' '
+    text.length > lastIndex + 1 && !['\n', ' '].includes(text[lastIndex + 1])
       ? text.substring(lastIndex + 1, text.length)
       : '';
 


### PR DESCRIPTION
We only consider `@` when the preceding char is either ` `, `\n`, `:`
or `#`. Because every email as `@` in it and we don't want to trigger
suggestions in such cases.

Fixes: #3289

![image](https://user-images.githubusercontent.com/18511177/51336105-c5182580-1aa9-11e9-9c74-c24d5782949a.png)
