### PR TITLE
webView, emoji, css: Fix Emoji rendering issue (twice, cut down).

### DIFF
--- a/src/webview/css/css.js
+++ b/src/webview/css/css.js
@@ -343,8 +343,8 @@ blockquote {
 }
 .emoji {
   display: inline-block;
-  height: 18px;
-  width: 18px;
+  height: 20px;
+  width: 20px;
   white-space: nowrap;
   color: transparent;
   vertical-align: text-top;


### PR DESCRIPTION
Use `overflow: hidden` in the emoji `span` tag (webapp also uses it)
and increase `width` & `height` to `20`.

Fixes: #2693, #3321.

Before:
On iPhone 5s
![image](https://user-images.githubusercontent.com/18511177/52231905-15ccb280-28e1-11e9-831a-590adcc44560.png)

On iPhone X
![image](https://user-images.githubusercontent.com/18511177/52232222-f5e9be80-28e1-11e9-87d4-087b6cdcb809.png)




This PR:
On iPhone 5s
![image](https://user-images.githubusercontent.com/18511177/52232032-6e03b480-28e1-11e9-859f-fef97c3c32fd.png)

iPhone X
![image](https://user-images.githubusercontent.com/18511177/52232120-b622d700-28e1-11e9-9565-11a8eaee1521.png)

