### PR TITLE
isMessageInNarrow: Fix regression in `matchRecipients`.

### DIFF
--- a/src/utils/narrow.js
+++ b/src/utils/narrow.js
@@ -1,6 +1,7 @@
 /* @flow strict-local */
 import isEqual from 'lodash.isequal';
 import unescape from 'lodash.unescape';
+import uniqby from 'lodash.uniqby';
 
 import type { Narrow, Message } from '../types';
 import { normalizeRecipients } from './recipient';
@@ -210,8 +211,10 @@ export const isSearchNarrow = (narrow?: Narrow): boolean =>
 export const isMessageInNarrow = (message: Message, narrow: Narrow, ownEmail: string): boolean => {
   const matchRecipients = (emails: string[]) => {
     const normalizedRecipients = normalizeRecipients(message.display_recipient);
-    const normalizedNarrow = [...emails, ownEmail].sort().join(',');
-    return normalizedRecipients === ownEmail || normalizedRecipients === normalizedNarrow;
+    const normalizedNarrow = uniqby([...emails, ownEmail])
+      .sort()
+      .join(',');
+    return normalizedRecipients === normalizedNarrow;
   };
 
   return caseNarrow(narrow, {


### PR DESCRIPTION
Remove `normalizedRecipients === ownEmail` condition, as it is not
taking `narrow` in consideration. For self message, `display_recipient`
will only consist of `ownEmail`. Thus for calling `isMessageInNarrow`
with self message and any private narrow was returning `true` (because
of `normalizedRecipients === ownEmail`). So remove this condition.

Also improve `normalizedNarrow`, so that it consist of only unique
values. Now this change will take care of logic which was intended to be
taken by `normalizedRecipients === ownEmail` (which is getting removed,
by this commit).

Fixes: #3324