### PR TITLE
webview: Do not throw on <img /> with no src attribute

### DIFF
--- a/src/webview/js/generatedEs3.js
+++ b/src/webview/js/generatedEs3.js
@@ -314,7 +314,7 @@ var scrollToPreserve = function scrollToPreserve(msgId, prevBoundTop) {
 var appendAuthToImages = function appendAuthToImages(auth) {
   var imageTags = document.getElementsByTagName('img');
   arrayFrom(imageTags).forEach(function (img) {
-    if (!img.src.startsWith(auth.realm)) {
+    if (!img.src || !img.src.startsWith(auth.realm)) {
       return;
     }
 

--- a/src/webview/js/js.js
+++ b/src/webview/js/js.js
@@ -433,7 +433,7 @@ const scrollToPreserve = (msgId: number, prevBoundTop: number) => {
 const appendAuthToImages = auth => {
   const imageTags = document.getElementsByTagName('img');
   arrayFrom(imageTags).forEach(img => {
-    if (!img.src.startsWith(auth.realm)) {
+    if (!img.src || !img.src.startsWith(auth.realm)) {
       return;
     }
 


### PR DESCRIPTION
It does not seem we have `img` tags with no `src` attributes,
these would be quite useless. Yet, such tag is completely valid
html and could exist.

Accessing a missing attribute on an html element almost always
returns `null` (except older browsers where the more useful empty
string is returned) so calling `img.src.startsWith` will throw.

This change adds a check to prevent an exception in such cases.