### PR TITLE
messageHeaderAsHtml: Modify topic header to include date.

### DIFF
--- a/src/webview/css/css.js
+++ b/src/webview/css/css.js
@@ -76,6 +76,10 @@ hr {
   justify-content: space-between;
   margin-bottom: 0.25em;
 }
+.topic-header {
+  margin-top: 0.2em;
+  margin-bottom: 0.00em;
+}
 .timerow {
   text-align: center;
   color: #999;
@@ -99,6 +103,11 @@ hr {
   color: #999;
   font-size: 0.9em;
   white-space: nowrap;
+}
+.topic-timestamp {
+  font-size: 0.9em;
+  white-space: nowrap;
+  margin-right: 0.5em;
 }
 .message {
   display: flex;

--- a/src/webview/html/messageHeaderAsHtml.js
+++ b/src/webview/html/messageHeaderAsHtml.js
@@ -13,12 +13,22 @@ import {
   groupNarrow,
 } from '../../utils/narrow';
 import { foregroundColorFromBackground } from '../../utils/color';
+import { shortDate } from '../../utils/date';
 
 const renderSubject = item =>
   // TODO: pin down if '' happens, and what its proper semantics are.
   item.match_subject !== undefined && item.match_subject !== ''
     ? item.match_subject
-    : template`${item.subject}`;
+    : template`
+    <div class="subheader topic-header">
+      <div class="topic-text">
+        ${item.subject}
+      </div>
+      <div class="topic-timestamp">
+        ${shortDate(new Date(item.timestamp * 1000))}
+      </div>
+    </div>
+    `;
 
 export default (
   { ownEmail, subscriptions }: BackgroundData,


### PR DESCRIPTION
Many times when people are scrolling through messages they need to see 
what date it is. This modification is made for this use-case. Users can 
simply see the header to determine the date a particular message was sent.

This is implemented using some basic `css` and `js`. When writing the css 
selector for the header of the topic, there was an issue arising where the 
sticky header (because a small part of it gets cut out) was showing 
misalignment. This is the reason why `margin-top: 0.2em` was added to 
`.topic-header` selector.

Tests have been conducted, and behaviour is checked for both Android and 
iOS, light and dark mode.

Fixes #1336