### PR TITLE
Revert "api: augment console.log with proper Sentry breadcrumb"

### DIFF
--- a/src/api/apiFetch.js
+++ b/src/api/apiFetch.js
@@ -1,5 +1,4 @@
 /* @flow strict-local */
-import Sentry from '@sentry/react-native';
 import type { UrlParams } from '../utils/url';
 import type { Auth } from './transportTypes';
 import { getAuthHeaders } from './transport';
@@ -68,11 +67,6 @@ export const apiCall = async (
     }
     // eslint-disable-next-line no-console
     console.log({ route, params, httpStatus: response.status, json });
-    Sentry.addBreadcrumb({
-      category: 'api',
-      level: 'info',
-      data: { route, params, httpStatus: response.status, json },
-    });
     throw makeErrorFromApi(response.status, json);
   } finally {
     networkActivityStop(isSilent);


### PR DESCRIPTION
This reverts commit a60a97a1ab5440e1b8221998a4c84623ded035eb.

Despite the commit order, this was originally written and tested
against the 0.x interface. In 1.x, these identifiers are no longer
available with this import method.

A future commit is planned which will incorporate this functionality
correctly, alongside Flow type declarations to ensure this does not
recur elsewhere.