### PR TITLE
Fix dev auth login error display

### DIFF
--- a/src/start/DevAuthScreen.js
+++ b/src/start/DevAuthScreen.js
@@ -59,7 +59,7 @@ class DevAuthScreen extends PureComponent<Props, State> {
           progress: false,
         });
       } catch (err) {
-        this.setState({ error: err.message });
+        this.setState({ error: err.data && err.data.msg });
       } finally {
         this.setState({ progress: false });
       }
@@ -76,7 +76,7 @@ class DevAuthScreen extends PureComponent<Props, State> {
       this.props.dispatch(loginSuccess(partialAuth.realm, email, api_key));
       this.setState({ progress: false });
     } catch (err) {
-      this.setState({ progress: false, error: err.message });
+      this.setState({ progress: false, error: err.data && err.data.msg });
     }
   };
 


### PR DESCRIPTION
Since we introduced `makeApiError` the error displayed to the user
is saying simply 'API'. This change extracts the error message the
server returns, which is in `err.data.message`.