### PR TITLE
composeBox, iOS: Fix msg input is not scrolled on typing.

### DIFF
--- a/src/compose/ComposeBox.js
+++ b/src/compose/ComposeBox.js
@@ -1,6 +1,6 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
-import { Platform, View, TextInput, findNodeHandle, ScrollView } from 'react-native';
+import { Platform, View, TextInput, findNodeHandle } from 'react-native';
 import type { LayoutEvent } from 'react-native/Libraries/Types/CoreEventTypes';
 import TextInputReset from 'react-native-text-input-reset';
 
@@ -292,6 +292,7 @@ class ComposeBox extends PureComponent<Props, State> {
       alignItems: 'flex-end',
     },
     composeText: {
+      flex: 1,
       paddingVertical: 8,
     },
     composeSendButton: {
@@ -360,7 +361,7 @@ class ComposeBox extends PureComponent<Props, State> {
             expanded={isMenuExpanded}
             onExpandContract={this.handleComposeMenuToggle}
           />
-          <ScrollView contentContainerStyle={this.styles.composeText}>
+          <View style={this.styles.composeText}>
             {this.getCanSelectTopic() && (
               <Input
                 style={this.styles.topicInput}
@@ -392,7 +393,7 @@ class ComposeBox extends PureComponent<Props, State> {
               onSelectionChange={this.handleMessageSelectionChange}
               onTouchStart={this.handleInputTouchStart}
             />
-          </ScrollView>
+          </View>
           <FloatingActionButton
             style={this.styles.composeSendButton}
             Icon={editMessage === null ? IconSend : IconDone}

--- a/src/compose/ComposeBox.js
+++ b/src/compose/ComposeBox.js
@@ -294,6 +294,7 @@ class ComposeBox extends PureComponent<Props, State> {
     composeText: {
       flex: 1,
       paddingVertical: 8,
+      justifyContent: 'flex-end',
     },
     composeSendButton: {
       padding: 8,


### PR DESCRIPTION
Now this is how it looks:

Fixes: #3614
This reverts #3595 and include fix for #3369.

![image](https://user-images.githubusercontent.com/18511177/68985229-22504500-083b-11ea-99fa-9b83cbd0ab6d.png)
![image](https://user-images.githubusercontent.com/18511177/68985233-2d0ada00-083b-11ea-969c-0158a61bb668.png)
