### PR TITLE
Add Flow types required for RN 0.59 migration

### DIFF
--- a/src/autocomplete/PeopleAutocomplete.js
+++ b/src/autocomplete/PeopleAutocomplete.js
@@ -28,8 +28,12 @@ class PeopleAutocomplete extends PureComponent<Props> {
     this.props.onAutocomplete(`*${name}*`);
   };
 
-  handleUserItemAutocomplete = ({ fullName }): void => {
-    this.props.onAutocomplete(`**${fullName}**`);
+  handleUserItemAutocomplete = (email: string): void => {
+    const { users, onAutocomplete } = this.props;
+    const user = users.find(x => x.email === email);
+    if (user) {
+      onAutocomplete(`**${user.full_name}**`);
+    }
   };
 
   render() {

--- a/src/boot/AppEventHandlers.js
+++ b/src/boot/AppEventHandlers.js
@@ -6,7 +6,7 @@ import SafeArea from 'react-native-safe-area';
 import Orientation from 'react-native-orientation';
 
 import type { Node as React$Node } from 'react';
-import type { Dispatch, Orientation as OrientationT } from '../types';
+import type { Dispatch, Orientation as OrientationT, ConnectionType } from '../types';
 import { connect } from '../react-redux';
 import { getUnreadByHuddlesMentionsAndPMs } from '../selectors';
 import { handleInitialNotification, NotificationListener } from '../notification';
@@ -38,7 +38,8 @@ class AppEventHandlers extends PureComponent<Props> {
     dispatch(appOrientation(orientation));
   };
 
-  handleConnectivityChange = connectionInfo => {
+  /** https://facebook.github.io/react-native/docs/netinfo */
+  handleConnectivityChange = (connectionInfo: ConnectionType) => {
     const { dispatch } = this.props;
     const isConnected = connectionInfo.type !== 'none' && connectionInfo.type !== 'unknown';
     dispatch(appOnline(isConnected));

--- a/src/boot/AppEventHandlers.js
+++ b/src/boot/AppEventHandlers.js
@@ -6,7 +6,7 @@ import SafeArea from 'react-native-safe-area';
 import Orientation from 'react-native-orientation';
 
 import type { Node as React$Node } from 'react';
-import type { Dispatch, Orientation as OrientationT, ConnectionType } from '../types';
+import type { Dispatch, Orientation as OrientationT } from '../types';
 import { connect } from '../react-redux';
 import { getUnreadByHuddlesMentionsAndPMs } from '../selectors';
 import { handleInitialNotification, NotificationListener } from '../notification';
@@ -17,6 +17,18 @@ import {
   initSafeAreaInsets,
   reportPresence,
 } from '../actions';
+
+/**
+ * Part of the type of upstream's `NetInfo`.
+ *
+ * Based on docs: https://facebook.github.io/react-native/docs/netinfo
+ *
+ * TODO move this to a libdef, and/or get an explicit type into upstream.
+ */
+type ConnectionInfo = {|
+  type: 'none' | 'wifi' | 'cellular' | 'unknown' | 'bluetooth' | 'ethernet' | 'wimax',
+  effectiveType: '2g' | '3g' | '4g' | 'unknown',
+|};
 
 const styles = StyleSheet.create({
   wrapper: {
@@ -39,7 +51,7 @@ class AppEventHandlers extends PureComponent<Props> {
   };
 
   /** https://facebook.github.io/react-native/docs/netinfo */
-  handleConnectivityChange = (connectionInfo: ConnectionType) => {
+  handleConnectivityChange = (connectionInfo: ConnectionInfo) => {
     const { dispatch } = this.props;
     const isConnected = connectionInfo.type !== 'none' && connectionInfo.type !== 'unknown';
     dispatch(appOnline(isConnected));

--- a/src/boot/AppEventHandlers.js
+++ b/src/boot/AppEventHandlers.js
@@ -44,7 +44,8 @@ class AppEventHandlers extends PureComponent<Props> {
     dispatch(appOnline(isConnected));
   };
 
-  handleAppStateChange = state => {
+  /** https://facebook.github.io/react-native/docs/appstate */
+  handleAppStateChange = (state: 'active' | 'background' | 'inactive') => {
     const { dispatch, unreadCount } = this.props;
     dispatch(reportPresence(state === 'active'));
     dispatch(appState(state === 'active'));

--- a/src/boot/AppEventHandlers.js
+++ b/src/boot/AppEventHandlers.js
@@ -57,7 +57,7 @@ class AppEventHandlers extends PureComponent<Props> {
     dispatch(appOnline(isConnected));
   };
 
-  /** https://facebook.github.io/react-native/docs/appstate */
+  /** For the type, see docs: https://facebook.github.io/react-native/docs/appstate */
   handleAppStateChange = (state: 'active' | 'background' | 'inactive') => {
     const { dispatch, unreadCount } = this.props;
     dispatch(reportPresence(state === 'active'));

--- a/src/chat/GroupDetailsScreen.js
+++ b/src/chat/GroupDetailsScreen.js
@@ -15,7 +15,7 @@ type Props = {|
 |};
 
 class GroupDetailsScreen extends PureComponent<Props> {
-  handlePress = ({ email }) => {
+  handlePress = (email: string) => {
     this.props.dispatch(navigateToAccountDetails(email));
   };
 

--- a/src/compose/ComposeBox.js
+++ b/src/compose/ComposeBox.js
@@ -1,6 +1,7 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
 import { Platform, View, TextInput, findNodeHandle } from 'react-native';
+import type { LayoutEvent } from 'react-native/Libraries/Types/CoreEventTypes';
 import TextInputReset from 'react-native-text-input-reset';
 
 import type {
@@ -152,7 +153,7 @@ class ComposeBox extends PureComponent<Props, State> {
     }));
   };
 
-  handleLayoutChange = event => {
+  handleLayoutChange = (event: LayoutEvent) => {
     this.setState({
       height: event.nativeEvent.layout.height,
     });

--- a/src/pm-conversations/PmConversationList.js
+++ b/src/pm-conversations/PmConversationList.js
@@ -25,8 +25,8 @@ type Props = {|
  * A list describing all PM conversations.
  * */
 export default class PmConversationList extends PureComponent<Props> {
-  handleUserNarrow = (params: { email: string }) => {
-    this.props.dispatch(doNarrow(privateNarrow(params.email)));
+  handleUserNarrow = (email: string) => {
+    this.props.dispatch(doNarrow(privateNarrow(email)));
   };
 
   handleGroupNarrow = (email: string) => {

--- a/src/settings/LanguagePicker.js
+++ b/src/settings/LanguagePicker.js
@@ -6,6 +6,7 @@ import type { GetText } from '../types';
 import { TranslationContext } from '../boot/TranslationProvider';
 
 import languages from './languages';
+import type { Language } from './languages';
 import LanguagePickerItem from './LanguagePickerItem';
 
 const styles = StyleSheet.create({
@@ -25,8 +26,8 @@ export default class LanguagePicker extends PureComponent<Props> {
   static contextType = TranslationContext;
   context: GetText;
 
-  getTranslatedLanguages = () =>
-    languages.map(language => {
+  getTranslatedLanguages = (): Language[] =>
+    languages.map((language: Language) => {
       const _ = this.context;
       const translatedName = _(language.name);
       return {
@@ -35,7 +36,7 @@ export default class LanguagePicker extends PureComponent<Props> {
       };
     });
 
-  getFilteredLanguageList = (filter: string) => {
+  getFilteredLanguageList = (filter: string): Language[] => {
     const list = this.getTranslatedLanguages();
 
     if (!filter) {

--- a/src/settings/languages.js
+++ b/src/settings/languages.js
@@ -1,6 +1,13 @@
 /* @flow strict */
 /* eslint-disable spellcheck/spell-checker */
-export default [
+
+export type Language = {
+  locale: string,
+  name: string,
+  nativeName: string,
+};
+
+const languages: $ReadOnlyArray<Language> = [
   {
     locale: 'en',
     name: 'English',
@@ -107,3 +114,5 @@ export default [
     nativeName: 'Türkçe',
   },
 ];
+
+export default languages;

--- a/src/start/AuthScreen.js
+++ b/src/start/AuthScreen.js
@@ -25,7 +25,14 @@ type Props = {|
 
 let otp = '';
 
-/** https://facebook.github.io/react-native/docs/linking */
+/**
+ * An event emitted by `Linking`.
+ *
+ * Determined by reading the implementation source code, and documentation:
+ *   https://facebook.github.io/react-native/docs/linking
+ *
+ * TODO move this to a libdef, and/or get an explicit type into upstream.
+ */
 type LinkingEvent = {
   url: string,
 };

--- a/src/start/AuthScreen.js
+++ b/src/start/AuthScreen.js
@@ -25,11 +25,16 @@ type Props = {|
 
 let otp = '';
 
+/** https://facebook.github.io/react-native/docs/linking */
+type LinkingEvent = {
+  url: string,
+};
+
 class AuthScreen extends PureComponent<Props> {
   componentDidMount = () => {
     Linking.addEventListener('url', this.endOAuth);
-    Linking.getInitialURL().then(initialUrl => {
-      if (initialUrl) {
+    Linking.getInitialURL().then((initialUrl: ?string) => {
+      if (initialUrl !== null && initialUrl !== undefined) {
         this.endOAuth({ url: initialUrl });
       }
     });
@@ -47,12 +52,12 @@ class AuthScreen extends PureComponent<Props> {
     Linking.removeEventListener('url', this.endOAuth);
   };
 
-  beginOAuth = async url => {
+  beginOAuth = async (url: string) => {
     otp = await generateOtp();
     openBrowser(`${this.props.realm}/${url}`, otp);
   };
 
-  endOAuth = event => {
+  endOAuth = (event: LinkingEvent) => {
     closeBrowser();
 
     const { dispatch, realm } = this.props;

--- a/src/start/RealmScreen.js
+++ b/src/start/RealmScreen.js
@@ -55,7 +55,7 @@ class RealmScreen extends PureComponent<Props, State> {
     }
   };
 
-  handleRealmChange = value => this.setState({ realm: value });
+  handleRealmChange = (value: string) => this.setState({ realm: value });
 
   componentDidMount() {
     const { initialRealm } = this.props;

--- a/src/title/TitleGroup.js
+++ b/src/title/TitleGroup.js
@@ -16,7 +16,7 @@ type Props = {
 };
 
 class TitleGroup extends PureComponent<Props> {
-  handlePress = user => {
+  handlePress = (user: UserOrBot) => {
     const { dispatch } = this.props;
     dispatch(navigateToAccountDetails(user.email));
   };

--- a/src/types.js
+++ b/src/types.js
@@ -218,11 +218,3 @@ export type PmConversationData = {|
   timestamp: number,
   unread: number,
 |};
-
-/**
- * Typed as documented at https://facebook.github.io/react-native/docs/netinfo.html
- */
-export type ConnectionType = {|
-  type: 'none' | 'wifi' | 'cellular' | 'unknown' | 'bluetooth' | 'ethernet' | 'wimax',
-  effectiveType: '2g' | '3g' | '4g' | 'unknown',
-|};

--- a/src/types.js
+++ b/src/types.js
@@ -218,3 +218,11 @@ export type PmConversationData = {|
   timestamp: number,
   unread: number,
 |};
+
+/**
+ * Typed as documented at https://facebook.github.io/react-native/docs/netinfo.html
+ */
+export type ConnectionType = {|
+  type: 'none' | 'wifi' | 'cellular' | 'unknown' | 'bluetooth' | 'ethernet' | 'wimax',
+  effectiveType: '2g' | '3g' | '4g' | 'unknown',
+|};

--- a/src/user-picker/UserPickerCard.js
+++ b/src/user-picker/UserPickerCard.js
@@ -58,7 +58,7 @@ class UserPickerCard extends PureComponent<Props, State> {
     }
   };
 
-  handleUserPress = ({ email }) => {
+  handleUserPress = (email: string) => {
     const { selected } = this.state;
 
     if (selected.find(x => x.email === email)) {

--- a/src/users/UserItem.js
+++ b/src/users/UserItem.js
@@ -31,7 +31,7 @@ type Props = {|
   isSelected: boolean,
   showEmail: boolean,
   unreadCount?: number,
-  onPress: ({ email: string, fullName: string }) => void,
+  onPress: (email: string) => void,
 |};
 
 export default class UserItem extends PureComponent<Props> {
@@ -41,9 +41,9 @@ export default class UserItem extends PureComponent<Props> {
   };
 
   handlePress = () => {
-    const { email, fullName, onPress } = this.props;
-    if (email && fullName && onPress) {
-      onPress({ email, fullName });
+    const { email, onPress } = this.props;
+    if (email && onPress) {
+      onPress(email);
     }
   };
 

--- a/src/users/UserList.js
+++ b/src/users/UserList.js
@@ -19,7 +19,7 @@ type Props = {|
   users: User[],
   selected: User[],
   presences: PresenceState,
-  onPress: ({ email: string, fullName: string }) => void,
+  onPress: (email: string) => void,
 |};
 
 export default class UserList extends PureComponent<Props> {

--- a/src/users/UsersCard.js
+++ b/src/users/UsersCard.js
@@ -17,7 +17,7 @@ type Props = {|
 |};
 
 class UsersCard extends PureComponent<Props> {
-  handleUserNarrow = ({ email }) => {
+  handleUserNarrow = (email: string) => {
     const { dispatch } = this.props;
     dispatch(navigateBack());
     dispatch(doNarrow(privateNarrow(email)));


### PR DESCRIPTION
This PR adds Flow types that if missing, result in errors in the React Native 0.59 upgrade PR (not because of RN but because of Flow 0.92)

Can be merged separately. Prerequisite for #3422