### PR TITLE
Fixed avatar fetching for larger image 

### DIFF
--- a/src/common/Avatar.js
+++ b/src/common/Avatar.js
@@ -22,12 +22,12 @@ const componentStyles = StyleSheet.create({
 
 type Props = {|
   avatarUrl: ?string,
-  email: string,
-  name: string,
-  size: number,
-  realm: string,
-  shape: 'square' | 'rounded' | 'circle',
-  onPress?: () => void,
+    email: string,
+      name: string,
+        size: number,
+          realm: string,
+            shape: 'square' | 'rounded' | 'circle',
+              onPress ?: () => void,
 |};
 
 /**
@@ -54,7 +54,7 @@ class Avatar extends PureComponent<Props> {
   render() {
     const { avatarUrl, email, name, size, onPress, realm, shape } = this.props;
     const fullAvatarUrl =
-      typeof avatarUrl === 'string' ? getFullUrl(avatarUrl, realm) : getGravatarFromEmail(email);
+      typeof avatarUrl === 'string' ? getFullUrl(avatarUrl, realm) : getGravatarFromEmail(email, size);
     const AvatarComponent = fullAvatarUrl ? ImageAvatar : TextAvatar;
 
     return (


### PR DESCRIPTION
The getGravatarFromEmail() function previously used default value of 80 for fetching the avatar image. Now size is given explicitly.

Concerning issue #3358 