### PR TITLE
userGroupItem, icon: Set `color` according to the theme.

### DIFF
--- a/src/user-groups/UserGroupItem.js
+++ b/src/user-groups/UserGroupItem.js
@@ -4,7 +4,8 @@ import { StyleSheet, View } from 'react-native';
 
 import { IconPeople } from '../common/Icons';
 import { RawLabel, Touchable } from '../common';
-import styles from '../styles';
+import styles, { ThemeContext } from '../styles';
+import type { ThemeColors } from '../styles';
 
 const componentStyles = StyleSheet.create({
   text: {
@@ -26,6 +27,9 @@ type Props = {|
 |};
 
 export default class UserGroupItem extends PureComponent<Props> {
+  static contextType = ThemeContext;
+  context: ThemeColors;
+
   handlePress = () => {
     const { name, onPress } = this.props;
     onPress(name);
@@ -37,7 +41,7 @@ export default class UserGroupItem extends PureComponent<Props> {
     return (
       <Touchable onPress={this.handlePress}>
         <View style={styles.listItem}>
-          <IconPeople size={32} />
+          <IconPeople size={32} color={this.context.color} />
           <View style={componentStyles.textWrapper}>
             <RawLabel
               style={componentStyles.text}


### PR DESCRIPTION
So that it can match color with the color of the text in both the
themes.

This PR:
![image](https://user-images.githubusercontent.com/18511177/53298158-aeef4900-384f-11e9-8e8e-58d2d9034481.png)
![image](https://user-images.githubusercontent.com/18511177/53298161-b9a9de00-384f-11e9-815f-a7ea1fdba8d8.png)


on master:
![image](https://user-images.githubusercontent.com/18511177/53298164-d6deac80-384f-11e9-868c-b4c951e221a8.png)
![image](https://user-images.githubusercontent.com/18511177/53298169-e5c55f00-384f-11e9-90d8-c2c368bd3509.png)
