### PR TITLE
Fix type of `connect` to fully work, and to work with newer Flow.

### DIFF
--- a/flow-typed/npm/react-redux_v5.x.x.js
+++ b/flow-typed/npm/react-redux_v5.x.x.js
@@ -1,40 +1,27 @@
-// flow-typed signature: b872fdc4da6b0c1021c55df6fab87e73
-// flow-typed version: f8afc4cfdd/react-redux_v5.x.x/flow_>=v0.68.0 <=v0.84.x
+// flow-typed signature: f06f00c3ad0cfedb90c0c6de04b219f3
+// flow-typed version: 3a6d556e4b/react-redux_v5.x.x/flow_>=v0.89.x
 
-declare module "react-redux" {
-  import type { ComponentType, ElementConfig } from 'react';
+/**
+The order of type arguments for connect() is as follows:
 
-  // These types are copied directly from the redux libdef. Importing them in
-  // this libdef causes a loss in type coverage.
-  declare type DispatchAPI<A> = (action: A) => A;
-  declare type Dispatch<A: { type: $Subtype<string> }> = DispatchAPI<A>;
-  declare type Reducer<S, A> = (state: S | void, action: A) => S;
-  declare type Store<S, A, D = Dispatch<A>> = {
-    dispatch: D;
-    getState(): S;
-    subscribe(listener: () => void): () => void;
-    replaceReducer(nextReducer: Reducer<S, A>): void
-  };
+connect<Props, OwnProps, StateProps, DispatchProps, State, Dispatch>(…)
 
-  declare export class Provider<S, A, D> extends React$Component<{
-    store: Store<S, A, D>,
-    children?: any
-  }> {}
+In Flow v0.89 only the first two are mandatory to specify. Other 4 can be repaced with the new awesome type placeholder:
 
-  declare export function createProvider(
-    storeKey?: string,
-    subKey?: string
-  ): Provider<*, *, *>;
+connect<Props, OwnProps, _, _, _, _>(…)
 
-  /*
+But beware, in case of weird type errors somewhere in random places
+just type everything and get to a green field and only then try to
+remove the definitions you see bogus.
 
+Decrypting the abbreviations:
+  WC = Component being wrapped
   S = State
-  A = Action
+  D = Dispatch
   OP = OwnProps
   SP = StateProps
   DP = DispatchProps
   MP = Merge props
-  MDP = Map dispatch to props object
   RSP = Returned state props
   RDP = Returned dispatch props
   RMP = Returned merge props
@@ -42,29 +29,192 @@ declare module "react-redux" {
   Com = React Component
   ST = Static properties of Com
   EFO = Extra factory options (used only in connectAdvanced)
-  */
+*/
 
-  declare type MapStateToProps<S: Object, SP: Object, RSP: Object> = (state: S, props: SP) => RSP;
+declare module "react-redux" {
+  // ------------------------------------------------------------
+  // Typings for connect()
+  // ------------------------------------------------------------
 
-  declare type MapDispatchToProps<A, OP: Object, RDP: Object> = (dispatch: Dispatch<A>, ownProps: OP) => RDP;
-
-  declare type MergeProps<SP: Object, DP: Object, MP: Object, RMP: Object> = (
-    stateProps: SP,
-    dispatchProps: DP,
-    ownProps: MP
-  ) => RMP;
-
-  declare type ConnectOptions<S: Object, OP: Object, RSP: Object, RMP: Object> = {|
+  declare export type Options<S, OP, SP, MP> = {|
     pure?: boolean,
     withRef?: boolean,
     areStatesEqual?: (next: S, prev: S) => boolean,
     areOwnPropsEqual?: (next: OP, prev: OP) => boolean,
-    areStatePropsEqual?: (next: RSP, prev: RSP) => boolean,
-    areMergedPropsEqual?: (next: RMP, prev: RMP) => boolean,
-    storeKey?: string
+    areStatePropsEqual?: (next: SP, prev: SP) => boolean,
+    areMergedPropsEqual?: (next: MP, prev: MP) => boolean,
+    storeKey?: string,
   |};
 
-  declare type OmitDispatch<Component> = $Diff<Component, {dispatch?: Dispatch<*>}>;
+  declare type MapStateToProps<-S, -OP, +SP> =
+    | ((state: S, ownProps: OP) => SP)
+    // If you want to use the factory function but get a strange error
+    // like "function is not an object" then just type the factory function
+    // like this:
+    // const factory: (State, OwnProps) => (State, OwnProps) => StateProps
+    // and provide the StateProps type to the SP type parameter.
+    | ((state: S, ownProps: OP) => (state: S, ownProps: OP) => SP);
+
+  declare type Bind<D> = <A, R>((...A) => R) => (...A) => $Call<D, R>;
+
+  declare type MapDispatchToPropsFn<D, -OP, +DP> =
+    | ((dispatch: D, ownProps: OP) => DP)
+    // If you want to use the factory function but get a strange error
+    // like "function is not an object" then just type the factory function
+    // like this:
+    // const factory: (Dispatch, OwnProps) => (Dispatch, OwnProps) => DispatchProps
+    // and provide the DispatchProps type to the DP type parameter.
+    | ((dispatch: D, ownProps: OP) => (dispatch: D, ownProps: OP) => DP);
+
+  declare class ConnectedComponent<OP, +WC> extends React$Component<OP> {
+    static +WrappedComponent: WC;
+    getWrappedInstance(): React$ElementRef<WC>;
+  }
+  // The connection of the Wrapped Component and the Connected Component
+  // happens here in `MP: P`. It means that type wise MP belongs to P,
+  // so to say MP >= P.
+  declare type Connector<P, OP, MP: P> = <WC: React$ComponentType<P>>(
+    WC,
+  ) => Class<ConnectedComponent<OP, WC>> & WC;
+
+  // No `mergeProps` argument
+
+  // Got error like inexact OwnProps is incompatible with exact object type?
+  // Just make the OP parameter for `connect()` an exact object.
+  declare type MergeOP<OP, D> = {| ...$Exact<OP>, dispatch: D |};
+  declare type MergeOPSP<OP, SP, D> = {| ...$Exact<OP>, ...SP, dispatch: D |};
+  declare type MergeOPDP<OP, DP> = {| ...$Exact<OP>, ...DP |};
+  declare type MergeOPSPDP<OP, SP, DP> = {| ...$Exact<OP>, ...SP, ...DP |};
+
+  declare export function connect<-P, -OP, -SP, -DP, -S, -D>(
+    mapStateToProps?: null | void,
+    mapDispatchToProps?: null | void,
+    mergeProps?: null | void,
+    options?: ?Options<S, OP, {||}, MergeOP<OP, D>>,
+  ): Connector<P, OP, MergeOP<OP, D>>;
+
+  declare export function connect<-P, -OP, -SP, -DP, -S, -D>(
+    // If you get error here try adding return type to your mapStateToProps function
+    mapStateToProps: MapStateToProps<S, OP, SP>,
+    mapDispatchToProps?: null | void,
+    mergeProps?: null | void,
+    options?: ?Options<S, OP, SP, MergeOPSP<OP, SP, D>>,
+  ): Connector<P, OP, MergeOPSP<OP, SP, D>>;
+
+  // In this case DP is an object of functions which has been bound to dispatch
+  // by the given mapDispatchToProps function.
+  declare export function connect<-P, -OP, -SP, -DP, S, D>(
+    mapStateToProps: null | void,
+    mapDispatchToProps: MapDispatchToPropsFn<D, OP, DP>,
+    mergeProps?: null | void,
+    options?: ?Options<S, OP, {||}, MergeOPDP<OP, DP>>,
+  ): Connector<P, OP, MergeOPDP<OP, DP>>;
+
+  // In this case DP is an object of action creators not yet bound to dispatch,
+  // this difference is not important in the vanila redux,
+  // but in case of usage with redux-thunk, the return type may differ.
+  declare export function connect<-P, -OP, -SP, -DP, S, D>(
+    mapStateToProps: null | void,
+    mapDispatchToProps: DP,
+    mergeProps?: null | void,
+    options?: ?Options<S, OP, {||}, MergeOPDP<OP, DP>>,
+  ): Connector<P, OP, MergeOPDP<OP, $ObjMap<DP, Bind<D>>>>;
+
+  declare export function connect<-P, -OP, -SP, -DP, S, D>(
+    // If you get error here try adding return type to your mapStateToProps function
+    mapStateToProps: MapStateToProps<S, OP, SP>,
+    mapDispatchToProps: MapDispatchToPropsFn<D, OP, DP>,
+    mergeProps?: null | void,
+    options?: ?Options<S, OP, SP, {| ...OP, ...SP, ...DP |}>,
+  ): Connector<P, OP, {| ...OP, ...SP, ...DP |}>;
+
+  declare export function connect<-P, -OP, -SP, -DP, S, D>(
+    // If you get error here try adding return type to your mapStateToProps function
+    mapStateToProps: MapStateToProps<S, OP, SP>,
+    mapDispatchToProps: DP,
+    mergeProps?: null | void,
+    options?: ?Options<S, OP, SP, MergeOPSPDP<OP, SP, DP>>,
+  ): Connector<P, OP, MergeOPSPDP<OP, SP, $ObjMap<DP, Bind<D>>>>;
+
+  // With `mergeProps` argument
+
+  declare type MergeProps<+P, -OP, -SP, -DP> = (
+    stateProps: SP,
+    dispatchProps: DP,
+    ownProps: OP,
+  ) => P;
+
+  declare export function connect<-P, -OP, -SP: {||}, -DP: {||}, S, D>(
+    mapStateToProps: null | void,
+    mapDispatchToProps: null | void,
+    // If you get error here try adding return type to you mapStateToProps function
+    mergeProps: MergeProps<P, OP, {||}, {| dispatch: D |}>,
+    options?: ?Options<S, OP, {||}, P>,
+  ): Connector<P, OP, P>;
+
+  declare export function connect<-P, -OP, -SP, -DP: {||}, S, D>(
+    mapStateToProps: MapStateToProps<S, OP, SP>,
+    mapDispatchToProps: null | void,
+    // If you get error here try adding return type to you mapStateToProps function
+    mergeProps: MergeProps<P, OP, SP, {| dispatch: D |}>,
+    options?: ?Options<S, OP, SP, P>,
+  ): Connector<P, OP, P>;
+
+  // In this case DP is an object of functions which has been bound to dispatch
+  // by the given mapDispatchToProps function.
+  declare export function connect<-P, -OP, -SP: {||}, -DP, S, D>(
+    mapStateToProps: null | void,
+    mapDispatchToProps: MapDispatchToPropsFn<D, OP, DP>,
+    mergeProps: MergeProps<P, OP, {||}, DP>,
+    options?: ?Options<S, OP, {||}, P>,
+  ): Connector<P, OP, P>;
+
+  // In this case DP is an object of action creators not yet bound to dispatch,
+  // this difference is not important in the vanila redux,
+  // but in case of usage with redux-thunk, the return type may differ.
+  declare export function connect<-P, -OP, -SP: {||}, -DP, S, D>(
+    mapStateToProps: null | void,
+    mapDispatchToProps: DP,
+    mergeProps: MergeProps<P, OP, {||}, $ObjMap<DP, Bind<D>>>,
+    options?: ?Options<S, OP, {||}, P>,
+  ): Connector<P, OP, P>;
+
+  // In this case DP is an object of functions which has been bound to dispatch
+  // by the given mapDispatchToProps function.
+  declare export function connect<-P, -OP, -SP, -DP, S, D>(
+    mapStateToProps: MapStateToProps<S, OP, SP>,
+    mapDispatchToProps: MapDispatchToPropsFn<D, OP, DP>,
+    mergeProps: MergeProps<P, OP, SP, DP>,
+    options?: ?Options<S, OP, SP, P>,
+  ): Connector<P, OP, P>;
+
+  // In this case DP is an object of action creators not yet bound to dispatch,
+  // this difference is not important in the vanila redux,
+  // but in case of usage with redux-thunk, the return type may differ.
+  declare export function connect<-P, -OP, -SP, -DP, S, D>(
+    mapStateToProps: MapStateToProps<S, OP, SP>,
+    mapDispatchToProps: DP,
+    mergeProps: MergeProps<P, OP, SP, $ObjMap<DP, Bind<D>>>,
+    options?: ?Options<S, OP, SP, P>,
+  ): Connector<P, OP, P>;
+
+  // ------------------------------------------------------------
+  // Typings for Provider
+  // ------------------------------------------------------------
+
+  declare export class Provider<Store> extends React$Component<{
+    store: Store,
+    children?: React$Node,
+  }> {}
+
+  declare export function createProvider(
+    storeKey?: string,
+    subKey?: string,
+  ): Class<Provider<*>>;
+
+  // ------------------------------------------------------------
+  // Typings for connectAdvanced()
+  // ------------------------------------------------------------
 
   declare type ConnectAdvancedOptions = {
     getDisplayName?: (name: string) => string,
@@ -87,170 +237,35 @@ declare module "react-redux" {
     WrappedComponent: Com,
   };
 
+  declare type MapStateToPropsEx<S: Object, SP: Object, RSP: Object> = (
+    state: S,
+    props: SP,
+  ) => RSP;
+
   declare type SelectorFactory<
-    Com: ComponentType<*>,
-    A,
+    Com: React$ComponentType<*>,
+    Dispatch,
     S: Object,
     OP: Object,
     EFO: Object,
-    CP: Object
-  > = (dispatch: Dispatch<A>, factoryOptions: SelectorFactoryOptions<Com> & EFO) =>
-      MapStateToProps<S, OP, CP>;
+    CP: Object,
+  > = (
+    dispatch: Dispatch,
+    factoryOptions: SelectorFactoryOptions<Com> & EFO,
+  ) => MapStateToPropsEx<S, OP, CP>;
 
   declare export function connectAdvanced<
-    Com: ComponentType<*>,
-    A,
+    Com: React$ComponentType<*>,
+    D,
     S: Object,
     OP: Object,
     CP: Object,
     EFO: Object,
-    ST: {[_: $Keys<Com>]: any}
-    >(
-    selectorFactory: SelectorFactory<Com, A, S, OP, EFO, CP>,
+    ST: { [_: $Keys<Com>]: any },
+  >(
+    selectorFactory: SelectorFactory<Com, D, S, OP, EFO, CP>,
     connectAdvancedOptions: ?(ConnectAdvancedOptions & EFO),
-  ): (component: Com) => ComponentType<OP> & $Shape<ST>;
-
-  declare export function connect<
-    Com: ComponentType<*>,
-    S: Object,
-    SP: Object,
-    RSP: Object,
-    CP: $Diff<OmitDispatch<ElementConfig<Com>>, RSP>,
-    ST: {[_: $Keys<Com>]: any}
-    >(
-    mapStateToProps: MapStateToProps<S, SP, RSP>,
-    mapDispatchToProps?: null
-  ): (component: Com) => ComponentType<CP & SP> & $Shape<ST>;
-
-  declare export function connect<
-    Com: ComponentType<*>,
-    ST: {[_: $Keys<Com>]: any}
-    >(
-    mapStateToProps?: null,
-    mapDispatchToProps?: null
-  ): (component: Com) => ComponentType<OmitDispatch<ElementConfig<Com>>> & $Shape<ST>;
-
-  declare export function connect<
-    Com: ComponentType<*>,
-    A,
-    S: Object,
-    DP: Object,
-    SP: Object,
-    RSP: Object,
-    RDP: Object,
-    CP: $Diff<$Diff<ElementConfig<Com>, RSP>, RDP>,
-    ST: $Subtype<{[_: $Keys<Com>]: any}>
-    >(
-    mapStateToProps: MapStateToProps<S, SP, RSP>,
-    mapDispatchToProps: MapDispatchToProps<A, DP, RDP>
-  ): (component: Com) => ComponentType<CP & SP & DP> & $Shape<ST>;
-
-  declare export function connect<
-    Com: ComponentType<*>,
-    A,
-    OP: Object,
-    DP: Object,
-    PR: Object,
-    CP: $Diff<ElementConfig<Com>, DP>,
-    ST: $Subtype<{[_: $Keys<Com>]: any}>
-    >(
-    mapStateToProps?: null,
-    mapDispatchToProps: MapDispatchToProps<A, OP, DP>
-  ): (Com) => ComponentType<CP & OP>;
-
-  declare export function connect<
-    Com: ComponentType<*>,
-    MDP: Object,
-    ST: $Subtype<{[_: $Keys<Com>]: any}>
-    >(
-    mapStateToProps?: null,
-    mapDispatchToProps: MDP
-  ): (component: Com) => ComponentType<$Diff<ElementConfig<Com>, MDP>> & $Shape<ST>;
-
-  declare export function connect<
-    Com: ComponentType<*>,
-    S: Object,
-    SP: Object,
-    RSP: Object,
-    MDP: Object,
-    CP: $Diff<ElementConfig<Com>, RSP>,
-    ST: $Subtype<{[_: $Keys<Com>]: any}>
-    >(
-    mapStateToProps: MapStateToProps<S, SP, RSP>,
-    mapDispatchToProps: MDP
-  ): (component: Com) => ComponentType<$Diff<CP, MDP> & SP> & $Shape<ST>;
-
-  declare export function connect<
-    Com: ComponentType<*>,
-    A,
-    S: Object,
-    DP: Object,
-    SP: Object,
-    RSP: Object,
-    RDP: Object,
-    MP: Object,
-    RMP: Object,
-    CP: $Diff<ElementConfig<Com>, RMP>,
-    ST: $Subtype<{[_: $Keys<Com>]: any}>
-    >(
-    mapStateToProps: MapStateToProps<S, SP, RSP>,
-    mapDispatchToProps: ?MapDispatchToProps<A, DP, RDP>,
-    mergeProps: MergeProps<RSP, RDP, MP, RMP>
-  ): (component: Com) => ComponentType<CP & SP & DP & MP> & $Shape<ST>;
-
-  declare export function connect<
-    Com: ComponentType<*>,
-    A,
-    S: Object,
-    DP: Object,
-    SP: Object,
-    RSP: Object,
-    RDP: Object,
-    MDP: Object,
-    MP: Object,
-    RMP: Object,
-    CP: $Diff<ElementConfig<Com>, RMP>,
-    ST: $Subtype<{[_: $Keys<Com>]: any}>
-    >(
-    mapStateToProps: MapStateToProps<S, SP, RSP>,
-    mapDispatchToProps: MDP,
-    mergeProps: MergeProps<RSP, RDP, MP, RMP>
-  ): (component: Com) => ComponentType<CP & SP & DP & MP> & $Shape<ST>;
-
-  declare export function connect<Com: ComponentType<*>,
-    A,
-    S: Object,
-    DP: Object,
-    SP: Object,
-    RSP: Object,
-    RDP: Object,
-    MP: Object,
-    RMP: Object,
-    ST: $Subtype<{[_: $Keys<Com>]: any}>
-    >(
-    mapStateToProps: ?MapStateToProps<S, SP, RSP>,
-    mapDispatchToProps: ?MapDispatchToProps<A, DP, RDP>,
-    mergeProps: ?MergeProps<RSP, RDP, MP, RMP>,
-    options: ConnectOptions<S, SP & DP & MP, RSP, RMP>
-  ): (component: Com) => ComponentType<$Diff<ElementConfig<Com>, RMP> & SP & DP & MP> & $Shape<ST>;
-
-  declare export function connect<Com: ComponentType<*>,
-    A,
-    S: Object,
-    DP: Object,
-    SP: Object,
-    RSP: Object,
-    RDP: Object,
-    MDP: Object,
-    MP: Object,
-    RMP: Object,
-    ST: $Subtype<{[_: $Keys<Com>]: any}>
-    >(
-    mapStateToProps: ?MapStateToProps<S, SP, RSP>,
-    mapDispatchToProps: ?MapDispatchToProps<A, DP, RDP>,
-    mergeProps: MDP,
-    options: ConnectOptions<S, SP & DP & MP, RSP, RMP>
-  ): (component: Com) => ComponentType<$Diff<ElementConfig<Com>, RMP> & SP & DP & MP> & $Shape<ST>;
+  ): (component: Com) => React$ComponentType<OP> & $Shape<ST>;
 
   declare export default {
     Provider: typeof Provider,

--- a/src/account-info/AccountDetails.js
+++ b/src/account-info/AccountDetails.js
@@ -1,9 +1,9 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
 import { View, StyleSheet } from 'react-native';
-import { connect } from 'react-redux';
 
 import type { GlobalState, User, Dispatch } from '../types';
+import { connect } from '../react-redux';
 import { UserAvatar, ComponentList, RawLabel } from '../common';
 import { getCurrentRealm, getUserStatusTextForUser } from '../selectors';
 import PresenceStatusIndicator from '../common/PresenceStatusIndicator';

--- a/src/account-info/AccountDetailsScreen.js
+++ b/src/account-info/AccountDetailsScreen.js
@@ -3,7 +3,7 @@ import React, { PureComponent } from 'react';
 import { StyleSheet } from 'react-native';
 
 import type { Dispatch, GlobalState, User } from '../types';
-import { connect } from '../react-redux';
+import { connectFlowFixMe } from '../react-redux';
 import { getAccountDetailsUserFromEmail } from '../selectors';
 import { Screen, ZulipButton } from '../common';
 import { IconPrivateChat } from '../common/Icons';
@@ -52,6 +52,6 @@ class AccountDetailsScreen extends PureComponent<Props> {
   }
 }
 
-export default connect((state: GlobalState, props) => ({
+export default connectFlowFixMe((state: GlobalState, props) => ({
   user: getAccountDetailsUserFromEmail(state, props.navigation.state.params.email),
 }))(AccountDetailsScreen);

--- a/src/account-info/AccountDetailsScreen.js
+++ b/src/account-info/AccountDetailsScreen.js
@@ -1,9 +1,9 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
 import { StyleSheet } from 'react-native';
-import { connect } from 'react-redux';
 
 import type { Dispatch, GlobalState, User } from '../types';
+import { connect } from '../react-redux';
 import { getAccountDetailsUserFromEmail } from '../selectors';
 import { Screen, ZulipButton } from '../common';
 import { IconPrivateChat } from '../common/Icons';

--- a/src/account-info/AwayStatusSwitch.js
+++ b/src/account-info/AwayStatusSwitch.js
@@ -1,8 +1,8 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
-import { connect } from 'react-redux';
 
 import type { Dispatch, GlobalState } from '../types';
+import { connect } from '../react-redux';
 import { OptionRow } from '../common';
 import { getSelfUserAwayStatus } from '../selectors';
 import { updateUserAwayStatus } from '../user-status/userStatusActions';

--- a/src/account-info/ProfileCard.js
+++ b/src/account-info/ProfileCard.js
@@ -1,9 +1,9 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
 import { ScrollView, StyleSheet, View } from 'react-native';
-import { connect } from 'react-redux';
 
 import type { Dispatch, GlobalState, User } from '../types';
+import { connect } from '../react-redux';
 import { getSelfUserDetail } from '../selectors';
 import { ZulipButton } from '../common';
 import {

--- a/src/account/AccountPickScreen.js
+++ b/src/account/AccountPickScreen.js
@@ -1,10 +1,10 @@
 /* @flow strict-local */
-import { connect } from 'react-redux';
 
 import React, { PureComponent } from 'react';
 import { StyleSheet } from 'react-native';
 
 import type { Dispatch, GlobalState } from '../types';
+import { connect } from '../react-redux';
 import { hasAuth, getAccountStatuses } from '../selectors';
 import type { AccountStatus } from './accountsSelectors';
 import { Centerer, ZulipButton, Logo, Screen } from '../common';

--- a/src/autocomplete/EmojiAutocomplete.js
+++ b/src/autocomplete/EmojiAutocomplete.js
@@ -1,5 +1,4 @@
 /* @flow strict-local */
-import { connect } from 'react-redux';
 
 import React, { PureComponent } from 'react';
 import { FlatList } from 'react-native';
@@ -8,6 +7,7 @@ import { Popup } from '../common';
 import EmojiRow from '../emoji/EmojiRow';
 import { getFilteredEmojiNames } from '../emoji/data';
 import type { GlobalState, RealmEmojiById, Dispatch } from '../types';
+import { connect } from '../react-redux';
 import { getActiveImageEmojiByName } from '../selectors';
 
 type Props = {|

--- a/src/autocomplete/PeopleAutocomplete.js
+++ b/src/autocomplete/PeopleAutocomplete.js
@@ -1,10 +1,10 @@
 /* @flow strict-local */
-import { connect } from 'react-redux';
 
 import React, { PureComponent } from 'react';
 import { SectionList } from 'react-native';
 
 import type { User, UserGroup, GlobalState, Dispatch } from '../types';
+import { connect } from '../react-redux';
 import { getOwnEmail, getSortedUsers, getUserGroups } from '../selectors';
 import {
   getAutocompleteSuggestion,

--- a/src/autocomplete/StreamAutocomplete.js
+++ b/src/autocomplete/StreamAutocomplete.js
@@ -1,10 +1,10 @@
 /* @flow strict-local */
-import { connect } from 'react-redux';
 
 import React, { PureComponent } from 'react';
 import { FlatList } from 'react-native';
 
 import type { GlobalState, SubscriptionsState, Dispatch } from '../types';
+import { connect } from '../react-redux';
 import { Popup } from '../common';
 import { getSubscribedStreams } from '../subscriptions/subscriptionSelectors';
 import StreamItem from '../streams/StreamItem';

--- a/src/autocomplete/TopicAutocomplete.js
+++ b/src/autocomplete/TopicAutocomplete.js
@@ -1,10 +1,10 @@
 /* @flow strict-local */
-import { connect } from 'react-redux';
 
 import React, { PureComponent } from 'react';
 import { FlatList, StyleSheet } from 'react-native';
 
 import type { GlobalState, Dispatch } from '../types';
+import { connect } from '../react-redux';
 import { getTopicsForNarrow } from '../selectors';
 import { Popup, RawLabel, Touchable } from '../common';
 import AnimatedScaleComponent from '../animation/AnimatedScaleComponent';

--- a/src/autocomplete/TopicAutocomplete.js
+++ b/src/autocomplete/TopicAutocomplete.js
@@ -4,7 +4,7 @@ import React, { PureComponent } from 'react';
 import { FlatList, StyleSheet } from 'react-native';
 
 import type { GlobalState, Dispatch } from '../types';
-import { connect } from '../react-redux';
+import { connectFlowFixMe } from '../react-redux';
 import { getTopicsForNarrow } from '../selectors';
 import { Popup, RawLabel, Touchable } from '../common';
 import AnimatedScaleComponent from '../animation/AnimatedScaleComponent';
@@ -55,6 +55,6 @@ class TopicAutocomplete extends PureComponent<Props> {
   }
 }
 
-export default connect((state: GlobalState, props) => ({
+export default connectFlowFixMe((state: GlobalState, props) => ({
   topics: getTopicsForNarrow(props.narrow)(state),
 }))(TopicAutocomplete);

--- a/src/boot/AppDataFetcher.js
+++ b/src/boot/AppDataFetcher.js
@@ -1,10 +1,10 @@
 /* @flow strict-local */
-import { connect } from 'react-redux';
 
 import { PureComponent } from 'react';
 
 import type { Node as React$Node } from 'react';
 import type { Dispatch, GlobalState } from '../types';
+import { connect } from '../react-redux';
 import { getSession } from '../directSelectors';
 import { doInitialFetch } from '../actions';
 

--- a/src/boot/AppEventHandlers.js
+++ b/src/boot/AppEventHandlers.js
@@ -1,5 +1,4 @@
 /* @flow strict-local */
-import { connect } from 'react-redux';
 
 import React, { PureComponent } from 'react';
 import { AppState, NetInfo, View, StyleSheet, Platform, NativeModules } from 'react-native';
@@ -8,6 +7,7 @@ import Orientation from 'react-native-orientation';
 
 import type { Node as React$Node } from 'react';
 import type { Dispatch, GlobalState, Orientation as OrientationT } from '../types';
+import { connect } from '../react-redux';
 import { getUnreadByHuddlesMentionsAndPMs } from '../selectors';
 import { handleInitialNotification, NotificationListener } from '../notification';
 import {

--- a/src/boot/StylesProvider.js
+++ b/src/boot/StylesProvider.js
@@ -1,10 +1,10 @@
 /* @flow strict-local */
-import { connect } from 'react-redux';
 
 import React, { PureComponent } from 'react';
 
 import type { Node as React$Node } from 'react';
 import type { GlobalState, ThemeName, Dispatch } from '../types';
+import { connect } from '../react-redux';
 import { getSettings } from '../directSelectors';
 import { stylesFromTheme, themeColors, ThemeContext } from '../styles/theme';
 

--- a/src/boot/TranslationProvider.js
+++ b/src/boot/TranslationProvider.js
@@ -1,5 +1,4 @@
 /* @flow strict-local */
-import { connect } from 'react-redux';
 import React, { PureComponent } from 'react';
 import type { ComponentType, ElementConfig, Node as React$Node } from 'react';
 import { Text } from 'react-native';
@@ -7,6 +6,7 @@ import { IntlProvider } from 'react-intl';
 import type { IntlShape } from 'react-intl';
 
 import type { GetText, GlobalState, Dispatch } from '../types';
+import { connect } from '../react-redux';
 import { getSettings } from '../selectors';
 import '../../vendor/intl/intl';
 import messages from '../i18n/messages';

--- a/src/chat/Chat.js
+++ b/src/chat/Chat.js
@@ -1,9 +1,9 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
 import { View, StyleSheet } from 'react-native';
-import { connect } from 'react-redux';
 
 import type { GlobalState, Narrow, Dispatch } from '../types';
+import { connect } from '../react-redux';
 import { KeyboardAvoider } from '../common';
 import MessageList from '../webview/MessageList';
 import NoMessages from '../message/NoMessages';

--- a/src/chat/GroupDetailsScreen.js
+++ b/src/chat/GroupDetailsScreen.js
@@ -1,10 +1,10 @@
 /* @flow strict-local */
-import { connect } from 'react-redux';
 import React, { PureComponent } from 'react';
 import { FlatList } from 'react-native';
 import type { NavigationScreenProp } from 'react-navigation';
 
 import type { Dispatch, UserOrBot } from '../types';
+import { connect } from '../react-redux';
 import { Screen } from '../common';
 import UserItem from '../users/UserItem';
 import { navigateToAccountDetails } from '../actions';

--- a/src/chat/MarkUnreadButton.js
+++ b/src/chat/MarkUnreadButton.js
@@ -1,10 +1,10 @@
 /* @flow strict-local */
-import { connect } from 'react-redux';
 
 import React, { PureComponent } from 'react';
 import { StyleSheet } from 'react-native';
 
 import type { Auth, GlobalState, Narrow, Stream, Dispatch } from '../types';
+import { connect } from '../react-redux';
 import { ZulipButton } from '../common';
 import { markAllAsRead, markStreamAsRead, markTopicAsRead } from '../api';
 import { getAuth, getStreams } from '../selectors';

--- a/src/chat/UnreadNotice.js
+++ b/src/chat/UnreadNotice.js
@@ -30,11 +30,16 @@ const styles = StyleSheet.create({
   },
 });
 
+type SelectorProps = {|
+  unreadCount: number,
+|};
+
 type Props = {|
-  dispatch: Dispatch,
   limited: boolean,
   narrow: Narrow,
-  unreadCount: number,
+
+  dispatch: Dispatch,
+  ...SelectorProps,
 |};
 
 class UnreadNotice extends PureComponent<Props> {
@@ -65,6 +70,6 @@ class UnreadNotice extends PureComponent<Props> {
   }
 }
 
-export default connect((state, props) => ({
+export default connect((state, props): SelectorProps => ({
   unreadCount: getUnreadCountForNarrow(state, props.narrow),
 }))(UnreadNotice);

--- a/src/chat/UnreadNotice.js
+++ b/src/chat/UnreadNotice.js
@@ -1,10 +1,10 @@
 /* @flow strict-local */
-import { connect } from 'react-redux';
 
 import React, { PureComponent } from 'react';
 import { StyleSheet, View } from 'react-native';
 
 import type { Narrow, Dispatch } from '../types';
+import { connect } from '../react-redux';
 import { getUnreadCountForNarrow } from '../selectors';
 import { Label, RawLabel } from '../common';
 import { unreadToLimitedCount } from '../utils/unread';

--- a/src/common/OfflineNotice.js
+++ b/src/common/OfflineNotice.js
@@ -1,10 +1,10 @@
 /* @flow strict-local */
-import { connect } from 'react-redux';
 
 import React, { PureComponent } from 'react';
 import { StyleSheet } from 'react-native';
 
 import type { GlobalState, Dispatch } from '../types';
+import { connect } from '../react-redux';
 import { getSession } from '../selectors';
 import Label from './Label';
 

--- a/src/common/OwnAvatar.js
+++ b/src/common/OwnAvatar.js
@@ -1,8 +1,8 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
-import { connect } from 'react-redux';
 
 import type { GlobalState, User, Dispatch } from '../types';
+import { connect } from '../react-redux';
 import { getCurrentRealm, getSelfUserDetail } from '../selectors';
 import UserAvatar from './UserAvatar';
 import { getAvatarFromUser } from '../utils/avatar';

--- a/src/common/PresenceStatusIndicator.js
+++ b/src/common/PresenceStatusIndicator.js
@@ -2,7 +2,6 @@
 /* eslint-disable react-native/no-unused-styles */
 import React, { PureComponent } from 'react';
 import { StyleSheet, View } from 'react-native';
-import { connect } from 'react-redux';
 
 import type {
   GlobalState,
@@ -12,6 +11,7 @@ import type {
   UserStatusMapObject,
   Dispatch,
 } from '../types';
+import { connect } from '../react-redux';
 import { statusFromPresenceAndUserStatus } from '../utils/presence';
 import { getPresence, getUserStatus } from '../selectors';
 import { getUsersByEmail } from '../users/userSelectors';

--- a/src/common/Screen.js
+++ b/src/common/Screen.js
@@ -1,11 +1,11 @@
 /* @flow strict-local */
-import { connect } from 'react-redux';
 
 import React, { PureComponent } from 'react';
 import type { Node as React$Node } from 'react';
 import { StyleSheet, View, ScrollView } from 'react-native';
 
 import type { Context, Dimensions, GlobalState, LocalizableText, Style, Dispatch } from '../types';
+import { connect } from '../react-redux';
 import KeyboardAvoider from './KeyboardAvoider';
 import OfflineNotice from './OfflineNotice';
 import ZulipStatusBar from './ZulipStatusBar';

--- a/src/common/UserAvatarWithPresence.js
+++ b/src/common/UserAvatarWithPresence.js
@@ -1,10 +1,10 @@
 /* @flow strict-local */
-import { connect } from 'react-redux';
 
 import React, { PureComponent } from 'react';
 import { StyleSheet } from 'react-native';
 
 import type { GlobalState, Dispatch } from '../types';
+import { connect } from '../react-redux';
 import { getCurrentRealm } from '../selectors';
 import UserAvatar from './UserAvatar';
 import { getAvatarUrl } from '../utils/avatar';

--- a/src/common/WebLink.js
+++ b/src/common/WebLink.js
@@ -1,10 +1,10 @@
 /* @flow strict-local */
-import { connect } from 'react-redux';
 
 import React, { PureComponent } from 'react';
 import { StyleSheet } from 'react-native';
 
 import type { GlobalState, Dispatch } from '../types';
+import { connect } from '../react-redux';
 import Label from './Label';
 import { getFullUrl } from '../utils/url';
 import openLink from '../utils/openLink';

--- a/src/common/ZulipStatusBar.js
+++ b/src/common/ZulipStatusBar.js
@@ -1,11 +1,11 @@
 /* @flow strict-local */
-import { connect } from 'react-redux';
 
 import React, { PureComponent } from 'react';
 import { Platform, StatusBar, View } from 'react-native';
 import Color from 'color';
 
 import type { Dimensions, GlobalState, Narrow, Orientation, ThemeName, Dispatch } from '../types';
+import { connect } from '../react-redux';
 import { DEFAULT_TITLE_BACKGROUND_COLOR, getTitleBackgroundColor } from '../title/titleSelectors';
 import { foregroundColorFromBackground } from '../utils/color';
 import { getSession, getSettings } from '../selectors';

--- a/src/common/ZulipStatusBar.js
+++ b/src/common/ZulipStatusBar.js
@@ -5,7 +5,7 @@ import { Platform, StatusBar, View } from 'react-native';
 import Color from 'color';
 
 import type { Dimensions, GlobalState, Narrow, Orientation, ThemeName, Dispatch } from '../types';
-import { connect } from '../react-redux';
+import { connectFlowFixMe } from '../react-redux';
 import { DEFAULT_TITLE_BACKGROUND_COLOR, getTitleBackgroundColor } from '../title/titleSelectors';
 import { foregroundColorFromBackground } from '../utils/color';
 import { getSession, getSettings } from '../selectors';
@@ -66,7 +66,7 @@ class ZulipStatusBar extends PureComponent<Props> {
   }
 }
 
-export default connect(
+export default connectFlowFixMe(
   (state: GlobalState, props: { backgroundColor?: string, narrow?: Narrow }) => ({
     safeAreaInsets: getSession(state).safeAreaInsets,
     theme: getSettings(state).theme,

--- a/src/compose/ComposeBox.js
+++ b/src/compose/ComposeBox.js
@@ -1,7 +1,6 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
 import { Platform, View, TextInput, findNodeHandle } from 'react-native';
-import { connect } from 'react-redux';
 import TextInputReset from 'react-native-text-input-reset';
 
 import type {
@@ -15,6 +14,7 @@ import type {
   Dimensions,
   GlobalState,
 } from '../types';
+import { connect } from '../react-redux';
 import {
   addToOutbox,
   cancelEditMessage,

--- a/src/compose/ComposeBox.js
+++ b/src/compose/ComposeBox.js
@@ -12,7 +12,6 @@ import type {
   UserOrBot,
   Dispatch,
   Dimensions,
-  GlobalState,
 } from '../types';
 import { connect } from '../react-redux';
 import {
@@ -47,18 +46,22 @@ import { getDraftForNarrow } from '../drafts/draftsSelectors';
 import TopicAutocomplete from '../autocomplete/TopicAutocomplete';
 import AutocompleteView from '../autocomplete/AutocompleteView';
 
-type Props = {|
+type SelectorProps = {|
   auth: Auth,
-  narrow: Narrow,
   usersByEmail: Map<string, UserOrBot>,
-  draft: string,
-  lastMessageTopic: string,
+  safeAreaInsets: Dimensions,
   isAdmin: boolean,
   isAnnouncementOnly: boolean,
   isSubscribed: boolean,
   editMessage: ?EditMessage,
-  safeAreaInsets: Dimensions,
+  draft: string,
+  lastMessageTopic: string,
+|};
+
+type Props = {|
+  narrow: Narrow,
   dispatch: Dispatch,
+  ...SelectorProps,
 |};
 
 type State = {|
@@ -402,7 +405,7 @@ class ComposeBox extends PureComponent<Props, State> {
   }
 }
 
-export default connect((state: GlobalState, props) => ({
+export default connect((state, props): SelectorProps => ({
   auth: getAuth(state),
   usersByEmail: getActiveUsersByEmail(state),
   safeAreaInsets: getSession(state).safeAreaInsets,

--- a/src/compose/ComposeMenu.js
+++ b/src/compose/ComposeMenu.js
@@ -3,9 +3,9 @@ import React, { PureComponent } from 'react';
 import { View } from 'react-native';
 // $FlowFixMe
 import ImagePicker from 'react-native-image-picker';
-import { connect } from 'react-redux';
 
 import type { Dispatch, Narrow } from '../types';
+import { connect } from '../react-redux';
 import { showErrorAlert } from '../utils/info';
 import styles from '../styles';
 import { IconPlus, IconLeft, IconPeople, IconImage, IconCamera } from '../common/Icons';

--- a/src/diagnostics/DiagnosticsScreen.js
+++ b/src/diagnostics/DiagnosticsScreen.js
@@ -1,11 +1,11 @@
 /* @flow strict-local */
-import { connect } from 'react-redux';
 
 import React, { PureComponent } from 'react';
 import { StyleSheet } from 'react-native';
 
 import DeviceInfo from 'react-native-device-info';
 import type { Dispatch } from '../types';
+import { connect } from '../react-redux';
 import { OptionButton, OptionDivider, Screen, RawLabel } from '../common';
 import {
   navigateToDebug,

--- a/src/diagnostics/StorageScreen.js
+++ b/src/diagnostics/StorageScreen.js
@@ -1,10 +1,10 @@
 /* @flow strict-local */
-import { connect } from 'react-redux';
 
 import React, { PureComponent } from 'react';
 import { FlatList } from 'react-native';
 
 import type { GlobalState, Dispatch } from '../types';
+import { connect } from '../react-redux';
 import { Screen } from '../common';
 import SizeItem from './SizeItem';
 

--- a/src/emoji/EmojiPickerScreen.js
+++ b/src/emoji/EmojiPickerScreen.js
@@ -1,5 +1,4 @@
 /* @flow strict-local */
-import { connect } from 'react-redux';
 
 import React, { PureComponent } from 'react';
 import { FlatList } from 'react-native';
@@ -11,6 +10,7 @@ import { Screen } from '../common';
 import EmojiRow from './EmojiRow';
 import { getFilteredEmojiNames } from './data';
 import type { GlobalState, RealmEmojiById, Auth, Dispatch, ReactionType } from '../types';
+import { connect } from '../react-redux';
 import { getAuth, getActiveImageEmojiByName } from '../selectors';
 import { navigateBack } from '../nav/navActions';
 import zulipExtraEmojiMap from './zulipExtraEmojiMap';

--- a/src/emoji/EmojiRow.js
+++ b/src/emoji/EmojiRow.js
@@ -1,9 +1,9 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
-import { connect } from 'react-redux';
 import { StyleSheet, View } from 'react-native';
 
 import type { GlobalState, ImageEmojiType, Dispatch } from '../types';
+import { connect } from '../react-redux';
 import { RawLabel, Touchable } from '../common';
 import Emoji from './Emoji';
 import ImageEmoji from './ImageEmoji';

--- a/src/lightbox/Lightbox.js
+++ b/src/lightbox/Lightbox.js
@@ -1,5 +1,4 @@
 /* @flow strict-local */
-import { connect } from 'react-redux';
 
 import React, { PureComponent } from 'react';
 import { View, StyleSheet, Dimensions, Easing } from 'react-native';
@@ -7,6 +6,7 @@ import PhotoView from 'react-native-photo-view';
 import { connectActionSheet } from '@expo/react-native-action-sheet';
 
 import type { Auth, Dispatch, GlobalState, Message } from '../types';
+import { connect } from '../react-redux';
 import type { ShowActionSheetWithOptions } from '../message/messageActionSheet';
 import { getAuth } from '../selectors';
 import { getResource } from '../utils/url';

--- a/src/main/HomeTab.js
+++ b/src/main/HomeTab.js
@@ -1,10 +1,10 @@
 /* @flow strict-local */
-import { connect } from 'react-redux';
 
 import React, { PureComponent } from 'react';
 import { StyleSheet, View } from 'react-native';
 
 import type { Dispatch } from '../types';
+import { connect } from '../react-redux';
 import { HOME_NARROW, MENTIONED_NARROW, STARRED_NARROW } from '../utils/narrow';
 import NavButton from '../nav/NavButton';
 import UnreadCards from '../unread/UnreadCards';

--- a/src/message/NoMessages.js
+++ b/src/message/NoMessages.js
@@ -1,10 +1,10 @@
 /* @flow strict-local */
-import { connect } from 'react-redux';
 
 import React, { PureComponent } from 'react';
 import { StyleSheet, View } from 'react-native';
 
 import type { Narrow, Dispatch } from '../types';
+import { connect } from '../react-redux';
 import { getIfNoMessages, getShowMessagePlaceholders } from '../selectors';
 import { Label } from '../common';
 

--- a/src/message/NotSubscribed.js
+++ b/src/message/NotSubscribed.js
@@ -1,10 +1,10 @@
 /* @flow strict-local */
-import { connect } from 'react-redux';
 
 import React, { PureComponent } from 'react';
 import { View } from 'react-native';
 
 import type { Auth, Stream, Dispatch } from '../types';
+import { connect } from '../react-redux';
 import { subscriptionAdd } from '../api';
 import { ZulipButton, Label } from '../common';
 import { getAuth, getStreamInNarrow } from '../selectors';

--- a/src/message/NotSubscribed.js
+++ b/src/message/NotSubscribed.js
@@ -4,7 +4,7 @@ import React, { PureComponent } from 'react';
 import { View } from 'react-native';
 
 import type { Auth, Stream, Dispatch } from '../types';
-import { connect } from '../react-redux';
+import { connectFlowFixMe } from '../react-redux';
 import { subscriptionAdd } from '../api';
 import { ZulipButton, Label } from '../common';
 import { getAuth, getStreamInNarrow } from '../selectors';
@@ -40,7 +40,7 @@ class NotSubscribed extends PureComponent<Props> {
   }
 }
 
-export default connect((state, props) => ({
+export default connectFlowFixMe((state, props) => ({
   auth: getAuth(state),
   stream: getStreamInNarrow(props.narrow)(state),
 }))(NotSubscribed);

--- a/src/nav/AppNavigator.js
+++ b/src/nav/AppNavigator.js
@@ -36,12 +36,12 @@ import LegalScreen from '../settings/LegalScreen';
 import UserStatusScreen from '../user-status/UserStatusScreen';
 
 export default StackNavigator(
+  // $FlowFixMe react-navigation types :-/ -- see a36814e80
   {
     account: { screen: AccountPickScreen },
     'account-details': { screen: AccountDetailsScreen },
     'group-details': { screen: GroupDetailsScreen },
     auth: { screen: AuthScreen },
-    // $FlowFixMe react-navigation types :-/
     chat: { screen: ChatScreen },
     dev: { screen: DevAuthScreen },
     'emoji-picker': { screen: EmojiPickerScreen },
@@ -54,7 +54,6 @@ export default StackNavigator(
     users: { screen: UsersScreen },
     settings: { screen: SettingsScreen },
     language: { screen: LanguageScreen },
-    // $FlowFixMe react-navigation types :-/
     lightbox: { screen: LightboxScreen },
     group: { screen: CreateGroupScreen },
     'invite-users': { screen: InviteUsersScreen },

--- a/src/nav/AppWithNavigation.js
+++ b/src/nav/AppWithNavigation.js
@@ -1,11 +1,11 @@
 /* @flow strict-local */
-import { connect } from 'react-redux';
 
 import React, { PureComponent } from 'react';
 import { addNavigationHelpers } from 'react-navigation';
 import { createReduxBoundAddListener } from 'react-navigation-redux-helpers';
 
 import type { Dispatch, GlobalState, NavigationState, PlainDispatch } from '../types';
+import { connect } from '../react-redux';
 import { getNav } from '../selectors';
 import AppNavigator from './AppNavigator';
 

--- a/src/nav/BackNavigationHandler.js
+++ b/src/nav/BackNavigationHandler.js
@@ -1,11 +1,11 @@
 /* @flow strict-local */
 import type { Node as React$Node } from 'react';
-import { connect } from 'react-redux';
 
 import { PureComponent } from 'react';
 import { BackHandler } from 'react-native';
 
 import type { Dispatch } from '../types';
+import { connect } from '../react-redux';
 import { getCanGoBack } from '../selectors';
 import { navigateBack } from '../actions';
 

--- a/src/nav/ChatNavBar.js
+++ b/src/nav/ChatNavBar.js
@@ -1,10 +1,10 @@
 /* @flow strict-local */
-import { connect } from 'react-redux';
 
 import React, { PureComponent } from 'react';
 import { View } from 'react-native';
 
 import type { Dispatch, GlobalState, Narrow } from '../types';
+import { connect } from '../react-redux';
 import styles, { BRAND_COLOR } from '../styles';
 import Title from '../title/Title';
 import NavButton from './NavButton';

--- a/src/nav/ChatNavBar.js
+++ b/src/nav/ChatNavBar.js
@@ -3,7 +3,7 @@
 import React, { PureComponent } from 'react';
 import { View } from 'react-native';
 
-import type { Dispatch, GlobalState, Narrow } from '../types';
+import type { Dispatch, Narrow } from '../types';
 import { connect } from '../react-redux';
 import styles, { BRAND_COLOR } from '../styles';
 import Title from '../title/Title';
@@ -13,10 +13,15 @@ import { foregroundColorFromBackground } from '../utils/color';
 import { navigateBack } from '../actions';
 import { ExtraButton, InfoButton } from '../title-buttons/titleButtonFromNarrow';
 
-type Props = {|
-  dispatch: Dispatch,
+type SelectorProps = {|
   backgroundColor: string,
+|};
+
+type Props = {|
   narrow: Narrow,
+
+  dispatch: Dispatch,
+  ...SelectorProps,
 |};
 
 class ChatNavBar extends PureComponent<Props> {
@@ -44,6 +49,6 @@ class ChatNavBar extends PureComponent<Props> {
   }
 }
 
-export default connect((state: GlobalState, props) => ({
+export default connect((state, props): SelectorProps => ({
   backgroundColor: getTitleBackgroundColor(props.narrow)(state),
 }))(ChatNavBar);

--- a/src/nav/IconUnreadConversations.js
+++ b/src/nav/IconUnreadConversations.js
@@ -1,10 +1,10 @@
 /* @flow strict-local */
-import { connect } from 'react-redux';
 
 import React, { PureComponent } from 'react';
 import { StyleSheet } from 'react-native';
 
 import type { GlobalState, Dispatch } from '../types';
+import { connect } from '../react-redux';
 import { getUnreadPmsTotal, getUnreadHuddlesTotal } from '../selectors';
 import { IconPeople } from '../common/Icons';
 import { ComponentWithOverlay, UnreadCount } from '../common';

--- a/src/nav/ModalNavBar.js
+++ b/src/nav/ModalNavBar.js
@@ -1,10 +1,10 @@
 /* @flow strict-local */
-import { connect } from 'react-redux';
 
 import React, { PureComponent } from 'react';
 import { View } from 'react-native';
 
 import type { Dispatch, Context, LocalizableText } from '../types';
+import { connect } from '../react-redux';
 import styles, { NAVBAR_SIZE } from '../styles';
 import Label from '../common/Label';
 import NavButton from './NavButton';

--- a/src/nav/ModalSearchNavBar.js
+++ b/src/nav/ModalSearchNavBar.js
@@ -1,9 +1,9 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
 import { View } from 'react-native';
-import { connect } from 'react-redux';
 
 import type { Dispatch, Context } from '../types';
+import { connect } from '../react-redux';
 import SearchInput from '../common/SearchInput';
 import NavButton from './NavButton';
 import { navigateBack } from '../actions';

--- a/src/pm-conversations/PmConversationsCard.js
+++ b/src/pm-conversations/PmConversationsCard.js
@@ -1,10 +1,10 @@
 /* @flow strict-local */
-import { connect } from 'react-redux';
 
 import React, { PureComponent } from 'react';
 import { View, StyleSheet } from 'react-native';
 
 import type { Context, Dispatch, GlobalState, PmConversationData, UserOrBot } from '../types';
+import { connect } from '../react-redux';
 import { Label, LoadingIndicator, ZulipButton } from '../common';
 import { IconPeople, IconSearch } from '../common/Icons';
 import PmConversationList from './PmConversationList';

--- a/src/react-redux.js
+++ b/src/react-redux.js
@@ -14,3 +14,19 @@ export const connect: <
 >(
   mapStateToProps?: (GlobalState, SP) => RSP,
 ) => C => ComponentType<CP & SP> = mapStateToProps => connectInner(mapStateToProps);
+
+/**
+ * DEPRECATED.  Don't add new uses; and PRs to remove existing uses are welcome.
+ *
+ * This is exactly like `connect` except with type-checking disabled.
+ * Any place we use it, it's because there's a type error there.
+ * To fix: change the call site to use `connect`; see what error Flow
+ * reports; and fix the error.
+ *
+ * (Backstory: for a long time `connect` had a type that partly defeated
+ * type-checking, so we accumulated a number of type errors that that hid.
+ * This untyped version lets us fix those errors one by one, while using the
+ * new, well-typed `connect` everywhere else.)
+ */
+export const connectFlowFixMe = (mapStateToProps: $FlowFixMe) => (c: $FlowFixMe) =>
+  connect(mapStateToProps)(c);

--- a/src/react-redux.js
+++ b/src/react-redux.js
@@ -1,0 +1,16 @@
+/* @flow strict-local */
+import type { ComponentType, ElementConfig } from 'react';
+import { connect as connectInner } from 'react-redux';
+
+import type { GlobalState } from './types';
+
+export const connect: <
+  C: ComponentType<*>,
+  // S == GlobalState
+  SP: {},
+  RSP: {},
+  CP: $Diff<$Diff<ElementConfig<C>, { dispatch: mixed }>, RSP>,
+  // ST ignore
+>(
+  mapStateToProps?: (GlobalState, SP) => RSP,
+) => C => ComponentType<CP & SP> = mapStateToProps => connectInner(mapStateToProps);

--- a/src/react-redux.js
+++ b/src/react-redux.js
@@ -2,18 +2,76 @@
 import type { ComponentType, ElementConfig } from 'react';
 import { connect as connectInner } from 'react-redux';
 
-import type { GlobalState } from './types';
+import type { GlobalState, Dispatch } from './types';
 
-export const connect: <
-  C: ComponentType<*>,
-  // S == GlobalState
-  SP: {},
-  RSP: {},
-  CP: $Diff<$Diff<ElementConfig<C>, { dispatch: mixed }>, RSP>,
-  // ST ignore
->(
-  mapStateToProps?: (GlobalState, SP) => RSP,
-) => C => ComponentType<CP & SP> = mapStateToProps => connectInner(mapStateToProps);
+/* eslint-disable flowtype/generic-spacing */
+
+/**
+ * The type `S`, plus a check that `S` is a supertype of `T`.
+ *
+ * Gives an error unless `S` is a supertype of `T` -- i.e., a `T` can always
+ * be used where an `S` is required.
+ */
+type IsSupertype<+S, +T: S> = S; // eslint-disable-line no-unused-vars
+
+/**
+ * An inverse of the operation `(A, B) => {| ...A, ...B |}`, with checking.
+ *
+ * Similar to `$Diff`, but checks that the subtraction makes sense.
+ * Also always subtracts a given property completely, even if its type on
+ * `L` happens to be more specific than on `U`.
+ *
+ * Assumes both U and L are exact object types.  (If not, behavior unknown.)
+ * Returns a solution, where possible, to the type equation
+ *   `U == {| ...D, ...L |}`
+ * with an (inexact) object type `D`.
+ *
+ * More generally, returns the most general solution `D` to the relation
+ *   `{| ...D, ...L |}: U`  (read "subtype of")
+ * I.e., the most general type `D` such that `{| ...D, ...L |}` can be used
+ * where a `U` is expected.  If there is no such `D`, causes a type error.
+ *
+ * In particular, this means:
+ *  * Error if `L` has any extra properties that aren't in `U`.
+ *  * Error unless each property of `L` has the same type as in `U`, or a subtype
+ *    (i.e., the property's values in `L` are valid for `U`).
+ *  * `D` has exactly the properties in `U` that aren't in `L`.
+ *  * Each property of `D` has the same type as in `U`.
+ */
+// Oddly, Flow accepts this declaration with <-U, -L> but also with <+U, +L>.
+export type BoundedDiff<-U, -L> = $Diff<
+  // This `IsSupertype` is the part that checks that all of L's properties
+  // (a) are present on U and (b) have appropriate types to use on U.
+  IsSupertype<U, $ReadOnly<{| ...U, ...L |}>>,
+  // This `$ObjMap` makes a variant of `L` that `$Diff` treats as more
+  // powerful, ensuring that all properties in `L` are removed completely.
+  $ObjMap<L, () => mixed>,
+>;
+
+export type OwnProps<-C, -SP> = $Diff<
+  BoundedDiff<$Exact<ElementConfig<C>>, SP>,
+  {| dispatch: Dispatch |},
+>;
+
+/**
+ * Exactly like the `connect` in `react-redux` upstream, but more typed.
+ *
+ * The upstream function, and its libdef in `flow-typed`, has an extremely
+ * complex type involving many overloads, and it's difficult to get useful
+ * results with it from the type-checker.  This trivial wrapper leaves out a
+ * bunch of features we don't use, and then gives a more specific type.
+ *
+ * (Most of those features probably *could* be supported with a more-helpful
+ * type like this if desired, just with a moderate amount of further work.
+ * Finding this type was a lot of work, and the extra features were left out
+ * for the sake of focus while iterating on that.)
+ */
+// prettier-ignore
+export function connect<SP, P, C: ComponentType<P>>(
+  mapStateToProps?: (GlobalState, OwnProps<C, SP>) => SP,
+): C => ComponentType<OwnProps<C, SP>> {
+  return connectInner(mapStateToProps);
+}
 
 /**
  * DEPRECATED.  Don't add new uses; and PRs to remove existing uses are welcome.

--- a/src/react-redux.js
+++ b/src/react-redux.js
@@ -68,7 +68,9 @@ export type OwnProps<-C, -SP> = $Diff<
  */
 // prettier-ignore
 export function connect<SP, P, C: ComponentType<P>>(
-  mapStateToProps?: (GlobalState, OwnProps<C, SP>) => SP,
+  mapStateToProps?: (GlobalState, OwnProps<C,
+    // Error "property `foo` is missing"?  Add to inner component's props.
+    SP>) => SP,
 ): C => ComponentType<OwnProps<C, SP>> {
   return connectInner(mapStateToProps);
 }

--- a/src/search/SearchMessagesCard.js
+++ b/src/search/SearchMessagesCard.js
@@ -1,5 +1,4 @@
 /* @flow strict-local */
-import { connect } from 'react-redux';
 
 import React, { PureComponent } from 'react';
 import { StyleSheet, View } from 'react-native';
@@ -7,6 +6,7 @@ import throttle from 'lodash.throttle';
 import { ActionSheetProvider } from '@expo/react-native-action-sheet';
 
 import type { Auth, GlobalState, Message, Dispatch } from '../types';
+import { connect } from '../react-redux';
 import { LoadingIndicator, SearchEmptyState } from '../common';
 import { HOME_NARROW, SEARCH_NARROW } from '../utils/narrow';
 import MessageList from '../webview/MessageList';

--- a/src/settings/DebugScreen.js
+++ b/src/settings/DebugScreen.js
@@ -1,9 +1,9 @@
 /* @flow strict-local */
-import { connect } from 'react-redux';
 
 import React, { PureComponent } from 'react';
 
 import type { Debug, Dispatch, GlobalState } from '../types';
+import { connect } from '../react-redux';
 import { getSession } from '../selectors';
 import { OptionRow, Screen } from '../common';
 import { debugFlagToggle } from '../actions';

--- a/src/settings/LanguageScreen.js
+++ b/src/settings/LanguageScreen.js
@@ -1,9 +1,9 @@
 /* @flow strict-local */
-import { connect } from 'react-redux';
 
 import React, { PureComponent } from 'react';
 
 import type { Dispatch, GlobalState } from '../types';
+import { connect } from '../react-redux';
 import { Screen } from '../common';
 import LanguagePicker from './LanguagePicker';
 import { getSettings } from '../selectors';

--- a/src/settings/LegalScreen.js
+++ b/src/settings/LegalScreen.js
@@ -1,9 +1,9 @@
 /* @flow strict-local */
-import { connect } from 'react-redux';
 
 import React, { PureComponent } from 'react';
 
 import type { Dispatch } from '../types';
+import { connect } from '../react-redux';
 import { Screen, OptionButton } from '../common';
 import openLink from '../utils/openLink';
 import { getFullUrl } from '../utils/url';

--- a/src/settings/NotificationsScreen.js
+++ b/src/settings/NotificationsScreen.js
@@ -1,9 +1,9 @@
 /* @flow strict-local */
-import { connect } from 'react-redux';
 
 import React, { PureComponent } from 'react';
 
 import type { Auth, Dispatch, GlobalState } from '../types';
+import { connect } from '../react-redux';
 import { getAuth, getSettings } from '../selectors';
 import { OptionRow, Screen } from '../common';
 import { toggleMobilePushSettings } from '../api';

--- a/src/settings/SettingsCard.js
+++ b/src/settings/SettingsCard.js
@@ -1,10 +1,10 @@
 /* @flow strict-local */
-import { connect } from 'react-redux';
 
 import React, { PureComponent } from 'react';
 import { StyleSheet, ScrollView } from 'react-native';
 
 import type { Dispatch, GlobalState } from '../types';
+import { connect } from '../react-redux';
 import { getSettings } from '../selectors';
 import { OptionButton, OptionRow } from '../common';
 import {

--- a/src/start/AuthScreen.js
+++ b/src/start/AuthScreen.js
@@ -1,5 +1,4 @@
 /* @flow strict-local */
-import { connect } from 'react-redux';
 
 import React, { PureComponent } from 'react';
 import { Linking } from 'react-native';
@@ -7,6 +6,7 @@ import parseURL from 'url-parse';
 import type { NavigationScreenProp } from 'react-navigation';
 
 import type { Dispatch, GlobalState, ApiResponseServerSettings } from '../types';
+import { connect } from '../react-redux';
 import { Centerer, Screen } from '../common';
 import { getCurrentRealm } from '../selectors';
 import RealmInfo from './RealmInfo';

--- a/src/start/DevAuthScreen.js
+++ b/src/start/DevAuthScreen.js
@@ -1,10 +1,10 @@
 /* @flow strict-local */
-import { connect } from 'react-redux';
 
 import React, { PureComponent } from 'react';
 import { ActivityIndicator, View, StyleSheet, FlatList } from 'react-native';
 
 import type { Auth, DevUser, Dispatch, GlobalState } from '../types';
+import { connect } from '../react-redux';
 import { ErrorMsg, Label, Screen, ZulipButton } from '../common';
 import { devListUsers, devFetchApiKey } from '../api';
 import { getPartialAuth } from '../selectors';

--- a/src/start/PasswordAuthScreen.js
+++ b/src/start/PasswordAuthScreen.js
@@ -1,10 +1,10 @@
 /* @flow strict-local */
-import { connect } from 'react-redux';
 import React, { PureComponent } from 'react';
 import { View, StyleSheet } from 'react-native';
 import type { NavigationScreenProp } from 'react-navigation';
 
 import type { Auth, Dispatch, GlobalState } from '../types';
+import { connect } from '../react-redux';
 import { fetchApiKey } from '../api';
 import {
   ErrorMsg,

--- a/src/start/RealmScreen.js
+++ b/src/start/RealmScreen.js
@@ -4,7 +4,7 @@ import { ScrollView, Keyboard } from 'react-native';
 import type { NavigationScreenProp } from 'react-navigation';
 
 import type { ApiResponseServerSettings, Dispatch } from '../types';
-import { connect } from '../react-redux';
+import { connectFlowFixMe } from '../react-redux';
 import { ErrorMsg, Label, SmartUrlInput, Screen, ZulipButton } from '../common';
 import { isValidUrl } from '../utils/url';
 import { getServerSettings } from '../api';
@@ -95,7 +95,7 @@ class RealmScreen extends PureComponent<Props, State> {
   }
 }
 
-export default connect((state, props) => ({
+export default connectFlowFixMe((state, props) => ({
   initialRealm:
     (props.navigation && props.navigation.state.params && props.navigation.state.params.realm)
     || '',

--- a/src/start/RealmScreen.js
+++ b/src/start/RealmScreen.js
@@ -1,10 +1,10 @@
 /* @flow strict-local */
-import { connect } from 'react-redux';
 import React, { PureComponent } from 'react';
 import { ScrollView, Keyboard } from 'react-native';
 import type { NavigationScreenProp } from 'react-navigation';
 
 import type { ApiResponseServerSettings, Dispatch } from '../types';
+import { connect } from '../react-redux';
 import { ErrorMsg, Label, SmartUrlInput, Screen, ZulipButton } from '../common';
 import { isValidUrl } from '../utils/url';
 import { getServerSettings } from '../api';

--- a/src/start/WelcomeScreen.js
+++ b/src/start/WelcomeScreen.js
@@ -1,9 +1,9 @@
 /* @flow strict-local */
-import { connect } from 'react-redux';
 
 import React, { PureComponent } from 'react';
 
 import type { Dispatch } from '../types';
+import { connect } from '../react-redux';
 import { Screen, ViewPlaceholder, ZulipButton } from '../common';
 import { navigateToRealmScreen, navigateToWelcomeHelp } from '../actions';
 

--- a/src/streams/CreateStreamScreen.js
+++ b/src/streams/CreateStreamScreen.js
@@ -1,8 +1,8 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
-import { connect } from 'react-redux';
 
 import type { Dispatch, GlobalState } from '../types';
+import { connect } from '../react-redux';
 import { createNewStream, navigateBack } from '../actions';
 import { getOwnEmail } from '../selectors';
 import { Screen } from '../common';

--- a/src/streams/EditStreamScreen.js
+++ b/src/streams/EditStreamScreen.js
@@ -1,8 +1,8 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
-import { connect } from 'react-redux';
 
 import type { Dispatch, GlobalState, Stream } from '../types';
+import { connect } from '../react-redux';
 import { updateExistingStream, navigateBack } from '../actions';
 import { getStreamFromId } from '../selectors';
 import { Screen } from '../common';

--- a/src/streams/EditStreamScreen.js
+++ b/src/streams/EditStreamScreen.js
@@ -2,7 +2,7 @@
 import React, { PureComponent } from 'react';
 
 import type { Dispatch, GlobalState, Stream } from '../types';
-import { connect } from '../react-redux';
+import { connectFlowFixMe } from '../react-redux';
 import { updateExistingStream, navigateBack } from '../actions';
 import { getStreamFromId } from '../selectors';
 import { Screen } from '../common';
@@ -36,6 +36,6 @@ class EditStreamScreen extends PureComponent<Props> {
   }
 }
 
-export default connect((state: GlobalState, props) => ({
+export default connectFlowFixMe((state: GlobalState, props) => ({
   stream: getStreamFromId(state, props.navigation.state.params.streamId),
 }))(EditStreamScreen);

--- a/src/streams/InviteUsersScreen.js
+++ b/src/streams/InviteUsersScreen.js
@@ -2,7 +2,7 @@
 import React, { PureComponent } from 'react';
 
 import type { Auth, Dispatch, GlobalState, Stream, User } from '../types';
-import { connect } from '../react-redux';
+import { connectFlowFixMe } from '../react-redux';
 import { Screen } from '../common';
 import { navigateBack } from '../actions';
 import { subscriptionAdd } from '../api';
@@ -44,7 +44,7 @@ class InviteUsersScreen extends PureComponent<Props, State> {
   }
 }
 
-export default connect((state: GlobalState, props) => ({
+export default connectFlowFixMe((state: GlobalState, props) => ({
   auth: getAuth(state),
   stream: getStreamFromId(state, props.navigation.state.params.streamId),
 }))(InviteUsersScreen);

--- a/src/streams/InviteUsersScreen.js
+++ b/src/streams/InviteUsersScreen.js
@@ -1,8 +1,8 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
-import { connect } from 'react-redux';
 
 import type { Auth, Dispatch, GlobalState, Stream, User } from '../types';
+import { connect } from '../react-redux';
 import { Screen } from '../common';
 import { navigateBack } from '../actions';
 import { subscriptionAdd } from '../api';

--- a/src/streams/StreamScreen.js
+++ b/src/streams/StreamScreen.js
@@ -1,9 +1,9 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
 import { View } from 'react-native';
-import { connect } from 'react-redux';
 
 import type { Dispatch, GlobalState, Stream, Subscription } from '../types';
+import { connect } from '../react-redux';
 import { delay } from '../utils/async';
 import { OptionRow, Screen, ZulipButton, OptionDivider } from '../common';
 import { getIsAdmin, getStreamFromId, getSubscriptionFromId } from '../selectors';

--- a/src/streams/StreamScreen.js
+++ b/src/streams/StreamScreen.js
@@ -3,7 +3,7 @@ import React, { PureComponent } from 'react';
 import { View } from 'react-native';
 
 import type { Dispatch, GlobalState, Stream, Subscription } from '../types';
-import { connect } from '../react-redux';
+import { connectFlowFixMe } from '../react-redux';
 import { delay } from '../utils/async';
 import { OptionRow, Screen, ZulipButton, OptionDivider } from '../common';
 import { getIsAdmin, getStreamFromId, getSubscriptionFromId } from '../selectors';
@@ -98,7 +98,7 @@ class StreamScreen extends PureComponent<Props> {
   }
 }
 
-export default connect((state: GlobalState, props) => ({
+export default connectFlowFixMe((state: GlobalState, props) => ({
   isAdmin: getIsAdmin(state),
   stream: getStreamFromId(state, props.navigation.state.params.streamId),
   subscription: getSubscriptionFromId(state, props.navigation.state.params.streamId),

--- a/src/streams/SubscriptionsCard.js
+++ b/src/streams/SubscriptionsCard.js
@@ -1,10 +1,10 @@
 /* @flow strict-local */
-import { connect } from 'react-redux';
 
 import React, { PureComponent } from 'react';
 import { View, StyleSheet } from 'react-native';
 
 import type { Dispatch, Narrow, Subscription, GlobalState } from '../types';
+import { connect } from '../react-redux';
 import StreamList from './StreamList';
 import { isStreamNarrow, streamNarrow } from '../utils/narrow';
 import { getUnreadByStream } from '../selectors';

--- a/src/streams/SubscriptionsCard.js
+++ b/src/streams/SubscriptionsCard.js
@@ -4,7 +4,7 @@ import React, { PureComponent } from 'react';
 import { View, StyleSheet } from 'react-native';
 
 import type { Dispatch, Narrow, Subscription, GlobalState } from '../types';
-import { connect } from '../react-redux';
+import { connectFlowFixMe } from '../react-redux';
 import StreamList from './StreamList';
 import { isStreamNarrow, streamNarrow } from '../utils/narrow';
 import { getUnreadByStream } from '../selectors';
@@ -47,7 +47,7 @@ class SubscriptionsCard extends PureComponent<Props> {
   }
 }
 
-export default connect((state: GlobalState, props) => ({
+export default connectFlowFixMe((state: GlobalState, props) => ({
   narrow: props.narrow || [],
   // Main screen no longer contains drawer,
   // so at any position we cannot show selected stream in the list

--- a/src/subscriptions/StreamListCard.js
+++ b/src/subscriptions/StreamListCard.js
@@ -1,10 +1,10 @@
 /* @flow strict-local */
-import { connect } from 'react-redux';
 
 import React, { PureComponent } from 'react';
 import { StyleSheet, View } from 'react-native';
 
 import type { Auth, Dispatch, GlobalState, Stream, Subscription } from '../types';
+import { connect } from '../react-redux';
 import { ZulipButton } from '../common';
 import { subscriptionAdd, subscriptionRemove } from '../api';
 import { delay } from '../utils/async';

--- a/src/title-buttons/ExtraNavButtonStream.js
+++ b/src/title-buttons/ExtraNavButtonStream.js
@@ -1,9 +1,9 @@
 /* @flow strict-local */
-import { connect } from 'react-redux';
 
 import React, { PureComponent } from 'react';
 
 import type { Dispatch, Narrow, Stream } from '../types';
+import { connect } from '../react-redux';
 import { getStreams } from '../selectors';
 import NavButton from '../nav/NavButton';
 import { navigateToTopicList } from '../actions';

--- a/src/title-buttons/ExtraNavButtonTopic.js
+++ b/src/title-buttons/ExtraNavButtonTopic.js
@@ -1,9 +1,9 @@
 /* @flow strict-local */
-import { connect } from 'react-redux';
 
 import React, { PureComponent } from 'react';
 
 import type { Dispatch, Narrow, Stream } from '../types';
+import { connect } from '../react-redux';
 import { getStreams } from '../selectors';
 import { streamNarrow } from '../utils/narrow';
 import NavButton from '../nav/NavButton';

--- a/src/title-buttons/InfoNavButtonGroup.js
+++ b/src/title-buttons/InfoNavButtonGroup.js
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 
 import React, { PureComponent } from 'react';
 
-import type { Dispatch, UserOrBot } from '../types';
+import type { Dispatch, Narrow, UserOrBot } from '../types';
 import { getRecipientsInGroupNarrow } from '../selectors';
 import NavButton from '../nav/NavButton';
 import { navigateToGroupDetails } from '../actions';
@@ -11,6 +11,7 @@ import { navigateToGroupDetails } from '../actions';
 type Props = {|
   dispatch: Dispatch,
   color: string,
+  narrow: Narrow,
   recipients: UserOrBot[],
 |};
 

--- a/src/title-buttons/InfoNavButtonGroup.js
+++ b/src/title-buttons/InfoNavButtonGroup.js
@@ -1,9 +1,9 @@
 /* @flow strict-local */
-import { connect } from 'react-redux';
 
 import React, { PureComponent } from 'react';
 
 import type { Dispatch, Narrow, UserOrBot } from '../types';
+import { connect } from '../react-redux';
 import { getRecipientsInGroupNarrow } from '../selectors';
 import NavButton from '../nav/NavButton';
 import { navigateToGroupDetails } from '../actions';

--- a/src/title-buttons/InfoNavButtonPrivate.js
+++ b/src/title-buttons/InfoNavButtonPrivate.js
@@ -1,9 +1,9 @@
 /* @flow strict-local */
-import { connect } from 'react-redux';
 
 import React, { PureComponent } from 'react';
 
 import type { Dispatch, Narrow } from '../types';
+import { connect } from '../react-redux';
 import NavButton from '../nav/NavButton';
 import { navigateToAccountDetails } from '../actions';
 

--- a/src/title-buttons/InfoNavButtonStream.js
+++ b/src/title-buttons/InfoNavButtonStream.js
@@ -1,9 +1,9 @@
 /* @flow strict-local */
-import { connect } from 'react-redux';
 
 import React, { PureComponent } from 'react';
 
 import type { Dispatch, Narrow, Stream } from '../types';
+import { connect } from '../react-redux';
 import { getStreams } from '../selectors';
 import NavButton from '../nav/NavButton';
 import { navigateToStream } from '../actions';

--- a/src/title/ActivityText.js
+++ b/src/title/ActivityText.js
@@ -3,7 +3,7 @@
 import React, { PureComponent } from 'react';
 
 import type { Style, UserPresence, UserStatus, Dispatch } from '../types';
-import { connect } from '../react-redux';
+import { connectFlowFixMe } from '../react-redux';
 import { getPresence, getUserStatus } from '../selectors';
 import { presenceToHumanTime } from '../utils/presence';
 import { RawLabel } from '../common';
@@ -29,7 +29,7 @@ class ActivityText extends PureComponent<Props> {
   }
 }
 
-export default connect((state, props) => ({
+export default connectFlowFixMe((state, props) => ({
   presence: getPresence(state)[props.user.email],
   userStatus: getUserStatus(state)[props.user.user_id],
 }))(ActivityText);

--- a/src/title/ActivityText.js
+++ b/src/title/ActivityText.js
@@ -1,9 +1,9 @@
 /* @flow strict-local */
-import { connect } from 'react-redux';
 
 import React, { PureComponent } from 'react';
 
 import type { Style, UserPresence, UserStatus, Dispatch } from '../types';
+import { connect } from '../react-redux';
 import { getPresence, getUserStatus } from '../selectors';
 import { presenceToHumanTime } from '../utils/presence';
 import { RawLabel } from '../common';

--- a/src/title/Title.js
+++ b/src/title/Title.js
@@ -1,5 +1,4 @@
 /* @flow strict-local */
-import { connect } from 'react-redux';
 
 import React, { PureComponent } from 'react';
 
@@ -7,6 +6,7 @@ import { caseNarrow } from '../utils/narrow';
 import { getSession } from '../selectors';
 
 import type { EditMessage, GlobalState, Narrow, Dispatch } from '../types';
+import { connect } from '../react-redux';
 import TitlePrivate from './TitlePrivate';
 import TitleGroup from './TitleGroup';
 import TitleSpecial from './TitleSpecial';

--- a/src/title/TitleGroup.js
+++ b/src/title/TitleGroup.js
@@ -1,10 +1,10 @@
 /* @flow strict-local */
-import { connect } from 'react-redux';
 
 import React, { PureComponent } from 'react';
 import { StyleSheet, View } from 'react-native';
 
 import type { Dispatch, UserOrBot } from '../types';
+import { connect } from '../react-redux';
 import { UserAvatarWithPresence } from '../common';
 import { getRecipientsInGroupNarrow } from '../selectors';
 import styles from '../styles';

--- a/src/title/TitleGroup.js
+++ b/src/title/TitleGroup.js
@@ -4,7 +4,7 @@ import React, { PureComponent } from 'react';
 import { StyleSheet, View } from 'react-native';
 
 import type { Dispatch, UserOrBot } from '../types';
-import { connect } from '../react-redux';
+import { connectFlowFixMe } from '../react-redux';
 import { UserAvatarWithPresence } from '../common';
 import { getRecipientsInGroupNarrow } from '../selectors';
 import styles from '../styles';
@@ -47,6 +47,6 @@ class TitleGroup extends PureComponent<Props> {
   }
 }
 
-export default connect((state, props) => ({
+export default connectFlowFixMe((state, props) => ({
   recipients: getRecipientsInGroupNarrow(state, props.narrow),
 }))(TitleGroup);

--- a/src/title/TitlePrivate.js
+++ b/src/title/TitlePrivate.js
@@ -4,7 +4,7 @@ import React, { PureComponent } from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 
 import type { Dispatch, UserOrBot } from '../types';
-import { connect } from '../react-redux';
+import { connectFlowFixMe } from '../react-redux';
 import { Touchable, UserAvatarWithPresence, ViewPlaceholder } from '../common';
 import ActivityText from './ActivityText';
 import { getAllUsersByEmail } from '../users/userSelectors';
@@ -47,6 +47,6 @@ class TitlePrivate extends PureComponent<Props> {
   }
 }
 
-export default connect((state, props) => ({
+export default connectFlowFixMe((state, props) => ({
   user: getAllUsersByEmail(state).get(props.email),
 }))(TitlePrivate);

--- a/src/title/TitlePrivate.js
+++ b/src/title/TitlePrivate.js
@@ -1,10 +1,10 @@
 /* @flow strict-local */
-import { connect } from 'react-redux';
 
 import React, { PureComponent } from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 
 import type { Dispatch, UserOrBot } from '../types';
+import { connect } from '../react-redux';
 import { Touchable, UserAvatarWithPresence, ViewPlaceholder } from '../common';
 import ActivityText from './ActivityText';
 import { getAllUsersByEmail } from '../users/userSelectors';

--- a/src/title/TitleStream.js
+++ b/src/title/TitleStream.js
@@ -1,10 +1,10 @@
 /* @flow strict-local */
-import { connect } from 'react-redux';
 
 import React, { PureComponent } from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 
 import type { Narrow, Stream, Subscription, Dispatch } from '../types';
+import { connect } from '../react-redux';
 import StreamIcon from '../streams/StreamIcon';
 import { isTopicNarrow } from '../utils/narrow';
 import { getStreamInNarrow } from '../selectors';

--- a/src/topics/TopicListScreen.js
+++ b/src/topics/TopicListScreen.js
@@ -1,9 +1,9 @@
 /* @flow strict-local */
-import { connect } from 'react-redux';
 
 import React, { PureComponent } from 'react';
 
 import type { Dispatch, GlobalState, Stream, TopicExtended } from '../types';
+import { connect } from '../react-redux';
 import { Screen } from '../common';
 import { topicNarrow } from '../utils/narrow';
 import { getTopicsForStream } from '../selectors';

--- a/src/topics/TopicListScreen.js
+++ b/src/topics/TopicListScreen.js
@@ -3,7 +3,7 @@
 import React, { PureComponent } from 'react';
 
 import type { Dispatch, GlobalState, Stream, TopicExtended } from '../types';
-import { connect } from '../react-redux';
+import { connectFlowFixMe } from '../react-redux';
 import { Screen } from '../common';
 import { topicNarrow } from '../utils/narrow';
 import { getTopicsForStream } from '../selectors';
@@ -52,7 +52,7 @@ class TopicListScreen extends PureComponent<Props, State> {
   }
 }
 
-export default connect((state: GlobalState, props) => ({
+export default connectFlowFixMe((state: GlobalState, props) => ({
   stream: getStreamFromId(state, props.navigation.state.params.streamId),
   topics: getTopicsForStream(state, props.navigation.state.params.streamId),
 }))(TopicListScreen);

--- a/src/unread/UnreadCards.js
+++ b/src/unread/UnreadCards.js
@@ -1,5 +1,4 @@
 /* @flow strict-local */
-import { connect } from 'react-redux';
 
 import React, { PureComponent } from 'react';
 import { SectionList } from 'react-native';
@@ -11,6 +10,7 @@ import type {
   UnreadStreamItem,
   UserOrBot,
 } from '../types';
+import { connect } from '../react-redux';
 import { LoadingIndicator, SearchEmptyState } from '../common';
 import PmConversationList from '../pm-conversations/PmConversationList';
 import StreamItem from '../streams/StreamItem';

--- a/src/user-groups/CreateGroupScreen.js
+++ b/src/user-groups/CreateGroupScreen.js
@@ -1,8 +1,8 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
-import { connect } from 'react-redux';
 
 import type { Dispatch, User } from '../types';
+import { connect } from '../react-redux';
 import { Screen } from '../common';
 import { doNarrow, navigateBack } from '../actions';
 import { groupNarrow } from '../utils/narrow';

--- a/src/user-picker/UserPickerCard.js
+++ b/src/user-picker/UserPickerCard.js
@@ -2,9 +2,9 @@
 import React, { PureComponent } from 'react';
 import { StyleSheet, View } from 'react-native';
 import type { FlatList } from 'react-native';
-import { connect } from 'react-redux';
 
 import type { GlobalState, User, PresenceState, Dispatch } from '../types';
+import { connect } from '../react-redux';
 import { FloatingActionButton, LineSeparator } from '../common';
 import { IconDone } from '../common/Icons';
 import UserList from '../users/UserList';

--- a/src/user-status/UserStatusScreen.js
+++ b/src/user-status/UserStatusScreen.js
@@ -1,9 +1,9 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
 import { FlatList, StyleSheet, View } from 'react-native';
-import { connect } from 'react-redux';
 
 import type { Dispatch, GlobalState } from '../types';
+import { connect } from '../react-redux';
 import { Input, OptionButton, Screen, ZulipButton } from '../common';
 import { getSelfUserStatusText } from '../selectors';
 import { IconCancel, IconDone } from '../common/Icons';

--- a/src/users/UsersCard.js
+++ b/src/users/UsersCard.js
@@ -1,9 +1,9 @@
 /* @flow strict-local */
-import { connect } from 'react-redux';
 
 import React, { PureComponent } from 'react';
 
 import type { Dispatch, GlobalState, PresenceState, User } from '../types';
+import { connect } from '../react-redux';
 import { privateNarrow } from '../utils/narrow';
 import UserList from './UserList';
 import { getUsers, getPresence } from '../selectors';

--- a/src/webview/MessageList.js
+++ b/src/webview/MessageList.js
@@ -1,7 +1,6 @@
 /* @flow strict-local */
 import React, { Component } from 'react';
 import { WebView } from 'react-native-webview';
-import { connect } from 'react-redux';
 
 import { connectActionSheet } from '@expo/react-native-action-sheet';
 
@@ -24,6 +23,7 @@ import type {
   ThemeName,
   User,
 } from '../types';
+import { connect } from '../react-redux';
 import {
   getAuth,
   getAllImageEmojiById,


### PR DESCRIPTION
This is part of #3399. See also discussion in #3422 and #3428 .

The new RN version (v0.59) comes with a new Flow version (v0.92). That Flow version, in turn, comes with [more consistent enforcement](https://medium.com/flow-type/asking-for-required-annotations-64d4f9c1edf8) of an annotation requirement that (a) on the one hand means fewer bogus "Santa Claus" types ("everything the code wants to be true, is true!", aka `empty`) but (b) means a lot of boilerplate when using `connect`, if relying on the libdef for it in `flow-typed` upstream.

Moreover, the new upstream libdef for `connect` doesn't understand `defaultProps`, causing a lot of spurious type errors.

So with this branch, we bring in the new libdef... but then add our own wrapper around it, with an utterly trivial implementation -- if you erase all the types, it looks like this:
```
export function connect(mapStateToProps) {
  return connectInner(mapStateToProps);
}
```
but with a bunch of complexity in the types to describe what `connect` really does, plus about 500 words of comments.

Also marks with a fixme the remaining places where we have type errors hidden by the ineffective old type on `connect`. I fixed a bunch of such errors last week and the week before, before I realized how much work was needed on the type of `connect` itself; for the rest, this just marks them so we can move on and fix them separately.

---

Posting this as a PR because (a) I'd like to shift to more of a practice of posting my own changes for discussion before merge, and (b) this change in particular deserves some discussion, because I want everyone to be aware of it so there are no surprises when Flow complains about a type error on `connect` in the future.
