### PR TITLE
dependency: Upgrade react-native-webview to `^5.0.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "react-native-sound": "^0.10.9",
     "react-native-text-input-reset": "^1.0.2",
     "react-native-vector-icons": "^4.6.0",
-    "react-native-webview": "2.0.0",
+    "react-native-webview": "^5.0.0",
     "react-navigation": "^1.5.12",
     "react-navigation-redux-helpers": "^1.1.1",
     "react-redux": "^5.0.7",

--- a/src/webview/js/generatedEs3.js
+++ b/src/webview/js/generatedEs3.js
@@ -44,7 +44,7 @@ var escapeHtml = function escapeHtml(text) {
 };
 
 var sendMessage = function sendMessage(msg) {
-  window.postMessage(JSON.stringify(msg), '*');
+  window.ReactNativeWebView.postMessage(JSON.stringify(msg));
 };
 
 window.onerror = function (message, source, line, column, error) {
@@ -435,7 +435,8 @@ var eventUpdateHandlers = {
   ready: handleUpdateEventReady,
   read: handleUpdateEventMessagesRead
 };
-document.addEventListener('message', function (e) {
+
+var handleMessageEvent = function handleMessageEvent(e) {
   scrollEventsDisabled = true;
   var decodedData = decodeURIComponent(escape(window.atob(e.data)));
   var updateEvents = JSON.parse(decodedData);
@@ -443,7 +444,13 @@ document.addEventListener('message', function (e) {
     eventUpdateHandlers[uevent.type](uevent);
   });
   scrollEventsDisabled = false;
-});
+};
+
+if (isIos) {
+  window.addEventListener('message', handleMessageEvent);
+} else {
+  document.addEventListener('message', handleMessageEvent);
+}
 
 var requireAttribute = function requireAttribute(e, name) {
   var value = e.getAttribute(name);

--- a/src/webview/js/generatedEs3.js
+++ b/src/webview/js/generatedEs3.js
@@ -11,6 +11,8 @@
 export default `
 'use strict';
 
+var platformOS = window.navigator.userAgent.match(/iPhone|iPad|iPod/) ? 'ios' : 'android';
+
 function arrayFrom(arrayLike) {
   return Array.prototype.slice.call(arrayLike);
 }
@@ -446,7 +448,7 @@ var handleMessageEvent = function handleMessageEvent(e) {
   scrollEventsDisabled = false;
 };
 
-if (isIos) {
+if (platformOS === 'ios') {
   window.addEventListener('message', handleMessageEvent);
 } else {
   document.addEventListener('message', handleMessageEvent);

--- a/src/webview/js/js.js
+++ b/src/webview/js/js.js
@@ -37,6 +37,9 @@ import type { MessageListEvent } from '../webViewEventHandlers';
  *     ancient, even when their Android version is.
  */
 
+/** Like RN's `Platform.OS`. */
+const platformOS = window.navigator.userAgent.match(/iPhone|iPad|iPod/) ? 'ios' : 'android';
+
 /**
  * Convert an array-like object to an actual array.
  *
@@ -589,15 +592,9 @@ const handleMessageEvent = e => {
   scrollEventsDisabled = false;
 };
 
-/**
- * after https://github.com/react-native-community/react-native-webview/commit/f3bdab5
- * The message is now being posted to window rather than document for iOS.
- * But on Android it is still on document
- */
-
-// prettier-ignore
-// $FlowFixMe this variable is being added in the script
-if (isIos) { // eslint-disable-line no-undef
+// Since its version 5.x, the `react-native-webview` library dispatches our
+// `message` events at `window` on iOS but `document` on Android.
+if (platformOS === 'ios') {
   window.addEventListener('message', handleMessageEvent);
 } else {
   document.addEventListener('message', handleMessageEvent);

--- a/src/webview/js/js.js
+++ b/src/webview/js/js.js
@@ -92,7 +92,7 @@ const escapeHtml = (text: string): string => {
 };
 
 const sendMessage = (msg: MessageListEvent) => {
-  window.postMessage(JSON.stringify(msg), '*');
+  window.ReactNativeWebView.postMessage(JSON.stringify(msg));
 };
 
 window.onerror = (message, source, line, column, error) => {
@@ -577,7 +577,7 @@ const eventUpdateHandlers = {
   read: handleUpdateEventMessagesRead,
 };
 
-document.addEventListener('message', e => {
+const handleMessageEvent = e => {
   scrollEventsDisabled = true;
   // $FlowFixMe
   const decodedData = decodeURIComponent(escape(window.atob(e.data)));
@@ -587,7 +587,21 @@ document.addEventListener('message', e => {
     eventUpdateHandlers[uevent.type](uevent);
   });
   scrollEventsDisabled = false;
-});
+};
+
+/**
+ * after https://github.com/react-native-community/react-native-webview/commit/f3bdab5
+ * The message is now being posted to window rather than document for iOS.
+ * But on Android it is still on document
+ */
+
+// prettier-ignore
+// $FlowFixMe this variable is being added in the script
+if (isIos) { // eslint-disable-line no-undef
+  window.addEventListener('message', handleMessageEvent);
+} else {
+  document.addEventListener('message', handleMessageEvent);
+}
 
 /*
  *

--- a/src/webview/js/script.js
+++ b/src/webview/js/script.js
@@ -1,4 +1,5 @@
 /* @flow strict-local */
+import { Platform } from 'react-native';
 import type { Auth } from '../../types';
 import smoothScroll from './smoothScroll.min';
 import matchesPolyfill from './matchesPolyfill';
@@ -12,6 +13,7 @@ ${smoothScroll}
 ${matchesPolyfill}
 window.enableWebViewErrorDisplay = ${config.enableWebViewErrorDisplay.toString()};
 document.addEventListener('DOMContentLoaded', function() {
+  var isIos = ${Platform.OS === 'ios' ? 'true' : 'false'};
   ${js}
   handleInitialLoad(${anchor}, ${JSON.stringify(auth)});
 });

--- a/src/webview/js/script.js
+++ b/src/webview/js/script.js
@@ -1,5 +1,4 @@
 /* @flow strict-local */
-import { Platform } from 'react-native';
 import type { Auth } from '../../types';
 import smoothScroll from './smoothScroll.min';
 import matchesPolyfill from './matchesPolyfill';
@@ -13,7 +12,6 @@ ${smoothScroll}
 ${matchesPolyfill}
 window.enableWebViewErrorDisplay = ${config.enableWebViewErrorDisplay.toString()};
 document.addEventListener('DOMContentLoaded', function() {
-  var isIos = ${Platform.OS === 'ios' ? 'true' : 'false'};
   ${js}
   handleInitialLoad(${anchor}, ${JSON.stringify(auth)});
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2762,7 +2762,7 @@ escape-html@~1.0.3:
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
   integrity sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=
 
-escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
+escape-string-regexp@1.0.5, escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
@@ -3288,7 +3288,7 @@ fbjs-scripts@^1.0.0:
     semver "^5.1.0"
     through2 "^2.0.0"
 
-fbjs@^0.8.17, fbjs@^0.8.9:
+fbjs@^0.8.9:
   version "0.8.17"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.17.tgz#c4d598ead6949112653d6588b01a5cdcd9f90fdd"
   integrity sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=
@@ -4187,7 +4187,7 @@ into-stream@^3.1.0:
     from2 "^2.1.1"
     p-is-promise "^1.1.0"
 
-invariant@^2.1.1, invariant@^2.2.2, invariant@^2.2.4:
+invariant@2.2.4, invariant@^2.1.1, invariant@^2.2.2, invariant@^2.2.4:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
   integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
@@ -7581,13 +7581,13 @@ react-native-vector-icons@^4.6.0:
     prop-types "^15.5.10"
     yargs "^8.0.2"
 
-react-native-webview@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/react-native-webview/-/react-native-webview-2.0.0.tgz#a805d7261004a6b3da43f05759999c79becb994f"
-  integrity sha512-JTRmjgKHhclZvAu1gdByfG2Vfymk1Iyd2Kx6/uCwePt/9EZm31aTHShxgMD4Lmd28zChsbV3YPuaHi64SVTpqg==
+react-native-webview@^5.0.0:
+  version "5.12.1"
+  resolved "https://registry.yarnpkg.com/react-native-webview/-/react-native-webview-5.12.1.tgz#5e2b124e9087d64fc40040d911c10ee5744b5d4d"
+  integrity sha512-pFYzyNUG+k7Jk2a0Z3S1+OL9qtp0VQxVP08d1ume/O6l1Xibi0K0hRZms7zPUHqQc2uWEfjZ0FOa17MIN7vruw==
   dependencies:
-    escape-string-regexp "^1.0.5"
-    fbjs "^0.8.17"
+    escape-string-regexp "1.0.5"
+    invariant "2.2.4"
 
 react-native@0.57.8:
   version "0.57.8"


### PR DESCRIPTION
There is a complete rewrite of communication between webview and rn
component starting from 5.0.0

So use following as stated in the release notes
```
window.ReactNativeWebView.postMessage(data)
```
https://github.com/react-native-community/react-native-webview/releases/tag/v5.0.0

Also due to following change in https://github.com/react-native-community/react-native-webview/commit/f3bdab5
```
-￼    stringWithFormat:@"document.dispatchEvent(new MessageEvent('message', %@));",
+    stringWithFormat:@"window.dispatchEvent(new MessageEvent('message', %@));",
```

on iOS `document.addEventListener` stopped working. So change it to `window.addEventListener`.

This also fixes #3550, #3518.