### PR TITLE
Allow user to specify "localhost:9991" as a realm

### DIFF
--- a/docs/howto/dev-server.md
+++ b/docs/howto/dev-server.md
@@ -55,13 +55,19 @@ in a browser on your computer, with the URL `http://localhost:9991/`.  This
 refers to port 9991 on `localhost`, which is a name that works for talking
 to a server on your own computer.
 
-That URL won't work for the mobile app, because on your phone (either
-physical or emulated), `localhost` would be a name for the phone itself,
-rather than your computer.  Instead, we'll find an IP address that we can
-use instead of `localhost`, which will reach your computer when used on the
-phone.
+That URL won't necessarily work for the mobile app, because on your phone
+(either physical or emulated), `localhost` would be a name for the phone
+itself, rather than your computer.  Instead, we'll find an IP address that we
+can use instead of `localhost`, which will reach your computer when used on
+the phone.
 
 There are several ways to do this, depending on your platform.  See below.
+
+### iOS simulator (macOS only)
+
+The iOS simulator shares its network interface with the computer it's running
+on. Happily, this means `https://localhost:9991` will work without further
+configuration; you can skip to [the last step](#last-step).
 
 ### Android emulator
 
@@ -80,11 +86,10 @@ alternative approach below, which additionally works on all platforms.
 
 [android-emulator-net]: https://developer.android.com/studio/run/emulator-networking
 
-### Any (?) physical or emulated device
+### Any physical or emulated device
 
-This method should work on any physical device, or the Android emulator or
-iOS simulator.  (It's been tested at least on the Android emulator and
-physical Android and iOS devices.)
+This method should work on any physical device, the Android emulator,
+or the iOS simulator.
 
 First:
 * If you're using a physical device, you'll need it and your computer to be
@@ -94,10 +99,12 @@ First:
 * For an emulator/simulator, you just need to run it on the same computer
   you're running the Zulip server on.
 
-We'll use **the IP address your computer uses on the local network**.  (For
-a physical device, we want this to be the same network the phone is on.  For
-an emulator/simulator, any IP address that belongs to your computer, and
-isn't a special "loopback" address like 127.0.0.1, will do.)
+We'll use **the IP address your computer uses on the local network**.
+  * For a physical device, this should be on the same network the phone is on.
+  * For an emulator, any IP address that belongs to your computer (and isn't a
+    special "loopback" address like 127.0.0.1) will do.
+  * For the iOS simulator, if you are not using the simpler method above,
+    even a loopback address like 127.0.0.1 will be fine.
 
 To find this, you can use a command-line tool like (on Linux or macOS)
 `ip addr` or `ifconfig`; or look in the network pane of macOS's System
@@ -116,8 +123,9 @@ address](find-ip-address.md).
 
 ## 3. Listen on all interfaces
 
-If you're using the Android emulator and the IP address 10.0.2.2, you can
-skip this step and move on to step 4.  Otherwise, read on.
+If you're using the Android emulator and the IP address 10.0.2.2, or if you're
+using the iOS simulator, you can skip this step and move on to step 4.
+Otherwise, read on.
 
 By default, the Zulip dev server only listens on the "loopback" network
 interface, 127.0.0.1, aka `localhost`.  This is a nice secure default,
@@ -180,6 +188,7 @@ or if step 3 called for `--interface=`, then
 in `zproject/dev_settings.py`, which is actually the critical part here.)
 
 
+<a id="last-step"></a>
 ## 5. Log in!
 
 Now [fire up the app](build-run.md) on your emulator or device, go to the

--- a/src/common/SmartUrlInput.js
+++ b/src/common/SmartUrlInput.js
@@ -6,6 +6,7 @@ import type { NavigationEventSubscription, NavigationScreenProp } from 'react-na
 
 import type { Context } from '../types';
 import { autocompleteRealmPieces, autocompleteRealm, fixRealmUrl } from '../utils/url';
+import type { Protocol } from '../utils/url';
 import RawLabel from './RawLabel';
 
 const styles = StyleSheet.create({
@@ -31,7 +32,7 @@ type Props = {|
    * The protocol which will be used if the user doesn't specify one.
    * Should almost certainly be "https://".
    */
-  defaultProtocol: string,
+  defaultProtocol: Protocol,
   /**
    * The example organization name that will be displayed while the
    * entry field is empty. Appears, briefly, as the initial (lowest-

--- a/src/start/RealmScreen.js
+++ b/src/start/RealmScreen.js
@@ -77,9 +77,9 @@ class RealmScreen extends PureComponent<Props, State> {
         <SmartUrlInput
           style={styles.marginVertical}
           navigation={navigation}
+          defaultProtocol="https://"
           defaultOrganization="your-org"
-          protocol="https://"
-          append=".zulipchat.com"
+          defaultDomain="zulipchat.com"
           defaultValue={initialRealm}
           onChangeText={this.handleRealmChange}
           onSubmitEditing={this.tryRealm}

--- a/src/utils/__tests__/url-test.js
+++ b/src/utils/__tests__/url-test.js
@@ -5,7 +5,7 @@ import {
   getFullUrl,
   getResource,
   isUrlOnRealm,
-  hasProtocol,
+  parseProtocol,
   fixRealmUrl,
   autocompleteUrl,
 } from '../url';
@@ -93,17 +93,30 @@ describe('isUrlOnRealm', () => {
   });
 });
 
-describe('hasProtocol', () => {
-  test('detects strings that have no http/https protocol', () => {
-    expect(hasProtocol(undefined)).toBe(false);
-    expect(hasProtocol('')).toBe(false);
-    expect(hasProtocol('chat.zulip.com')).toBe(false);
-    expect(hasProtocol('ftp://chat.zulip.com')).toBe(false);
+describe('parseProtocol', () => {
+  test('rejects strings that have no http/https protocol', () => {
+    expect(parseProtocol('')).toEqual([null, '']);
+    expect(parseProtocol('chat.zulip.com')).toEqual([null, 'chat.zulip.com']);
+    expect(parseProtocol('ftp://chat.zulip.com')).toEqual([null, 'ftp://chat.zulip.com']);
+    expect(parseProtocol('localhost:9991')).toEqual([null, 'localhost:9991']);
   });
 
-  test('recognizes strings that include the http/https protocol', () => {
-    expect(hasProtocol('http://chat.zulip.com')).toBe(true);
-    expect(hasProtocol('https://chat.zulip.com')).toBe(true);
+  test('accepts strings that include the http/https protocol', () => {
+    expect(parseProtocol('http://chat.zulip.com')).toEqual(['http://', 'chat.zulip.com']);
+    expect(parseProtocol('https://chat.zulip.com')).toEqual(['https://', 'chat.zulip.com']);
+    expect(parseProtocol('http://localhost:9991')).toEqual(['http://', 'localhost:9991']);
+  });
+
+  test('rejects strings that include a bogus http/https protocol indicator', () => {
+    expect(parseProtocol('chat.zulip.com/http://')).toEqual([null, 'chat.zulip.com/http://']);
+    expect(parseProtocol('example.net/https://')).toEqual([null, 'example.net/https://']);
+  });
+
+  test('accepts strings that include spaces before the protocol', () => {
+    expect(parseProtocol('   https://chat.zulip.com')).toEqual(['https://', 'chat.zulip.com']);
+    expect(parseProtocol('\t http://example.net')).toEqual(['http://', 'example.net']);
+    // non-breaking space
+    expect(parseProtocol('\xA0http://example.org')).toEqual(['http://', 'example.org']);
   });
 });
 

--- a/src/utils/url.js
+++ b/src/utils/url.js
@@ -44,7 +44,10 @@ export const getResource = (
 ): {| uri: string, headers?: { [string]: string } |} =>
   isUrlOnRealm(uri, auth.realm) ? getResourceWithAuth(uri, auth) : getResourceNoAuth(uri);
 
-export const hasProtocol = (url: string = '') => url.search(/\b(http|https):\/\//) !== -1;
+const protocolRegex = /^\s*((?:http|https):\/\/)(.*)$/;
+
+/** DEPRECATED */
+export const hasProtocol = (url: string = '') => url.search(protocolRegex) !== -1;
 
 export const fixRealmUrl = (url: string = '') =>
   url.length > 0 ? (!hasProtocol(url) ? 'https://' : '') + url.trim().replace(/\s+|\/$/g, '') : '';

--- a/src/utils/url.js
+++ b/src/utils/url.js
@@ -44,6 +44,8 @@ export const getResource = (
 ): {| uri: string, headers?: { [string]: string } |} =>
   isUrlOnRealm(uri, auth.realm) ? getResourceWithAuth(uri, auth) : getResourceNoAuth(uri);
 
+export type Protocol = 'https://' | 'http://';
+
 const protocolRegex = /^\s*((?:http|https):\/\/)(.*)$/;
 
 /** DEPRECATED */
@@ -55,9 +57,18 @@ const hasProtocol = (url: string = '') => url.search(protocolRegex) !== -1;
 //
 // Ignores initial spaces.
 /** PRIVATE -- exported only for testing */
-export const parseProtocol = (value: string): [string | null, string] => {
+export const parseProtocol = (value: string): [Protocol | null, string] => {
   const match = protocolRegex.exec(value);
-  return match ? [match[1], match[2]] : [null, value];
+
+  if (match) {
+    const [, protocol, rest] = match;
+    if (protocol === 'http://' || protocol === 'https://') {
+      return [protocol, rest];
+    } else {
+      throw new Error(`impossible match: protocol = '${escape(protocol)}'`);
+    }
+  }
+  return [null, value];
 };
 
 /** DEPRECATED */
@@ -93,11 +104,11 @@ export const getMimeTypeFromFileExtension = (extension: string): string =>
 export const isValidUrl = (url: string): boolean => urlRegex({ exact: true }).test(url);
 
 export type AutocompletionDefaults = {|
-  protocol: string,
+  protocol: Protocol,
   domain: string,
 |};
 
-export type AutocompletionPieces = [string | null, string, string | null];
+export type AutocompletionPieces = [Protocol | null, string, string | null];
 
 /**
  * A short list of some characters not permitted in subdomain name elements.

--- a/src/utils/url.js
+++ b/src/utils/url.js
@@ -98,3 +98,37 @@ export const autocompleteUrl = (value: string = '', protocol: string, append: st
     : '';
 
 export const isValidUrl = (url: string): boolean => urlRegex({ exact: true }).test(url);
+
+export type AutocompletionDefaults = {|
+  protocol: string,
+  domain: string,
+|};
+
+export type AutocompletionPieces = [string | null, string, string | null];
+
+/**
+ * Given user input purporting to identify a Zulip realm, provide a prefix,
+ * derived value, and suffix which may suffice to turn it into a full URL.
+ *
+ * Presently, the derived value will always be equal to the input value;
+ * this property should not be relied on, as it may change in future.
+ */
+export const autocompleteRealmPieces = (
+  value: string,
+  defaults: AutocompletionDefaults,
+): AutocompletionPieces => {
+  const [protocol, nonProtocolValue] = parseProtocol(value);
+
+  const prefix = protocol === null ? defaults.protocol : null;
+
+  const suffix = nonProtocolValue.includes('.') ? null : `.${defaults.domain}`;
+
+  return [prefix, value, suffix];
+};
+
+export const autocompleteRealm = (value: string, data: AutocompletionDefaults): string =>
+  value === ''
+    ? ''
+    : autocompleteRealmPieces(value, data)
+        .filter(s => s)
+        .join('');

--- a/src/utils/url.js
+++ b/src/utils/url.js
@@ -100,6 +100,11 @@ export type AutocompletionDefaults = {|
 export type AutocompletionPieces = [string | null, string, string | null];
 
 /**
+ * A short list of some characters not permitted in subdomain name elements.
+ */
+const disallowedCharacters: Array<string> = [...'.:/'];
+
+/**
  * Given user input purporting to identify a Zulip realm, provide a prefix,
  * derived value, and suffix which may suffice to turn it into a full URL.
  *
@@ -114,7 +119,10 @@ export const autocompleteRealmPieces = (
 
   const prefix = protocol === null ? defaults.protocol : null;
 
-  const suffix = nonProtocolValue.includes('.') ? null : `.${defaults.domain}`;
+  // If the user supplies one of these characters, assume they know what they're doing.
+  const suffix = disallowedCharacters.some(c => nonProtocolValue.includes(c))
+    ? null
+    : `.${defaults.domain}`;
 
   return [prefix, value, suffix];
 };

--- a/src/utils/url.js
+++ b/src/utils/url.js
@@ -47,7 +47,7 @@ export const getResource = (
 const protocolRegex = /^\s*((?:http|https):\/\/)(.*)$/;
 
 /** DEPRECATED */
-export const hasProtocol = (url: string = '') => url.search(protocolRegex) !== -1;
+const hasProtocol = (url: string = '') => url.search(protocolRegex) !== -1;
 
 // Split a (possible) URL into protocol and non-protocol parts.
 // The former will be null if no recognized protocol is a component
@@ -89,13 +89,6 @@ const mimes = {
 
 export const getMimeTypeFromFileExtension = (extension: string): string =>
   mimes[extension.toLowerCase()] || 'application/octet-stream';
-
-export const autocompleteUrl = (value: string = '', protocol: string, append: string): string =>
-  value.length > 0
-    ? `${hasProtocol(value) ? '' : protocol}${value || 'your-org'}${
-        value.indexOf('.') === -1 ? append : ''
-      }`
-    : '';
 
 export const isValidUrl = (url: string): boolean => urlRegex({ exact: true }).test(url);
 

--- a/src/utils/url.js
+++ b/src/utils/url.js
@@ -60,8 +60,17 @@ export const parseProtocol = (value: string): [string | null, string] => {
   return match ? [match[1], match[2]] : [null, value];
 };
 
-export const fixRealmUrl = (url: string = '') =>
-  url.length > 0 ? (!hasProtocol(url) ? 'https://' : '') + url.trim().replace(/\s+|\/$/g, '') : '';
+/** DEPRECATED */
+export const fixRealmUrl = (url: string = '') => {
+  if (url === '') {
+    return '';
+  }
+  const trimmedUrl = url
+    .replace(/\s/g, '') // strip any spaces, internal or otherwise
+    .replace(/\/$/g, ''); // eliminate trailing slash
+
+  return hasProtocol(trimmedUrl) ? trimmedUrl : `https://${trimmedUrl}`;
+};
 
 export const getFileExtension = (filename: string): string => filename.split('.').pop();
 

--- a/src/utils/url.js
+++ b/src/utils/url.js
@@ -49,6 +49,17 @@ const protocolRegex = /^\s*((?:http|https):\/\/)(.*)$/;
 /** DEPRECATED */
 export const hasProtocol = (url: string = '') => url.search(protocolRegex) !== -1;
 
+// Split a (possible) URL into protocol and non-protocol parts.
+// The former will be null if no recognized protocol is a component
+// of the string.
+//
+// Ignores initial spaces.
+/** PRIVATE -- exported only for testing */
+export const parseProtocol = (value: string): [string | null, string] => {
+  const match = protocolRegex.exec(value);
+  return match ? [match[1], match[2]] : [null, value];
+};
+
 export const fixRealmUrl = (url: string = '') =>
   url.length > 0 ? (!hasProtocol(url) ? 'https://' : '') + url.trim().replace(/\s+|\/$/g, '') : '';
 


### PR DESCRIPTION
... and in the process, unify the URL parsing logic between `SmartUrlInput` and `url.js`.

This permits simpler use of the iOS simulator, which has also been documented.