### PR TITLE
Add Types (#2052): for url-parse and in js.js

### DIFF
--- a/src/start/webAuth.js
+++ b/src/start/webAuth.js
@@ -1,7 +1,7 @@
 /* @flow strict-local */
 import { NativeModules, Platform } from 'react-native';
 import SafariView from 'react-native-safari-view';
-import parseURL from 'url-parse';
+import parseURL, { type Url } from 'url-parse';
 
 import type { Auth } from '../types';
 import openLink from '../utils/openLink';
@@ -69,7 +69,7 @@ export const authFromCallbackUrl = (
   otp: string,
   realm: string,
 ): Auth | null => {
-  const url = parseURL(callbackUrl, true);
+  const url: Url = parseURL(callbackUrl, true);
 
   // callback format expected: zulip://login?realm={}&email={}&otp_encrypted_api_key={}
   if (

--- a/src/webview/js/js.js
+++ b/src/webview/js/js.js
@@ -71,7 +71,7 @@ if (!Element.prototype.closest) {
    Taken (with minor edits) from the relevant MDN page. */
 if (!String.prototype.startsWith) {
   // $FlowFixMe (polyfill)
-  String.prototype.startsWith = function startsWith(search, rawPos) {
+  String.prototype.startsWith = function startsWith(search: string, rawPos: number) {
     const pos = rawPos > 0 ? rawPos | 0 : 0;
     return this.substring(pos, pos + search.length) === search;
   };
@@ -82,7 +82,7 @@ if (!String.prototype.startsWith) {
      https://tc39.es/ecma262/#sec-string.prototype.includes */
 if (!String.prototype.includes) {
   // $FlowFixMe (polyfill)
-  String.prototype.includes = function includes(search, start = 0) {
+  String.prototype.includes = function includes(search: string, start: number = 0) {
     /* required by the spec, but not worth the trouble */
     // if (search instanceof RegExp) { throw new TypeError('...'); }
     return this.indexOf(search, start) !== -1;
@@ -108,7 +108,7 @@ const sendMessage = (msg: MessageListEvent) => {
   window.ReactNativeWebView.postMessage(JSON.stringify(msg));
 };
 
-window.onerror = (message, source, line, column, error) => {
+window.onerror = (message: string, source: string, line: number, column: number, error: Error) => {
   if (window.enableWebViewErrorDisplay) {
     const elementJsError = document.getElementById('js-error-detailed');
     if (elementJsError) {


### PR DESCRIPTION
I spent a lot of time at understanding the code and types but I was not able to discover any major new types as I feel most of them are already covered and many are just uncovered due to use of objects like window, document which does not have any typing.

This is my first PR at Zulip. I am very new to this codebase as well as TypeFlow due to which I have a few doubts which may be silly but I want someone to help me understand.

* In `src/common/icon.js`, we haven't mentioned types of `props`. Can anyone help me in extracting the possible properties of this object `props`? I traced its references and found some properties like `size`, `colour`. 
I also found `style` property in `props` which makes it really hard or even impossible to determine the type. Please correct me if I'm wrong.
Also, I found an `IconProps` type defined in `icon.js`. It looks the same but it's not been used so I assume this is not the right type of props.

* In `src/api/modelTypes.js` `$FlowFixMe` is used for `display_recipient` property of Message. This left around 50 uncovered types in src/webview/html/messageHeaderAsHtml.js and many other places (like narrow.js)
Comment at `modelTypes.js` says its type is either 'string' or PmRecipientUser[] so why can't we use type as `string|PmRecipientUser[]`?


