### PR TITLE
[FIX] Emoji reaction search only checks beginning of name

### DIFF
--- a/src/emoji/data.js
+++ b/src/emoji/data.js
@@ -30,5 +30,7 @@ export const getFilteredEmojiNames = (
   activeRealmEmojiByName: $ReadOnly<{ [string]: ImageEmojiType }>,
 ): string[] => {
   const names = [...unicodeEmojiNames, ...Object.keys(activeRealmEmojiByName)];
-  return Array.from(new Set([...names.filter(x => x.indexOf(query) === 0).sort()]));
+  const matchFromStart = Array.from(new Set([...names.filter(x => x.indexOf(query) === 0).sort()]));
+  const matchAfterStart = Array.from(new Set([...names.filter(x => x.indexOf(query) > 0).sort()]));
+  return [...matchFromStart, ...matchAfterStart];
 };


### PR DESCRIPTION
closes #3833 
### After changes:
![zzzz](https://user-images.githubusercontent.com/43786728/73178393-26e88200-4137-11ea-9b36-037bf938cf4a.gif)

