### PR TITLE
MessageActionSheet: Remove reply option from ActionSheet when in a topic narrow

### DIFF
--- a/src/message/messageActionSheet.js
+++ b/src/message/messageActionSheet.js
@@ -2,7 +2,13 @@
 import { Clipboard, Share } from 'react-native';
 import type { Auth, Dispatch, GetText, Message, Narrow, Outbox, Subscription } from '../types';
 import type { BackgroundData } from '../webview/MessageList';
-import { getNarrowFromMessage, isHomeNarrow, isSpecialNarrow } from '../utils/narrow';
+import {
+  getNarrowFromMessage,
+  isHomeNarrow,
+  isPrivateNarrow,
+  isSpecialNarrow,
+  isTopicNarrow,
+} from '../utils/narrow';
 import { isTopicMuted } from '../utils/message';
 import * as api from '../api';
 import { showToast } from '../utils/info';
@@ -192,7 +198,7 @@ export const constructMessageActionButtons = ({
   if (!isAnOutboxMessage(message) && messageNotDeleted(message)) {
     buttons.push('addReaction');
   }
-  if (!isAnOutboxMessage(message)) {
+  if (!isAnOutboxMessage(message) && !isTopicNarrow(narrow) && !isPrivateNarrow(narrow)) {
     buttons.push('reply');
   }
   if (messageNotDeleted(message)) {


### PR DESCRIPTION
Fixes #3528 
![report-reply](https://user-images.githubusercontent.com/7714968/72279137-7f118580-365b-11ea-99f8-9590cfff7211.gif)

Earlier, a `reply` option was also shown in the messageActionSheet, which essentially performed no action, since the user is already in a topic narrow.
