### PR TITLE
lint: Add `flowtype/no-dupe-keys` to eslint

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -98,6 +98,7 @@ rules:
   flowtype/define-flow-type: warn
   flowtype/delimiter-dangle: off
   flowtype/generic-spacing: [error, never]
+  flowtype/no-dupe-keys: error
   flowtype/no-primitive-constructor-types: error
   flowtype/no-types-missing-file-annotation: error
   ################# flowtype/no-weak-types: error

--- a/src/api/modelTypes.js
+++ b/src/api/modelTypes.js
@@ -217,7 +217,6 @@ export type Subscription = {|
   audible_notifications: boolean,
   desktop_notifications: boolean,
   email_address: string,
-  push_notifications: boolean,
   is_old_stream: boolean,
   push_notifications: boolean,
   stream_weekly_traffic: number,


### PR DESCRIPTION
Activate a linter in `eslint-plugin-flowtype` to warn about duplicate
keys in type declarations. Without this lint, flow does not warn when
a later-declared key in the same type shadows an earlier one, even
when the two are declared with incompatible types.

This presently only catches a duplicate parameter in modelTypes.js
(also fixed in this commit).