### PR TITLE
 accountDetails: Use `ProgressiveImage` to render `UserAvatar`.

### DIFF
--- a/src/account-info/AccountDetails.js
+++ b/src/account-info/AccountDetails.js
@@ -6,7 +6,6 @@ import type { User } from '../types';
 import { UserAvatar, ComponentList, RawLabel } from '../common';
 import PresenceStatusIndicator from '../common/PresenceStatusIndicator';
 import ActivityText from '../title/ActivityText';
-import { getMediumAvatar } from '../utils/avatar';
 import { nowInTimeZone } from '../utils/date';
 import styles from '../styles';
 
@@ -32,10 +31,11 @@ export default class AccountDetails extends PureComponent<Props, void> {
     return (
       <View>
         <UserAvatar
-          avatarUrl={typeof user.avatar_url === 'string' ? getMediumAvatar(user.avatar_url) : null}
+          avatarUrl={user.avatar_url}
           email={user.email}
           size={screenWidth}
           shape="square"
+          useProgressiveImage
         />
         <ComponentList outerSpacing itemStyle={componentStyles.componentListItem}>
           <View style={componentStyles.statusWrapper}>

--- a/src/account-info/AccountDetails.js
+++ b/src/account-info/AccountDetails.js
@@ -3,7 +3,7 @@ import React, { PureComponent } from 'react';
 import { View, Dimensions, StyleSheet } from 'react-native';
 
 import type { User } from '../types';
-import { UserAvatarWithPresence, ComponentList, RawLabel } from '../common';
+import { UserAvatar, ComponentList, RawLabel } from '../common';
 import PresenceStatusIndicator from '../common/PresenceStatusIndicator';
 import ActivityText from '../title/ActivityText';
 import { getMediumAvatar } from '../utils/avatar';
@@ -31,7 +31,7 @@ export default class AccountDetails extends PureComponent<Props, void> {
 
     return (
       <View>
-        <UserAvatarWithPresence
+        <UserAvatar
           avatarUrl={typeof user.avatar_url === 'string' ? getMediumAvatar(user.avatar_url) : null}
           email={user.email}
           size={screenWidth}

--- a/src/common/OwnAvatar.js
+++ b/src/common/OwnAvatar.js
@@ -3,15 +3,12 @@ import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';
 
 import type { GlobalState, User } from '../types';
-import { getCurrentRealm, getSelfUserDetail } from '../selectors';
+import { getSelfUserDetail } from '../selectors';
 import UserAvatar from './UserAvatar';
-import { getFullUrl } from '../utils/url';
-import { getGravatarFromEmail } from '../utils/avatar';
 
 type Props = {|
   user: User,
   size: number,
-  realm: string,
 |};
 
 /**
@@ -21,17 +18,12 @@ type Props = {|
  */
 class OwnAvatar extends PureComponent<Props> {
   render() {
-    const { user, size, realm } = this.props;
-    const fullAvatarUrl =
-      typeof user.avatar_url === 'string'
-        ? getFullUrl(user.avatar_url, realm)
-        : getGravatarFromEmail(user.email);
+    const { user, size } = this.props;
 
-    return <UserAvatar avatarUrl={fullAvatarUrl} size={size} shape="circle" />;
+    return <UserAvatar avatarUrl={user.avatar_url} size={size} shape="circle" email={user.email} />;
   }
 }
 
 export default connect((state: GlobalState) => ({
-  realm: getCurrentRealm(state),
   user: getSelfUserDetail(state),
 }))(OwnAvatar);

--- a/src/common/ProgressiveImage.js
+++ b/src/common/ProgressiveImage.js
@@ -1,0 +1,72 @@
+/* @flow strict-local */
+import React from 'react';
+import { View, StyleSheet, Animated } from 'react-native';
+
+import type { Style } from '../types';
+import { BRAND_COLOR } from '../styles';
+
+const styles = StyleSheet.create({
+  imageOverlay: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    bottom: 0,
+    top: 0,
+  },
+  container: {
+    backgroundColor: BRAND_COLOR,
+  },
+});
+
+/**
+ * Renders image thumbnail till full image is fetched.
+ *
+ * @prop thumbnailSource - string url of the thumbnail.
+ * @prop source - string url of the image to be loaded.
+ * @prop [style] - Style object for additional customization.
+ */
+
+type Props = {
+  thumbnailSource: string,
+  source: string,
+  style?: Style,
+};
+
+export default class ProgressiveImage extends React.PureComponent<Props> {
+  thumbnailAnimated = new Animated.Value(0);
+  imageAnimated = new Animated.Value(0);
+
+  handleThumbnailLoad = () => {
+    Animated.timing(this.thumbnailAnimated, {
+      toValue: 1,
+    }).start();
+  };
+
+  onImageLoad = () => {
+    Animated.timing(this.imageAnimated, {
+      toValue: 1,
+    }).start();
+  };
+
+  render() {
+    const { thumbnailSource, source, style, ...props } = this.props;
+
+    return (
+      <View style={styles.container}>
+        <Animated.Image
+          {...props}
+          source={{ uri: thumbnailSource }}
+          style={[style, { opacity: this.thumbnailAnimated }]}
+          onLoad={this.handleThumbnailLoad}
+          blurRadius={1}
+        />
+        <Animated.Image
+          {...props}
+          source={{ uri: source }}
+          style={[styles.imageOverlay, { opacity: this.imageAnimated }, style]}
+          onLoad={this.onImageLoad}
+        />
+      </View>
+    );
+  }
+}

--- a/src/common/UserAvatar.js
+++ b/src/common/UserAvatar.js
@@ -1,14 +1,20 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
 import { ImageBackground, View } from 'react-native';
+import { connect } from 'react-redux';
 
-import type { ChildrenArray } from '../types';
+import type { ChildrenArray, GlobalState } from '../types';
+import { getCurrentRealm } from '../selectors';
 import Touchable from './Touchable';
+import { getFullUrl } from '../utils/url';
+import { getGravatarFromEmail } from '../utils/avatar';
 
 type Props = {
-  avatarUrl: string,
+  email: string,
+  realm: string,
   size: number,
   shape: string,
+  avatarUrl: ?string,
   children?: ChildrenArray<*>,
   onPress?: () => void,
 };
@@ -19,16 +25,18 @@ type Props = {
  * @prop avatarUrl - Absolute or relative url to an avatar image.
  * @prop size - Sets width and height in pixels.
  * @prop shape - One of 'square', 'rounded', 'circle'.
+ * @prop [email] - User's' email address, to calculate Gravatar URL if not given `avatarUrl`.
+ * @prop [realm] - Current realm url, used if avatarUrl is relative.
  * @prop [children] - If provided, will render inside the component body.
  * @prop [onPress] - Event fired on pressing the component.
  */
-export default class UserAvatar extends PureComponent<Props> {
+class UserAvatar extends PureComponent<Props> {
   static defaultProps = {
     shape: 'rounded',
   };
 
   render() {
-    const { avatarUrl, children, size, shape, onPress } = this.props;
+    const { avatarUrl, children, email, realm, size, shape, onPress } = this.props;
     const touchableStyle = {
       height: size,
       width: size,
@@ -37,12 +45,15 @@ export default class UserAvatar extends PureComponent<Props> {
     const borderRadius =
       shape === 'rounded' ? size / 8 : shape === 'circle' ? size / 2 : shape === 'square' ? 0 : 0;
 
+    const fullAvatarUrl =
+      typeof avatarUrl === 'string' ? getFullUrl(avatarUrl, realm) : getGravatarFromEmail(email);
+
     return (
       <View>
         <Touchable onPress={onPress} style={touchableStyle}>
           <ImageBackground
             style={touchableStyle}
-            source={{ uri: avatarUrl }}
+            source={{ uri: fullAvatarUrl }}
             resizeMode="cover"
             borderRadius={borderRadius}
           >
@@ -53,3 +64,7 @@ export default class UserAvatar extends PureComponent<Props> {
     );
   }
 }
+
+export default connect((state: GlobalState) => ({
+  realm: getCurrentRealm(state),
+}))(UserAvatar);

--- a/src/common/UserAvatar.js
+++ b/src/common/UserAvatar.js
@@ -7,13 +7,15 @@ import type { ChildrenArray, GlobalState } from '../types';
 import { getCurrentRealm } from '../selectors';
 import Touchable from './Touchable';
 import { getFullUrl } from '../utils/url';
-import { getGravatarFromEmail } from '../utils/avatar';
+import { getGravatarFromEmail, getMediumAvatar } from '../utils/avatar';
+import ProgressiveImage from './ProgressiveImage';
 
 type Props = {
   email: string,
   realm: string,
   size: number,
   shape: string,
+  useProgressiveImage: boolean,
   avatarUrl: ?string,
   children?: ChildrenArray<*>,
   onPress?: () => void,
@@ -33,10 +35,20 @@ type Props = {
 class UserAvatar extends PureComponent<Props> {
   static defaultProps = {
     shape: 'rounded',
+    useProgressiveImage: false,
   };
 
   render() {
-    const { avatarUrl, children, email, realm, size, shape, onPress } = this.props;
+    const {
+      avatarUrl,
+      children,
+      email,
+      realm,
+      size,
+      shape,
+      onPress,
+      useProgressiveImage,
+    } = this.props;
     const touchableStyle = {
       height: size,
       width: size,
@@ -44,6 +56,26 @@ class UserAvatar extends PureComponent<Props> {
 
     const borderRadius =
       shape === 'rounded' ? size / 8 : shape === 'circle' ? size / 2 : shape === 'square' ? 0 : 0;
+
+    if (!children && useProgressiveImage) {
+      let thumbnailSource;
+      let source;
+
+      if (typeof avatarUrl === 'string') {
+        thumbnailSource = getFullUrl(avatarUrl, realm);
+        source = getMediumAvatar(thumbnailSource);
+      } else {
+        thumbnailSource = getGravatarFromEmail(email, size / 8);
+        source = getGravatarFromEmail(email, size);
+      }
+      return (
+        <ProgressiveImage
+          thumbnailSource={thumbnailSource}
+          source={source}
+          style={[touchableStyle]}
+        />
+      );
+    }
 
     const fullAvatarUrl =
       typeof avatarUrl === 'string' ? getFullUrl(avatarUrl, realm) : getGravatarFromEmail(email);

--- a/src/common/UserAvatarWithPresence.js
+++ b/src/common/UserAvatarWithPresence.js
@@ -1,14 +1,8 @@
 /* @flow strict-local */
-import { connect } from 'react-redux';
-
 import React, { PureComponent } from 'react';
 import { StyleSheet } from 'react-native';
 
-import type { GlobalState } from '../types';
-import { getCurrentRealm } from '../selectors';
 import UserAvatar from './UserAvatar';
-import { getFullUrl } from '../utils/url';
-import { getGravatarFromEmail } from '../utils/avatar';
 import PresenceStatusIndicator from './PresenceStatusIndicator';
 
 const componentStyles = StyleSheet.create({
@@ -23,7 +17,6 @@ type Props = {|
   avatarUrl: ?string,
   email: string,
   size: number,
-  realm: string,
   shape: 'square' | 'rounded' | 'circle',
   onPress?: () => void,
 |};
@@ -34,32 +27,24 @@ type Props = {|
  * @prop [avatarUrl] - Absolute or relative url to an avatar image.
  * @prop [email] - User's' email address, to calculate Gravatar URL if not given `avatarUrl`.
  * @prop [size] - Sets width and height in pixels.
- * @prop [realm] - Current realm url, used if avatarUrl is relative.
  * @prop [shape] - One of 'square', 'rounded', 'circle'.
  * @prop [onPress] - Event fired on pressing the component.
  */
-class UserAvatarWithPresence extends PureComponent<Props> {
+export default class UserAvatarWithPresence extends PureComponent<Props> {
   static defaultProps = {
     avatarUrl: '',
     email: '',
     size: 32,
-    realm: '',
     shape: 'rounded',
   };
 
   render() {
-    const { avatarUrl, email, size, onPress, realm, shape } = this.props;
-    const fullAvatarUrl =
-      typeof avatarUrl === 'string' ? getFullUrl(avatarUrl, realm) : getGravatarFromEmail(email);
+    const { avatarUrl, email, size, onPress, shape } = this.props;
 
     return (
-      <UserAvatar avatarUrl={fullAvatarUrl} size={size} onPress={onPress} shape={shape}>
+      <UserAvatar avatarUrl={avatarUrl} size={size} onPress={onPress} shape={shape} email={email}>
         <PresenceStatusIndicator style={componentStyles.status} email={email} hideIfOffline />
       </UserAvatar>
     );
   }
 }
-
-export default connect((state: GlobalState) => ({
-  realm: getCurrentRealm(state),
-}))(UserAvatarWithPresence);


### PR DESCRIPTION
Fixes: #3352

`ProgressiveImage` component will be used in `AccountDetails` to render `UserAvatar`.
`ProgressiveImage` component first shows thumbnail of the image till full image is
loaded. Then full image is show with a smooth transition between
thumbnail and original image.

Two commits in this PR are of #3362