### PR TITLE
Avatar sizes increase to 48px globally.

### DIFF
--- a/src/pm-conversations/GroupPmConversationItem.js
+++ b/src/pm-conversations/GroupPmConversationItem.js
@@ -9,7 +9,7 @@ import styles from '../styles';
 const componentStyles = StyleSheet.create({
   text: {
     flex: 1,
-    marginLeft: 8,
+    marginLeft: 16,
     marginRight: 8,
   },
 });
@@ -46,7 +46,7 @@ export default class GroupPmConversationItem extends PureComponent<Props> {
     return (
       <Touchable onPress={this.handlePress}>
         <View style={styles.listItem}>
-          <GroupAvatar size={32} names={allNames} />
+          <GroupAvatar size={48} names={allNames} />
           <RawLabel
             style={componentStyles.text}
             numberOfLines={2}

--- a/src/users/UserItem.js
+++ b/src/users/UserItem.js
@@ -10,7 +10,7 @@ const componentStyles = StyleSheet.create({
     backgroundColor: BRAND_COLOR,
   },
   text: {
-    marginLeft: 8,
+    marginLeft: 16,
   },
   selectedText: {
     color: 'white',
@@ -54,7 +54,7 @@ export default class UserItem extends PureComponent<Props> {
       <Touchable onPress={this.handlePress}>
         <View style={[styles.listItem, isSelected && componentStyles.selectedRow]}>
           <UserAvatarWithPresence
-            size={32}
+            size={48}
             avatarUrl={avatarUrl}
             email={email}
             onPress={this.handlePress}

--- a/src/webview/css/css.js
+++ b/src/webview/css/css.js
@@ -103,7 +103,7 @@ hr {
   -webkit-tap-highlight-color: transparent;
 }
 .message-brief {
-  padding: 0 16px 16px 64px;
+  padding: 0 16px 16px 80px;
 }
 .static-timestamp {
   color: hsl(0, 0%, 60%);
@@ -144,9 +144,9 @@ hr {
 }
 .avatar,
 .loading-avatar {
-  min-width: 32px;
-  width: 32px;
-  height: 32px;
+  min-width: 48px;
+  width: 48px;
+  height: 48px;
   margin-right: 16px;
 }
 .avatar img {


### PR DESCRIPTION
Changes the avatar sizes found everywhere in the application to 48px. Since this is the size used by most other comparable messaging applications, 48px seems like a good option to go for (other reasons explained in the commit/s).

In the first commit `.message-brief` is set to `padding: 0 16px 16px 73px`. While this 73 might seem like an arbitrary number, it's confusing to me and I don't know why this is the case, but that is the only one which makes the messages perfectly aligned.