### PR TITLE
flow: Add missing types for 'navigation' prop

### DIFF
--- a/src/account-info/AccountDetailsScreen.js
+++ b/src/account-info/AccountDetailsScreen.js
@@ -1,6 +1,7 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
 import { StyleSheet } from 'react-native';
+import type { NavigationScreenProp } from 'react-navigation';
 
 import type { Dispatch, GlobalState, User } from '../types';
 import { connectFlowFixMe } from '../react-redux';
@@ -19,6 +20,7 @@ const styles = StyleSheet.create({
 
 type Props = {|
   user: User,
+  navigation: NavigationScreenProp<{ params: {| email: string |} }>,
   dispatch: Dispatch,
 |};
 

--- a/src/start/RealmScreen.js
+++ b/src/start/RealmScreen.js
@@ -13,7 +13,7 @@ import styles from '../styles';
 
 type Props = {|
   dispatch: Dispatch,
-  navigation: NavigationScreenProp<mixed>,
+  navigation: NavigationScreenProp<{ params: {| realm: string |} }>,
   initialRealm: string,
 |};
 

--- a/src/streams/EditStreamScreen.js
+++ b/src/streams/EditStreamScreen.js
@@ -1,5 +1,6 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
+import type { NavigationScreenProp } from 'react-navigation';
 
 import type { Dispatch, GlobalState, Stream } from '../types';
 import { connectFlowFixMe } from '../react-redux';
@@ -11,6 +12,7 @@ import EditStreamCard from './EditStreamCard';
 type Props = {|
   dispatch: Dispatch,
   stream: Stream,
+  navigation: NavigationScreenProp<{ params: {| streamId: number |} }>,
 |};
 
 class EditStreamScreen extends PureComponent<Props> {

--- a/src/streams/InviteUsersScreen.js
+++ b/src/streams/InviteUsersScreen.js
@@ -1,5 +1,6 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
+import type { NavigationScreenProp } from 'react-navigation';
 
 import type { Auth, Dispatch, GlobalState, Stream, User } from '../types';
 import { connectFlowFixMe } from '../react-redux';
@@ -13,6 +14,7 @@ type Props = {|
   dispatch: Dispatch,
   auth: Auth,
   stream: Stream,
+  navigation: NavigationScreenProp<{ params: {| streamId: number |} }>,
 |};
 
 type State = {|

--- a/src/streams/StreamScreen.js
+++ b/src/streams/StreamScreen.js
@@ -1,6 +1,7 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
 import { View } from 'react-native';
+import type { NavigationScreenProp } from 'react-navigation';
 
 import type { Dispatch, GlobalState, Stream, Subscription } from '../types';
 import { connectFlowFixMe } from '../react-redux';
@@ -23,6 +24,7 @@ type Props = {|
   isAdmin: boolean,
   stream: Stream,
   subscription: Subscription,
+  navigation: NavigationScreenProp<{ params: {| streamId: number |} }>,
 |};
 
 class StreamScreen extends PureComponent<Props> {

--- a/src/topics/TopicListScreen.js
+++ b/src/topics/TopicListScreen.js
@@ -1,6 +1,7 @@
 /* @flow strict-local */
 
 import React, { PureComponent } from 'react';
+import type { NavigationScreenProp } from 'react-navigation';
 
 import type { Dispatch, GlobalState, Stream, TopicExtended } from '../types';
 import { connectFlowFixMe } from '../react-redux';
@@ -15,6 +16,7 @@ type Props = {|
   dispatch: Dispatch,
   stream: Stream,
   topics: TopicExtended[],
+  navigation: NavigationScreenProp<{ params: {| streamId: number |} }>,
 |};
 
 type State = {|


### PR DESCRIPTION
Adds several straightforward types for `navigation` props that
wre missing them.

Note: Incoming commits will improve Flow's understanding of the
`connect()` typing and will start showing errors.