### PR TITLE
drafts: Cleanup state when switching accounts

### DIFF
--- a/src/drafts/draftsReducers.js
+++ b/src/drafts/draftsReducers.js
@@ -1,6 +1,6 @@
 /* @flow strict-local */
 import type { DraftState, Action } from '../types';
-import { DRAFT_UPDATE, LOGOUT } from '../actionConstants';
+import { ACCOUNT_SWITCH, DRAFT_UPDATE, LOGOUT } from '../actionConstants';
 import { NULL_OBJECT } from '../nullObjects';
 
 const initialState = NULL_OBJECT;
@@ -23,6 +23,7 @@ const draftUpdate = (state, action) => {
 
 export default (state: DraftState = initialState, action: Action): DraftState => {
   switch (action.type) {
+    case ACCOUNT_SWITCH:
     case LOGOUT:
       return initialState;
 


### PR DESCRIPTION
We previously did not reset the state on switching accounts but
only on logout.

This fix has the added benefit that a user can cleanup the drafts
by switching accounts (but this is also a aside effect that we will
not persist the drafts if the user switches accounts and gets back).