### PR TITLE
RGB > HSL

### DIFF
--- a/docs/howto/editor.md
+++ b/docs/howto/editor.md
@@ -29,19 +29,8 @@ codebase. Each extension page has install instructions at the top.
 * [ESLint](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint)
 * [prettier-vscode](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode)
 
-For the extensions to work properly, make sure that VS Code has recognized
-[our settings file](https://github.com/zulip/zulip-mobile/tree/master/.vscode/settings.json)
-in the zulip-mobile repository. Usually, this should happen automatically
-when you open the `zulip-mobile` folder in VS Code. You can verify that the
-settings were recognized by opening your Workspace Settings with
-`Ctrl+Shift+P` -> `Open Workspace Settings`. If the editor on the right-hand
-side starts with the comment
-```js
-// Workspace Settings for the zulip-mobile repo.
-```
-you're all set - VS Code has recognized your workspace settings. If not,
-make sure that you opened VS Code as a folder. Do this by pressing
-`Ctrl+K Ctrl+O` and navigating to your local `zulip-mobile` clone.
+If something doesn't seem right, see the items under "Troubleshooting" below.
+
 
 ### Getting familiar with VS Code
 
@@ -64,7 +53,27 @@ Take a look through some of VS Code's docs.  In particular:
   enable this feature, and configure it to use our standard formatting
   rules.
 
+
 ### Troubleshooting
+
+#### Confirm our workspace settings took effect
+
+For the extensions to work properly, make sure that VS Code has recognized
+[our settings file](https://github.com/zulip/zulip-mobile/tree/master/.vscode/settings.json)
+in the zulip-mobile repository. Usually, this should happen automatically
+when you open the `zulip-mobile` folder in VS Code.
+
+You can verify that the settings were recognized by opening your
+Workspace Settings with `Ctrl+Shift+P` -> `Open Workspace
+Settings`. If the editor on the right-hand side starts with the
+comment
+```js
+// Workspace Settings for the zulip-mobile repo.
+```
+you're all set - VS Code has recognized your workspace settings. If not,
+make sure that you opened VS Code as a folder. Do this by pressing
+`Ctrl+K Ctrl+O` and navigating to your local `zulip-mobile` clone.
+
 
 #### Saving causes bad reformatting of code
 

--- a/docs/howto/editor.md
+++ b/docs/howto/editor.md
@@ -31,6 +31,11 @@ codebase. Each extension page has install instructions at the top.
 
 If something doesn't seem right, see the items under "Troubleshooting" below.
 
+Perhaps try the following extensions too, which can be handy:
+
+* [Color Picker](https://marketplace.visualstudio.com/items?itemName=anseki.vscode-color)
+* [Color Highlight](https://marketplace.visualstudio.com/items?itemName=naumovs.color-highlight)
+
 
 ### Getting familiar with VS Code
 

--- a/src/account/AccountItem.js
+++ b/src/account/AccountItem.js
@@ -13,7 +13,7 @@ const styles = StyleSheet.create({
   accountItem: {
     flexDirection: 'row',
     alignItems: 'center',
-    backgroundColor: 'hsla(177.1, 69.7%, 46.7%, 0.1)',
+    backgroundColor: 'hsla(177, 70%, 47%, 0.1)',
     borderRadius: 4,
     height: 72,
   },

--- a/src/account/AccountItem.js
+++ b/src/account/AccountItem.js
@@ -13,7 +13,7 @@ const styles = StyleSheet.create({
   accountItem: {
     flexDirection: 'row',
     alignItems: 'center',
-    backgroundColor: 'rgba(36, 202, 194, 0.1)',
+    backgroundColor: 'hsla(177.1, 69.7%, 46.7%, 0.1)',
     borderRadius: 4,
     height: 72,
   },

--- a/src/chat/UnreadNotice.js
+++ b/src/chat/UnreadNotice.js
@@ -14,7 +14,7 @@ const styles = StyleSheet.create({
   unreadContainer: {
     paddingHorizontal: 8,
     paddingVertical: 4,
-    backgroundColor: 'hsl(232.1, 89%, 78.2%)',
+    backgroundColor: 'hsl(232, 89%, 78%)',
     flexDirection: 'row',
     justifyContent: 'space-between',
     overflow: 'hidden',

--- a/src/chat/UnreadNotice.js
+++ b/src/chat/UnreadNotice.js
@@ -14,7 +14,7 @@ const styles = StyleSheet.create({
   unreadContainer: {
     paddingHorizontal: 8,
     paddingVertical: 4,
-    backgroundColor: '#96A3F9',
+    backgroundColor: 'hsl(232.1, 89%, 78.2%)',
     flexDirection: 'row',
     justifyContent: 'space-between',
     overflow: 'hidden',

--- a/src/common/OfflineNotice.js
+++ b/src/common/OfflineNotice.js
@@ -15,7 +15,7 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     justifyContent: 'center',
     alignItems: 'center',
-    backgroundColor: 'hsl(6.4, 98.1%, 57.1%)',
+    backgroundColor: 'hsl(6, 98%, 57%)',
   },
   text: {
     fontSize: 14,

--- a/src/common/OfflineNotice.js
+++ b/src/common/OfflineNotice.js
@@ -15,7 +15,7 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     justifyContent: 'center',
     alignItems: 'center',
-    backgroundColor: '#FD3D26',
+    backgroundColor: 'hsl(6.4, 98.1%, 57.1%)',
   },
   text: {
     fontSize: 14,

--- a/src/common/PresenceStatusIndicator.js
+++ b/src/common/PresenceStatusIndicator.js
@@ -22,10 +22,10 @@ const styles = StyleSheet.create({
   },
   idleWrapper: {
     borderWidth: 2,
-    borderColor: 'hsl(38.8, 100%, 50%)',
+    borderColor: 'hsl(39, 100%, 50%)',
   },
   idleHalfCircle: {
-    backgroundColor: 'hsl(38.8, 100%, 50%)',
+    backgroundColor: 'hsl(39, 100%, 50%)',
     width: 8,
     height: 4,
     marginTop: 4,

--- a/src/common/PresenceStatusIndicator.js
+++ b/src/common/PresenceStatusIndicator.js
@@ -22,10 +22,10 @@ const styles = StyleSheet.create({
   },
   idleWrapper: {
     borderWidth: 2,
-    borderColor: 'rgba(255, 165, 0, 1)',
+    borderColor: 'hsl(38.8, 100%, 50%)',
   },
   idleHalfCircle: {
-    backgroundColor: 'rgba(255, 165, 0, 1)',
+    backgroundColor: 'hsl(38.8, 100%, 50%)',
     width: 8,
     height: 4,
     marginTop: 4,

--- a/src/common/SectionHeader.js
+++ b/src/common/SectionHeader.js
@@ -8,7 +8,7 @@ import Label from './Label';
 const styles = StyleSheet.create({
   header: {
     padding: 10,
-    backgroundColor: 'hsla(0, 0%, 49.8%, 0.75)',
+    backgroundColor: 'hsla(0, 0%, 50%, 0.75)',
   },
 });
 

--- a/src/common/SectionHeader.js
+++ b/src/common/SectionHeader.js
@@ -8,7 +8,7 @@ import Label from './Label';
 const styles = StyleSheet.create({
   header: {
     padding: 10,
-    backgroundColor: 'rgba(127, 127, 127, 0.75)',
+    backgroundColor: 'hsla(0, 0%, 49.8%, 0.75)',
   },
 });
 

--- a/src/common/SectionSeparator.js
+++ b/src/common/SectionSeparator.js
@@ -6,7 +6,7 @@ const styles = StyleSheet.create({
   separator: {
     height: 1,
     margin: 10,
-    backgroundColor: 'hsla(0, 0%, 49.8%, 0.75)',
+    backgroundColor: 'hsla(0, 0%, 50%, 0.75)',
   },
 });
 

--- a/src/common/SectionSeparator.js
+++ b/src/common/SectionSeparator.js
@@ -6,7 +6,7 @@ const styles = StyleSheet.create({
   separator: {
     height: 1,
     margin: 10,
-    backgroundColor: 'rgba(127, 127, 127, 0.75)',
+    backgroundColor: 'hsla(0, 0%, 49.8%, 0.75)',
   },
 });
 

--- a/src/common/ZulipButton.js
+++ b/src/common/ZulipButton.js
@@ -48,14 +48,14 @@ const styles = StyleSheet.create({
     color: BRAND_COLOR,
   },
   disabledPrimaryFrame: {
-    backgroundColor: 'hsla(0, 0%, 49.8%, 0.4)',
+    backgroundColor: 'hsla(0, 0%, 50%, 0.4)',
   },
   disabledSecondaryFrame: {
     borderWidth: 1.5,
-    borderColor: 'hsla(0, 0%, 49.8%, 0.4)',
+    borderColor: 'hsla(0, 0%, 50%, 0.4)',
   },
   disabledText: {
-    color: 'hsla(0, 0%, 49.8%, 0.8)',
+    color: 'hsla(0, 0%, 50%, 0.8)',
   },
 });
 

--- a/src/common/ZulipButton.js
+++ b/src/common/ZulipButton.js
@@ -29,7 +29,7 @@ const styles = StyleSheet.create({
     borderColor: BRAND_COLOR,
   },
   text: {
-    color: '#FFFFFF',
+    color: 'hsl(0, 0%, 100%)',
     fontSize: 16,
   },
   primaryText: {
@@ -48,14 +48,14 @@ const styles = StyleSheet.create({
     color: BRAND_COLOR,
   },
   disabledPrimaryFrame: {
-    backgroundColor: 'rgba(127, 127, 127, 0.4)',
+    backgroundColor: 'hsla(0, 0%, 49.8%, 0.4)',
   },
   disabledSecondaryFrame: {
     borderWidth: 1.5,
-    borderColor: 'rgba(127, 127, 127, 0.4)',
+    borderColor: 'hsla(0, 0%, 49.8%, 0.4)',
   },
   disabledText: {
-    color: 'rgba(127, 127, 127, 0.8)',
+    color: 'hsla(0, 0%, 49.8%, 0.8)',
   },
 });
 

--- a/src/common/ZulipStatusBar.js
+++ b/src/common/ZulipStatusBar.js
@@ -15,7 +15,7 @@ type BarStyle = $PropertyType<$PropertyType<StatusBar, 'props'>, 'barStyle'>;
 export const getStatusBarColor = (backgroundColor: string, theme: ThemeName): string =>
   backgroundColor === DEFAULT_TITLE_BACKGROUND_COLOR
     ? theme === 'night'
-      ? '#212D3B'
+      ? 'hsl(212.4, 28.3%, 18%)'
       : 'white'
     : backgroundColor;
 

--- a/src/common/ZulipStatusBar.js
+++ b/src/common/ZulipStatusBar.js
@@ -15,7 +15,7 @@ type BarStyle = $PropertyType<$PropertyType<StatusBar, 'props'>, 'barStyle'>;
 export const getStatusBarColor = (backgroundColor: string, theme: ThemeName): string =>
   backgroundColor === DEFAULT_TITLE_BACKGROUND_COLOR
     ? theme === 'night'
-      ? 'hsl(212.4, 28.3%, 18%)'
+      ? 'hsl(212, 28%, 18%)'
       : 'white'
     : backgroundColor;
 

--- a/src/common/ZulipSwitch.js
+++ b/src/common/ZulipSwitch.js
@@ -56,7 +56,7 @@ export default class ZulipSwitch extends PureComponent<Props, State> {
       <Switch
         value={switchValue}
         trackColor={{
-          false: 'hsl(0, 0%, 86.3%)',
+          false: 'hsl(0, 0%, 86%)',
           true: BRAND_COLOR,
         }}
         onValueChange={this.handleValueChange}

--- a/src/common/ZulipSwitch.js
+++ b/src/common/ZulipSwitch.js
@@ -56,7 +56,7 @@ export default class ZulipSwitch extends PureComponent<Props, State> {
       <Switch
         value={switchValue}
         trackColor={{
-          false: 'rgba(220, 220, 220, 1)',
+          false: 'hsl(0, 0%, 86.3%)',
           true: BRAND_COLOR,
         }}
         onValueChange={this.handleValueChange}

--- a/src/common/__tests__/getStatusBarColor-test.js
+++ b/src/common/__tests__/getStatusBarColor-test.js
@@ -14,7 +14,7 @@ describe('getStatusBarColor', () => {
   test('returns color according to theme for default case', () => {
     expect(getStatusBarColor(DEFAULT_TITLE_BACKGROUND_COLOR, themeDefault)).toEqual('white');
     expect(getStatusBarColor(DEFAULT_TITLE_BACKGROUND_COLOR, themeNight)).toEqual(
-      'hsl(212.4, 28.3%, 18%)',
+      'hsl(212, 28%, 18%)',
     );
   });
 });

--- a/src/common/__tests__/getStatusBarColor-test.js
+++ b/src/common/__tests__/getStatusBarColor-test.js
@@ -13,6 +13,8 @@ describe('getStatusBarColor', () => {
 
   test('returns color according to theme for default case', () => {
     expect(getStatusBarColor(DEFAULT_TITLE_BACKGROUND_COLOR, themeDefault)).toEqual('white');
-    expect(getStatusBarColor(DEFAULT_TITLE_BACKGROUND_COLOR, themeNight)).toEqual('#212D3B');
+    expect(getStatusBarColor(DEFAULT_TITLE_BACKGROUND_COLOR, themeNight)).toEqual(
+      'hsl(212.4, 28.3%, 18%)',
+    );
   });
 });

--- a/src/compose/ComposeBox.js
+++ b/src/compose/ComposeBox.js
@@ -332,7 +332,7 @@ class ComposeBox extends PureComponent<Props, State> {
     const placeholder = getComposeInputPlaceholder(narrow, auth.email, usersByEmail);
     const style = {
       paddingBottom: safeAreaInsets.bottom,
-      backgroundColor: 'rgba(127, 127, 127, 0.1)',
+      backgroundColor: 'hsla(0, 0%, 49.8%, 0.1)',
     };
 
     return (

--- a/src/compose/ComposeBox.js
+++ b/src/compose/ComposeBox.js
@@ -332,7 +332,7 @@ class ComposeBox extends PureComponent<Props, State> {
     const placeholder = getComposeInputPlaceholder(narrow, auth.email, usersByEmail);
     const style = {
       paddingBottom: safeAreaInsets.bottom,
-      backgroundColor: 'hsla(0, 0%, 49.8%, 0.1)',
+      backgroundColor: 'hsla(0, 0%, 50%, 0.1)',
     };
 
     return (

--- a/src/diagnostics/InfoItem.js
+++ b/src/diagnostics/InfoItem.js
@@ -8,7 +8,7 @@ const styles = StyleSheet.create({
   item: {
     padding: 16,
     borderBottomWidth: 1,
-    borderColor: 'rgba(127, 127, 127, 0.25)',
+    borderColor: 'hsla(0, 0%, 49.8%, 0.25)',
   },
   label: {
     fontWeight: 'bold',

--- a/src/diagnostics/InfoItem.js
+++ b/src/diagnostics/InfoItem.js
@@ -8,7 +8,7 @@ const styles = StyleSheet.create({
   item: {
     padding: 16,
     borderBottomWidth: 1,
-    borderColor: 'hsla(0, 0%, 49.8%, 0.25)',
+    borderColor: 'hsla(0, 0%, 50%, 0.25)',
   },
   label: {
     fontWeight: 'bold',

--- a/src/diagnostics/SizeItem.js
+++ b/src/diagnostics/SizeItem.js
@@ -11,7 +11,7 @@ const styles = StyleSheet.create({
     justifyContent: 'space-between',
     padding: 8,
     borderBottomWidth: 1,
-    borderColor: 'rgba(127, 127, 127, 0.25)',
+    borderColor: 'hsla(0, 0%, 49.8%, 0.25)',
   },
   key: {},
   size: {

--- a/src/diagnostics/SizeItem.js
+++ b/src/diagnostics/SizeItem.js
@@ -11,7 +11,7 @@ const styles = StyleSheet.create({
     justifyContent: 'space-between',
     padding: 8,
     borderBottomWidth: 1,
-    borderColor: 'hsla(0, 0%, 49.8%, 0.25)',
+    borderColor: 'hsla(0, 0%, 50%, 0.25)',
   },
   key: {},
   size: {

--- a/src/diagnostics/TimeItem.js
+++ b/src/diagnostics/TimeItem.js
@@ -11,7 +11,7 @@ const styles = StyleSheet.create({
   item: {
     padding: 16,
     borderBottomWidth: 1,
-    borderColor: 'rgba(127, 127, 127, 0.25)',
+    borderColor: 'hsla(0, 0%, 49.8%, 0.25)',
   },
   label: {
     fontWeight: 'bold',

--- a/src/diagnostics/TimeItem.js
+++ b/src/diagnostics/TimeItem.js
@@ -11,7 +11,7 @@ const styles = StyleSheet.create({
   item: {
     padding: 16,
     borderBottomWidth: 1,
-    borderColor: 'hsla(0, 0%, 49.8%, 0.25)',
+    borderColor: 'hsla(0, 0%, 50%, 0.25)',
   },
   label: {
     fontWeight: 'bold',

--- a/src/settings/LanguagePicker.js
+++ b/src/settings/LanguagePicker.js
@@ -12,7 +12,7 @@ import LanguagePickerItem from './LanguagePickerItem';
 const styles = StyleSheet.create({
   separator: {
     height: 1,
-    backgroundColor: 'rgba(0, 0, 0, 0.1)',
+    backgroundColor: 'hsla(0, 0%, 0%, 0.1)',
   },
 });
 

--- a/src/styles/constants.js
+++ b/src/styles/constants.js
@@ -3,8 +3,8 @@
 export const CONTROL_SIZE = 44;
 export const NAVBAR_SIZE = 58;
 
-export const BRAND_COLOR = 'hsl(169.8, 47.9%, 54.1%)';
+export const BRAND_COLOR = 'hsl(170, 48%, 54%)';
 export const BORDER_COLOR = BRAND_COLOR;
-export const HIGHLIGHT_COLOR = 'hsla(186.8, 35.2%, 51%, 0.5)';
-export const HALF_COLOR = 'hsla(0, 0%, 49.8%, 0.5)';
-export const QUARTER_COLOR = 'hsla(0, 0%, 49.8%, 0.25)';
+export const HIGHLIGHT_COLOR = 'hsla(187, 35%, 51%, 0.5)';
+export const HALF_COLOR = 'hsla(0, 0%, 50%, 0.5)';
+export const QUARTER_COLOR = 'hsla(0, 0%, 50%, 0.25)';

--- a/src/styles/constants.js
+++ b/src/styles/constants.js
@@ -3,8 +3,8 @@
 export const CONTROL_SIZE = 44;
 export const NAVBAR_SIZE = 58;
 
-export const BRAND_COLOR = 'rgba(82, 194, 175, 1)';
+export const BRAND_COLOR = 'hsl(169.8, 47.9%, 54.1%)';
 export const BORDER_COLOR = BRAND_COLOR;
-export const HIGHLIGHT_COLOR = 'rgba(86, 164, 174, 0.5)';
-export const HALF_COLOR = 'rgba(127, 127, 127, 0.5)';
-export const QUARTER_COLOR = 'rgba(127, 127, 127, 0.25)';
+export const HIGHLIGHT_COLOR = 'hsla(186.8, 35.2%, 51%, 0.5)';
+export const HALF_COLOR = 'hsla(0, 0%, 49.8%, 0.5)';
+export const QUARTER_COLOR = 'hsla(0, 0%, 49.8%, 0.25)';

--- a/src/styles/navStyles.js
+++ b/src/styles/navStyles.js
@@ -18,7 +18,7 @@ export const statics = {
     fontSize: 20,
   },
   navBar: {
-    borderColor: 'hsla(0, 0%, 49.8%, 0.25)',
+    borderColor: 'hsla(0, 0%, 50%, 0.25)',
     flexDirection: 'row',
     height: NAVBAR_SIZE,
     alignItems: 'center',

--- a/src/styles/navStyles.js
+++ b/src/styles/navStyles.js
@@ -18,7 +18,7 @@ export const statics = {
     fontSize: 20,
   },
   navBar: {
-    borderColor: 'rgba(127, 127, 127, 0.25)',
+    borderColor: 'hsla(0, 0%, 49.8%, 0.25)',
     flexDirection: 'row',
     height: NAVBAR_SIZE,
     alignItems: 'center',

--- a/src/styles/theme.js
+++ b/src/styles/theme.js
@@ -21,20 +21,20 @@ export type AppStyles = $ReadOnly<{|
 
 export const themeColors: { [string]: ThemeColors } = {
   night: {
-    color: '#d5d9dd',
-    backgroundColor: '#212D3B',
-    cardColor: '#253547',
+    color: 'hsl(210, 10.7%, 85.1%)',
+    backgroundColor: 'hsl(212.4, 28.3%, 18%)',
+    cardColor: 'hsl(211.6, 31.4%, 21.2%)',
     // Dividers follow Material Design: opacity 12% black or 12% white.
     // See https://material.io/guidelines/components/dividers.html
-    dividerColor: 'rgba(255, 255, 255, 0.12)',
+    dividerColor: 'hsla(0, 0%, 100%, 0.12)',
   },
   light: {
-    color: '#333',
+    color: 'hsl(0, 0%, 20%)',
     backgroundColor: 'white',
-    cardColor: '#F8F8F8',
+    cardColor: 'hsl(0, 0%, 97.3%)',
     // Dividers follow Material Design: opacity 12% black or 12% white.
     // See https://material.io/guidelines/components/dividers.html
-    dividerColor: 'rgba(0, 0, 0, 0.12)',
+    dividerColor: 'hsla(0, 0%, 0%, 0.12)',
   },
 };
 themeColors.default = themeColors.light;

--- a/src/styles/theme.js
+++ b/src/styles/theme.js
@@ -21,9 +21,9 @@ export type AppStyles = $ReadOnly<{|
 
 export const themeColors: { [string]: ThemeColors } = {
   night: {
-    color: 'hsl(210, 10.7%, 85.1%)',
-    backgroundColor: 'hsl(212.4, 28.3%, 18%)',
-    cardColor: 'hsl(211.6, 31.4%, 21.2%)',
+    color: 'hsl(210, 11%, 85%)',
+    backgroundColor: 'hsl(212, 28%, 18%)',
+    cardColor: 'hsl(212, 31%, 21%)',
     // Dividers follow Material Design: opacity 12% black or 12% white.
     // See https://material.io/guidelines/components/dividers.html
     dividerColor: 'hsla(0, 0%, 100%, 0.12)',
@@ -31,7 +31,7 @@ export const themeColors: { [string]: ThemeColors } = {
   light: {
     color: 'hsl(0, 0%, 20%)',
     backgroundColor: 'white',
-    cardColor: 'hsl(0, 0%, 97.3%)',
+    cardColor: 'hsl(0, 0%, 97%)',
     // Dividers follow Material Design: opacity 12% black or 12% white.
     // See https://material.io/guidelines/components/dividers.html
     dividerColor: 'hsla(0, 0%, 0%, 0.12)',

--- a/src/user-groups/UserGroupItem.js
+++ b/src/user-groups/UserGroupItem.js
@@ -13,7 +13,7 @@ const componentStyles = StyleSheet.create({
   },
   textEmail: {
     fontSize: 10,
-    color: '#999',
+    color: 'hsl(0, 0%, 60%)',
   },
   textWrapper: {
     flex: 1,

--- a/src/users/UserItem.js
+++ b/src/users/UserItem.js
@@ -17,7 +17,7 @@ const componentStyles = StyleSheet.create({
   },
   textEmail: {
     fontSize: 10,
-    color: '#999',
+    color: 'hsl(0, 0%, 60%)',
   },
   textWrapper: {
     flex: 1,

--- a/src/webview/css/css.js
+++ b/src/webview/css/css.js
@@ -21,7 +21,7 @@ body {
   max-width: 100%;
 }
 a {
-  color: #08c;
+  color: hsl(200, 100%, 40%);
 }
 p {
   margin: 0;
@@ -41,8 +41,8 @@ pre {
 }
 code, pre {
   border-radius: 3px;
-  border: 1px solid rgba(127, 127, 127, 0.25);
-  background-color: rgba(127, 127, 127, 0.125);
+  border: 1px solid hsla(0, 0%, 49.8%, 0.25);
+  background-color: hsla(0, 0%, 49.8%, 0.125);
   font-family: Monaco, Menlo, Consolas, "Courier New", monospace;
 }
 table {
@@ -50,10 +50,10 @@ table {
   width: 100%;
 }
 table, th, td {
-  border: 1px solid rgba(127, 127, 127, 0.25);
+  border: 1px solid hsla(0, 0%, 49.8%, 0.25);
 }
 thead {
-  background: rgba(127, 127, 127, 0.1);
+  background: hsla(0, 0%, 49.8%, 0.1);
 }
 th, td {
   align: center;
@@ -62,7 +62,7 @@ th, td {
 hr {
   margin: 16px 0;
   border: 0;
-  border-top: 1px solid rgba(127, 127, 127, 0.5);
+  border-top: 1px solid hsla(0, 0%, 49.8%, 0.5);
 }
 .alert-word {
   background-color: hsla(102, 85%, 57%, .5);
@@ -78,7 +78,7 @@ hr {
 }
 .timerow {
   text-align: center;
-  color: #999;
+  color: hsl(0, 0%, 60%);
   display: flex;
   align-items: center;
   padding: 8px 0;
@@ -90,10 +90,10 @@ hr {
   margin: 8px;
 }
 .timerow-left {
-  background: -webkit-linear-gradient(left, transparent 10%, #999 100%);
+  background: -webkit-linear-gradient(left, transparent 10%, hsl(0, 0%, 60%) 100%);
 }
 .timerow-right {
-  background: -webkit-linear-gradient(left, #999 0%, transparent 90%);
+  background: -webkit-linear-gradient(left, hsl(0, 0%, 60%) 0%, transparent 90%);
 }
 .message,
 .loading {
@@ -106,7 +106,7 @@ hr {
   padding: 0 16px 16px 64px;
 }
 .static-timestamp {
-  color: #999;
+  color: hsl(0, 0%, 60%);
   font-size: 0.9rem;
   white-space: nowrap;
 }
@@ -127,7 +127,7 @@ hr {
   padding: 2px 4px;
   font-size: 0.9rem;
   white-space: nowrap;
-  color: #999;
+  color: hsl(0, 0%, 60%);
   background: hsl(0, 0%, 97%);
   border-radius: 3px;
   box-shadow:
@@ -167,11 +167,11 @@ hr {
 .user-group-mention,
 .user-mention {
   white-space: nowrap;
-  background-color: rgba(0, 0, 0, 0.1);
+  background-color: hsla(0, 0%, 0%, 0.1);
   border-radius: 3px;
   padding: 0 2px;
   margin: 0 1px;
-  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.2);
+  box-shadow: 0 0 0 1px hsla(0, 0%, 0%, 0.2);
 }
 .header-wrapper {
   position: -webkit-sticky;
@@ -201,7 +201,7 @@ hr {
   padding: 0 8px;
 }
 .topic-header {
-  background: #ccc;
+  background: hsl(0, 0%, 80%);
   min-width: 30%;
 }
 .stream-text {
@@ -220,7 +220,7 @@ hr {
   pointer-events: none;
 }
 [data-mentioned="true"], [data-wildcard_mentioned="true"] {
-  background: rgba(255, 0, 0, 0.05);
+  background: hsla(0, 100%, 50%, 0.05);
 }
 .message:not([data-read="true"]) {
   box-shadow: inset 4px 0 ${BRAND_COLOR};
@@ -233,12 +233,12 @@ hr {
   transition-timing-function: ease-out;
 }
 .private-header {
-  background: #444;
+  background: hsl(0, 0%, 26.7%);
   color: white;
 }
 .loading-avatar {
   border-radius: 3px;
-  background: rgba(127, 127, 127, 0.9);
+  background: hsla(0, 0%, 49.8%, 0.9);
 }
 .loading-content {
   width: 100%;
@@ -250,11 +250,11 @@ hr {
 .loading-content .block {
   background: linear-gradient(
     to right,
-    rgba(127, 127, 127, 0.5) 0%,
-    rgba(127, 127, 127, 0.5) 40%,
-    rgba(127, 127, 127, 0.25) 51%,
-    rgba(127, 127, 127, 0.5) 60%,
-    rgba(127, 127, 127, 0.5) 100%
+    hsla(0, 0%, 49.8%, 0.5) 0%,
+    hsla(0, 0%, 49.8%, 0.5) 40%,
+    hsla(0, 0%, 49.8%, 0.25) 51%,
+    hsla(0, 0%, 49.8%, 0.5) 60%,
+    hsla(0, 0%, 49.8%, 0.5) 100%
   );
   background-size: 200% 200%;
   animation: gradient-scroll 1s linear infinite;
@@ -269,7 +269,7 @@ hr {
 }
 .loading-subheader .name {
   width: 10rem;
-  background-color: rgba(127, 127, 127, 0.9);
+  background-color: hsla(0, 0%, 49.8%, 0.9);
 }
 .loading-subheader .timestamp {
   width: 5rem;
@@ -284,8 +284,8 @@ hr {
   border-radius: 50%;
   margin: 16px auto;
   font-size: 10px;
-  border: 3px solid rgba(82, 194, 175, 0.25);
-  border-left: 3px solid rgba(82, 194, 175, 0.75);
+  border: 3px solid hsla(169.8, 47.9%, 54.1%, 0.25);
+  border-left: 3px solid hsla(169.8, 47.9%, 54.1%, 0.75);
   animation: spin 1s linear infinite;
 }
 .outbox-spinner {
@@ -308,7 +308,7 @@ hr {
 blockquote {
   padding-left: 8px;
   margin: 8px 0 8px 0;
-  border-left: 3px solid rgba(127, 127, 127, 0.5);
+  border-left: 3px solid hsla(0, 0%, 49.8%, 0.5);
 }
 .message ul {
   padding-left: 20px;
@@ -317,20 +317,20 @@ blockquote {
 .message ul + p {
   margin-top: 16px;
 }
-.codehilite .gi { color: #00a000; }
-.codehilite .gd { color: #a00000; }
-.codehilite .k { color: #008000; font-weight: bold; }
-.codehilite .kd { color: #008000; font-weight: bold; }
-.codehilite .nf { color: #00f; }
-.codehilite .s2 { color: #ba2121; }
-.codehilite .cp { color: #bc7a00; }
-.codehilite .kt { color: #b00040; }
-.codehilite .nc { color: #00f; font-weight: bold; }
-.codehilite .nb { color: #008000; }
-.codehilite .s1 { color: #ba2121; }
+.codehilite .gi { color: hsl(120, 100%, 31.4%); }
+.codehilite .gd { color: hsl(0, 100%, 31.4%); }
+.codehilite .k { color: hsl(120, 100%, 25.1%); font-weight: bold; }
+.codehilite .kd { color: hsl(120, 100%, 25.1%); font-weight: bold; }
+.codehilite .nf { color: hsl(240, 100%, 50%); }
+.codehilite .s2 { color: hsl(0, 69.9%, 42.9%); }
+.codehilite .cp { color: hsl(38.9, 100%, 36.9%); }
+.codehilite .kt { color: hsl(338.2, 100%, 34.5%); }
+.codehilite .nc { color: hsl(240, 100%, 50%); font-weight: bold; }
+.codehilite .nb { color: hsl(120, 100%, 25.1%); }
+.codehilite .s1 { color: hsl(0, 69.9%, 42.9%); }
 .twitter-tweet {
-  border: 2px solid rgba(29, 161, 242, 0.5);
-  background: rgba(29, 161, 242, 0.1);
+  border: 2px solid hsla(202.8, 89.1%, 53.1%, 0.5);
+  background: hsla(202.8, 89.1%, 53.1%, 0.1);
   border-radius: 6px;
   padding: 8px 16px;
   margin: 8px 0;
@@ -355,18 +355,18 @@ blockquote {
   padding: 4px 4px;
   margin-left: 4px;
   border-radius: 3px;
-  color: rgba(127, 127, 127, 0.75);
-  background: rgba(0, 0, 0, 0.1);
+  color: hsla(0, 0%, 49.8%, 0.75);
+  background: hsla(0, 0%, 0%, 0.1);
 }
 .reaction-list {
   margin: 8px 0;
 }
 .reaction {
-  color: rgba(127, 127, 127, 1);
+  color: hsl(0, 0%, 49.8%);
   display: inline-block;
   padding: 5px 6.5px;
   border-radius: 3px;
-  border: 1px solid rgba(127, 127, 127, 0.75);
+  border: 1px solid hsla(0, 0%, 49.8%, 0.75);
   line-height: 1rem;
   height: 1rem;
   margin: 4px 8px 4px 0;
@@ -381,7 +381,7 @@ blockquote {
 .self-voted {
   color: ${BRAND_COLOR};
   border: 1px solid ${BRAND_COLOR};
-  background: rgba(36, 202, 194, 0.1);
+  background: hsla(177.1, 69.7%, 46.7%, 0.1);
 }
 .hidden {
   display: none;
@@ -403,8 +403,8 @@ blockquote {
   align-items: center;
   justify-content: center;
   padding: 1rem;
-  background: rgba(127, 127, 127, 0.1);
-  border: 1px dashed rgba(127, 127, 127, 0.5);
+  background: hsla(0, 0%, 49.8%, 0.1);
+  border: 1px dashed hsla(0, 0%, 49.8%, 0.5);
   border-radius: 0.5rem;
 }
 #typing {
@@ -417,7 +417,7 @@ blockquote {
 }
 #typing span {
   display: inline-block;
-  background-color: #B6B5BA;
+  background-color: hsl(252.6, 3.4%, 72%);
   width: 0.5rem;
   height: 0.5rem;
   border-radius: 100%;
@@ -434,11 +434,11 @@ blockquote {
 @keyframes bob {
   10% {
     transform: translateY(-10px);
-    background-color: #9E9DA2;
+    background-color: hsl(252.6, 2.5%, 62.6%);
   }
   50% {
     transform: translateY(0);
-    background-color: #B6B5BA;
+    background-color: hsl(252.6, 3.4%, 72%);
   }
 }
 #message-loading {
@@ -478,7 +478,7 @@ blockquote {
   width: 32px;
   height: 32px;
   border-radius: 50%;
-  background: rgba(82, 194, 175, 0.5);
+  background: hsla(169.8, 47.9%, 54.1%, 0.5);
 }
 #scroll-bottom .text {
   clip: rect(0 0 0 0);
@@ -490,7 +490,7 @@ blockquote {
 #scroll-bottom svg {
   width: 32px;
   height: 32px;
-  fill: rgba(255, 255, 255, 0.75);
+  fill: hsla(0, 0%, 100%, 0.75);
 }
 `;
 

--- a/src/webview/css/css.js
+++ b/src/webview/css/css.js
@@ -41,8 +41,8 @@ pre {
 }
 code, pre {
   border-radius: 3px;
-  border: 1px solid hsla(0, 0%, 49.8%, 0.25);
-  background-color: hsla(0, 0%, 49.8%, 0.125);
+  border: 1px solid hsla(0, 0%, 50%, 0.25);
+  background-color: hsla(0, 0%, 50%, 0.125);
   font-family: Monaco, Menlo, Consolas, "Courier New", monospace;
 }
 table {
@@ -50,10 +50,10 @@ table {
   width: 100%;
 }
 table, th, td {
-  border: 1px solid hsla(0, 0%, 49.8%, 0.25);
+  border: 1px solid hsla(0, 0%, 50%, 0.25);
 }
 thead {
-  background: hsla(0, 0%, 49.8%, 0.1);
+  background: hsla(0, 0%, 50%, 0.1);
 }
 th, td {
   align: center;
@@ -62,7 +62,7 @@ th, td {
 hr {
   margin: 16px 0;
   border: 0;
-  border-top: 1px solid hsla(0, 0%, 49.8%, 0.5);
+  border-top: 1px solid hsla(0, 0%, 50%, 0.5);
 }
 .alert-word {
   background-color: hsla(102, 85%, 57%, .5);
@@ -233,12 +233,12 @@ hr {
   transition-timing-function: ease-out;
 }
 .private-header {
-  background: hsl(0, 0%, 26.7%);
+  background: hsl(0, 0%, 27%);
   color: white;
 }
 .loading-avatar {
   border-radius: 3px;
-  background: hsla(0, 0%, 49.8%, 0.9);
+  background: hsla(0, 0%, 50%, 0.9);
 }
 .loading-content {
   width: 100%;
@@ -250,11 +250,11 @@ hr {
 .loading-content .block {
   background: linear-gradient(
     to right,
-    hsla(0, 0%, 49.8%, 0.5) 0%,
-    hsla(0, 0%, 49.8%, 0.5) 40%,
-    hsla(0, 0%, 49.8%, 0.25) 51%,
-    hsla(0, 0%, 49.8%, 0.5) 60%,
-    hsla(0, 0%, 49.8%, 0.5) 100%
+    hsla(0, 0%, 50%, 0.5) 0%,
+    hsla(0, 0%, 50%, 0.5) 40%,
+    hsla(0, 0%, 50%, 0.25) 51%,
+    hsla(0, 0%, 50%, 0.5) 60%,
+    hsla(0, 0%, 50%, 0.5) 100%
   );
   background-size: 200% 200%;
   animation: gradient-scroll 1s linear infinite;
@@ -269,7 +269,7 @@ hr {
 }
 .loading-subheader .name {
   width: 10rem;
-  background-color: hsla(0, 0%, 49.8%, 0.9);
+  background-color: hsla(0, 0%, 50%, 0.9);
 }
 .loading-subheader .timestamp {
   width: 5rem;
@@ -284,8 +284,8 @@ hr {
   border-radius: 50%;
   margin: 16px auto;
   font-size: 10px;
-  border: 3px solid hsla(169.8, 47.9%, 54.1%, 0.25);
-  border-left: 3px solid hsla(169.8, 47.9%, 54.1%, 0.75);
+  border: 3px solid hsla(170, 48%, 54%, 0.25);
+  border-left: 3px solid hsla(170, 48%, 54%, 0.75);
   animation: spin 1s linear infinite;
 }
 .outbox-spinner {
@@ -308,7 +308,7 @@ hr {
 blockquote {
   padding-left: 8px;
   margin: 8px 0 8px 0;
-  border-left: 3px solid hsla(0, 0%, 49.8%, 0.5);
+  border-left: 3px solid hsla(0, 0%, 50%, 0.5);
 }
 .message ul {
   padding-left: 20px;
@@ -317,20 +317,20 @@ blockquote {
 .message ul + p {
   margin-top: 16px;
 }
-.codehilite .gi { color: hsl(120, 100%, 31.4%); }
-.codehilite .gd { color: hsl(0, 100%, 31.4%); }
-.codehilite .k { color: hsl(120, 100%, 25.1%); font-weight: bold; }
-.codehilite .kd { color: hsl(120, 100%, 25.1%); font-weight: bold; }
+.codehilite .gi { color: hsl(120, 100%, 31%); }
+.codehilite .gd { color: hsl(0, 100%, 31%); }
+.codehilite .k { color: hsl(120, 100%, 25%); font-weight: bold; }
+.codehilite .kd { color: hsl(120, 100%, 25%); font-weight: bold; }
 .codehilite .nf { color: hsl(240, 100%, 50%); }
-.codehilite .s2 { color: hsl(0, 69.9%, 42.9%); }
-.codehilite .cp { color: hsl(38.9, 100%, 36.9%); }
-.codehilite .kt { color: hsl(338.2, 100%, 34.5%); }
+.codehilite .s2 { color: hsl(0, 70%, 43%); }
+.codehilite .cp { color: hsl(39, 100%, 37%); }
+.codehilite .kt { color: hsl(338, 100%, 35%); }
 .codehilite .nc { color: hsl(240, 100%, 50%); font-weight: bold; }
-.codehilite .nb { color: hsl(120, 100%, 25.1%); }
-.codehilite .s1 { color: hsl(0, 69.9%, 42.9%); }
+.codehilite .nb { color: hsl(120, 100%, 25%); }
+.codehilite .s1 { color: hsl(0, 70%, 43%); }
 .twitter-tweet {
-  border: 2px solid hsla(202.8, 89.1%, 53.1%, 0.5);
-  background: hsla(202.8, 89.1%, 53.1%, 0.1);
+  border: 2px solid hsla(203, 89%, 53%, 0.5);
+  background: hsla(203, 89%, 53%, 0.1);
   border-radius: 6px;
   padding: 8px 16px;
   margin: 8px 0;
@@ -355,18 +355,18 @@ blockquote {
   padding: 4px 4px;
   margin-left: 4px;
   border-radius: 3px;
-  color: hsla(0, 0%, 49.8%, 0.75);
+  color: hsla(0, 0%, 50%, 0.75);
   background: hsla(0, 0%, 0%, 0.1);
 }
 .reaction-list {
   margin: 8px 0;
 }
 .reaction {
-  color: hsl(0, 0%, 49.8%);
+  color: hsl(0, 0%, 50%);
   display: inline-block;
   padding: 5px 6.5px;
   border-radius: 3px;
-  border: 1px solid hsla(0, 0%, 49.8%, 0.75);
+  border: 1px solid hsla(0, 0%, 50%, 0.75);
   line-height: 1rem;
   height: 1rem;
   margin: 4px 8px 4px 0;
@@ -403,8 +403,8 @@ blockquote {
   align-items: center;
   justify-content: center;
   padding: 1rem;
-  background: hsla(0, 0%, 49.8%, 0.1);
-  border: 1px dashed hsla(0, 0%, 49.8%, 0.5);
+  background: hsla(0, 0%, 50%, 0.1);
+  border: 1px dashed hsla(0, 0%, 50%, 0.5);
   border-radius: 0.5rem;
 }
 #typing {
@@ -417,7 +417,7 @@ blockquote {
 }
 #typing span {
   display: inline-block;
-  background-color: hsl(252.6, 3.4%, 72%);
+  background-color: hsl(253, 3%, 72%);
   width: 0.5rem;
   height: 0.5rem;
   border-radius: 100%;
@@ -434,11 +434,11 @@ blockquote {
 @keyframes bob {
   10% {
     transform: translateY(-10px);
-    background-color: hsl(252.6, 2.5%, 62.6%);
+    background-color: hsl(253, 3%, 63%);
   }
   50% {
     transform: translateY(0);
-    background-color: hsl(252.6, 3.4%, 72%);
+    background-color: hsl(253, 3%, 72%);
   }
 }
 #message-loading {
@@ -478,7 +478,7 @@ blockquote {
   width: 32px;
   height: 32px;
   border-radius: 50%;
-  background: hsla(169.8, 47.9%, 54.1%, 0.5);
+  background: hsla(170, 48%, 54%, 0.5);
 }
 #scroll-bottom .text {
   clip: rect(0 0 0 0);

--- a/src/webview/css/cssNight.js
+++ b/src/webview/css/cssNight.js
@@ -2,11 +2,11 @@
 
 export default `
 body {
-  color: #d5d9dd;
-  background: #212D3B;
+  color: hsl(210, 10.7%, 85.1%);
+  background: hsl(212.4, 28.3%, 18%);
 }
 .topic-header {
-  background: #54606E;
+  background: hsl(212.4, 13.4%, 38%);
 }
 .timestamp {
   background: hsl(212, 28%, 25%);

--- a/src/webview/css/cssNight.js
+++ b/src/webview/css/cssNight.js
@@ -2,11 +2,11 @@
 
 export default `
 body {
-  color: hsl(210, 10.7%, 85.1%);
-  background: hsl(212.4, 28.3%, 18%);
+  color: hsl(210, 11%, 85%);
+  background: hsl(212, 28%, 18%);
 }
 .topic-header {
-  background: hsl(212.4, 13.4%, 38%);
+  background: hsl(212, 13%, 38%);
 }
 .timestamp {
   background: hsl(212, 28%, 25%);

--- a/src/webview/html/messageHeaderAsHtml.js
+++ b/src/webview/html/messageHeaderAsHtml.js
@@ -64,7 +64,7 @@ export default (
     const { display_recipient } = item;
     const stream = subscriptions.find(x => x.name === display_recipient);
 
-    const backgroundColor = stream ? stream.color : '#ccc';
+    const backgroundColor = stream ? stream.color : 'hsl(0, 0%, 80%)';
     const textColor = foregroundColorFromBackground(backgroundColor);
     const streamNarrowStr = JSON.stringify(streamNarrow(item.display_recipient));
     const topicNarrowStr = JSON.stringify(topicNarrow(item.display_recipient, item.subject));


### PR DESCRIPTION
These three commits change the color schema as described in #3516.

The second commit rounds off the colors in `css.js` and there is no equivalent commit for rounding off values used in the rest of the app. My reasoning for such is that in CSS.js it's quite helpful for developers to see the changes made in the color instantly in the file itself (using the extension 'Color Highlight'), mostly because the 'hot reload' feature in react-native doesn't apply to WebViews. Hot reloading however works well in react-native environments and hence doesn't need to be rounded off in order to see the color changes properly and fast. In any case, the second commit is optional, and may be dropped depending on whether the maintainers are okay with the very slight color changes caused due to round off (±0.5 in every case).