### PR TITLE
#3591  Correct notification information and reformat notification display.

### DIFF
--- a/android/app/src/main/java/com/zulipmobile/notifications/FCMPushNotifications.kt
+++ b/android/app/src/main/java/com/zulipmobile/notifications/FCMPushNotifications.kt
@@ -113,7 +113,9 @@ private fun getNotificationBuilder(
         builder.setSmallIcon(R.drawable.zulip_notification)
     }
 
-    if (conversations.size == 1) {
+    val nameList = extractNames(conversations)
+
+    if (conversations.size == 1 && nameList.size == 1) {
         //Only one 1 notification therefore no using of big view styles
         if (totalMessagesCount > 1) {
             builder.setContentTitle("${fcmMessage.sender.fullName} ($totalMessagesCount)")
@@ -131,7 +133,7 @@ private fun getNotificationBuilder(
         builder.setStyle(Notification.BigTextStyle().bigText(fcmMessage.content))
     } else {
         builder.setContentTitle("$totalMessagesCount messages in ${conversations.size} conversations")
-        builder.setContentText("Messages from ${TextUtils.join(",", extractNames(conversations))}")
+        builder.setContentText("Messages from ${TextUtils.join(",", nameList)}")
         val inboxStyle = Notification.InboxStyle(builder)
         inboxStyle.setSummaryText("${conversations.size} conversations")
         buildNotificationContent(conversations, inboxStyle, context)

--- a/android/app/src/main/java/com/zulipmobile/notifications/FcmMessage.kt
+++ b/android/app/src/main/java/com/zulipmobile/notifications/FcmMessage.kt
@@ -42,18 +42,8 @@ data class Sender(
  * Data identifying where a Zulip message was sent.
  */
 sealed class Recipient {
-    /**
-     * A 1:1 private message.  Must be identified by the participants in the
-     * private conversation, i.e. who sent it and who received it.
-     */
-    data class Pm (val senderIdString: String, val userIdString: String ) : Recipient() {
-        fun getPmParticipantIdsString() =
-            if (userIdString < senderIdString){
-                "$userIdString:$senderIdString"
-                } else {
-                    "$senderIdString:$userIdString"
-        }
-    }
+    /** A 1:1 private message.  Must have been sent to this user, so nothing more to say. */
+    object Pm : Recipient()
 
     /**
      * A group PM.
@@ -151,9 +141,7 @@ data class MessageFcmMessage(
                 "private" ->
                     data["pm_users"]?.parseCommaSeparatedInts("pm_users")?.let {
                         Recipient.GroupPm(it.toSet())
-                    } ?: Recipient.Pm(
-                            data.require("sender_id"),
-                            data.require("user_id"))
+                    } ?: Recipient.Pm
                 else -> throw FcmMessageParseException("unexpected recipient_type: $recipientType")
             }
 

--- a/android/app/src/main/java/com/zulipmobile/notifications/FcmMessage.kt
+++ b/android/app/src/main/java/com/zulipmobile/notifications/FcmMessage.kt
@@ -42,8 +42,18 @@ data class Sender(
  * Data identifying where a Zulip message was sent.
  */
 sealed class Recipient {
-    /** A 1:1 private message.  Must have been sent to this user, so nothing more to say. */
-    object Pm : Recipient()
+    /**
+     * A 1:1 private message.  Must be identified by the participants in the
+     * private conversation, i.e. who sent it and who received it.
+     */
+    data class Pm (val senderIdString: String, val userIdString: String ) : Recipient() {
+        fun getPmParticipantIdsString() =
+            if (userIdString < senderIdString){
+                "$userIdString:$senderIdString"
+                } else {
+                    "$senderIdString:$userIdString"
+        }
+    }
 
     /**
      * A group PM.
@@ -141,7 +151,9 @@ data class MessageFcmMessage(
                 "private" ->
                     data["pm_users"]?.parseCommaSeparatedInts("pm_users")?.let {
                         Recipient.GroupPm(it.toSet())
-                    } ?: Recipient.Pm
+                    } ?: Recipient.Pm(
+                            data.require("sender_id"),
+                            data.require("user_id"))
                 else -> throw FcmMessageParseException("unexpected recipient_type: $recipientType")
             }
 

--- a/android/app/src/main/java/com/zulipmobile/notifications/NotificationHelper.kt
+++ b/android/app/src/main/java/com/zulipmobile/notifications/NotificationHelper.kt
@@ -7,7 +7,7 @@ import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.text.Spannable
-import android.text.SpannableString
+import android.text.SpannableStringBuilder
 import android.text.style.StyleSpan
 import android.util.Log
 import android.util.TypedValue
@@ -67,14 +67,18 @@ fun sizedURL(context: Context, url: URL, dpSize: Float): URL {
 
 fun buildNotificationContent(conversations: ByConversationMap, inboxStyle: Notification.InboxStyle, mContext: Context) {
     for (messages in conversations.values) {
+
         val messagesByNameMap = buildMessagesByNameMap(messages)
-        for ((name, messagesForName) in messagesByNameMap) {
-            val sb = SpannableString(String.format(Locale.ENGLISH, "%s%s: %s", name,
-                mContext.resources.getQuantityString(R.plurals.messages, messagesForName.size, messagesForName.size),
-                messagesForName[messagesForName.size - 1].content))
-            sb.setSpan(StyleSpan(android.graphics.Typeface.BOLD), 0, name.length, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
-            inboxStyle.addLine(sb)
+        val builder = SpannableStringBuilder()
+
+        for (name in messagesByNameMap.keys) {
+            builder.append("$name, ")
         }
+        val namesLength = builder.length
+        builder.replace(namesLength - 2, namesLength - 1, ":" )
+        builder.append(messages[messages.size - 1].content)
+        builder.setSpan(StyleSpan(android.graphics.Typeface.BOLD), 0, namesLength, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
+        inboxStyle.addLine(builder)
     }
 }
 

--- a/android/app/src/main/java/com/zulipmobile/notifications/NotificationHelper.kt
+++ b/android/app/src/main/java/com/zulipmobile/notifications/NotificationHelper.kt
@@ -65,19 +65,31 @@ fun sizedURL(context: Context, url: URL, dpSize: Float): URL {
     return URL(url, "?$query")
 }
 
-private fun extractName(key: String): String {
-    return key.split(":")[0]
+fun buildNotificationContent(conversations: ByConversationMap, inboxStyle: Notification.InboxStyle, mContext: Context) {
+    for (messages in conversations.values) {
+        val messagesByNameMap = buildMessagesByNameMap(messages)
+        for ((name, messagesForName) in messagesByNameMap) {
+            val sb = SpannableString(String.format(Locale.ENGLISH, "%s%s: %s", name,
+                mContext.resources.getQuantityString(R.plurals.messages, messagesForName.size, messagesForName.size),
+                messagesForName[messagesForName.size - 1].content))
+            sb.setSpan(StyleSpan(android.graphics.Typeface.BOLD), 0, name.length, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
+            inboxStyle.addLine(sb)
+        }
+    }
 }
 
-fun buildNotificationContent(conversations: ByConversationMap, inboxStyle: Notification.InboxStyle, mContext: Context) {
-    for ((key, messages) in conversations) {
-        val name = extractName(key)
-        val sb = SpannableString(String.format(Locale.ENGLISH, "%s%s: %s", name,
-            mContext.resources.getQuantityString(R.plurals.messages, messages.size, messages.size),
-            messages[messages.size - 1].content))
-        sb.setSpan(StyleSpan(android.graphics.Typeface.BOLD), 0, name.length, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
-        inboxStyle.addLine(sb)
+fun buildMessagesByNameMap(allMessages: List<MessageFcmMessage>) :LinkedHashMap<String, MutableList<MessageFcmMessage>> {
+    val map = LinkedHashMap<String, MutableList<MessageFcmMessage>>()
+    for (message in allMessages) {
+        val name = message.sender.fullName
+        var messagesForName :MutableList<MessageFcmMessage>? = map[name]
+        if (messagesForName == null){
+            messagesForName = ArrayList()
+        }
+        messagesForName.add(message)
+        map[name] = messagesForName
     }
+    return map
 }
 
 fun extractTotalMessagesCount(conversations: ByConversationMap): Int {
@@ -97,21 +109,20 @@ fun extractTotalMessagesCount(conversations: ByConversationMap): Int {
 private fun buildKeyString(fcmMessage: MessageFcmMessage): String {
     val recipient = fcmMessage.recipient
     return when (recipient) {
-        is Recipient.Stream -> String.format("%s:%s:stream", fcmMessage.sender.fullName,
-            recipient.stream)
-        is Recipient.GroupPm -> String.format("%s:%s:group", fcmMessage.sender.fullName,
-            recipient.getPmUsersString())
-        else -> String.format("%s:%s:private", fcmMessage.sender.fullName,
-            fcmMessage.sender.email)
+        is Recipient.Stream -> String.format("%s:%s:stream", recipient.stream, recipient.topic)
+        is Recipient.GroupPm -> String.format("%s:group", recipient.getPmUsersString())
+        is Recipient.Pm -> String.format("%s:private", recipient.getPmParticipantIdsString())
     }
 }
 
 fun extractNames(conversations: ByConversationMap): ArrayList<String> {
-    val names = arrayListOf<String>()
-    for ((key) in conversations) {
-        names.add(key.split(":")[0])
+    val namesSet = LinkedHashSet<String>()
+    for ( fcmMessages in conversations.values) {
+        for (fcmMessage in fcmMessages){
+            namesSet.add(fcmMessage.sender.fullName)
+        }
     }
-    return names
+    return ArrayList(namesSet)
 }
 
 fun addConversationToMap(fcmMessage: MessageFcmMessage, conversations: ConversationMap) {

--- a/android/app/src/main/java/com/zulipmobile/notifications/NotificationHelper.kt
+++ b/android/app/src/main/java/com/zulipmobile/notifications/NotificationHelper.kt
@@ -109,16 +109,16 @@ fun extractTotalMessagesCount(conversations: ByConversationMap): Int {
 private fun buildKeyString(fcmMessage: MessageFcmMessage): String {
     val recipient = fcmMessage.recipient
     return when (recipient) {
-        is Recipient.Stream -> String.format("%s:%s:stream", recipient.stream, recipient.topic)
+        is Recipient.Stream -> String.format("%s:stream", recipient.stream)
         is Recipient.GroupPm -> String.format("%s:group", recipient.getPmUsersString())
-        is Recipient.Pm -> String.format("%s:private", recipient.getPmParticipantIdsString())
+        is Recipient.Pm -> String.format("%s:private", fcmMessage.sender.id)
     }
 }
 
 fun extractNames(conversations: ByConversationMap): ArrayList<String> {
     val namesSet = LinkedHashSet<String>()
-    for ( fcmMessages in conversations.values) {
-        for (fcmMessage in fcmMessages){
+    for (fcmMessages in conversations.values) {
+        for (fcmMessage in fcmMessages) {
             namesSet.add(fcmMessage.sender.fullName)
         }
     }


### PR DESCRIPTION
Due to using the sender id as part of the sort key,  messages were being sorted into more conversations than actually existed.  The incorrect number of conversations was then reported in the notification.  This has been corrected.
Also the notification display has been changed as described in issue 3591.  Instead of showing a line for every person who sent a message, along with the last message they sent, now one line is shown for each conversation.  Each line shows a comma separated list of the names of the people in the conversation, along with the last message that was sent in the conversation.