### PR TITLE
compose box: enable Send button in PMs 

### DIFF
--- a/src/compose/ComposeBox.js
+++ b/src/compose/ComposeBox.js
@@ -117,7 +117,7 @@ class ComposeBox extends PureComponent<Props, State> {
     isFocused: false,
     isMenuExpanded: false,
     height: 20,
-    topic: this.props.lastMessageTopic,
+    topic: this.props.lastMessageTopic || 'topic',
     message: this.props.draft,
     selection: { start: 0, end: 0 },
   };


### PR DESCRIPTION
Fixes Issue #3820 Send button in private messages is disabled.
When the state 'topic' is initialized, it's value will be set to this.props.lastMessageTopic if this value is not empty, else the state's value will be set to the string 'topic'. This will avoid the topic in personal messages becoming empty, and hence won't disable the Send button.