### PR TITLE
prettier: Remove old VSCode setting

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,8 +8,7 @@
     // https://github.com/Microsoft/vscode-react-native/blob/master/doc/intellisense.md .
     "flow.useNPMPackagedFlow": true,
 
-    // Format on save, with prettier-eslint.
-    "prettier.eslintIntegration": true,
+    // Format on save (with prettier-eslint).
     "[javascript]": {
         "editor.formatOnSave": true,
     },


### PR DESCRIPTION
New versions of the Prettier VSCode plugin (in particular, 3.8) have
started to complain about certain out-of-date settings in VSCode
config files.  Remove the relevant (or rather, now-irrelevant) config
option from our workspace.

Users may need to manually update their Prettier VSCode extension to
continue to format code with Prettier on save.

See, e.g:
- https://github.com/prettier/prettier-vscode/blob/62004a02b4/README.md#user-content-error-messages