### PR TITLE
No sticky headers in UserList

### DIFF
--- a/src/users/UserList.js
+++ b/src/users/UserList.js
@@ -44,7 +44,7 @@ export default class UserList extends PureComponent<Props> {
     return (
       <SectionList
         style={[styles.list, style]}
-        stickySectionHeadersEnabled
+        stickySectionHeadersEnabled={false}
         keyboardShouldPersistTaps="always"
         initialNumToRender={20}
         sections={sections}


### PR DESCRIPTION
Fixes #3381

The sticky headers displayed a jumping behaviour after scrolling
about half of the list and also pulled the list further above.

Related fix in upstream but not merged:
[facebook/react-native#22025](https://github.com/facebook/react-native/pull/22025)

This will make the UserList SectionList have standard,
non-sticky headers.