### PR TITLE
android, unicode urls: Fix correct url not passed to custom tabs.

### DIFF
--- a/src/utils/url.js
+++ b/src/utils/url.js
@@ -45,7 +45,7 @@ export const encodeParamsForUrl = (params: UrlParams): string =>
     .join('&');
 
 export const getFullUrl = (url: string = '', realm: string): string =>
-  !url.startsWith('http') ? `${realm}${url.startsWith('/') ? '' : '/'}${url}` : url;
+  url.indexOf('http') !== 0 ? `${realm}${url.startsWith('/') ? '' : '/'}${url}` : url;
 
 export const isUrlOnRealm = (url: string = '', realm: string): boolean =>
   url.startsWith('/') || url.startsWith(realm) || !/^(http|www.)/i.test(url);


### PR DESCRIPTION
Before `getFullUrl` was adding `realm` even if unicode url string
starts with `http`. This issue is completely wired. It can not be
reproducible when remote debugger is on, on Android, but can
otherwise.

Replacing `startsWith` with `indexOf` doesn't make any logically
change, but have internal implementation difference. Thus this got
fixed.