### PR TITLE
No sticky headers in Unread tab

### DIFF
--- a/src/unread/UnreadCards.js
+++ b/src/unread/UnreadCards.js
@@ -57,7 +57,7 @@ class UnreadCards extends PureComponent<Props> {
 
     return (
       <SectionList
-        stickySectionHeadersEnabled
+        stickySectionHeadersEnabled={false}
         initialNumToRender={20}
         sections={unreadCards}
         keyExtractor={item => item.key}


### PR DESCRIPTION
Fixes: #3286 and #3176

Related fix upstream but not ready to merge:
https://github.com/facebook/react-native/pull/22025

A planed minor redesign (discussed with Rishi) to make the Unread
tabs less flashy and 'circus-colors-like' requires us to remove
the stickiness from the headers.

Even though though the design is still WIP, it makes sense to use
this change as a fix to an issue that was already reported multiple
times.

This makes the UnreadCards SectionList have normal, non-sticky
headers. We have to set `stickySectionHeadersEnabled` explicitly
to `false` as the defaults differ for iOS (true) and Android (false)