### PR TITLE
time pills: Make slide-in time pills quieter.

### DIFF
--- a/src/webview/css/css.js
+++ b/src/webview/css/css.js
@@ -105,6 +105,11 @@ hr {
 .message-brief {
   padding: 0 16px 16px 64px;
 }
+.static-timestamp {
+  color: #999;
+  font-size: 0.9rem;
+  white-space: nowrap;
+}
 .time-container {
   position: absolute;
   left: 0;
@@ -122,10 +127,13 @@ hr {
   padding: 2px 4px;
   font-size: 0.9rem;
   white-space: nowrap;
-  color: hsla(0, 0%, 0%, 0.65);
-  background: hsl(0, 0%, 92%);
+  color: #999;
+  background: hsl(0, 0%, 97%);
   border-radius: 3px;
-  box-shadow: -1px 1px 2px 0 hsla(0, 0%, 0%, 0.3), -2px 2px 4px 0 hsla(0, 0%, 0%, 0.3);
+  box-shadow:
+      0px 3px 1px -2px hsla(0, 0%, 0%, 0.2),
+      0px 2px 2px  0px hsla(0, 0%, 0%, 0.14),
+      0px 1px 5px  0px hsla(0, 0%, 0%, 0.12);
 }
 .timestamp.show {
   right: 8px;
@@ -175,7 +183,7 @@ hr {
 }
 .avatar,
 .header-wrapper,
-.message {
+.message-brief {
   cursor: pointer;
 }
 .stream-header {

--- a/src/webview/css/cssNight.js
+++ b/src/webview/css/cssNight.js
@@ -9,8 +9,7 @@ body {
   background: #54606E;
 }
 .timestamp {
-  color: hsla(0, 0%, 100%, 0.5);
-  background: hsl(213, 14%, 34%);
+  background: hsl(212, 28%, 25%);
 }
 .highlight {
   background-color: hsla(51, 100%, 64%, 0.42);

--- a/src/webview/html/messageAsHtml.js
+++ b/src/webview/html/messageAsHtml.js
@@ -90,11 +90,12 @@ export default (backgroundData: BackgroundData, message: Message | Outbox, isBri
      data-msg-id="${id}"
      $!${flagStrings.map(flag => template`data-${flag}="true" `).join('')}
     >`;
+  const messageTime = shortTime(new Date(timestamp * 1000), backgroundData.twentyFourHourTime);
 
   const timestampHtml = (showOnRender: boolean) => template`
 <div class="time-container">
   <div class="timestamp ${showOnRender ? 'show' : ''}">
-    ${shortTime(new Date(timestamp * 1000), backgroundData.twentyFourHourTime)}
+    ${messageTime}
   </div>
 </div>
 `;
@@ -121,7 +122,7 @@ $!${divOpenHtml}
   <div class="username">
     ${sender_full_name}
   </div>
-  $!${timestampHtml(true)}
+  <div class="static-timestamp">${messageTime}</div>
 </div>
 `;
 

--- a/src/webview/js/generatedEs3.js
+++ b/src/webview/js/generatedEs3.js
@@ -528,7 +528,7 @@ documentBody.addEventListener('click', function (e) {
     return;
   }
 
-  var messageElement = target.closest('.message');
+  var messageElement = target.closest('.message-brief');
 
   if (messageElement) {
     messageElement.getElementsByClassName('timestamp')[0].classList.toggle('show');

--- a/src/webview/js/js.js
+++ b/src/webview/js/js.js
@@ -685,7 +685,7 @@ documentBody.addEventListener('click', (e: MouseEvent) => {
     return;
   }
 
-  const messageElement = target.closest('.message');
+  const messageElement = target.closest('.message-brief');
   if (messageElement) {
     messageElement.getElementsByClassName('timestamp')[0].classList.toggle('show');
     return;


### PR DESCRIPTION
Shadows on time slide in timepills have been modified to be centric
instead of leaning toward the left. The changes in the shadow could
be found in the material.io design guidelines/source code, with 2dp
elevation
https://github.com/material-components/material-components-web/blob/master/packages/mdc-elevation/_mixins.scss.

The background matches the default message-list background, but has
a little more added contrast in order to differenciate the top of
the pill with the message list.

@gnprice here's the time pills edit asked for in [chat](https://chat.zulip.org/#narrow/stream/48-mobile/topic/message.20timestamps/near/754237)! (screenshots present there)
