### PR TITLE
Cleaned up flow type for selectors in narrowSelector

### DIFF
--- a/src/chat/narrowsSelectors.js
+++ b/src/chat/narrowsSelectors.js
@@ -2,7 +2,17 @@
 import isEqual from 'lodash.isequal';
 import { createSelector } from 'reselect';
 
-import type { GlobalState, Message, Narrow, Outbox, RealmBot, Selector, User } from '../types';
+import type {
+  GlobalState,
+  Message,
+  Narrow,
+  Outbox,
+  RealmBot,
+  Selector,
+  User,
+  Stream,
+  Subscription,
+} from '../types';
 import {
   getAllNarrows,
   getSubscriptions,
@@ -93,7 +103,9 @@ export const getRecipientsInGroupNarrow: Selector<(User | RealmBot)[], Narrow> =
     }),
 );
 
-export const getStreamInNarrow = (narrow: Narrow) =>
+export const getStreamInNarrow = (
+  narrow: Narrow,
+): Selector<Subscription | {| ...Stream, in_home_view: boolean |}> =>
   createSelector(getSubscriptions, getStreams, (subscriptions, streams) => {
     if (!isStreamOrTopicNarrow(narrow)) {
       return NULL_SUBSCRIPTION;

--- a/src/chat/narrowsSelectors.js
+++ b/src/chat/narrowsSelectors.js
@@ -103,6 +103,7 @@ export const getRecipientsInGroupNarrow: Selector<(User | RealmBot)[], Narrow> =
     }),
 );
 
+// TODO: clean up what this returns.
 export const getStreamInNarrow = (
   narrow: Narrow,
 ): Selector<Subscription | {| ...Stream, in_home_view: boolean |}> =>

--- a/src/chat/narrowsSelectors.js
+++ b/src/chat/narrowsSelectors.js
@@ -115,10 +115,10 @@ export const getStreamInNarrow = (narrow: Narrow) =>
     return NULL_SUBSCRIPTION;
   });
 
-export const getIfNoMessages = (narrow: Narrow) =>
+export const getIfNoMessages = (narrow: Narrow): Selector<boolean> =>
   createSelector(
     state => getShownMessagesForNarrow(state, narrow),
-    messages => messages && messages.length === 0,
+    messages => messages.length === 0,
   );
 
 export const getShowMessagePlaceholders = (narrow: Narrow): Selector<boolean> =>

--- a/src/message/NotSubscribed.js
+++ b/src/message/NotSubscribed.js
@@ -12,7 +12,7 @@ import styles from '../styles';
 
 type Props = {
   auth: Auth,
-  stream: Stream,
+  stream: { ...Stream },
 };
 
 class NotSubscribed extends PureComponent<Props> {

--- a/src/title/TitleStream.js
+++ b/src/title/TitleStream.js
@@ -4,7 +4,7 @@ import { connect } from 'react-redux';
 import React, { PureComponent } from 'react';
 import { Text, View } from 'react-native';
 
-import type { Narrow, Subscription } from '../types';
+import type { Narrow, Stream, Subscription } from '../types';
 import StreamIcon from '../streams/StreamIcon';
 import { isTopicNarrow } from '../utils/narrow';
 import { getStreamInNarrow } from '../selectors';
@@ -12,7 +12,7 @@ import styles from '../styles';
 
 type Props = {|
   narrow: Narrow,
-  stream: Subscription,
+  stream: Subscription | {| ...Stream, in_home_view: boolean |},
   color: string,
 |};
 


### PR DESCRIPTION
Issues in focus: #2971, #3166
Removed redundant messages word in the logical operation performed under getIfNoMessages and added flow type for it

Added flow type for getStream in narrow. This one was different because the selector returned either Subscription if the Stream was subscribed to before, or Stream + in_home_view=true if it was not subscribed to before. A type could have been declared for the latter case but it seemed unnecessary so instead, I used spread syntax to define the return type. 

Tests ran:
- [x] tools/test