### PR TITLE
Permit use of commas in stream names

### DIFF
--- a/src/api/messages/sendMessage.js
+++ b/src/api/messages/sendMessage.js
@@ -6,18 +6,20 @@ import { apiPost } from '../apiFetch';
 /** See https://zulipchat.com/api/send-message */
 export default async (
   auth: Auth,
-  type: 'private' | 'stream',
-  to: string,
-  subject: string,
-  content: string,
-  localId: number,
-  eventQueueId: number,
+  params: {|
+    type: 'private' | 'stream',
+    to: string,
+    subject: string,
+    content: string,
+    localId: number,
+    eventQueueId: number,
+  |},
 ): Promise<ApiResponse> =>
   apiPost(auth, 'messages', {
-    type,
-    to,
-    subject,
-    content,
-    local_id: localId,
-    queue_id: eventQueueId,
+    type: params.type,
+    to: params.to,
+    subject: params.subject,
+    content: params.content,
+    local_id: params.localId,
+    queue_id: params.eventQueueId,
   });

--- a/src/outbox/outboxActions.js
+++ b/src/outbox/outboxActions.js
@@ -52,15 +52,14 @@ export const trySendMessages = (dispatch: Dispatch, getState: GetState): boolean
   const outboxToSend = state.outbox.filter(outbox => !outbox.isSent);
   try {
     outboxToSend.forEach(async item => {
-      await api.sendMessage(
-        auth,
-        item.type,
-        isPrivateOrGroupNarrow(item.narrow) ? item.narrow[0].operand : item.display_recipient,
-        item.subject,
-        item.markdownContent,
-        item.timestamp,
-        state.session.eventQueueId,
-      );
+      await api.sendMessage(auth, {
+        type: item.type,
+        to: isPrivateOrGroupNarrow(item.narrow) ? item.narrow[0].operand : item.display_recipient,
+        subject: item.subject,
+        content: item.markdownContent,
+        localId: item.timestamp,
+        eventQueueId: state.session.eventQueueId,
+      });
       dispatch(messageSendComplete(item.timestamp));
     });
     return true;

--- a/src/outbox/outboxActions.js
+++ b/src/outbox/outboxActions.js
@@ -64,9 +64,21 @@ export const trySendMessages = (dispatch: Dispatch, getState: GetState): boolean
         return; // i.e., continue
       }
 
+      const to = ((): string => {
+        const { narrow } = item;
+        // TODO: can this test be `if (item.type === private)`?
+        if (isPrivateOrGroupNarrow(narrow)) {
+          return narrow[0].operand;
+        } else {
+          // HACK: the server attempts to interpret this argument as JSON, then
+          // CSV, then a literal. To avoid misparsing, always use JSON.
+          return JSON.stringify([item.display_recipient]);
+        }
+      })();
+
       await api.sendMessage(auth, {
         type: item.type,
-        to: isPrivateOrGroupNarrow(item.narrow) ? item.narrow[0].operand : item.display_recipient,
+        to,
         subject: item.subject,
         content: item.markdownContent,
         localId: item.timestamp,


### PR DESCRIPTION
Should fix #3729.

This is just a draft PR because it doesn't take into account the problem of what to do about existing messages in the outbox. (We *probably* don't want to flush a potential backlog of hundreds of messages all at once. Perhaps, during the following migration, we should drop messages stalled due to this bug that are more than a day old?)