### PR TITLE
types: Describe current state of reaction object in redux.

### DIFF
--- a/src/api/modelTypes.js
+++ b/src/api/modelTypes.js
@@ -281,7 +281,8 @@ export type Reaction = $ReadOnly<{|
   user: $ReadOnly<{|
     email: string,
     full_name: string,
-    user_id: number,
+    user_id?: number, //  present in reaction add event
+    id?: number, // present when messages are fetched via `getMessages` API
   |}>,
   emoji_name: string,
   reaction_type: ReactionType,


### PR DESCRIPTION
When messages are fetched from server via GET `/messages`, then it
contains `id` as key in `user` of the reaction object. While reaction
add event has `user_id` in it.

As we weren't using this attributes anywhere, so there was no problem
and fortunately app never crashed.