### PR TITLE
accountPickerScreen: Fix re-render on every event of long poll.

### DIFF
--- a/src/account/accountsSelectors.js
+++ b/src/account/accountsSelectors.js
@@ -14,10 +14,11 @@ export type AccountStatus = {| ...Identity, isLoggedIn: boolean |};
  * This should be used in preference to `getAccounts` where we don't
  * actually need the API keys, but just need to know whether we have them.
  */
-export const getAccountStatuses = (state: GlobalState): AccountStatus[] => {
-  const accounts = getAccounts(state);
-  return accounts.map(({ realm, email, apiKey }) => ({ realm, email, isLoggedIn: apiKey !== '' }));
-};
+export const getAccountStatuses: Selector<$ReadOnlyArray<AccountStatus>> = createSelector(
+  getAccounts,
+  accounts =>
+    accounts.map(({ realm, email, apiKey }) => ({ realm, email, isLoggedIn: apiKey !== '' })),
+);
 
 /**
  * All known accounts, indexed by identity.


### PR DESCRIPTION
Use `reselect` in `getAccountStatuses`, so that it memorize accounts and
return same object for same value and saves re-render.