### PR TITLE
narrows reducer: Fix bad `sort` in an edge case.

### DIFF
--- a/src/chat/narrowsReducer.js
+++ b/src/chat/narrowsReducer.js
@@ -68,7 +68,7 @@ const updateFlagNarrow = (state, narrowStr, operation, messageIds): NarrowsState
     case 'add':
       return {
         ...state,
-        [narrowStr]: [...state[narrowStr], ...messageIds].sort(),
+        [narrowStr]: [...state[narrowStr], ...messageIds].sort((a, b) => a - b),
       };
     case 'remove': {
       const messageIdSet = new Set(messageIds);


### PR DESCRIPTION
It turns out that `sort` without an explicit comparison function
has surprising behavior -- it converts everything to strings, and
compares the UTF-16 sequences.  So e.g.

  > [11, 2, 22, 1].sort()
  [ 1, 11, 2, 22 ]

This makes it acceptable really only for sorting strings, and even
then only for identifier-like strings.

For numbers, the right pattern is:

  > [11, 2, 22, 1].sort((a, b) => a - b)
  [ 1, 2, 11, 22 ]

A quick grep for nullary `sort` finds we've mostly handled this
correctly; but a quick grep finds one exception, where we're using
nullary `sort` on numbers.  It's the message IDs in a narrow, so
in fact we really are relying on keeping them in numeric order.
Fix the sort.

Happily this isn't a very common codepath, so it isn't likely many
users have hit this bug.

Fixes: #3752