### PR TITLE
webview, android: Fix Keypad emoji fail to render.

### DIFF
--- a/src/emoji/data.js
+++ b/src/emoji/data.js
@@ -10,7 +10,7 @@ const parseUnicodeEmojiCode = (code: string): string /* force line */ =>
   code
     .split('-')
     .map(hex => String.fromCodePoint(parseInt(hex, 16)))
-    .join('');
+    .join('\uFE0F');
 
 export const nameToEmojiMap = unicodeEmojiNames.reduce((obj, name) => {
   obj[name] = parseUnicodeEmojiCode(unicodeCodeByName[name]);


### PR DESCRIPTION
There are 11 emojis (*, #, 0-9) which contain COMBINING ENCLOSING KEYCAP
(U+20E3) and codePoint of such emoji contains '-' in it. We parse
codePoint by splitting '-', then getting string from it and finally
joining all strings. But in this processing we were missing out '-', which was
causing invalid char render on phones like Pixel XL, One Plus Six
Android 9. Now joining with corresponding unicode value of '-' i.e '\uFE0F',
renders whole emoji correctly.

https://www.fileformat.info/info/unicode/char/20e3/index.htm

Fixes: #3517

![image](https://user-images.githubusercontent.com/18511177/59979143-61b69480-9601-11e9-9010-1f4fab94de3d.png)
