### PR TITLE
lightbox: Fix `SafeAreaInsets` padding is not applied.

### DIFF
--- a/src/lightbox/LightboxScreen.js
+++ b/src/lightbox/LightboxScreen.js
@@ -1,6 +1,6 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
-import { View, StyleSheet } from 'react-native';
+import { SafeAreaView, StyleSheet } from 'react-native';
 import type { NavigationScreenProp } from 'react-navigation';
 import { ActionSheetProvider } from '@expo/react-native-action-sheet';
 
@@ -25,12 +25,12 @@ export default class LightboxScreen extends PureComponent<Props> {
   render() {
     const { src, message } = this.props.navigation.state.params;
     return (
-      <View style={styles.screen}>
+      <SafeAreaView style={styles.screen}>
         <ZulipStatusBar hidden backgroundColor="black" />
         <ActionSheetProvider>
           <Lightbox src={src} message={message} />
         </ActionSheetProvider>
-      </View>
+      </SafeAreaView>
     );
   }
 }


### PR DESCRIPTION
Wrap screen content with `SafeAreaView` from `react-native` instead of
`View`.

References: https://facebook.github.io/react-native/docs/safeareaview

Fixes: #3291

<img width="370" alt="image" src="https://user-images.githubusercontent.com/18511177/51338801-d0228400-1ab0-11e9-9a72-53c327127d74.png">
