### PR TITLE
zulipSwitch: Derive `valueControlled` from props change.

### DIFF
--- a/src/account-info/AwayStatusSwitch.js
+++ b/src/account-info/AwayStatusSwitch.js
@@ -29,7 +29,7 @@ class AwayStatusSwitch extends PureComponent<Props> {
     return (
       <OptionRow
         label="Set yourself to away"
-        defaultValue={awayStatus}
+        value={awayStatus}
         onValueChange={this.handleUpdateAwayStatus}
       />
     );

--- a/src/common/OptionRow.js
+++ b/src/common/OptionRow.js
@@ -36,7 +36,7 @@ export default class OptionRow extends PureComponent<Props> {
         {!!Icon && <Icon size={18} style={this.styles.icon} />}
         <Label text={label} style={styles.flexed} />
         <View style={styles.rightItem}>
-          <ZulipSwitch defaultValue={value} onValueChange={onValueChange} />
+          <ZulipSwitch value={value} onValueChange={onValueChange} />
         </View>
       </View>
     );

--- a/src/common/OptionRow.js
+++ b/src/common/OptionRow.js
@@ -12,7 +12,7 @@ import styles, { ThemeContext } from '../styles';
 type Props = {|
   Icon?: IconType,
   label: string,
-  defaultValue: boolean,
+  value: boolean,
   style?: ViewStyleProp,
   onValueChange: (newValue: boolean) => void,
 |};
@@ -29,14 +29,14 @@ export default class OptionRow extends PureComponent<Props> {
   };
 
   render() {
-    const { label, defaultValue, onValueChange, style, Icon } = this.props;
+    const { label, value, onValueChange, style, Icon } = this.props;
 
     return (
       <View style={[styles.listItem, style]}>
         {!!Icon && <Icon size={18} style={this.styles.icon} />}
         <Label text={label} style={styles.flexed} />
         <View style={styles.rightItem}>
-          <ZulipSwitch defaultValue={defaultValue} onValueChange={onValueChange} />
+          <ZulipSwitch defaultValue={value} onValueChange={onValueChange} />
         </View>
       </View>
     );

--- a/src/common/ZulipSwitch.js
+++ b/src/common/ZulipSwitch.js
@@ -22,14 +22,8 @@ export default class ZulipSwitch extends PureComponent<Props> {
     disabled: false,
   };
 
-  handleValueChange = (newValue: boolean) => {
-    const { onValueChange } = this.props;
-
-    onValueChange(newValue);
-  };
-
   render() {
-    const { disabled, value } = this.props;
+    const { disabled, onValueChange, value } = this.props;
 
     return (
       <Switch
@@ -38,7 +32,7 @@ export default class ZulipSwitch extends PureComponent<Props> {
           false: 'hsl(0, 0%, 86%)',
           true: BRAND_COLOR,
         }}
-        onValueChange={this.handleValueChange}
+        onValueChange={onValueChange}
         disabled={disabled}
       />
     );

--- a/src/common/ZulipSwitch.js
+++ b/src/common/ZulipSwitch.js
@@ -5,12 +5,8 @@ import { BRAND_COLOR } from '../styles';
 
 type Props = {|
   disabled: boolean,
-  defaultValue: boolean,
+  value: boolean,
   onValueChange: (arg: boolean) => void,
-|};
-
-type State = {|
-  valueControlled: boolean,
 |};
 
 /**
@@ -18,14 +14,10 @@ type State = {|
  * built-in Switch component.
  *
  * @prop [disabled] - If set the component is not switchable and visually looks disabled.
- * @prop defaultValue - Initial value of the switch.
+ * @prop value - value of the switch.
  * @prop onValueChange - Event called on switch.
  */
-export default class ZulipSwitch extends PureComponent<Props, State> {
-  state = {
-    valueControlled: this.props.defaultValue,
-  };
-
+export default class ZulipSwitch extends PureComponent<Props> {
   static defaultProps = {
     disabled: false,
   };
@@ -34,19 +26,14 @@ export default class ZulipSwitch extends PureComponent<Props, State> {
     const { onValueChange } = this.props;
 
     onValueChange(newValue);
-
-    this.setState({
-      valueControlled: newValue,
-    });
   };
 
   render() {
-    const { disabled } = this.props;
-    const { valueControlled } = this.state;
+    const { disabled, value } = this.props;
 
     return (
       <Switch
-        value={valueControlled}
+        value={value}
         trackColor={{
           false: 'hsl(0, 0%, 86%)',
           true: BRAND_COLOR,

--- a/src/settings/DebugScreen.js
+++ b/src/settings/DebugScreen.js
@@ -26,7 +26,7 @@ class DebugScreen extends PureComponent<Props> {
       <Screen title="Debug">
         <OptionRow
           label="Do not mark messages read on scroll"
-          defaultValue={debug.doNotMarkMessagesAsRead}
+          value={debug.doNotMarkMessagesAsRead}
           onValueChange={() => this.handleSettingToggle('doNotMarkMessagesAsRead')}
         />
       </Screen>

--- a/src/settings/NotificationsScreen.js
+++ b/src/settings/NotificationsScreen.js
@@ -55,17 +55,17 @@ class NotificationsScreen extends PureComponent<Props> {
       <Screen title="Notifications">
         <OptionRow
           label="Notifications when offline"
-          defaultValue={offlineNotification}
+          value={offlineNotification}
           onValueChange={this.handleOfflineNotificationChange}
         />
         <OptionRow
           label="Notifications when online"
-          defaultValue={onlineNotification}
+          value={onlineNotification}
           onValueChange={this.handleOnlineNotificationChange}
         />
         <OptionRow
           label="Stream notifications"
-          defaultValue={streamNotification}
+          value={streamNotification}
           onValueChange={this.handleStreamNotificationChange}
         />
       </Screen>

--- a/src/settings/SettingsCard.js
+++ b/src/settings/SettingsCard.js
@@ -47,7 +47,7 @@ class SettingsCard extends PureComponent<Props> {
         <OptionRow
           Icon={IconNight}
           label="Night mode"
-          defaultValue={theme === 'night'}
+          value={theme === 'night'}
           onValueChange={this.handleThemeChange}
         />
         <OptionButton

--- a/src/streams/EditStreamCard.js
+++ b/src/streams/EditStreamCard.js
@@ -79,7 +79,7 @@ export default class EditStreamCard extends PureComponent<Props, State> {
           style={componentStyles.optionRow}
           Icon={IconPrivate}
           label="Private"
-          defaultValue={initialValues.invite_only}
+          value={initialValues.invite_only}
           onValueChange={this.handleIsPrivateChange}
         />
         <ZulipButton

--- a/src/streams/StreamItem.js
+++ b/src/streams/StreamItem.js
@@ -126,7 +126,7 @@ export default class StreamItem extends PureComponent<Props> {
           <UnreadCount color={iconColor} count={unreadCount} inverse={isSelected} />
           {showSwitch && (
             <ZulipSwitch
-              defaultValue={!!isSwitchedOn}
+              value={!!isSwitchedOn}
               onValueChange={this.handleSwitch}
               disabled={!isSwitchedOn && isPrivate}
             />

--- a/src/streams/StreamScreen.js
+++ b/src/streams/StreamScreen.js
@@ -60,19 +60,19 @@ class StreamScreen extends PureComponent<Props> {
         <OptionRow
           Icon={IconPin}
           label="Pinned"
-          defaultValue={subscription.pin_to_top}
+          value={subscription.pin_to_top}
           onValueChange={this.handleTogglePinStream}
         />
         <OptionRow
           Icon={IconMute}
           label="Muted"
-          defaultValue={subscription.in_home_view === false}
+          value={subscription.in_home_view === false}
           onValueChange={this.handleToggleMuteStream}
         />
         <OptionRow
           Icon={IconNotifications}
           label="Notifications"
-          defaultValue={subscription.push_notifications}
+          value={subscription.push_notifications}
           onValueChange={this.toggleStreamPushNotification}
         />
         <View style={styles.padding}>


### PR DESCRIPTION
Before we were only deriving `valueControlled` (which is value of the
switch) on component mount (at the time of initializing state).

But if defaultValue props gets changed, then it's value will not get
reflected. Thus when subscription add event arrives, it's value is
propagated till switch, but we aren't taking defaultValue expect at the
time of mounting.

If we want to go with the convention that defaultValue can only be used
at the first time, then we need to use value prop. Which will make
things complicated, as when switch wants to update it will receive both
defaultValue and value from parent, and it will add some logic to handle
such situations.

Actually it is not default value, rather it is original value which parent
caller wants. Basically original value before user (may) make changes.
So `originalValue` better fits here.

So use `getDerivedStateFromProps` which will derive new value of
`valueControlled` and returns an object to update the state.

> getDerivedStateFromProps is invoked right before calling the render
method, both on the initial mount and on subsequent updates.

Reference: https://reactjs.org/docs/react-component.html#static-getderivedstatefromprops

Fixes: #3106