### PR TITLE
Group Nav: limit avatars & hide overflow

### DIFF
--- a/src/styles/navStyles.js
+++ b/src/styles/navStyles.js
@@ -8,6 +8,7 @@ export const statics = {
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'flex-start',
+    overflow: 'hidden',
   },
   navSubtitle: {
     fontSize: 13,

--- a/src/title/TitleGroup.js
+++ b/src/title/TitleGroup.js
@@ -1,7 +1,7 @@
 /* @flow strict-local */
 
 import React, { PureComponent } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { StyleSheet, View, Dimensions } from 'react-native';
 
 import type { Dispatch, UserOrBot } from '../types';
 import { connectFlowFixMe } from '../react-redux';
@@ -29,10 +29,12 @@ class TitleGroup extends PureComponent<Props> {
 
   render() {
     const { recipients } = this.props;
+    const { width, height } = Dimensions.get('window');
+    const numOfAvatar = Math.ceil(Math.max(width, height) / (32 + 16)); // ImgSize: 32, margin: 16
 
     return (
       <View style={styles.navWrapper}>
-        {recipients.map((user, index) => (
+        {recipients.slice(0, numOfAvatar).map((user, index) => (
           <View key={user.email} style={this.styles.titleAvatar}>
             <UserAvatarWithPresence
               onPress={() => this.handlePress(user)}


### PR DESCRIPTION
Fixes issue: #3700

**Before**
![020ef3fa-5a60-47ed-a558-91507f142451](https://user-images.githubusercontent.com/31537546/72142553-f07ed900-33ba-11ea-9e28-cec5b30944e3.jpeg)
---
**After**
![7e721bb2-0bb6-4b62-ab45-f32916c5e20d](https://user-images.githubusercontent.com/31537546/72142540-e9f06180-33ba-11ea-9d0d-8ad9d67cea96.jpeg)

`navWrapper` style is being used multiple places but I guess it's safe to set `overflow: hidden` as overflow anyways goes beyond the screen in other cases.

This fixes the issue but I also limited the number of avatars to be rendered as in a large group without this limit, 100s of avatar images will stay in memory without being displayed.
* I used screen height as well so as to have enough avatars for landscape mode. 
* I didn't consider navigation and info icon's width so as to have 1 or 2 extra avatars just to be on a safer side.