### PR TITLE
Icons: Extend type-checking to the icon names, and small other cleanups.

### DIFF
--- a/src/common/FloatingActionButton.js
+++ b/src/common/FloatingActionButton.js
@@ -3,7 +3,7 @@ import React, { PureComponent } from 'react';
 import { StyleSheet, View } from 'react-native';
 import type { ViewStyleProp } from 'react-native/Libraries/StyleSheet/StyleSheet';
 
-import type { IconType } from './Icons';
+import type { SpecificIconType } from './Icons';
 import { BRAND_COLOR } from '../styles';
 import Touchable from './Touchable';
 
@@ -20,7 +20,7 @@ type Props = $ReadOnly<{|
   style?: ViewStyleProp,
   disabled: boolean,
   size: number,
-  Icon: IconType,
+  Icon: SpecificIconType,
   onPress: () => void,
 |}>;
 

--- a/src/common/Icons.js
+++ b/src/common/Icons.js
@@ -41,12 +41,12 @@ export type IconNames = FeatherGlyphs;
 export const Icon = fixIconType<IconNames>(Feather);
 
 /** A (type for a) component-type like `Icon` but with `name` already specified. */
-export type IconType = ComponentType<$Diff<IconProps<empty>, {| name: mixed |}>>;
+export type SpecificIconType = ComponentType<$Diff<IconProps<empty>, {| name: mixed |}>>;
 
 const makeIcon = <Glyphs: string>(
   iconSet: ComponentType<IconPropsBusted<Glyphs>>,
   name: Glyphs,
-): IconType => props => {
+): SpecificIconType => props => {
   const FixedIcon = fixIconType<Glyphs>(iconSet);
   return <FixedIcon name={name} {...props} />;
 };

--- a/src/common/Icons.js
+++ b/src/common/Icons.js
@@ -2,7 +2,7 @@
 import React from 'react';
 import type { ComponentType } from 'react';
 import type { Text } from 'react-native';
-import type { Color } from 'react-native-vector-icons';
+import type { Color, IconProps as IconPropsBusted } from 'react-native-vector-icons';
 import Feather from 'react-native-vector-icons/Feather';
 import type { FeatherGlyphs } from 'react-native-vector-icons/Feather';
 import IoniconsIcon from 'react-native-vector-icons/Ionicons';
@@ -30,47 +30,59 @@ type IconProps<Glyphs: string> = {|
   color?: Color,
 |};
 
+const fixIconType = <Glyphs: string>(
+  iconSet: ComponentType<IconPropsBusted<Glyphs>>,
+): ComponentType<IconProps<Glyphs>> => (iconSet: $FlowFixMe); // See comment above about wrong types.
+
+/** Names acceptable for `Icon`. */
 export type IconNames = FeatherGlyphs;
 
-/** The type of an Icon whose `name` has already been specified. */
-export type IconType = ComponentType<$Diff<IconProps<IconNames>, {| name: mixed |}>>;
+/** A component-type for the icon set we mainly use. */
+export const Icon = fixIconType<IconNames>(Feather);
 
-/* $FlowFixMe: See comments above. */
-export const Icon: ComponentType<IconProps<IconNames>> = Feather;
+/** A (type for a) component-type like `Icon` but with `name` already specified. */
+export type IconType = ComponentType<$Diff<IconProps<empty>, {| name: mixed |}>>;
 
-export const IconInbox: IconType = props => <Feather name="inbox" {...props} />;
-export const IconStar: IconType = props => <Feather name="star" {...props} />;
-export const IconMention: IconType = props => <Feather name="at-sign" {...props} />;
-export const IconSearch: IconType = props => <Feather name="search" {...props} />;
-export const IconDone: IconType = props => <Feather name="check" {...props} />;
-export const IconCancel: IconType = props => <Feather name="slash" {...props} />;
-export const IconTrash: IconType = props => <Feather name="trash-2" {...props} />;
-export const IconWarning: IconType = props => <Feather name="alert-triangle" {...props} />;
-export const IconSend: IconType = props => <MaterialIcon name="send" {...props} />;
-export const IconMute: IconType = props => <MaterialIcon name="volume-off" {...props} />;
-export const IconStream: IconType = props => <Feather name="hash" {...props} />;
-export const IconPin: IconType = props => <SimpleLineIcons name="pin" {...props} />;
-export const IconPrivate: IconType = props => <Feather name="lock" {...props} />;
-export const IconPrivateChat: IconType = props => <Feather name="mail" {...props} />;
-export const IconDownArrow: IconType = props => <Feather name="chevron-down" {...props} />;
-export const IconGoogle: IconType = props => <IoniconsIcon name="logo-google" {...props} />;
-export const IconGitHub: IconType = props => <Feather name="github" {...props} />;
-export const IconWindows: IconType = props => <IoniconsIcon name="logo-windows" {...props} />;
-export const IconCross: IconType = props => <Feather name="x" {...props} />;
-export const IconDiagnostics: IconType = props => <Feather name="activity" {...props} />;
-export const IconNotifications: IconType = props => <Feather name="bell" {...props} />;
-export const IconLanguage: IconType = props => <Feather name="globe" {...props} />;
-export const IconNight: IconType = props => <Feather name="moon" {...props} />;
-export const IconSettings: IconType = props => <Feather name="settings" {...props} />;
-export const IconRight: IconType = props => <Feather name="chevron-right" {...props} />;
-export const IconPlusCircle: IconType = props => <Feather name="plus-circle" {...props} />;
-export const IconLeft: IconType = props => <Feather name="chevron-left" {...props} />;
-export const IconPeople: IconType = props => <Feather name="users" {...props} />;
-export const IconImage: IconType = props => <Feather name="image" {...props} />;
-export const IconCamera: IconType = props => <Feather name="camera" {...props} />;
-export const IconFile: IconType = props => <Feather name="file" {...props} />;
-export const IconTerminal: IconType = props => <Feather name="terminal" {...props} />;
-export const IconMoreHorizontal: IconType = props => <Feather name="more-horizontal" {...props} />;
-export const IconEdit: IconType = props => <Feather name="edit" {...props} />;
-export const IconPlusSquare: IconType = props => <Feather name="plus-square" {...props} />;
-export const IconPlus: IconType = props => <Feather name="plus" {...props} />;
+const makeIcon = <Glyphs: string>(
+  iconSet: ComponentType<IconPropsBusted<Glyphs>>,
+  name: Glyphs,
+): IconType => props => {
+  const FixedIcon = fixIconType<Glyphs>(iconSet);
+  return <FixedIcon name={name} {...props} />;
+};
+
+export const IconInbox = makeIcon(Feather, 'inbox');
+export const IconStar = makeIcon(Feather, 'star');
+export const IconMention = makeIcon(Feather, 'at-sign');
+export const IconSearch = makeIcon(Feather, 'search');
+export const IconDone = makeIcon(Feather, 'check');
+export const IconCancel = makeIcon(Feather, 'slash');
+export const IconTrash = makeIcon(Feather, 'trash-2');
+export const IconWarning = makeIcon(Feather, 'alert-triangle');
+export const IconSend = makeIcon(MaterialIcon, 'send');
+export const IconMute = makeIcon(MaterialIcon, 'volume-off');
+export const IconStream = makeIcon(Feather, 'hash');
+export const IconPin = makeIcon(SimpleLineIcons, 'pin');
+export const IconPrivate = makeIcon(Feather, 'lock');
+export const IconPrivateChat = makeIcon(Feather, 'mail');
+export const IconDownArrow = makeIcon(Feather, 'chevron-down');
+export const IconGoogle = makeIcon(IoniconsIcon, 'logo-google');
+export const IconGitHub = makeIcon(Feather, 'github');
+export const IconWindows = makeIcon(IoniconsIcon, 'logo-windows');
+export const IconCross = makeIcon(Feather, 'x');
+export const IconDiagnostics = makeIcon(Feather, 'activity');
+export const IconNotifications = makeIcon(Feather, 'bell');
+export const IconLanguage = makeIcon(Feather, 'globe');
+export const IconNight = makeIcon(Feather, 'moon');
+export const IconSettings = makeIcon(Feather, 'settings');
+export const IconRight = makeIcon(Feather, 'chevron-right');
+export const IconPlusCircle = makeIcon(Feather, 'plus-circle');
+export const IconLeft = makeIcon(Feather, 'chevron-left');
+export const IconPeople = makeIcon(Feather, 'users');
+export const IconImage = makeIcon(Feather, 'image');
+export const IconCamera = makeIcon(Feather, 'camera');
+export const IconFile = makeIcon(Feather, 'file');
+export const IconTerminal = makeIcon(Feather, 'terminal');
+export const IconMoreHorizontal = makeIcon(Feather, 'more-horizontal');
+export const IconEdit = makeIcon(Feather, 'edit');
+export const IconPlusSquare = makeIcon(Feather, 'plus-square');

--- a/src/common/Icons.js
+++ b/src/common/Icons.js
@@ -9,15 +9,19 @@ import IoniconsIcon from 'react-native-vector-icons/Ionicons';
 import MaterialIcon from 'react-native-vector-icons/MaterialIcons';
 import SimpleLineIcons from 'react-native-vector-icons/SimpleLineIcons';
 
-/*
- * This is a reimplementation of react-native-vector-icons (RVNI)'s own
- * IconProps<...> type, corresponding to the documented interface:
+/**
+ * The props actually accepted by icon components in r-n-vector-icons.
  *
- * https://github.com/oblador/react-native-vector-icons/blob/v6.6.0/README.md#properties
+ * This corresponds to the documented interface:
+ *   https://github.com/oblador/react-native-vector-icons/blob/v6.6.0/README.md#properties
  *
- * Unfortunately the upstream implementation of this type explicitly includes
- * `allowFontScaling?: boolean` -- a misrespecification of the React Native
- * property (which RN itself specifies to be `allowFontScaling?: ?boolean`).
+ * Upstream has a .js.flow file which is meant to describe this.  But the
+ * type definition there is wrong in a couple of ways:
+ *  * it leaves most of the properties of `Text` unspecified, and just
+ *    defines an inexact object type so that it's much looser than reality;
+ *  * of the handful of properties it does mention, it defines one more
+ *    narrowly than the actual `Text`, as `allowFontScaling?: boolean` when
+ *    it should be `allowFontScaling?: ?boolean`.
  */
 type IconProps<Glyphs: string> = {|
   ...$Exact<$PropertyType<Text, 'props'>>,

--- a/src/common/Icons.js
+++ b/src/common/Icons.js
@@ -52,24 +52,20 @@ const makeIcon = <Glyphs: string>(
 };
 
 export const IconInbox = makeIcon(Feather, 'inbox');
-export const IconStar = makeIcon(Feather, 'star');
 export const IconMention = makeIcon(Feather, 'at-sign');
 export const IconSearch = makeIcon(Feather, 'search');
 export const IconDone = makeIcon(Feather, 'check');
 export const IconCancel = makeIcon(Feather, 'slash');
 export const IconTrash = makeIcon(Feather, 'trash-2');
-export const IconWarning = makeIcon(Feather, 'alert-triangle');
 export const IconSend = makeIcon(MaterialIcon, 'send');
 export const IconMute = makeIcon(MaterialIcon, 'volume-off');
 export const IconStream = makeIcon(Feather, 'hash');
 export const IconPin = makeIcon(SimpleLineIcons, 'pin');
 export const IconPrivate = makeIcon(Feather, 'lock');
 export const IconPrivateChat = makeIcon(Feather, 'mail');
-export const IconDownArrow = makeIcon(Feather, 'chevron-down');
 export const IconGoogle = makeIcon(IoniconsIcon, 'logo-google');
 export const IconGitHub = makeIcon(Feather, 'github');
 export const IconWindows = makeIcon(IoniconsIcon, 'logo-windows');
-export const IconCross = makeIcon(Feather, 'x');
 export const IconDiagnostics = makeIcon(Feather, 'activity');
 export const IconNotifications = makeIcon(Feather, 'bell');
 export const IconLanguage = makeIcon(Feather, 'globe');

--- a/src/common/OptionButton.js
+++ b/src/common/OptionButton.js
@@ -5,12 +5,12 @@ import { View } from 'react-native';
 import Label from './Label';
 import Touchable from './Touchable';
 import { IconRight } from './Icons';
-import type { IconType } from './Icons';
+import type { SpecificIconType } from './Icons';
 import type { ThemeColors } from '../styles';
 import styles, { ThemeContext } from '../styles';
 
 type Props = $ReadOnly<{|
-  Icon?: IconType,
+  Icon?: SpecificIconType,
   label: string,
   onPress: () => void,
 |}>;

--- a/src/common/OptionRow.js
+++ b/src/common/OptionRow.js
@@ -3,14 +3,14 @@ import React, { PureComponent } from 'react';
 import { View } from 'react-native';
 import type { ViewStyleProp } from 'react-native/Libraries/StyleSheet/StyleSheet';
 
-import type { IconType } from './Icons';
+import type { SpecificIconType } from './Icons';
 import Label from './Label';
 import ZulipSwitch from './ZulipSwitch';
 import type { ThemeColors } from '../styles';
 import styles, { ThemeContext } from '../styles';
 
 type Props = $ReadOnly<{|
-  Icon?: IconType,
+  Icon?: SpecificIconType,
   label: string,
   value: boolean,
   style?: ViewStyleProp,

--- a/src/common/ZulipButton.js
+++ b/src/common/ZulipButton.js
@@ -4,7 +4,7 @@ import { StyleSheet, Text, View, ActivityIndicator } from 'react-native';
 import type { ViewStyleProp } from 'react-native/Libraries/StyleSheet/StyleSheet';
 import TranslatedText from './TranslatedText';
 
-import type { IconType } from './Icons';
+import type { SpecificIconType } from './Icons';
 import { BRAND_COLOR } from '../styles';
 import Touchable from './Touchable';
 
@@ -63,7 +63,7 @@ type Props = $ReadOnly<{|
   style?: ViewStyleProp,
   progress: boolean,
   disabled: boolean,
-  Icon?: IconType,
+  Icon?: SpecificIconType,
   text: string,
   secondary: boolean,
   onPress: () => void | Promise<void>,

--- a/src/start/AuthScreen.js
+++ b/src/start/AuthScreen.js
@@ -12,7 +12,7 @@ import type {
   ApiResponseServerSettings,
 } from '../types';
 import { IconPrivate, IconGoogle, IconGitHub, IconWindows, IconTerminal } from '../common/Icons';
-import type { IconType } from '../common/Icons';
+import type { SpecificIconType } from '../common/Icons';
 import { connect } from '../react-redux';
 import styles from '../styles';
 import { Centerer, Screen, ZulipButton } from '../common';
@@ -36,7 +36,7 @@ type AuthenticationMethodDetails = {|
   /** A name to show in the UI. */
   displayName: string,
 
-  Icon: IconType,
+  Icon: SpecificIconType,
   action: 'dev' | 'password' | {| url: string |},
 |};
 


### PR DESCRIPTION
Before this change, if we write a `name` prop that mistypes an icon's
name, or refers to an icon that for any reason doesn't exist, Flow
won't give an error.  Now it will.

Was looking at this a couple of weeks ago in reviewing #3617 and experimenting with the code. Most of these changes are a set of followups I'd drafted then, and just cleaned up now.
