### PR TITLE
Write up our approach to supporting old platforms; drop KitKat

### DIFF
--- a/android/app/src/main/java/com/zulipmobile/notifications/FCMPushNotifications.kt
+++ b/android/app/src/main/java/com/zulipmobile/notifications/FCMPushNotifications.kt
@@ -156,22 +156,16 @@ private fun getNotificationBuilder(
 
     builder.setDefaults(Notification.DEFAULT_VIBRATE or Notification.DEFAULT_LIGHTS)
 
-    if (Build.VERSION.SDK_INT > Build.VERSION_CODES.KITKAT) {
-        val dismissIntent = Intent(context, NotificationIntentService::class.java)
-        dismissIntent.action = ACTION_CLEAR
-        val piDismiss = PendingIntent.getService(context, 0, dismissIntent, 0)
-        val action = Notification.Action(android.R.drawable.ic_menu_close_clear_cancel, "Clear", piDismiss)
-        builder.addAction(action)
-    }
+    val dismissIntent = Intent(context, NotificationIntentService::class.java)
+    dismissIntent.action = ACTION_CLEAR
+    val piDismiss = PendingIntent.getService(context, 0, dismissIntent, 0)
+    val action = Notification.Action(android.R.drawable.ic_menu_close_clear_cancel, "Clear", piDismiss)
+    builder.addAction(action)
 
     val soundUri = getNotificationSoundUri(context)
-    if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.LOLLIPOP) {
-        val audioAttr = AudioAttributes.Builder()
-            .setUsage(AudioAttributes.USAGE_NOTIFICATION).build()
-        builder.setSound(soundUri, audioAttr)
-    } else {
-        builder.setSound(soundUri)
-    }
+    val audioAttr = AudioAttributes.Builder()
+        .setUsage(AudioAttributes.USAGE_NOTIFICATION).build()
+    builder.setSound(soundUri, audioAttr)
     return builder
 }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         // The oldest Android version we support.  Increasing this stops updates
         // for users on old devices, but can simplify the system.  Synced with
         // our dev docs: docs/developer-guide.md
-        minSdkVersion = 19
+        minSdkVersion = 21
 
         // A bit subtle: we should try to keep this at the latest version,
         // but some testing is required and code changes are often required.

--- a/docs/architecture/platform-versions.md
+++ b/docs/architecture/platform-versions.md
@@ -83,10 +83,16 @@ History:
 * We [dropped iOS 9 support][] in 2019-07.  It was 0.4% of iOS users
   who tried Zulip, and an Xcode upgrade had dropped iOS 9 from the
   simulator.
+* We [dropped Android 4.4 KitKat support][dropped-android-k] in
+  2019-10.  It represented 0.6% of our Android users, and we'd just
+  discovered that we'd been mistaken in thinking since 2018 that its
+  WebView browser got updated independently; in fact it's pinned at a
+  version a couple of years older than any other browser we support.
 
 [dropped-android-j]: https://chat.zulip.org/#narrow/stream/48-mobile/topic/platform.20versions/near/625585
 [dropped iOS 8 support]: https://chat.zulip.org/#narrow/stream/48-mobile/topic/platform.20versions/near/628412
 [dropped iOS 9 support]: https://chat.zulip.org/#narrow/stream/48-mobile/topic/platform.20versions/near/771761
+[dropped-android-k]: https://chat.zulip.org/#narrow/stream/48-mobile/topic/platform.20versions/near/794551
 
 
 Related observations:
@@ -188,8 +194,8 @@ General policy:
 
 Empirical details on Android Chrome versions found in WebViews:
 
-* Starting in Android 4.4 KitKat (which is <= our minimum supported
-  Android version), the browser in a WebView is updated as an APK 🎉,
+* Starting in Android 5 Lollipop (which is <= our minimum supported
+  Android version), the browser in a WebView [is updated as an APK][] 🎉,
   independently of the OS...
   * but [empirically][browser-data-2018-10] something like 10% of
     users are stuck on older versions than the latest 😞.
@@ -211,13 +217,14 @@ Empirical details on Android Chrome versions found in WebViews:
     have the same version.  But they get updated the same way, so
     there's at least no obvious mechanism for one to be systematically
     more commonly up to date than the other.)
-  * Android versions 4.4 K, 5 L, 6 M, 7 N, 8 O had originally shipped
-    with Chrome versions 30, 37, 44, 51, 58 respectively (based on
+  * Android versions 5 L, 6 M, 7 N, 8 O had originally shipped
+    with Chrome versions 37, 44, 51, 58 respectively (based on
     looking at stock emulator images.)
   * At that time about 17% of our Android users were on Android
     versions <=6 M -- far more than the 2% or so of Android users with
     Chrome versions older than what shipped with Android 7 N.
 
+[is updated as an APK]: https://developer.chrome.com/multidevice/webview/overview
 [browser-data-2018-10]: https://chat.zulip.org/#narrow/stream/48-mobile/topic/platform.20versions/near/656679
 
 

--- a/docs/architecture/platform-versions.md
+++ b/docs/architecture/platform-versions.md
@@ -238,3 +238,11 @@ Related observations:
     it makes the app slower and more battery-draining for all users --
     which is why we don't pursue it.  See discussion in
     `tools/generate-webview-js` for details.
+
+
+* For more about how WebView implementations are tied to Chrome
+  versions -- which has changed several times! -- see the WebView
+  docs [on pre-release channels][webview-docs/channels].  Handy in
+  particular for trying beta versions of Chrome.
+
+[webview-docs/channels]: https://chromium.googlesource.com/chromium/src/+/HEAD/android_webview/docs/channels.md

--- a/docs/architecture/platform-versions.md
+++ b/docs/architecture/platform-versions.md
@@ -1,0 +1,190 @@
+# Platform versions we support
+
+## Android and iOS versions
+
+### Policy
+
+For our current minimum versions of Android and iOS, see [the
+developer guide](../developer-guide.md).
+
+Our general policy is:
+
+* We routinely test and develop on the latest 1-2 versions of each of
+  iOS and Android.
+
+* We support older versions with primarily a lazy algorithm: when we
+  learn about bugs, we fix them.
+  * Also when writing platform-specific code, we rely on the
+    facilities of the IDE (Android Studio or Xcode) to point out when
+    an API doesn't exist on old versions, and write an appropriate
+    conditional.
+
+* Once the use of an old OS version (plus any older versions) falls
+  below about 1-2% of our overall userbase on that platform, then if
+  we learn things don't work or require effort to keep working, we
+  just drop support for it.
+
+* A few times a year, we consult updated statistics on what OS
+  versions our users are using.  These are posted in [a long-running
+  chat thread][versions-thread] on `#mobile`, and help inform
+  decisions to drop support for a version as well as when to
+  prioritize a feature that only works on new versions.
+
+[versions-thread]: https://chat.zulip.org/#narrow/stream/48-mobile/topic/platform.20versions/near/786467
+
+
+### Data and commentary
+
+Empirically, the way this works out is:
+
+* Those 1-2 latest versions cover the majority of our users.
+  * For example, when Android 10 was released in 2019-09, [Android 9
+    was already][data-2019-09-android] on over 60% of our Android
+    users' devices, and Android 8+ were on over 80%.
+  * Similarly but more so: shortly before iOS 13 was released in
+    2019-09, [iOS 12 was already][data-2019-09-ios] on over 95% of our
+    iOS users' devices.
+
+* Bug reports that turn out to be specific to an older OS version are
+  vanishingly rare.
+  * Of issues filed in the tracker, these seem to be <1% of them.
+  * Of reviews on Google Play, a small fraction are from older OS
+    versions, consistent with the distribution in our userbase, and
+    the ratings in these reviews are consistent with our ratings
+    overall.
+    * Of the 43 reviews in the past year as of 2019-10, 1 is from
+      Android 4.4 KitKat; 0 from Android 5 Lollipop; 4 from Android 6
+      Marshmallow.  That's 5/43 = 12% on Android <=6.  Over the same
+      period the fraction of our userbase on Android <=6 ranged from
+      17% down to 8%, so that's right in line.
+    * Moreover, as of late 2019, every complaint we've seen in these
+      reviews is one we also hear from people on the latest OS
+      versions.
+  * Put another way: anything we're missing in our support for old
+    OS versions doesn't rank among the most important issues with
+    Zulip even for people using those versions.
+
+* Among the complaints we hear from people who try using Zulip, we
+  rarely (possibly never?) hear that the app didn't support their
+  older device.  Meanwhile there are plenty of complaints we do hear
+  regularly!
+
+[data-2019-09-android]: https://chat.zulip.org/#narrow/stream/48-mobile/topic/platform.20versions/near/786475
+[data-2019-09-ios]: https://chat.zulip.org/#narrow/stream/48-mobile/topic/platform.20versions/near/786471
+
+
+History:
+* We [dropped Android 4.1-4.3 Jelly Bean support][dropped-android-j]
+  in 2018-08.  It represented 0.5% of our Android users, and we hadn't
+  tested on it in a long time if ever.  Shortly thereafter, we
+  confirmed that the app rendered quite badly there.
+* We [dropped iOS 8 support][] in 2018-08.  It represented <1% of iOS
+  users who tried Zulip, and we'd learned that it didn't run there.
+* We [dropped iOS 9 support][] in 2019-07.  It was 0.4% of iOS users
+  who tried Zulip, and an Xcode upgrade had dropped iOS 9 from the
+  simulator.
+
+[dropped-android-j]: https://chat.zulip.org/#narrow/stream/48-mobile/topic/platform.20versions/near/625585
+[dropped iOS 8 support]: https://chat.zulip.org/#narrow/stream/48-mobile/topic/platform.20versions/near/628412
+[dropped iOS 9 support]: https://chat.zulip.org/#narrow/stream/48-mobile/topic/platform.20versions/near/771761
+
+
+Related observations:
+
+* Our userbase tends to be far more updated than the ecosystem at
+  large, especially on Android.
+
+  * For example, as of May 2019, Android 5 "Lollipop" (released in
+    2014) and later had reached 88.5% of all devices connecting to
+    Google Play; among users with Zulip installed, it had reached
+    99.1% in figures from the previous month.
+
+  * Broadly, the ratio new:old of devices which have at least a given
+    version vs. those with an earlier version tends to be about 5-10x
+    more for our Android users than for those on Google Play at large.
+
+
+## Browser versions (for the WebView for the message list)
+
+### Policy
+
+For our current minimum versions of Chrome and (Mobile) Safari, see
+the block comment at the top of `js.js`.
+
+General policy:
+
+* Our basic approach is the same as for OS versions:
+
+  * We routinely test and develop on up-to-date platforms.
+
+  * We support older versions primarily by a lazy algorithm; plus
+    before using a fancy feature we consult a compatibility table,
+    e.g. on MDN or on caniuse.com.
+
+  * When an older version (and below) falls below 1-2% of our overall
+    userbase, we simply drop support for it if faced with significant
+    effort to keep it working.
+
+* On iOS, there's little more to say, because the Safari version
+  corresponds directly to the iOS version.  So for example so we'll
+  support Mobile Safari 13 for exactly as long as we support iOS 13.
+
+* On Android, we have additional choices, because the Chrome version
+  (including in a WebView) is generally much more recent than the OS.
+
+  * As a result, we may drop support for old Chrome versions as much
+    as 2-3 years more recent than our oldest supported Android
+    version.
+
+  * Our support thresholds are always a version found in a stock
+    emulator image for some past Android release, for practicality of
+    testing.
+
+
+### Data and commentary
+
+Empirical details on Android Chrome versions found in WebViews:
+
+* Starting in Android 4.4 KitKat (which is <= our minimum supported
+  Android version), the browser in a WebView is updated as an APK 🎉,
+  independently of the OS...
+  * but [empirically][browser-data-2018-10] something like 10% of
+    users are stuck on older versions than the latest 😞.
+  * On the other hand, even of those 10%, a large majority still have
+    newer versions than their OS was released with.
+
+* In [data from 2018-10][browser-data-2018-10] based on web traffic to
+  zulipchat.com, we found:
+  * Among Chrome users on Android, about 90% had a "latest" version:
+    either Chrome 69 or Chrome 70, as Chrome 70 was then in the middle
+    of rolling out.
+  * About 98% had at least Chrome 49.  That version was released
+    2016-03, about 2.5 years earlier.
+  * The oldest version in the data (excluding one that appeared to be
+    an emulator, not a real user's device) was Chrome 37.
+  * (These data don't precisely track what we really want to know: the
+    mix of users may be different, and on some OS releases Chrome and
+    the WebView implementation are separate APKs so may not always
+    have the same version.  But they get updated the same way, so
+    there's at least no obvious mechanism for one to be systematically
+    more commonly up to date than the other.)
+  * Android versions 4.4 K, 5 L, 6 M, 7 N, 8 O had originally shipped
+    with Chrome versions 30, 37, 44, 51, 58 respectively (based on
+    looking at stock emulator images.)
+  * At that time about 17% of our Android users were on Android
+    versions <=6 M -- far more than the 2% or so of Android users with
+    Chrome versions older than what shipped with Android 7 N.
+
+[browser-data-2018-10]: https://chat.zulip.org/#narrow/stream/48-mobile/topic/platform.20versions/near/656679
+
+
+Related observations:
+
+* One strategy people use for dealing with old browsers is to
+  automatically introduce polyfills en masse, e.g. from `core-js`
+  driven by `@babel/preset-env`.
+
+  * This has a significant cost in size and speed of code -- meaning
+    it makes the app slower and more battery-draining for all users --
+    which is why we don't pursue it.  See discussion in
+    `tools/generate-webview-js` for details.

--- a/docs/architecture/platform-versions.md
+++ b/docs/architecture/platform-versions.md
@@ -103,6 +103,49 @@ Related observations:
     version vs. those with an earlier version tends to be about 5-10x
     more for our Android users than for those on Google Play at large.
 
+* Android [upstream's advice][android-doc-supporting-platforms] is:
+
+  > Generally, it’s a good practice to support about 90% of the active devices
+
+  with a link to the dashboard of [global Google Play figures][].
+  Based on the May 2019 figures quoted above, this advice roughly
+  corresponds to dropping an old platform at a threshold of about 1%
+  of our userbase.
+
+[android-doc-supporting-platforms]: https://developer.android.com/training/basics/supporting-devices/platforms
+[global Google Play figures]: https://developer.android.com/about/dashboards/
+
+
+* On both the Play Store and the App Store, when we upload a new app
+  version that drops support for a given OS version, that appears to
+  make the app unavailable to install on devices with older versions.
+
+  * We haven't seen clear documentation of this; but we confirmed
+    empirically in 2019-10 (a little over a year after dropping
+    Android 4.1-4.3 J support) that an Android J device couldn't see
+    Zulip on the Play Store.
+
+  * Also in 2019-10, the [App Store listing][] (on the web) for Zulip
+    had a line "Compatibility: Requires iOS 10.3 or later.", which
+    matches the metadata in our uploaded app versions of the previous
+    few months.
+
+  * On the other hand, in the Play Console under ["Release management >
+    Artifact library"][play-artifact-library], the last APK that did
+    still support Android J still appears (as of 2019-10) under
+    "Active artifacts" -- which is glossed "Artifacts being served to
+    device configurations" -- rather than "Archived artifacts".
+
+    It's not made entirely clear what that means.  One sensible thing
+    that might mean (but we haven't confirmed it does mean) would be
+    that an Android J device which already had a previous version of
+    Zulip will upgrade as far as that version, even while an Android J
+    device that doesn't already have Zulip won't be shown it for a
+    fresh install.
+
+[App Store listing]: https://apps.apple.com/us/app/zulip/id1203036395
+[play-artifact-library]: https://play.google.com/apps/publish/?account=8060868091387311598#ArtifactLibraryPlace:p=com.zulipmobile
+
 
 ## Browser versions (for the WebView for the message list)
 

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -1,7 +1,7 @@
 # Developer guide
 
-We target operating systems >= Android 4.4 (API 19) and >= iOS 10.3.
-(Details [here](architecture/platform-versions.md).)
+We target operating systems >= Android 5 Lollipop (API 21)
+and >= iOS 10.3.  (Details [here](architecture/platform-versions.md).)
 
 ## Why React Native?
 

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -1,6 +1,7 @@
 # Developer guide
 
 We target operating systems >= Android 4.4 (API 19) and >= iOS 10.3.
+(Details [here](architecture/platform-versions.md).)
 
 ## Why React Native?
 

--- a/src/webview/js/js.js
+++ b/src/webview/js/js.js
@@ -30,7 +30,7 @@ import appendAuthToImages from './appendAuthToImages';
  *     more recent than the Safari on most iOS devices.)
  *
  *   * Below Chrome 44, it's possible (but rare) for a user to be on a
- *     version as old as Chrome 30, which shipped with Android 4.4 KitKat.
+ *     version as old as Chrome 37, which shipped with Android 5 Lollipop.
  *     We sometimes fix issues affecting those versions, only when trivial.
  *
  * * See docs/architecture/platform-versions.md for data and discussion

--- a/src/webview/js/js.js
+++ b/src/webview/js/js.js
@@ -19,24 +19,22 @@ import appendAuthToImages from './appendAuthToImages';
  * * We support iOS 10.  So this code needs to work on Mobile Safari 10.
  *   Graceful degradation is acceptable below iOS 12 / Mobile Safari 12.
  *
- * * On Android, core functionality needs to work on Chrome 44 (conveniently
- *   available for testing in a stock Android 6.0 Marshmallow image.)
- *   Graceful degradation is acceptable below Chrome 58 (ditto 8.0 Oreo.)
- *   When aware of issues down to Chrome 30 (shipped with 4.4 KitKat), we
- *   fix them if trivial, or else record in comments here.
+ * * For Android, core functionality needs to work on Chrome 44.
+ *   Graceful degradation is acceptable below Chrome 58.
  *
- *   * More details: Starting in Android 4.4 KitKat, which is our minimum
- *     supported Android version, the browser in a WebView is updated as an
- *     APK, independently of the OS... but empirically something like 10% of
- *     users are stuck on older versions than the latest, though usually
- *     still newer than their OS was released with.  These targets are based
- *     on figures from 2018-10.
+ *   * These versions are found in stock images for Android 6 Marshmallow
+ *     and Android 8 Oreo, respectively, for convenient testing.
  *
- *   * To be explicit: although we support Android as old as 4.4 and 5.0,
- *     the app *doesn't work correctly* on the Chrome versions (30 and 37)
- *     that those Android releases originally shipped with.  That's OK
- *     because it is rare for a user's Chrome version to still be that
- *     ancient, even when their Android version is.
+ *   * (Note that Android's Chrome auto-updates independently of the OS, and
+ *     the large majority of Android users have a fully-updated Chrome --
+ *     more recent than the Safari on most iOS devices.)
+ *
+ *   * Below Chrome 44, it's possible (but rare) for a user to be on a
+ *     version as old as Chrome 30, which shipped with Android 4.4 KitKat.
+ *     We sometimes fix issues affecting those versions, only when trivial.
+ *
+ * * See docs/architecture/platform-versions.md for data and discussion
+ *   about our version-support strategy.
  */
 
 /** Like RN's `Platform.OS`. */

--- a/tools/generate-webview-js
+++ b/tools/generate-webview-js
@@ -143,8 +143,8 @@ ${es3Code.replace(/\\/g, '\\\\')}
  * For all that, `core-js` _does_ work. Using it, or not using it, is a
  * tradeoff... but then, so is supporting older WebViews at all.
  *
- * See the comments heading `js.js` for details about our version-support
- * strategy.
+ * See docs/architecture/platform-versions.md for details about our
+ * version-support strategy.
  */
 
 /**


### PR DESCRIPTION
Much of this is data we already had in various places, pulled together into one; together with ways I'd been thinking about this but never written down in prose.

A thought I hadn't previously put together was:

* Among the complaints we hear from people who try using Zulip, we
  rarely (possibly never?) hear that the app didn't support their
  older device.  Meanwhile there are plenty of complaints we do hear
  regularly!

And this reflects data I compiled for the first time while writing this up:

* Bug reports that turn out to be specific to an older OS version are
  vanishingly rare.
  * Of issues filed in the tracker, these seem to be <1% of them.
  * Of reviews on Google Play, a small fraction are from older OS
    versions, consistent with the distribution in our userbase, and
    the ratings in these reviews are consistent with our ratings
    overall.
    * Of the 43 reviews in the past year as of 2019-10, 1 is from
      Android 4.4 KitKat; 0 from Android 5 Lollipop; 4 from Android 6
      Marshmallow.  That's 5/43 = 12% on Android <=6.  Over the same
      period the fraction of our userbase on Android <=6 ranged from
      17% down to 8%, so that's right in line.
    * Moreover, as of late 2019, every complaint we've seen in these
      reviews is one we also hear from people on the latest OS
      versions.
  * Put another way: anything we're missing in our support for old
    OS versions doesn't rank among the most important issues with
    Zulip even for people using those versions.

Pulling this all together left me half-convinced it's time already we should drop support for Android 4.4 KitKat, bumping the `minSdkVersion` to 21 aka Android 5 Lollipop.

This branch doesn't change any of the concrete threshold versions we support, though; just adds a bunch of discussion and data, and reorganizes slightly.

---

**EDIT:** After discussion below, now it does: the later commits drop support for KitKat.
