### PR TITLE
fix: Android emoji being horizontally cropped on ending line

### DIFF
--- a/src/webview/css/css.js
+++ b/src/webview/css/css.js
@@ -343,8 +343,8 @@ blockquote {
 }
 .emoji {
   display: inline-block;
-  height: 18px;
   width: 18px;
+  max-height: 100%;
   white-space: nowrap;
   color: transparent;
   vertical-align: text-top;


### PR DESCRIPTION
changed height of emoji from 18px to max-height 100%

fixes: #3318 

before:
![whatsapp image 2019-02-13 at 4 34 45 pm 1](https://user-images.githubusercontent.com/44601530/52707431-b1c77f80-2fad-11e9-8856-1c09c2f40eac.jpeg)

after:
![whatsapp image 2019-02-13 at 4 34 45 pm](https://user-images.githubusercontent.com/44601530/52707377-8e9cd000-2fad-11e9-91b7-6a4be88a62b4.jpeg)

