### PR TITLE
Issue #3015 Fix caching in "for narrow/streamId" selectors.

### DIFF
--- a/src/autocomplete/TopicAutocomplete.js
+++ b/src/autocomplete/TopicAutocomplete.js
@@ -62,5 +62,5 @@ class TopicAutocomplete extends PureComponent<Props> {
 }
 
 export default connect<SelectorProps, _, _>((state, props) => ({
-  topics: getTopicsForNarrow(props.narrow)(state),
+  topics: getTopicsForNarrow(state, props.narrow),
 }))(TopicAutocomplete);

--- a/src/chat/__tests__/narrowsSelectors-test.js
+++ b/src/chat/__tests__/narrowsSelectors-test.js
@@ -207,25 +207,25 @@ describe('getStreamInNarrow', () => {
   test('return subscription if stream in narrow is subscribed', () => {
     const narrow = streamNarrow('stream');
 
-    expect(getStreamInNarrow(narrow)(state)).toEqual({ name: 'stream', in_home_view: false });
+    expect(getStreamInNarrow(state, narrow)).toEqual({ name: 'stream', in_home_view: false });
   });
 
   test('return stream if stream in narrow is not subscribed', () => {
     const narrow = streamNarrow('stream3');
 
-    expect(getStreamInNarrow(narrow)(state)).toEqual({ name: 'stream3', in_home_view: true });
+    expect(getStreamInNarrow(state, narrow)).toEqual({ name: 'stream3', in_home_view: true });
   });
 
   test('return NULL_SUBSCRIPTION if stream in narrow is not valid', () => {
     const narrow = streamNarrow('stream4');
 
-    expect(getStreamInNarrow(narrow)(state)).toEqual(NULL_SUBSCRIPTION);
+    expect(getStreamInNarrow(state, narrow)).toEqual(NULL_SUBSCRIPTION);
   });
 
   test('return NULL_SUBSCRIPTION is narrow is not topic or stream', () => {
-    expect(getStreamInNarrow(undefined)(state)).toEqual(NULL_SUBSCRIPTION);
-    expect(getStreamInNarrow(privateNarrow('abc@zulip.com'))(state)).toEqual(NULL_SUBSCRIPTION);
-    expect(getStreamInNarrow(topicNarrow('stream4', 'topic'))(state)).toEqual(NULL_SUBSCRIPTION);
+    expect(getStreamInNarrow(state, undefined)).toEqual(NULL_SUBSCRIPTION);
+    expect(getStreamInNarrow(state, privateNarrow('abc@zulip.com'))).toEqual(NULL_SUBSCRIPTION);
+    expect(getStreamInNarrow(state, topicNarrow('stream4', 'topic'))).toEqual(NULL_SUBSCRIPTION);
   });
 });
 
@@ -236,7 +236,7 @@ describe('isNarrowValid', () => {
     };
     const narrow = STARRED_NARROW;
 
-    const result = isNarrowValid(narrow)(state);
+    const result = isNarrowValid(state, narrow);
 
     expect(result).toBe(true);
   });
@@ -248,7 +248,7 @@ describe('isNarrowValid', () => {
     };
     const narrow = streamNarrow('some stream');
 
-    const result = isNarrowValid(narrow)(state);
+    const result = isNarrowValid(state, narrow);
 
     expect(result).toBe(true);
   });
@@ -260,7 +260,7 @@ describe('isNarrowValid', () => {
     };
     const narrow = streamNarrow('nonexisting');
 
-    const result = isNarrowValid(narrow)(state);
+    const result = isNarrowValid(state, narrow);
 
     expect(result).toBe(false);
   });
@@ -272,7 +272,7 @@ describe('isNarrowValid', () => {
     };
     const narrow = topicNarrow('some stream', 'topic does not matter');
 
-    const result = isNarrowValid(narrow)(state);
+    const result = isNarrowValid(state, narrow);
 
     expect(result).toBe(true);
   });
@@ -288,7 +288,7 @@ describe('isNarrowValid', () => {
     };
     const narrow = privateNarrow('bob@example.com');
 
-    const result = isNarrowValid(narrow)(state);
+    const result = isNarrowValid(state, narrow);
 
     expect(result).toBe(true);
   });
@@ -304,7 +304,7 @@ describe('isNarrowValid', () => {
     };
     const narrow = privateNarrow('bob@example.com');
 
-    const result = isNarrowValid(narrow)(state);
+    const result = isNarrowValid(state, narrow);
 
     expect(result).toBe(false);
   });
@@ -320,7 +320,7 @@ describe('isNarrowValid', () => {
     };
     const narrow = groupNarrow(['john@example.com', 'mark@example.com']);
 
-    const result = isNarrowValid(narrow)(state);
+    const result = isNarrowValid(state, narrow);
 
     expect(result).toBe(true);
   });
@@ -336,7 +336,7 @@ describe('isNarrowValid', () => {
     };
     const narrow = groupNarrow(['john@example.com', 'mark@example.com']);
 
-    const result = isNarrowValid(narrow)(state);
+    const result = isNarrowValid(state, narrow);
 
     expect(result).toBe(true);
   });
@@ -352,7 +352,7 @@ describe('isNarrowValid', () => {
     };
     const narrow = privateNarrow('some-bot@example.com');
 
-    const result = isNarrowValid(narrow)(state);
+    const result = isNarrowValid(state, narrow);
 
     expect(result).toBe(true);
   });
@@ -368,7 +368,7 @@ describe('isNarrowValid', () => {
     };
     const narrow = privateNarrow('not-active@example.com');
 
-    const result = isNarrowValid(narrow)(state);
+    const result = isNarrowValid(state, narrow);
 
     expect(result).toBe(true);
   });

--- a/src/chat/narrowsSelectors.js
+++ b/src/chat/narrowsSelectors.js
@@ -103,48 +103,48 @@ export const getRecipientsInGroupNarrow: Selector<UserOrBot[], Narrow> = createS
     }),
 );
 
+// Prettier mishandles this Flow syntax.
+// prettier-ignore
 // TODO: clean up what this returns.
-export const getStreamInNarrow = (
-  narrow: Narrow,
-): Selector<Subscription | {| ...Stream, in_home_view: boolean |}> =>
-  createSelector(
-    getSubscriptions,
-    getStreams,
-    (subscriptions, streams) => {
-      if (!isStreamOrTopicNarrow(narrow)) {
-        return NULL_SUBSCRIPTION;
-      }
-
-      const subscription = subscriptions.find(x => x.name === narrow[0].operand);
-      if (subscription) {
-        return subscription;
-      }
-
-      const stream = streams.find(x => x.name === narrow[0].operand);
-      if (stream) {
-        return {
-          ...stream,
-          in_home_view: true,
-        };
-      }
-
+export const getStreamInNarrow: Selector<Subscription | {| ...Stream, in_home_view: boolean |}, Narrow> = createSelector(
+  (state, narrow) => narrow,
+  state => getSubscriptions(state),
+  state => getStreams(state),
+  (narrow, subscriptions, streams) => {
+    if (!isStreamOrTopicNarrow(narrow)) {
       return NULL_SUBSCRIPTION;
-    },
-  );
+    }
 
-export const isNarrowValid = (narrow: Narrow): Selector<boolean> =>
-  createSelector(
-    getStreams,
-    getAllUsersByEmail,
-    (streams, allUsersByEmail) => {
-      if (isStreamOrTopicNarrow(narrow)) {
-        return streams.find(s => s.name === narrow[0].operand) !== undefined;
-      }
+    const subscription = subscriptions.find(x => x.name === narrow[0].operand);
+    if (subscription) {
+      return subscription;
+    }
 
-      if (isPrivateNarrow(narrow)) {
-        return allUsersByEmail.get(narrow[0].operand) !== undefined;
-      }
+    const stream = streams.find(x => x.name === narrow[0].operand);
+    if (stream) {
+      return {
+        ...stream,
+        in_home_view: true,
+      };
+    }
 
-      return true;
-    },
-  );
+    return NULL_SUBSCRIPTION;
+  },
+);
+
+export const isNarrowValid: Selector<boolean, Narrow> = createSelector(
+  (state, narrow) => narrow,
+  state => getStreams(state),
+  state => getAllUsersByEmail(state),
+  (narrow, streams, allUsersByEmail) => {
+    if (isStreamOrTopicNarrow(narrow)) {
+      return streams.find(s => s.name === narrow[0].operand) !== undefined;
+    }
+
+    if (isPrivateNarrow(narrow)) {
+      return allUsersByEmail.get(narrow[0].operand) !== undefined;
+    }
+
+    return true;
+  },
+);

--- a/src/compose/ComposeBox.js
+++ b/src/compose/ComposeBox.js
@@ -432,6 +432,6 @@ export default connect<SelectorProps, _, _>((state, props) => ({
   isAnnouncementOnly: getIsActiveStreamAnnouncementOnly(state, props.narrow),
   isSubscribed: getIsActiveStreamSubscribed(state, props.narrow),
   editMessage: getSession(state).editMessage,
-  draft: getDraftForNarrow(props.narrow)(state),
+  draft: getDraftForNarrow(state, props.narrow),
   lastMessageTopic: getLastMessageTopic(state, props.narrow),
 }))(ComposeBox);

--- a/src/compose/ComposeBox.js
+++ b/src/compose/ComposeBox.js
@@ -433,5 +433,5 @@ export default connect<SelectorProps, _, _>((state, props) => ({
   isSubscribed: getIsActiveStreamSubscribed(state, props.narrow),
   editMessage: getSession(state).editMessage,
   draft: getDraftForNarrow(props.narrow)(state),
-  lastMessageTopic: getLastMessageTopic(props.narrow)(state),
+  lastMessageTopic: getLastMessageTopic(state, props.narrow),
 }))(ComposeBox);

--- a/src/drafts/__tests__/draftsSelectors-test.js
+++ b/src/drafts/__tests__/draftsSelectors-test.js
@@ -12,7 +12,7 @@ describe('getDraftForNarrow', () => {
       },
     });
 
-    const draft = getDraftForNarrow(narrow)(state);
+    const draft = getDraftForNarrow(state, narrow);
 
     expect(draft).toEqual('content');
   });
@@ -25,7 +25,7 @@ describe('getDraftForNarrow', () => {
       },
     });
 
-    const draft = getDraftForNarrow(topicNarrow('stream', 'topic1'))(state);
+    const draft = getDraftForNarrow(state, topicNarrow('stream', 'topic1'));
 
     expect(draft).toEqual('');
   });

--- a/src/drafts/draftsSelectors.js
+++ b/src/drafts/draftsSelectors.js
@@ -1,11 +1,5 @@
 /* @flow strict-local */
-import { createSelector } from 'reselect';
+import type { Narrow, GlobalState } from '../types';
 
-import { getDrafts } from '../directSelectors';
-import type { Narrow, Selector } from '../types';
-
-export const getDraftForNarrow = (narrow: Narrow): Selector<string> =>
-  createSelector(
-    getDrafts,
-    drafts => drafts[JSON.stringify(narrow)] || '',
-  );
+export const getDraftForNarrow = (state: GlobalState, narrow: Narrow): string =>
+  state.drafts[JSON.stringify(narrow)] || '';

--- a/src/message/NotSubscribed.js
+++ b/src/message/NotSubscribed.js
@@ -48,5 +48,5 @@ class NotSubscribed extends PureComponent<Props> {
 
 export default connect<SelectorProps, _, _>((state, props) => ({
   auth: getAuth(state),
-  stream: getStreamInNarrow(props.narrow)(state),
+  stream: getStreamInNarrow(state, props.narrow),
 }))(NotSubscribed);

--- a/src/message/messageSelectors.js
+++ b/src/message/messageSelectors.js
@@ -62,11 +62,11 @@ export const getPrivateMessages: Selector<Message[]> = createSelector(
   },
 );
 
-export const getRenderedMessages = (narrow: Narrow): Selector<RenderedSectionDescriptor[]> =>
-  createSelector(
-    state => getShownMessagesForNarrow(state, narrow),
-    messages => renderMessages(messages, narrow),
-  );
+export const getRenderedMessages: Selector<RenderedSectionDescriptor[], Narrow> = createSelector(
+  (state, narrow) => narrow,
+  getShownMessagesForNarrow,
+  (narrow, messages) => renderMessages(messages, narrow),
+);
 
 export const getFirstUnreadIdInNarrow: Selector<number | null, Narrow> = createSelector(
   (state, narrow) => getShownMessagesForNarrow(state, narrow),

--- a/src/message/messagesActions.js
+++ b/src/message/messagesActions.js
@@ -27,7 +27,7 @@ export const doNarrow = (narrow: Narrow, anchor: number = FIRST_UNREAD_ANCHOR) =
 ) => {
   const state = getState();
 
-  if (!isNarrowValid(narrow)(state) || !getIsHydrated(state)) {
+  if (!isNarrowValid(state, narrow) || !getIsHydrated(state)) {
     return;
   }
 

--- a/src/title/TitleStream.js
+++ b/src/title/TitleStream.js
@@ -71,5 +71,5 @@ class TitleStream extends PureComponent<Props> {
 }
 
 export default connect<SelectorProps, _, _>((state, props) => ({
-  stream: getStreamInNarrow(props.narrow)(state),
+  stream: getStreamInNarrow(state, props.narrow),
 }))(TitleStream);

--- a/src/topics/__tests__/topicsSelectors-test.js
+++ b/src/topics/__tests__/topicsSelectors-test.js
@@ -32,7 +32,7 @@ describe('getLastMessageTopic', () => {
       narrows: {},
     });
 
-    const topic = getLastMessageTopic(HOME_NARROW)(state);
+    const topic = getLastMessageTopic(state, HOME_NARROW);
 
     expect(topic).toEqual('');
   });
@@ -52,7 +52,7 @@ describe('getLastMessageTopic', () => {
       },
     });
 
-    const topic = getLastMessageTopic(narrow)(state);
+    const topic = getLastMessageTopic(state, narrow);
 
     expect(topic).toEqual('some topic');
   });

--- a/src/topics/__tests__/topicsSelectors-test.js
+++ b/src/topics/__tests__/topicsSelectors-test.js
@@ -7,7 +7,7 @@ describe('getTopicsForNarrow', () => {
   test('when no topics return an empty list', () => {
     const state = deepFreeze({});
 
-    const topics = getTopicsForNarrow(HOME_NARROW)(state);
+    const topics = getTopicsForNarrow(state, HOME_NARROW);
 
     expect(topics).toEqual([]);
   });
@@ -20,7 +20,7 @@ describe('getTopicsForNarrow', () => {
       },
     });
 
-    const topics = getTopicsForNarrow(streamNarrow('hello'))(state);
+    const topics = getTopicsForNarrow(state, streamNarrow('hello'));
 
     expect(topics).toEqual(['hi', 'wow']);
   });

--- a/src/topics/topicSelectors.js
+++ b/src/topics/topicSelectors.js
@@ -4,6 +4,7 @@ import { createSelector } from 'reselect';
 import type {
   MuteState,
   Narrow,
+  GlobalState,
   Selector,
   Stream,
   StreamsState,
@@ -66,8 +67,7 @@ export const getTopicsForStream: Selector<?(TopicExtended[]), number> = createSe
   },
 );
 
-export const getLastMessageTopic = (narrow: Narrow): Selector<string> =>
-  createSelector(
-    state => getShownMessagesForNarrow(state, narrow),
-    messages => (messages.length === 0 ? '' : messages[messages.length - 1].subject),
-  );
+export const getLastMessageTopic = (state: GlobalState, narrow: Narrow): string => {
+  const messages = getShownMessagesForNarrow(state, narrow);
+  return messages.length === 0 ? '' : messages[messages.length - 1].subject;
+};

--- a/src/topics/topicSelectors.js
+++ b/src/topics/topicSelectors.js
@@ -19,23 +19,23 @@ import { getStreamsById } from '../subscriptions/subscriptionSelectors';
 import { NULL_ARRAY } from '../nullObjects';
 import { isStreamNarrow } from '../utils/narrow';
 
-export const getTopicsForNarrow = (narrow: Narrow): Selector<string[]> =>
-  createSelector(
-    getTopics,
-    getStreams,
-    (topics: TopicsState, streams: StreamsState) => {
-      if (!isStreamNarrow(narrow)) {
-        return NULL_ARRAY;
-      }
-      const stream = streams.find(x => x.name === narrow[0].operand);
+export const getTopicsForNarrow: Selector<string[], Narrow> = createSelector(
+  (state, narrow) => narrow,
+  state => getTopics(state),
+  state => getStreams(state),
+  (narrow: Narrow, topics: TopicsState, streams: StreamsState) => {
+    if (!isStreamNarrow(narrow)) {
+      return NULL_ARRAY;
+    }
+    const stream = streams.find(x => x.name === narrow[0].operand);
 
-      if (!stream || !topics[stream.stream_id]) {
-        return NULL_ARRAY;
-      }
+    if (!stream || !topics[stream.stream_id]) {
+      return NULL_ARRAY;
+    }
 
-      return topics[stream.stream_id].map(x => x.name);
-    },
-  );
+    return topics[stream.stream_id].map(x => x.name);
+  },
+);
 
 export const getTopicsForStream: Selector<?(TopicExtended[]), number> = createSelector(
   (state, streamId) => getTopics(state)[streamId],

--- a/src/webview/MessageList.js
+++ b/src/webview/MessageList.js
@@ -375,7 +375,7 @@ export default connect<SelectorProps, _, _>((state, props: OuterProps) => {
         : getFirstUnreadIdInNarrow(state, props.narrow),
     fetching: props.fetching || getFetchingForNarrow(state, props.narrow),
     messages: props.messages || getShownMessagesForNarrow(state, props.narrow),
-    renderedMessages: props.renderedMessages || getRenderedMessages(props.narrow)(state),
+    renderedMessages: props.renderedMessages || getRenderedMessages(state, props.narrow),
     typingUsers: props.typingUsers || getCurrentTypingUsers(state, props.narrow),
   };
 })(connectActionSheet(withGetText(MessageList)));


### PR DESCRIPTION
part of #3015
Converted all to new style.
```
➜  zulip-mobile git:(issue-3015) perl -0ne '
          print "$ARGV: $1\n" while (/^export const (\w+) = [^\n]*=>\s*createSelector/msg)
        ' src/**/*.js
```