### PR TITLE
android: Upgrade Gradle to 5.1.1, and Android Gradle Plugin to 3.4.0.

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -76,6 +76,7 @@ import com.android.build.OutputFile
 
 project.ext.react = [
     entryFile: "index.js",
+    jsBundleDirRelease: "$buildDir/intermediates/merged_assets/release/out"
 ]
 
 apply from: "../../node_modules/react-native/react.gradle"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -29,7 +29,7 @@ buildscript {
     }
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath 'com.android.tools.build:gradle:3.3.2'
+        classpath 'com.android.tools.build:gradle:3.4.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
TODO before merge:
- [ ] I should test a release build with this.
- [x] @jainkuniya @borisyankov : I'd appreciate one or both of you building with this branch and confirming all seems to be well.

---

Plugin release notes here:
  https://developer.android.com/studio/releases/gradle-plugin#3-4-0
Nothing super exciting; main thing is it requires Gradle 5.1.1.

Gradle release notes here:
  https://docs.gradle.org/5.1.1/release-notes.html
but mostly here, for upgrading from 4.x as we are:
  https://docs.gradle.org/5.1.1/userguide/upgrading_version_4.html

Probably the most interesting new feature: Gradle config files
(like `build.gradle`) can now be written in Kotlin, instead of in
Groovy as they are now.  This apparently comes with much better IDE
support too, which makes sense as Kotlin has static types (whee!).

Also a small change I noticed which hopefully is helpful: apparently
before 5.0 the `gradle` command would by default allocate a whole
GiB of RAM, just for the CLI?!  Yikes.  Now it defaults to 64 MiB.
That may make it a lot faster on machines that don't have whole gigs
of memory lying around free all the time.