### PR TITLE
safari view, iOS: Fix app crash when URLs contains non-ASCII.

### DIFF
--- a/src/utils/openLink.js
+++ b/src/utils/openLink.js
@@ -4,7 +4,7 @@ import SafariView from 'react-native-safari-view';
 
 export default (url: string): void => {
   if (Platform.OS === 'ios') {
-    SafariView.show({ url });
+    SafariView.show({ url: encodeURI(url) });
   } else {
     NativeModules.CustomTabsAndroid.openURL(url);
   }


### PR DESCRIPTION
Encode url with `encodeURI` before passing it to safari view.

Refer issue thread for complete diagnosis.

Fixes: #3315