### PR TITLE
Fix: #3544. Fix empty selector is being provided to querySelectorAll.

### DIFF
--- a/src/webview/js/generatedEs3.js
+++ b/src/webview/js/generatedEs3.js
@@ -415,6 +415,10 @@ var handleUpdateEventReady = function handleUpdateEventReady(uevent) {
 };
 
 var handleUpdateEventMessagesRead = function handleUpdateEventMessagesRead(uevent) {
+  if (uevent.messageIds.length === 0) {
+    return;
+  }
+
   var selector = uevent.messageIds.map(function (id) {
     return "[data-msg-id=\\"" + id + "\\"]";
   }).join(',');

--- a/src/webview/js/js.js
+++ b/src/webview/js/js.js
@@ -559,6 +559,9 @@ const handleUpdateEventReady = (uevent: WebViewUpdateEventReady) => {
  * Handles messages that have been read outside of the WebView
  */
 const handleUpdateEventMessagesRead = (uevent: WebViewUpdateEventMessagesRead) => {
+  if (uevent.messageIds.length === 0) {
+    return;
+  }
   const selector = uevent.messageIds.map(id => `[data-msg-id="${id}"]`).join(',');
   const messageElements = arrayFromNodes(document.querySelectorAll(selector));
   messageElements.forEach(element => {

--- a/src/webview/webViewHandleUpdates.js
+++ b/src/webview/webViewHandleUpdates.js
@@ -105,7 +105,7 @@ export const getUpdateEvents = (prevProps: Props, nextProps: Props): WebViewUpda
 
   if (
     prevProps.backgroundData.flags
-    && prevProps.backgroundData.flags.read !== nextProps.backgroundData.flags.read
+    && !isEqual(prevProps.backgroundData.flags.read, nextProps.backgroundData.flags.read)
   ) {
     uevents.push(updateRead(prevProps, nextProps));
   }

--- a/src/webview/webViewHandleUpdates.js
+++ b/src/webview/webViewHandleUpdates.js
@@ -77,13 +77,6 @@ const updateTyping = (prevProps: Props, nextProps: Props): WebViewUpdateEventTyp
       : '',
 });
 
-const updateRead = (prevProps: Props, nextProps: Props): WebViewUpdateEventMessagesRead => ({
-  type: 'read',
-  messageIds: Object.keys(nextProps.backgroundData.flags.read)
-    .filter(id => !prevProps.backgroundData.flags.read[+id])
-    .map(id => +id),
-});
-
 const equalFlagsExcludingRead = (prevFlags: FlagsState, nextFlags: FlagsState): boolean => {
   const allFlagNames = Array.from(
     new Set([...Object.keys(prevFlags || {}), ...Object.keys(nextFlags || {})]),
@@ -105,9 +98,17 @@ export const getUpdateEvents = (prevProps: Props, nextProps: Props): WebViewUpda
 
   if (
     prevProps.backgroundData.flags
-    && !isEqual(prevProps.backgroundData.flags.read, nextProps.backgroundData.flags.read)
+    && prevProps.backgroundData.flags.read !== nextProps.backgroundData.flags.read
   ) {
-    uevents.push(updateRead(prevProps, nextProps));
+    const messageIds = Object.keys(nextProps.backgroundData.flags.read)
+      .filter(id => !prevProps.backgroundData.flags.read[+id])
+      .map(id => +id);
+    if (messageIds.length > 0) {
+      uevents.push({
+        type: 'read',
+        messageIds,
+      });
+    }
   }
 
   if (


### PR DESCRIPTION
* messageList, getUpdateEvents: Use `lodash.isequal` to compare object.
* web, msg read event: Make sure querySelectorAll never get empty selector

For more debug information, please refer #3544 