### PR TITLE
Lightbox: fix support for GIFs

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -210,7 +210,7 @@ dependencies {
     implementation "com.google.firebase:firebase-messaging:17.3.4"
     implementation "me.leolin:ShortcutBadger:1.1.16@aar"
     implementation "com.facebook.react:react-native:+"  // From node_modules
-    implementation 'com.facebook.fresco:animated-gif:1.3.0' // For animated GIF support
+    implementation 'com.facebook.fresco:animated-gif:1.10.0' // For animated GIF support
     implementation "com.android.support:customtabs:${rootProject.ext.supportLibVersion}"
 
     testImplementation 'junit:junit:4.12'


### PR DESCRIPTION
Closes #3497.
GIFs weren't working on Android. This patch fixes that.

**Reason for changes**:
The earlier dependencies in build.gradle worked only for RN Version>0.60.
This configuration works for RN Version 0.59.

This is documented in the official docs for React Native 0.59 (https://facebook.github.io/react-native/docs/0.59/image#gif-and-webp-support-on-android)

![gif](https://user-images.githubusercontent.com/7714968/72748255-bbedf700-3bdc-11ea-806d-602531d9017f.gif)
