### PR TITLE
fetch: don't complain to Sentry about bad data in 5xx errors

### DIFF
--- a/src/api/apiErrors.js
+++ b/src/api/apiErrors.js
@@ -38,6 +38,11 @@ export const makeErrorFromApi = (httpStatus: number, data: mixed): Error => {
     }
   }
 
+  // HTTP 5xx errors aren't generally expected to come with JSON data.
+  if (httpStatus >= 500 && httpStatus <= 599) {
+    return new Error(`Network request failed: HTTP error ${httpStatus}`);
+  }
+
   // Server has responded, but the response is not a valid error-object.
   // (This should never happen, even on old versions of the Zulip server.)
   logging.warn(`Bad response from server: ${JSON.stringify(data)}`);

--- a/src/sentry.js
+++ b/src/sentry.js
@@ -58,7 +58,10 @@ export const initializeSentry = () => {
 
     Sentry.init({
       dsn: key,
-      ignoreErrors: ['Network request failed'],
+      ignoreErrors: [
+        // RN's fetch implementation can raise these; we sometimes mimic it
+        'Network request failed',
+      ],
     });
   } else {
     // This is normal behavior when running locally; only published release


### PR DESCRIPTION
A 504 error _with_ JSON data is probably more surprising than one without.