### PR TITLE
webview js: fix prelude JS function call syntax

### DIFF
--- a/src/webview/js/script.js
+++ b/src/webview/js/script.js
@@ -18,7 +18,7 @@ document.addEventListener('DOMContentLoaded', function() {
   compiledWebviewJs.handleInitialLoad(
     ${JSON.stringify(Platform.OS)},
     ${anchor},
-    ${JSON.stringify(auth)},
+    ${JSON.stringify(auth)}
   );
 });
 </script>


### PR DESCRIPTION
Extraneous trailing commas in function calls only became legal in ECMAScript 2017.