### PR TITLE
docs/dev server: Add explicit vagrant restart command

### DIFF
--- a/docs/howto/dev-server.md
+++ b/docs/howto/dev-server.md
@@ -149,7 +149,7 @@ following line to a file `~/.zulip-vagrant-config` on the host computer
 HOST_IP_ADDR 0.0.0.0
 ```
 
-Then restart the Vagrant guest.
+Then restart the Vagrant guest using `vagrant reload`.
 
 ### If running server directly on host
 


### PR DESCRIPTION
A naïve `vagrant halt` + `vagrant up [--provision]` doesn't suffice.