### PR TITLE
Enable modularization and testing of Javascript injected into webview

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -25,5 +25,5 @@ module.exports = {
     __TEST__: true,
   },
   setupFiles: ['./jest/globalFetch.js'],
-  setupFilesAfterEnv: ['./jest/jestSetup.js'],
+  setupFilesAfterEnv: ['./jest/jestSetup.js', 'jest-extended'],
 };

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.4.5",
+    "@babel/preset-env": "^7.6.3",
     "babel-eslint": "^10.0.2",
     "babel-plugin-transform-remove-console": "^6.9.4",
     "deep-freeze": "^0.0.1",
@@ -111,6 +112,9 @@
     "prettier-eslint-cli": "^5.0.0",
     "prop-types": "^15.7.2",
     "react-native-cli": "^2.0.1",
-    "redux-mock-store": "^1.5.1"
+    "redux-mock-store": "^1.5.1",
+    "rollup": "^1.23.1",
+    "rollup-plugin-babel": "^4.3.3",
+    "rollup-plugin-node-resolve": "^5.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -105,6 +105,8 @@
     "flow-typed": "^2.4.0",
     "jest": "^24.9.0",
     "jest-cli": "^24.9.0",
+    "jest-environment-jsdom": "^24.9.0",
+    "jest-environment-jsdom-global": "^1.2.0",
     "jest-extended": "^0.11.2",
     "metro-react-native-babel-preset": "^0.54.1",
     "prettier": "^1.18.2",

--- a/src/__tests__/metatests.js
+++ b/src/__tests__/metatests.js
@@ -1,0 +1,75 @@
+/** @jest-environment jest-environment-jsdom-global */
+// @flow strict
+
+/**
+ * This file should not test any part of the application. It exists to test that
+ * certain functionality is present in the development environment used to run
+ * other tests.
+ */
+
+describe('jsdom-global', () => {
+  /* All cryptic strings are courtesy of random.org's string generator. */
+  test('is reconfigurable', () => {
+    const hostname = 'rgi3npqqem36kcabzjct';
+    const paths = [
+      'AYfhTK8ABTJPrN7pbc8M',
+      '8RbKFoRC82El6uop05Xo',
+      'npiWKcEuuPw90yVQxISh',
+      '0qrkWHiLXTr3TqgTR3RM',
+    ];
+
+    global.jsdom.reconfigure({
+      url: `https://www.${hostname}.com/${paths.join('/')}/index.html`,
+    });
+
+    expect(document.location.host).toContain(hostname);
+    paths.forEach(element => {
+      expect(document.location.pathname).toContain(element);
+    });
+  });
+
+  describe('properly resolves a URL', () => {
+    // Segments of the source URL.
+    const protocol = 'https';
+    const hostname = 'jmur7s0lluxumpbgg7kq';
+    const path = 'nDYYQXuN2yaOe6JQiN0q';
+    const file = 'gp36FBqcuUxGHgQn9aDX';
+
+    // The source URL itself, which later URL references will be resolved
+    // relative to.
+    const sourceURL = `${protocol}://www.${hostname}.com/${path}/${file}`;
+
+    // Auxiliary function: given a URL, how many of the above segments does it
+    // share with the sourceURL?
+    const matchCount: (s: string) => number = (() => {
+      const vals = [protocol, hostname, path, file];
+      return (s: string) => vals.reduce((c, val) => c + s.includes(val), 0);
+    })();
+
+    // Test data, as a series of tuples:
+    //  [human-readable-reference-type, url-reference, expected-match-count]
+    const data: [string, string, number][] = [
+      ['document-internal', '#anchors-aweigh', 4],
+      ['immediate', '.', 3],
+      ['path-relative', 'index2.html', 3],
+      ['explicitly-path-relative', './wat.jpg', 3],
+      ['root-relative', '/an/arbitrary/path.mp3', 2],
+      ['protocol-relative', '//github.com/zulip/zulip-mobile/', 1],
+      ['absolute', 'file:///bin/sh', 0],
+    ];
+
+    // eslint-disable-next-line no-restricted-syntax
+    for (const [urlType, url, expectedCount] of data) {
+      test(`from a(n) ${urlType} URL`, () => {
+        global.jsdom.reconfigure({ url: sourceURL });
+
+        // implicitly resolve URL via an anchor-element's `href`
+        const link: HTMLAnchorElement = document.createElement('a');
+        link.href = url;
+        const result: string = link.href;
+
+        expect(matchCount(result)).toBe(expectedCount);
+      });
+    }
+  });
+});

--- a/src/events/__tests__/eventActions--test.js
+++ b/src/events/__tests__/eventActions--test.js
@@ -7,14 +7,14 @@ describe('responseToActions', () => {
     const events = [];
     const actions = responseToActions({}, events);
 
-    expect(actions).toEqual([]);
+    expect(actions).toBeEmpty();
   });
 
   test('filter out unknown event types and some known ones', () => {
     const events = [{ type: 'some unknown type' }, { type: 'heartbeat' }];
     const actions = responseToActions({}, events);
 
-    expect(actions).toEqual([]);
+    expect(actions).toBeEmpty();
   });
 
   test('when known events process and return actions', () => {

--- a/src/webview/js/__tests__/appendAuthToImages.js
+++ b/src/webview/js/__tests__/appendAuthToImages.js
@@ -1,0 +1,118 @@
+/** @jest-environment jsdom-global */
+// @flow strict-local
+
+import appendAuthToImages from '../appendAuthToImages';
+import type { Auth } from '../../../types';
+
+describe('appendAuthToImages', () => {
+  // URL will be on-realm
+  const realm = 'https://realm.example.com';
+  global.jsdom.reconfigure({ url: `${realm}/` });
+
+  const auth: Auth = {
+    realm,
+    apiKey: 'hMV41eMjVmr6dajvnyOA', // arbitrary random string
+    email: 'rosencrantz+guildenstern@zulipchat.com',
+  };
+
+  const rewrite = (src: string): { input: string, before: string, after: string } => {
+    const img = document.createElement('img');
+    img.setAttribute('src', src);
+    const before = img.src;
+    appendAuthToImages(auth, img);
+    const after = img.src;
+    return { input: src, before, after };
+  };
+
+  // URL prefixes. May have a final slash.
+  const prefixes = {
+    relative: '',
+    'root-relative': '/',
+    absolute: realm,
+    'absolute off-realm': 'https://example.org',
+  };
+
+  // URL suffixes. May have an initial slash.
+  const suffixes = {
+    empty: '',
+    'known endpoint': 'avatar/example',
+    'known endpoint plus': 'avatar/example?size=large',
+    'other endpoint': 'placekitten?w=640&w=480',
+  };
+
+  Object.keys(prefixes).forEach(pType => {
+    const prefix: string = prefixes[pType];
+    describe(`${pType} URL`, () => {
+      Object.keys(suffixes).forEach(sType => {
+        const suffix: string = suffixes[sType];
+        if (!prefix && !suffix) {
+          return;
+        }
+        describe(`+ ${sType} path`, () => {
+          const divider =
+            prefix && !prefix.endsWith('/') && suffix && !suffix.startsWith('/') ? '/' : '';
+          const url = `${prefix}${divider}${suffix}`;
+          const { before, after } = rewrite(url);
+
+          if (pType.includes('absolute')) {
+            test('... is not relativized', () => {
+              expect(before).toStartWith(url);
+              expect(after).toStartWith(url);
+            });
+          } else {
+            test('... gains a prefix when relativized', () => {
+              expect(before).not.toStartWith(url);
+              expect(after).not.toStartWith(url);
+            });
+          }
+
+          if (pType.includes('off-realm')) {
+            test('... yields an off-realm URL', () => {
+              expect(new URL(before).hostname).not.toBe('realm.example.com');
+            });
+          } else {
+            test('... yields an on-realm URL', () => {
+              expect(new URL(before).hostname).toBe('realm.example.com');
+            });
+          }
+
+          if (sType.includes('known endpoint') && !pType.includes('off-realm')) {
+            test('... has `api_key` added', () => {
+              expect(after).toContain(auth.apiKey);
+              expect(new URL(after).searchParams.getAll('api_key')).toEqual([auth.apiKey]);
+            });
+          } else {
+            test('... does not have `api_key` added', () => {
+              expect(after).not.toContain(auth.apiKey);
+              expect(new URL(after).searchParams.getAll('api_key')).toEqual([]);
+            });
+          }
+        });
+      });
+    });
+  });
+
+  /* Specific concrete examples.
+
+    Formally redundant with the preceding tests, but useful for calibrating
+    those against human expectations.
+  */
+
+  test('on-realm known endpoint is modified', () => {
+    const { input, before, after } = rewrite('https://realm.example.com/thumbnail?nyancat.gif');
+    expect(before).toBe(input);
+    expect(after).not.toBe(input);
+  });
+
+  test('on-realm unknown endpoint is left alone', () => {
+    const { input, before, after } = rewrite('https://realm.example.com/placekitten?h=300&w=200');
+    expect(before).toBe(input);
+    expect(after).toBe(input);
+  });
+
+  test('absolute non-realm url is left alone', () => {
+    const { input, before, after } = rewrite('https://cataas.com/cat/computer');
+    expect(before).toBe(input);
+    expect(after).toBe(input);
+  });
+});

--- a/src/webview/js/appendAuthToImages.js
+++ b/src/webview/js/appendAuthToImages.js
@@ -3,13 +3,20 @@
 import type { Auth } from '../../types';
 
 /**
- * appendAuthToImages
+ * Rewrite the source URLs of relevant <img> tags beneath the specified parent
+ * element to include the `api_key`.
  *
- * Rewrite certain relative <img> URLs to include the needed `api_key`.
+ * DEPRECATED: If no parent element is specified, we transform every <img> in
+ * the entire document.
  */
-export default (auth: Auth) => {
-  const imageTags = document.getElementsByTagName('img');
-  Array.from(imageTags).forEach(img => {
+export default (auth: Auth, element: Element | Document = document) => {
+  // Extract all image tags including and/or beneath `element`.
+  const imageTags: $ReadOnlyArray<HTMLImageElement> = [].concat(
+    element instanceof HTMLImageElement ? [element] : [],
+    Array.from(element.getElementsByTagName('img')),
+  );
+
+  imageTags.forEach(img => {
     if (!img.src.startsWith(auth.realm)) {
       return;
     }

--- a/src/webview/js/appendAuthToImages.js
+++ b/src/webview/js/appendAuthToImages.js
@@ -1,0 +1,34 @@
+/* @flow strict-local */
+
+import type { Auth } from '../../types';
+
+/**
+ * appendAuthToImages
+ *
+ * Rewrite certain relative <img> URLs to include the needed `api_key`.
+ */
+export default (auth: Auth) => {
+  const imageTags = document.getElementsByTagName('img');
+  Array.from(imageTags).forEach(img => {
+    if (!img.src.startsWith(auth.realm)) {
+      return;
+    }
+
+    // This unusual form of authentication is only accepted by the server
+    // for a small number of routes.  Rather than append the API key to all
+    // kinds of URLs on the server, do so only for those routes.
+    const srcPath = img.src.substring(auth.realm.length);
+    if (
+      !(
+        srcPath.startsWith('/user_uploads/')
+        || srcPath.startsWith('/thumbnail?')
+        || srcPath.startsWith('/avatar/')
+      )
+    ) {
+      return;
+    }
+
+    const delimiter = img.src.includes('?') ? '&' : '?';
+    img.src += `${delimiter}api_key=${auth.apiKey}`;
+  });
+};

--- a/src/webview/js/generatedEs3.js
+++ b/src/webview/js/generatedEs3.js
@@ -14,6 +14,24 @@ export default `
 var compiledWebviewJs = (function (exports) {
   'use strict';
 
+  var appendAuthToImages = (function (auth) {
+    var imageTags = document.getElementsByTagName('img');
+    Array.from(imageTags).forEach(function (img) {
+      if (!img.src.startsWith(auth.realm)) {
+        return;
+      }
+
+      var srcPath = img.src.substring(auth.realm.length);
+
+      if (!(srcPath.startsWith('/user_uploads/') || srcPath.startsWith('/thumbnail?') || srcPath.startsWith('/avatar/'))) {
+        return;
+      }
+
+      var delimiter = img.src.includes('?') ? '&' : '?';
+      img.src += "".concat(delimiter, "api_key=").concat(auth.apiKey);
+    });
+  });
+
   var platformOS = window.navigator.userAgent.match(/iPhone|iPad|iPod/) ? 'ios' : 'android';
 
   if (!Array.from) {
@@ -347,24 +365,6 @@ var compiledWebviewJs = (function (exports) {
 
     var newBoundRect = newElement.getBoundingClientRect();
     window.scrollBy(0, newBoundRect.top - prevBoundTop);
-  };
-
-  var appendAuthToImages = function appendAuthToImages(auth) {
-    var imageTags = document.getElementsByTagName('img');
-    Array.from(imageTags).forEach(function (img) {
-      if (!img.src.startsWith(auth.realm)) {
-        return;
-      }
-
-      var srcPath = img.src.substring(auth.realm.length);
-
-      if (!(srcPath.startsWith('/user_uploads/') || srcPath.startsWith('/thumbnail?') || srcPath.startsWith('/avatar/'))) {
-        return;
-      }
-
-      var delimiter = img.src.includes('?') ? '&' : '?';
-      img.src += "".concat(delimiter, "api_key=").concat(auth.apiKey);
-    });
   };
 
   var handleUpdateEventContent = function handleUpdateEventContent(uevent) {

--- a/src/webview/js/generatedEs3.js
+++ b/src/webview/js/generatedEs3.js
@@ -15,8 +15,9 @@ var compiledWebviewJs = (function (exports) {
   'use strict';
 
   var appendAuthToImages = (function (auth) {
-    var imageTags = document.getElementsByTagName('img');
-    Array.from(imageTags).forEach(function (img) {
+    var element = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : document;
+    var imageTags = [].concat(element instanceof HTMLImageElement ? [element] : [], Array.from(element.getElementsByTagName('img')));
+    imageTags.forEach(function (img) {
       if (!img.src.startsWith(auth.realm)) {
         return;
       }

--- a/src/webview/js/generatedEs3.js
+++ b/src/webview/js/generatedEs3.js
@@ -71,7 +71,7 @@ var compiledWebviewJs = (function (exports) {
       var elementJsError = document.getElementById('js-error-detailed');
 
       if (elementJsError) {
-        elementJsError.innerHTML = ["Message: " + message, "Source: " + source, "Line: " + line + ":" + column, "Error: " + JSON.stringify(error), ''].map(escapeHtml).join('<br>');
+        elementJsError.innerHTML = ["Message: ".concat(message), "Source: ".concat(source), "Line: ".concat(line, ":").concat(column), "Error: ".concat(JSON.stringify(error)), ''].map(escapeHtml).join('<br>');
       }
     } else {
       var _elementJsError = document.getElementById('js-error-plain');
@@ -82,7 +82,7 @@ var compiledWebviewJs = (function (exports) {
       if (_elementJsError && elementSheetGenerated && elementSheetHide && elementSheetHide instanceof HTMLStyleElement && elementSheetHide.sheet && elementSheetGenerated instanceof HTMLStyleElement && elementSheetGenerated.sheet) {
         elementSheetHide.sheet.disabled = true;
         var height = _elementJsError.offsetHeight;
-        elementSheetGenerated.sheet.insertRule(".header-wrapper { top: " + height + "px; }", 0);
+        elementSheetGenerated.sheet.insertRule(".header-wrapper { top: ".concat(height, "px; }"), 0);
       }
     }
 
@@ -228,7 +228,7 @@ var compiledWebviewJs = (function (exports) {
   };
 
   var setMessagesReadAttributes = function setMessagesReadAttributes(rangeHull) {
-    var element = document.querySelector("[data-msg-id='" + rangeHull.first + "']");
+    var element = document.querySelector("[data-msg-id='".concat(rangeHull.first, "']"));
 
     while (element) {
       if (element.classList.contains('message')) {
@@ -308,7 +308,7 @@ var compiledWebviewJs = (function (exports) {
   };
 
   var scrollToAnchor = function scrollToAnchor(anchor) {
-    var anchorNode = document.getElementById("msg-" + anchor);
+    var anchorNode = document.getElementById("msg-".concat(anchor));
 
     if (anchorNode) {
       anchorNode.scrollIntoView({
@@ -341,7 +341,7 @@ var compiledWebviewJs = (function (exports) {
   };
 
   var scrollToPreserve = function scrollToPreserve(msgId, prevBoundTop) {
-    var newElement = document.getElementById("msg-" + msgId);
+    var newElement = document.getElementById("msg-".concat(msgId));
 
     if (!newElement) {
       return;
@@ -365,7 +365,7 @@ var compiledWebviewJs = (function (exports) {
       }
 
       var delimiter = img.src.includes('?') ? '&' : '?';
-      img.src += delimiter + "api_key=" + auth.apiKey;
+      img.src += "".concat(delimiter, "api_key=").concat(auth.apiKey);
     });
   };
 
@@ -439,7 +439,7 @@ var compiledWebviewJs = (function (exports) {
     }
 
     var selector = uevent.messageIds.map(function (id) {
-      return "[data-msg-id=\\"" + id + "\\"]";
+      return "[data-msg-id=\\"".concat(id, "\\"]");
     }).join(',');
     var messageElements = arrayFromNodes(document.querySelectorAll(selector));
     messageElements.forEach(function (element) {
@@ -475,7 +475,7 @@ var compiledWebviewJs = (function (exports) {
     var value = e.getAttribute(name);
 
     if (value === null || value === undefined) {
-      throw new Error("Missing expected attribute " + name);
+      throw new Error("Missing expected attribute ".concat(name));
     }
 
     return value;

--- a/src/webview/js/generatedEs3.js
+++ b/src/webview/js/generatedEs3.js
@@ -16,12 +16,10 @@ var compiledWebviewJs = (function (exports) {
 
   var platformOS = window.navigator.userAgent.match(/iPhone|iPad|iPod/) ? 'ios' : 'android';
 
-  function arrayFrom(arrayLike) {
-    return Array.prototype.slice.call(arrayLike);
-  }
-
-  function arrayFromNodes(arrayLike) {
-    return Array.prototype.slice.call(arrayLike);
+  if (!Array.from) {
+    Array.from = function from(arr) {
+      return Array.prototype.slice.call(arr);
+    };
   }
 
   if (!Element.prototype.closest) {
@@ -353,7 +351,7 @@ var compiledWebviewJs = (function (exports) {
 
   var appendAuthToImages = function appendAuthToImages(auth) {
     var imageTags = document.getElementsByTagName('img');
-    arrayFrom(imageTags).forEach(function (img) {
+    Array.from(imageTags).forEach(function (img) {
       if (!img.src.startsWith(auth.realm)) {
         return;
       }
@@ -441,7 +439,7 @@ var compiledWebviewJs = (function (exports) {
     var selector = uevent.messageIds.map(function (id) {
       return "[data-msg-id=\\"".concat(id, "\\"]");
     }).join(',');
-    var messageElements = arrayFromNodes(document.querySelectorAll(selector));
+    var messageElements = Array.from(document.querySelectorAll(selector));
     messageElements.forEach(function (element) {
       element.setAttribute('data-read', 'true');
     });

--- a/src/webview/js/generatedEs3.js
+++ b/src/webview/js/generatedEs3.js
@@ -11,604 +11,614 @@
 export default `
 'use strict';
 
-var platformOS = window.navigator.userAgent.match(/iPhone|iPad|iPod/) ? 'ios' : 'android';
+var compiledWebviewJs = (function (exports) {
+  'use strict';
 
-function arrayFrom(arrayLike) {
-  return Array.prototype.slice.call(arrayLike);
-}
+  var platformOS = window.navigator.userAgent.match(/iPhone|iPad|iPod/) ? 'ios' : 'android';
 
-function arrayFromNodes(arrayLike) {
-  return Array.prototype.slice.call(arrayLike);
-}
+  function arrayFrom(arrayLike) {
+    return Array.prototype.slice.call(arrayLike);
+  }
 
-if (!Element.prototype.closest) {
-  Element.prototype.closest = function closest(selector) {
-    var element = this;
+  function arrayFromNodes(arrayLike) {
+    return Array.prototype.slice.call(arrayLike);
+  }
 
-    while (element && !element.matches(selector)) {
-      element = element.parentElement;
+  if (!Element.prototype.closest) {
+    Element.prototype.closest = function closest(selector) {
+      var element = this;
+
+      while (element && !element.matches(selector)) {
+        element = element.parentElement;
+      }
+
+      return element;
+    };
+  }
+
+  if (!String.prototype.startsWith) {
+    String.prototype.startsWith = function startsWith(search, rawPos) {
+      var pos = rawPos > 0 ? rawPos | 0 : 0;
+      return this.substring(pos, pos + search.length) === search;
+    };
+  }
+
+  if (!String.prototype.includes) {
+    String.prototype.includes = function includes(search) {
+      var start = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : 0;
+      return this.indexOf(search, start) !== -1;
+    };
+  }
+
+  var documentBody = document.body;
+
+  if (!documentBody) {
+    throw new Error('No document.body element!');
+  }
+
+  var escapeHtml = function escapeHtml(text) {
+    var element = document.createElement('div');
+    element.innerText = text;
+    return element.innerHTML;
+  };
+
+  var sendMessage = function sendMessage(msg) {
+    window.ReactNativeWebView.postMessage(JSON.stringify(msg));
+  };
+
+  window.onerror = function (message, source, line, column, error) {
+    if (window.enableWebViewErrorDisplay) {
+      var elementJsError = document.getElementById('js-error-detailed');
+
+      if (elementJsError) {
+        elementJsError.innerHTML = ["Message: " + message, "Source: " + source, "Line: " + line + ":" + column, "Error: " + JSON.stringify(error), ''].map(escapeHtml).join('<br>');
+      }
+    } else {
+      var _elementJsError = document.getElementById('js-error-plain');
+
+      var elementSheetGenerated = document.getElementById('generated-styles');
+      var elementSheetHide = document.getElementById('style-hide-js-error-plain');
+
+      if (_elementJsError && elementSheetGenerated && elementSheetHide && elementSheetHide instanceof HTMLStyleElement && elementSheetHide.sheet && elementSheetGenerated instanceof HTMLStyleElement && elementSheetGenerated.sheet) {
+        elementSheetHide.sheet.disabled = true;
+        var height = _elementJsError.offsetHeight;
+        elementSheetGenerated.sheet.insertRule(".header-wrapper { top: " + height + "px; }", 0);
+      }
+    }
+
+    sendMessage({
+      type: 'error',
+      details: {
+        message: message,
+        source: source,
+        line: line,
+        column: column,
+        error: error
+      }
+    });
+    return true;
+  };
+
+  var showHideElement = function showHideElement(elementId, show) {
+    var element = document.getElementById(elementId);
+
+    if (element) {
+      element.classList.toggle('hidden', !show);
+    }
+  };
+
+  var viewportHeight = documentBody.clientHeight;
+  window.addEventListener('resize', function (event) {
+    var difference = viewportHeight - documentBody.clientHeight;
+
+    if (documentBody.scrollHeight !== documentBody.scrollTop + documentBody.clientHeight) {
+      window.scrollBy({
+        left: 0,
+        top: difference
+      });
+    }
+
+    viewportHeight = documentBody.clientHeight;
+  });
+
+  function midMessagePeer(top, bottom) {
+    var midY = (bottom + top) / 2;
+
+    if (document.elementsFromPoint === undefined) {
+      var element = document.elementFromPoint(0, midY);
+      return element && element.closest('body > *');
+    }
+
+    var midElements = document.elementsFromPoint(0, midY);
+
+    if (midElements.length < 3) {
+      return null;
+    }
+
+    return midElements[midElements.length - 3];
+  }
+
+  function walkToMessage(start, step) {
+    var element = start;
+
+    while (element && !element.classList.contains('message')) {
+      element = element[step];
     }
 
     return element;
-  };
-}
+  }
 
-if (!String.prototype.startsWith) {
-  String.prototype.startsWith = function startsWith(search, rawPos) {
-    var pos = rawPos > 0 ? rawPos | 0 : 0;
-    return this.substring(pos, pos + search.length) === search;
-  };
-}
+  function firstMessage() {
+    return walkToMessage(documentBody.firstElementChild, 'nextElementSibling');
+  }
 
-if (!String.prototype.includes) {
-  String.prototype.includes = function includes(search) {
-    var start = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : 0;
-    return this.indexOf(search, start) !== -1;
-  };
-}
+  function lastMessage() {
+    return walkToMessage(documentBody.lastElementChild, 'previousElementSibling');
+  }
 
-var documentBody = document.body;
+  var minOverlap = 20;
 
-if (!documentBody) {
-  throw new Error('No document.body element!');
-}
+  function isVisible(element, top, bottom) {
+    var rect = element.getBoundingClientRect();
+    return top + minOverlap < rect.bottom && rect.top + minOverlap < bottom;
+  }
 
-var escapeHtml = function escapeHtml(text) {
-  var element = document.createElement('div');
-  element.innerText = text;
-  return element.innerHTML;
-};
-
-var sendMessage = function sendMessage(msg) {
-  window.ReactNativeWebView.postMessage(JSON.stringify(msg));
-};
-
-window.onerror = function (message, source, line, column, error) {
-  if (window.enableWebViewErrorDisplay) {
-    var elementJsError = document.getElementById('js-error-detailed');
-
-    if (elementJsError) {
-      elementJsError.innerHTML = ["Message: " + message, "Source: " + source, "Line: " + line + ":" + column, "Error: " + JSON.stringify(error), ''].map(escapeHtml).join('<br>');
+  function someVisibleMessage(top, bottom) {
+    function checkVisible(candidate) {
+      return candidate && isVisible(candidate, top, bottom) ? candidate : null;
     }
-  } else {
-    var _elementJsError = document.getElementById('js-error-plain');
 
-    var elementSheetGenerated = document.getElementById('generated-styles');
-    var elementSheetHide = document.getElementById('style-hide-js-error-plain');
+    var midPeer = midMessagePeer(top, bottom);
+    return checkVisible(walkToMessage(midPeer, 'previousElementSibling')) || checkVisible(walkToMessage(midPeer, 'nextElementSibling')) || checkVisible(firstMessage()) || checkVisible(lastMessage());
+  }
 
-    if (_elementJsError && elementSheetGenerated && elementSheetHide && elementSheetHide instanceof HTMLStyleElement && elementSheetHide.sheet && elementSheetGenerated instanceof HTMLStyleElement && elementSheetGenerated.sheet) {
-      elementSheetHide.sheet.disabled = true;
-      var height = _elementJsError.offsetHeight;
-      elementSheetGenerated.sheet.insertRule(".header-wrapper { top: " + height + "px; }", 0);
+  function idFromMessage(element) {
+    var idStr = element.getAttribute('data-msg-id');
+
+    if (idStr === null || idStr === undefined) {
+      throw new Error('Bad message element');
     }
+
+    return +idStr;
   }
 
-  sendMessage({
-    type: 'error',
-    details: {
-      message: message,
-      source: source,
-      line: line,
-      column: column,
-      error: error
+  function visibleMessageIds() {
+    var top = 0;
+    var bottom = viewportHeight;
+    var first = Number.MAX_SAFE_INTEGER;
+    var last = 0;
+
+    function walkElements(start, step) {
+      var element = start;
+
+      while (element && isVisible(element, top, bottom)) {
+        if (element.classList.contains('message')) {
+          var id = idFromMessage(element);
+          first = Math.min(first, id);
+          last = Math.max(last, id);
+        }
+
+        element = element[step];
+      }
     }
-  });
-  return true;
-};
 
-var showHideElement = function showHideElement(elementId, show) {
-  var element = document.getElementById(elementId);
-
-  if (element) {
-    element.classList.toggle('hidden', !show);
-  }
-};
-
-var viewportHeight = documentBody.clientHeight;
-window.addEventListener('resize', function (event) {
-  var difference = viewportHeight - documentBody.clientHeight;
-
-  if (documentBody.scrollHeight !== documentBody.scrollTop + documentBody.clientHeight) {
-    window.scrollBy({
-      left: 0,
-      top: difference
-    });
+    var start = someVisibleMessage(top, bottom);
+    walkElements(start, 'nextElementSibling');
+    walkElements(start, 'previousElementSibling');
+    return {
+      first: first,
+      last: last
+    };
   }
 
-  viewportHeight = documentBody.clientHeight;
-});
+  var getMessageNode = function getMessageNode(node) {
+    var curNode = node;
 
-function midMessagePeer(top, bottom) {
-  var midY = (bottom + top) / 2;
+    while (curNode && curNode.parentNode && curNode.parentNode !== documentBody) {
+      curNode = curNode.parentNode;
+    }
 
-  if (document.elementsFromPoint === undefined) {
-    var element = document.elementFromPoint(0, midY);
-    return element && element.closest('body > *');
-  }
+    return curNode;
+  };
 
-  var midElements = document.elementsFromPoint(0, midY);
+  var getMessageIdFromNode = function getMessageIdFromNode(node) {
+    var defaultValue = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : -1;
+    var msgNode = getMessageNode(node);
+    return msgNode && msgNode instanceof Element ? +msgNode.getAttribute('data-msg-id') : defaultValue;
+  };
 
-  if (midElements.length < 3) {
-    return null;
-  }
+  var setMessagesReadAttributes = function setMessagesReadAttributes(rangeHull) {
+    var element = document.querySelector("[data-msg-id='" + rangeHull.first + "']");
 
-  return midElements[midElements.length - 3];
-}
-
-function walkToMessage(start, step) {
-  var element = start;
-
-  while (element && !element.classList.contains('message')) {
-    element = element[step];
-  }
-
-  return element;
-}
-
-function firstMessage() {
-  return walkToMessage(documentBody.firstElementChild, 'nextElementSibling');
-}
-
-function lastMessage() {
-  return walkToMessage(documentBody.lastElementChild, 'previousElementSibling');
-}
-
-var minOverlap = 20;
-
-function isVisible(element, top, bottom) {
-  var rect = element.getBoundingClientRect();
-  return top + minOverlap < rect.bottom && rect.top + minOverlap < bottom;
-}
-
-function someVisibleMessage(top, bottom) {
-  function checkVisible(candidate) {
-    return candidate && isVisible(candidate, top, bottom) ? candidate : null;
-  }
-
-  var midPeer = midMessagePeer(top, bottom);
-  return checkVisible(walkToMessage(midPeer, 'previousElementSibling')) || checkVisible(walkToMessage(midPeer, 'nextElementSibling')) || checkVisible(firstMessage()) || checkVisible(lastMessage());
-}
-
-function idFromMessage(element) {
-  var idStr = element.getAttribute('data-msg-id');
-
-  if (idStr === null || idStr === undefined) {
-    throw new Error('Bad message element');
-  }
-
-  return +idStr;
-}
-
-function visibleMessageIds() {
-  var top = 0;
-  var bottom = viewportHeight;
-  var first = Number.MAX_SAFE_INTEGER;
-  var last = 0;
-
-  function walkElements(start, step) {
-    var element = start;
-
-    while (element && isVisible(element, top, bottom)) {
+    while (element) {
       if (element.classList.contains('message')) {
-        var id = idFromMessage(element);
-        first = Math.min(first, id);
-        last = Math.max(last, id);
+        element.setAttribute('data-read', 'true');
+
+        if (idFromMessage(element) >= rangeHull.last) {
+          break;
+        }
       }
 
-      element = element[step];
+      element = element.nextElementSibling;
     }
-  }
-
-  var start = someVisibleMessage(top, bottom);
-  walkElements(start, 'nextElementSibling');
-  walkElements(start, 'previousElementSibling');
-  return {
-    first: first,
-    last: last
   };
-}
 
-var getMessageNode = function getMessageNode(node) {
-  var curNode = node;
+  var prevMessageRange = visibleMessageIds();
 
-  while (curNode && curNode.parentNode && curNode.parentNode !== documentBody) {
-    curNode = curNode.parentNode;
-  }
-
-  return curNode;
-};
-
-var getMessageIdFromNode = function getMessageIdFromNode(node) {
-  var defaultValue = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : -1;
-  var msgNode = getMessageNode(node);
-  return msgNode && msgNode instanceof Element ? +msgNode.getAttribute('data-msg-id') : defaultValue;
-};
-
-var setMessagesReadAttributes = function setMessagesReadAttributes(rangeHull) {
-  var element = document.querySelector("[data-msg-id='" + rangeHull.first + "']");
-
-  while (element) {
-    if (element.classList.contains('message')) {
-      element.setAttribute('data-read', 'true');
-
-      if (idFromMessage(element) >= rangeHull.last) {
-        break;
-      }
-    }
-
-    element = element.nextElementSibling;
-  }
-};
-
-var prevMessageRange = visibleMessageIds();
-
-var sendScrollMessage = function sendScrollMessage() {
-  var messageRange = visibleMessageIds();
-  var rangeHull = {
-    first: Math.min(prevMessageRange.first, messageRange.first),
-    last: Math.max(prevMessageRange.last, messageRange.last)
-  };
-  sendMessage({
-    type: 'scroll',
-    offsetHeight: documentBody.offsetHeight,
-    innerHeight: window.innerHeight,
-    scrollY: window.scrollY,
-    startMessageId: rangeHull.first,
-    endMessageId: rangeHull.last
-  });
-  setMessagesReadAttributes(rangeHull);
-  prevMessageRange = messageRange;
-};
-
-var sendScrollMessageIfListShort = function sendScrollMessageIfListShort() {
-  if (documentBody.scrollHeight === documentBody.clientHeight) {
-    sendScrollMessage();
-  }
-};
-
-var scrollEventsDisabled = true;
-var hasLongPressed = false;
-var longPressTimeout;
-var lastTouchPositionX = -1;
-var lastTouchPositionY = -1;
-
-var handleScrollEvent = function handleScrollEvent() {
-  clearTimeout(longPressTimeout);
-
-  if (scrollEventsDisabled) {
-    return;
-  }
-
-  sendScrollMessage();
-  var nearEnd = documentBody.offsetHeight - window.scrollY - window.innerHeight > 100;
-  showHideElement('scroll-bottom', nearEnd);
-};
-
-window.addEventListener('scroll', handleScrollEvent);
-
-var scrollToBottom = function scrollToBottom() {
-  window.scroll({
-    left: 0,
-    top: documentBody.scrollHeight,
-    behavior: 'smooth'
-  });
-};
-
-var isNearBottom = function isNearBottom() {
-  return documentBody.scrollHeight - 100 < documentBody.scrollTop + documentBody.clientHeight;
-};
-
-var scrollToBottomIfNearEnd = function scrollToBottomIfNearEnd() {
-  if (isNearBottom()) {
-    scrollToBottom();
-  }
-};
-
-var scrollToAnchor = function scrollToAnchor(anchor) {
-  var anchorNode = document.getElementById("msg-" + anchor);
-
-  if (anchorNode) {
-    anchorNode.scrollIntoView({
-      block: 'start'
+  var sendScrollMessage = function sendScrollMessage() {
+    var messageRange = visibleMessageIds();
+    var rangeHull = {
+      first: Math.min(prevMessageRange.first, messageRange.first),
+      last: Math.max(prevMessageRange.last, messageRange.last)
+    };
+    sendMessage({
+      type: 'scroll',
+      offsetHeight: documentBody.offsetHeight,
+      innerHeight: window.innerHeight,
+      scrollY: window.scrollY,
+      startMessageId: rangeHull.first,
+      endMessageId: rangeHull.last
     });
-  } else {
+    setMessagesReadAttributes(rangeHull);
+    prevMessageRange = messageRange;
+  };
+
+  var sendScrollMessageIfListShort = function sendScrollMessageIfListShort() {
+    if (documentBody.scrollHeight === documentBody.clientHeight) {
+      sendScrollMessage();
+    }
+  };
+
+  var scrollEventsDisabled = true;
+  var hasLongPressed = false;
+  var longPressTimeout;
+  var lastTouchPositionX = -1;
+  var lastTouchPositionY = -1;
+
+  var handleScrollEvent = function handleScrollEvent() {
+    clearTimeout(longPressTimeout);
+
+    if (scrollEventsDisabled) {
+      return;
+    }
+
+    sendScrollMessage();
+    var nearEnd = documentBody.offsetHeight - window.scrollY - window.innerHeight > 100;
+    showHideElement('scroll-bottom', nearEnd);
+  };
+
+  window.addEventListener('scroll', handleScrollEvent);
+
+  var scrollToBottom = function scrollToBottom() {
     window.scroll({
       left: 0,
-      top: documentBody.scrollHeight + 200
+      top: documentBody.scrollHeight,
+      behavior: 'smooth'
     });
-  }
-};
-
-var findPreserveTarget = function findPreserveTarget() {
-  var message = someVisibleMessage(0, viewportHeight);
-
-  if (!message) {
-    return {
-      type: 'none'
-    };
-  }
-
-  var messageId = idFromMessage(message);
-  var prevBoundRect = message.getBoundingClientRect();
-  return {
-    type: 'preserve',
-    msgId: messageId,
-    prevBoundTop: prevBoundRect.top
   };
-};
 
-var scrollToPreserve = function scrollToPreserve(msgId, prevBoundTop) {
-  var newElement = document.getElementById("msg-" + msgId);
+  var isNearBottom = function isNearBottom() {
+    return documentBody.scrollHeight - 100 < documentBody.scrollTop + documentBody.clientHeight;
+  };
 
-  if (!newElement) {
-    return;
-  }
-
-  var newBoundRect = newElement.getBoundingClientRect();
-  window.scrollBy(0, newBoundRect.top - prevBoundTop);
-};
-
-var appendAuthToImages = function appendAuthToImages(auth) {
-  var imageTags = document.getElementsByTagName('img');
-  arrayFrom(imageTags).forEach(function (img) {
-    if (!img.src.startsWith(auth.realm)) {
-      return;
+  var scrollToBottomIfNearEnd = function scrollToBottomIfNearEnd() {
+    if (isNearBottom()) {
+      scrollToBottom();
     }
+  };
 
-    var srcPath = img.src.substring(auth.realm.length);
+  var scrollToAnchor = function scrollToAnchor(anchor) {
+    var anchorNode = document.getElementById("msg-" + anchor);
 
-    if (!(srcPath.startsWith('/user_uploads/') || srcPath.startsWith('/thumbnail?') || srcPath.startsWith('/avatar/'))) {
-      return;
-    }
-
-    var delimiter = img.src.includes('?') ? '&' : '?';
-    img.src += delimiter + "api_key=" + auth.apiKey;
-  });
-};
-
-var handleUpdateEventContent = function handleUpdateEventContent(uevent) {
-  var target;
-
-  if (uevent.updateStrategy === 'replace') {
-    target = {
-      type: 'none'
-    };
-  } else if (uevent.updateStrategy === 'scroll-to-anchor') {
-    target = {
-      type: 'anchor',
-      anchor: uevent.anchor
-    };
-  } else if (uevent.updateStrategy === 'scroll-to-bottom-if-near-bottom' && isNearBottom()) {
-      target = {
-        type: 'bottom'
-      };
+    if (anchorNode) {
+      anchorNode.scrollIntoView({
+        block: 'start'
+      });
     } else {
-    target = findPreserveTarget();
-  }
+      window.scroll({
+        left: 0,
+        top: documentBody.scrollHeight + 200
+      });
+    }
+  };
 
-  documentBody.innerHTML = uevent.content;
-  appendAuthToImages(uevent.auth);
+  var findPreserveTarget = function findPreserveTarget() {
+    var message = someVisibleMessage(0, viewportHeight);
 
-  if (target.type === 'bottom') {
-    scrollToBottom();
-  } else if (target.type === 'anchor') {
-    scrollToAnchor(target.anchor);
-  } else if (target.type === 'preserve') {
-    scrollToPreserve(target.msgId, target.prevBoundTop);
-  }
+    if (!message) {
+      return {
+        type: 'none'
+      };
+    }
 
-  sendScrollMessageIfListShort();
-};
+    var messageId = idFromMessage(message);
+    var prevBoundRect = message.getBoundingClientRect();
+    return {
+      type: 'preserve',
+      msgId: messageId,
+      prevBoundTop: prevBoundRect.top
+    };
+  };
 
-var handleInitialLoad = function handleInitialLoad(anchor, auth) {
-  scrollToAnchor(anchor);
-  appendAuthToImages(auth);
-  sendScrollMessageIfListShort();
-  scrollEventsDisabled = false;
-};
+  var scrollToPreserve = function scrollToPreserve(msgId, prevBoundTop) {
+    var newElement = document.getElementById("msg-" + msgId);
 
-var handleUpdateEventFetching = function handleUpdateEventFetching(uevent) {
-  showHideElement('message-loading', uevent.showMessagePlaceholders);
-  showHideElement('spinner-older', uevent.fetchingOlder);
-  showHideElement('spinner-newer', uevent.fetchingNewer);
-};
+    if (!newElement) {
+      return;
+    }
 
-var handleUpdateEventTyping = function handleUpdateEventTyping(uevent) {
-  var elementTyping = document.getElementById('typing');
+    var newBoundRect = newElement.getBoundingClientRect();
+    window.scrollBy(0, newBoundRect.top - prevBoundTop);
+  };
 
-  if (elementTyping) {
-    elementTyping.innerHTML = uevent.content;
-    setTimeout(function () {
-      return scrollToBottomIfNearEnd();
+  var appendAuthToImages = function appendAuthToImages(auth) {
+    var imageTags = document.getElementsByTagName('img');
+    arrayFrom(imageTags).forEach(function (img) {
+      if (!img.src.startsWith(auth.realm)) {
+        return;
+      }
+
+      var srcPath = img.src.substring(auth.realm.length);
+
+      if (!(srcPath.startsWith('/user_uploads/') || srcPath.startsWith('/thumbnail?') || srcPath.startsWith('/avatar/'))) {
+        return;
+      }
+
+      var delimiter = img.src.includes('?') ? '&' : '?';
+      img.src += delimiter + "api_key=" + auth.apiKey;
     });
-  }
-};
+  };
 
-var handleUpdateEventReady = function handleUpdateEventReady(uevent) {
-  sendMessage({
-    type: 'ready'
-  });
-};
+  var handleUpdateEventContent = function handleUpdateEventContent(uevent) {
+    var target;
 
-var handleUpdateEventMessagesRead = function handleUpdateEventMessagesRead(uevent) {
-  if (uevent.messageIds.length === 0) {
-    return;
-  }
+    if (uevent.updateStrategy === 'replace') {
+      target = {
+        type: 'none'
+      };
+    } else if (uevent.updateStrategy === 'scroll-to-anchor') {
+      target = {
+        type: 'anchor',
+        anchor: uevent.anchor
+      };
+    } else if (uevent.updateStrategy === 'scroll-to-bottom-if-near-bottom' && isNearBottom()) {
+        target = {
+          type: 'bottom'
+        };
+      } else {
+      target = findPreserveTarget();
+    }
 
-  var selector = uevent.messageIds.map(function (id) {
-    return "[data-msg-id=\\"" + id + "\\"]";
-  }).join(',');
-  var messageElements = arrayFromNodes(document.querySelectorAll(selector));
-  messageElements.forEach(function (element) {
-    element.setAttribute('data-read', 'true');
-  });
-};
+    documentBody.innerHTML = uevent.content;
+    appendAuthToImages(uevent.auth);
 
-var eventUpdateHandlers = {
-  content: handleUpdateEventContent,
-  fetching: handleUpdateEventFetching,
-  typing: handleUpdateEventTyping,
-  ready: handleUpdateEventReady,
-  read: handleUpdateEventMessagesRead
-};
+    if (target.type === 'bottom') {
+      scrollToBottom();
+    } else if (target.type === 'anchor') {
+      scrollToAnchor(target.anchor);
+    } else if (target.type === 'preserve') {
+      scrollToPreserve(target.msgId, target.prevBoundTop);
+    }
 
-var handleMessageEvent = function handleMessageEvent(e) {
-  scrollEventsDisabled = true;
-  var decodedData = decodeURIComponent(escape(window.atob(e.data)));
-  var updateEvents = JSON.parse(decodedData);
-  updateEvents.forEach(function (uevent) {
-    eventUpdateHandlers[uevent.type](uevent);
-  });
-  scrollEventsDisabled = false;
-};
+    sendScrollMessageIfListShort();
+  };
 
-if (platformOS === 'ios') {
-  window.addEventListener('message', handleMessageEvent);
-} else {
-  document.addEventListener('message', handleMessageEvent);
-}
+  var handleInitialLoad = function handleInitialLoad(anchor, auth) {
+    scrollToAnchor(anchor);
+    appendAuthToImages(auth);
+    sendScrollMessageIfListShort();
+    scrollEventsDisabled = false;
+  };
 
-var requireAttribute = function requireAttribute(e, name) {
-  var value = e.getAttribute(name);
+  var handleUpdateEventFetching = function handleUpdateEventFetching(uevent) {
+    showHideElement('message-loading', uevent.showMessagePlaceholders);
+    showHideElement('spinner-older', uevent.fetchingOlder);
+    showHideElement('spinner-newer', uevent.fetchingNewer);
+  };
 
-  if (value === null || value === undefined) {
-    throw new Error("Missing expected attribute " + name);
-  }
+  var handleUpdateEventTyping = function handleUpdateEventTyping(uevent) {
+    var elementTyping = document.getElementById('typing');
 
-  return value;
-};
+    if (elementTyping) {
+      elementTyping.innerHTML = uevent.content;
+      setTimeout(function () {
+        return scrollToBottomIfNearEnd();
+      });
+    }
+  };
 
-documentBody.addEventListener('click', function (e) {
-  e.preventDefault();
-  clearTimeout(longPressTimeout);
-
-  if (hasLongPressed) {
-    hasLongPressed = false;
-    return;
-  }
-
-  var target = e.target;
-
-  if (!(target instanceof Element)) {
-    return;
-  }
-
-  if (target.matches('.scroll-bottom')) {
-    scrollToBottom();
-    return;
-  }
-
-  if (target.matches('.avatar-img')) {
+  var handleUpdateEventReady = function handleUpdateEventReady(uevent) {
     sendMessage({
-      type: 'avatar',
-      fromEmail: requireAttribute(target, 'data-email')
+      type: 'ready'
     });
-    return;
-  }
+  };
 
-  if (target.matches('.header')) {
-    sendMessage({
-      type: 'narrow',
-      narrow: requireAttribute(target, 'data-narrow')
+  var handleUpdateEventMessagesRead = function handleUpdateEventMessagesRead(uevent) {
+    if (uevent.messageIds.length === 0) {
+      return;
+    }
+
+    var selector = uevent.messageIds.map(function (id) {
+      return "[data-msg-id=\\"" + id + "\\"]";
+    }).join(',');
+    var messageElements = arrayFromNodes(document.querySelectorAll(selector));
+    messageElements.forEach(function (element) {
+      element.setAttribute('data-read', 'true');
     });
-    return;
-  }
+  };
 
-  var inlineImageLink = target.closest('.message_inline_image a');
+  var eventUpdateHandlers = {
+    content: handleUpdateEventContent,
+    fetching: handleUpdateEventFetching,
+    typing: handleUpdateEventTyping,
+    ready: handleUpdateEventReady,
+    read: handleUpdateEventMessagesRead
+  };
 
-  if (inlineImageLink && !inlineImageLink.closest('.youtube-video, .vimeo-video')) {
-    sendMessage({
-      type: 'image',
-      src: requireAttribute(inlineImageLink, 'href'),
-      messageId: getMessageIdFromNode(inlineImageLink)
+  var handleMessageEvent = function handleMessageEvent(e) {
+    scrollEventsDisabled = true;
+    var decodedData = decodeURIComponent(escape(window.atob(e.data)));
+    var updateEvents = JSON.parse(decodedData);
+    updateEvents.forEach(function (uevent) {
+      eventUpdateHandlers[uevent.type](uevent);
     });
-    return;
+    scrollEventsDisabled = false;
+  };
+
+  if (platformOS === 'ios') {
+    window.addEventListener('message', handleMessageEvent);
+  } else {
+    document.addEventListener('message', handleMessageEvent);
   }
 
-  if (target.matches('a')) {
-    sendMessage({
-      type: 'url',
-      href: requireAttribute(target, 'href'),
-      messageId: getMessageIdFromNode(target)
-    });
-    return;
-  }
+  var requireAttribute = function requireAttribute(e, name) {
+    var value = e.getAttribute(name);
 
-  if (target.parentNode instanceof Element && target.parentNode.matches('a')) {
-    sendMessage({
-      type: 'url',
-      href: requireAttribute(target.parentNode, 'href'),
-      messageId: getMessageIdFromNode(target.parentNode)
-    });
-    return;
-  }
+    if (value === null || value === undefined) {
+      throw new Error("Missing expected attribute " + name);
+    }
 
-  if (target.matches('.reaction')) {
-    sendMessage({
-      type: 'reaction',
-      name: requireAttribute(target, 'data-name'),
-      code: requireAttribute(target, 'data-code'),
-      reactionType: requireAttribute(target, 'data-type'),
-      messageId: getMessageIdFromNode(target),
-      voted: target.classList.contains('self-voted')
-    });
-    return;
-  }
+    return value;
+  };
 
-  var messageElement = target.closest('.message-brief');
-
-  if (messageElement) {
-    messageElement.getElementsByClassName('timestamp')[0].classList.toggle('show');
-    return;
-  }
-});
-
-var handleLongPress = function handleLongPress(target) {
-  hasLongPressed = true;
-  sendMessage({
-    type: 'longPress',
-    target: target.matches('.header') ? 'header' : target.matches('a') ? 'link' : 'message',
-    messageId: getMessageIdFromNode(target),
-    href: target.matches('a') ? requireAttribute(target, 'href') : null
-  });
-};
-
-documentBody.addEventListener('touchstart', function (e) {
-  var target = e.target;
-
-  if (e.changedTouches[0].pageX < 20 || !(target instanceof Element)) {
-    return;
-  }
-
-  lastTouchPositionX = e.changedTouches[0].pageX;
-  lastTouchPositionY = e.changedTouches[0].pageY;
-  hasLongPressed = false;
-  clearTimeout(longPressTimeout);
-  longPressTimeout = setTimeout(function () {
-    return handleLongPress(target);
-  }, 500);
-});
-
-var isNearPositions = function isNearPositions() {
-  var x1 = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : 0;
-  var y1 = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : 0;
-  var x2 = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : 0;
-  var y2 = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : 0;
-  return Math.abs(x1 - x2) < 10 && Math.abs(y1 - y2) < 10;
-};
-
-documentBody.addEventListener('touchend', function (e) {
-  if (isNearPositions(lastTouchPositionX, lastTouchPositionY, e.changedTouches[0].pageX, e.changedTouches[0].pageY)) {
+  documentBody.addEventListener('click', function (e) {
+    e.preventDefault();
     clearTimeout(longPressTimeout);
-  }
-});
-documentBody.addEventListener('touchcancel', function (e) {
-  clearTimeout(longPressTimeout);
-});
-documentBody.addEventListener('touchmove', function (e) {
-  clearTimeout(longPressTimeout);
-});
-documentBody.addEventListener('drag', function (e) {
-  clearTimeout(longPressTimeout);
-});
+
+    if (hasLongPressed) {
+      hasLongPressed = false;
+      return;
+    }
+
+    var target = e.target;
+
+    if (!(target instanceof Element)) {
+      return;
+    }
+
+    if (target.matches('.scroll-bottom')) {
+      scrollToBottom();
+      return;
+    }
+
+    if (target.matches('.avatar-img')) {
+      sendMessage({
+        type: 'avatar',
+        fromEmail: requireAttribute(target, 'data-email')
+      });
+      return;
+    }
+
+    if (target.matches('.header')) {
+      sendMessage({
+        type: 'narrow',
+        narrow: requireAttribute(target, 'data-narrow')
+      });
+      return;
+    }
+
+    var inlineImageLink = target.closest('.message_inline_image a');
+
+    if (inlineImageLink && !inlineImageLink.closest('.youtube-video, .vimeo-video')) {
+      sendMessage({
+        type: 'image',
+        src: requireAttribute(inlineImageLink, 'href'),
+        messageId: getMessageIdFromNode(inlineImageLink)
+      });
+      return;
+    }
+
+    if (target.matches('a')) {
+      sendMessage({
+        type: 'url',
+        href: requireAttribute(target, 'href'),
+        messageId: getMessageIdFromNode(target)
+      });
+      return;
+    }
+
+    if (target.parentNode instanceof Element && target.parentNode.matches('a')) {
+      sendMessage({
+        type: 'url',
+        href: requireAttribute(target.parentNode, 'href'),
+        messageId: getMessageIdFromNode(target.parentNode)
+      });
+      return;
+    }
+
+    if (target.matches('.reaction')) {
+      sendMessage({
+        type: 'reaction',
+        name: requireAttribute(target, 'data-name'),
+        code: requireAttribute(target, 'data-code'),
+        reactionType: requireAttribute(target, 'data-type'),
+        messageId: getMessageIdFromNode(target),
+        voted: target.classList.contains('self-voted')
+      });
+      return;
+    }
+
+    var messageElement = target.closest('.message-brief');
+
+    if (messageElement) {
+      messageElement.getElementsByClassName('timestamp')[0].classList.toggle('show');
+      return;
+    }
+  });
+
+  var handleLongPress = function handleLongPress(target) {
+    hasLongPressed = true;
+    sendMessage({
+      type: 'longPress',
+      target: target.matches('.header') ? 'header' : target.matches('a') ? 'link' : 'message',
+      messageId: getMessageIdFromNode(target),
+      href: target.matches('a') ? requireAttribute(target, 'href') : null
+    });
+  };
+
+  documentBody.addEventListener('touchstart', function (e) {
+    var target = e.target;
+
+    if (e.changedTouches[0].pageX < 20 || !(target instanceof Element)) {
+      return;
+    }
+
+    lastTouchPositionX = e.changedTouches[0].pageX;
+    lastTouchPositionY = e.changedTouches[0].pageY;
+    hasLongPressed = false;
+    clearTimeout(longPressTimeout);
+    longPressTimeout = setTimeout(function () {
+      return handleLongPress(target);
+    }, 500);
+  });
+
+  var isNearPositions = function isNearPositions() {
+    var x1 = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : 0;
+    var y1 = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : 0;
+    var x2 = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : 0;
+    var y2 = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : 0;
+    return Math.abs(x1 - x2) < 10 && Math.abs(y1 - y2) < 10;
+  };
+
+  documentBody.addEventListener('touchend', function (e) {
+    if (isNearPositions(lastTouchPositionX, lastTouchPositionY, e.changedTouches[0].pageX, e.changedTouches[0].pageY)) {
+      clearTimeout(longPressTimeout);
+    }
+  });
+  documentBody.addEventListener('touchcancel', function (e) {
+    clearTimeout(longPressTimeout);
+  });
+  documentBody.addEventListener('touchmove', function (e) {
+    clearTimeout(longPressTimeout);
+  });
+  documentBody.addEventListener('drag', function (e) {
+    clearTimeout(longPressTimeout);
+  });
+
+  exports.handleInitialLoad = handleInitialLoad;
+
+  return exports;
+
+}({}));
+
 `;

--- a/src/webview/js/js.js
+++ b/src/webview/js/js.js
@@ -549,8 +549,8 @@ const handleUpdateEventContent = (uevent: WebViewUpdateEventContent) => {
   sendScrollMessageIfListShort();
 };
 
-/** We call this when the webview's content first loads. */
-const handleInitialLoad = /* eslint-disable-line */ (anchor: number, auth: Auth) => {
+// We call this when the webview's content first loads.
+export const handleInitialLoad = /* eslint-disable-line */ (anchor: number, auth: Auth) => {
   scrollToAnchor(anchor);
   appendAuthToImages(auth);
   sendScrollMessageIfListShort();

--- a/src/webview/js/js.js
+++ b/src/webview/js/js.js
@@ -11,6 +11,8 @@ import type {
 } from '../webViewHandleUpdates';
 import type { MessageListEvent } from '../webViewEventHandlers';
 
+import appendAuthToImages from './appendAuthToImages';
+
 /*
  * Supported platforms:
  *
@@ -477,32 +479,6 @@ const scrollToPreserve = (msgId: number, prevBoundTop: number) => {
   }
   const newBoundRect = newElement.getBoundingClientRect();
   window.scrollBy(0, newBoundRect.top - prevBoundTop);
-};
-
-const appendAuthToImages = auth => {
-  const imageTags = document.getElementsByTagName('img');
-  Array.from(imageTags).forEach(img => {
-    if (!img.src.startsWith(auth.realm)) {
-      return;
-    }
-
-    // This unusual form of authentication is only accepted by the server
-    // for a small number of routes.  Rather than append the API key to all
-    // kinds of URLs on the server, do so only for those routes.
-    const srcPath = img.src.substring(auth.realm.length);
-    if (
-      !(
-        srcPath.startsWith('/user_uploads/')
-        || srcPath.startsWith('/thumbnail?')
-        || srcPath.startsWith('/avatar/')
-      )
-    ) {
-      return;
-    }
-
-    const delimiter = img.src.includes('?') ? '&' : '?';
-    img.src += `${delimiter}api_key=${auth.apiKey}`;
-  });
 };
 
 const handleUpdateEventContent = (uevent: WebViewUpdateEventContent) => {

--- a/src/webview/js/script.js
+++ b/src/webview/js/script.js
@@ -2,7 +2,7 @@
 import type { Auth } from '../../types';
 import smoothScroll from './smoothScroll.min';
 import matchesPolyfill from './matchesPolyfill';
-import js from './generatedEs3';
+import compiledWebviewJs from './generatedEs3';
 import config from '../../config';
 
 export default (anchor: number, auth: Auth): string => `
@@ -12,8 +12,8 @@ ${smoothScroll}
 ${matchesPolyfill}
 window.enableWebViewErrorDisplay = ${config.enableWebViewErrorDisplay.toString()};
 document.addEventListener('DOMContentLoaded', function() {
-  ${js}
-  handleInitialLoad(${anchor}, ${JSON.stringify(auth)});
+  ${compiledWebviewJs}
+  compiledWebviewJs.handleInitialLoad(${anchor}, ${JSON.stringify(auth)});
 });
 </script>
 `;

--- a/tools/generate-webview-js
+++ b/tools/generate-webview-js
@@ -63,7 +63,11 @@ ${es3Code.replace(/\\/g, '\\\\')}
         plugins: [['@babel/transform-flow-strip-types']],
 
         /* See comments in src/webview/js/js.js for details about the target set
-           selected here. */
+           selected here.
+
+           See comments below about (the absence of) automatic polyfills via
+           `core-js`.
+        */
         presets: [['@babel/preset-env', { targets: { android: '4.4', chrome: 30, safari: 10 } }]],
       }),
     ],
@@ -102,3 +106,56 @@ ${es3Code.replace(/\\/g, '\\\\')}
   asset file. Only a <script> tag and a one-to-three-line invocation should need
   to be emitted into the dynamically-rendered HTML.
 */
+
+/**
+ * # Babel, core-js and polyfills
+ *
+ * The `@babel/preset-env` package relies on the definitions and compatibility
+ * declarations in `core-js` to select polyfills for rollup to include.
+ *
+ * Alas, this induces problems.
+ *
+ * The `core-js` package is dedicated to 100% compatibility, even on very old
+ * (ES3) engines. This means that its compatibility profile includes polyfills
+ * for marginal (read: irrelevant) functionality like `@@species` support
+ * [c#644].
+ *
+ * Furthermore, the compatibility table checks aren't run recursively on the
+ * dependencies of those polyfills; instead, the polyfills' dependencies are
+ * polyfilled automatically. [t] `core-js`'s feature-detection _should_ prevent
+ * these unnecessary polyfills from actually attaching to global objects; but
+ * Rollup is entirely oblivious to this, and will (as directed by `core-js`)
+ * cheerfully push into the final bundle all sorts of unnecessary-but-
+ * `require()`d polyfills containing all sorts of support functionality that,
+ * due to their runtime checks, can't be tree-shaken away. [c#388]
+ *
+ * It is possible to exclude individual polyfills on an item-by-item basis
+ * [b.excl]; but this will only block detection at the top level by
+ * @babel/preset-env. Even `core-js`'s own exclusion system [c.cloa] will not
+ * honor internal polyfill block requests. [c#388]
+ *
+ * It's bad enough that `core-js` inflates the bundle with things like IE8- bug
+ * workarounds [t] [c#388] and unstripped comments [t], and that it replaces
+ * fast, sufficient native code with complex, less-JITtable code. Worse, though,
+ * is that its aggressive replacement of native functionality can introduce
+ * slowdown even on formally-unrelated code paths. [b#5771] [c#306]
+ *
+ * For all that, `core-js` _does_ work. Using it, or not using it, is a
+ * tradeoff... but then, so is supporting older WebViews at all.
+ *
+ * See the comments heading `js.js` for details about our version-support
+ * strategy.
+ */
+
+/**
+ * Footnotes (separated to keep the paragraph rewrapper from trying to wrap
+ * them):
+ *
+ *   [b#5771] https://github.com/babel/babel/issues/5771
+ *   [b.excl] https://babeljs.io/docs/en/babel-preset-env#exclude
+ *   [c#306] https://github.com/zloirock/core-js/issues/306
+ *   [c#388] https://github.com/zloirock/core-js/issues/388
+ *   [c#644] https://github.com/zloirock/core-js/issues/644
+ *   [c.cloa] https://github.com/zloirock/core-js#configurable-level-of-aggressiveness
+ *   [t] Observed in tests.
+ */

--- a/tools/generate-webview-js
+++ b/tools/generate-webview-js
@@ -1,20 +1,33 @@
 #!/usr/bin/env node
 /* eslint-env node */
 
+const { rollup } = require('rollup');
+const rollupBabel = require('rollup-plugin-babel');
+const rollupResolve = require('rollup-plugin-node-resolve');
+
+const assert = require('assert');
 const fs = require('fs');
-const babel = require('@babel/core');
+const util = require('util');
 
 const sourceFilename = 'src/webview/js/js.js';
 const outputFilename = 'src/webview/js/generatedEs3.js';
 
-const es3Code = babel.transformFileSync(sourceFilename, {
-  compact: false,
-}).code;
+// Disable the default react-native transformations.
+// See `$ROOT/babel.config.js`.
+process.env.BABEL_ENV = 'webview';
 
-/* eslint-disable-next-line no-useless-concat */
-const generatedMarker = '@' + 'generated';
+// node's fs predates async/await, alas
+const writeFileAsync = util.promisify(fs.writeFile);
 
-const output = `/*
+/**
+ * Transform the transpiled code into the text of a module which exports that
+ * code as a string.
+ */
+const wrapCode = es3Code => {
+  /* eslint-disable-next-line no-useless-concat */
+  const generatedMarker = '@' + 'generated';
+
+  return `/*
  * This is a GENERATED file -- do not edit.
  * To make changes:
  *   1. Edit \`js.js\`, which is the source for this file.
@@ -30,5 +43,65 @@ export default \`
 ${es3Code.replace(/\\/g, '\\\\')}
 \`;
 `;
+};
 
-fs.writeFileSync(outputFilename, output);
+(async () => {
+  // Define the build process.
+  const build = await rollup({
+    input: sourceFilename,
+    plugins: [
+      rollupResolve(),
+      rollupBabel({
+        exclude: 'node_modules/**',
+        /* Our global config file applies React-Native-supplied and -targeted
+           transforms. Those are somewhat counterproductive here. */
+        configFile: false,
+        babelrc: false,
+
+        compact: false,
+        comments: false,
+        plugins: [
+          ['@babel/transform-flow-strip-types'],
+          ['@babel/plugin-transform-template-literals', { loose: true }],
+        ],
+
+        /* See comments in src/webview/js/js.js for details about the target set
+           selected here. */
+        presets: [['@babel/preset-env', { targets: { android: '4.4', chrome: 30, safari: 10 } }]],
+      }),
+    ],
+  });
+
+  // Execute the build process.
+  const { output } = await build.generate({
+    format: 'iife' /* "immediately-invoked function expression" */,
+    name: 'compiledWebviewJs',
+    // TODO: eliminate `wrappedOutput`. See "TODO", below.
+    /* file: outputFilename, */
+  });
+
+  // In general, Babel may return multiple output chunks. This particular
+  // compilation setup, however, should return only a single chunk.
+  assert.strictEqual(output.length, 1);
+
+  // Extract and wrap that chunk's code.
+  const wrappedOutput = wrapCode(output[0].code);
+
+  // Write the transformed code.
+  await writeFileAsync(outputFilename, wrappedOutput);
+})().catch(
+  // eslint-disable-next-line no-console
+  console.error,
+);
+
+/* TODO:
+
+  At present, `webview/script.js` wraps this script's output; in turn this
+  script applies a wrapper around (the compiled text of) `webview/js.js`.
+
+  This is at least one layer of abstraction more than we need.
+
+  In the future, we'll probably want to make `js.js` compile to a single static
+  asset file. Only a <script> tag and a one-to-three-line invocation should need
+  to be emitted into the dynamically-rendered HTML.
+*/

--- a/tools/generate-webview-js
+++ b/tools/generate-webview-js
@@ -60,10 +60,7 @@ ${es3Code.replace(/\\/g, '\\\\')}
 
         compact: false,
         comments: false,
-        plugins: [
-          ['@babel/transform-flow-strip-types'],
-          ['@babel/plugin-transform-template-literals', { loose: true }],
-        ],
+        plugins: [['@babel/transform-flow-strip-types']],
 
         /* See comments in src/webview/js/js.js for details about the target set
            selected here. */

--- a/yarn.lock
+++ b/yarn.lock
@@ -4726,6 +4726,11 @@ jest-each@^24.9.0:
     jest-util "^24.9.0"
     pretty-format "^24.9.0"
 
+jest-environment-jsdom-global@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/jest-environment-jsdom-global/-/jest-environment-jsdom-global-1.2.0.tgz#dd5b16fe0a0566ee40010d8632be5adf5a5ccb65"
+  integrity sha512-41cDl0OxzmFY/cnW0COUN+lnt2N2ks1r3V4fAKOnlZ9xIrGy0PNPan+Bz8HP+uQy/8bGV6T7J4Oi7X+h43It6g==
+
 jest-environment-jsdom@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/jest-environment-jsdom/-/jest-environment-jsdom-24.9.0.tgz#4b0806c7fc94f95edb369a69cc2778eec2b7375b"

--- a/yarn.lock
+++ b/yarn.lock
@@ -138,7 +138,7 @@
   dependencies:
     "@babel/types" "^7.0.0"
 
-"@babel/helper-module-transforms@^7.4.4":
+"@babel/helper-module-transforms@^7.1.0", "@babel/helper-module-transforms@^7.4.4":
   version "7.5.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.5.5.tgz#f84ff8a09038dcbca1fd4355661a500937165b4a"
   integrity sha512-jBeCvETKuJqeiaCdyaheF40aXnnU1+wkSiUs/IQg3tB85up1LyL8x77ClY8qJpuRJUcXQo+ZtdNESmZl4j56Pw==
@@ -245,6 +245,15 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
+"@babel/plugin-proposal-async-generator-functions@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.2.0.tgz#b289b306669dce4ad20b0252889a15768c9d417e"
+  integrity sha512-+Dfo/SCQqrwx48ptLVGLdE39YtWRuKc/Y9I5Fy0P1DDBB9lsAHpjcEJQt+4IifuSOSTLBKJObJqMvaO1pIE8LQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/helper-remap-async-to-generator" "^7.1.0"
+    "@babel/plugin-syntax-async-generators" "^7.2.0"
+
 "@babel/plugin-proposal-class-properties@^7.0.0":
   version "7.5.5"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.5.5.tgz#a974cfae1e37c3110e71f3c6a2e48b8e71958cd4"
@@ -253,6 +262,14 @@
     "@babel/helper-create-class-features-plugin" "^7.5.5"
     "@babel/helper-plugin-utils" "^7.0.0"
 
+"@babel/plugin-proposal-dynamic-import@^7.5.0":
+  version "7.5.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.5.0.tgz#e532202db4838723691b10a67b8ce509e397c506"
+  integrity sha512-x/iMjggsKTFHYC6g11PL7Qy58IK8H5zqfm9e6hu4z1iH2IRyAp9u9dL80zA6R76yFovETFLKz2VJIC2iIPBuFw==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/plugin-syntax-dynamic-import" "^7.2.0"
+
 "@babel/plugin-proposal-export-default-from@^7.0.0":
   version "7.5.2"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-export-default-from/-/plugin-proposal-export-default-from-7.5.2.tgz#2c0ac2dcc36e3b2443fead2c3c5fc796fb1b5145"
@@ -260,6 +277,14 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/plugin-syntax-export-default-from" "^7.2.0"
+
+"@babel/plugin-proposal-json-strings@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.2.0.tgz#568ecc446c6148ae6b267f02551130891e29f317"
+  integrity sha512-MAFV1CA/YVmYwZG0fBQyXhmj0BHCB5egZHCKWIFVv/XCxAeVGIHfos3SwDck4LvCllENIAg7xMKOG5kH0dzyUg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/plugin-syntax-json-strings" "^7.2.0"
 
 "@babel/plugin-proposal-nullish-coalescing-operator@^7.0.0":
   version "7.4.4"
@@ -277,7 +302,15 @@
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/plugin-syntax-object-rest-spread" "^7.2.0"
 
-"@babel/plugin-proposal-optional-catch-binding@^7.0.0":
+"@babel/plugin-proposal-object-rest-spread@^7.6.2":
+  version "7.6.2"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.6.2.tgz#8ffccc8f3a6545e9f78988b6bf4fe881b88e8096"
+  integrity sha512-LDBXlmADCsMZV1Y9OQwMc0MyGZ8Ta/zlD9N67BfQT8uYwkRswiu2hU6nJKrjrt/58aH/vqfQlR/9yId/7A2gWw==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/plugin-syntax-object-rest-spread" "^7.2.0"
+
+"@babel/plugin-proposal-optional-catch-binding@^7.0.0", "@babel/plugin-proposal-optional-catch-binding@^7.2.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.2.0.tgz#135d81edb68a081e55e56ec48541ece8065c38f5"
   integrity sha512-mgYj3jCcxug6KUcX4OBoOJz3CMrwRfQELPQ5560F70YQUBZB7uac9fqaWamKR1iWUzGiK2t0ygzjTScZnVz75g==
@@ -293,6 +326,22 @@
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/plugin-syntax-optional-chaining" "^7.2.0"
 
+"@babel/plugin-proposal-unicode-property-regex@^7.6.2":
+  version "7.6.2"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.6.2.tgz#05413762894f41bfe42b9a5e80919bd575dcc802"
+  integrity sha512-NxHETdmpeSCtiatMRYWVJo7266rrvAC3DTeG5exQBIH/fMIUK7ejDNznBbn3HQl/o9peymRRg7Yqkx6PdUXmMw==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/helper-regex" "^7.4.4"
+    regexpu-core "^4.6.0"
+
+"@babel/plugin-syntax-async-generators@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.2.0.tgz#69e1f0db34c6f5a0cf7e2b3323bf159a76c8cb7f"
+  integrity sha512-1ZrIRBv2t0GSlcwVoQ6VgSLpLgiN/FVQUzt9znxo7v2Ov4jJrs8RY8tv0wvDmFN3qIdMKWrmMMW6yZ0G19MfGg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
 "@babel/plugin-syntax-class-properties@^7.0.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.2.0.tgz#23b3b7b9bcdabd73672a9149f728cd3be6214812"
@@ -300,7 +349,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
-"@babel/plugin-syntax-dynamic-import@^7.0.0":
+"@babel/plugin-syntax-dynamic-import@^7.0.0", "@babel/plugin-syntax-dynamic-import@^7.2.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.2.0.tgz#69c159ffaf4998122161ad8ebc5e6d1f55df8612"
   integrity sha512-mVxuJ0YroI/h/tbFTPGZR8cv6ai+STMKNBq0f8hFxsxWjl94qqhsb+wXbpNMDPU3cfR1TIsVFzU3nXyZMqyK4w==
@@ -318,6 +367,13 @@
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.2.0.tgz#a765f061f803bc48f240c26f8747faf97c26bf7c"
   integrity sha512-r6YMuZDWLtLlu0kqIim5o/3TNRAlWb073HwT3e2nKf9I8IIvOggPrnILYPsrrKilmn/mYEMCf/Z07w3yQJF6dg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-syntax-json-strings@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.2.0.tgz#72bd13f6ffe1d25938129d2a186b11fd62951470"
+  integrity sha512-5UGYnMSLRE1dqqZwug+1LISpA403HzlSfsg6P9VXU6TBjcSHeNlw4DxDx7LgpF+iKZoOG/+uzqoRHTdcUpiZNg==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
@@ -363,14 +419,14 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
-"@babel/plugin-transform-arrow-functions@^7.0.0":
+"@babel/plugin-transform-arrow-functions@^7.0.0", "@babel/plugin-transform-arrow-functions@^7.2.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.2.0.tgz#9aeafbe4d6ffc6563bf8f8372091628f00779550"
   integrity sha512-ER77Cax1+8/8jCB9fo4Ud161OZzWN5qawi4GusDuRLcDbDG+bIGYY20zb2dfAFdTRGzrfq2xZPvF0R64EHnimg==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
-"@babel/plugin-transform-async-to-generator@^7.0.0":
+"@babel/plugin-transform-async-to-generator@^7.0.0", "@babel/plugin-transform-async-to-generator@^7.5.0":
   version "7.5.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.5.0.tgz#89a3848a0166623b5bc481164b5936ab947e887e"
   integrity sha512-mqvkzwIGkq0bEF1zLRRiTdjfomZJDV33AH3oQzHVGkI2VzEmXLpKKOBvEVaFZBJdN0XTyH38s9j/Kiqr68dggg==
@@ -379,7 +435,7 @@
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/helper-remap-async-to-generator" "^7.1.0"
 
-"@babel/plugin-transform-block-scoped-functions@^7.0.0":
+"@babel/plugin-transform-block-scoped-functions@^7.0.0", "@babel/plugin-transform-block-scoped-functions@^7.2.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.2.0.tgz#5d3cc11e8d5ddd752aa64c9148d0db6cb79fd190"
   integrity sha512-ntQPR6q1/NKuphly49+QiQiTN0O63uOwjdD6dhIjSWBI5xlrbUFh720TIpzBhpnrLfv2tNH/BXvLIab1+BAI0w==
@@ -394,7 +450,15 @@
     "@babel/helper-plugin-utils" "^7.0.0"
     lodash "^4.17.13"
 
-"@babel/plugin-transform-classes@^7.0.0":
+"@babel/plugin-transform-block-scoping@^7.6.3":
+  version "7.6.3"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.6.3.tgz#6e854e51fbbaa84351b15d4ddafe342f3a5d542a"
+  integrity sha512-7hvrg75dubcO3ZI2rjYTzUrEuh1E9IyDEhhB6qfcooxhDA33xx2MasuLVgdxzcP6R/lipAC6n9ub9maNW6RKdw==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    lodash "^4.17.13"
+
+"@babel/plugin-transform-classes@^7.0.0", "@babel/plugin-transform-classes@^7.5.5":
   version "7.5.5"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-classes/-/plugin-transform-classes-7.5.5.tgz#d094299d9bd680a14a2a0edae38305ad60fb4de9"
   integrity sha512-U2htCNK/6e9K7jGyJ++1p5XRU+LJjrwtoiVn9SzRlDT2KubcZ11OOwy3s24TjHxPgxNwonCYP7U2K51uVYCMDg==
@@ -408,7 +472,7 @@
     "@babel/helper-split-export-declaration" "^7.4.4"
     globals "^11.1.0"
 
-"@babel/plugin-transform-computed-properties@^7.0.0":
+"@babel/plugin-transform-computed-properties@^7.0.0", "@babel/plugin-transform-computed-properties@^7.2.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.2.0.tgz#83a7df6a658865b1c8f641d510c6f3af220216da"
   integrity sha512-kP/drqTxY6Xt3NNpKiMomfgkNn4o7+vKxK2DDKcBG9sHj51vHqMBGy8wbDS/J4lMxnqs153/T3+DmCEAkC5cpA==
@@ -422,7 +486,30 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
-"@babel/plugin-transform-exponentiation-operator@^7.0.0":
+"@babel/plugin-transform-destructuring@^7.6.0":
+  version "7.6.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.6.0.tgz#44bbe08b57f4480094d57d9ffbcd96d309075ba6"
+  integrity sha512-2bGIS5P1v4+sWTCnKNDZDxbGvEqi0ijeqM/YqHtVGrvG2y0ySgnEEhXErvE9dA0bnIzY9bIzdFK0jFA46ASIIQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-transform-dotall-regex@^7.6.2":
+  version "7.6.2"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.6.2.tgz#44abb948b88f0199a627024e1508acaf8dc9b2f9"
+  integrity sha512-KGKT9aqKV+9YMZSkowzYoYEiHqgaDhGmPNZlZxX6UeHC4z30nC1J9IrZuGqbYFB1jaIGdv91ujpze0exiVK8bA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/helper-regex" "^7.4.4"
+    regexpu-core "^4.6.0"
+
+"@babel/plugin-transform-duplicate-keys@^7.5.0":
+  version "7.5.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.5.0.tgz#c5dbf5106bf84cdf691222c0974c12b1df931853"
+  integrity sha512-igcziksHizyQPlX9gfSjHkE2wmoCH3evvD2qR5w29/Dk0SMKE/eOI7f1HhBdNhR/zxJDqrgpoDTq5YSLH/XMsQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-transform-exponentiation-operator@^7.0.0", "@babel/plugin-transform-exponentiation-operator@^7.2.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.2.0.tgz#a63868289e5b4007f7054d46491af51435766008"
   integrity sha512-umh4hR6N7mu4Elq9GG8TOu9M0bakvlsREEC+ialrQN6ABS4oDQ69qJv1VtR3uxlKMCQMCvzk7vr17RHKcjx68A==
@@ -438,14 +525,14 @@
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/plugin-syntax-flow" "^7.2.0"
 
-"@babel/plugin-transform-for-of@^7.0.0":
+"@babel/plugin-transform-for-of@^7.0.0", "@babel/plugin-transform-for-of@^7.4.4":
   version "7.4.4"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.4.4.tgz#0267fc735e24c808ba173866c6c4d1440fc3c556"
   integrity sha512-9T/5Dlr14Z9TIEXLXkt8T1DU7F24cbhwhMNUziN3hB1AXoZcdzPcTiKGRn/6iOymDqtTKWnr/BtRKN9JwbKtdQ==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
-"@babel/plugin-transform-function-name@^7.0.0":
+"@babel/plugin-transform-function-name@^7.0.0", "@babel/plugin-transform-function-name@^7.4.4":
   version "7.4.4"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.4.4.tgz#e1436116abb0610c2259094848754ac5230922ad"
   integrity sha512-iU9pv7U+2jC9ANQkKeNF6DrPy4GBa4NWQtl6dHB4Pb3izX2JOEvDTFarlNsBj/63ZEzNNIAMs3Qw4fNCcSOXJA==
@@ -453,19 +540,28 @@
     "@babel/helper-function-name" "^7.1.0"
     "@babel/helper-plugin-utils" "^7.0.0"
 
-"@babel/plugin-transform-literals@^7.0.0":
+"@babel/plugin-transform-literals@^7.0.0", "@babel/plugin-transform-literals@^7.2.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-literals/-/plugin-transform-literals-7.2.0.tgz#690353e81f9267dad4fd8cfd77eafa86aba53ea1"
   integrity sha512-2ThDhm4lI4oV7fVQ6pNNK+sx+c/GM5/SaML0w/r4ZB7sAneD/piDJtwdKlNckXeyGK7wlwg2E2w33C/Hh+VFCg==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
-"@babel/plugin-transform-member-expression-literals@^7.0.0":
+"@babel/plugin-transform-member-expression-literals@^7.0.0", "@babel/plugin-transform-member-expression-literals@^7.2.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.2.0.tgz#fa10aa5c58a2cb6afcf2c9ffa8cb4d8b3d489a2d"
   integrity sha512-HiU3zKkSU6scTidmnFJ0bMX8hz5ixC93b4MHMiYebmk2lUVNGOboPsqQvx5LzooihijUoLR/v7Nc1rbBtnc7FA==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-transform-modules-amd@^7.5.0":
+  version "7.5.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.5.0.tgz#ef00435d46da0a5961aa728a1d2ecff063e4fb91"
+  integrity sha512-n20UsQMKnWrltocZZm24cRURxQnWIvsABPJlw/fvoy9c6AgHZzoelAIzajDHAQrDpuKFFPPcFGd7ChsYuIUMpg==
+  dependencies:
+    "@babel/helper-module-transforms" "^7.1.0"
+    "@babel/helper-plugin-utils" "^7.0.0"
+    babel-plugin-dynamic-import-node "^2.3.0"
 
 "@babel/plugin-transform-modules-commonjs@^7.0.0":
   version "7.5.0"
@@ -477,6 +573,47 @@
     "@babel/helper-simple-access" "^7.1.0"
     babel-plugin-dynamic-import-node "^2.3.0"
 
+"@babel/plugin-transform-modules-commonjs@^7.6.0":
+  version "7.6.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.6.0.tgz#39dfe957de4420445f1fcf88b68a2e4aa4515486"
+  integrity sha512-Ma93Ix95PNSEngqomy5LSBMAQvYKVe3dy+JlVJSHEXZR5ASL9lQBedMiCyVtmTLraIDVRE3ZjTZvmXXD2Ozw3g==
+  dependencies:
+    "@babel/helper-module-transforms" "^7.4.4"
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/helper-simple-access" "^7.1.0"
+    babel-plugin-dynamic-import-node "^2.3.0"
+
+"@babel/plugin-transform-modules-systemjs@^7.5.0":
+  version "7.5.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.5.0.tgz#e75266a13ef94202db2a0620977756f51d52d249"
+  integrity sha512-Q2m56tyoQWmuNGxEtUyeEkm6qJYFqs4c+XyXH5RAuYxObRNz9Zgj/1g2GMnjYp2EUyEy7YTrxliGCXzecl/vJg==
+  dependencies:
+    "@babel/helper-hoist-variables" "^7.4.4"
+    "@babel/helper-plugin-utils" "^7.0.0"
+    babel-plugin-dynamic-import-node "^2.3.0"
+
+"@babel/plugin-transform-modules-umd@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.2.0.tgz#7678ce75169f0877b8eb2235538c074268dd01ae"
+  integrity sha512-BV3bw6MyUH1iIsGhXlOK6sXhmSarZjtJ/vMiD9dNmpY8QXFFQTj+6v92pcfy1iqa8DeAfJFwoxcrS/TUZda6sw==
+  dependencies:
+    "@babel/helper-module-transforms" "^7.1.0"
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-transform-named-capturing-groups-regex@^7.6.3":
+  version "7.6.3"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.6.3.tgz#aaa6e409dd4fb2e50b6e2a91f7e3a3149dbce0cf"
+  integrity sha512-jTkk7/uE6H2s5w6VlMHeWuH+Pcy2lmdwFoeWCVnvIrDUnB5gQqTVI8WfmEAhF2CDEarGrknZcmSFg1+bkfCoSw==
+  dependencies:
+    regexpu-core "^4.6.0"
+
+"@babel/plugin-transform-new-target@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.4.4.tgz#18d120438b0cc9ee95a47f2c72bc9768fbed60a5"
+  integrity sha512-r1z3T2DNGQwwe2vPGZMBNjioT2scgWzK9BCnDEh+46z8EEwXBq24uRzd65I7pjtugzPSj921aM15RpESgzsSuA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
 "@babel/plugin-transform-object-assign@^7.0.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-object-assign/-/plugin-transform-object-assign-7.2.0.tgz#6fdeea42be17040f119e38e23ea0f49f31968bde"
@@ -484,7 +621,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
-"@babel/plugin-transform-object-super@^7.0.0":
+"@babel/plugin-transform-object-super@^7.0.0", "@babel/plugin-transform-object-super@^7.5.5":
   version "7.5.5"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.5.5.tgz#c70021df834073c65eb613b8679cc4a381d1a9f9"
   integrity sha512-un1zJQAhSosGFBduPgN/YFNvWVpRuHKU7IHBglLoLZsGmruJPOo6pbInneflUdmq7YvSVqhpPs5zdBvLnteltQ==
@@ -492,7 +629,7 @@
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/helper-replace-supers" "^7.5.5"
 
-"@babel/plugin-transform-parameters@^7.0.0":
+"@babel/plugin-transform-parameters@^7.0.0", "@babel/plugin-transform-parameters@^7.4.4":
   version "7.4.4"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.4.4.tgz#7556cf03f318bd2719fe4c922d2d808be5571e16"
   integrity sha512-oMh5DUO1V63nZcu/ZVLQFqiihBGo4OpxJxR1otF50GMeCLiRx5nUdtokd+u9SuVJrvvuIh9OosRFPP4pIPnwmw==
@@ -501,7 +638,7 @@
     "@babel/helper-get-function-arity" "^7.0.0"
     "@babel/helper-plugin-utils" "^7.0.0"
 
-"@babel/plugin-transform-property-literals@^7.0.0":
+"@babel/plugin-transform-property-literals@^7.0.0", "@babel/plugin-transform-property-literals@^7.2.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.2.0.tgz#03e33f653f5b25c4eb572c98b9485055b389e905"
   integrity sha512-9q7Dbk4RhgcLp8ebduOpCbtjh7C0itoLYHXd9ueASKAG/is5PQtMR5VJGka9NKqGhYEGn5ITahd4h9QeBMylWQ==
@@ -532,12 +669,19 @@
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/plugin-syntax-jsx" "^7.2.0"
 
-"@babel/plugin-transform-regenerator@^7.0.0":
+"@babel/plugin-transform-regenerator@^7.0.0", "@babel/plugin-transform-regenerator@^7.4.5":
   version "7.4.5"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.4.5.tgz#629dc82512c55cee01341fb27bdfcb210354680f"
   integrity sha512-gBKRh5qAaCWntnd09S8QC7r3auLCqq5DI6O0DlfoyDjslSBVqBibrMdsqO+Uhmx3+BlOmE/Kw1HFxmGbv0N9dA==
   dependencies:
     regenerator-transform "^0.14.0"
+
+"@babel/plugin-transform-reserved-words@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.2.0.tgz#4792af87c998a49367597d07fedf02636d2e1634"
+  integrity sha512-fz43fqW8E1tAB3DKF19/vxbpib1fuyCwSPE418ge5ZxILnBhWyhtPgz8eh1RCGGJlwvksHkyxMxh0eenFi+kFw==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
 
 "@babel/plugin-transform-runtime@^7.0.0":
   version "7.5.5"
@@ -549,7 +693,7 @@
     resolve "^1.8.1"
     semver "^5.5.1"
 
-"@babel/plugin-transform-shorthand-properties@^7.0.0":
+"@babel/plugin-transform-shorthand-properties@^7.0.0", "@babel/plugin-transform-shorthand-properties@^7.2.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.2.0.tgz#6333aee2f8d6ee7e28615457298934a3b46198f0"
   integrity sha512-QP4eUM83ha9zmYtpbnyjTLAGKQritA5XW/iG9cjtuOI8s1RuL/3V6a3DeSHfKutJQ+ayUfeZJPcnCYEQzaPQqg==
@@ -563,7 +707,14 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
-"@babel/plugin-transform-sticky-regex@^7.0.0":
+"@babel/plugin-transform-spread@^7.6.2":
+  version "7.6.2"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-spread/-/plugin-transform-spread-7.6.2.tgz#fc77cf798b24b10c46e1b51b1b88c2bf661bb8dd"
+  integrity sha512-DpSvPFryKdK1x+EDJYCy28nmAaIMdxmhot62jAXF/o99iA33Zj2Lmcp3vDmz+MUh0LNYVPvfj5iC3feb3/+PFg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-transform-sticky-regex@^7.0.0", "@babel/plugin-transform-sticky-regex@^7.2.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.2.0.tgz#a1e454b5995560a9c1e0d537dfc15061fd2687e1"
   integrity sha512-KKYCoGaRAf+ckH8gEL3JHUaFVyNHKe3ASNsZ+AlktgHevvxGigoIttrEJb8iKN03Q7Eazlv1s6cx2B2cQ3Jabw==
@@ -571,12 +722,19 @@
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/helper-regex" "^7.0.0"
 
-"@babel/plugin-transform-template-literals@^7.0.0":
+"@babel/plugin-transform-template-literals@^7.0.0", "@babel/plugin-transform-template-literals@^7.4.4":
   version "7.4.4"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.4.4.tgz#9d28fea7bbce637fb7612a0750989d8321d4bcb0"
   integrity sha512-mQrEC4TWkhLN0z8ygIvEL9ZEToPhG5K7KDW3pzGqOfIGZ28Jb0POUkeWcoz8HnHvhFy6dwAT1j8OzqN8s804+g==
   dependencies:
     "@babel/helper-annotate-as-pure" "^7.0.0"
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-transform-typeof-symbol@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.2.0.tgz#117d2bcec2fbf64b4b59d1f9819894682d29f2b2"
+  integrity sha512-2LNhETWYxiYysBtrBTqL8+La0jIoQQnIScUJc74OYvUGRmkskNY4EzLCnjHBzdmb38wqtTaixpo1NctEcvMDZw==
+  dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
 "@babel/plugin-transform-typescript@^7.0.0":
@@ -597,6 +755,15 @@
     "@babel/helper-regex" "^7.4.4"
     regexpu-core "^4.5.4"
 
+"@babel/plugin-transform-unicode-regex@^7.6.2":
+  version "7.6.2"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.6.2.tgz#b692aad888a7e8d8b1b214be6b9dc03d5031f698"
+  integrity sha512-orZI6cWlR3nk2YmYdb0gImrgCUwb5cBUwjf6Ks6dvNVvXERkwtJWOQaEOjPiu0Gu1Tq6Yq/hruCZZOOi9F34Dw==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/helper-regex" "^7.4.4"
+    regexpu-core "^4.6.0"
+
 "@babel/polyfill@^7.0.0":
   version "7.4.4"
   resolved "https://registry.yarnpkg.com/@babel/polyfill/-/polyfill-7.4.4.tgz#78801cf3dbe657844eeabf31c1cae3828051e893"
@@ -604,6 +771,62 @@
   dependencies:
     core-js "^2.6.5"
     regenerator-runtime "^0.13.2"
+
+"@babel/preset-env@^7.6.3":
+  version "7.6.3"
+  resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.6.3.tgz#9e1bf05a2e2d687036d24c40e4639dc46cef2271"
+  integrity sha512-CWQkn7EVnwzlOdR5NOm2+pfgSNEZmvGjOhlCHBDq0J8/EStr+G+FvPEiz9B56dR6MoiUFjXhfE4hjLoAKKJtIQ==
+  dependencies:
+    "@babel/helper-module-imports" "^7.0.0"
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/plugin-proposal-async-generator-functions" "^7.2.0"
+    "@babel/plugin-proposal-dynamic-import" "^7.5.0"
+    "@babel/plugin-proposal-json-strings" "^7.2.0"
+    "@babel/plugin-proposal-object-rest-spread" "^7.6.2"
+    "@babel/plugin-proposal-optional-catch-binding" "^7.2.0"
+    "@babel/plugin-proposal-unicode-property-regex" "^7.6.2"
+    "@babel/plugin-syntax-async-generators" "^7.2.0"
+    "@babel/plugin-syntax-dynamic-import" "^7.2.0"
+    "@babel/plugin-syntax-json-strings" "^7.2.0"
+    "@babel/plugin-syntax-object-rest-spread" "^7.2.0"
+    "@babel/plugin-syntax-optional-catch-binding" "^7.2.0"
+    "@babel/plugin-transform-arrow-functions" "^7.2.0"
+    "@babel/plugin-transform-async-to-generator" "^7.5.0"
+    "@babel/plugin-transform-block-scoped-functions" "^7.2.0"
+    "@babel/plugin-transform-block-scoping" "^7.6.3"
+    "@babel/plugin-transform-classes" "^7.5.5"
+    "@babel/plugin-transform-computed-properties" "^7.2.0"
+    "@babel/plugin-transform-destructuring" "^7.6.0"
+    "@babel/plugin-transform-dotall-regex" "^7.6.2"
+    "@babel/plugin-transform-duplicate-keys" "^7.5.0"
+    "@babel/plugin-transform-exponentiation-operator" "^7.2.0"
+    "@babel/plugin-transform-for-of" "^7.4.4"
+    "@babel/plugin-transform-function-name" "^7.4.4"
+    "@babel/plugin-transform-literals" "^7.2.0"
+    "@babel/plugin-transform-member-expression-literals" "^7.2.0"
+    "@babel/plugin-transform-modules-amd" "^7.5.0"
+    "@babel/plugin-transform-modules-commonjs" "^7.6.0"
+    "@babel/plugin-transform-modules-systemjs" "^7.5.0"
+    "@babel/plugin-transform-modules-umd" "^7.2.0"
+    "@babel/plugin-transform-named-capturing-groups-regex" "^7.6.3"
+    "@babel/plugin-transform-new-target" "^7.4.4"
+    "@babel/plugin-transform-object-super" "^7.5.5"
+    "@babel/plugin-transform-parameters" "^7.4.4"
+    "@babel/plugin-transform-property-literals" "^7.2.0"
+    "@babel/plugin-transform-regenerator" "^7.4.5"
+    "@babel/plugin-transform-reserved-words" "^7.2.0"
+    "@babel/plugin-transform-shorthand-properties" "^7.2.0"
+    "@babel/plugin-transform-spread" "^7.6.2"
+    "@babel/plugin-transform-sticky-regex" "^7.2.0"
+    "@babel/plugin-transform-template-literals" "^7.4.4"
+    "@babel/plugin-transform-typeof-symbol" "^7.2.0"
+    "@babel/plugin-transform-unicode-regex" "^7.6.2"
+    "@babel/types" "^7.6.3"
+    browserslist "^4.6.0"
+    core-js-compat "^3.1.1"
+    invariant "^2.2.2"
+    js-levenshtein "^1.1.3"
+    semver "^5.5.0"
 
 "@babel/register@^7.0.0":
   version "7.5.5"
@@ -652,6 +875,15 @@
   version "7.5.5"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.5.5.tgz#97b9f728e182785909aa4ab56264f090a028d18a"
   integrity sha512-s63F9nJioLqOlW3UkyMd+BYhXt44YuaFm/VV0VwuteqjYwRrObkU7ra9pY4wAJR3oXi8hJrMcrcJdO/HH33vtw==
+  dependencies:
+    esutils "^2.0.2"
+    lodash "^4.17.13"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.6.3":
+  version "7.6.3"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.6.3.tgz#3f07d96f854f98e2fbd45c64b0cb942d11e8ba09"
+  integrity sha512-CqbcpTxMcpuQTMhjI37ZHVgjBkysg5icREQIEZ0eG1yCNwg3oy+5AaLiOKmjsCj6nqOsa6Hf0ObjRVwokb7srA==
   dependencies:
     esutils "^2.0.2"
     lodash "^4.17.13"
@@ -984,6 +1216,11 @@
   resolved "https://registry.yarnpkg.com/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#1ee30d79544ca84d68d4b3cdb0af4f205663dd2d"
   integrity sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==
 
+"@types/estree@*":
+  version "0.0.39"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
+  integrity sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==
+
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz#42995b446db9a48a11a07ec083499a860e9138ff"
@@ -1009,10 +1246,22 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.3.tgz#bdfd69d61e464dcc81b25159c270d75a73c1a636"
   integrity sha512-Il2DtDVRGDcqjDtE+rF8iqg1CArehSK84HZJCT7AMITlyXRBpuPhqGLDQMowraqqu1coEaimg4ZOqggt6L6L+A==
 
+"@types/node@*":
+  version "12.11.0"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.11.0.tgz#7f893924970076b20ca0089df50ab9f171088909"
+  integrity sha512-7v0K9WHdjFpE3LMj1rdRan7PDO2d9Qky51T0cYzzk7fWoqoYKu/fZHnrF7OhNZVx0uKwYoQFMZ3dgVD51s/vYA==
+
 "@types/q@^1.5.1":
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/@types/q/-/q-1.5.2.tgz#690a1475b84f2a884fd07cd797c00f5f31356ea8"
   integrity sha512-ce5d3q03Ex0sy4R14722Rmt6MT07Ua+k4FwDfdcToYJcMKNtRVQvJ6JCAPdAmAnbRb6CsX6aYb9m96NGod9uTw==
+
+"@types/resolve@0.0.8":
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/@types/resolve/-/resolve-0.0.8.tgz#f26074d238e02659e323ce1a13d041eee280e194"
+  integrity sha512-auApPaJf3NPfe18hSoJkp8EbZzer2ISk7o8mCC3M9he/a04+gbMF97NkpD2S8riMGvm4BMRI59/SZQSaLTKpsQ==
+  dependencies:
+    "@types/node" "*"
 
 "@types/stack-utils@^1.0.1":
   version "1.0.1"
@@ -1127,6 +1376,11 @@ acorn@^6.0.1, acorn@^6.0.7:
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.2.1.tgz#3ed8422d6dec09e6121cc7a843ca86a330a86b51"
   integrity sha512-JD0xT5FCRDNyjDda3Lrg/IxFscp9q4tiYtxE1/nOzlKCk7hIRuYjhq1kCNkbPjMRMZuFq20HNQn1I9k8Oj0E+Q==
+
+acorn@^7.1.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.1.0.tgz#949d36f2c292535da602283586c2477c57eb2d6c"
+  integrity sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==
 
 agent-base@4, agent-base@^4.3.0:
   version "4.3.0"
@@ -1696,6 +1950,15 @@ browser-resolve@^1.11.3:
   dependencies:
     resolve "1.1.7"
 
+browserslist@^4.6.0, browserslist@^4.7.0:
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.7.0.tgz#9ee89225ffc07db03409f2fee524dc8227458a17"
+  integrity sha512-9rGNDtnj+HaahxiVV38Gn8n8Lr8REKsel68v1sPFfIGEK6uSXTY3h9acgiT1dZVtOOUtifo/Dn8daDQ5dUgVsA==
+  dependencies:
+    caniuse-lite "^1.0.30000989"
+    electron-to-chromium "^1.3.247"
+    node-releases "^1.1.29"
+
 bser@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/bser/-/bser-2.1.0.tgz#65fc784bf7f87c009b973c12db6546902fa9c7b5"
@@ -1727,6 +1990,11 @@ buffers@~0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/buffers/-/buffers-0.1.1.tgz#b24579c3bed4d6d396aeee6d9a8ae7f5482ab7bb"
   integrity sha1-skV5w77U1tOWru5tmorn9Ugqt7s=
+
+builtin-modules@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-3.1.0.tgz#aad97c15131eb76b65b50ef208e7584cd76a7484"
+  integrity sha512-k0KL0aWZuBt2lrxrcASWDfwOLMnodeQjodT/1SxEQAXsHANgo6ZC/VEaSEHCXt7aSTZ4/4H5LKa+tBXmW7Vtvw==
 
 bytes@3.0.0:
   version "3.0.0"
@@ -1808,6 +2076,11 @@ camelcase@^5.0.0, camelcase@^5.3.1:
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
+
+caniuse-lite@^1.0.30000989:
+  version "1.0.30000999"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000999.tgz#427253a69ad7bea4aa8d8345687b8eec51ca0e43"
+  integrity sha512-1CUyKyecPeksKwXZvYw0tEoaMCo/RwBlXmEtN5vVnabvO0KPd9RQLcaAuR9/1F+KDMv6esmOFWlsXuzDk+8rxg==
 
 capture-exit@^1.2.0:
   version "1.2.0"
@@ -2119,6 +2392,14 @@ copy-descriptor@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
   integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
+
+core-js-compat@^3.1.1:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.3.2.tgz#1096c989c1b929ede06b5b6b4768dc4439078c03"
+  integrity sha512-gfiK4QnNXhnnHVOIZst2XHdFfdMTPxtR0EGs0TdILMlGIft+087oH6/Sw2xTTIjpWXC9vEwsJA8VG3XTGcmO5g==
+  dependencies:
+    browserslist "^4.7.0"
+    semver "^6.3.0"
 
 core-js@^1.0.0:
   version "1.2.7"
@@ -2527,6 +2808,11 @@ ee-first@1.1.1:
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
   integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
 
+electron-to-chromium@^1.3.247:
+  version "1.3.282"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.282.tgz#16118ae9c79a32ea93a17591d5b16e28d10fc08d"
+  integrity sha512-irSaDeCGgfMu1OA30bhqIBr+dx+pDJjRbwCpob7YWqVZbzXblybNzPGklVnWqv4EXxbkEAzQYqiNCqNTgu00lQ==
+
 emoji-regex@^7.0.1, emoji-regex@^7.0.2:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-7.0.3.tgz#933a04052860c85e83c122479c4748a8e4c72156"
@@ -2884,6 +3170,11 @@ estraverse@^4.0.0, estraverse@^4.1.0, estraverse@^4.1.1, estraverse@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.2.0.tgz#0dee3fed31fcd469618ce7342099fc1afa0bdb13"
   integrity sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=
+
+estree-walker@^0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-0.6.1.tgz#53049143f40c6eb918b23671d1fe3219f3a1b362"
+  integrity sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==
 
 esutils@^2.0.0, esutils@^2.0.2:
   version "2.0.3"
@@ -4163,6 +4454,11 @@ is-glob@^2.0.0, is-glob@^2.0.1:
   dependencies:
     is-extglob "^1.0.0"
 
+is-module@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-module/-/is-module-1.0.0.tgz#3258fb69f78c14d5b815d664336b4cffb6441591"
+  integrity sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=
+
 is-number@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-2.1.0.tgz#01fcbbb393463a548f2f466cce16dece49db908f"
@@ -4770,6 +5066,11 @@ jest@^24.9.0:
   dependencies:
     import-local "^2.0.0"
     jest-cli "^24.9.0"
+
+js-levenshtein@^1.1.3:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/js-levenshtein/-/js-levenshtein-1.1.6.tgz#c6cee58eb3550372df8deb85fad5ce66ce01d59d"
+  integrity sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==
 
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
@@ -6096,6 +6397,13 @@ node-pre-gyp@^0.12.0:
     rimraf "^2.6.1"
     semver "^5.3.0"
     tar "^4"
+
+node-releases@^1.1.29:
+  version "1.1.35"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.35.tgz#32a74a3cd497aa77f23d509f483475fd160e4c48"
+  integrity sha512-JGcM/wndCN/2elJlU0IGdVEJQQnJwsLbgPCFd2pY7V0mxf17bZ0Gb/lgOtL29ZQhvEX5shnVhxQyZz3ex94N8w==
+  dependencies:
+    semver "^6.3.0"
 
 nopt@^4.0.1:
   version "4.0.1"
@@ -7446,7 +7754,7 @@ redux@^4.0.0:
     loose-envify "^1.4.0"
     symbol-observable "^1.2.0"
 
-regenerate-unicode-properties@^8.0.2:
+regenerate-unicode-properties@^8.0.2, regenerate-unicode-properties@^8.1.0:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/regenerate-unicode-properties/-/regenerate-unicode-properties-8.1.0.tgz#ef51e0f0ea4ad424b77bf7cb41f3e015c70a3f0e"
   integrity sha512-LGZzkgtLY79GeXLm8Dp0BVLdQlWICzBnJz/ipWUgo59qBaZ+BHtq51P2q1uVZlppMuUAT37SDk39qUbjTWB7bA==
@@ -7507,6 +7815,18 @@ regexpu-core@^4.5.4:
   dependencies:
     regenerate "^1.4.0"
     regenerate-unicode-properties "^8.0.2"
+    regjsgen "^0.5.0"
+    regjsparser "^0.6.0"
+    unicode-match-property-ecmascript "^1.0.4"
+    unicode-match-property-value-ecmascript "^1.1.0"
+
+regexpu-core@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/regexpu-core/-/regexpu-core-4.6.0.tgz#2037c18b327cfce8a6fea2a4ec441f2432afb8b6"
+  integrity sha512-YlVaefl8P5BnFYOITTNzDvan1ulLOiXJzCNZxduTIosN17b87h3bvG9yHMoHaRuo88H4mQ06Aodj5VtYGGGiTg==
+  dependencies:
+    regenerate "^1.4.0"
+    regenerate-unicode-properties "^8.1.0"
     regjsgen "^0.5.0"
     regjsparser "^0.6.0"
     unicode-match-property-ecmascript "^1.0.4"
@@ -7646,7 +7966,7 @@ resolve@1.1.7:
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
   integrity sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=
 
-resolve@^1.1.6, resolve@^1.10.0, resolve@^1.10.1, resolve@^1.11.0, resolve@^1.3.2, resolve@^1.5.0, resolve@^1.8.1:
+resolve@^1.1.6, resolve@^1.10.0, resolve@^1.10.1, resolve@^1.11.0, resolve@^1.11.1, resolve@^1.3.2, resolve@^1.5.0, resolve@^1.8.1:
   version "1.12.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.12.0.tgz#3fc644a35c84a48554609ff26ec52b66fa577df6"
   integrity sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==
@@ -7697,6 +8017,41 @@ rn-fetch-blob@^0.10.15:
   dependencies:
     base-64 "0.1.0"
     glob "7.0.6"
+
+rollup-plugin-babel@^4.3.3:
+  version "4.3.3"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-babel/-/rollup-plugin-babel-4.3.3.tgz#7eb5ac16d9b5831c3fd5d97e8df77ba25c72a2aa"
+  integrity sha512-tKzWOCmIJD/6aKNz0H1GMM+lW1q9KyFubbWzGiOG540zxPPifnEAHTZwjo0g991Y+DyOZcLqBgqOdqazYE5fkw==
+  dependencies:
+    "@babel/helper-module-imports" "^7.0.0"
+    rollup-pluginutils "^2.8.1"
+
+rollup-plugin-node-resolve@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-5.2.0.tgz#730f93d10ed202473b1fb54a5997a7db8c6d8523"
+  integrity sha512-jUlyaDXts7TW2CqQ4GaO5VJ4PwwaV8VUGA7+km3n6k6xtOEacf61u0VXwN80phY/evMcaS+9eIeJ9MOyDxt5Zw==
+  dependencies:
+    "@types/resolve" "0.0.8"
+    builtin-modules "^3.1.0"
+    is-module "^1.0.0"
+    resolve "^1.11.1"
+    rollup-pluginutils "^2.8.1"
+
+rollup-pluginutils@^2.8.1:
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz#72f2af0748b592364dbd3389e600e5a9444a351e"
+  integrity sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==
+  dependencies:
+    estree-walker "^0.6.1"
+
+rollup@^1.23.1:
+  version "1.24.0"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-1.24.0.tgz#0ace969508babb7a5fcb228e831e9c9a2873c2b0"
+  integrity sha512-PiFETY/rPwodQ8TTC52Nz2DSCYUATznGh/ChnxActCr8rV5FIk3afBUb3uxNritQW/Jpbdn3kq1Rwh1HHYMwdQ==
+  dependencies:
+    "@types/estree" "*"
+    "@types/node" "*"
+    acorn "^7.1.0"
 
 rsvp@^3.3.3:
   version "3.6.2"
@@ -7823,7 +8178,7 @@ semver@5.5.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
   integrity sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==
 
-semver@^6.0.0, semver@^6.2.0:
+semver@^6.0.0, semver@^6.2.0, semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==


### PR DESCRIPTION
A comedy in three (somewhat intertwined) acts:
  * Use Rollup to collect and collapse ES6 modules into a single file.
  * Extend the Jest environment to allow mimicking a browser at an arbitrary URL.
  * Extract a single function from the webview JS and test it.
