### PR TITLE
Improve Flow typing of 'navigation' props, rework how params are extracted

### DIFF
--- a/src/account-info/AccountDetailsScreen.js
+++ b/src/account-info/AccountDetailsScreen.js
@@ -53,5 +53,5 @@ class AccountDetailsScreen extends PureComponent<Props> {
 }
 
 export default connect((state: GlobalState, props) => ({
-  user: getAccountDetailsUserFromEmail(state, props.navigation.state.params.email),
+  user: getAccountDetailsUserFromEmail(state, props.navigation.getParam('email')),
 }))(AccountDetailsScreen);

--- a/src/chat/ChatScreen.js
+++ b/src/chat/ChatScreen.js
@@ -1,7 +1,7 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
 import { View, StyleSheet } from 'react-native';
-import type { NavigationScreenProp } from 'react-navigation';
+import type { NavigationScreenProp, NavigationStateRoute } from 'react-navigation';
 import { ActionSheetProvider } from '@expo/react-native-action-sheet';
 
 import type { Context, Narrow } from '../types';
@@ -10,13 +10,7 @@ import Chat from '../chat/Chat';
 import ChatNavBar from '../nav/ChatNavBar';
 
 type Props = {|
-  navigation: NavigationScreenProp<*> & {
-    state: {
-      params: {
-        narrow: Narrow,
-      },
-    },
-  },
+  navigation: NavigationScreenProp<NavigationStateRoute>,
 |};
 
 const styles = StyleSheet.create({
@@ -35,7 +29,7 @@ export default class ChatScreen extends PureComponent<Props> {
 
   render() {
     const { styles: contextStyles } = this.context;
-    const { narrow } = this.props.navigation.state.params;
+    const narrow: Narrow = this.props.navigation.getParam('narrow');
 
     return (
       <ActionSheetProvider>

--- a/src/chat/GroupDetailsScreen.js
+++ b/src/chat/GroupDetailsScreen.js
@@ -2,6 +2,7 @@
 import { connect } from 'react-redux';
 import React, { PureComponent } from 'react';
 import { FlatList } from 'react-native';
+import type { NavigationScreenProp, NavigationStateRoute } from 'react-navigation';
 
 import type { Dispatch } from '../types';
 import { Screen } from '../common';
@@ -9,7 +10,7 @@ import UserItem from '../users/UserItem';
 import { navigateToAccountDetails } from '../actions';
 
 type Props = {|
-  navigation: Object,
+  navigation: NavigationScreenProp<NavigationStateRoute>,
   dispatch: Dispatch,
 |};
 

--- a/src/chat/GroupDetailsScreen.js
+++ b/src/chat/GroupDetailsScreen.js
@@ -19,7 +19,8 @@ class GroupDetailsScreen extends PureComponent<Props> {
   };
 
   render() {
-    const { recipients } = this.props.navigation.state.params;
+    const { navigation } = this.props;
+    const recipients = navigation.getParam('recipients');
     return (
       <Screen title="Recipients" scrollEnabled={false}>
         <FlatList

--- a/src/common/SmartUrlInput.js
+++ b/src/common/SmartUrlInput.js
@@ -1,6 +1,7 @@
 /* @flow */
 import React, { PureComponent } from 'react';
 import { StyleSheet, TextInput, TouchableWithoutFeedback, View } from 'react-native';
+import type { NavigationScreenProp, NavigationStateRoute } from 'react-navigation';
 
 import type { Context, Style } from '../types';
 import { autocompleteUrl, fixRealmUrl, hasProtocol } from '../utils/url';
@@ -28,7 +29,7 @@ type Props = {|
   defaultOrganization: string,
   protocol: string,
   append: string,
-  navigation: Object,
+  navigation: NavigationScreenProp<NavigationStateRoute>,
   style?: Style,
   onChangeText: (value: string) => void,
   onSubmitEditing: () => Promise<void>,

--- a/src/emoji/EmojiPickerScreen.js
+++ b/src/emoji/EmojiPickerScreen.js
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 
 import React, { PureComponent } from 'react';
 import { FlatList } from 'react-native';
-import type { NavigationScreenProp } from 'react-navigation';
+import type { NavigationScreenProp, NavigationStateRoute } from 'react-navigation';
 
 import { emojiReactionAdd } from '../api';
 import { unicodeCodeByName } from './codePointMap';
@@ -19,13 +19,7 @@ type Props = {|
   activeImageEmojiByName: RealmEmojiById,
   auth: Auth,
   dispatch: Dispatch,
-  navigation: NavigationScreenProp<*> & {
-    state: {
-      params: {
-        messageId: number,
-      },
-    },
-  },
+  navigation: NavigationScreenProp<NavigationStateRoute>,
 |};
 
 type State = {|

--- a/src/emoji/EmojiPickerScreen.js
+++ b/src/emoji/EmojiPickerScreen.js
@@ -59,7 +59,7 @@ class EmojiPickerScreen extends PureComponent<Props, State> {
 
   addReaction = (emojiName: string) => {
     const { auth, dispatch, navigation } = this.props;
-    const { messageId } = navigation.state.params;
+    const messageId = navigation.getParam('messageId');
 
     const { reactionType, emojiCode } = this.getReactionTypeAndCode(emojiName);
     emojiReactionAdd(auth, messageId, reactionType, emojiCode, emojiName);

--- a/src/lightbox/LightboxScreen.js
+++ b/src/lightbox/LightboxScreen.js
@@ -30,7 +30,9 @@ type Props = {|
 
 export default class LightboxScreen extends PureComponent<Props> {
   render() {
-    const { src, message } = this.props.navigation.state.params;
+    const { navigation } = this.props;
+    const src = navigation.getParam('src');
+    const message = navigation.getParam('message');
     return (
       <View style={styles.screen}>
         <ZulipStatusBar hidden backgroundColor="black" />

--- a/src/lightbox/LightboxScreen.js
+++ b/src/lightbox/LightboxScreen.js
@@ -1,7 +1,7 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
 import { View, StyleSheet } from 'react-native';
-import type { NavigationScreenProp } from 'react-navigation';
+import type { NavigationScreenProp, NavigationStateRoute } from 'react-navigation';
 import { ActionSheetProvider } from '@expo/react-native-action-sheet';
 
 import { ZulipStatusBar } from '../common';
@@ -18,21 +18,14 @@ const styles = StyleSheet.create({
 });
 
 type Props = {|
-  navigation: NavigationScreenProp<*> & {
-    state: {
-      params: {
-        src: string,
-        message: Message,
-      },
-    },
-  },
+  navigation: NavigationScreenProp<NavigationStateRoute>,
 |};
 
 export default class LightboxScreen extends PureComponent<Props> {
   render() {
     const { navigation } = this.props;
-    const src = navigation.getParam('src');
-    const message = navigation.getParam('message');
+    const src: string = navigation.getParam('src');
+    const message: Message = navigation.getParam('message');
     return (
       <View style={styles.screen}>
         <ZulipStatusBar hidden backgroundColor="black" />

--- a/src/start/AuthScreen.js
+++ b/src/start/AuthScreen.js
@@ -40,9 +40,9 @@ class AuthScreen extends PureComponent<Props> {
       }
     });
 
-    const authList = activeAuthentications(
-      this.props.navigation.state.params.serverSettings.authentication_methods,
-    );
+    const { navigation } = this.props;
+    const { authentication_methods } = navigation.getParam('serverSettings');
+    const authList = activeAuthentications(authentication_methods);
     if (authList.length === 1) {
       // $FlowFixMe
       this[authList[0].handler]();
@@ -83,8 +83,9 @@ class AuthScreen extends PureComponent<Props> {
   };
 
   handlePassword = () => {
-    const { serverSettings } = this.props.navigation.state.params;
-    this.props.dispatch(navigateToPassword(serverSettings.require_email_format_usernames));
+    const { navigation } = this.props;
+    const { require_email_format_usernames } = navigation.getParam('serverSettings');
+    this.props.dispatch(navigateToPassword(require_email_format_usernames));
   };
 
   handleGoogle = () => {
@@ -104,7 +105,8 @@ class AuthScreen extends PureComponent<Props> {
   };
 
   render() {
-    const { serverSettings } = this.props.navigation.state.params;
+    const { navigation } = this.props;
+    const serverSettings = navigation.getParam('serverSettings');
 
     return (
       <Screen title="Log in" centerContent padding>

--- a/src/start/PasswordAuthScreen.js
+++ b/src/start/PasswordAuthScreen.js
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 
 import React, { PureComponent } from 'react';
 import { View, StyleSheet } from 'react-native';
+import type { NavigationScreenProp, NavigationStateRoute } from 'react-navigation';
 
 import type { Auth, Dispatch, GlobalState } from '../types';
 import { fetchApiKey } from '../api';
@@ -28,7 +29,7 @@ const styles = StyleSheet.create({
 type Props = {|
   partialAuth: Auth,
   dispatch: Dispatch,
-  navigation: Object,
+  navigation: NavigationScreenProp<NavigationStateRoute>,
 |};
 
 type State = {|

--- a/src/start/PasswordAuthScreen.js
+++ b/src/start/PasswordAuthScreen.js
@@ -48,7 +48,7 @@ class PasswordAuthScreen extends PureComponent<Props, State> {
 
   tryPasswordLogin = async () => {
     const { dispatch, partialAuth, navigation } = this.props;
-    const { requireEmailFormat } = navigation.state.params;
+    const requireEmailFormat = navigation.getParam('requireEmailFormat');
     const { email, password } = this.state;
 
     this.setState({ progress: true, error: undefined });
@@ -68,8 +68,9 @@ class PasswordAuthScreen extends PureComponent<Props, State> {
   };
 
   validateForm = () => {
-    const { requireEmailFormat } = this.props.navigation.state.params;
+    const { navigation } = this.props;
     const { email, password } = this.state;
+    const requireEmailFormat = navigation.getParam('requireEmailFormat');
 
     if (requireEmailFormat && !isValidEmailFormat(email)) {
       this.setState({ error: 'Enter a valid email address' });
@@ -83,8 +84,9 @@ class PasswordAuthScreen extends PureComponent<Props, State> {
   };
 
   render() {
-    const { requireEmailFormat } = this.props.navigation.state.params;
+    const { navigation } = this.props;
     const { email, password, progress, error } = this.state;
+    const requireEmailFormat = navigation.getParam('requireEmailFormat');
     const isButtonDisabled =
       password.length === 0
       || email.length === 0

--- a/src/start/RealmScreen.js
+++ b/src/start/RealmScreen.js
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 
 import React, { PureComponent } from 'react';
 import { ScrollView, Keyboard } from 'react-native';
+import type { NavigationScreenProp, NavigationStateRoute } from 'react-navigation';
 
 import type { ApiResponseServerSettings, Dispatch } from '../types';
 import { ErrorMsg, Label, SmartUrlInput, Screen, ZulipButton } from '../common';
@@ -13,7 +14,7 @@ import styles from '../styles';
 
 type Props = {|
   dispatch: Dispatch,
-  navigation: Object,
+  navigation: NavigationScreenProp<NavigationStateRoute>,
   initialRealm: string,
 |};
 

--- a/src/start/RealmScreen.js
+++ b/src/start/RealmScreen.js
@@ -96,7 +96,5 @@ class RealmScreen extends PureComponent<Props, State> {
 }
 
 export default connect((state, props) => ({
-  initialRealm:
-    (props.navigation && props.navigation.state.params && props.navigation.state.params.realm)
-    || '',
+  initialRealm: props.navigation.getParam('realm', ''),
 }))(RealmScreen);

--- a/src/streams/EditStreamScreen.js
+++ b/src/streams/EditStreamScreen.js
@@ -37,5 +37,5 @@ class EditStreamScreen extends PureComponent<Props> {
 }
 
 export default connect((state: GlobalState, props) => ({
-  stream: getStreamFromId(state, props.navigation.state.params.streamId),
+  stream: getStreamFromId(state, props.navigation.getParam('streamId')),
 }))(EditStreamScreen);

--- a/src/streams/InviteUsersScreen.js
+++ b/src/streams/InviteUsersScreen.js
@@ -46,5 +46,5 @@ class InviteUsersScreen extends PureComponent<Props, State> {
 
 export default connect((state: GlobalState, props) => ({
   auth: getAuth(state),
-  stream: getStreamFromId(state, props.navigation.state.params.streamId),
+  stream: getStreamFromId(state, props.navigation.getParam('streamId')),
 }))(InviteUsersScreen);

--- a/src/streams/StreamScreen.js
+++ b/src/streams/StreamScreen.js
@@ -100,6 +100,6 @@ class StreamScreen extends PureComponent<Props> {
 
 export default connect((state: GlobalState, props) => ({
   isAdmin: getIsAdmin(state),
-  stream: getStreamFromId(state, props.navigation.state.params.streamId),
-  subscription: getSubscriptionFromId(state, props.navigation.state.params.streamId),
+  stream: getStreamFromId(state, props.navigation.getParam('streamId')),
+  subscription: getSubscriptionFromId(state, props.navigation.getParam('streamId')),
 }))(StreamScreen);

--- a/src/topics/TopicListScreen.js
+++ b/src/topics/TopicListScreen.js
@@ -53,6 +53,6 @@ class TopicListScreen extends PureComponent<Props, State> {
 }
 
 export default connect((state: GlobalState, props) => ({
-  stream: getStreamFromId(state, props.navigation.state.params.streamId),
-  topics: getTopicsForStream(state, props.navigation.state.params.streamId),
+  stream: getStreamFromId(state, props.navigation.getParam('streamId')),
+  topics: getTopicsForStream(state, props.navigation.getParam('streamId')),
 }))(TopicListScreen);


### PR DESCRIPTION
Prerequisite for #3422

More details in each commit.


* connect: Use `navigation.getParam()` instead of `navigation.state.params`
*  Replace `navigation.state.params` with `getParam`
* flow: Use better types for `navigation` properties 