### PR TITLE
UnreadNotice: Remove disused 'limited' property

### DIFF
--- a/src/chat/UnreadNotice.js
+++ b/src/chat/UnreadNotice.js
@@ -7,7 +7,6 @@ import type { Narrow, Dispatch } from '../types';
 import { connect } from '../react-redux';
 import { getUnreadCountForNarrow } from '../selectors';
 import { Label, RawLabel } from '../common';
-import { unreadToLimitedCount } from '../utils/unread';
 import MarkUnreadButton from './MarkUnreadButton';
 import AnimatedScaleComponent from '../animation/AnimatedScaleComponent';
 
@@ -35,7 +34,6 @@ type SelectorProps = {|
 |};
 
 type Props = {|
-  limited: boolean,
   narrow: Narrow,
 
   dispatch: Dispatch,
@@ -43,21 +41,14 @@ type Props = {|
 |};
 
 class UnreadNotice extends PureComponent<Props> {
-  static defaultProps = {
-    limited: false,
-  };
-
   render() {
-    const { limited, narrow, unreadCount } = this.props;
+    const { narrow, unreadCount } = this.props;
 
     return (
       <AnimatedScaleComponent visible={unreadCount > 0}>
         <View style={styles.unreadContainer}>
           <View style={styles.unreadTextWrapper}>
-            <RawLabel
-              style={styles.unreadText}
-              text={limited ? unreadToLimitedCount(unreadCount) : unreadCount.toString()}
-            />
+            <RawLabel style={styles.unreadText} text={unreadCount.toString()} />
             <Label
               style={styles.unreadText}
               text={unreadCount === 1 ? 'unread message' : 'unread messages'}


### PR DESCRIPTION
Standalone, but also a prerequisite for #3471 because it removes the need for a Flow fix.