### PR TITLE
queueMarkAsRead: Set timeout if there is mark request in less than 2s.

### DIFF
--- a/src/__tests__/exampleData.js
+++ b/src/__tests__/exampleData.js
@@ -4,9 +4,10 @@ import { createStore } from 'redux';
 
 import type { CrossRealmBot, Message, PmRecipientUser, Stream, User } from '../api/modelTypes';
 import type { GlobalState, RealmState } from '../reduxTypes';
-import type { Account } from '../types';
+import type { Auth, Account } from '../types';
 import { ACCOUNT_SWITCH, LOGIN_SUCCESS } from '../actionConstants';
 import rootReducer from '../boot/reducers';
+import { authOfAccount } from '../account/accountMisc';
 
 // TODO either fix Jest test-discovery patterns, or rename this file,
 // so this dummy test isn't required.
@@ -66,6 +67,7 @@ const makeAccount = (user: User): Account => ({
 
 export const selfUser: User = makeUser({ name: 'self' });
 export const selfAccount: Account = makeAccount(selfUser);
+export const selfAuth: Auth = authOfAccount(selfAccount);
 
 export const otherUser: User = makeUser({ name: 'other' });
 

--- a/src/api/__tests__/queueMarkAsRead-test.js
+++ b/src/api/__tests__/queueMarkAsRead-test.js
@@ -41,17 +41,21 @@ describe('queueMarkAsRead', () => {
     expect(messagesFlags.default).toHaveBeenCalledTimes(2);
   });
 
-  test('should call messagesFlags after 2s to clear queue', async () => {
+  test('should set timeout for time remaining for next API call to clear queue', async () => {
     const currentDate = Date.now();
-    const secondCall = currentDate + 2100;
+    const secondCall = currentDate + 1900;
+    const thirdCall = currentDate + 2001;
     // $FlowFixMe Make flow understand about mocking
     Date.now = jest.fn().mockReturnValue(currentDate);
 
     queueMarkAsRead(eg.selfAuth, [1, 2, 3]);
-    queueMarkAsRead(eg.selfAuth, [4, 5, 6]);
 
     // $FlowFixMe Make flow understand about mocking
     Date.now = jest.fn().mockReturnValue(secondCall);
+    queueMarkAsRead(eg.selfAuth, [4, 5, 6]);
+
+    // $FlowFixMe Make flow understand about mocking
+    Date.now = jest.fn().mockReturnValue(thirdCall);
     jest.runOnlyPendingTimers();
 
     expect(messagesFlags.default).toHaveBeenCalledTimes(2);

--- a/src/api/__tests__/queueMarkAsRead-test.js
+++ b/src/api/__tests__/queueMarkAsRead-test.js
@@ -6,6 +6,8 @@ import * as eg from '../../__tests__/exampleData';
 // $FlowFixMe Make flow understand about mocking
 messagesFlags.default = jest.fn(() => {});
 
+jest.useFakeTimers();
+
 describe('queueMarkAsRead', () => {
   beforeEach(() => {
     resetAll();
@@ -13,12 +15,13 @@ describe('queueMarkAsRead', () => {
     jest.clearAllTimers();
   });
 
-  test('should not call messagesFlags on consecutive calls of queueMarkAsRead', () => {
+  test('should not call messagesFlags on consecutive calls of queueMarkAsRead,  setTimout on further calls', () => {
     queueMarkAsRead(eg.selfAuth, [1, 2, 3]);
     queueMarkAsRead(eg.selfAuth, [4, 5, 6]);
     queueMarkAsRead(eg.selfAuth, [7, 8, 9]);
     queueMarkAsRead(eg.selfAuth, [10, 11, 12]);
 
+    expect(setTimeout).toHaveBeenCalledTimes(1);
     expect(messagesFlags.default).toHaveBeenCalledTimes(1);
   });
 
@@ -34,6 +37,22 @@ describe('queueMarkAsRead', () => {
     Date.now = jest.fn().mockReturnValue(secondCall);
 
     queueMarkAsRead(eg.selfAuth, [16, 17, 18]);
+
+    expect(messagesFlags.default).toHaveBeenCalledTimes(2);
+  });
+
+  test('should call messagesFlags after 2s to clear queue', async () => {
+    const currentDate = Date.now();
+    const secondCall = currentDate + 2100;
+    // $FlowFixMe Make flow understand about mocking
+    Date.now = jest.fn().mockReturnValue(currentDate);
+
+    queueMarkAsRead(eg.selfAuth, [1, 2, 3]);
+    queueMarkAsRead(eg.selfAuth, [4, 5, 6]);
+
+    // $FlowFixMe Make flow understand about mocking
+    Date.now = jest.fn().mockReturnValue(secondCall);
+    jest.runOnlyPendingTimers();
 
     expect(messagesFlags.default).toHaveBeenCalledTimes(2);
   });

--- a/src/api/__tests__/queueMarkAsRead-test.js
+++ b/src/api/__tests__/queueMarkAsRead-test.js
@@ -1,0 +1,40 @@
+/* @flow strict-local */
+import queueMarkAsRead, { resetAll } from '../queueMarkAsRead';
+import * as messagesFlags from '../messages/messagesFlags';
+import * as eg from '../../__tests__/exampleData';
+
+// $FlowFixMe Make flow understand about mocking
+messagesFlags.default = jest.fn(() => {});
+
+describe('queueMarkAsRead', () => {
+  beforeEach(() => {
+    resetAll();
+    jest.clearAllMocks();
+    jest.clearAllTimers();
+  });
+
+  test('should not call messagesFlags on consecutive calls of queueMarkAsRead', () => {
+    queueMarkAsRead(eg.selfAuth, [1, 2, 3]);
+    queueMarkAsRead(eg.selfAuth, [4, 5, 6]);
+    queueMarkAsRead(eg.selfAuth, [7, 8, 9]);
+    queueMarkAsRead(eg.selfAuth, [10, 11, 12]);
+
+    expect(messagesFlags.default).toHaveBeenCalledTimes(1);
+  });
+
+  test('should call messagesFlags, if calls to queueMarkAsRead are 2s apart', async () => {
+    const currentDate = Date.now();
+    const secondCall = currentDate + 2100;
+    // $FlowFixMe Make flow understand about mocking
+    Date.now = jest.fn().mockReturnValue(currentDate);
+
+    queueMarkAsRead(eg.selfAuth, [13, 14, 15]);
+
+    // $FlowFixMe Make flow understand about mocking
+    Date.now = jest.fn().mockReturnValue(secondCall);
+
+    queueMarkAsRead(eg.selfAuth, [16, 17, 18]);
+
+    expect(messagesFlags.default).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/api/__tests__/queueMarkAsRead-test.js
+++ b/src/api/__tests__/queueMarkAsRead-test.js
@@ -25,39 +25,32 @@ describe('queueMarkAsRead', () => {
     expect(messagesFlags.default).toHaveBeenCalledTimes(1);
   });
 
-  test('should call messagesFlags, if calls to queueMarkAsRead are 2s apart', async () => {
-    const currentDate = Date.now();
-    const secondCall = currentDate + 2100;
+  test('should call messagesFlags, if calls to queueMarkAsRead are 2s apart', () => {
+    const start = Date.now();
     // $FlowFixMe Make flow understand about mocking
-    Date.now = jest.fn().mockReturnValue(currentDate);
-
+    Date.now = jest.fn().mockReturnValue(start);
     queueMarkAsRead(eg.selfAuth, [13, 14, 15]);
 
     // $FlowFixMe Make flow understand about mocking
-    Date.now = jest.fn().mockReturnValue(secondCall);
-
+    Date.now = jest.fn().mockReturnValue(start + 2100);
     queueMarkAsRead(eg.selfAuth, [16, 17, 18]);
 
     expect(messagesFlags.default).toHaveBeenCalledTimes(2);
   });
 
-  test('should set timeout for time remaining for next API call to clear queue', async () => {
-    const currentDate = Date.now();
-    const secondCall = currentDate + 1900;
-    const thirdCall = currentDate + 2001;
+  test('should set timeout for time remaining for next API call to clear queue', () => {
+    const start = Date.now();
     // $FlowFixMe Make flow understand about mocking
-    Date.now = jest.fn().mockReturnValue(currentDate);
-
+    Date.now = jest.fn().mockReturnValue(start);
     queueMarkAsRead(eg.selfAuth, [1, 2, 3]);
 
     // $FlowFixMe Make flow understand about mocking
-    Date.now = jest.fn().mockReturnValue(secondCall);
+    Date.now = jest.fn().mockReturnValue(start + 1900);
     queueMarkAsRead(eg.selfAuth, [4, 5, 6]);
 
     // $FlowFixMe Make flow understand about mocking
-    Date.now = jest.fn().mockReturnValue(thirdCall);
+    Date.now = jest.fn().mockReturnValue(start + 2001);
     jest.runOnlyPendingTimers();
-
     expect(messagesFlags.default).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/api/queueMarkAsRead.js
+++ b/src/api/queueMarkAsRead.js
@@ -2,8 +2,10 @@
 import type { Auth } from './transportTypes';
 import messagesFlags from './messages/messagesFlags';
 
+const TIME_INTERVAL_BETWEEN_CONSECUTIVE_CALLS_MS = 2000;
 let unsentMessageIds = [];
 let lastSentTime = 0;
+let timeout = null;
 
 /**
  * Exported so that it can be used in test
@@ -12,13 +14,19 @@ let lastSentTime = 0;
 export const resetAll = () => {
   unsentMessageIds = [];
   lastSentTime = 0;
+  timeout = null;
 };
 
 const processQueue = (auth: Auth) => {
-  if (Date.now() - lastSentTime > 2000) {
+  if (Date.now() - lastSentTime > TIME_INTERVAL_BETWEEN_CONSECUTIVE_CALLS_MS) {
     messagesFlags(auth, unsentMessageIds, 'add', 'read');
     unsentMessageIds = [];
     lastSentTime = Date.now();
+  } else if (timeout === null) {
+    timeout = setTimeout(() => {
+      timeout = null;
+      processQueue(auth);
+    }, TIME_INTERVAL_BETWEEN_CONSECUTIVE_CALLS_MS);
   }
 };
 

--- a/src/api/queueMarkAsRead.js
+++ b/src/api/queueMarkAsRead.js
@@ -18,7 +18,8 @@ export const resetAll = () => {
 };
 
 const processQueue = (auth: Auth) => {
-  if (Date.now() - lastSentTime > TIME_INTERVAL_BETWEEN_CONSECUTIVE_CALLS_MS) {
+  const timeInMsSinceLastApiCall = Date.now() - lastSentTime;
+  if (timeInMsSinceLastApiCall > TIME_INTERVAL_BETWEEN_CONSECUTIVE_CALLS_MS) {
     messagesFlags(auth, unsentMessageIds, 'add', 'read');
     unsentMessageIds = [];
     lastSentTime = Date.now();
@@ -26,7 +27,7 @@ const processQueue = (auth: Auth) => {
     timeout = setTimeout(() => {
       timeout = null;
       processQueue(auth);
-    }, TIME_INTERVAL_BETWEEN_CONSECUTIVE_CALLS_MS);
+    }, TIME_INTERVAL_BETWEEN_CONSECUTIVE_CALLS_MS - timeInMsSinceLastApiCall);
   }
 };
 

--- a/src/api/queueMarkAsRead.js
+++ b/src/api/queueMarkAsRead.js
@@ -17,17 +17,22 @@ export const resetAll = () => {
 };
 
 const processQueue = (auth: Auth) => {
-  const sinceSentMs = Date.now() - lastSentTime;
-  if (sinceSentMs > debouncePeriodMs) {
-    messagesFlags(auth, unsentMessageIds, 'add', 'read');
-    unsentMessageIds = [];
-    lastSentTime = Date.now();
-  } else if (timeout === null) {
+  if (timeout !== null) {
+    return;
+  }
+
+  const remainingMs = lastSentTime + debouncePeriodMs - Date.now();
+  if (remainingMs > 0) {
     timeout = setTimeout(() => {
       timeout = null;
       processQueue(auth);
-    }, debouncePeriodMs - sinceSentMs);
+    }, remainingMs);
+    return;
   }
+
+  messagesFlags(auth, unsentMessageIds, 'add', 'read');
+  unsentMessageIds = [];
+  lastSentTime = Date.now();
 };
 
 export default (auth: Auth, messageIds: number[]): void => {

--- a/src/api/queueMarkAsRead.js
+++ b/src/api/queueMarkAsRead.js
@@ -5,6 +5,15 @@ import messagesFlags from './messages/messagesFlags';
 let unsentMessageIds = [];
 let lastSentTime = 0;
 
+/**
+ * Exported so that it can be used in test
+ * See queueMarkAsRead-test.js
+ */
+export const resetAll = () => {
+  unsentMessageIds = [];
+  lastSentTime = 0;
+};
+
 export default (auth: Auth, messageIds: number[]): void => {
   unsentMessageIds.push(...messageIds);
 

--- a/src/api/queueMarkAsRead.js
+++ b/src/api/queueMarkAsRead.js
@@ -14,12 +14,15 @@ export const resetAll = () => {
   lastSentTime = 0;
 };
 
-export default (auth: Auth, messageIds: number[]): void => {
-  unsentMessageIds.push(...messageIds);
-
+const processQueue = (auth: Auth) => {
   if (Date.now() - lastSentTime > 2000) {
     messagesFlags(auth, unsentMessageIds, 'add', 'read');
     unsentMessageIds = [];
     lastSentTime = Date.now();
   }
+};
+
+export default (auth: Auth, messageIds: number[]): void => {
+  unsentMessageIds.push(...messageIds);
+  processQueue(auth);
 };


### PR DESCRIPTION
If there are multiple requests to mark messages as read with interval
less than 2s, and if there is no further request then later were
stuck in the queue. Becuase there was only one caller to
`messagesFlags`, which was only called by user scroll event.
So even after reaching at the end of message list, unread banner is
visible with some unread count.

So now set timeout to send read message flag to server.

Fixes: #3509