### PR TITLE
Fix a message loading bug and improve behavior

### DIFF
--- a/src/message/__tests__/fetchActions-test.js
+++ b/src/message/__tests__/fetchActions-test.js
@@ -1,6 +1,6 @@
 import mockStore from 'redux-mock-store'; // eslint-disable-line
 
-import { fetchMessages, fetchMessagesAtFirstUnread, fetchOlder, fetchNewer } from '../fetchActions';
+import { fetchMessages, fetchOlder, fetchNewer } from '../fetchActions';
 import { streamNarrow, HOME_NARROW, HOME_NARROW_STR } from '../../utils/narrow';
 import { navStateWithNarrow } from '../../utils/testHelpers';
 
@@ -77,23 +77,6 @@ describe('fetchActions', () => {
       });
 
       store.dispatch(fetchMessages(HOME_NARROW, 0, 1, -1, true));
-      const actions = store.getActions();
-
-      expect(actions).toHaveLength(1);
-      expect(actions[0].type).toBe('MESSAGE_FETCH_START');
-    });
-  });
-
-  describe('fetchMessagesAtFirstUnread', () => {
-    test('message fetch start action is dispatched with fetchingOlder and fetchingNewer true', () => {
-      const store = mockStore({
-        ...navStateWithNarrow(HOME_NARROW),
-        narrows: {
-          [streamNarrowStr]: [{ id: 1 }],
-        },
-      });
-
-      store.dispatch(fetchMessagesAtFirstUnread(HOME_NARROW));
       const actions = store.getActions();
 
       expect(actions).toHaveLength(1);

--- a/src/message/fetchActions.js
+++ b/src/message/fetchActions.js
@@ -106,6 +106,9 @@ const initialFetchComplete = (): Action => ({
 });
 
 const isFetchNeededAtAnchor = (state: GlobalState, narrow: Narrow, anchor: number): boolean => {
+  // Ideally this would detect whether, even if we don't have *all* the
+  // messages in the narrow, we have enough of them around the anchor
+  // to show a message list already.  For now it's simple and cautious.
   const caughtUp = getCaughtUpForNarrow(state, narrow);
   return !(caughtUp.newer && caughtUp.older);
 };

--- a/src/message/fetchActions.js
+++ b/src/message/fetchActions.js
@@ -73,18 +73,6 @@ export const fetchMessages = (
   );
 };
 
-const fetchMessagesAroundAnchor = (narrow: Narrow, anchor: number) =>
-  fetchMessages(
-    narrow,
-    anchor,
-    config.messagesPerRequest / 2,
-    config.messagesPerRequest / 2,
-    false,
-  );
-
-export const fetchMessagesAtFirstUnread = (narrow: Narrow) =>
-  fetchMessages(narrow, 0, config.messagesPerRequest / 2, config.messagesPerRequest / 2, true);
-
 export const fetchOlder = (narrow: Narrow) => (dispatch: Dispatch, getState: GetState) => {
   const state = getState();
   const firstMessageId = getFirstMessageId(state, narrow);
@@ -129,11 +117,15 @@ export const fetchMessagesInNarrow = (
   if (!isFetchNeededAtAnchor(getState(), narrow, anchor)) {
     return;
   }
-  if (anchor === FIRST_UNREAD_ANCHOR) {
-    dispatch(fetchMessagesAtFirstUnread(narrow));
-  } else {
-    dispatch(fetchMessagesAroundAnchor(narrow, anchor));
-  }
+  dispatch(
+    fetchMessages(
+      narrow,
+      anchor,
+      config.messagesPerRequest / 2,
+      config.messagesPerRequest / 2,
+      anchor === FIRST_UNREAD_ANCHOR,
+    ),
+  );
 };
 
 const fetchPrivateMessages = () => async (dispatch: Dispatch, getState: GetState) => {

--- a/src/message/fetchActions.js
+++ b/src/message/fetchActions.js
@@ -20,7 +20,6 @@ import {
 import { FIRST_UNREAD_ANCHOR, LAST_MESSAGE_ANCHOR } from '../constants';
 import { ALL_PRIVATE_NARROW } from '../utils/narrow';
 import { tryUntilSuccessful } from '../utils/async';
-import { getFetchedMessageIdsForNarrow } from '../chat/narrowsSelectors';
 import { initNotifications } from '../notification/notificationActions';
 import { addToOutbox, sendOutbox } from '../outbox/outboxActions';
 import { realmInit } from '../realm/realmActions';
@@ -120,11 +119,7 @@ const initialFetchComplete = (): Action => ({
 
 const needFetchAtFirstUnread = (state: GlobalState, narrow: Narrow): boolean => {
   const caughtUp = getCaughtUpForNarrow(state, narrow);
-  if (caughtUp.newer && caughtUp.older) {
-    return false;
-  }
-  const numKnownMessages = getFetchedMessageIdsForNarrow(state, narrow).length;
-  return numKnownMessages < config.messagesPerRequest / 2;
+  return !(caughtUp.newer && caughtUp.older);
 };
 
 export const fetchMessagesInNarrow = (

--- a/src/message/fetchActions.js
+++ b/src/message/fetchActions.js
@@ -117,7 +117,7 @@ const initialFetchComplete = (): Action => ({
   type: INITIAL_FETCH_COMPLETE,
 });
 
-const needFetchAtFirstUnread = (state: GlobalState, narrow: Narrow): boolean => {
+const isFetchNeededAtAnchor = (state: GlobalState, narrow: Narrow, anchor: number): boolean => {
   const caughtUp = getCaughtUpForNarrow(state, narrow);
   return !(caughtUp.newer && caughtUp.older);
 };
@@ -126,12 +126,11 @@ export const fetchMessagesInNarrow = (
   narrow: Narrow,
   anchor: number = FIRST_UNREAD_ANCHOR,
 ) => async (dispatch: Dispatch, getState: GetState) => {
-  const state = getState();
-
+  if (!isFetchNeededAtAnchor(getState(), narrow, anchor)) {
+    return;
+  }
   if (anchor === FIRST_UNREAD_ANCHOR) {
-    if (needFetchAtFirstUnread(state, narrow)) {
-      dispatch(fetchMessagesAtFirstUnread(narrow));
-    }
+    dispatch(fetchMessagesAtFirstUnread(narrow));
   } else {
     dispatch(fetchMessagesAroundAnchor(narrow, anchor));
   }


### PR DESCRIPTION
The behavior of 'needFetchAtFirstUnread' is quite wrong.
First, we do the minimal work to fix #3441 in the first commit.
The rest of the work implements correctly the originally intended behavior.