### PR TITLE
Migrate logging to new functions `logging.error` and `logging.warn`.

### DIFF
--- a/src/boot/ZulipAsyncStorage.js
+++ b/src/boot/ZulipAsyncStorage.js
@@ -1,6 +1,6 @@
 /* @flow strict-local */
 import { AsyncStorage, NativeModules } from 'react-native';
-import { logErrorRemotely } from '../utils/logging';
+import * as logging from '../utils/logging';
 
 export default class ZulipAsyncStorage {
   static async getItem(key: string, callback: (error: ?Error, result: ?string) => void) {
@@ -34,7 +34,7 @@ export default class ZulipAsyncStorage {
         // the data.  This error should not happen unless a user downgrades
         // their version of the app.
         const err = new Error(`No decompression module found for format ${header}`);
-        logErrorRemotely(err, '');
+        logging.error(err);
         if (callback) {
           callback(err, null);
         }

--- a/src/notification/index.js
+++ b/src/notification/index.js
@@ -5,7 +5,7 @@ import NotificationsIOS from 'react-native-notifications';
 import type { Auth, Dispatch, Narrow, User } from '../types';
 import { topicNarrow, privateNarrow, groupNarrow } from '../utils/narrow';
 import * as api from '../api';
-import { logErrorRemotely } from '../utils/logging';
+import * as logging from '../utils/logging';
 import {
   unackPushToken,
   gotPushToken,
@@ -149,8 +149,8 @@ export class NotificationListener {
     this.listen('notificationOpened', this.handleNotificationOpen);
     this.listen('remoteNotificationsRegistered', this.handleDeviceToken);
     if (Platform.OS === 'ios') {
-      this.listen('remoteNotificationsRegistrationFailed', (error: string) => {
-        logErrorRemotely(new Error(error), 'Failed to register iOS push token');
+      this.listen('remoteNotificationsRegistrationFailed', (errMsg: string) => {
+        logging.warn(`Failed to register iOS push token: ${errMsg}`);
       });
     }
   }
@@ -199,7 +199,7 @@ export const tryStopNotifications = async (
     try {
       await api.forgetPushToken(auth, Platform.OS, token);
     } catch (e) {
-      logErrorRemotely(e, 'failed to unregister Push token');
+      logging.warn(e);
     }
   }
 };

--- a/src/outbox/outboxActions.js
+++ b/src/outbox/outboxActions.js
@@ -1,7 +1,7 @@
 /* @flow strict-local */
 import parseMarkdown from 'zulip-markdown-parser';
 
-import { logErrorRemotely } from '../utils/logging';
+import * as logging from '../utils/logging';
 import type {
   Dispatch,
   GetState,
@@ -65,7 +65,7 @@ export const trySendMessages = (dispatch: Dispatch, getState: GetState): boolean
     });
     return true;
   } catch (e) {
-    logErrorRemotely(e, 'error caught while sending');
+    logging.warn(e);
     return false;
   }
 };

--- a/src/redux-persist-migrate/index.js
+++ b/src/redux-persist-migrate/index.js
@@ -3,7 +3,7 @@ import type { Reducer, Store, Dispatch } from 'redux';
 
 import { REHYDRATE } from '../actionConstants';
 import type { Action, GlobalState as State } from '../types';
-import { logErrorRemotely } from '../utils/logging';
+import * as logging from '../utils/logging';
 
 const processKey = key => {
   const int = parseInt(key, 10);
@@ -28,10 +28,8 @@ export default function createMigration(
     const realVersionSelector = state => state && state[reducerKey] && state[reducerKey].version;
     const realVersionSetter = (state, version) => {
       if (['undefined', 'object'].indexOf(typeof state[reducerKey]) === -1) {
-        logErrorRemotely(
-          new Error(
-            'redux-persist-migrate: state for versionSetter key must be an object or undefined',
-          ),
+        logging.error(
+          'redux-persist-migrate: state for versionSetter key must be an object or undefined',
         );
         return state;
       }

--- a/src/utils/logging.js
+++ b/src/utils/logging.js
@@ -18,3 +18,82 @@ export const logWarningToSentry = (msg: string) => {
     });
   }
 };
+
+// Notes on the behavior of `console.error`, `console.warn`, `console.log`:
+//
+// * When debugging JS: all display in the Chrome dev console, and not in
+//   the Android system log.
+//   * `error` and `warn` produce a nice expando-hidden stack trace, in
+//     addition to formatting their arguments.
+//   * `log` just formats the arguments.
+//   * An `Error` argument formats with its embedded stack trace.  (As just
+//     text, with no spiffy expando.)
+//
+// * In a debug build, whether debugging JS or not:
+//   * `error` pops up the RN error red-screen.
+//   * `warn` could pop up an RN yellow-box, but we've set
+//     `console.disableYellowBox` so it doesn't.
+//
+// * On Android, on both debug and release builds, except when debugging JS:
+//   * All of `error`, `warn`, `log` go to the system log (for `adb logcat`).
+//   * An `Error` argument formats with (the name + message and) just the
+//     single source location where it was created, no stack trace.
+
+/**
+ * Log an error at "error" severity.
+ *
+ * The error will be logged to Sentry and/or the console as appropriate,
+ * including a stack trace.  The stack trace is taken from `err` if an
+ * `Error` object, and otherwise from the call site.
+ *
+ * In a debug build, this pops up the RN error red-screen.  This is
+ * appropriate when the condition should never happen and definitely
+ * represents a bug.  For conditions that can happen without a bug (e.g. a
+ * failure to reach the server), consider `logging.warn`.
+ *
+ * See also:
+ *  * `logging.warn` for logging at lower severity
+ */
+export const error = (err: string | Error) => {
+  if (config.enableSentry) {
+    // If `err` is a string, this will dispatch to captureMessage and
+    // synthesize a stack trace.
+    Sentry.captureException(err, {
+      level: SentrySeverity.Error,
+      trimHeadFrames: 1, // mark this frame as non-app code
+    });
+  }
+  if (config.enableErrorConsoleLogging) {
+    // See toplevel comment about behavior of `console` methods.
+    console.error(err); // eslint-disable-line
+  }
+};
+
+/**
+ * Log an event at "warning" severity.
+ *
+ * The event will be logged to Sentry and/or the console as appropriate,
+ * including a stack trace.  The stack trace is taken from `event` if an
+ * `Error` object, and otherwise from the call site.
+ *
+ * In the JS debugging console, this produces a yellow-highlighted warning,
+ * but no popup interruption.  This makes it appropriate for conditions
+ * which have an inevitable background rate.  For conditions which
+ * definitely represent a bug in the app, consider `logging.error` instead.
+ *
+ * See also:
+ *  * `logging.error` for logging at higher severity
+ */
+export const warn = (event: string | Error) => {
+  if (config.enableSentry) {
+    // See comment in `error` about behavior of `Sentry.captureException`.
+    Sentry.captureException(event, {
+      level: SentrySeverity.Warning,
+      trimHeadFrames: 1,
+    });
+  }
+  if (config.enableErrorConsoleLogging) {
+    // See toplevel comment about behavior of `console` methods.
+    console.warn(event); // eslint-disable-line
+  }
+};

--- a/src/utils/logging.js
+++ b/src/utils/logging.js
@@ -11,14 +11,6 @@ export const logErrorRemotely = (e: Error, msg: ?string) => {
   }
 };
 
-export const logWarningToSentry = (msg: string) => {
-  if (config.enableSentry) {
-    Sentry.captureMessage(msg, {
-      level: SentrySeverity.Warning,
-    });
-  }
-};
-
 // Notes on the behavior of `console.error`, `console.warn`, `console.log`:
 //
 // * When debugging JS: all display in the Chrome dev console, and not in

--- a/src/utils/logging.js
+++ b/src/utils/logging.js
@@ -2,15 +2,6 @@
 import { Sentry, SentrySeverity } from 'react-native-sentry';
 import config from '../config';
 
-export const logErrorRemotely = (e: Error, msg: ?string) => {
-  if (config.enableSentry) {
-    Sentry.captureException(e);
-  }
-  if (config.enableErrorConsoleLogging) {
-    console.log(msg || '', e); // eslint-disable-line
-  }
-};
-
 // Notes on the behavior of `console.error`, `console.warn`, `console.log`:
 //
 // * When debugging JS: all display in the Chrome dev console, and not in

--- a/src/utils/sound.js
+++ b/src/utils/sound.js
@@ -1,6 +1,6 @@
 /* @flow strict-local */
 import Sound from 'react-native-sound';
-import { logErrorRemotely } from './logging';
+import * as logging from './logging';
 
 if (Sound && Sound.setCategory) {
   Sound.setCategory('Ambient', true);
@@ -8,7 +8,7 @@ if (Sound && Sound.setCategory) {
 
 const messageSound = new Sound('zulip.mp3', Sound.MAIN_BUNDLE, (error: Error) => {
   if (error) {
-    logErrorRemotely(error, 'Failed to load the sound');
+    logging.error(error);
   }
 });
 

--- a/src/webview/webViewEventHandlers.js
+++ b/src/webview/webViewEventHandlers.js
@@ -7,7 +7,7 @@ import type { BackgroundData } from './MessageList';
 import type { ShowActionSheetWithOptions } from '../message/messageActionSheet';
 import { showToast } from '../utils/info';
 import { isUrlAnImage } from '../utils/url';
-import { logErrorRemotely } from '../utils/logging';
+import * as logging from '../utils/logging';
 import { filterUnreadMessagesInRange } from '../utils/unread';
 import { parseNarrowString } from '../utils/narrow';
 import {
@@ -231,12 +231,12 @@ export const handleMessageListEvent = (props: Props, _: GetText, event: MessageL
       break;
 
     case 'error':
-      logErrorRemotely(new Error(JSON.stringify(event.details)), 'WebView Exception');
+      logging.error(`WebView exception: ${JSON.stringify(event.details)}`);
       break;
 
     default:
       ensureUnreachable(event);
-      logErrorRemotely(new Error(event.type), 'WebView event of unknown type');
+      logging.error(`WebView event of unknown type: ${event.type}`);
       break;
   }
 };


### PR DESCRIPTION
See commit messages for details.

I was moved to go and do this by some other work where I found I wanted to log warnings to Sentry, and was dissatisfied with the existing API.
