### PR TITLE
android, notif: Narrow to conversation on click even if app is in bg.

### DIFF
--- a/android/app/src/main/java/com/zulipmobile/notifications/NotifyReact.java
+++ b/android/app/src/main/java/com/zulipmobile/notifications/NotifyReact.java
@@ -40,7 +40,7 @@ class NotifyReact {
         if (reactContext != null && reactContext.getLifecycleState() == LifecycleState.RESUMED) {
             return;
         }
-        launchMainActivity((Context) application);
+        launchOrResumeMainActivity((Context) application);
     }
 
     private static void emitIfResumed(ReactApplication application, final String eventName, final @Nullable Object data) {
@@ -67,7 +67,7 @@ class NotifyReact {
                 .emit(eventName, data);
     }
 
-    private static void launchMainActivity(Context context) {
+    private static void launchOrResumeMainActivity(Context context) {
         final Intent intent = new Intent(context, MainActivity.class);
         // See these sections in the Android docs:
         //   https://developer.android.com/guide/components/activities/tasks-and-back-stack#TaskLaunchModes


### PR DESCRIPTION
Notify react about the notification when app is:
- in forground and notification comes (LifecycleState = RESUMEND)
when user is using app and notification comes
- in background and notification comes (LifecycleState = BEFORE_RESUME)
when user is not using app. But app is present in the recent apps.

and finally launch (bring app to foreground)
MainActivity after emiting event.

Fixes #3582