### PR TITLE
typingEvent: Report stop event to server on sending message.

### DIFF
--- a/src/compose/ComposeBox.js
+++ b/src/compose/ComposeBox.js
@@ -20,7 +20,7 @@ import {
   cancelEditMessage,
   draftUpdate,
   fetchTopicsForActiveStream,
-  sendTypingEvent,
+  sendTypingStart,
 } from '../actions';
 import * as api from '../api';
 import { FloatingActionButton, Input } from '../common';
@@ -172,7 +172,7 @@ class ComposeBox extends PureComponent<Props, State> {
   handleMessageChange = (message: string) => {
     this.setState({ message, isMenuExpanded: false });
     const { dispatch, narrow } = this.props;
-    dispatch(sendTypingEvent(narrow));
+    dispatch(sendTypingStart(narrow));
     dispatch(draftUpdate(narrow, message));
   };
 

--- a/src/compose/ComposeBox.js
+++ b/src/compose/ComposeBox.js
@@ -21,6 +21,7 @@ import {
   draftUpdate,
   fetchTopicsForActiveStream,
   sendTypingStart,
+  sendTypingStop,
 } from '../actions';
 import * as api from '../api';
 import { FloatingActionButton, Input } from '../common';
@@ -232,12 +233,13 @@ class ComposeBox extends PureComponent<Props, State> {
   };
 
   handleSend = () => {
-    const { dispatch } = this.props;
+    const { dispatch, narrow } = this.props;
     const { message } = this.state;
 
     dispatch(addToOutbox(this.getDestinationNarrow(), message));
 
     this.setMessageInputValue('');
+    dispatch(sendTypingStop(narrow));
   };
 
   handleEdit = () => {

--- a/src/users/usersActions.js
+++ b/src/users/usersActions.js
@@ -34,7 +34,7 @@ export const reportPresence = (hasFocus: boolean = true, newUserInput: boolean =
   });
 };
 
-export const sendTypingEvent = (narrow: Narrow) => async (
+export const sendTypingStart = (narrow: Narrow) => async (
   dispatch: Dispatch,
   getState: GetState,
 ) => {

--- a/src/users/usersActions.js
+++ b/src/users/usersActions.js
@@ -53,3 +53,16 @@ export const sendTypingStart = (narrow: Narrow) => async (
   const auth = getAuth(getState());
   api.typing(auth, narrow[0].operand, 'start');
 };
+
+export const sendTypingStop = (narrow: Narrow) => async (
+  dispatch: Dispatch,
+  getState: GetState,
+) => {
+  if (!isPrivateOrGroupNarrow(narrow)) {
+    return;
+  }
+
+  const auth = getAuth(getState());
+  api.typing(auth, narrow[0].operand, 'stop');
+  lastTypingStart = new Date(0);
+};


### PR DESCRIPTION
So that other user doesn't think that user is typing another message.

Set `lastTypingStart` as 0, when typing operation is stop, so that
immediate start typing event can be send to the server, if required.