### PR TITLE
ComposeBox: Prevent message with whitespace-only topic from sending.

### DIFF
--- a/src/compose/ComposeBox.js
+++ b/src/compose/ComposeBox.js
@@ -397,7 +397,7 @@ class ComposeBox extends PureComponent<Props, State> {
             style={this.styles.composeSendButton}
             Icon={editMessage === null ? IconSend : IconDone}
             size={32}
-            disabled={message.trim().length === 0}
+            disabled={message.trim().length === 0 || topic.trim().length === 0}
             onPress={editMessage === null ? this.handleSend : this.handleEdit}
           />
         </View>


### PR DESCRIPTION
Fixes #3743.
This trims the topic string whenever the message text input is focused. Apart from preventing message with whitespace-only topic from sending, it will also remove whitespace from the start and end of the topic string like Zulip web version.

**GIF:**
![ezgif com-optimize](https://user-images.githubusercontent.com/45683359/71754712-3ca4b780-2ea9-11ea-8238-c14f92201d10.gif)
