### PR TITLE
Windows build issues

### DIFF
--- a/docs/howto/build-run.md
+++ b/docs/howto/build-run.md
@@ -23,6 +23,10 @@ Before starting, install these dependencies if you don't have them:
   latest 10.x (LTS) version
 * [Yarn](https://yarnpkg.com/en/docs/install), latest stable version
 
+**Windows** users may also need to [install `rsync`][install-rsync].
+
+[install-rsync]: https://serverfault.com/a/872557
+
 Then, run the commands below in your terminal:
 ```
 git clone https://github.com/zulip/zulip-mobile

--- a/docs/howto/build-run.md
+++ b/docs/howto/build-run.md
@@ -11,11 +11,9 @@ with `brew install coreutils`.)
 
 [GNU coreutils]: https://www.gnu.org/software/coreutils/
 
-(If using **Windows**: The step-by-step instructions below should work
-fine on Windows.  Alternatively if you'd like a richer command-line
-environment and are up for trying a beta install process, we have
-[a draft guide](windows.md) for setting up Zulip app development to
-use the WSL `bash` command line.)
+(If using **Windows**: If you'd like a richer command-line environment and are
+up for trying a beta install process, we have [a draft guide](windows.md) for
+setting up Zulip app development to use the WSL `bash` command line.)
 
 Before starting, install these dependencies if you don't have them:
 * [Git](https://git-scm.com/)
@@ -48,6 +46,11 @@ Continue those instructions until you can run the Zulip Mobile app
 with either `react-native run-android` or `react-native run-ios`.
 You'll want to be able to use both an emulator and a physical device; but
 for starting out, just get either one working so you can play with the app.
+
+(**Windows** users will need to run these from within Git Bash, rather than from
+the usual command prompt -- [at least for now][issue-3776].)
+
+[issue-3776]: https://github.com/zulip/zulip-mobile/issues/3776
 
 Once you have it running, look at our [debugging tips](debugging.md)
 to help see what's happening in the code.  On your first sitting, just

--- a/tools/build-webview
+++ b/tools/build-webview
@@ -35,9 +35,13 @@ err() {
 # Environment
 ################################################################################
 
-# The project root (or at least the current git repo's root), for absolutizing
-# paths.
-root="$(git rev-parse --show-toplevel)"
+# The project root, for absolutizing paths. (Assumed to be one directory up from
+# the script's own location.)
+#
+# This must return a name for the project root directory which coincides with
+# the one Gradle/Xcode will provide. This is unlikely to be a problem on Linux
+# or macOS, but has caused isues on Windows; see GitHub issue #3777.)
+root="$(readlink -m "$(dirname "${BASH_SOURCE[0]}")"/../)"
 readonly root
 
 


### PR DESCRIPTION
Address three mostly unrelated Windows issues:

* Fix up the webview build script.
* Document a new explicit requirement to install `rsync`.
* Warn users to prefer Git Bash, rather than the Command Prompt, for now (#3776).