### PR TITLE
Revert "ComposeBox: Don't send message with whitespace-only topic."

### DIFF
--- a/src/compose/ComposeBox.js
+++ b/src/compose/ComposeBox.js
@@ -403,7 +403,7 @@ class ComposeBox extends PureComponent<Props, State> {
             style={this.styles.composeSendButton}
             Icon={editMessage === null ? IconSend : IconDone}
             size={32}
-            disabled={message.trim().length === 0 || topic.trim().length === 0}
+            disabled={message.trim().length === 0}
             onPress={editMessage === null ? this.handleSend : this.handleEdit}
           />
         </View>


### PR DESCRIPTION
This reverts commit a2d6793aeac19259c205a175048f4017bf89ddcb.

Fixes #3820 (Send button never enabled in PMs), which was a regression
induced by the reverted commit.

Reopens #3743. Obviates and closes #3821.