### PR TITLE
[Android] autocomplete: Fix text doesn't autocompletes on selecting item

### DIFF
--- a/src/compose/ComposeBox.js
+++ b/src/compose/ComposeBox.js
@@ -332,13 +332,8 @@ class ComposeBox extends PureComponent<Props, State> {
     };
 
     return (
-      <View style={style}>
-        <View
-          style={[
-            this.styles.autocompleteWrapper,
-            { marginBottom: safeAreaInsets.bottom + height },
-          ]}
-        >
+      <View>
+        <View style={[this.styles.autocompleteWrapper, { marginBottom: height }]}>
           <TopicAutocomplete
             isFocused={isTopicFocused}
             narrow={narrow}
@@ -352,7 +347,7 @@ class ComposeBox extends PureComponent<Props, State> {
             onAutocomplete={this.handleMessageAutocomplete}
           />
         </View>
-        <View style={this.styles.composeBox} onLayout={this.handleLayoutChange}>
+        <View style={[this.styles.composeBox, style]} onLayout={this.handleLayoutChange}>
           <ComposeMenu
             destinationNarrow={this.getDestinationNarrow()}
             expanded={isMenuExpanded}


### PR DESCRIPTION
This got introduced in 41ce55, where background color is set to the
parent of `absolute` autocomplete view.

This seems to be a RN issue that, `absolute` positioned components
doesn't receive touchable events if inside component which has
background color set. (will try to verify it on new RN project)

So set background color to compose input view, sibling of autocomplete
view instead of parent of autocomplete view.

Fixes: #3378