### PR TITLE
edit message : allow cancellation of edit

### DIFF
--- a/src/nav/navActions.js
+++ b/src/nav/navActions.js
@@ -1,5 +1,6 @@
 /* @flow strict-local */
 import { StackActions } from 'react-navigation';
+import { cancelEditMessage } from '../session/sessionActions';
 
 import type {
   Dispatch,
@@ -10,10 +11,24 @@ import type {
   UserOrBot,
   ApiResponseServerSettings,
 } from '../types';
+
+import type { Action } from '../actionTypes';
 import { getSameRoutesCount } from '../selectors';
 
-export const navigateBack = () => (dispatch: Dispatch, getState: GetState): NavigationAction =>
-  dispatch(StackActions.pop({ n: getSameRoutesCount(getState()) }));
+export const navigateBack = () => (
+  dispatch: Dispatch,
+  getState: GetState,
+): NavigationAction | Action => {
+  /**
+   * If a message is currently being edited, cancel the edit. Otherwise,
+   * navigate back.
+   */
+  if (getState().session.editMessage) {
+    return dispatch(cancelEditMessage());
+  } else {
+    return dispatch(StackActions.pop({ n: getSameRoutesCount(getState()) }));
+  }
+};
 
 // Other stack routes reached through `navReducer`:
 //    StackActions.push({ routeName: 'loading' });


### PR DESCRIPTION
Fixes https://github.com/zulip/zulip-mobile/issues/2757

Before:
![old](https://user-images.githubusercontent.com/7714968/72819420-3b3e0200-3c93-11ea-80fb-4d9cd5d1069c.gif)

Now:
![now](https://user-images.githubusercontent.com/7714968/72782176-250b5400-3c49-11ea-8deb-21b488f448f5.gif)





