### PR TITLE
autocomplete: Add support for composing "silent mentions".

### DIFF
--- a/src/autocomplete/__tests__/getAutocompleteFilter-test.js
+++ b/src/autocomplete/__tests__/getAutocompleteFilter-test.js
@@ -11,6 +11,18 @@ describe('getAutocompleteFilter', () => {
     selection = { start: 1, end: 1 };
     expect(getAutocompleteFilter('@', selection)).toEqual({ filter: '', lastWordPrefix: '@' });
 
+    selection = { start: 2, end: 2 };
+    expect(getAutocompleteFilter('@_', selection)).toEqual({ filter: '', lastWordPrefix: '@' });
+
+    selection = { start: 4, end: 4 };
+    expect(getAutocompleteFilter('@_ab', selection)).toEqual({ filter: 'ab', lastWordPrefix: '@' });
+
+    selection = { start: 7, end: 7 };
+    expect(getAutocompleteFilter('@_ab cd', selection)).toEqual({
+      filter: 'ab cd',
+      lastWordPrefix: '@',
+    });
+
     selection = { start: 3, end: 3 };
     expect(getAutocompleteFilter('@ab', selection)).toEqual({ filter: 'ab', lastWordPrefix: '@' });
 

--- a/src/autocomplete/__tests__/getAutocompletedText-test.js
+++ b/src/autocomplete/__tests__/getAutocompletedText-test.js
@@ -33,4 +33,9 @@ describe('getAutocompletedText', () => {
     selection = { start: 3, end: 3 };
     expect(getAutocompletedText(':abSome text', 'abcd', selection)).toEqual(':abcd: Some text');
   });
+
+  test('can autocomplete users (silently)', () => {
+    selection = { start: 4, end: 4 };
+    expect(getAutocompletedText('@_ab', '**abcd**', selection)).toEqual('@_**abcd** ');
+  });
 });

--- a/src/autocomplete/getAutocompleteFilter.js
+++ b/src/autocomplete/getAutocompleteFilter.js
@@ -20,7 +20,10 @@ export default (textWhole: string, selection: InputSelectionType) => {
   const lastWordPrefix: string = lastIndex !== -1 ? text[lastIndex] : '';
   const filter: string =
     text.length > lastIndex + 1 && !['\n', ' '].includes(text[lastIndex + 1])
-      ? text.substring(lastIndex + 1, text.length)
+      ? text.substring(
+          lastIndex + 1 + (text[lastIndex] === '@' && text[lastIndex + 1] === '_'),
+          text.length,
+        )
       : '';
 
   return { lastWordPrefix, filter };

--- a/src/autocomplete/getAutocompletedText.js
+++ b/src/autocomplete/getAutocompletedText.js
@@ -17,7 +17,10 @@ export default (textWhole: string, autocompleteText: string, selection: InputSel
     text.lastIndexOf('@'),
   );
 
-  const prefix = text[lastIndex] === ':' ? ':' : `${text[lastIndex]}`;
+  let prefix = text[lastIndex] === ':' ? ':' : `${text[lastIndex]}`;
+  if (text[lastIndex] === '@' && text[lastIndex + 1] === '_') {
+    prefix += '_';
+  }
   const suffix = text[lastIndex] === ':' ? ':' : '';
 
   return `${text.substring(0, lastIndex)}${prefix}${autocompleteText}${suffix} ${remainder}`;

--- a/src/webview/css/css.js
+++ b/src/webview/css/css.js
@@ -140,6 +140,8 @@ hr {
   padding: 0 .2em;
   box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.2);
 }
+.silent {
+}
 .header-wrapper {
   position: -webkit-sticky;
   position: sticky;


### PR DESCRIPTION
Add markdown syntax for "silent mentions", which happens when
a user starts their mention with "@_". Add empty "silent" class
for future styling changes.

There is also a PR with some changes on zulip-markdown-parser repo. https://github.com/zulip/zulip-markdown-parser/pull/1

Issue: https://github.com/zulip/zulip-mobile/issues/3374