### PR TITLE
safariView: Replace `\` with `/`.

### DIFF
--- a/src/utils/openLink.js
+++ b/src/utils/openLink.js
@@ -4,6 +4,7 @@ import SafariView from 'react-native-safari-view';
 
 export default (url: string): void => {
   if (Platform.OS === 'ios') {
+    url.replace(/\\/g, '/'); // Fix for #3315
     SafariView.show({ url });
   } else {
     NativeModules.CustomTabsAndroid.openURL(url);


### PR DESCRIPTION
While opening links consisting of `\`, `SafariView` was throwing
error. So replace it with `/`.

Fixes: #3315