### PR TITLE
webViewEventHandlers: Add ability to copy links to Clipboard.

### DIFF
--- a/src/webview/js/generatedEs3.js
+++ b/src/webview/js/generatedEs3.js
@@ -152,7 +152,7 @@ function someVisibleMessage(top, bottom) {
 function idFromMessage(element) {
   var idStr = element.getAttribute('data-msg-id');
 
-  if (!idStr) {
+  if (idStr === null || idStr === undefined) {
     throw new Error('Bad message element');
   }
 
@@ -231,6 +231,7 @@ var sendScrollMessageIfListShort = function sendScrollMessageIfListShort() {
 
 var scrollEventsDisabled = true;
 var lastTouchEventTimestamp = 0;
+var hasLongPressed = false;
 var lastTouchPositionX = -1;
 var lastTouchPositionY = -1;
 
@@ -421,6 +422,12 @@ var requireAttribute = function requireAttribute(e, name) {
 documentBody.addEventListener('click', function (e) {
   e.preventDefault();
   lastTouchEventTimestamp = 0;
+
+  if (hasLongPressed) {
+    hasLongPressed = false;
+    return;
+  }
+
   var target = e.target;
 
   if (!(target instanceof Element)) {
@@ -495,6 +502,7 @@ var handleLongPress = function handleLongPress(target) {
   }
 
   lastTouchEventTimestamp = 0;
+  hasLongPressed = true;
   sendMessage({
     type: 'longPress',
     target: target.matches('.header') ? 'header' : 'message',
@@ -512,6 +520,7 @@ documentBody.addEventListener('touchstart', function (e) {
   lastTouchPositionX = e.changedTouches[0].pageX;
   lastTouchPositionY = e.changedTouches[0].pageY;
   lastTouchEventTimestamp = Date.now();
+  hasLongPressed = false;
   setTimeout(function () {
     return handleLongPress(target);
   }, 500);

--- a/src/webview/js/generatedEs3.js
+++ b/src/webview/js/generatedEs3.js
@@ -505,8 +505,9 @@ var handleLongPress = function handleLongPress(target) {
   hasLongPressed = true;
   sendMessage({
     type: 'longPress',
-    target: target.matches('.header') ? 'header' : 'message',
-    messageId: getMessageIdFromNode(target)
+    target: target.matches('.header') ? 'header' : target.matches('a') ? 'link' : 'message',
+    messageId: getMessageIdFromNode(target),
+    href: target.matches('a') ? requireAttribute(target, 'href') : null
   });
 };
 

--- a/src/webview/js/js.js
+++ b/src/webview/js/js.js
@@ -351,6 +351,7 @@ const sendScrollMessageIfListShort = () => {
 let scrollEventsDisabled = true;
 
 let lastTouchEventTimestamp = 0;
+let hasLongPressed = false;
 let lastTouchPositionX = -1;
 let lastTouchPositionY = -1;
 
@@ -558,6 +559,13 @@ documentBody.addEventListener('click', (e: MouseEvent) => {
   e.preventDefault();
   lastTouchEventTimestamp = 0;
 
+  /* Without a flag `hasLongPressed`, both the short press and the long
+   * press actions get triggered. See PR #3404 for more context. */
+  if (hasLongPressed) {
+    hasLongPressed = false;
+    return;
+  }
+
   const { target } = e;
 
   if (!(target instanceof Element)) {
@@ -650,6 +658,7 @@ const handleLongPress = (target: Element) => {
   }
 
   lastTouchEventTimestamp = 0;
+  hasLongPressed = true;
 
   sendMessage({
     type: 'longPress',
@@ -667,6 +676,7 @@ documentBody.addEventListener('touchstart', (e: TouchEvent) => {
   lastTouchPositionX = e.changedTouches[0].pageX;
   lastTouchPositionY = e.changedTouches[0].pageY;
   lastTouchEventTimestamp = Date.now();
+  hasLongPressed = false;
   setTimeout(() => handleLongPress(target), 500);
 });
 

--- a/src/webview/js/js.js
+++ b/src/webview/js/js.js
@@ -662,8 +662,9 @@ const handleLongPress = (target: Element) => {
 
   sendMessage({
     type: 'longPress',
-    target: target.matches('.header') ? 'header' : 'message',
+    target: target.matches('.header') ? 'header' : target.matches('a') ? 'link' : 'message',
     messageId: getMessageIdFromNode(target),
+    href: target.matches('a') ? requireAttribute(target, 'href') : null,
   });
 };
 

--- a/static/translations/messages_ar.json
+++ b/static/translations/messages_ar.json
@@ -50,6 +50,7 @@
   "Reply": "Reply",
   "Add a reaction": "Add a reaction",
   "Copy to clipboard": "Copy to clipboard",
+  "Link copied to clipboard": "Link copied to clipboard",
   "Mute topic": "Mute topic",
   "Unmute topic": "Unmute topic",
   "Mute stream": "Mute stream",

--- a/static/translations/messages_bg.json
+++ b/static/translations/messages_bg.json
@@ -50,6 +50,7 @@
   "Reply": "Отговори",
   "Add a reaction": "Добави реакция",
   "Copy to clipboard": "Копирай в клипборд",
+  "Link copied to clipboard": "Линкът е копиран в клипборда",
   "Mute topic": "Заглуши тема",
   "Unmute topic": "Не заглушавай тема",
   "Mute stream": "Заглуши канал",

--- a/static/translations/messages_ca.json
+++ b/static/translations/messages_ca.json
@@ -50,6 +50,7 @@
   "Reply": "Respondre",
   "Add a reaction": "Add a reaction",
   "Copy to clipboard": "Copiar al porta-retalls",
+  "Link copied to clipboard": "Link copied to clipboard",
   "Mute topic": "Silenciar tema",
   "Unmute topic": "Unmute topic",
   "Mute stream": "Silenciar canal",

--- a/static/translations/messages_cs.json
+++ b/static/translations/messages_cs.json
@@ -50,6 +50,7 @@
   "Reply": "Odpovědět",
   "Add a reaction": "Přidat odpověď",
   "Copy to clipboard": "Kopírovat do schránky",
+  "Link copied to clipboard": "Odkaz zkopírován do schránky",
   "Mute topic": "Ztlumit téma",
   "Unmute topic": "Zrušit ztlumení tématu",
   "Mute stream": "Ztlumit kanál",

--- a/static/translations/messages_da.json
+++ b/static/translations/messages_da.json
@@ -50,6 +50,7 @@
   "Reply": "Reply",
   "Add a reaction": "Add a reaction",
   "Copy to clipboard": "Copy to clipboard",
+  "Link copied to clipboard": "Link copied to clipboard",
   "Mute topic": "Mute topic",
   "Unmute topic": "Unmute topic",
   "Mute stream": "Mute stream",

--- a/static/translations/messages_de.json
+++ b/static/translations/messages_de.json
@@ -50,6 +50,7 @@
   "Reply": "Antworten",
   "Add a reaction": "Reaktion hinzufügen",
   "Copy to clipboard": "In die Ablage kopieren",
+  "Link copied to clipboard": "Link in die Ablage kopiert",
   "Mute topic": "Thema stummschalten",
   "Unmute topic": "Stummschaltung aufheben",
   "Mute stream": "Stream stummschalten",

--- a/static/translations/messages_en.json
+++ b/static/translations/messages_en.json
@@ -50,6 +50,7 @@
   "Reply": "Reply",
   "Add a reaction": "Add a reaction",
   "Copy to clipboard": "Copy to clipboard",
+  "Link copied to clipboard": "Link copied to clipboard",
   "Mute topic": "Mute topic",
   "Unmute topic": "Unmute topic",
   "Mute stream": "Mute stream",

--- a/static/translations/messages_es.json
+++ b/static/translations/messages_es.json
@@ -50,6 +50,7 @@
   "Reply": "Responder",
   "Add a reaction": "Añadir una reacción",
   "Copy to clipboard": "Copiar al portapapeles",
+  "Link copied to clipboard": "Enlace copiado al portapapeles",
   "Mute topic": "Silenciar tema",
   "Unmute topic": "No silenciar el tema",
   "Mute stream": "Silenciar canal",

--- a/static/translations/messages_fa.json
+++ b/static/translations/messages_fa.json
@@ -50,6 +50,7 @@
   "Reply": "Reply",
   "Add a reaction": "Add a reaction",
   "Copy to clipboard": "Copy to clipboard",
+  "Link copied to clipboard": "Link copied to clipboard",
   "Mute topic": "Mute topic",
   "Unmute topic": "Unmute topic",
   "Mute stream": "Mute stream",

--- a/static/translations/messages_fi.json
+++ b/static/translations/messages_fi.json
@@ -50,6 +50,7 @@
   "Reply": "Vastaa",
   "Add a reaction": "Add a reaction",
   "Copy to clipboard": "Kopioi leikepöydälle",
+  "Link copied to clipboard": "Link copied to clipboard",
   "Mute topic": "Mykistä aihe",
   "Unmute topic": "Poista aiheen mykistys",
   "Mute stream": "Mykistä kanava",

--- a/static/translations/messages_fr.json
+++ b/static/translations/messages_fr.json
@@ -50,6 +50,7 @@
   "Reply": "Répondre",
   "Add a reaction": "Ajouter une réaction",
   "Copy to clipboard": "Copier dans le presse-papier",
+  "Link copied to clipboard": "Lien copié vers le presse-papier",
   "Mute topic": "Rendre le sujet muet",
   "Unmute topic": "Ne plus rendre le sujet muet",
   "Mute stream": "Rendre le canal muet ",

--- a/static/translations/messages_gl.json
+++ b/static/translations/messages_gl.json
@@ -50,6 +50,7 @@
   "Reply": "Responder",
   "Add a reaction": "Add a reaction",
   "Copy to clipboard": "Copiar no portarretallos",
+  "Link copied to clipboard": "Link copied to clipboard",
   "Mute topic": "Silenciar este tema",
   "Unmute topic": "Deixar de silenciar este tema",
   "Mute stream": "Silenciar o fío",

--- a/static/translations/messages_hi.json
+++ b/static/translations/messages_hi.json
@@ -50,6 +50,7 @@
   "Reply": "जवाब दें",
   "Add a reaction": "एक प्रतिक्रिया जोड़ें",
   "Copy to clipboard": "क्लिपबोर्ड पर कॉपी करें",
+  "Link copied to clipboard": "Link copied to clipboard",
   "Mute topic": "विषय म्यूट करें",
   "Unmute topic": "विषय अनम्यूट करें",
   "Mute stream": " धारा म्यूट करें",

--- a/static/translations/messages_hr.json
+++ b/static/translations/messages_hr.json
@@ -50,6 +50,7 @@
   "Reply": "Reply",
   "Add a reaction": "Add a reaction",
   "Copy to clipboard": "Copy to clipboard",
+  "Link copied to clipboard": "Link copied to clipboard",
   "Mute topic": "Mute topic",
   "Unmute topic": "Unmute topic",
   "Mute stream": "Mute stream",

--- a/static/translations/messages_hu.json
+++ b/static/translations/messages_hu.json
@@ -50,6 +50,7 @@
   "Reply": "Válasz",
   "Add a reaction": "Add a reaction",
   "Copy to clipboard": "Másolás vágólapra",
+  "Link copied to clipboard": "Link copied to clipboard",
   "Mute topic": "Téma némítása",
   "Unmute topic": "Téma némítás feloldása",
   "Mute stream": "Üzenetfolyam némítása",

--- a/static/translations/messages_id_ID.json
+++ b/static/translations/messages_id_ID.json
@@ -50,6 +50,7 @@
   "Reply": "Balas",
   "Add a reaction": "Add a reaction",
   "Copy to clipboard": "Salin ke clipboard",
+  "Link copied to clipboard": "Tautan disalin ke clipboard",
   "Mute topic": "Senyapkan topik",
   "Unmute topic": "Nyalakan topik",
   "Mute stream": "Senyapkan stream",

--- a/static/translations/messages_it.json
+++ b/static/translations/messages_it.json
@@ -50,6 +50,7 @@
   "Reply": "Rispondi",
   "Add a reaction": "Aggiungi una reazione",
   "Copy to clipboard": "Copia negli appunti",
+  "Link copied to clipboard": "Link copiato negli appunti",
   "Mute topic": "Silenzia il topic",
   "Unmute topic": "Riattiva audio dell'argomento",
   "Mute stream": "Zittisci il canale",

--- a/static/translations/messages_ja.json
+++ b/static/translations/messages_ja.json
@@ -50,6 +50,7 @@
   "Reply": "返信",
   "Add a reaction": "Add a reaction",
   "Copy to clipboard": "クリップボードにコピー",
+  "Link copied to clipboard": "リンクをクリップボードにコピー",
   "Mute topic": "トピックをミュート",
   "Unmute topic": "トピックのミュートを解除",
   "Mute stream": "ストリームをミュート",

--- a/static/translations/messages_ko.json
+++ b/static/translations/messages_ko.json
@@ -50,6 +50,7 @@
   "Reply": "답장",
   "Add a reaction": "반응 추가",
   "Copy to clipboard": "클립보드에 복사하기",
+  "Link copied to clipboard": "링크가 클립보드에 복사되었습니다.",
   "Mute topic": "주제 뮤트하기",
   "Unmute topic": "주제 언뮤트하기",
   "Mute stream": "스트림 뮤트하기",

--- a/static/translations/messages_ml.json
+++ b/static/translations/messages_ml.json
@@ -50,6 +50,7 @@
   "Reply": "മറുപടി",
   "Add a reaction": "Add a reaction",
   "Copy to clipboard": "Copy to clipboard",
+  "Link copied to clipboard": "Link copied to clipboard",
   "Mute topic": "Mute topic",
   "Unmute topic": "Unmute topic",
   "Mute stream": "Mute stream",

--- a/static/translations/messages_nl.json
+++ b/static/translations/messages_nl.json
@@ -50,6 +50,7 @@
   "Reply": "Antwoorden",
   "Add a reaction": "Add a reaction",
   "Copy to clipboard": "Kopiëren",
+  "Link copied to clipboard": "Link gekopieerd naar klembord",
   "Mute topic": "Onderwerp dempen",
   "Unmute topic": "Onderwerp aanzetten",
   "Mute stream": "Kanaal dempen",

--- a/static/translations/messages_pl.json
+++ b/static/translations/messages_pl.json
@@ -50,6 +50,7 @@
   "Reply": "Odpowiedz",
   "Add a reaction": "Dodaj reakcje",
   "Copy to clipboard": "Kopiuj do schowka",
+  "Link copied to clipboard": "Link skopiowany do schowka",
   "Mute topic": "Wycisz wątek",
   "Unmute topic": "Przywróć powiadomienia w wątku",
   "Mute stream": "Wycisz kanał",

--- a/static/translations/messages_pt.json
+++ b/static/translations/messages_pt.json
@@ -50,6 +50,7 @@
   "Reply": "Responder",
   "Add a reaction": "Adicionar uma reação",
   "Copy to clipboard": "Copiar para área de transferência",
+  "Link copied to clipboard": "Link copied to clipboard",
   "Mute topic": "Silenciar tópico",
   "Unmute topic": "Cancelar o silenciamento do tópico",
   "Mute stream": "Silenciar fluxo",

--- a/static/translations/messages_ro.json
+++ b/static/translations/messages_ro.json
@@ -50,6 +50,7 @@
   "Reply": "Răspunde",
   "Add a reaction": "Reacționează",
   "Copy to clipboard": "Copiere în clipboard",
+  "Link copied to clipboard": "Link copied to clipboard",
   "Mute topic": "Dezactivează sunetele pentru subiect",
   "Unmute topic": "Activează sunetele pentru subiect",
   "Mute stream": "Dezactivează sunetele pentru flux",

--- a/static/translations/messages_ru.json
+++ b/static/translations/messages_ru.json
@@ -50,6 +50,7 @@
   "Reply": "Ответить",
   "Add a reaction": "Add a reaction",
   "Copy to clipboard": "Скопировать в буфер обмена",
+  "Link copied to clipboard": "Ссылка скопирована в буфер обмена",
   "Mute topic": "Заглушить тему",
   "Unmute topic": "Включить тему",
   "Mute stream": "Заглушить канал",

--- a/static/translations/messages_sr.json
+++ b/static/translations/messages_sr.json
@@ -50,6 +50,7 @@
   "Reply": "Reply",
   "Add a reaction": "Add a reaction",
   "Copy to clipboard": "Copy to clipboard",
+  "Link copied to clipboard": "Link copied to clipboard",
   "Mute topic": "Mute topic",
   "Unmute topic": "Unmute topic",
   "Mute stream": "Mute stream",

--- a/static/translations/messages_sv.json
+++ b/static/translations/messages_sv.json
@@ -50,6 +50,7 @@
   "Reply": "Reply",
   "Add a reaction": "Add a reaction",
   "Copy to clipboard": "Copy to clipboard",
+  "Link copied to clipboard": "Link copied to clipboard",
   "Mute topic": "Mute topic",
   "Unmute topic": "Unmute topic",
   "Mute stream": "Mute stream",

--- a/static/translations/messages_ta.json
+++ b/static/translations/messages_ta.json
@@ -50,6 +50,7 @@
   "Reply": "மறுமொழி",
   "Add a reaction": "Add a reaction",
   "Copy to clipboard": "நகல் நினைவியை நகலெடுக்கவும்",
+  "Link copied to clipboard": "Link copied to clipboard",
   "Mute topic": "தலைப்பை அமைதியாக்கு",
   "Unmute topic": "தலைப்பு தடையை நீக்கு",
   "Mute stream": "தொடரை அமைதியாக்கு",

--- a/static/translations/messages_tr.json
+++ b/static/translations/messages_tr.json
@@ -50,6 +50,7 @@
   "Reply": "Yanıtla",
   "Add a reaction": "Tepki ekle",
   "Copy to clipboard": "Panoya kopyala",
+  "Link copied to clipboard": "Link copied to clipboard",
   "Mute topic": "Konuyu susturun",
   "Unmute topic": "Konunun sesini açın",
   "Mute stream": "Kanalı sessize al",

--- a/static/translations/messages_uk.json
+++ b/static/translations/messages_uk.json
@@ -50,6 +50,7 @@
   "Reply": "Відповісти",
   "Add a reaction": "Додати реакцію",
   "Copy to clipboard": "Копіювати в буфер обміну",
+  "Link copied to clipboard": "Link copied to clipboard",
   "Mute topic": "Заглушити тему",
   "Unmute topic": "Увімкнути сповіщення теми",
   "Mute stream": "Заглушити канал",

--- a/static/translations/messages_uz.json
+++ b/static/translations/messages_uz.json
@@ -50,6 +50,7 @@
   "Reply": "Reply",
   "Add a reaction": "Add a reaction",
   "Copy to clipboard": "Copy to clipboard",
+  "Link copied to clipboard": "Link copied to clipboard",
   "Mute topic": "Mute topic",
   "Unmute topic": "Unmute topic",
   "Mute stream": "Mute stream",

--- a/static/translations/messages_zh-Hans.json
+++ b/static/translations/messages_zh-Hans.json
@@ -50,6 +50,7 @@
   "Reply": "回复",
   "Add a reaction": "添加映射",
   "Copy to clipboard": "复制到剪贴板",
+  "Link copied to clipboard": "链接已复制到剪贴板",
   "Mute topic": "静音主题",
   "Unmute topic": "非静音主题",
   "Mute stream": "静音频道",

--- a/static/translations/messages_zh-Hant.json
+++ b/static/translations/messages_zh-Hant.json
@@ -50,6 +50,7 @@
   "Reply": "Reply",
   "Add a reaction": "Add a reaction",
   "Copy to clipboard": "Copy to clipboard",
+  "Link copied to clipboard": "Link copied to clipboard",
   "Mute topic": "Mute topic",
   "Unmute topic": "Unmute topic",
   "Mute stream": "Mute stream",


### PR DESCRIPTION
There is no way to copy only links from a message at the moment, which
makes it hard for some users to copy only the links to share with other
people. There could be two solutions to this. One is that another menu
option could be provided to copy only the link in your message, which
is not a correct approach as immediately some problems come to mind.
For example, if there were two links in the message, which one would
the app copy? Another solution to this could be what commercial
applications already apply, which is if you hold the link text, it
gets copied. Which is what has been implemented here. I have added
another event to `MessageListEvent` which abstracts a long press on a
url, and edited the long press listener on `js.js` a little bit.

I have only conducted the automated tests here (besides manually
checking if copying links works by building the application).

I have edited the `js.js` file and tweaked the long press functionality
to make it possible to copy links on long press. Long press itself is
very shaky to capture in a webview on mobile, which is why I was
compelled to tweak it in this manner. Please consider this before
merging.

Fixes #3385.