### PR TITLE
editor: Add config for recommended extensions.

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,16 @@
+{
+	// See http://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
+	// Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
+
+	// List of extensions which should be recommended for users of this workspace.
+	"recommendations": [
+		"msjsdiag.vscode-react-native",
+		"flowtype.flow-for-vscode",
+		"dbaeumer.vscode-eslint",
+		"esbenp.prettier-vscode"
+	],
+
+	// List of extensions recommended by VS Code that should not be recommended for users of this workspace.
+	// Nothing in here but adding this in order to add extentions later as required.
+	"unwantedRecommendations": []
+}

--- a/docs/howto/editor.md
+++ b/docs/howto/editor.md
@@ -19,8 +19,12 @@ To use it, [install VS Code](https://code.visualstudio.com/).
 
 ### Useful extensions for VS Code
 
-Install the following extensions, which support important aspects of our
-codebase. Each extension page has install instructions at the top.
+VS Code should prompt you to install the recommended extensions when you open the
+workspace for the first time. If you don't get the notification you can also review
+the list with the `Extensions: Show Recommended Extensions` command (press
+`ctrl/cmd + shift + P` to bring up command prompt).
+
+The following are the recommended extensions for reference.
 
 * [React Native
     Tools](https://marketplace.visualstudio.com/items?itemName=msjsdiag.vscode-react-native)

--- a/docs/howto/editor.md
+++ b/docs/howto/editor.md
@@ -23,7 +23,7 @@ Install the following extensions, which support important aspects of our
 codebase. Each extension page has install instructions at the top.
 
 * [React Native
-    Tools](https://marketplace.visualstudio.com/items?itemName=vsmobile.vscode-react-native)
+    Tools](https://marketplace.visualstudio.com/items?itemName=msjsdiag.vscode-react-native)
 * [Flow Language
     Support](https://marketplace.visualstudio.com/items?itemName=flowtype.flow-for-vscode)
 * [ESLint](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint)


### PR DESCRIPTION
This PR adds a configuration file for recommending extensions required for a smooth developer experience. It uses the default [feature](https://code.visualstudio.com/docs/editor/extension-gallery#_workspace-recommended-extensions) in vscode to do so.

The doc `editor.md` has been updated to reflect this change.

Based on #3219.