### PR TITLE
Cleanup SubscriptionCard

### DIFF
--- a/src/streams/SubscriptionsCard.js
+++ b/src/streams/SubscriptionsCard.js
@@ -3,10 +3,10 @@
 import React, { PureComponent } from 'react';
 import { View, StyleSheet } from 'react-native';
 
-import type { Dispatch, Narrow, Subscription, GlobalState } from '../types';
+import type { Dispatch, Subscription, GlobalState } from '../types';
 import { connectFlowFixMe } from '../react-redux';
 import StreamList from './StreamList';
-import { isStreamNarrow, streamNarrow } from '../utils/narrow';
+import { streamNarrow } from '../utils/narrow';
 import { getUnreadByStream } from '../selectors';
 import { getSubscribedStreams } from '../subscriptions/subscriptionSelectors';
 import { doNarrow } from '../actions';
@@ -20,7 +20,6 @@ const styles = StyleSheet.create({
 
 type Props = {|
   dispatch: Dispatch,
-  narrow: Narrow,
   subscriptions: Subscription[],
   unreadByStream: number[],
 |};
@@ -31,14 +30,12 @@ class SubscriptionsCard extends PureComponent<Props> {
   };
 
   render() {
-    const { narrow, subscriptions, unreadByStream } = this.props;
-    const selected = isStreamNarrow(narrow) && narrow[0].operand;
+    const { subscriptions, unreadByStream } = this.props;
 
     return (
       <View style={styles.container}>
         <StreamList
           streams={subscriptions}
-          selected={selected}
           unreadByStream={unreadByStream}
           onPress={this.handleNarrow}
         />
@@ -48,10 +45,6 @@ class SubscriptionsCard extends PureComponent<Props> {
 }
 
 export default connectFlowFixMe((state: GlobalState, props) => ({
-  narrow: props.narrow || [],
-  // Main screen no longer contains drawer,
-  // so at any position we cannot show selected stream in the list
-  // needs to be removed when we finalize navigation without drawer
   subscriptions: getSubscribedStreams(state),
   unreadByStream: getUnreadByStream(state),
 }))(SubscriptionsCard);


### PR DESCRIPTION
Removes several lines of code that have had no effect for a very
long time (since we had a drawer in the app)

The purpose of the code being removed was to show as 'selected'
a subscription, if it was the currently active narrow (this
component was rendered in the drawer)
  
This component now only serves as a Tab in StreamTabs. It never
receives a value for the 'narrow' property, thus it remains the
default `[]`. This in turn always sets `selected` to `false`.

None of the removed code had any effect except cluttering the code.
