### PR TITLE
ComposeBox.js: On componentWillUnmount, clear 200ms timeout on input …

### DIFF
--- a/src/compose/ComposeBox.js
+++ b/src/compose/ComposeBox.js
@@ -107,6 +107,8 @@ class ComposeBox extends PureComponent<Props, State> {
   messageInput: ?TextInput = null;
   topicInput: ?TextInput = null;
 
+  inputBlurTimeoutId: ?TimeoutID = null;
+
   static contextTypes = {
     styles: () => null,
   };
@@ -121,6 +123,11 @@ class ComposeBox extends PureComponent<Props, State> {
     message: this.props.draft,
     selection: { start: 0, end: 0 },
   };
+
+  componentWillUnmount() {
+    clearTimeout(this.inputBlurTimeoutId);
+    this.inputBlurTimeoutId = null;
+  }
 
   updateIsFocused = () => {
     this.setState(state => ({
@@ -201,7 +208,9 @@ class ComposeBox extends PureComponent<Props, State> {
       isMessageFocused: false,
       isMenuExpanded: false,
     });
-    setTimeout(this.updateIsFocused, 200); // give a chance to the topic input to get the focus
+    // give a chance to the topic input to get the focus
+    clearTimeout(this.inputBlurTimeoutId);
+    this.inputBlurTimeoutId = setTimeout(this.updateIsFocused, 200);
   };
 
   handleTopicFocus = () => {
@@ -219,7 +228,9 @@ class ComposeBox extends PureComponent<Props, State> {
       isTopicFocused: false,
       isMenuExpanded: false,
     });
-    setTimeout(this.updateIsFocused, 200); // give a chance to the message input to get the focus
+    // give a chance to the message input to get the focus
+    clearTimeout(this.inputBlurTimeoutId);
+    this.inputBlurTimeoutId = setTimeout(this.updateIsFocused, 200);
   };
 
   handleInputTouchStart = () => {


### PR DESCRIPTION
…blurs.

Discovered in https://github.com/zulip/zulip-mobile/issues/2937#issuecomment-577368784.

To avoid calling setState on an unmounted component (yellow box warning
observed at https://github.com/zulip/zulip-mobile/issues/2937#issuecomment-577368784),
this clears the timeouts on componentWillUnmount that get set on handleMessageBlur
and handleTopicBlur to delay the call to this.updateIsFocused (which calls
this.setState) by 200ms.

From a quick search through the code, I don't see any other obvious cases where a
setTimeout delays a call to setState, but there may be other asynchronous tasks
that would trigger this warning.