### PR TITLE
search: prevent race conditions between subsequent queries

### DIFF
--- a/src/search/SearchMessagesCard.js
+++ b/src/search/SearchMessagesCard.js
@@ -29,7 +29,11 @@ export default class SearchMessagesCard extends PureComponent<Props> {
     const { isFetching, messages } = this.props;
 
     if (isFetching) {
-      return <LoadingIndicator size={40} />;
+      // Display loading indicator only if there are no messages to
+      // display from a previous search.
+      if ((messages ?? []).length === 0) {
+        return <LoadingIndicator size={40} />;
+      }
     }
 
     if (messages === null) {

--- a/src/search/SearchMessagesCard.js
+++ b/src/search/SearchMessagesCard.js
@@ -18,8 +18,7 @@ const styles = StyleSheet.create({
 });
 
 type Props = {|
-  queryIsEmpty: boolean,
-  messages: Message[],
+  messages: Message[] | null,
   isFetching: boolean,
 |};
 
@@ -27,14 +26,18 @@ export default class SearchMessagesCard extends PureComponent<Props> {
   static NOT_FETCHING = { older: false, newer: false };
 
   render() {
-    const { queryIsEmpty, isFetching, messages } = this.props;
+    const { isFetching, messages } = this.props;
 
     if (isFetching) {
       return <LoadingIndicator size={40} />;
     }
 
+    if (messages === null) {
+      return null;
+    }
+
     if (messages.length === 0) {
-      return !queryIsEmpty ? <SearchEmptyState text="No results" /> : null;
+      return <SearchEmptyState text="No results" />;
     }
 
     const renderedMessages = renderMessages(messages, []);

--- a/src/search/SearchMessagesScreen.js
+++ b/src/search/SearchMessagesScreen.js
@@ -13,10 +13,16 @@ import { getAuth } from '../account/accountsSelectors';
 
 type Props = {|
   auth: Auth,
+  // Warning: do not add new props without considering their effect on the
+  // behavior of this component's non-React internal state. See comment below.
 |};
 
 type State = {|
+  /** The list of messages returned for the latest query, or `null` if there is
+   *  effectively no "latest query" to have results from.
+   */
   messages: Message[] | null,
+  /** Whether there is currently an active valid network request. */
   isFetching: boolean,
 |};
 
@@ -26,11 +32,12 @@ class SearchMessagesScreen extends PureComponent<Props, State> {
     isFetching: false,
   };
 
-  performQuery = async (query: string) => {
+  /** PRIVATE
+   *  Performs a network request associated with a query. Does not
+   *  update or access internal state (except `auth`).
+   */
+  performQueryRaw = async (query: string): Promise<Message[]> => {
     const { auth } = this.props;
-
-    this.setState({ isFetching: true });
-
     const { messages } = await api.getMessages(
       auth,
       SEARCH_NARROW(query),
@@ -39,7 +46,54 @@ class SearchMessagesScreen extends PureComponent<Props, State> {
       0,
       false,
     );
+    return messages;
+  };
 
+  // Non-React state. See comment following.
+  lastIdSent: number = 1000;
+  lastIdReceived: number = 1000;
+
+  // This component is less pure than most. The correct behavior here is
+  // probably that, when props change, all outstanding asynchronous requests
+  // should be **synchronously** invalidated before the next render.
+  //
+  // As the only React prop this component has is `auth`, we ignore this for
+  // now: any updates to `auth` would involve this screen being torn down and
+  // reconstructed anyway. However, addition of any new props which need to
+  // invalidate outstanding requests on change will require more work.
+  //
+  // This should probably be handled by moving the state above into the Redux
+  // store, and ensuring that Redux actions trigger appropriate resets.
+  // Alternatively, we could use `componentDidUpdate()` (see the blog post at
+  // [1] for more details), though calls to `setState()` from there are
+  // currently linted against.
+  //
+  // [1] https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html
+
+  /** PRIVATE
+   * Asynchronously performs a search query. Discards any responses thereto
+   * which have been delayed long enough to be out-of-order.
+   */
+  performQuery = async (query: string) => {
+    const id = ++this.lastIdSent;
+
+    let messages: Message[] | null = null;
+    if (query !== '') {
+      // Make note that we're performing a query.
+      this.setState({ isFetching: true });
+      messages = await this.performQueryRaw(query);
+    } else {
+      // The empty query can be resolved without a network call.
+      messages = null;
+    }
+
+    if (this.lastIdReceived > id) {
+      return;
+    }
+
+    this.lastIdReceived = id;
+
+    // A query is concluded. Report the message-list.
     this.setState({ messages, isFetching: false });
   };
 

--- a/src/search/SearchMessagesScreen.js
+++ b/src/search/SearchMessagesScreen.js
@@ -94,7 +94,7 @@ class SearchMessagesScreen extends PureComponent<Props, State> {
     this.lastIdReceived = id;
 
     // A query is concluded. Report the message-list.
-    this.setState({ messages, isFetching: false });
+    this.setState({ messages, isFetching: this.lastIdReceived === id });
   };
 
   handleQueryChange = (query: string) => {

--- a/src/search/SearchMessagesScreen.js
+++ b/src/search/SearchMessagesScreen.js
@@ -1,30 +1,70 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
 
+import * as api from '../api';
+import type { Auth, Message } from '../types';
 import { Screen } from '../common';
 import SearchMessagesCard from './SearchMessagesCard';
 import styles from '../styles';
+import { SEARCH_NARROW } from '../utils/narrow';
+import { LAST_MESSAGE_ANCHOR } from '../constants';
+import { connect } from '../react-redux';
+import { getAuth } from '../account/accountsSelectors';
 
-type Props = {||};
+type Props = {|
+  auth: Auth,
+|};
 
 type State = {|
   query: string,
+  messages: Message[],
+  isFetching: boolean,
 |};
 
-export default class SearchMessagesScreen extends PureComponent<Props, State> {
+class SearchMessagesScreen extends PureComponent<Props, State> {
   state = {
     query: '',
+    messages: [],
+    isFetching: false,
   };
 
-  handleQueryChange = (query: string) => this.setState({ query });
+  performQuery = async (query: string) => {
+    const { auth } = this.props;
+
+    this.setState({ isFetching: true });
+
+    const { messages } = await api.getMessages(
+      auth,
+      SEARCH_NARROW(query),
+      LAST_MESSAGE_ANCHOR,
+      20,
+      0,
+      false,
+    );
+
+    this.setState({ messages, isFetching: false });
+  };
+
+  handleQueryChange = (query: string) => {
+    this.setState({ query });
+    this.performQuery(query);
+  };
 
   render() {
-    const { query } = this.state;
+    const { query, messages, isFetching } = this.state;
 
     return (
       <Screen search autoFocus searchBarOnChange={this.handleQueryChange} style={styles.flexed}>
-        <SearchMessagesCard query={query} />
+        <SearchMessagesCard
+          queryIsEmpty={query === ''}
+          messages={messages}
+          isFetching={isFetching}
+        />
       </Screen>
     );
   }
 }
+
+export default connect(state => ({
+  auth: getAuth(state),
+}))(SearchMessagesScreen);

--- a/src/search/SearchMessagesScreen.js
+++ b/src/search/SearchMessagesScreen.js
@@ -1,6 +1,7 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
 
+import throttle from 'lodash.throttle';
 import * as api from '../api';
 import type { Auth, Message } from '../types';
 import { Screen } from '../common';
@@ -74,7 +75,7 @@ class SearchMessagesScreen extends PureComponent<Props, State> {
    * Asynchronously performs a search query. Discards any responses thereto
    * which have been delayed long enough to be out-of-order.
    */
-  performQuery = async (query: string) => {
+  performQuery = throttle(async (query: string) => {
     const id = ++this.lastIdSent;
 
     let messages: Message[] | null = null;
@@ -95,7 +96,7 @@ class SearchMessagesScreen extends PureComponent<Props, State> {
 
     // A query is concluded. Report the message-list.
     this.setState({ messages, isFetching: this.lastIdReceived === id });
-  };
+  }, 500);
 
   handleQueryChange = (query: string) => {
     this.performQuery(query);

--- a/src/search/SearchMessagesScreen.js
+++ b/src/search/SearchMessagesScreen.js
@@ -16,14 +16,12 @@ type Props = {|
 |};
 
 type State = {|
-  query: string,
-  messages: Message[],
+  messages: Message[] | null,
   isFetching: boolean,
 |};
 
 class SearchMessagesScreen extends PureComponent<Props, State> {
   state = {
-    query: '',
     messages: [],
     isFetching: false,
   };
@@ -46,20 +44,15 @@ class SearchMessagesScreen extends PureComponent<Props, State> {
   };
 
   handleQueryChange = (query: string) => {
-    this.setState({ query });
     this.performQuery(query);
   };
 
   render() {
-    const { query, messages, isFetching } = this.state;
+    const { messages, isFetching } = this.state;
 
     return (
       <Screen search autoFocus searchBarOnChange={this.handleQueryChange} style={styles.flexed}>
-        <SearchMessagesCard
-          queryIsEmpty={query === ''}
-          messages={messages}
-          isFetching={isFetching}
-        />
+        <SearchMessagesCard messages={messages} isFetching={isFetching} />
       </Screen>
     );
   }


### PR DESCRIPTION
Enforce an ordering on resolution of asynchronous search requests by discarding any delayed, out-of-order responses.

Fixes #3058.