### PR TITLE
brief-messages: Add timestamp.

### DIFF
--- a/src/webview/css/css.js
+++ b/src/webview/css/css.js
@@ -95,7 +95,7 @@ hr {
 .timerow-right {
   background: -webkit-linear-gradient(left, #999 0%, transparent 90%);
 }
-.timestamp {
+.timestamp, .message-brief > .content > :last-child::after {
   color: #999;
   font-size: 0.9rem;
   white-space: nowrap;
@@ -108,6 +108,14 @@ hr {
 }
 .message-brief {
   padding: 0 1rem 1rem 4rem;
+}
+.message-brief > .content > :first-child {
+  clear: right;
+}
+.message-brief > .content > :last-child::after {
+  content: var(--time);
+  float: right;
+  margin: 0.1rem 0 0 2rem;
 }
 .message p + p {
   margin-top: 1rem;

--- a/src/webview/html/messageAsHtml.js
+++ b/src/webview/html/messageAsHtml.js
@@ -75,19 +75,22 @@ $!${message.content}
  ><p>Interactive message</p
  ><p>To use, open on web or desktop</p
 ></div>
+<div class="dummy-element-to-align-timestamp"></div>
 `;
 
 export const flagsStateToStringList = (flags: FlagsState, id: number): string[] =>
   Object.keys(flags).filter(key => flags[key][id]);
 
 export default (backgroundData: BackgroundData, message: Message | Outbox, isBrief: boolean) => {
-  const { id } = message;
+  const { id, timestamp } = message;
   const flagStrings = flagsStateToStringList(backgroundData.flags, id);
+  const messageTime = shortTime(new Date(timestamp * 1000), backgroundData.twentyFourHourTime);
   const divOpenHtml = template`
     <div
      class="message ${isBrief ? 'message-brief' : 'message-full'}"
      id="msg-${id}"
      data-msg-id="${id}"
+     $!${isBrief ? template`style="--time:'${messageTime}'"` : ''}
      $!${flagStrings.map(flag => template`data-${flag}="true" `).join('')}
     >`;
 
@@ -106,7 +109,7 @@ $!${divOpenHtml}
 `;
   }
 
-  const { sender_full_name, sender_email, timestamp } = message;
+  const { sender_full_name, sender_email } = message;
   const avatarUrl = getAvatarFromMessage(message, backgroundData.auth.realm);
   const subheaderHtml = template`
 <div class="subheader">
@@ -114,7 +117,7 @@ $!${divOpenHtml}
     ${sender_full_name}
   </div>
   <div class="timestamp">
-    ${shortTime(new Date(timestamp * 1000), backgroundData.twentyFourHourTime)}
+    ${messageTime}
   </div>
 </div>
 `;


### PR DESCRIPTION
There have been multiple complaints about differing timestamps not
being available for messages sent at differing times by the same
user in succession. This commit aims to solve that problem by adding
a timestamp which comes right after a brief message (on the same
line, so as to conserve space). This timestamp uses the
`float:right` property, and clears itself from timestamps appearing
in further messages.

One thing of concern here is that the `top-margin` of the `::after` pseudo-element, based on calculation should be 0.2em, because the `font-size` is set to 0.8em. Inspite of this, 0.3em top-margin appears to be slightly better in terms of keeping the text aligned to the bottom of the line and not the top.

0.2
<img width="316" alt="0 2" src="https://user-images.githubusercontent.com/33200024/57981243-fc481480-7a52-11e9-9290-9324b6ab6f9e.png">

0.3
<img width="320" alt="0 3" src="https://user-images.githubusercontent.com/33200024/57981244-00743200-7a53-11e9-8f1c-a9e4334490d5.png">


0.4em seems to make it fit perfectly!
<img width="321" alt="0 4" src="https://user-images.githubusercontent.com/33200024/57981231-d458b100-7a52-11e9-93bf-370d5fad3e27.png">