### PR TITLE
Improved readability of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Release versions of the app are available here:
     from the official build we post on GitHub.
 
 You can also help out by [running beta versions](#using-the-beta) of
-the app, and reporting bugs!
+the app, and reporting any bugs you find!
 
 ## Contributing
 
@@ -26,8 +26,9 @@ the app, and reporting bugs!
 
 To get involved in Zulip Mobile development, please join us on
 [the Zulip community Zulip server][czo-doc], in the
-[#mobile][czo-mobile] stream.  Come say hello, discuss areas to
-work on, and ask and answer questions.
+[#mobile][czo-mobile] stream.  Come say hello, discuss areas 
+that need to be worked on, help answer questions and if you need
+any help feel free to ask questions.
 
 [czo-mobile]: https://chat.zulip.org/#narrow/stream/mobile
 [czo-doc]: https://zulip.readthedocs.io/en/latest/contributing/chat-zulip-org.html
@@ -35,7 +36,7 @@ work on, and ask and answer questions.
 ### Using the beta
 
 One important way to contribute is to run beta versions of the app, and report
-bugs!  To get the beta:
+any bugs you find!  To get the beta:
 
 * Android: install the app, then just
   [join the testing program](https://play.google.com/apps/testing/com.zulipmobile/)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -9,8 +9,8 @@ architecture and terminology (such as actions, reducers, and stores).
 See [our React/Redux architecture doc](architecture/react.md) for a more
 detailed explanation as applied to our app.
 
-At a high-level, global app state should be immutable and is stored in
-centralized place. Modifying state requires new copies of each data structure.
+At a high-level, global app state should be immutable and should be stored in
+a centralized place. Modifying state requires new copies of each data structure.
 
 We use selectors to extract (or select) data from Redux Stores. [Learn more
 about the concept of selectors](http://redux.js.org/docs/recipes/ComputingDerivedData.html)


### PR DESCRIPTION
README.md
"reporting bugs!" -> "reporting any bugs you find!"  Easier to read.

"Come say hello, discuss areas to work on, and ask and answer questions." ->
"Come say hello, discuss areas that need to be worked on, help answer questions and if you need
any help feel free to ask questions." 

Made it clear that people are helping by answering questions, and if they have questions this is where to go to ask them. Also removed unnecessary second "and" from sentence.

"reporting bugs!" -> "reporting any bugs you find!"  Easier to read.

/docs/architecture.md

"is stored in centralized place." -> 
"should be stored in a centralized place."

Changed "is" to "should be" to follow tense from "global app state should be immutable".
Added "a" for grammar.



