### PR TITLE
Render `/me ...` messages

### DIFF
--- a/src/webview/css/css.js
+++ b/src/webview/css/css.js
@@ -123,6 +123,9 @@ hr {
   width: 100%;
   border-radius: 3px;
 }
+.message-me {
+  font-style: italic;
+}
 .content {
   width: 100%;
   max-width: 100%;

--- a/src/webview/html/__tests__/processMeMessage-test.js
+++ b/src/webview/html/__tests__/processMeMessage-test.js
@@ -1,0 +1,33 @@
+import processMeMessage from '../processMeMessage';
+
+describe('processMeMessage', () => {
+  test('empty string is not changed', () => {
+    const message = '';
+    const result = processMeMessage(message);
+    expect(result).toEqual(message);
+  });
+
+  test('a simple string is returned as is', () => {
+    const message = 'Some message';
+    const result = processMeMessage(message);
+    expect(result).toEqual(message);
+  });
+
+  test('if the string contains a "/me" in <p> tag replace it', () => {
+    const message = '<p>/me is happy</p>';
+    const result = processMeMessage(message);
+    expect(result).toEqual('<span class="message-me">is happy</span>');
+  });
+
+  test('no "<p>" tag, no change', () => {
+    const message = '/me is happy';
+    const result = processMeMessage(message);
+    expect(result).toEqual(message);
+  });
+
+  test('the "/me" has to come in the first paragraph or else no change', () => {
+    const message = '<p>Hey its</p><p>/me Mario</p>';
+    const result = processMeMessage(message);
+    expect(result).toEqual(message);
+  });
+});

--- a/src/webview/html/messageAsHtml.js
+++ b/src/webview/html/messageAsHtml.js
@@ -15,6 +15,7 @@ import { shortTime } from '../../utils/date';
 import aggregateReactions from '../../reactions/aggregateReactions';
 import { codeToEmojiMap } from '../../emoji/data';
 import processAlertWords from './processAlertWords';
+import processMeMessage from './processMeMessage';
 
 const messageTagsAsHtml = (isStarred: boolean, timeEdited: number | void): string => {
   const pieces = [];
@@ -62,7 +63,7 @@ const messageBody = (
   const { id, isOutbox, last_edit_timestamp, reactions } = message;
   const content = message.match_content !== undefined ? message.match_content : message.content;
   return template`
-$!${processAlertWords(content, id, alertWords, flags)}
+$!${processAlertWords(processMeMessage(content), id, alertWords, flags)}
 $!${isOutbox ? '<div class="loading-spinner outbox-spinner"></div>' : ''}
 $!${messageTagsAsHtml(!!flags.starred[id], last_edit_timestamp)}
 $!${messageReactionListAsHtml(reactions, ownEmail, allImageEmojiById)}

--- a/src/webview/html/processMeMessage.js
+++ b/src/webview/html/processMeMessage.js
@@ -1,0 +1,12 @@
+/* @flow strict-local */
+/* eslint-disable */
+/*
+ * The corresponding code in front-end is here:
+ * https://github.com/zulip/zulip/blob/8aee6a1dd/static/js/message_list_view.js
+ *
+ * This implements the exact strict matching as this function but produces
+ * slightly different result (for simpler formatting later) 
+ */
+
+export default (content: string): string =>
+  content.replace(/^<p>\/me (.+)<\/p>$/, '<span class="message-me">$1</span>');


### PR DESCRIPTION
Fixes #1773

* Add `processMeMessage` function
* Run `processMeMessage` on each message's content before rendering.
* Add simple 'italics' style to '/me ...' messages.

The styling is the exact same one Slack uses (just italics) and
saves on having to support another completely different message
layout on all the various device sizes.