### PR TITLE
css: Make alert-words more readable.

### DIFF
--- a/src/webview/css/css.js
+++ b/src/webview/css/css.js
@@ -66,7 +66,7 @@ hr {
   border-top: 1px solid hsla(0, 0%, 50%, 0.5);
 }
 .alert-word {
-  background-color: hsla(102, 85%, 57%, .5);
+  background-color: hsla(102, 85%, 57%, 0.3);
 }
 .highlight {
   background-color: hsl(51, 94%, 74%);


### PR DESCRIPTION
The previous iteration of alert words was not ready accessable for
people with color blindness. As @jmandel reports, he wasn't able to
see the white text on the bright green background while in dark
mode.

This commit is a temporary fix for the issue, by reducing the alpha
of the background color in order to make the white text on it more
readable (in dark mode).

References #3531.

(does not fix the issue, just provides a temporary patch for it).