### PR TITLE
notifications: normalize case of realm_uri and account.realm

### DIFF
--- a/src/notification/index.js
+++ b/src/notification/index.js
@@ -59,9 +59,18 @@ export const getAccountFromNotificationData = (
     return null;
   }
 
+  // The `realm_uri` we get from the server should be case-normalized already;
+  // but better safe than sorry.
+  const normalized_realm_uri = realm_uri.toLowerCase();
   const urlMatches = [];
   identities.forEach((account, i) => {
-    if (account.realm === realm_uri) {
+    // `account.realm` is _not_ case-normalized; it's straight from user input,
+    // which (judging from error reports) autocorrect seems to be forcibly
+    // autocapitalizing on some devices.
+    //
+    // (TODO: instead of performing case-mangling, just compare against the
+    // value of `realm_uri` we get from `/server_settings` at login time.)
+    if (account.realm.toLowerCase() === normalized_realm_uri) {
       urlMatches.push(i);
     }
   });


### PR DESCRIPTION
`account.realm` is an only-lightly-normalized form of whatever the
user typed in; what little normalization is done does not include
case-folding.

On the other hand, based on errors in Sentry, the notification's
provided URL *is* case-normalized.

N.B.: case-normalization may be destructive to non-ASCII URLs or in
Turkish locales.

* Non-ASCII URL comparison is probably already broken, because we
  don't do punycode encoding on our end.

* Turkish locale users with ASCII realm URLs should be mostly
  unaffected, unless they have typed a capital (dotless) I in their
  realm URL. In this case they will need to replace it with a
  lowercase (dotted) i.