### PR TITLE
Stream settings user default

### DIFF
--- a/src/api/modelTypes.js
+++ b/src/api/modelTypes.js
@@ -218,7 +218,7 @@ export type Subscription = {|
   desktop_notifications: boolean,
   email_address: string,
   is_old_stream: boolean,
-  push_notifications: boolean,
+  push_notifications: null | boolean,
   stream_weekly_traffic: number,
 |};
 

--- a/src/api/registerForEvents.js
+++ b/src/api/registerForEvents.js
@@ -12,8 +12,15 @@ type RegisterForEventsParams = {|
   include_subscribers?: boolean,
   narrow?: Narrow,
   queue_lifespan_secs?: number,
+  client_capabilities?: {|
+    notification_settings_null: boolean,
+  |},
 |};
 
 /** See https://zulipchat.com/api/register-queue */
 export default (auth: Auth, params: RegisterForEventsParams) =>
-  apiPost(auth, 'register', objectToParams(params));
+  apiPost(
+    auth,
+    'register',
+    objectToParams({ ...params, client_capabilities: JSON.stringify(params.client_capabilities) }),
+  );

--- a/src/message/fetchActions.js
+++ b/src/message/fetchActions.js
@@ -233,6 +233,9 @@ export const doInitialFetch = () => async (dispatch: Dispatch, getState: GetStat
         apply_markdown: true,
         include_subscribers: false,
         client_gravatar: true,
+        client_capabilities: {
+          notification_settings_null: true,
+        },
       }),
     );
   } catch (e) {

--- a/src/streams/StreamScreen.js
+++ b/src/streams/StreamScreen.js
@@ -2,7 +2,7 @@
 import React, { PureComponent } from 'react';
 import { View } from 'react-native';
 
-import type { Dispatch, GlobalState, Stream, Subscription } from '../types';
+import type { Dispatch, Stream, Subscription } from '../types';
 import { connectFlowFixMe } from '../react-redux';
 import { delay } from '../utils/async';
 import { OptionRow, Screen, ZulipButton } from '../common';
@@ -18,11 +18,16 @@ import {
 } from '../actions';
 import styles from '../styles';
 
-type Props = $ReadOnly<{|
-  dispatch: Dispatch,
+type SelectorProps = $ReadOnly<{|
   isAdmin: boolean,
   stream: Stream,
   subscription: Subscription,
+|}>;
+
+type Props = $ReadOnly<{|
+  dispatch: Dispatch,
+
+  ...SelectorProps,
 |}>;
 
 class StreamScreen extends PureComponent<Props> {
@@ -98,7 +103,7 @@ class StreamScreen extends PureComponent<Props> {
   }
 }
 
-export default connectFlowFixMe((state: GlobalState, props) => ({
+export default connectFlowFixMe((state, props) => ({
   isAdmin: getIsAdmin(state),
   stream: getStreamForId(state, props.navigation.state.params.streamId),
   subscription: getSubscriptionForId(state, props.navigation.state.params.streamId),

--- a/src/streams/StreamScreen.js
+++ b/src/streams/StreamScreen.js
@@ -1,9 +1,10 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
 import { View } from 'react-native';
+import type { NavigationScreenProp } from 'react-navigation';
 
 import type { Dispatch, Stream, Subscription } from '../types';
-import { connectFlowFixMe } from '../react-redux';
+import { connect } from '../react-redux';
 import { delay } from '../utils/async';
 import { OptionRow, Screen, ZulipButton } from '../common';
 import { getIsAdmin, getStreamForId, getSubscriptionForId } from '../selectors';
@@ -25,6 +26,7 @@ type SelectorProps = $ReadOnly<{|
 |}>;
 
 type Props = $ReadOnly<{|
+  navigation: NavigationScreenProp<{ params: {| streamId: number |} }>,
   dispatch: Dispatch,
 
   ...SelectorProps,
@@ -103,7 +105,7 @@ class StreamScreen extends PureComponent<Props> {
   }
 }
 
-export default connectFlowFixMe((state, props) => ({
+export default connect((state, props) => ({
   isAdmin: getIsAdmin(state),
   stream: getStreamForId(state, props.navigation.state.params.streamId),
   subscription: getSubscriptionForId(state, props.navigation.state.params.streamId),

--- a/src/streams/StreamScreen.js
+++ b/src/streams/StreamScreen.js
@@ -7,6 +7,7 @@ import type { Dispatch, Stream, Subscription } from '../types';
 import { connect } from '../react-redux';
 import { delay } from '../utils/async';
 import { OptionRow, Screen, ZulipButton } from '../common';
+import { getSettings } from '../directSelectors';
 import { getIsAdmin, getStreamForId, getSubscriptionForId } from '../selectors';
 import StreamCard from './StreamCard';
 import { IconPin, IconMute, IconNotifications, IconEdit, IconPlusSquare } from '../common/Icons';
@@ -23,6 +24,7 @@ type SelectorProps = $ReadOnly<{|
   isAdmin: boolean,
   stream: Stream,
   subscription: Subscription,
+  userSettingStreamNotification: boolean,
 |}>;
 
 type Props = $ReadOnly<{|
@@ -54,12 +56,13 @@ class StreamScreen extends PureComponent<Props> {
   };
 
   toggleStreamPushNotification = () => {
-    const { dispatch, subscription, stream } = this.props;
-    dispatch(toggleStreamNotification(stream.stream_id, !subscription.push_notifications));
+    const { dispatch, subscription, stream, userSettingStreamNotification } = this.props;
+    const currentValue = subscription.push_notifications ?? userSettingStreamNotification;
+    dispatch(toggleStreamNotification(stream.stream_id, !currentValue));
   };
 
   render() {
-    const { isAdmin, stream, subscription } = this.props;
+    const { isAdmin, stream, subscription, userSettingStreamNotification } = this.props;
 
     return (
       <Screen title="Stream">
@@ -79,7 +82,7 @@ class StreamScreen extends PureComponent<Props> {
         <OptionRow
           Icon={IconNotifications}
           label="Notifications"
-          value={subscription.push_notifications}
+          value={subscription.push_notifications ?? userSettingStreamNotification}
           onValueChange={this.toggleStreamPushNotification}
         />
         <View style={styles.padding}>
@@ -109,4 +112,5 @@ export default connect((state, props) => ({
   isAdmin: getIsAdmin(state),
   stream: getStreamForId(state, props.navigation.state.params.streamId),
   subscription: getSubscriptionForId(state, props.navigation.state.params.streamId),
+  userSettingStreamNotification: getSettings(state).streamNotification,
 }))(StreamScreen);


### PR DESCRIPTION
Updating the mobile app to respond to the overhaul of stream notification settings at #3449, so that a stream's notification setting can be null, instead of true or false. If null, it will default to the user's stream notification setting. The mobile app signals to the server that it will accept null by passing the following with the /register request:
    
```
client_capabilities: {
    notification_settings_null: true,
}
```

### Asides

(EDIT: now in new PR https://github.com/zulip/zulip-mobile/pull/3789) This also fixes all but one of the instances of connectFlowFixMe; one remains in ZulipStatusBar.js where the name `backgroundColor` is used for two different purposes and needs closer attention.

Also discovered (now at #3767) was a desire to stop reusing the StreamList component; it is currently used in both tabs on the 'streams' screen (StreamTabs.js): in "Subscribed," showing unread counts, and in "All streams," with a switch to add or remove subscriptions. There's enough of a difference in functionality that it makes sense to have separate components for each.

When passing an object as a param (client_capabilities in this case), I had to remember to JSON.stringify first. Other formats are parsed by objectToParams in apiFetch.js -- arrays are stringified, and undefined is filtered out -- so it might be nice to have objectToParams also JSON.stringify objects, as long as this is always what the server expects.