### PR TITLE
subscriptionsReducers: Delete subscriptions when a stream is deleted

### DIFF
--- a/src/subscriptions/__tests__/subscriptionsReducers-test.js
+++ b/src/subscriptions/__tests__/subscriptionsReducers-test.js
@@ -1,6 +1,7 @@
 import deepFreeze from 'deep-freeze';
 
-import { REALM_INIT, EVENT_SUBSCRIPTION, ACCOUNT_SWITCH } from '../../actionConstants';
+import { EventTypes } from '../../api/eventTypes';
+import { REALM_INIT, EVENT_SUBSCRIPTION, ACCOUNT_SWITCH, EVENT } from '../../actionConstants';
 import subscriptionsReducers from '../subscriptionsReducers';
 
 describe('subscriptionsReducers', () => {
@@ -259,6 +260,100 @@ describe('subscriptionsReducers', () => {
           in_home_view: true,
         },
       ];
+
+      const actualState = subscriptionsReducers(initialState, action);
+
+      expect(actualState).toEqual(expectedState);
+    });
+  });
+
+  describe('EVENT_STREAM -> delete', () => {
+    test('when a stream is delrted but user is not subscribed to it, do not change state', () => {
+      const initialState = deepFreeze([
+        {
+          stream_id: 3,
+          name: 'not subscribed to stream',
+        },
+      ]);
+      const action = deepFreeze({
+        type: EVENT,
+        event: {
+          type: EventTypes.stream,
+          op: 'delete',
+          streams: [
+            {
+              name: 'some stream',
+              stream_id: 1,
+            },
+          ],
+        },
+      });
+
+      const actualState = subscriptionsReducers(initialState, action);
+
+      expect(actualState).toBe(initialState);
+    });
+
+    test('when a stream is deleted the user is unsubscribed', () => {
+      const initialState = deepFreeze([
+        {
+          stream_id: 1,
+          name: 'some stream',
+        },
+      ]);
+      const action = deepFreeze({
+        type: EVENT,
+        event: {
+          type: EventTypes.stream,
+          op: 'delete',
+          streams: [
+            {
+              name: 'some stream',
+              stream_id: 1,
+            },
+            {
+              name: 'some other stream',
+              stream_id: 2,
+            },
+          ],
+        },
+      });
+      const expectedState = [];
+
+      const actualState = subscriptionsReducers(initialState, action);
+
+      expect(actualState).toEqual(expectedState);
+    });
+
+    test('when multiple streams are deleted the user is unsubscribed from all of them', () => {
+      const initialState = deepFreeze([
+        {
+          stream_id: 1,
+          name: 'some stream',
+        },
+        {
+          name: 'some other stream',
+          stream_id: 2,
+        },
+      ]);
+      const action = deepFreeze({
+        type: EVENT,
+        event: {
+          type: EventTypes.stream,
+          op: 'delete',
+          streams: [
+            {
+              name: 'some stream',
+              stream_id: 1,
+            },
+            {
+              name: 'some other stream',
+              stream_id: 2,
+            },
+          ],
+        },
+      });
+      const expectedState = [];
 
       const actualState = subscriptionsReducers(initialState, action);
 

--- a/src/subscriptions/subscriptionsReducers.js
+++ b/src/subscriptions/subscriptionsReducers.js
@@ -65,7 +65,7 @@ export default (state: SubscriptionsState = initialState, action: Action): Subsc
             case 'delete':
               return filterArray(
                 state,
-                x => !event.streams.find(y => x && y && x.stream_id === y.stream_id),
+                sub => !event.streams.find(stream => sub.stream_id === stream.stream_id),
               );
 
             case 'create':

--- a/src/subscriptions/subscriptionsReducers.js
+++ b/src/subscriptions/subscriptionsReducers.js
@@ -62,8 +62,13 @@ export default (state: SubscriptionsState = initialState, action: Action): Subsc
             case 'update':
               return updateSubscription(state, event);
 
-            case 'create':
             case 'delete':
+              return filterArray(
+                state,
+                x => !event.streams.find(y => x && y && x.stream_id === y.stream_id),
+              );
+
+            case 'create':
             case 'occupy':
             case 'vacate':
               return state;


### PR DESCRIPTION
Fixes #3474

We are not recieving a subscription 'unsubscribe' event from the
server when a stream we are subscribed to is deleted and thus we
keep subscribed to non-exiting stream until the state is refreshed.

The ideal fix for this issue should be implemented on the back-end.

This code is compatible with eventual server-side fix that would
issue an unsubscription on stream deletion.

We require this code regardless of such a fix, as we would need
to support old and new back-end versions.