### PR TITLE
messages: Add missing conditions for `shouldBeMuted`.

### DIFF
--- a/src/__tests__/exampleData.js
+++ b/src/__tests__/exampleData.js
@@ -2,8 +2,15 @@
 import deepFreeze from 'deep-freeze';
 import { createStore } from 'redux';
 
-import type { CrossRealmBot, Message, PmRecipientUser, Stream, User } from '../api/modelTypes';
-import type { GlobalState, RealmState } from '../reduxTypes';
+import type {
+  CrossRealmBot,
+  Message,
+  PmRecipientUser,
+  Stream,
+  Subscription,
+  User,
+} from '../api/modelTypes';
+import type { GlobalState, FlagsState, RealmState } from '../reduxTypes';
 import type { Account } from '../types';
 import { ACCOUNT_SWITCH, LOGIN_SUCCESS } from '../actionConstants';
 import rootReducer from '../boot/reducers';
@@ -89,6 +96,11 @@ export const stream: Stream = makeStream({
   name: 'a stream',
   description: 'An example stream.',
 });
+
+export const subscription = (extra?: $Rest<Subscription, {}>): Subscription =>
+  deepFreeze({
+    ...extra,
+  });
 
 const displayRecipientFromUser = (user: User): PmRecipientUser => {
   const { email, full_name, user_id: id } = user;
@@ -200,6 +212,12 @@ export const reduxState = (extra?: $Rest<GlobalState, {}>): GlobalState =>
 export const realmState = (extra?: $Rest<RealmState, {}>): RealmState =>
   deepFreeze({
     ...baseReduxState.realm,
+    ...extra,
+  });
+
+export const flagsState = (extra?: $Rest<FlagsState, {}>): FlagsState =>
+  deepFreeze({
+    ...baseReduxState.flags,
     ...extra,
   });
 

--- a/src/chat/__tests__/flagsReducer-test.js
+++ b/src/chat/__tests__/flagsReducer-test.js
@@ -49,6 +49,29 @@ describe('flagsReducer', () => {
 
       expect(actualState).toBe(initialState);
     });
+
+    test('merge mentioned and wildcard_mentioned in FlagsState', () => {
+      const initialState = NULL_OBJECT;
+
+      const action = deepFreeze({
+        type: MESSAGE_FETCH_COMPLETE,
+        messages: [{ id: 1, flags: ['wildcard_mentioned'] }, { id: 2, flags: ['mentioned'] }],
+      });
+
+      const expectedState = {
+        mentioned: {
+          2: true,
+          1: true,
+        },
+        wildcard_mentioned: {
+          1: true,
+        },
+      };
+
+      const actualState = flagsReducer(initialState, action);
+
+      expect(actualState).toEqual(expectedState);
+    });
   });
 
   test('flags are added or replace existing flags', () => {
@@ -85,6 +108,28 @@ describe('flagsReducer', () => {
       });
 
       const expectedState = {};
+
+      const actualState = flagsReducer(initialState, action);
+
+      expect(actualState).toEqual(expectedState);
+    });
+
+    test('merge mentioned and wildcard_mentioned in FlagsState', () => {
+      const initialState = NULL_OBJECT;
+
+      const action = deepFreeze({
+        type: EVENT_NEW_MESSAGE,
+        message: { id: 1, flags: ['wildcard_mentioned'] },
+      });
+
+      const expectedState = {
+        mentioned: {
+          1: true,
+        },
+        wildcard_mentioned: {
+          1: true,
+        },
+      };
 
       const actualState = flagsReducer(initialState, action);
 

--- a/src/chat/narrowsSelectors.js
+++ b/src/chat/narrowsSelectors.js
@@ -15,6 +15,7 @@ import type {
 import {
   getAllNarrows,
   getSubscriptions,
+  getFlags,
   getMessages,
   getMute,
   getStreams,
@@ -75,10 +76,11 @@ export const getShownMessagesForNarrow: Selector<$ReadOnlyArray<Message | Outbox
   createSelector(
     (state, narrow) => narrow,
     getMessagesForNarrow,
+    state => getFlags(state),
     state => getSubscriptions(state),
     state => getMute(state),
-    (narrow, messagesForNarrow, subscriptions, mute) =>
-      messagesForNarrow.filter(item => !shouldBeMuted(item, narrow, subscriptions, mute)),
+    (narrow, messagesForNarrow, flags, subscriptions, mute) =>
+      messagesForNarrow.filter(item => !shouldBeMuted(item, narrow, flags, subscriptions, mute)),
   );
 
 export const getFirstMessageId = (state: GlobalState, narrow: Narrow): number | void => {

--- a/src/utils/__tests__/message-test.js
+++ b/src/utils/__tests__/message-test.js
@@ -8,7 +8,21 @@ describe('shouldBeMuted', () => {
   test('private messages are never muted', () => {
     const message = eg.pmMessage();
 
-    const isMuted = shouldBeMuted(message, HOME_NARROW);
+    const isMuted = shouldBeMuted(message, HOME_NARROW, eg.flagsState());
+
+    expect(isMuted).toBe(false);
+  });
+
+  test('message in a muted stream is un-muted if it mentions the current user', () => {
+    const message = eg.streamMessage();
+    const flags = eg.flagsState({
+      mentioned: {
+        [message.id]: true,
+      },
+    });
+    const mutes = [[message.display_recipient, message.subject]];
+
+    const isMuted = shouldBeMuted(message, HOME_NARROW, flags, [], mutes);
 
     expect(isMuted).toBe(false);
   });
@@ -21,7 +35,7 @@ describe('shouldBeMuted', () => {
     const narrow = topicNarrow('stream', 'some topic');
     const mutes = [['stream', 'some topic']];
 
-    const isMuted = shouldBeMuted(message, narrow, [], mutes);
+    const isMuted = shouldBeMuted(message, narrow, eg.flagsState(), [], mutes);
 
     expect(isMuted).toBe(false);
   });
@@ -29,7 +43,7 @@ describe('shouldBeMuted', () => {
   test('message in a stream is muted if stream is not in mute list', () => {
     const message = eg.streamMessage();
 
-    const isMuted = shouldBeMuted(message, HOME_NARROW);
+    const isMuted = shouldBeMuted(message, HOME_NARROW, eg.flagsState());
 
     expect(isMuted).toBe(true);
   });
@@ -42,7 +56,7 @@ describe('shouldBeMuted', () => {
         in_home_view: false,
       }),
     ];
-    const isMuted = shouldBeMuted(message, HOME_NARROW, subscriptions);
+    const isMuted = shouldBeMuted(message, HOME_NARROW, eg.flagsState(), subscriptions);
 
     expect(isMuted).toBe(true);
   });
@@ -56,7 +70,7 @@ describe('shouldBeMuted', () => {
       }),
     ];
     const mutes = [[message.display_recipient, message.subject]];
-    const isMuted = shouldBeMuted(message, HOME_NARROW, subscriptions, mutes);
+    const isMuted = shouldBeMuted(message, HOME_NARROW, eg.flagsState(), subscriptions, mutes);
 
     expect(isMuted).toBe(true);
   });

--- a/src/utils/message.js
+++ b/src/utils/message.js
@@ -8,11 +8,16 @@ export const isTopicMuted = (stream: string, topic: string, mute: MuteState = []
 export const shouldBeMuted = (
   message: Message | Outbox,
   narrow: Narrow,
+  flags: FlagsState,
   subscriptions: Subscription[] = [],
   mutes: MuteState = [],
 ): boolean => {
   if (message.type === 'private') {
     return false; // private/group messages are not muted
+  }
+
+  if (flags.mentioned && flags.mentioned[message.id] === true) {
+    return false; // never hide a message which mentions current user
   }
 
   if (isTopicNarrow(narrow)) {
@@ -34,7 +39,8 @@ export const isMessageRead = (
   flags: FlagsState,
   subscriptions: Subscription[],
   mute: MuteState,
-): boolean => shouldBeMuted(message, HOME_NARROW, subscriptions, mute) || !!flags.read[message.id];
+): boolean =>
+  shouldBeMuted(message, HOME_NARROW, flags, subscriptions, mute) || !!flags.read[message.id];
 
 export const findFirstUnread = (
   messages: $ReadOnlyArray<Message | Outbox>,


### PR DESCRIPTION
Based on the WebApp there are three conditions to be added -
(based in `../zulip/static/js/notifications.js` under
exports.message_is_notifiable)
- If the message is sent by the current user.
- If the message @mentions the current user.
- If the notification has already been sent out (to avoid spam).

This commit handles the first two.
The third can be handled at a later point of time, since (IIUC) we don't already handle that type of logic. At this point, this PR is made to fix 3472 (and conveniently another issue).

Fixes #3472.