### PR TITLE
Add interactive timestamp to brief messages.

### DIFF
--- a/src/webview/css/css.js
+++ b/src/webview/css/css.js
@@ -74,7 +74,7 @@ hr {
   display: flex;
   flex-direction: row;
   justify-content: space-between;
-  margin-bottom: 4px;
+  margin-bottom: 6px;
 }
 .timerow {
   text-align: center;
@@ -95,19 +95,39 @@ hr {
 .timerow-right {
   background: -webkit-linear-gradient(left, #999 0%, transparent 90%);
 }
-.timestamp {
-  color: #999;
-  font-size: 0.9rem;
-  white-space: nowrap;
-}
 .message,
 .loading {
   display: flex;
   word-wrap: break-word;
   padding: 16px;
+  -webkit-tap-highlight-color: transparent;
 }
 .message-brief {
   padding: 0 16px 16px 64px;
+}
+.time-container {
+  position: absolute;
+  right: 0;
+  width: 7em;
+  height: 2em;
+  overflow: hidden;
+  pointer-events: none;
+}
+.timestamp {
+  color: hsla(0, 0%, 0%, 0.65);
+  background: hsl(0, 0%, 92%);
+  box-shadow: -1px 1px 2px 0 hsla(0, 0%, 0%, 0.3), -2px 2px 4px 0 hsla(0, 0%, 0%, 0.3);
+  border-radius: 3px;
+  padding: 0.125em 0;
+  margin: 0 1.5em;
+  font-size: 0.9rem;
+  text-align: center;
+  white-space: nowrap;
+  transition: transform 0.2s;
+  transform: translateX(125%);
+}
+.timestamp.show {
+  transform: translateX(15%);
 }
 .message p + p {
   margin-top: 16px;
@@ -152,7 +172,8 @@ hr {
   justify-content: space-between;
 }
 .avatar,
-.header-wrapper {
+.header-wrapper,
+.message {
   cursor: pointer;
 }
 .stream-header {

--- a/src/webview/css/cssNight.js
+++ b/src/webview/css/cssNight.js
@@ -8,6 +8,10 @@ body {
 .topic-header {
   background: #54606E;
 }
+.timestamp {
+  color: hsla(0, 0%, 100%, 0.5);
+  background: hsl(213, 14%, 34%);
+}
 .highlight {
   background-color: hsla(51, 100%, 64%, 0.42);
 }

--- a/src/webview/html/htmlBody.js
+++ b/src/webview/html/htmlBody.js
@@ -7,7 +7,7 @@ const messageLoadingHtml = template`
   <div class="loading-content">
     <div class="loading-subheader">
       <div class="block name"></div>
-      <div class="block timestamp"></div>
+      <div class="block timestamp show"></div>
     </div>
     <div class="block"></div>
     <div class="block"></div>

--- a/src/webview/html/messageAsHtml.js
+++ b/src/webview/html/messageAsHtml.js
@@ -81,7 +81,7 @@ export const flagsStateToStringList = (flags: FlagsState, id: number): string[] 
   Object.keys(flags).filter(key => flags[key][id]);
 
 export default (backgroundData: BackgroundData, message: Message | Outbox, isBrief: boolean) => {
-  const { id } = message;
+  const { id, timestamp } = message;
   const flagStrings = flagsStateToStringList(backgroundData.flags, id);
   const divOpenHtml = template`
     <div
@@ -91,6 +91,13 @@ export default (backgroundData: BackgroundData, message: Message | Outbox, isBri
      $!${flagStrings.map(flag => template`data-${flag}="true" `).join('')}
     >`;
 
+  const timestampHtml = (showOnRender: boolean) => template`
+<div class="time-container">
+  <div class="timestamp ${showOnRender ? 'show' : ''}">
+    ${shortTime(new Date(timestamp * 1000), backgroundData.twentyFourHourTime)}
+  </div>
+</div>
+`;
   const bodyHtml =
     message.submessages && message.submessages.length > 0
       ? widgetBody(message)
@@ -100,22 +107,21 @@ export default (backgroundData: BackgroundData, message: Message | Outbox, isBri
     return template`
 $!${divOpenHtml}
   <div class="content">
+    $!${timestampHtml(false)}
     $!${bodyHtml}
   </div>
 </div>
 `;
   }
 
-  const { sender_full_name, sender_email, timestamp } = message;
+  const { sender_full_name, sender_email } = message;
   const avatarUrl = getAvatarFromMessage(message, backgroundData.auth.realm);
   const subheaderHtml = template`
 <div class="subheader">
   <div class="username">
     ${sender_full_name}
   </div>
-  <div class="timestamp">
-    ${shortTime(new Date(timestamp * 1000), backgroundData.twentyFourHourTime)}
-  </div>
+  $!${timestampHtml(true)}
 </div>
 `;
 

--- a/src/webview/js/generatedEs3.js
+++ b/src/webview/js/generatedEs3.js
@@ -527,6 +527,13 @@ documentBody.addEventListener('click', function (e) {
     });
     return;
   }
+
+  var messageElement = target.closest('.message');
+
+  if (messageElement) {
+    messageElement.getElementsByClassName('timestamp')[0].classList.toggle('show');
+    return;
+  }
 });
 
 var handleLongPress = function handleLongPress(target) {

--- a/src/webview/js/js.js
+++ b/src/webview/js/js.js
@@ -684,6 +684,12 @@ documentBody.addEventListener('click', (e: MouseEvent) => {
     });
     return;
   }
+
+  const messageElement = target.closest('.message');
+  if (messageElement) {
+    messageElement.getElementsByClassName('timestamp')[0].classList.toggle('show');
+    return;
+  }
 });
 
 const handleLongPress = (target: Element) => {


### PR DESCRIPTION
Two problems have plagued user experience for a long time. One,
there is no separation between two different messages, that is, one
does not know when one message ends and another one begins. Two,
there are no timestamps displayed for brief messages.

This commit aims to solve both with a sliding label which shows the
timestamp of the message if clicked on it. We do this buy
introducing two elements under `message-brief`, `timestamp-container`
and `timestamp-label`.

Browsers, by default, increase the size of the viewport to fit the
size of any element inside it. This causes the horizontal size of
the viewport to increase if we attempt to 'slide' an element out of
the viewport. The only way to not allow the browser to increase the
size is if there were an element which always inside the browser,
and another element (our actual timestamp) nested inside it which
moves around inside our outer element (which has the overflow
property set to hidden). Doing this causes the browser to think that
we're not moving the element out of the viewport, but that it's
simply overflowing from the outer element.

Has been tested on both platforms.