### PR TITLE
message list: Fix difference in spacing.

### DIFF
--- a/src/webview/css/css.js
+++ b/src/webview/css/css.js
@@ -114,9 +114,9 @@ hr {
 }
 .avatar,
 .loading-avatar {
-  min-width: 40px;
-  width: 40px;
-  height: 40px;
+  min-width: 32px;
+  width: 32px;
+  height: 32px;
   margin-right: 1rem;
 }
 .avatar img {


### PR DESCRIPTION
The apparent spacing of the left margin is differing between a
`message-full` and a `message-brief` at the time of this
commit. This was due to merging a previous commit which incorrectly
replaced `2rem` to `40px` instead of the `32px` correct value. This
small commit fixes that.

Fixes #3508.