### PR TITLE
webview js: Improve `longPress` detection logic.

### DIFF
--- a/src/webview/js/generatedEs3.js
+++ b/src/webview/js/generatedEs3.js
@@ -230,13 +230,13 @@ var sendScrollMessageIfListShort = function sendScrollMessageIfListShort() {
 };
 
 var scrollEventsDisabled = true;
-var lastTouchEventTimestamp = 0;
 var hasLongPressed = false;
+var longPressTimeout;
 var lastTouchPositionX = -1;
 var lastTouchPositionY = -1;
 
 var handleScrollEvent = function handleScrollEvent() {
-  lastTouchEventTimestamp = 0;
+  clearTimeout(longPressTimeout);
 
   if (scrollEventsDisabled) {
     return;
@@ -421,7 +421,7 @@ var requireAttribute = function requireAttribute(e, name) {
 
 documentBody.addEventListener('click', function (e) {
   e.preventDefault();
-  lastTouchEventTimestamp = 0;
+  clearTimeout(longPressTimeout);
 
   if (hasLongPressed) {
     hasLongPressed = false;
@@ -497,11 +497,6 @@ documentBody.addEventListener('click', function (e) {
 });
 
 var handleLongPress = function handleLongPress(target) {
-  if (!lastTouchEventTimestamp || Date.now() - lastTouchEventTimestamp < 500) {
-    return;
-  }
-
-  lastTouchEventTimestamp = 0;
   hasLongPressed = true;
   sendMessage({
     type: 'longPress',
@@ -520,9 +515,9 @@ documentBody.addEventListener('touchstart', function (e) {
 
   lastTouchPositionX = e.changedTouches[0].pageX;
   lastTouchPositionY = e.changedTouches[0].pageY;
-  lastTouchEventTimestamp = Date.now();
   hasLongPressed = false;
-  setTimeout(function () {
+  clearTimeout(longPressTimeout);
+  longPressTimeout = setTimeout(function () {
     return handleLongPress(target);
   }, 500);
 });
@@ -537,13 +532,13 @@ var isNearPositions = function isNearPositions() {
 
 documentBody.addEventListener('touchend', function (e) {
   if (isNearPositions(lastTouchPositionX, lastTouchPositionY, e.changedTouches[0].pageX, e.changedTouches[0].pageY)) {
-    lastTouchEventTimestamp = Date.now();
+    clearTimeout(longPressTimeout);
   }
 });
 documentBody.addEventListener('touchmove', function (e) {
-  lastTouchEventTimestamp = 0;
+  clearTimeout(longPressTimeout);
 });
 documentBody.addEventListener('drag', function (e) {
-  lastTouchEventTimestamp = 0;
+  clearTimeout(longPressTimeout);
 });
 `;

--- a/src/webview/js/generatedEs3.js
+++ b/src/webview/js/generatedEs3.js
@@ -535,6 +535,9 @@ documentBody.addEventListener('touchend', function (e) {
     clearTimeout(longPressTimeout);
   }
 });
+documentBody.addEventListener('touchcancel', function (e) {
+  clearTimeout(longPressTimeout);
+});
 documentBody.addEventListener('touchmove', function (e) {
   clearTimeout(longPressTimeout);
 });

--- a/src/webview/js/js.js
+++ b/src/webview/js/js.js
@@ -685,6 +685,10 @@ documentBody.addEventListener('touchend', (e: TouchEvent) => {
   }
 });
 
+documentBody.addEventListener('touchcancel', (e: TouchEvent) => {
+  clearTimeout(longPressTimeout);
+});
+
 documentBody.addEventListener('touchmove', (e: TouchEvent) => {
   clearTimeout(longPressTimeout);
 });


### PR DESCRIPTION
The existing `longPress` logic is very convoluted. It makes the user
study the code for a long amount of time to follow the state machine
and figure out exactly how the logic works. There are also a few
inconsistencies with respect to how the code handles events, in
particular `lastTouchEventTimestamp = Date.now()` in the `touchend`
listener, and a few more inconsistencies.

This commit aims to fix these inconsistencies by removing the
timestamp factor from `lastTouchEventTimestamp` altogether. It (the
replaced name being `touchActive`) acts as a flag for if the user is
touching the screen at present, which is an accurate indicator for
if the user wants to `longPress` (when the handler for longPress
triggers he would still be touching the screen if he wants to
longPress.)

Tested on Android and iOS emulators and a physical Android device.