### PR TITLE
Helpers to make example data for tests

### DIFF
--- a/src/__tests__/exampleData.js
+++ b/src/__tests__/exampleData.js
@@ -1,0 +1,168 @@
+/* @flow strict-local */
+
+import type { Message, PmRecipientUser, Stream, User } from '../api/modelTypes';
+
+// TODO either fix Jest test-discovery patterns, or rename this file,
+// so this dummy test isn't required.
+describe('nothing', () => {
+  test('nothing', () => {});
+});
+
+/** Caveat emptor!  These values may not be representative. */
+const selfUser: User = {
+  avatar_url: 'https://zulip.example.org/an/avatar.png',
+  // bot_type omitted
+  // bot_owner omitted
+
+  date_joined: '2014-04-01',
+
+  email: 'user@example.org',
+  full_name: 'Self User',
+
+  is_admin: false,
+  is_bot: false,
+
+  is_guest: false,
+
+  // profile_data omitted
+
+  timezone: 'UTC',
+  user_id: 123,
+};
+
+/** Caveat emptor!  These values may not be representative. */
+const otherUser: User = {
+  avatar_url: 'https://zulip.example.org/an/other-avatar.png',
+  // bot_type omitted
+  // bot_owner omitted
+
+  date_joined: '2014-04-01',
+
+  email: 'other@example.org',
+  full_name: 'Other User',
+
+  is_admin: false,
+  is_bot: false,
+
+  is_guest: false,
+
+  // profile_data omitted
+
+  timezone: 'Pacific/Chatham', // i.e. UTC+1245 / UTC+1345 :-D
+  user_id: 234,
+};
+
+const stream: Stream = {
+  stream_id: 34,
+  description: 'An example stream.',
+  name: 'a stream',
+  invite_only: false,
+  is_announcement_only: false,
+  history_public_to_subscribers: true,
+};
+
+const displayRecipientFromUser = (user: User): PmRecipientUser => {
+  const { email, full_name, user_id: id } = user;
+  return {
+    email,
+    full_name,
+    id,
+    is_mirror_dummy: false,
+    short_name: '', // what is this, anyway?
+  };
+};
+
+/** Boring properties common to all example Message objects. */
+const messagePropertiesBase = {
+  isOutbox: false,
+
+  // match_content omitted
+  // match_subject omitted
+
+  // flags omitted
+
+  edit_history: [],
+  is_me_message: false,
+  // last_edit_timestamp omitted
+  reactions: [],
+  subject_links: [],
+  submessages: [],
+};
+
+const messagePropertiesFromSender = (user: User) => {
+  const {
+    avatar_url,
+    user_id: sender_id,
+    email: sender_email,
+    full_name: sender_full_name,
+  } = otherUser;
+
+  return {
+    sender_domain: '',
+
+    avatar_url,
+    client: 'ExampleClient',
+    gravatar_hash: 'd3adb33f',
+    sender_email,
+    sender_full_name,
+    sender_id,
+    sender_realm_str: 'zulip',
+    sender_short_name: '',
+  };
+};
+
+/** Caveat emptor!  These values may not be representative. */
+const pmMessage = (extra?: $Rest<Message, {}>): Message => {
+  const baseMessage: Message = {
+    ...messagePropertiesBase,
+    ...messagePropertiesFromSender(otherUser),
+
+    content: 'This is an example PM message.',
+    content_type: 'text/markdown',
+    display_recipient: [displayRecipientFromUser(selfUser)],
+    id: 1234567,
+    recipient_id: 2342,
+    stream_id: -1,
+    subject: '',
+    timestamp: 1556579160,
+    type: 'private',
+  };
+
+  return { ...baseMessage, ...extra };
+};
+
+const messagePropertiesFromStream = (stream1: Stream) => {
+  const { stream_id, name: display_recipient } = stream1;
+  return {
+    recipient_id: 2567,
+    display_recipient,
+    stream_id,
+  };
+};
+
+/** Caveat emptor!  These values may not be representative. */
+const streamMessage = (extra?: $Rest<Message, {}>): Message => {
+  const baseMessage: Message = {
+    ...messagePropertiesBase,
+    ...messagePropertiesFromSender(otherUser),
+    ...messagePropertiesFromStream(stream),
+
+    content: 'This is an example stream message.',
+    content_type: 'text/markdown',
+    id: 1234789,
+    subject: 'example topic',
+    timestamp: 1556579727,
+    type: 'stream',
+  };
+
+  return { ...baseMessage, ...extra };
+};
+
+export const eg = {
+  selfUser,
+  otherUser,
+  stream,
+
+  pmMessage,
+  streamMessage,
+};

--- a/src/webview/html/__tests__/messageHeaderAsHtml-test.js
+++ b/src/webview/html/__tests__/messageHeaderAsHtml-test.js
@@ -1,0 +1,26 @@
+/* @flow strict-local */
+
+import { eg } from '../../../__tests__/exampleData';
+import { streamNarrow } from '../../../utils/narrow';
+import messageHeaderAsHtml from '../messageHeaderAsHtml';
+import type { BackgroundData } from '../../MessageList';
+
+const backgroundData: BackgroundData = ({
+  ownEmail: eg.selfUser.email,
+  subscriptions: [eg.stream],
+}: $FlowFixMe);
+
+describe('messageHeaderAsHtml', () => {
+  test('correctly encodes `<` in topic, in stream narrow', () => {
+    const h = messageHeaderAsHtml(
+      backgroundData,
+      streamNarrow(eg.stream.name),
+      eg.streamMessage({ subject: '1 < 2' }),
+    );
+    expect(h).not.toContain('1 < 2');
+    expect(h).toContain('1 &lt; 2');
+    expect(h).not.toContain('1 &amp;lt; 2');
+  });
+
+  // TODO: test other cases, and other pieces of data (stream name, user names, etc.)
+});


### PR DESCRIPTION
Make a start at some well-typed example data for tests.
    
This will help us to write unit tests that deal with large objects
like users and messages
 * while passing genuine well-typed data,
 * and with less repetition of boilerplate boring bits of data.

This contains enough to write the particular tests I wanted to write
today, but it's quite incomplete -- there are plenty more types of
objects, and also directions in which to customize the data, that we
might add to it for the sake of other tests.

Also, as the jsdoc comments announce, some of these property values
may not look anything like they would in a real user/message/etc.!
They match our types, and I've made them plausible values where I know
off the top of my head what values are plausible, but e.g. `User` has
`timezone: string`, which isn't very informative and I don't know what
those strings are actually supposed to be.  We can fix such details as
we run into them -- fortunately, because this is test code, we'll
always know it when we do.

---

Also add a quick partial test of proper "escaping", i.e. HTML-encoding, in `messageHeaderAsHtml`, using the new helpers.

---

I'm going ahead and merging this now so the test can be helpful on #3435, but I'm definitely interested in feedback on the new `exampleData` helpers -- the API for them and the organization of them. This is something I'm hoping to see us use widely (and expand as needed), as I think it will be useful for a wide swath of our Jest test suite.

Also these could use some jsdoc, but I'm not getting to that today.
