### PR TITLE
Buttons on Create Stream: Fix Button UI not turns On clicking over,

### DIFF
--- a/src/streams/EditStreamCard.js
+++ b/src/streams/EditStreamCard.js
@@ -79,7 +79,7 @@ export default class EditStreamCard extends PureComponent<Props, State> {
           style={componentStyles.optionRow}
           Icon={IconPrivate}
           label="Private"
-          value={initialValues.invite_only}
+          value={this.state.isPrivate}
           onValueChange={this.handleIsPrivateChange}
         />
         <ZulipButton


### PR DESCRIPTION
button was referencing initialValue, when user clicks on that button it was not updating it's value
I have fixed it by changing current value of the button
Fixes:#3760