### PR TITLE
Strip any number of trailing slashes from realm URLs

### DIFF
--- a/src/boot/store.js
+++ b/src/boot/store.js
@@ -132,6 +132,15 @@ const migrations: { [string]: (GlobalState) => GlobalState } = {
       },
     };
   },
+
+  // Fixes #3567 for users with cached realm urls with multiple trailing slashes.
+  '11': state => ({
+    ...state,
+    accounts: state.accounts.map(a => ({
+      ...a,
+      realm: a.realm.replace(/\/+$/, ''),
+    })),
+  }),
 };
 
 const reduxPersistConfig: Config = {

--- a/src/utils/__tests__/url-test.js
+++ b/src/utils/__tests__/url-test.js
@@ -139,6 +139,10 @@ describe('fixRealmUrl', () => {
     expect(fixRealmUrl('https://example.com/')).toEqual('https://example.com');
   });
 
+  test('when a realm url has two trailing "/" remove them', () => {
+    expect(fixRealmUrl('https://example.com//')).toEqual('https://example.com');
+  });
+
   test('when input url is correct, do not change it', () => {
     expect(fixRealmUrl('https://example.com')).toEqual('https://example.com');
   });

--- a/src/utils/url.js
+++ b/src/utils/url.js
@@ -56,7 +56,6 @@ export type Protocol = 'https://' | 'http://';
 
 const protocolRegex = /^\s*((?:http|https):\/\/)(.*)$/;
 
-/** DEPRECATED */
 const hasProtocol = (url: string = '') => url.search(protocolRegex) !== -1;
 
 // Split a (possible) URL into protocol and non-protocol parts.
@@ -79,7 +78,6 @@ export const parseProtocol = (value: string): [Protocol | null, string] => {
   return [null, value];
 };
 
-/** DEPRECATED */
 export const fixRealmUrl = (url: string = '') => {
   if (url === '') {
     return '';

--- a/src/utils/url.js
+++ b/src/utils/url.js
@@ -84,7 +84,7 @@ export const fixRealmUrl = (url: string = '') => {
   }
   const trimmedUrl = url
     .replace(/\s/g, '') // strip any spaces, internal or otherwise
-    .replace(/\/$/g, ''); // eliminate trailing slash
+    .replace(/\/+$/, ''); // eliminate trailing slash(es)
 
   return hasProtocol(trimmedUrl) ? trimmedUrl : `https://${trimmedUrl}`;
 };


### PR DESCRIPTION
This does the following, to fix https://github.com/zulip/zulip-mobile/issues/3567:

> Things I expect we'll want to do to clean this up:
> 
> * Tweak fixRealmUrl so it strips any number of trailing slashes.
> * Add a migration that strips trailing slashes on realm in all existing accounts.

It also removes some "DEPRECATED" comments that don't seem to apply.