### PR TITLE
Enable end to end testing via Pirlo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,10 @@ jdk: oraclejdk8
 
 env:
   global:
-    - ANDROID_HOME=${TRAVIS_BUILD_DIR}/android-sdk
-    - PATH=${ANDROID_HOME}/:${ANDROID_HOME}/tools/:${ANDROID_HOME}/platform-tools/:${PATH}
+    - COVERALLS_REPO_TOKEN=4eYQDtWoBJlDz2QkxoQ2UcnmJFcOB7zkv
+  jobs:
+    - TEST_SUITE=''
+    - TEST_SUITE=functional
 
 android:
   components:
@@ -43,8 +45,5 @@ install:
   - echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
 
 script:
-  - TERM=dumb tools/test --full
+  - TERM=dumb tools/test --full ${TEST_SUITE}
   - tools/verify-webview-js
-
-env:
-  - COVERALLS_REPO_TOKEN=4eYQDtWoBJlDz2QkxoQ2UcnmJFcOB7zkv

--- a/tools/pirlo-tests.sh
+++ b/tools/pirlo-tests.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -e
+echo "Downloading pirlo-cli tool"
+curl https://pirlo-downloads.s3-us-west-1.amazonaws.com/pirlo-cli/pirlo-cli -o pirlo-cli
+
+chmod a+x pirlo-cli
+
+echo "Initiating a new automated test run."
+
+./pirlo-cli run -k jNmWe3iFhWjvSy_SCjlvLsCWgfw=  android/app/build/outputs/apk/release/app-release.apk

--- a/tools/test
+++ b/tools/test
@@ -47,7 +47,7 @@ while (( $# )); do
         --diff) shift; files=diff:"$1"; shift;;
         --full) files=full; shift;;
         --fix) fix=1; shift;;
-        android|flow|lint|jest|prettier|deps|spell)
+        android|flow|lint|jest|prettier|deps|spell|functional)
             suites+=("$1"); shift;;
         *) usage;;
     esac
@@ -192,6 +192,12 @@ run_spell() {
     eslint --no-eslintrc -c tools/spellcheck.eslintrc.yaml "$@"
 }
 
+run_functional() {
+
+    yarn run build:android-nokeys
+    ./tools/pirlo-tests.sh
+}
+
 failed=()
 for suite in "${suites[@]}"; do
     echo "Running $suite..."
@@ -216,6 +222,10 @@ for suite in "${suites[@]}"; do
             ;;
         spell)
             run_spell $(files_js)
+            ;;
+
+        functional)
+            run_functional
             ;;
     esac || failed+=($suite)
 done


### PR DESCRIPTION
This change will integrate Pirlo CLI with the Travis CI system. The Pirlo CLI script will execute a set of pre-defined test cases on real devices in the cloud. The CLI script will output the link to the latest test run in the console.
For your reference, the UI tests can be viewed at https://app.pirlo.io/tests?authToken=9mf3-dtyE1lMeDFFoRjm391oY-0%3D and results for each build is available at https://app.pirlo.io/runs?authToken=9mf3-dtyE1lMeDFFoRjm391oY-0%3D