### PR TITLE
android: Trust user-added CAs for all secure connections

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -32,7 +32,9 @@
       android:allowBackup="true"
       android:label="@string/app_name"
       android:icon="@mipmap/ic_launcher"
-      android:theme="@style/AppTheme">
+      android:theme="@style/AppTheme"
+      android:networkSecurityConfig="@xml/network_security_config"
+    >
       <activity
         android:name=".MainActivity"
         android:label="@string/app_name"

--- a/android/app/src/main/res/xml/network_security_config.xml
+++ b/android/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,10 @@
+<network-security-config>
+  <base-config>
+    <trust-anchors>
+      <!-- Trust preinstalled CAs -->
+      <certificates src="system" />
+      <!-- Trust user added CAs -->
+      <certificates src="user" />
+    </trust-anchors>
+  </base-config>
+</network-security-config>


### PR DESCRIPTION
Fixes #3312

Apps that target API Level 24 and above no longer trust user or
admin-added CAs for secure connections, by default.

This config allows the app to trust user-added certificate
authorities for all secure connections

More details here:
 * [Changes to Trusted Certificate Authorities in Android Nougat](https://android-developers.googleblog.com/2016/07/changes-to-trusted-certificate.html)
 * [Network security configuration](https://developer.android.com/training/articles/security-config)