### PR TITLE
 Reduce waiting for messages to load by fetching more messages earlier

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -7,7 +7,6 @@ const isEmulator = NativeModules.RNDeviceInfo ? DeviceInfo.isEmulator() : false;
 
 type Config = {|
   messagesPerRequest: number,
-  scrollCallbackThrottle: number,
   messageListThreshold: number,
   enableReduxLogging: boolean,
   enableReduxSlowReducerWarnings: boolean,
@@ -21,7 +20,6 @@ type Config = {|
 
 const config: Config = {
   messagesPerRequest: 50,
-  scrollCallbackThrottle: 250,
   messageListThreshold: 250,
   enableReduxLogging: isDevelopment && !!global.btoa,
   enableReduxSlowReducerWarnings: isDevelopment && !!global.btoa,

--- a/src/config.js
+++ b/src/config.js
@@ -19,8 +19,8 @@ type Config = {|
 |};
 
 const config: Config = {
-  messagesPerRequest: 50,
-  messageListThreshold: 250,
+  messagesPerRequest: 100,
+  messageListThreshold: 4000,
   enableReduxLogging: isDevelopment && !!global.btoa,
   enableReduxSlowReducerWarnings: isDevelopment && !!global.btoa,
   enableSentry: !isDevelopment && !isEmulator,


### PR DESCRIPTION
The original values were changed several times and the currently
used ones are chosen conservatively to reduce issues we had in
the past.

We no longer have the positioning issues we used to have so it
makes sense to revisit these and change for better user experience.

These changes are a result of extensive testing and analysis.