### PR TITLE
clean up, chat: Remove unused `scrollOffset` variable.

### DIFF
--- a/src/chat/Chat.js
+++ b/src/chat/Chat.js
@@ -34,8 +34,6 @@ const componentStyles = StyleSheet.create({
 });
 
 class Chat extends PureComponent<Props> {
-  scrollOffset: number = 0;
-
   render() {
     const { canSend, narrow } = this.props;
 


### PR DESCRIPTION
It got introduced in 9dc95ccba4cfb257a44e5e062ea7542035e34f9e, when we
were using native message list. Now we are no longer using this
variable, so remove it.