### PR TITLE
Add Android NDK installation instructions

### DIFF
--- a/docs/howto/build-run.md
+++ b/docs/howto/build-run.md
@@ -50,11 +50,10 @@ might look through the other tools and try some more of them out.
 
 ## Android tips
 
-* To set up the Android emulator, follow the heading "Using a virtual device"
-  in those React Native [Getting Started][rn-getting-started] instructions.
-* After you set up the Android emulator, you no longer need Android
-  Studio.  You can start the emulator [from the command line][
-  android-emu-cmd-line].
+* To set up the Android emulator, follow the heading "Using a virtual device" in
+  the React Native [Getting Started][rn-getting-started] instructions. After you
+  set up the emulator in Android Studio, you can start it [from the command
+  line][android-emu-cmd-line].
 * When running on a physical device, if the device has Zulip installed
   from the Play Store, you may need to uninstall that version first.
 * Commands once you've set up:

--- a/docs/howto/build-run.md
+++ b/docs/howto/build-run.md
@@ -54,6 +54,10 @@ might look through the other tools and try some more of them out.
   the React Native [Getting Started][rn-getting-started] instructions. After you
   set up the emulator in Android Studio, you can start it [from the command
   line][android-emu-cmd-line].
+* To build to a physical Android device, you may also need to install the
+  Android NDK. In Android Studio's SDK Manager, under the **SDK Tools** tab,
+  select **NDK (Side by side)** for installation; then click **OK** or
+  **Apply**.
 * When running on a physical device, if the device has Zulip installed
   from the Play Store, you may need to uninstall that version first.
 * Commands once you've set up:

--- a/docs/howto/build-run.md
+++ b/docs/howto/build-run.md
@@ -51,12 +51,10 @@ might look through the other tools and try some more of them out.
 ## Android tips
 
 * To set up the Android emulator, follow the heading "Using a virtual device"
-  in those React Native
-  [Getting Started](https://facebook.github.io/react-native/docs/getting-started.html)
-  instructions.
+  in those React Native [Getting Started][rn-getting-started] instructions.
 * After you set up the Android emulator, you no longer need Android
-  Studio.  You can start the emulator [from the command
-  line](https://developer.android.com/studio/run/emulator-commandline.html).
+  Studio.  You can start the emulator [from the command line][
+  android-emu-cmd-line].
 * When running on a physical device, if the device has Zulip installed
   from the Play Store, you may need to uninstall that version first.
 * Commands once you've set up:
@@ -70,6 +68,9 @@ might look through the other tools and try some more of them out.
     mode, just skipping Sentry setup (which requires an authentication
     token).  The output APK will be at
     `android/app/build/outputs/apk/release/app-release.apk`.
+
+[rn-getting-started]: https://facebook.github.io/react-native/docs/getting-started.html
+[android-emu-cmd-line]: https://developer.android.com/studio/run/emulator-commandline.html
 
 ## iOS tips
 


### PR DESCRIPTION
Its absence is precisely diagnosed by relevant error messages and not difficult to fix, but we should still note it somewhere.