### PR TITLE
Fix invocation of bash script from Gradle on Windows

### DIFF
--- a/android/app/webviewAssets.gradle
+++ b/android/app/webviewAssets.gradle
@@ -1,3 +1,6 @@
+import org.apache.tools.ant.taskdefs.condition.Os
+import java.nio.file.Paths
+
 /**
  * Build and merge static webview assets.
  *
@@ -6,6 +9,49 @@
  * processes. See comments therein (or $ROOT/src/webview/static/README.md) for
  * more information.
  */
+
+/*
+ * Windows support functions.
+ *
+ * On Windows, we have three different possible setups:
+ *   1. Windows Gradle + Git Bash.
+ *   2. Windows Gradle + WSL's bash.
+ *   3. WSL Gradle + WSL's bash.
+ *
+ * Case 3, fortunately, should behave exactly like Linux.
+ *
+ * In cases 1 and 2, however, all paths Gradle provides are backslash-separated.
+ * This is problematic on its own, as the script we're invoking doesn't grok
+ * backslashes, so we normalize those on Windows. That's enough for case 1.
+ *
+ * Case 2 is worse, though. The `bash` of Git Bash groks both "C:/" and "C:\";
+ * more generally, it operates on the Windows filesystem with Windows path
+ * names. The WSL `bash` _doesn't_ -- it's a standard Linux `bash` (or close
+ * enough), and it only sees the Windows disks as ordinary mounts under the lone
+ * root path '/'. Paths beginning with either "C:/" or "C:\" will confuse it
+ * terribly.
+ *
+ * And, of course, Gradle has no good way of distinguishing between cases 1 and
+ * 2. As far as it's concerned, `bash.exe` is `bash.exe`.
+ *
+ * Since we can't predict the environment of our callee, we can't use absolute
+ * paths. Fortunately, with only a little extra work within the script itself,
+ * we _can_ use relative paths; the script must derelativize them appropriately.
+ */
+
+/** Normalize the path-separators of `path` to be forward slashes. */
+def normalizePath(String path) {
+    if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+        return path.replace('\\', '/')
+    } else {
+        return path
+    }
+}
+
+/** Return `path`, made relative to `basePath`. */
+def relativizePath(String path, String basePath) {
+    return Paths.get(basePath).relativize(Paths.get(path)).toString();
+}
 
 gradle.projectsEvaluated {
     // The root of our git repository.
@@ -24,8 +70,13 @@ gradle.projectsEvaluated {
             name: "build${variant.name.capitalize()}StaticWebviewAssets",
             type: Exec
         ) {
-            executable "${repoDir}/tools/build-webview"
-            args "android", "--destination", "${assetsDir}/webview"
+            // All arguments to our script must be relative to `workingDir`.
+            workingDir repoDir
+            executable "bash"
+            args "./tools/build-webview",
+                "android", "--destination",
+                // See above note on Windows compatibility.
+                normalizePath(relativizePath("${assetsDir}/webview", repoDir))
         }
 
         // Run this task as part of assets merging for this variant.

--- a/docs/howto/build-run.md
+++ b/docs/howto/build-run.md
@@ -4,9 +4,10 @@ This guide describes how to build and run the app so you can develop it.
 
 ## Main steps
 
-(First, if using **macOS**: Upgrade to the latest version of the OS and then
-to the latest Xcode.  In particular, Xcode versions before 9.0 are known to
-definitely not work.)
+(First, if using **macOS**: Upgrade to the latest version of the OS and then to
+the latest Xcode.  In particular, Xcode versions before 9.0 are known to
+definitely not work. You'll also need the GNU coreutils package from Homebrew,
+installable via `brew install coreutils`.)
 
 (If using **Windows**: The step-by-step instructions below should work
 fine on Windows.  Alternatively if you'd like a richer command-line

--- a/docs/howto/build-run.md
+++ b/docs/howto/build-run.md
@@ -6,8 +6,10 @@ This guide describes how to build and run the app so you can develop it.
 
 (First, if using **macOS**: Upgrade to the latest version of the OS and then to
 the latest Xcode.  In particular, Xcode versions before 9.0 are known to
-definitely not work. You'll also need the GNU coreutils package from Homebrew,
-installable via `brew install coreutils`.)
+definitely not work.  You'll also need [GNU coreutils][] installed, e.g.
+with `brew install coreutils`.)
+
+[GNU coreutils]: https://www.gnu.org/software/coreutils/
 
 (If using **Windows**: The step-by-step instructions below should work
 fine on Windows.  Alternatively if you'd like a richer command-line

--- a/tools/build-webview
+++ b/tools/build-webview
@@ -25,7 +25,7 @@ EOF
 
 # print error and die
 err() {
-    echo "$0:" $'\e[31merror:\e[0m' "$1" >&2
+    echo -e "$0:" $'\e[31merror:\e[0m' "$@" >&2
     exit 1;
 }
 

--- a/tools/build-webview
+++ b/tools/build-webview
@@ -29,8 +29,6 @@ err() {
     exit 1;
 }
 
-
-
 ################################################################################
 # Parameters and environment
 ################################################################################
@@ -38,6 +36,8 @@ err() {
 # chdir to the current git repo's root
 ROOT="$(git rev-parse --show-toplevel)"
 cd "$ROOT"
+
+. "$ROOT"/tools/lib/ensure-coreutils.sh
 
 # Parse arguments. Sloppy, but sufficient for now.
 unset TARGET
@@ -61,6 +61,9 @@ if  [ -z "${TARGET-}" ]; then
 elif [ -z "${DEST-}" ]; then
     usage; exit 2
 fi
+
+# Make $DEST absolute, if it isn't already.
+DEST=$(readlink -m "$DEST")
 
 # Sanity-check DEST and TARGET.
 case "$TARGET" in

--- a/tools/lib/ensure-coreutils.sh
+++ b/tools/lib/ensure-coreutils.sh
@@ -4,17 +4,34 @@
 # Ensures GNU coreutils are available in PATH.
 # May add to PATH, or exit with a message to stderr.
 #
-# We don't yet have good docs for handling failure here if on
-# Windows or macOS, so until then this isn't suitable for scripts
-# used in normal development -- only for maintainer-facing scripts.
+# The GNU coreutils are a basic piece of infrastructure for having
+# a reasonable 21st-century shell scripting environment, so we
+# freely invoke this in any of our scripts that need `readlink -f`
+# or other features not always found without them.
+#
+# On any GNU/Linux system this is of course a non-issue.  Likewise
+# on Windows: we inevitably require Git, and Git for Windows comes
+# with a GNU environment called "Git BASH", based on MSYS2.
+#
+# So this is really all about macOS.  Fortunately it's easy to get
+# coreutils installed there too... plus, many people already have
+# it installed but just not in their PATH.  We write our scripts
+# for a GNU environment, so we bring it into the PATH.
 
 check_coreutils() {
+    # Check a couple of commands for GNU-style --help and --version,
+    # which macOS's default BSD-based implementations don't understand.
     fmt --help >/dev/null 2>&1
+    readlink --version 2>&1 | grep -q GNU
 }
 
 ensure_coreutils() {
+    # If we already have it, then great.
     check_coreutils && return
 
+    # Homebrew provides names like `greadlink` on the PATH,
+    # but also provides the standard names in this directory.
+    # Try that.
     homebrew_gnubin=/usr/local/opt/coreutils/libexec/gnubin
     if [ -d "$homebrew_gnubin" ]; then
         export PATH="$homebrew_gnubin":"$PATH"
@@ -24,8 +41,10 @@ ensure_coreutils() {
     cat >&2 <<EOF
 This script requires GNU coreutils.
 
-Install from your favorite package manager, or from:
+Install from upstream:
   https://www.gnu.org/software/coreutils/
+or from your favorite package manager; for example:
+  brew install coreutils
 EOF
     return 2
 }


### PR DESCRIPTION
Sadly, this was more complicated than it looked, due to WSL/MSYS disagreements. (See comments.)

As a side effect, for the sake of script-maintainers' sanity, macOS users are now required to install `coreutils`.