### PR TITLE
Emoji reaction search: Fix emoji query search

### DIFF
--- a/src/emoji/__tests__/data-test.js
+++ b/src/emoji/__tests__/data-test.js
@@ -36,7 +36,7 @@ describe('getFilteredEmojiNames', () => {
   });
 
   test('returns a sorted list of emojis starting with query', () => {
-    const list = getFilteredEmojiNames('go', []);
+    const list = getFilteredEmojiNames('go', {});
     expect(list).toEqual([
       'go',
       'goal',

--- a/src/emoji/__tests__/data-test.js
+++ b/src/emoji/__tests__/data-test.js
@@ -36,7 +36,7 @@ describe('getFilteredEmojiNames', () => {
   });
 
   test('returns a sorted list of emojis starting with query', () => {
-    const list = getFilteredEmojiNames('go', {});
+    const list = getFilteredEmojiNames('go', []);
     expect(list).toEqual([
       'go',
       'goal',
@@ -50,6 +50,17 @@ describe('getFilteredEmojiNames', () => {
       'gooooooooal',
       'gorilla',
       'got_it',
+      'agony',
+      'dango',
+      'dragon',
+      'dragon_face',
+      'virgo',
+      'all_good',
+      'octagonal_sign',
+      'synagogue',
+      'merry_go_round',
+      'heart_of_gold',
+      'easy_come_easy_go',
     ]);
   });
 
@@ -58,7 +69,7 @@ describe('getFilteredEmojiNames', () => {
   });
 
   test('remove duplicates', () => {
-    expect(getFilteredEmojiNames('dog', {})).toEqual(['dog', 'dogi']);
-    expect(getFilteredEmojiNames('dog', { dog: {} })).toEqual(['dog', 'dogi']);
+    expect(getFilteredEmojiNames('dog', {})).toEqual(['dog', 'dogi', 'hotdog']);
+    expect(getFilteredEmojiNames('dog', { dog: {} })).toEqual(['dog', 'dogi', 'hotdog']);
   });
 });

--- a/src/emoji/data.js
+++ b/src/emoji/data.js
@@ -25,10 +25,24 @@ export const codeToEmojiMap = objectFromEntries<string, string>(
   }),
 );
 
+const sortEmojiByQueryName = (
+  emoji: Array<string>,
+  query: string
+): string[] => emoji.sort(
+  (a, b) => {
+    if (a.indexOf(query) !== b.indexOf(query)) {
+       return a.indexOf(query) - b.indexOf(query);
+    } else { return (a > b ? 1 : -1); }
+  }
+);
+
 export const getFilteredEmojiNames = (
   query: string,
   activeRealmEmojiByName: $ReadOnly<{ [string]: ImageEmojiType }>,
 ): string[] => {
   const names = [...unicodeEmojiNames, ...Object.keys(activeRealmEmojiByName)];
-  return Array.from(new Set([...names.filter(x => x.includes(query)).sort()]));
+  const emoji = Array.from(new Set(
+    [...names.filter(x => x.includes(query))])
+  );
+  return sortEmojiByQueryName(emoji, query);
 };

--- a/src/emoji/data.js
+++ b/src/emoji/data.js
@@ -30,5 +30,5 @@ export const getFilteredEmojiNames = (
   activeRealmEmojiByName: $ReadOnly<{ [string]: ImageEmojiType }>,
 ): string[] => {
   const names = [...unicodeEmojiNames, ...Object.keys(activeRealmEmojiByName)];
-  return Array.from(new Set([...names.filter(x => x.indexOf(query) === 0).sort()]));
+  return Array.from(new Set([...names.filter(x => x.includes(query)).sort()]));
 };


### PR DESCRIPTION
Emoji reaction search was querying emoji whose name begins with search term.
But if a search term is valid but not present at the beginning of that emoji
name, then searching was inefficient to query the required emoji.
This issue has resolved by querrying of emoji whose name contains the search
-Term, no matter where the search term is present.
manual testing has done.
Fixes:#3833