### PR TITLE
Convert all object types to exact

### DIFF
--- a/src/api/eventTypes.js
+++ b/src/api/eventTypes.js
@@ -27,11 +27,11 @@ type EventCommon = {|
 |};
 
 /** A common supertype of all events, known or unknown. */
-export type GeneralEvent = {
+export type GeneralEvent = {|
   ...EventCommon,
   type: string,
   // Note this is an inexact object type!  There will be more properties.
-};
+|};
 
 export type HeartbeatEvent = {|
   ...EventCommon,

--- a/src/autocomplete/TopicAutocomplete.js
+++ b/src/autocomplete/TopicAutocomplete.js
@@ -15,13 +15,13 @@ const styles = StyleSheet.create({
   },
 });
 
-type Props = {
+type Props = {|
   dispatch: Dispatch,
   isFocused: boolean,
   text: string,
   topics: string[],
   onAutocomplete: (name: string) => void,
-};
+|};
 
 class TopicAutocomplete extends PureComponent<Props> {
   render() {

--- a/src/common/SectionSeparatorBetween.js
+++ b/src/common/SectionSeparatorBetween.js
@@ -6,10 +6,10 @@ import SectionSeparator from './SectionSeparator';
  * Upstream `SectionList` is full of `any`s.  This type is incomplete,
  * and just captures what we use.
  */
-type Props = {
+type Props = {|
   leadingItem: ?{},
   leadingSection: ?{ data: { length: number } },
-};
+|};
 
 /** Can be passed to RN's `SectionList` as `SectionSeparatorComponent`. */
 export default class SectionSeparatorBetween extends PureComponent<Props> {

--- a/src/common/ZulipStatusBar.js
+++ b/src/common/ZulipStatusBar.js
@@ -24,14 +24,14 @@ export const getStatusBarStyle = (statusBarColor: string): BarStyle =>
     ? 'light-content'
     : 'dark-content';
 
-type Props = {
+type Props = {|
   dispatch: Dispatch,
   hidden: boolean,
   theme: ThemeName,
   backgroundColor: string,
   safeAreaInsets: Dimensions,
   orientation: Orientation,
-};
+|};
 
 /**
  * Controls the status bar settings depending on platform

--- a/src/message/NotSubscribed.js
+++ b/src/message/NotSubscribed.js
@@ -10,11 +10,11 @@ import { ZulipButton, Label } from '../common';
 import { getAuth, getStreamInNarrow } from '../selectors';
 import styles from '../styles';
 
-type Props = {
+type Props = {|
   dispatch: Dispatch,
   auth: Auth,
   stream: { ...Stream },
-};
+|};
 
 class NotSubscribed extends PureComponent<Props> {
   subscribeToStream = () => {

--- a/src/settings/languages.js
+++ b/src/settings/languages.js
@@ -1,11 +1,11 @@
 /* @flow strict */
 /* eslint-disable spellcheck/spell-checker */
 
-export type Language = {
+export type Language = {|
   locale: string,
   name: string,
   nativeName: string,
-};
+|};
 
 const languages: $ReadOnlyArray<Language> = [
   {

--- a/src/start/AuthScreen.js
+++ b/src/start/AuthScreen.js
@@ -33,9 +33,9 @@ let otp = '';
  *
  * TODO move this to a libdef, and/or get an explicit type into upstream.
  */
-type LinkingEvent = {
+type LinkingEvent = {|
   url: string,
-};
+|};
 
 class AuthScreen extends PureComponent<Props> {
   componentDidMount = () => {

--- a/src/title/ActivityText.js
+++ b/src/title/ActivityText.js
@@ -9,12 +9,12 @@ import { getPresence, getUserStatus } from '../selectors';
 import { presenceToHumanTime } from '../utils/presence';
 import { RawLabel } from '../common';
 
-type Props = {
+type Props = {|
   dispatch: Dispatch,
   presence: UserPresence,
   style: TextStyleProp,
   userStatus: UserStatus,
-};
+|};
 
 class ActivityText extends PureComponent<Props> {
   render() {

--- a/src/title/TitleGroup.js
+++ b/src/title/TitleGroup.js
@@ -10,10 +10,10 @@ import { getRecipientsInGroupNarrow } from '../selectors';
 import styles from '../styles';
 import { navigateToAccountDetails } from '../nav/navActions';
 
-type Props = {
+type Props = {|
   dispatch: Dispatch,
   recipients: UserOrBot[],
-};
+|};
 
 class TitleGroup extends PureComponent<Props> {
   handlePress = (user: UserOrBot) => {

--- a/src/title/TitlePrivate.js
+++ b/src/title/TitlePrivate.js
@@ -11,11 +11,11 @@ import { getAllUsersByEmail } from '../users/userSelectors';
 import styles from '../styles';
 import { navigateToAccountDetails } from '../nav/navActions';
 
-type Props = {
+type Props = {|
   dispatch: Dispatch,
   user: UserOrBot,
   color: string,
-};
+|};
 
 class TitlePrivate extends PureComponent<Props> {
   handlePress = () => {

--- a/src/webview/webViewHandleUpdates.js
+++ b/src/webview/webViewHandleUpdates.js
@@ -33,10 +33,10 @@ export type WebViewUpdateEventReady = {|
   type: 'ready',
 |};
 
-export type WebViewUpdateEventMessagesRead = {
+export type WebViewUpdateEventMessagesRead = {|
   type: 'read',
   messageIds: number[],
-};
+|};
 
 export type WebViewUpdateEvent =
   | WebViewUpdateEventContent


### PR DESCRIPTION
fixes#3452
this commit convert object type into exact.Have only made change to those that didn't show any error in error with yarn flow.After this only src/message/messageActionSheet.js is left for the changes which shows couple of errors.