### PR TITLE
account details screen: Display deactivation information for user

### DIFF
--- a/src/account-info/AccountDetailsScreen.js
+++ b/src/account-info/AccountDetailsScreen.js
@@ -5,20 +5,28 @@ import { StyleSheet } from 'react-native';
 import type { Dispatch, GlobalState, User } from '../types';
 import { connectFlowFixMe } from '../react-redux';
 import { getAccountDetailsUserForEmail } from '../selectors';
-import { Screen, ZulipButton } from '../common';
+import { Screen, ZulipButton, Label } from '../common';
 import { IconPrivateChat } from '../common/Icons';
 import { privateNarrow } from '../utils/narrow';
 import AccountDetails from './AccountDetails';
 import { doNarrow } from '../actions';
+import { getUserIsActive } from '../users/userSelectors';
 
 const styles = StyleSheet.create({
   pmButton: {
     marginHorizontal: 16,
   },
+  deactivatedText: {
+    textAlign: 'center',
+    paddingBottom: 20,
+    fontStyle: 'italic',
+    fontSize: 18,
+  },
 });
 
 type Props = $ReadOnly<{|
   user: User,
+  isActive: boolean,
   dispatch: Dispatch,
 |}>;
 
@@ -29,7 +37,7 @@ class AccountDetailsScreen extends PureComponent<Props> {
   };
 
   render() {
-    const { user } = this.props;
+    const { user, isActive } = this.props;
     const title = {
       text: '{_}',
       values: {
@@ -41,9 +49,12 @@ class AccountDetailsScreen extends PureComponent<Props> {
     return (
       <Screen title={title}>
         <AccountDetails user={user} />
+        {!isActive && (
+          <Label style={styles.deactivatedText} text="(This user has been deactivated)" />
+        )}
         <ZulipButton
           style={styles.pmButton}
-          text="Send private message"
+          text={isActive ? 'Send private message' : 'View private messages'}
           onPress={this.handleChatPress}
           Icon={IconPrivateChat}
         />
@@ -54,4 +65,5 @@ class AccountDetailsScreen extends PureComponent<Props> {
 
 export default connectFlowFixMe((state: GlobalState, props) => ({
   user: getAccountDetailsUserForEmail(state, props.navigation.state.params.email),
+  isActive: getUserIsActive(state, props.navigation.state.params.email),
 }))(AccountDetailsScreen);

--- a/src/users/__tests__/userSelectors-test.js
+++ b/src/users/__tests__/userSelectors-test.js
@@ -6,6 +6,7 @@ import {
   getAllUsersById,
   getUsersById,
   getUsersSansMe,
+  getUserIsActive,
 } from '../userSelectors';
 import * as eg from '../../__tests__/exampleData';
 
@@ -122,5 +123,27 @@ describe('getUsersSansMe', () => {
       realm: eg.realmState({ email: eg.selfUser.email }),
     });
     expect(getUsersSansMe(state)).toEqual([eg.otherUser]);
+  });
+});
+
+describe('getUserIsActive', () => {
+  const state = eg.reduxState({
+    users: [eg.selfUser],
+    realm: {
+      ...eg.baseReduxState.realm,
+      crossRealmBots: [eg.crossRealmBot],
+      nonActiveUsers: [eg.makeUser(), eg.makeUser()],
+    },
+  });
+  test('returns false for a user that has been deactivated', () => {
+    expect(getUserIsActive(state, state.realm.nonActiveUsers[0].email)).toBeFalse();
+  });
+
+  test('returns true for a user that has not been deactivated', () => {
+    expect(getUserIsActive(state, state.users[0].email)).toBeTrue();
+  });
+
+  test('returns true for a cross realm bot', () => {
+    expect(getUserIsActive(state, state.realm.crossRealmBots[0].email)).toBeTrue();
   });
 });

--- a/src/users/userSelectors.js
+++ b/src/users/userSelectors.js
@@ -173,3 +173,19 @@ export const getAccountDetailsUserForEmail: Selector<UserOrBot, string> = create
     );
   },
 );
+
+/**
+ * The activation status of a user - whether or not a user/bot has
+ * been deactivated (`is_active` in the Zulip API).
+ */
+export const getUserIsActive: Selector<boolean, string> = createSelector(
+  (state, email) => email,
+  state => getActiveUsersByEmail(state),
+  (email, usersByEmail) => {
+    if (!email) {
+      return false;
+    } else {
+      return usersByEmail.has(email);
+    }
+  },
+);

--- a/static/translations/messages_en.json
+++ b/static/translations/messages_en.json
@@ -86,6 +86,8 @@
   "Jot down something": "Jot down something",
   "Message {recipient}": "Message {recipient}",
   "Send private message": "Send private message",
+  "View private messages": "View private messages",
+  "(This user has been deactivated)": "(This user has been deactivated)",
   "Forgot password?": "Forgot password?",
   "Members": "Members",
   "Recipients": "Recipients",


### PR DESCRIPTION
Fixes #3551.

Two changes:
1. Deactivation status is shown.
1. Button text is "View private messages" instead of "Send private message"

**Before**: (Assume Cyphase is deactivated ) 
![before](https://user-images.githubusercontent.com/7714968/72449566-e6a40e00-37de-11ea-90cb-42d3e28cccf8.png)

**After**:
![after](https://user-images.githubusercontent.com/7714968/72502566-a3d64a80-385f-11ea-8955-a295267b1e31.png)

I had to fiddle around a  lot to understand to get the relevant data, here is the reasoning why it is done in this manner:
 - The get-all-users *is not* used by the mobile app to fetch user lists ( this is the list that contains is_deactivated data ). Instead, /register event queue is used.
- So, there is no direct way to get if a user is deactivated. However, `getActiveUsersByEmail()` returns only activated users, comparing it with current user can give us `is_deactivated`.
- A lot of informative and detailed comments are present in `/src/api/modelTypes.js:47` and  `/src/users/userSelectors.js`, the reviewer may go through them.

I *really* enjoyed doing this :D