### PR TITLE
activityText: Fix inconsistency with user status indicator.

### DIFF
--- a/src/title/ActivityText.js
+++ b/src/title/ActivityText.js
@@ -24,9 +24,19 @@ class ActivityText extends PureComponent<Props> {
 
     const activity = presenceToHumanTime(presence);
 
-    return (
-      <RawLabel style={[style, color !== undefined && { color }]} text={`Active ${activity}`} />
-    );
+    const activityText = {
+      active: `Active ${activity}`,
+      idle: `Idle ${activity}`,
+      offline: null,
+    };
+
+    const text = activityText[presence.aggregated.status];
+
+    if (text === null) {
+      return null;
+    }
+
+    return <RawLabel style={[style, color !== undefined && { color }]} text={text} />;
   }
 }
 


### PR DESCRIPTION
If `status` in `aggregated` is `idle`, then show `Idle
[presenceToHumanTime]` and likewise for `active` & `offline`.

Fixes: #3147

![image](https://user-images.githubusercontent.com/18511177/51765320-67b15380-20fd-11e9-82e4-4dbe581e40c8.png)
