### PR TITLE
settings card: Add header - Label and separator.

### DIFF
--- a/src/settings/SettingsCard.js
+++ b/src/settings/SettingsCard.js
@@ -14,6 +14,7 @@ import {
   IconLanguage,
   IconMoreHorizontal,
 } from '../common/Icons';
+import ModalNavBar from '../nav/ModalNavBar';
 import {
   settingsChange,
   navigateToNotifications,
@@ -44,6 +45,7 @@ class SettingsCard extends PureComponent<Props> {
 
     return (
       <ScrollView style={styles.optionWrapper}>
+        <ModalNavBar canGoBack={false} title="Settings" />
         <OptionRow
           Icon={IconNight}
           label="Night mode"


### PR DESCRIPTION
The settings card by itself looks a little empty. @timabbot
suggested that this was due to a label being absent from the
settings screen.
https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/mascot/near/756544

Also added a separator to make things cleaner. Used a `Label`
component for including translations.