### PR TITLE
Fixing Travic CI problems by disabling a lint rule

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -50,6 +50,7 @@ rules:
 
   # Imports
   import/prefer-default-export: off
+  import/no-named-as-default: off
   import/no-extraneous-dependencies:
   - error
   - devDependencies: ['**/__tests__/*.js', tools/**]

--- a/src/unread/unreadSelectors.js
+++ b/src/unread/unreadSelectors.js
@@ -46,8 +46,9 @@ export const getUnreadByStream = createSelector(
     }, ({}: { [number]: number })),
 );
 
-export const getUnreadStreamTotal = createSelector(getUnreadByStream, unreadByStream =>
-  Object.values(unreadByStream).reduce((total, x) => +x + total, 0),
+export const getUnreadStreamTotal: Selector<number> = createSelector(
+  getUnreadByStream,
+  unreadByStream => Object.values(unreadByStream).reduce((total, x) => +x + total, 0),
 );
 
 export const getUnreadByPms = createSelector(getUnreadPms, unreadPms =>
@@ -57,7 +58,7 @@ export const getUnreadByPms = createSelector(getUnreadPms, unreadPms =>
   }, ({}: { [number]: number })),
 );
 
-export const getUnreadPmsTotal = createSelector(getUnreadPms, unreadPms =>
+export const getUnreadPmsTotal: Selector<number> = createSelector(getUnreadPms, unreadPms =>
   unreadPms.reduce((total, pm) => total + pm.unread_message_ids.length, 0),
 );
 
@@ -69,16 +70,18 @@ export const getUnreadByHuddles = createSelector(getUnreadHuddles, unreadHuddles
   }, ({}: { [string]: number })),
 );
 
-export const getUnreadHuddlesTotal = createSelector(getUnreadHuddles, unreadHuddles =>
-  unreadHuddles.reduce((total, huddle) => total + huddle.unread_message_ids.length, 0),
+export const getUnreadHuddlesTotal: Selector<number> = createSelector(
+  getUnreadHuddles,
+  unreadHuddles =>
+    unreadHuddles.reduce((total, huddle) => total + huddle.unread_message_ids.length, 0),
 );
 
-export const getUnreadMentionsTotal = createSelector(
+export const getUnreadMentionsTotal: Selector<number> = createSelector(
   getUnreadMentions,
   unreadMentions => unreadMentions.length,
 );
 
-export const getUnreadTotal = createSelector(
+export const getUnreadTotal: Selector<number> = createSelector(
   getUnreadStreamTotal,
   getUnreadPmsTotal,
   getUnreadHuddlesTotal,
@@ -149,7 +152,7 @@ export const getUnreadStreamsAndTopicsSansMuted = createSelector(
       .filter(stream => !stream.isMuted && stream.data.length > 0),
 );
 
-export const getUnreadPrivateMessagesCount = createSelector(
+export const getUnreadPrivateMessagesCount: Selector<number> = createSelector(
   getPrivateMessages,
   getReadFlags,
   (privateMessages, readFlags) => countUnread(privateMessages.map(msg => msg.id), readFlags),


### PR DESCRIPTION
Fixes Issue #3353 

Commit 4b19108d03ee4b6c93661df443ee93840c748004 ( Icons: Describe the general type; fix a call site's vague type ) started the problem and it is caused by adding export type Icon = ComponentType<IconProps>; line because now all the imports are importing Icon and eslint is confused on if we meant to import the default import Feather or the named import Icon. 
To avoid this check the lint rule of no-named-as-default is disabled.