### PR TITLE
android, composeBox: Fix placeholder text padding irregularity.

### DIFF
--- a/src/compose/ComposeBox.js
+++ b/src/compose/ComposeBox.js
@@ -293,7 +293,7 @@ class ComposeBox extends PureComponent<Props, State> {
     const placeholder = getComposeInputPlaceholder(narrow, auth.email, users);
     const style = {
       marginBottom: safeAreaInsets.bottom,
-      ...(canSend ? {} : { display: 'none' }),
+      ...(canSend ? {} : { height: 0 }),
     };
 
     return (

--- a/src/compose/ComposeBox.js
+++ b/src/compose/ComposeBox.js
@@ -351,7 +351,7 @@ class ComposeBox extends PureComponent<Props, State> {
             <FloatingActionButton
               style={styles.composeSendButton}
               Icon={editMessage === null ? IconSend : IconDone}
-              size={32}
+              size={canSend ? 32 : 0}
               disabled={message.trim().length === 0}
               onPress={editMessage === null ? this.handleSend : this.handleEdit}
             />


### PR DESCRIPTION
Few observations:

* Only reproducible when compose box is shown after message loading
(GIF like loader) after narrowing on Android. Can't reproduce on
narrows whose messages are cached and immediately visible after
narrowing.

* If `this.getCanSelectTopic()` condition is removed from topic input
and `multiline` is added to `Input`, it start behaving like `Message`
input.

So from this it can be inferred that:

* It is a `multiline` input issue, which occurs when its parent first
got rendered with `display: none`. Normally it is not reproducible on
topic input because at the time of first render (when style is
`display: none`), topic input is not rendered (because
`this.getCanSelectTopic()` is false).

So to fix this issue, this commit replace `display: none` with `height:0,
width:0`, without breaking any functionality.

Fixes: #3295

I tried to use `git bisect`, but on some commits I wasn't able to build app. Was taking lots of time to check on multiple steps. So I thought instead of finding what caused it let's go for finding a solution to fix it. 

This is mostly a hack and I don't have complete reasoning. This is just based on observation and facts.

@Jigar3 in case you find better solution, we would love to take it.
