### PR TITLE
url parsing: remove unused emoji-url functions

### DIFF
--- a/src/utils/__tests__/url-test.js
+++ b/src/utils/__tests__/url-test.js
@@ -3,8 +3,6 @@ import {
   getFullUrl,
   getResource,
   isUrlOnRealm,
-  isEmojiUrl,
-  getEmojiUrl,
   hasProtocol,
   fixRealmUrl,
   autocompleteUrl,
@@ -84,27 +82,6 @@ describe('isUrlOnRealm', () => {
     expect(isUrlOnRealm('https://demo.example.com', 'https://example.com')).toBe(false);
 
     expect(isUrlOnRealm('www.google.com', 'https://example.com')).toBe(false);
-  });
-});
-
-describe('isEmojiUrl', () => {
-  test('when url is on realm, but not an emoji url', () => {
-    const result = isEmojiUrl('/user_uploads/abc.png', 'https://example.com');
-    expect(result).toBe(false);
-  });
-  test('when url is on realm and emoji', () => {
-    const result = isEmojiUrl(
-      '/static/generated/emoji/images/emoji/unicode/1f680.png',
-      'https://example.com',
-    );
-    expect(result).toBe(true);
-  });
-});
-
-describe('getEmojiUrl', () => {
-  test('when unicode is passed, output relative link on server', () => {
-    const url = getEmojiUrl('1f680');
-    expect(url).toBe('/static/generated/emoji/images/emoji/unicode/1f680.png');
   });
 });
 

--- a/src/utils/url.js
+++ b/src/utils/url.js
@@ -29,12 +29,6 @@ export const getFullUrl = (url: string = '', realm: string): string =>
 export const isUrlOnRealm = (url: string = '', realm: string): boolean =>
   url.startsWith('/') || url.startsWith(realm) || !/^(http|www.)/i.test(url);
 
-export const isEmojiUrl = (url: string, realm: string): boolean =>
-  isUrlOnRealm(url, realm) && url.includes('/static/generated/emoji/images/emoji/unicode/');
-
-export const getEmojiUrl = (unicode: string): string =>
-  `/static/generated/emoji/images/emoji/unicode/${unicode}.png`;
-
 const getResourceWithAuth = (uri: string, auth: Auth) => ({
   uri: getFullUrl(uri, auth.realm),
   headers: getAuthHeaders(auth),


### PR DESCRIPTION
Remove functions unused since the removal of render-native (commit
401fbfb, pull #2066).