### PR TITLE
logging: truncate list of unknown message IDs

### DIFF
--- a/src/message/messageSelectors.js
+++ b/src/message/messageSelectors.js
@@ -55,7 +55,7 @@ export const getPrivateMessages: Selector<Message[]> = createSelector(
     if (unknownIds.length > 0) {
       logging.error('narrow IDs not found in state.messages', {
         all_ids: truncateForLogging(pmIds),
-        unknown_ids: unknownIds,
+        unknown_ids: truncateForLogging(unknownIds),
       });
     }
     return privateMessages;


### PR DESCRIPTION
Followup to #3733. (This list isn't necessarily any shorter than the
list of all private messages.)