### PR TITLE
webview [nfc]: Further write up what we've learned about asset paths.

### DIFF
--- a/src/webview/MessageList.js
+++ b/src/webview/MessageList.js
@@ -117,30 +117,39 @@ export type Props = $ReadOnly<{|
  */
 const assetsPath = Platform.OS === 'ios' ? './webview' : 'file:///android_asset/webview';
 // What the value above probably _should_ be, semantically, is an absolute
-// `file:`-scheme URL naming the path to the webview-assets folder. [1]
+// `file:`-scheme URL pointing to the webview-assets folder. [1]
 //
 // * On Android, that's exactly what it is. Different apps' WebViews see
-//   different (virtual) root directories as `file:///`, and at runtime, the
-//   APK's `assets/` directory is mounted at `file:///android_asset/`. We can
-//   easily hardcode that, so we do.
+//   different (virtual) root directories as `file:///`, and in particular
+//   the WebView provides the APK's `assets/` directory as
+//   `file:///android_asset/`. [2]  We can easily hardcode that, so we do.
 //
 // * On iOS, it's not: it's a relative path. (Or relative URL, if you prefer.)
 //   We can't make it absolute here, because neither React Native itself nor any
 //   of our current dependencies directly expose the Foundation API that would
-//   tell us the absolute path that our bundle is located at [2].
+//   tell us the absolute path that our bundle is located at [3].
 //
-//   Instead, for now, we exploit the fact that (the iOS version of) React
-//   Native will resolve it with respect to the bundle's absolute path. [3] This
-//   fact is not known to be documented, however, and should not be taken for
-//   granted indefinitely.
+//   Instead, for now, we exploit the fact that (the iOS version of)
+//   react-native-webview will have React Native resolve it with respect to
+//   the bundle's absolute path. [4]  This fact is not known to be
+//   documented, however, and should not be taken for granted indefinitely.
 //
 // [1] See `tools/build-webview` for more information on what folder that is.
 //
-// [2] Specifically, `Bundle.main.bundleURL` (aka `[[NSBundle mainbundle]
-//     bundleURL]`). Alternatively, the value of `resourceURL` is (believed to
-//     be) equivalent in this context.
+// [2] Oddly, this essential feature doesn't seem to be documented!  It's
+//     widely described in how-tos across the web and StackOverflow answers.
+//     It's assumed in some related docs which mention it in passing, and
+//     treated matter-of-factly in some Chromium bug threads.  Details at:
+//     https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/android.20filesystem/near/796440
 //
-// [3] https://github.com/facebook/react-native/blob/0.59-stable/React/Base/RCTConvert.m#L85
+// [3] Specifically, `Bundle.main.bundleURL` (aka `[[NSBundle mainbundle]
+//     bundleURL]`).  Alternatively, `resourceURL` has a meaning similar to
+//     the `assets/` directory in an Android app; for iOS app bundles, it
+//     has the same value as `bundleURL`.
+//     https://github.com/zulip/zulip-mobile/pull/3677#discussion_r344423032
+//
+// [4] https://github.com/react-native-community/react-native-webview/blob/v5.12.1/ios/RNCWKWebView.m#L376
+//     https://github.com/facebook/react-native/blob/v0.59.10/React/Base/RCTConvert.m#L85
 
 class MessageList extends Component<Props> {
   static contextType = ThemeContext;


### PR DESCRIPTION
This follows up on b2b274c4b with some further things we learned in
the discussion on its PR #3677, and in a pair of related chat threads:
  https://chat.zulip.org/#narrow/stream/243-mobile-team/near/796432

Also add a couple more reference links, and adjust wording around
`file:///android_asset/` to avoid seeming to assert that it
corresponds to a directory really mounted somewhere in the filesystem.
