### PR TITLE
tests: push some complex expectations into Jest helpers

### DIFF
--- a/src/boot/__tests__/reducers-test.js
+++ b/src/boot/__tests__/reducers-test.js
@@ -11,6 +11,6 @@ describe('reducers', () => {
   test('every reducer is listed in config as "discard", "store" or "cache"', () => {
     const configKeys = [...discardKeys, ...storeKeys, ...cacheKeys];
     expect(configKeys).toHaveLength(ALL_KEYS.length);
-    expect(configKeys.every(key => ALL_KEYS.includes(key))).toBeTruthy();
+    expect(configKeys).toSatisfyAll(key => ALL_KEYS.includes(key));
   });
 });

--- a/src/utils/__tests__/async-test.js
+++ b/src/utils/__tests__/async-test.js
@@ -7,7 +7,8 @@ describe('sleep', () => {
     const start = Date.now();
     await sleep(expectedMs);
     const durationMs = Date.now() - start;
-    expect(expectedMs <= durationMs && durationMs < 10 * expectedMs).toBeTruthy();
+    expect(expectedMs).toBeLessThanOrEqual(durationMs);
+    expect(durationMs).toBeLessThan(10 * expectedMs);
   });
 });
 

--- a/src/utils/__tests__/url-test.js
+++ b/src/utils/__tests__/url-test.js
@@ -251,8 +251,7 @@ describe('autocompleteRealm', () => {
 
   test('do not use any other protocol than http and https', () => {
     const result = autocompleteRealm('ftp://example', zulipData);
-    const isAsExpected = result.startsWith('https://ftp://');
-    expect(isAsExpected).toBeTruthy();
+    expect(result).toStartWith('https://ftp://');
   });
 
   test('if the hostname contains a dot, consider it complete', () => {


### PR DESCRIPTION
Use jest-community helpers to compute certain properties, to provide
more precise information in case of failure.

(Inspired by a test flake for `sleep` in `async-tests`.)