### PR TITLE
Linter tweaks

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -65,6 +65,11 @@ rules:
   no-plusplus: off
   no-nested-ternary: off
 
+  # We also partly repeal AirBnB's forbidden-syntax subrules. (This must be done
+  # in the `overrides:` section.)
+  #
+  # no-restricted-syntax: ...
+
   # Likely-wrong code
   no-unused-vars: [warn, {vars: local, args: none}]
   # no-param-reassign seems well-intentioned... but fires on common uses
@@ -125,3 +130,45 @@ rules:
   flowtype/valid-syntax: warn
 
   # spellcheck/spell-checker: see tools/spellcheck.eslintrc.yaml .
+
+overrides:
+# Global overrides
+- files: ["*.js"]
+  rules:
+    # Here we repeal several AirBnB subrules.
+    #
+    # - The AirBnB rule disallowing labeled statements arises largely from their
+    #   controversial hardcore anti-loop position [1], which we don't share.
+    #
+    # - The AirBnB rule disallowing `for..of` statements is partly based on the
+    #   above. More reasonably, though, it cites the `regenerator-runtime`
+    #   library (which Babel uses to implement them) as being too heavyweight.
+    #   Unfortunately, we're already including `regenerator-runtime` for other
+    #   reasons, and there's no easy way to find out what. (In for a penny, in
+    #   for a pound.)
+    #
+    # - The AirBnB rule disallowing `with` statements has a shorter built-in
+    #   equivalent. (And the parser enforces it in strict mode, anyway.)
+    #
+    # Alas, ESLint does not allow these repeals to be done surgically; we must
+    # duplicate the entire acceptable portion of the rule. The original text
+    # thereof can be found at [2].
+
+    # [1]: https://github.com/airbnb/javascript/issues/1103
+    # [2]: https://github.com/airbnb/javascript/blob/dee4f17/packages/eslint-config-airbnb-base/rules/style.js#L334
+    no-restricted-syntax: [
+      'error',
+      {
+        selector: 'ForInStatement',
+        message: 'for..in loops iterate over the entire prototype chain, which
+        is virtually never what you want. Use Object.{keys,values,entries}, and
+        iterate over the resulting array.'
+        # They're also slightly buggy in JSC [1], on which react-native is
+        # built... and, surprisingly, their semantics weren't fully nailed down
+        # until as late as 2019-12 [2]. But the above is reason enough.
+
+        # [1]: https://bugs.webkit.org/show_bug.cgi?id=38970
+        # [2]: https://github.com/tc39/proposals/commit/cb9c6e50
+      },
+    ]
+    no-with: error

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -32,6 +32,15 @@ rules:
   # Formatting and naming
   camelcase: off
 
+  # Permit dangling underscores in class property names, to denote "private"
+  # fields. (These should be replaced with true private fields per the TC39
+  # class fields proposal [1], once that's available to us.)
+  #
+  # [1]: https://github.com/tc39/proposal-class-fields
+  no-underscore-dangle: ["error", { allowAfterThis: true } ]
+  # Disallow double underscores and trailing underscores.
+  id-match: ["error", "^_?([a-zA-Z0-9$]+_?)*$", { "properties": true }]
+
   # Disable a bunch of rules that should be taken care of by prettier.
   arrow-parens: off
   comma-dangle: off

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -156,19 +156,16 @@ overrides:
 
     # [1]: https://github.com/airbnb/javascript/issues/1103
     # [2]: https://github.com/airbnb/javascript/blob/dee4f17/packages/eslint-config-airbnb-base/rules/style.js#L334
-    no-restricted-syntax: [
-      'error',
-      {
-        selector: 'ForInStatement',
-        message: 'for..in loops iterate over the entire prototype chain, which
+    no-restricted-syntax:
+    - error
+    - selector: ForInStatement
+      message: 'for..in loops iterate over the entire prototype chain, which
         is virtually never what you want. Use Object.{keys,values,entries}, and
         iterate over the resulting array.'
         # They're also slightly buggy in JSC [1], on which react-native is
         # built... and, surprisingly, their semantics weren't fully nailed down
         # until as late as 2019-12 [2]. But the above is reason enough.
-
         # [1]: https://bugs.webkit.org/show_bug.cgi?id=38970
         # [2]: https://github.com/tc39/proposals/commit/cb9c6e50
-      },
-    ]
+
     no-with: error


### PR DESCRIPTION
Allow leading single underscores in object properties, as a stand-in for real private fields.

Also allow `for..of` loops and labeled statements. (I run into this about once a month, and end up going down a rabbit hole wondering why.)