### PR TITLE
Loading indicator on message list when data is stale

### DIFF
--- a/src/chat/Chat.js
+++ b/src/chat/Chat.js
@@ -9,6 +9,7 @@ import MessageList from '../webview/MessageList';
 import NoMessages from '../message/NoMessages';
 import ComposeBox from '../compose/ComposeBox';
 import UnreadNotice from './UnreadNotice';
+import LoadingNotice from './LoadingNotice';
 import styles from '../styles';
 import { canSendToNarrow } from '../utils/narrow';
 import { getShowMessagePlaceholders } from '../selectors';
@@ -40,6 +41,7 @@ class Chat extends PureComponent<Props> {
             <MessageList narrow={narrow} />
             <NoMessages narrow={narrow} />
             <UnreadNotice narrow={narrow} />
+            <LoadingNotice narrow={narrow} />
           </View>
           {canSend && <ComposeBox narrow={narrow} />}
         </View>

--- a/src/chat/LoadingNotice.js
+++ b/src/chat/LoadingNotice.js
@@ -1,0 +1,53 @@
+/* @flow strict-local */
+import { connect } from 'react-redux';
+
+import React, { PureComponent } from 'react';
+import { StyleSheet } from 'react-native';
+
+import type { CaughtUp, Narrow } from '../types';
+import { getCaughtUpForNarrow } from '../selectors';
+import { Label } from '../common';
+
+import AnimatedComponent from '../animation/AnimatedComponent';
+
+const styles = StyleSheet.create({
+  block: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: '#FD3D26',
+  },
+  text: {
+    fontSize: 14,
+    color: 'white',
+    padding: 2,
+  },
+});
+
+type Props = {|
+  narrow: Narrow,
+  caughtUp: CaughtUp,
+|};
+
+class LoadingNotice extends PureComponent<Props> {
+  render() {
+    const { caughtUp } = this.props;
+    const hasCaughtUp = caughtUp.newer;
+
+    return (
+      <AnimatedComponent
+        stylePropertyName="height"
+        fullValue={30}
+        useNativeDriver={false}
+        visible={!hasCaughtUp}
+        style={styles.block}
+      >
+        {!hasCaughtUp && <Label style={styles.text} text="Connecting to server" />}
+      </AnimatedComponent>
+    );
+  }
+}
+
+export default connect((state, props) => ({
+  caughtUp: getCaughtUpForNarrow(state, props.narrow),
+}))(LoadingNotice);


### PR DESCRIPTION
Issue #3387. The check if data is stale is `const hasCaughtUp = caughtUp.newer;` where `caughtUp` is  `getCaughtUpForNarrow(state, props.narrow)`. Based on the use case describe in #3387 , I understand we want to indicate to the users if they have had all new message (when they open from a notification for example), so I check for `caughtUp.newer` here. Let me know if this check is not sufficient or incorrect.

Screenshot:
![image](https://user-images.githubusercontent.com/19589970/55123861-34ac3000-513f-11e9-8562-27d0cd475488.png)
