### PR TITLE
composeBox, iOS: Fix msg input is not scrolled on typing.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,10 @@ env:
     - COVERALLS_REPO_TOKEN=4eYQDtWoBJlDz2QkxoQ2UcnmJFcOB7zkv
   jobs:
     - TEST_SUITE=''
-    - TEST_SUITE=pirlo
+
+    # Pirlo suite disabled until we adjust the test script to match
+    # changes in order to accomodate #3750.
+    # - TEST_SUITE=pirlo
 
 android:
   components:

--- a/src/compose/ComposeBox.js
+++ b/src/compose/ComposeBox.js
@@ -282,6 +282,9 @@ class ComposeBox extends PureComponent<Props, State> {
   };
 
   styles = {
+    wrapper: {
+      flexShrink: 1,
+    },
     autocompleteWrapper: {
       position: 'absolute',
       bottom: 0,
@@ -290,6 +293,7 @@ class ComposeBox extends PureComponent<Props, State> {
     composeBox: {
       flexDirection: 'row',
       alignItems: 'flex-end',
+      flexShrink: 1,
     },
     composeText: {
       flex: 1,
@@ -309,6 +313,7 @@ class ComposeBox extends PureComponent<Props, State> {
       borderWidth: 0,
       borderRadius: 5,
       fontSize: 15,
+      flexShrink: 1,
       ...this.inputMarginPadding,
       ...this.context.styles.backgroundColor,
     },
@@ -340,7 +345,7 @@ class ComposeBox extends PureComponent<Props, State> {
     };
 
     return (
-      <View>
+      <View style={this.styles.wrapper}>
         <View style={[this.styles.autocompleteWrapper, { marginBottom: height }]}>
           <TopicAutocomplete
             isFocused={isTopicFocused}

--- a/src/compose/ComposeBox.js
+++ b/src/compose/ComposeBox.js
@@ -1,6 +1,6 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
-import { Platform, View, TextInput, findNodeHandle, ScrollView } from 'react-native';
+import { Platform, View, TextInput, findNodeHandle } from 'react-native';
 import type { LayoutEvent } from 'react-native/Libraries/Types/CoreEventTypes';
 import TextInputReset from 'react-native-text-input-reset';
 
@@ -292,6 +292,7 @@ class ComposeBox extends PureComponent<Props, State> {
       alignItems: 'flex-end',
     },
     composeText: {
+      flex: 1,
       paddingVertical: 8,
     },
     composeSendButton: {
@@ -360,7 +361,7 @@ class ComposeBox extends PureComponent<Props, State> {
             expanded={isMenuExpanded}
             onExpandContract={this.handleComposeMenuToggle}
           />
-          <ScrollView contentContainerStyle={this.styles.composeText}>
+          <View style={this.styles.composeText}>
             {this.getCanSelectTopic() && (
               <Input
                 style={this.styles.topicInput}
@@ -392,7 +393,7 @@ class ComposeBox extends PureComponent<Props, State> {
               onSelectionChange={this.handleMessageSelectionChange}
               onTouchStart={this.handleInputTouchStart}
             />
-          </ScrollView>
+          </View>
           <FloatingActionButton
             style={this.styles.composeSendButton}
             Icon={editMessage === null ? IconSend : IconDone}


### PR DESCRIPTION
Fixes: #3614

Now it looks like this:
- When unread notice is present, then it shrinks to a line. 
I am not sure, in ideal situation will it be visible fully or should we make it scroll up (hide behind navbar)
![image](https://user-images.githubusercontent.com/18511177/71694370-fd0c9b80-2dd4-11ea-9133-d3c245a66d74.png)
![image](https://user-images.githubusercontent.com/18511177/71694475-4d83f900-2dd5-11ea-8634-c141078d9484.png)

- When unread notice is not present
![image](https://user-images.githubusercontent.com/18511177/71694499-5ffe3280-2dd5-11ea-8a68-94c0cc627093.png)


Behaviour is same on both Android and iOS
