### PR TITLE
tests: Add example-data helpers for Redux state, more users, and cross-realm bots

### DIFF
--- a/src/__tests__/exampleData.js
+++ b/src/__tests__/exampleData.js
@@ -2,7 +2,14 @@
 import deepFreeze from 'deep-freeze';
 import { createStore } from 'redux';
 
-import type { CrossRealmBot, Message, PmRecipientUser, Stream, User } from '../api/modelTypes';
+import type {
+  CrossRealmBot,
+  Message,
+  PmRecipientUser,
+  Stream,
+  Subscription,
+  User,
+} from '../api/modelTypes';
 import type { GlobalState } from '../reduxTypes';
 import type { Account } from '../types';
 import rootReducer from '../boot/reducers';
@@ -80,6 +87,19 @@ const stream: Stream = {
   invite_only: false,
   is_announcement_only: false,
   history_public_to_subscribers: true,
+};
+
+const subscription: Subscription = {
+  ...stream,
+  color: '#123456',
+  in_home_view: true,
+  pin_to_top: false,
+  audible_notifications: false,
+  desktop_notifications: false,
+  push_notifications: false,
+  email_address: '???',
+  stream_weekly_traffic: 9000,
+  is_old_stream: false, // ??
 };
 
 const displayRecipientFromUser = (user: User): PmRecipientUser => {
@@ -197,6 +217,7 @@ export const eg = {
   otherUser,
   crossRealmBot,
   stream,
+  subscription,
 
   pmMessage,
   streamMessage,

--- a/src/utils/__tests__/message-test.js
+++ b/src/utils/__tests__/message-test.js
@@ -10,51 +10,37 @@ describe('shouldBeMuted', () => {
 
   test('messages when narrowed to a topic are never muted', () => {
     const message = eg.streamMessage();
-    const narrow = topicNarrow(eg.stream.name, 'some topic');
-    const mutes = [[eg.stream.name, 'some topic']];
+    const narrow = topicNarrow(eg.stream.name, message.subject);
+    const mutes = [[eg.stream.name, message.subject]];
     expect(shouldBeMuted(message, narrow, [], mutes)).toBe(false);
   });
 
   test('message in a stream is muted if stream is not in mute list', () => {
-    const message = {
-      display_recipient: 'stream',
-    };
-
-    const isMuted = shouldBeMuted(message, HOME_NARROW, []);
-
-    expect(isMuted).toBe(true);
+    const message = eg.streamMessage();
+    expect(shouldBeMuted(message, HOME_NARROW, [])).toBe(true);
   });
 
   test('message in a stream is muted if the stream is muted', () => {
-    const message = {
-      display_recipient: 'stream',
-    };
-    const subscriptions = [
-      {
-        name: 'stream',
-        in_home_view: false,
-      },
-    ];
-    const isMuted = shouldBeMuted(message, HOME_NARROW, subscriptions);
-
-    expect(isMuted).toBe(true);
+    expect(
+      shouldBeMuted(
+        eg.streamMessage(),
+        HOME_NARROW,
+        [{ ...eg.subscription, in_home_view: false }],
+        [],
+      ),
+    ).toBe(true);
   });
 
   test('message in a stream is muted if the topic is muted and topic matches', () => {
-    const message = {
-      display_recipient: 'stream',
-      subject: 'topic',
-    };
-    const subscriptions = [
-      {
-        name: 'stream',
-        in_home_view: true,
-      },
-    ];
-    const mutes = [['stream', 'topic']];
-    const isMuted = shouldBeMuted(message, HOME_NARROW, subscriptions, mutes);
-
-    expect(isMuted).toBe(true);
+    const message = eg.streamMessage();
+    expect(
+      shouldBeMuted(
+        message,
+        HOME_NARROW,
+        [{ ...eg.subscription, in_home_view: true }],
+        [[eg.stream.name, message.subject]],
+      ),
+    ).toBe(true);
   });
 });
 

--- a/src/utils/__tests__/message-test.js
+++ b/src/utils/__tests__/message-test.js
@@ -46,57 +46,39 @@ describe('shouldBeMuted', () => {
 
 describe('isMessageRead', () => {
   test('message with no flags entry is considered not read', () => {
-    const message = { id: 0, display_recipient: 'testStream', type: 'stream' };
-    const flags = { read: {} };
-    const subscriptions = [{ name: 'testStream', in_home_view: true }];
+    const message = eg.streamMessage();
+    const flags = eg.baseReduxState.flags;
+    const subscriptions = [eg.subscription];
 
-    const result = isMessageRead(message, flags, subscriptions);
+    const result = isMessageRead(message, flags, subscriptions, []);
 
     expect(result).toEqual(false);
   });
 
   test('message with flags entry is considered read', () => {
-    const message = { id: 123 };
-    const flags = { read: { 123: true } };
+    const message = eg.streamMessage();
+    const flags = { ...eg.baseReduxState.flags, read: { [123]: true } }; // eslint-disable-line no-useless-computed-key
 
-    const result = isMessageRead(message, flags);
+    const result = isMessageRead(message, flags, [], []);
 
     expect(result).toEqual(true);
   });
 
   test('a message in a muted stream is considered read', () => {
-    const message = {
-      id: 0,
-      display_recipient: 'muted stream',
-      subject: 'topic',
-    };
-    const flags = { read: {} };
-    const subscriptions = [
-      {
-        name: 'muted stream',
-        in_home_view: false,
-      },
-    ];
+    const message = eg.streamMessage();
+    const flags = eg.baseReduxState.flags;
+    const subscriptions = [{ ...eg.subscription, in_home_view: false }];
 
-    const result = isMessageRead(message, flags, subscriptions);
+    const result = isMessageRead(message, flags, subscriptions, []);
 
     expect(result).toEqual(true);
   });
 
   test('a message in a muted topic is considered read', () => {
-    const message = {
-      id: 0,
-      display_recipient: 'stream',
-      subject: 'muted topic',
-    };
-    const flags = { read: {} };
-    const subscriptions = [
-      {
-        name: 'stream',
-        in_home_view: false,
-      },
-    ];
-    const mute = [['stream', 'muted topic']];
+    const message = eg.streamMessage();
+    const flags = eg.baseReduxState.flags;
+    const subscriptions = [eg.subscription];
+    const mute = [[eg.stream.name, message.subject]];
 
     const result = isMessageRead(message, flags, subscriptions, mute);
 

--- a/src/utils/__tests__/message-test.js
+++ b/src/utils/__tests__/message-test.js
@@ -1,29 +1,18 @@
+/* @flow strict-local */
 import { shouldBeMuted, isMessageRead, findFirstUnread } from '../message';
 import { HOME_NARROW, topicNarrow } from '../narrow';
+import { eg } from '../../__tests__/exampleData';
 
 describe('shouldBeMuted', () => {
   test('private messages are never muted', () => {
-    const message = {
-      display_recipient: [],
-      type: 'private',
-    };
-
-    const isMuted = shouldBeMuted(message, HOME_NARROW, []);
-
-    expect(isMuted).toBe(false);
+    expect(shouldBeMuted(eg.pmMessage(), HOME_NARROW, [])).toBe(false);
   });
 
   test('messages when narrowed to a topic are never muted', () => {
-    const message = {
-      display_recipient: 'stream',
-      subject: 'some topic',
-    };
-    const narrow = topicNarrow('some topic');
-    const mutes = [['stream', 'some topic']];
-
-    const isMuted = shouldBeMuted(message, narrow, [], mutes);
-
-    expect(isMuted).toBe(false);
+    const message = eg.streamMessage();
+    const narrow = topicNarrow(eg.stream.name, 'some topic');
+    const mutes = [[eg.stream.name, 'some topic']];
+    expect(shouldBeMuted(message, narrow, [], mutes)).toBe(false);
   });
 
   test('message in a stream is muted if stream is not in mute list', () => {

--- a/src/utils/__tests__/message-test.js
+++ b/src/utils/__tests__/message-test.js
@@ -49,29 +49,20 @@ describe('isMessageRead', () => {
     const message = eg.streamMessage();
     const flags = eg.baseReduxState.flags;
     const subscriptions = [eg.subscription];
-
-    const result = isMessageRead(message, flags, subscriptions, []);
-
-    expect(result).toEqual(false);
+    expect(isMessageRead(message, flags, subscriptions, [])).toEqual(false);
   });
 
   test('message with flags entry is considered read', () => {
     const message = eg.streamMessage();
     const flags = { ...eg.baseReduxState.flags, read: { [123]: true } }; // eslint-disable-line no-useless-computed-key
-
-    const result = isMessageRead(message, flags, [], []);
-
-    expect(result).toEqual(true);
+    expect(isMessageRead(message, flags, [], [])).toEqual(true);
   });
 
   test('a message in a muted stream is considered read', () => {
     const message = eg.streamMessage();
     const flags = eg.baseReduxState.flags;
     const subscriptions = [{ ...eg.subscription, in_home_view: false }];
-
-    const result = isMessageRead(message, flags, subscriptions, []);
-
-    expect(result).toEqual(true);
+    expect(isMessageRead(message, flags, subscriptions, [])).toEqual(true);
   });
 
   test('a message in a muted topic is considered read', () => {
@@ -79,10 +70,7 @@ describe('isMessageRead', () => {
     const flags = eg.baseReduxState.flags;
     const subscriptions = [eg.subscription];
     const mute = [[eg.stream.name, message.subject]];
-
-    const result = isMessageRead(message, flags, subscriptions, mute);
-
-    expect(result).toEqual(true);
+    expect(isMessageRead(message, flags, subscriptions, mute)).toEqual(true);
   });
 });
 

--- a/src/utils/__tests__/message-test.js
+++ b/src/utils/__tests__/message-test.js
@@ -54,7 +54,11 @@ describe('isMessageRead', () => {
   });
 
   test('message with flags entry is considered read', () => {
-    expect(isMessageRead(message, flags(true), [], [])).toEqual(true);
+    expect(isMessageRead(message, flags(true), [eg.subscription], [])).toEqual(true);
+  });
+
+  test('message in not-subscribed-to stream is considered read', () => {
+    expect(isMessageRead(message, flags(false), [], [])).toEqual(true);
   });
 
   test('a message in a muted stream is considered read', () => {

--- a/src/utils/__tests__/message-test.js
+++ b/src/utils/__tests__/message-test.js
@@ -11,24 +11,32 @@ describe('shouldBeMuted', () => {
     expect(shouldBeMuted(eg.pmMessage(), HOME_NARROW, [], [])).toBe(false);
   });
 
-  test('messages when narrowed to a topic are never muted', () => {
-    expect(
-      shouldBeMuted(message, topicNarrow(eg.stream.name, message.subject), [], [messageMute]),
-    ).toBe(false);
+  test('stream message not muted in base case', () => {
+    expect(shouldBeMuted(message, HOME_NARROW, [eg.subscription], [])).toBe(false);
   });
 
-  test('message in a stream is muted if stream is not in mute list', () => {
+  test('stream message is muted if stream not subscribed to', () => {
     expect(shouldBeMuted(message, HOME_NARROW, [], [])).toBe(true);
   });
 
-  test('message in a stream is muted if the stream is muted', () => {
+  test('stream message is muted if the stream is muted', () => {
     expect(
       shouldBeMuted(message, HOME_NARROW, [{ ...eg.subscription, in_home_view: false }], []),
     ).toBe(true);
   });
 
-  test('message in a stream is muted if the topic is muted and topic matches', () => {
+  test('stream message is muted if the topic is muted', () => {
     expect(shouldBeMuted(message, HOME_NARROW, [eg.subscription], [messageMute])).toBe(true);
+  });
+
+  test('stream message not muted when narrowed to topic, even if otherwise would be', () => {
+    const narrow = topicNarrow(eg.stream.name, message.subject);
+    expect(shouldBeMuted(message, narrow, [], [])).toBe(false);
+    expect(shouldBeMuted(message, narrow, [{ ...eg.subscription, in_home_view: false }], [])).toBe(
+      false,
+    );
+    expect(shouldBeMuted(message, narrow, [eg.subscription], [messageMute])).toBe(false);
+    expect(shouldBeMuted(message, narrow, [], [messageMute])).toBe(false);
   });
 });
 

--- a/src/utils/__tests__/message-test.js
+++ b/src/utils/__tests__/message-test.js
@@ -47,9 +47,7 @@ describe('shouldBeMuted', () => {
 describe('isMessageRead', () => {
   const message = eg.streamMessage();
   const flags = read =>
-    read
-      ? { ...eg.baseReduxState.flags, read: { [123]: true } } // eslint-disable-line no-useless-computed-key
-      : eg.baseReduxState.flags;
+    read ? { ...eg.baseReduxState.flags, read: { [message.id]: true } } : eg.baseReduxState.flags;
 
   test('message with no flags entry is considered not read', () => {
     expect(isMessageRead(message, flags(false), [eg.subscription], [])).toEqual(false);

--- a/src/utils/__tests__/message-test.js
+++ b/src/utils/__tests__/message-test.js
@@ -45,32 +45,30 @@ describe('shouldBeMuted', () => {
 });
 
 describe('isMessageRead', () => {
+  const message = eg.streamMessage();
+  const flags = read =>
+    read
+      ? { ...eg.baseReduxState.flags, read: { [123]: true } } // eslint-disable-line no-useless-computed-key
+      : eg.baseReduxState.flags;
+
   test('message with no flags entry is considered not read', () => {
-    const message = eg.streamMessage();
-    const flags = eg.baseReduxState.flags;
-    const subscriptions = [eg.subscription];
-    expect(isMessageRead(message, flags, subscriptions, [])).toEqual(false);
+    expect(isMessageRead(message, flags(false), [eg.subscription], [])).toEqual(false);
   });
 
   test('message with flags entry is considered read', () => {
-    const message = eg.streamMessage();
-    const flags = { ...eg.baseReduxState.flags, read: { [123]: true } }; // eslint-disable-line no-useless-computed-key
-    expect(isMessageRead(message, flags, [], [])).toEqual(true);
+    expect(isMessageRead(message, flags(true), [], [])).toEqual(true);
   });
 
   test('a message in a muted stream is considered read', () => {
-    const message = eg.streamMessage();
-    const flags = eg.baseReduxState.flags;
-    const subscriptions = [{ ...eg.subscription, in_home_view: false }];
-    expect(isMessageRead(message, flags, subscriptions, [])).toEqual(true);
+    expect(
+      isMessageRead(message, flags(false), [{ ...eg.subscription, in_home_view: false }], []),
+    ).toEqual(true);
   });
 
   test('a message in a muted topic is considered read', () => {
-    const message = eg.streamMessage();
-    const flags = eg.baseReduxState.flags;
-    const subscriptions = [eg.subscription];
-    const mute = [[eg.stream.name, message.subject]];
-    expect(isMessageRead(message, flags, subscriptions, mute)).toEqual(true);
+    expect(
+      isMessageRead(message, flags(false), [eg.subscription], [[eg.stream.name, message.subject]]),
+    ).toEqual(true);
   });
 });
 

--- a/src/utils/__tests__/message-test.js
+++ b/src/utils/__tests__/message-test.js
@@ -4,43 +4,31 @@ import { HOME_NARROW, topicNarrow } from '../narrow';
 import { eg } from '../../__tests__/exampleData';
 
 describe('shouldBeMuted', () => {
+  const message = eg.streamMessage();
+  const messageMute = [eg.stream.name, message.subject];
+
   test('private messages are never muted', () => {
-    expect(shouldBeMuted(eg.pmMessage(), HOME_NARROW, [])).toBe(false);
+    expect(shouldBeMuted(eg.pmMessage(), HOME_NARROW, [], [])).toBe(false);
   });
 
   test('messages when narrowed to a topic are never muted', () => {
-    const message = eg.streamMessage();
-    const narrow = topicNarrow(eg.stream.name, message.subject);
-    const mutes = [[eg.stream.name, message.subject]];
-    expect(shouldBeMuted(message, narrow, [], mutes)).toBe(false);
+    expect(
+      shouldBeMuted(message, topicNarrow(eg.stream.name, message.subject), [], [messageMute]),
+    ).toBe(false);
   });
 
   test('message in a stream is muted if stream is not in mute list', () => {
-    const message = eg.streamMessage();
-    expect(shouldBeMuted(message, HOME_NARROW, [])).toBe(true);
+    expect(shouldBeMuted(message, HOME_NARROW, [], [])).toBe(true);
   });
 
   test('message in a stream is muted if the stream is muted', () => {
     expect(
-      shouldBeMuted(
-        eg.streamMessage(),
-        HOME_NARROW,
-        [{ ...eg.subscription, in_home_view: false }],
-        [],
-      ),
+      shouldBeMuted(message, HOME_NARROW, [{ ...eg.subscription, in_home_view: false }], []),
     ).toBe(true);
   });
 
   test('message in a stream is muted if the topic is muted and topic matches', () => {
-    const message = eg.streamMessage();
-    expect(
-      shouldBeMuted(
-        message,
-        HOME_NARROW,
-        [{ ...eg.subscription, in_home_view: true }],
-        [[eg.stream.name, message.subject]],
-      ),
-    ).toBe(true);
+    expect(shouldBeMuted(message, HOME_NARROW, [eg.subscription], [messageMute])).toBe(true);
   });
 });
 


### PR DESCRIPTION
This builds on #3467 / 415f0546b, with the same purpose of helping us to write
unit tests that
 * pass genuine well-typed data,
 * and don't have a lot of repetitive boilerplate for the boring bits.

We have a lot of tests for selectors, and they generally need a value
of type `GlobalState` to pass to the selector.  This lets us start
doing that.

Also convert `userSelectors-test.js` entirely to the new form, for demonstration -- note the full type-checking and the highly negative diffstat.

My approach was to look for test files we've repeatedly made changes to in the last 6 months:
```
$ git log --after=2018-12-01 --format= --numstat -- src/**/__tests__/ | sort -k 3
```
and I found `userSelectors-test.js` was one of the leaders. So then I went about seeing what it would take to convert it to well-typed data, and doing that.
