### PR TITLE
userStatus, input: Set max length to 60.

### DIFF
--- a/src/user-status/UserStatusScreen.js
+++ b/src/user-status/UserStatusScreen.js
@@ -67,6 +67,7 @@ class UserStatusScreen extends PureComponent<Props, State> {
       <Screen title="User status">
         <Input
           autoFocus
+          maxLength={60}
           style={styles.statusTextInput}
           placeholder="What's your status?"
           value={statusText}


### PR DESCRIPTION
Server only supports status message with max length 60, and otherwise
throws error on updating it. So set max length in the input itself so
that user can enter status of only valid length.