### PR TITLE
types [nfc]: remove optionality from Narrow::operator

### DIFF
--- a/src/api/modelTypes.js
+++ b/src/api/modelTypes.js
@@ -248,7 +248,7 @@ export type NarrowOperator =
 
 export type NarrowElement = $ReadOnly<{|
   operand: string,
-  operator?: NarrowOperator, // TODO type: this shouldn't be absent.
+  operator: NarrowOperator,
 |}>;
 
 export type Narrow = $ReadOnlyArray<NarrowElement>;


### PR DESCRIPTION
Narrow's `operator` field was originally optional to encompass a hack in the `TitleSpecial` and (former) `TitleHome` components. As that's long gone (see commit 806a131), we can tighten the type a bit.