### PR TITLE
android notif: Accept a batch of message IDs for `remove`.

### DIFF
--- a/android/app/src/main/java/com/zulipmobile/notifications/FCMPushNotifications.java
+++ b/android/app/src/main/java/com/zulipmobile/notifications/FCMPushNotifications.java
@@ -67,10 +67,10 @@ public class FCMPushNotifications {
             data.putString(entry.getKey(), entry.getValue());
         }
         logNotificationData(data);
-        final PushNotificationsProp props = new PushNotificationsProp(data);
-        final String eventType = props.getEvent();
+        final String eventType = mapData.get("event");
         switch (eventType) {
           case "message":
+            final PushNotificationsProp props = new PushNotificationsProp(data);
             addConversationToMap(props, conversations);
             updateNotification(context, conversations, props);
             break;

--- a/android/app/src/main/java/com/zulipmobile/notifications/FCMPushNotifications.java
+++ b/android/app/src/main/java/com/zulipmobile/notifications/FCMPushNotifications.java
@@ -4,7 +4,6 @@ import android.app.Notification;
 import android.app.NotificationChannel;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
-import android.content.ContentResolver;
 import android.content.Context;
 import android.content.Intent;
 import android.graphics.Bitmap;
@@ -76,7 +75,8 @@ public class FCMPushNotifications {
             updateNotification(context, conversations, props);
             break;
           case "remove":
-            removeMessageFromMap(props, conversations);
+            final int zulipMessageId = Integer.parseInt(mapData.get("zulip_message_id"));
+            removeMessageFromMap(conversations, zulipMessageId);
             if (conversations.isEmpty()) {
                 getNotificationManager(context).cancelAll();
             }

--- a/android/app/src/main/java/com/zulipmobile/notifications/FCMPushNotifications.java
+++ b/android/app/src/main/java/com/zulipmobile/notifications/FCMPushNotifications.java
@@ -13,6 +13,7 @@ import android.os.Build;
 import android.os.Bundle;
 import android.provider.Settings;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.text.TextUtils;
 import android.util.Log;
 
@@ -81,18 +82,24 @@ public class FCMPushNotifications {
         }
     }
 
+    private static void parseMessageIdInto(Set<Integer> messageIds, @Nullable String idStr) {
+        try {
+            messageIds.add(Integer.parseInt(idStr));
+        } catch(NumberFormatException e) {
+            Log.w(TAG, String.format("Ignoring malformed message ID: %s", idStr));
+        }
+    }
+
     @NonNull
     private static Set<Integer> parseMessageIds(Map<String, String> mapData) {
         final Set<Integer> messageIds = new HashSet<>();
         final String idStr = mapData.get("zulip_message_id");
-        if (idStr != null) {
-            messageIds.add(Integer.parseInt(idStr));
-        }
+        parseMessageIdInto(messageIds, idStr);
         final String idsStr = mapData.get("zulip_message_ids");
         if (idsStr != null) {
             final String[] idStrs = idsStr.split(",");
             for (final String idStr1 : idStrs) {
-                messageIds.add(Integer.parseInt(idStr1));
+                parseMessageIdInto(messageIds, idStr1);
             }
         }
         return messageIds;

--- a/android/app/src/main/java/com/zulipmobile/notifications/NotificationHelper.java
+++ b/android/app/src/main/java/com/zulipmobile/notifications/NotificationHelper.java
@@ -134,13 +134,12 @@ public class NotificationHelper {
         conversations.put(key, messages);
     }
 
-    public static void removeMessageFromMap(PushNotificationsProp prop, ConversationMap conversations) {
+    public static void removeMessageFromMap(ConversationMap conversations, int zulipMessageId) {
         // We don't have the information to compute what key we ought to find this message under,
         // so just walk the whole thing.  If the user has >100 notifications, this linear scan
         // won't be their worst problem anyway...
         //
         // TODO redesign this whole data structure, for many reasons.
-        final int zulipMessageId = prop.getZulipMessageId();
         for (String key : conversations.keySet()) {
             List<MessageInfo> messages = conversations.get(key);
             for (int i = 0; i < messages.size(); i++) {

--- a/android/app/src/main/java/com/zulipmobile/notifications/NotificationHelper.java
+++ b/android/app/src/main/java/com/zulipmobile/notifications/NotificationHelper.java
@@ -130,12 +130,7 @@ public class NotificationHelper {
         conversations.put(key, messages);
     }
 
-    public static void removeMessageFromMap(ConversationMap conversations, int zulipMessageId) {
-        final Set<Integer> messageIds = new HashSet<>(Collections.singletonList(zulipMessageId));
-        removeMessagesFromMap(conversations, messageIds);
-    }
-
-    private static void removeMessagesFromMap(ConversationMap conversations, Set<Integer> messageIds) {
+    static void removeMessagesFromMap(ConversationMap conversations, Set<Integer> messageIds) {
         // We don't have the information to compute what key we ought to find each message under,
         // so just walk the whole thing.  If the user has >100 notifications, this linear scan
         // won't be their worst problem anyway...


### PR DESCRIPTION
This is the client logic to correspond with the server code in zulip/zulip#11561 .

I believe this code is right, but it needs testing together with the server changes; holding off on merge until I've done that.
