### PR TITLE
Correctly display user's status when 'unavailable'

### DIFF
--- a/src/account-info/AccountDetails.js
+++ b/src/account-info/AccountDetails.js
@@ -57,7 +57,7 @@ class AccountDetails extends PureComponent<Props, void> {
             />
           )}
           <View>
-            <ActivityText style={styles.largerText} email={user.email} />
+            <ActivityText style={styles.largerText} user={user} />
           </View>
           {user.timezone ? (
             <View>

--- a/src/api/modelTypes.js
+++ b/src/api/modelTypes.js
@@ -84,9 +84,8 @@ export type UserGroup = {|
 /**
  * Specifies user status related properties
  * @prop away - present if we are to override user's presence status
- *       * when `true` the user is always `offline`
- *       * when missing the presence is not changed
- *       * can not be `false`
+ *   * This is the "user status" / "unavailable" feature added in early 2019.
+ *     (At time of writing, there are no docs to link to.)
  * @prop status_text - a string representing information the user decided to
  *   manually set as his 'current status'
  */

--- a/src/api/modelTypes.js
+++ b/src/api/modelTypes.js
@@ -87,7 +87,7 @@ export type UserGroup = {|
  *   * This is the "user status" / "unavailable" feature added in early 2019.
  *     (At time of writing, there are no docs to link to.)
  * @prop status_text - a string representing information the user decided to
- *   manually set as his 'current status'
+ *   manually set as their 'current status'
  */
 export type UserStatus = {|
   away?: true,

--- a/src/common/PresenceStatusIndicator.js
+++ b/src/common/PresenceStatusIndicator.js
@@ -20,6 +20,9 @@ const styles = StyleSheet.create({
   active: {
     backgroundColor: '#44c21d',
   },
+  unavailable: {
+    backgroundColor: 'lightgray',
+  },
   idle: {
     backgroundColor: 'rgba(255, 165, 0, 1)',
   },

--- a/src/common/PresenceStatusIndicator.js
+++ b/src/common/PresenceStatusIndicator.js
@@ -121,6 +121,7 @@ class PresenceStatusIndicator extends PureComponent<Props> {
         return <PresenceStatusIndicatorUnavailable style={style} />;
 
       default:
+        (status: empty); // eslint-disable-line no-unused-expressions
         return null;
     }
   }

--- a/src/common/PresenceStatusIndicator.js
+++ b/src/common/PresenceStatusIndicator.js
@@ -14,22 +14,58 @@ const styles = StyleSheet.create({
     width: 12,
     height: 12,
     borderRadius: 6,
-    borderColor: 'white',
-    borderWidth: 2,
   },
   active: {
-    backgroundColor: '#44c21d',
+    backgroundColor: 'hsl(106, 74%, 44%)',
   },
-  unavailable: {
-    backgroundColor: 'lightgray',
+  idleWrapper: {
+    borderWidth: 2,
+    borderColor: 'rgba(255, 165, 0, 1)',
   },
-  idle: {
+  idleHalfCircle: {
     backgroundColor: 'rgba(255, 165, 0, 1)',
+    width: 8,
+    height: 4,
+    marginTop: 4,
+    borderTopLeftRadius: 0,
+    borderTopRightRadius: 0,
+    borderBottomLeftRadius: 4,
+    borderBottomRightRadius: 4,
   },
   offline: {
-    backgroundColor: 'lightgray',
+    backgroundColor: 'gray',
+  },
+  unavailableWrapper: {
+    borderColor: 'gray',
+    borderWidth: 1.5,
+  },
+  unavailableLine: {
+    backgroundColor: 'gray',
+    marginVertical: 3.5,
+    marginHorizontal: 1.5,
+    height: 2,
   },
 });
+
+const PresenceStatusIndicatorIdle = ({ style }: { style: Style }) => (
+  <View style={[styles.idleWrapper, styles.common, style]}>
+    <View style={styles.idleHalfCircle} />
+  </View>
+);
+
+const PresenceStatusIndicatorOnline = ({ style }: { style: Style }) => (
+  <View style={[styles.active, styles.common, style]} />
+);
+
+const PresenceStatusIndicatorOffline = ({ style }: { style: Style }) => (
+  <View style={[styles.offline, styles.common, style]} />
+);
+
+const PresenceStatusIndicatorUnavailable = ({ style }: { style: Style }) => (
+  <View style={[styles.unavailableWrapper, styles.common, style]}>
+    <View style={styles.unavailableLine} />
+  </View>
+);
 
 type PropsFromConnect = {|
   presence: PresenceState,
@@ -71,7 +107,22 @@ class PresenceStatusIndicator extends PureComponent<Props> {
       return null;
     }
 
-    return <View style={[styles.common, styles[status], style]} />;
+    switch (status) {
+      case 'active':
+        return <PresenceStatusIndicatorOnline style={style} />;
+
+      case 'idle':
+        return <PresenceStatusIndicatorIdle style={style} />;
+
+      case 'offline':
+        return <PresenceStatusIndicatorOffline style={style} />;
+
+      case 'unavailable':
+        return <PresenceStatusIndicatorUnavailable style={style} />;
+
+      default:
+        return null;
+    }
   }
 }
 

--- a/src/common/PresenceStatusIndicator.js
+++ b/src/common/PresenceStatusIndicator.js
@@ -47,14 +47,14 @@ const styles = StyleSheet.create({
   },
 });
 
+const PresenceStatusIndicatorActive = ({ style }: { style: Style }) => (
+  <View style={[styles.active, styles.common, style]} />
+);
+
 const PresenceStatusIndicatorIdle = ({ style }: { style: Style }) => (
   <View style={[styles.idleWrapper, styles.common, style]}>
     <View style={styles.idleHalfCircle} />
   </View>
-);
-
-const PresenceStatusIndicatorOnline = ({ style }: { style: Style }) => (
-  <View style={[styles.active, styles.common, style]} />
 );
 
 const PresenceStatusIndicatorOffline = ({ style }: { style: Style }) => (
@@ -109,7 +109,7 @@ class PresenceStatusIndicator extends PureComponent<Props> {
 
     switch (status) {
       case 'active':
-        return <PresenceStatusIndicatorOnline style={style} />;
+        return <PresenceStatusIndicatorActive style={style} />;
 
       case 'idle':
         return <PresenceStatusIndicatorIdle style={style} />;

--- a/src/title/ActivityText.js
+++ b/src/title/ActivityText.js
@@ -28,5 +28,5 @@ class ActivityText extends PureComponent<Props> {
 }
 
 export default connect((state, props) => ({
-  presence: getPresence(state)[props.email],
+  presence: getPresence(state)[props.user.email],
 }))(ActivityText);

--- a/src/title/ActivityText.js
+++ b/src/title/ActivityText.js
@@ -9,14 +9,13 @@ import { presenceToHumanTime } from '../utils/presence';
 import { RawLabel } from '../common';
 
 type Props = {
-  color?: string,
   presence: UserPresence,
   style: Style,
 };
 
 class ActivityText extends PureComponent<Props> {
   render() {
-    const { style, presence, color } = this.props;
+    const { style, presence } = this.props;
 
     if (!presence) {
       return null;
@@ -24,9 +23,7 @@ class ActivityText extends PureComponent<Props> {
 
     const activity = presenceToHumanTime(presence);
 
-    return (
-      <RawLabel style={[style, color !== undefined && { color }]} text={`Active ${activity}`} />
-    );
+    return <RawLabel style={style} text={`Active ${activity}`} />;
   }
 }
 

--- a/src/title/ActivityText.js
+++ b/src/title/ActivityText.js
@@ -3,25 +3,26 @@ import { connect } from 'react-redux';
 
 import React, { PureComponent } from 'react';
 
-import type { UserPresence, Style } from '../types';
-import { getPresence } from '../selectors';
+import type { Style, UserPresence, UserStatus } from '../types';
+import { getPresence, getUserStatus } from '../selectors';
 import { presenceToHumanTime } from '../utils/presence';
 import { RawLabel } from '../common';
 
 type Props = {
   presence: UserPresence,
   style: Style,
+  userStatus: UserStatus,
 };
 
 class ActivityText extends PureComponent<Props> {
   render() {
-    const { style, presence } = this.props;
+    const { style, presence, userStatus } = this.props;
 
     if (!presence) {
       return null;
     }
 
-    const activity = presenceToHumanTime(presence);
+    const activity = presenceToHumanTime(presence, userStatus);
 
     return <RawLabel style={style} text={`Active ${activity}`} />;
   }
@@ -29,4 +30,5 @@ class ActivityText extends PureComponent<Props> {
 
 export default connect((state, props) => ({
   presence: getPresence(state)[props.user.email],
+  userStatus: getUserStatus(state)[props.user.user_id],
 }))(ActivityText);

--- a/src/title/TitlePrivate.js
+++ b/src/title/TitlePrivate.js
@@ -41,7 +41,7 @@ class TitlePrivate extends PureComponent<Props> {
             <Text style={[styles.navTitle, { color }]} numberOfLines={1} ellipsizeMode="tail">
               {user.full_name}
             </Text>
-            <ActivityText style={[styles.navSubtitle, { color }]} email={user.email} />
+            <ActivityText style={[styles.navSubtitle, { color }]} user={user} />
           </View>
         </View>
       </Touchable>

--- a/src/title/TitlePrivate.js
+++ b/src/title/TitlePrivate.js
@@ -41,7 +41,7 @@ class TitlePrivate extends PureComponent<Props> {
             <Text style={[styles.navTitle, { color }]} numberOfLines={1} ellipsizeMode="tail">
               {user.full_name}
             </Text>
-            <ActivityText style={styles.navSubtitle} color={color} email={user.email} />
+            <ActivityText style={[styles.navSubtitle, { color }]} email={user.email} />
           </View>
         </View>
       </Touchable>

--- a/src/users/__tests__/userHelpers-test.js
+++ b/src/users/__tests__/userHelpers-test.js
@@ -271,7 +271,7 @@ describe('groupUsersByStatus', () => {
     const presence = deepFreeze({});
 
     const groupedUsers = groupUsersByStatus(users, presence);
-    expect(groupedUsers).toEqual({ active: [], idle: [], offline: [] });
+    expect(groupedUsers).toEqual({ active: [], idle: [], unavailable: [], offline: [] });
   });
 
   test('sort input by status, when no presence entry consider offline', () => {
@@ -290,6 +290,7 @@ describe('groupUsersByStatus', () => {
       active: [{ email: 'allen@example.com' }],
       idle: [{ email: 'bob@example.com' }],
       offline: [{ email: 'carter@example.com' }, { email: 'dan@example.com' }],
+      unavailable: [],
     };
 
     const groupedUsers = groupUsersByStatus(users, presence);

--- a/src/users/userHelpers.js
+++ b/src/users/userHelpers.js
@@ -8,14 +8,14 @@ import { statusFromPresence } from '../utils/presence';
 export const groupUsersByStatus = (
   users: User[],
   presences: PresenceState,
-): {| active: User[], idle: User[], offline: User[] |} =>
+): {| active: User[], idle: User[], offline: User[], unavailable: User[] |} =>
   users.reduce(
     (groupedUsers, user) => {
       const status = statusFromPresence(presences[user.email]);
       groupedUsers[status].push(user);
       return groupedUsers;
     },
-    { active: [], idle: [], offline: [] },
+    { active: [], idle: [], offline: [], unavailable: [] },
   );
 
 const statusOrder = (presence: UserPresence): number => {

--- a/src/utils/__tests__/presence-test.js
+++ b/src/utils/__tests__/presence-test.js
@@ -215,13 +215,13 @@ describe('statusFromPresenceAndUserStatus', () => {
     expect(result).toBe('active');
   });
 
-  test('if `userPresence` is provided and `away` is `true` override status', () => {
+  test('if `userPresence` is provided and `away` is `true` override status with "unavailable"', () => {
     const presence = {
       aggregated: {
         status: 'active',
       },
     };
     const result = statusFromPresenceAndUserStatus(presence, { away: true });
-    expect(result).toBe('offline');
+    expect(result).toBe('unavailable');
   });
 });

--- a/src/utils/__tests__/presence-test.js
+++ b/src/utils/__tests__/presence-test.js
@@ -141,6 +141,15 @@ describe('presenceToHumanTime', () => {
     };
     expect(presenceToHumanTime(presence)).toBe('now');
   });
+
+  test('if less than a day, and the user is "away" the user is ...', () => {
+    const presence = {
+      aggregated: {
+        timestamp: currentTimestamp - 100,
+      },
+    };
+    expect(presenceToHumanTime(presence, { away: true })).toBe('today');
+  });
 });
 
 describe('statusFromPresence', () => {

--- a/src/utils/presence.js
+++ b/src/utils/presence.js
@@ -86,4 +86,5 @@ export const statusFromPresence = (presence?: UserPresence): PresenceStatus => {
 export const statusFromPresenceAndUserStatus = (
   presence?: UserPresence,
   userStatus?: UserStatus,
-): PresenceStatus => (userStatus && userStatus.away ? 'offline' : statusFromPresence(presence));
+): PresenceStatus | 'unavailable' =>
+  userStatus && userStatus.away ? 'unavailable' : statusFromPresence(presence);


### PR DESCRIPTION
Implements #3384

* introduce the new 'Unavailable' status and do not treat it the same as 'Offline'
* render that new state exactly the same as on the web (a bit more tricky than the purely css solution)
* change the text for 'last active' if 'unavailable'