### PR TITLE
webview: Add auth to local documents

### DIFF
--- a/src/webview/js/generatedEs3.js
+++ b/src/webview/js/generatedEs3.js
@@ -346,6 +346,24 @@ var appendAuthToImages = function appendAuthToImages(auth) {
   });
 };
 
+var appendAuthToFileLinks = function appendAuthToFileLinks(auth) {
+  var aTags = document.getElementsByTagName('a');
+  arrayFrom(aTags).forEach(function (a) {
+    if (!(a.href && a.href.startsWith(auth.realm))) {
+      return;
+    }
+
+    var hrefPath = a.href.substring(auth.realm.length);
+
+    if (!hrefPath.startsWith('/user_uploads/')) {
+      return;
+    }
+
+    var delimiter = a.href.includes('?') ? '&' : '?';
+    a.href += delimiter + "api_key=" + auth.apiKey;
+  });
+};
+
 var handleUpdateEventContent = function handleUpdateEventContent(uevent) {
   var target;
 
@@ -368,6 +386,7 @@ var handleUpdateEventContent = function handleUpdateEventContent(uevent) {
 
   documentBody.innerHTML = uevent.content;
   appendAuthToImages(uevent.auth);
+  appendAuthToFileLinks(uevent.auth);
 
   if (target.type === 'bottom') {
     scrollToBottom();

--- a/src/webview/js/js.js
+++ b/src/webview/js/js.js
@@ -475,6 +475,23 @@ const appendAuthToImages = auth => {
   });
 };
 
+const appendAuthToFileLinks = auth => {
+  const aTags = document.getElementsByTagName('a');
+  arrayFrom(aTags).forEach(a => {
+    if (!(a.href && a.href.startsWith(auth.realm))) {
+      return;
+    }
+
+    const hrefPath = a.href.substring(auth.realm.length);
+    if (!hrefPath.startsWith('/user_uploads/')) {
+      return;
+    }
+
+    const delimiter = a.href.includes('?') ? '&' : '?';
+    a.href += `${delimiter}api_key=${auth.apiKey}`;
+  });
+};
+
 const handleUpdateEventContent = (uevent: WebViewUpdateEventContent) => {
   let target: ScrollTarget;
   if (uevent.updateStrategy === 'replace') {
@@ -494,6 +511,7 @@ const handleUpdateEventContent = (uevent: WebViewUpdateEventContent) => {
   documentBody.innerHTML = uevent.content;
 
   appendAuthToImages(uevent.auth);
+  appendAuthToFileLinks(uevent.auth);
 
   if (target.type === 'bottom') {
     scrollToBottom();


### PR DESCRIPTION
Fixes #3487
Fixes #3303 (but does not implement the exact suggestion)

Just as we do with images, check if a link is local and is poining
to `/user_uploads/`. If so, adds the `api_key` value to the url
to enable opening it in Chrome Custom Tab / Safari View.

The file can then be downloaded via the oveflow menu (three-dots)
on Android. On iOS, similar actions can be taken via the 'Share'
button available at the bottom of the screen.