### PR TITLE
redux: Discard messages/narrows on REALM_INIT, not DEAD_QUEUE.

### DIFF
--- a/src/caughtup/caughtUpReducer.js
+++ b/src/caughtup/caughtUpReducer.js
@@ -1,7 +1,7 @@
 /* @flow strict-local */
 import type { CaughtUp, CaughtUpState, Action } from '../types';
 import {
-  DEAD_QUEUE,
+  REALM_INIT,
   LOGOUT,
   LOGIN_SUCCESS,
   ACCOUNT_SWITCH,
@@ -56,7 +56,7 @@ const legacyInferCaughtUp = (prevCaughtUp: CaughtUp | void, action) => {
 
 export default (state: CaughtUpState = initialState, action: Action): CaughtUpState => {
   switch (action.type) {
-    case DEAD_QUEUE:
+    case REALM_INIT:
     case LOGOUT:
     case LOGIN_SUCCESS:
     case ACCOUNT_SWITCH:

--- a/src/chat/Chat.js
+++ b/src/chat/Chat.js
@@ -11,10 +11,12 @@ import ComposeBox from '../compose/ComposeBox';
 import UnreadNotice from './UnreadNotice';
 import styles from '../styles';
 import { canSendToNarrow } from '../utils/narrow';
+import { getLoading } from '../directSelectors';
 import { getFetchingForNarrow } from './fetchingSelectors';
 import { getShownMessagesForNarrow } from './narrowsSelectors';
 
 type SelectorProps = {|
+  loading: boolean,
   fetching: Fetching,
   haveNoMessages: boolean,
 |};
@@ -37,9 +39,9 @@ const componentStyles = StyleSheet.create({
 
 class Chat extends PureComponent<Props> {
   render() {
-    const { fetching, haveNoMessages, narrow } = this.props;
+    const { fetching, loading, haveNoMessages, narrow } = this.props;
 
-    const isFetching = fetching.older || fetching.newer;
+    const isFetching = fetching.older || fetching.newer || loading;
     const showMessagePlaceholders = haveNoMessages && isFetching;
     const sayNoMessages = haveNoMessages && !isFetching;
     const showComposeBox = canSendToNarrow(narrow) && !showMessagePlaceholders;
@@ -59,6 +61,7 @@ class Chat extends PureComponent<Props> {
 }
 
 export default connect<SelectorProps, _, _>((state, props) => ({
+  loading: getLoading(state),
   fetching: getFetchingForNarrow(state, props.narrow),
   haveNoMessages: getShownMessagesForNarrow(state, props.narrow).length === 0,
 }))(Chat);

--- a/src/chat/fetchingReducer.js
+++ b/src/chat/fetchingReducer.js
@@ -1,7 +1,6 @@
 /* @flow strict-local */
 import type { FetchingState, Action } from '../types';
 import {
-  DEAD_QUEUE,
   LOGOUT,
   LOGIN_SUCCESS,
   ACCOUNT_SWITCH,
@@ -42,7 +41,6 @@ const messageFetchComplete = (state, action) => {
 
 export default (state: FetchingState = initialState, action: Action): FetchingState => {
   switch (action.type) {
-    case DEAD_QUEUE:
     case LOGOUT:
     case LOGIN_SUCCESS:
     case DO_NARROW:

--- a/src/chat/flagsReducer.js
+++ b/src/chat/flagsReducer.js
@@ -6,6 +6,7 @@ import {
   EVENT_NEW_MESSAGE,
   EVENT_UPDATE_MESSAGE_FLAGS,
   LOGOUT,
+  LOGIN_SUCCESS,
   ACCOUNT_SWITCH,
 } from '../actionConstants';
 import { deeperMerge } from '../utils/misc';
@@ -100,6 +101,7 @@ export default (state: FlagsState = initialState, action: Action): FlagsState =>
   switch (action.type) {
     case REALM_INIT:
     case LOGOUT:
+    case LOGIN_SUCCESS:
     case ACCOUNT_SWITCH:
       return initialState;
 

--- a/src/chat/flagsReducer.js
+++ b/src/chat/flagsReducer.js
@@ -1,7 +1,7 @@
 /* @flow strict-local */
 import type { Action, FlagsState, Message } from '../types';
 import {
-  DEAD_QUEUE,
+  REALM_INIT,
   MESSAGE_FETCH_COMPLETE,
   EVENT_NEW_MESSAGE,
   EVENT_UPDATE_MESSAGE_FLAGS,
@@ -98,7 +98,7 @@ const eventUpdateMessageFlags = (state, action) => {
 
 export default (state: FlagsState = initialState, action: Action): FlagsState => {
   switch (action.type) {
-    case DEAD_QUEUE:
+    case REALM_INIT:
     case LOGOUT:
     case ACCOUNT_SWITCH:
       return initialState;

--- a/src/chat/narrowsReducer.js
+++ b/src/chat/narrowsReducer.js
@@ -4,7 +4,7 @@ import union from 'lodash.union';
 import type { NarrowsState, Action } from '../types';
 import { ensureUnreachable } from '../types';
 import {
-  DEAD_QUEUE,
+  REALM_INIT,
   LOGOUT,
   LOGIN_SUCCESS,
   ACCOUNT_SWITCH,
@@ -95,7 +95,7 @@ const eventUpdateMessageFlags = (state, action) => {
 
 export default (state: NarrowsState = initialState, action: Action): NarrowsState => {
   switch (action.type) {
-    case DEAD_QUEUE:
+    case REALM_INIT:
     case LOGOUT:
     case LOGIN_SUCCESS:
     case ACCOUNT_SWITCH:

--- a/src/message/messagesReducer.js
+++ b/src/message/messagesReducer.js
@@ -3,7 +3,7 @@ import omit from 'lodash.omit';
 
 import type { MessagesState, Action } from '../types';
 import {
-  DEAD_QUEUE,
+  REALM_INIT,
   LOGOUT,
   LOGIN_SUCCESS,
   ACCOUNT_SWITCH,
@@ -139,7 +139,7 @@ const eventUpdateMessage = (state, action) => {
 
 export default (state: MessagesState = initialState, action: Action): MessagesState => {
   switch (action.type) {
-    case DEAD_QUEUE:
+    case REALM_INIT:
     case LOGOUT:
     case LOGIN_SUCCESS:
     case ACCOUNT_SWITCH:


### PR DESCRIPTION
Fixes: #3802.

When returning to the app after the event queue has expired, there's
a moment after stale data is purged when the app incorrectly
believes that an empty message list is the up-to-date state, and "No
messages! Why not start the conversation?" displays until fresh data
arrives.

Currently, state.messages and state.narrows are emptied on the
DEAD_QUEUE action, which is dispatched before the /register request.
Instead, preserve the stale data until /register completes, clearing
it in response to REALM_INIT.

In doInitialFetch, fetchTopMostNarrow, fetchPrivateMessages, and
(sometimes) fetchMessagesInNarrow are also dispatched after
/register to ensure the stale data is refreshed. All of these
already handle their loading states correctly, on a per-narrow basis
in state.fetching.

Clearing the messages in MESSAGE_FETCH_START instead of REALM_INIT
was considered but rejected because MESSAGE_FETCH_START is
dispatched before the /register request.