### PR TITLE
Handle user update events

### DIFF
--- a/src/actionTypes.js
+++ b/src/actionTypes.js
@@ -91,6 +91,7 @@ import type {
   CaughtUpState,
   MuteState,
   AlertWordsState,
+  UserAvatarSource,
   UserStatusEvent,
 } from './types';
 
@@ -405,10 +406,39 @@ type EventUserRemoveAction = {|
   // the type before going and adding those other properties here properly.
 |};
 
+/** Sent when editing a custom profile field */
+type UserUpdatePayloadCustomProfileField = {|
+  custom_profile_field: {
+    id: number,
+    rendered_value: string,
+    value: string,
+  },
+|};
+
+/** Sent when editing full name */
+type UserUpdatePayloadName = {|
+  email: string,
+  full_name: string,
+|};
+
+/** Sent when changing user's avatar */
+type UserUpdatePayloadAvatar = {|
+  avatar_source: UserAvatarSource,
+  avatar_url: string,
+  avatar_url_medium: string,
+  email: string,
+|};
+
+/** Contains only one of the possible payloads */
+export type UserUpdatePayload = {|
+  user_id: number,
+  ...UserUpdatePayloadName | UserUpdatePayloadAvatar | UserUpdatePayloadCustomProfileField,
+|};
+
 type EventUserUpdateAction = {|
   type: typeof EVENT_USER_UPDATE,
-  // In reality there's more -- but this will prevent accidentally using
-  // the type before going and adding those other properties here properly.
+  op: 'update',
+  person: UserUpdatePayload,
 |};
 
 type EventMutedTopicsAction = {|

--- a/src/api/initialDataTypes.js
+++ b/src/api/initialDataTypes.js
@@ -6,6 +6,7 @@ import type {
   RealmFilter,
   Subscription,
   User,
+  UserAvatarSource,
   UserGroup,
   UserPresence,
   UserStatusMapObject,
@@ -88,7 +89,7 @@ export type InitialDataRealmFilters = {|
 |};
 
 export type InitialDataRealmUser = {|
-  avatar_source: 'G',
+  avatar_source: UserAvatarSource,
   avatar_url: string | null,
   avatar_url_medium: string,
   can_create_streams: boolean,

--- a/src/api/modelTypes.js
+++ b/src/api/modelTypes.js
@@ -46,6 +46,9 @@ export type DevUser = {|
   email: string,
 |};
 
+/** Gravatar or Upload */
+export type UserAvatarSource = 'G' | 'U';
+
 /**
  * A Zulip user.
  *

--- a/src/users/__tests__/userHelpers-test.js
+++ b/src/users/__tests__/userHelpers-test.js
@@ -12,6 +12,7 @@ import {
   filterUserMatchesEmail,
   getUniqueUsers,
   groupUsersByStatus,
+  updateUser,
 } from '../userHelpers';
 
 describe('filterUserList', () => {
@@ -354,5 +355,92 @@ describe('getUniqueUsers', () => {
       { full_name: 'app', email: 'own@example.com' },
     ];
     expect(getUniqueUsers(users)).toEqual(expectedUsers);
+  });
+});
+
+describe('updateUser', () => {
+  test('updates full name if that is the form of the payload', () => {
+    const initialValue = {
+      user_id: 1,
+      full_name: 'Some Guy',
+    };
+    const person = {
+      user_id: 1,
+      full_name: 'New Name',
+    };
+    const expectedValue = {
+      user_id: 1,
+      full_name: 'New Name',
+    };
+
+    const updatedValue = updateUser(initialValue, person);
+
+    expect(updatedValue).toEqual(expectedValue);
+  });
+
+  test('updating avatar using only the `avatar_url` value', () => {
+    const initialValue = {
+      user_id: 1,
+      full_name: 'Some Guy',
+      avatar_url: 'https://example.com/avatar.png',
+    };
+    const person = {
+      user_id: 1,
+      avatar_source: 'G',
+      avatar_url: 'https://example.com/new-avatar.png',
+      avatar_url_medium: 'https://example.com/new-avatar-medium.png',
+    };
+    const expectedValue = {
+      user_id: 1,
+      full_name: 'Some Guy',
+      avatar_url: 'https://example.com/new-avatar.png',
+    };
+
+    const updatedValue = updateUser(initialValue, person);
+
+    expect(updatedValue).toEqual(expectedValue);
+  });
+
+  test('updating custom profile field', () => {
+    const initialValue = {
+      user_id: 1,
+      full_name: 'Some Guy',
+      profile_data: {
+        1: {
+          value: 'CA',
+          rendered_value: null,
+        },
+        2: {
+          value: 'Blue',
+          rendered_value: null,
+        },
+      },
+    };
+    const person = {
+      user_id: 1,
+      custom_profile_field: {
+        id: 2,
+        value: 'Red',
+        rendered_value: null,
+      },
+    };
+    const expectedValue = {
+      user_id: 1,
+      full_name: 'Some Guy',
+      profile_data: {
+        1: {
+          value: 'CA',
+          rendered_value: null,
+        },
+        2: {
+          value: 'Red',
+          rendered_value: null,
+        },
+      },
+    };
+
+    const updatedValue = updateUser(initialValue, person);
+
+    expect(updatedValue).toEqual(expectedValue);
   });
 });

--- a/src/users/__tests__/usersReducers-test.js
+++ b/src/users/__tests__/usersReducers-test.js
@@ -1,6 +1,11 @@
 import deepFreeze from 'deep-freeze';
 
-import { REALM_INIT, EVENT_USER_ADD, ACCOUNT_SWITCH } from '../../actionConstants';
+import {
+  REALM_INIT,
+  EVENT_USER_ADD,
+  ACCOUNT_SWITCH,
+  EVENT_USER_UPDATE,
+} from '../../actionConstants';
 import usersReducers from '../usersReducers';
 
 describe('usersReducers', () => {
@@ -93,6 +98,74 @@ describe('usersReducers', () => {
       const actualState = usersReducers(initialState, action);
 
       expect(actualState).toEqual(expectedState);
+    });
+  });
+
+  describe('EVENT_USER_UPDATE', () => {
+    test('updating non existing user does not mutate state', () => {
+      const initialState = deepFreeze([
+        {
+          user_id: 1,
+          full_name: 'Some Guy',
+        },
+      ]);
+      const action = deepFreeze({
+        type: EVENT_USER_UPDATE,
+        person: {
+          user_id: 2,
+          full_name: 'New Name',
+        },
+      });
+
+      const actualState = usersReducers(initialState, action);
+
+      expect(actualState).toBe(initialState);
+    });
+
+    test('updating an existing user mutates state', () => {
+      const initialState = deepFreeze([
+        {
+          user_id: 1,
+          full_name: 'Some Guy',
+        },
+      ]);
+      const action = deepFreeze({
+        type: EVENT_USER_UPDATE,
+        person: {
+          user_id: 1,
+          full_name: 'New Name',
+        },
+      });
+      const expectedState = [
+        {
+          user_id: 1,
+          full_name: 'New Name',
+        },
+      ];
+
+      const actualState = usersReducers(initialState, action);
+
+      expect(actualState).toEqual(expectedState);
+    });
+
+    test('updating existing user with the same values does not mutate state', () => {
+      const initialState = deepFreeze([
+        {
+          user_id: 1,
+          full_name: 'Some Guy',
+        },
+      ]);
+      const action = deepFreeze({
+        type: EVENT_USER_UPDATE,
+        person: {
+          user_id: 1,
+          full_name: 'Some Guy',
+        },
+      });
+
+      const actualState = usersReducers(initialState, action);
+
+      expect(actualState).toBe(initialState);
     });
   });
 

--- a/src/users/userHelpers.js
+++ b/src/users/userHelpers.js
@@ -1,7 +1,7 @@
 /* @flow strict-local */
 import uniqby from 'lodash.uniqby';
 
-import type { UserPresence, User, UserGroup, PresenceState } from '../types';
+import type { UserPresence, User, UserGroup, UserUpdatePayload, PresenceState } from '../types';
 import { NULL_USER } from '../nullObjects';
 import { statusFromPresence } from '../utils/presence';
 
@@ -124,3 +124,34 @@ export const getAutocompleteUserGroupSuggestions = (
       userGroup.name.toLowerCase().includes(filter.toLowerCase())
       || userGroup.description.toLowerCase().includes(filter.toLowerCase()),
   );
+
+export const updateUser = (oldValue: User, updateData: UserUpdatePayload): User => {
+  if (updateData.full_name !== undefined) {
+    // update full name
+    return {
+      ...oldValue,
+      full_name: updateData.full_name,
+    };
+  } else if (updateData.avatar_url !== undefined) {
+    // update avatar
+    return {
+      ...oldValue,
+      avatar_url: updateData.avatar_url,
+    };
+  } else if (updateData.custom_profile_field) {
+    // update a profile field
+    return {
+      ...oldValue,
+      profile_data: {
+        ...oldValue.profile_data,
+        [updateData.custom_profile_field.id]: {
+          value: updateData.custom_profile_field.value,
+          rendered_value: updateData.custom_profile_field.rendered_value,
+        },
+      },
+    };
+  }
+
+  // unsupported/unrecognized update, do nothing
+  return oldValue;
+};

--- a/src/users/usersReducers.js
+++ b/src/users/usersReducers.js
@@ -1,5 +1,7 @@
 /* @flow strict-local */
-import type { UsersState, Action } from '../types';
+import isEqual from 'lodash.isequal';
+
+import type { User, UsersState, Action } from '../types';
 import {
   LOGOUT,
   LOGIN_SUCCESS,
@@ -10,6 +12,7 @@ import {
   EVENT_USER_UPDATE,
 } from '../actionConstants';
 import { NULL_ARRAY } from '../nullObjects';
+import { updateUser } from './userHelpers';
 
 const initialState: UsersState = NULL_ARRAY;
 
@@ -29,8 +32,22 @@ export default (state: UsersState = initialState, action: Action): UsersState =>
     case EVENT_USER_REMOVE:
       return state; // TODO
 
-    case EVENT_USER_UPDATE:
-      return state; // TODO
+    case EVENT_USER_UPDATE: {
+      const userIndex = state.findIndex(x => x.user_id === action.person.user_id);
+      const oldUser: User = state[userIndex];
+
+      if (userIndex === -1) {
+        return state;
+      }
+
+      const updatedUser = updateUser(oldUser, action.person);
+
+      if (isEqual(updatedUser, oldUser)) {
+        return state;
+      }
+
+      return [...state.slice(0, userIndex), updatedUser, ...state.slice(userIndex + 1)];
+    }
 
     default:
       return state;


### PR DESCRIPTION
Fixes #3397 Part of #3408

Handles the three types of user data updates possible:
* full name
* avatar
* custom profile field

Extra care is taken not to mutate the state if not necessary.

This is done for two reasons:
 * currently editing values throught he web app causes two events,
   one of which is not necessary (maybe should be fixed)
 * this is likely the largest state, doing an extra `isEqual` can
   save copying all this data