### PR TITLE
actions: fix typos in type of `notification_name`

### DIFF
--- a/src/actionTypes.js
+++ b/src/actionTypes.js
@@ -245,9 +245,9 @@ type EventRealmFiltersAction = {|
 type EventUpdateGlobalNotificationsSettingsAction = {|
   ...ServerEvent,
   type: typeof EVENT_UPDATE_GLOBAL_NOTIFICATIONS_SETTINGS,
-  notification_name: | 'enable_offline_push_notiications'
-    | 'enable_online_push_notiications'
-    | 'enable_stream_push_notifiations',
+  notification_name: | 'enable_offline_push_notifications'
+    | 'enable_online_push_notifications'
+    | 'enable_stream_push_notifications',
   setting: boolean,
 |};
 

--- a/src/settings/settingsReducer.js
+++ b/src/settings/settingsReducer.js
@@ -5,6 +5,7 @@ import {
   REALM_INIT,
   EVENT_UPDATE_GLOBAL_NOTIFICATIONS_SETTINGS,
 } from '../actionConstants';
+import { ensureUnreachable } from '../types';
 
 const initialState: SettingsState = {
   locale: 'en',
@@ -39,6 +40,7 @@ export default (state: SettingsState = initialState, action: Action): SettingsSt
         case 'enable_stream_push_notifications':
           return { ...state, streamNotification: action.setting };
         default:
+          ensureUnreachable(action.notification_name);
           return state;
       }
 


### PR DESCRIPTION
... and manually ensure that its declaration and use-site match.

(As seen Friday evening.)