### PR TITLE
emoji: Use parseUnicodeEmojiCode to render unicode emoji.

### DIFF
--- a/src/autocomplete/EmojiAutocomplete.js
+++ b/src/autocomplete/EmojiAutocomplete.js
@@ -5,7 +5,7 @@ import { FlatList } from 'react-native';
 
 import { Popup } from '../common';
 import EmojiRow from '../emoji/EmojiRow';
-import { getFilteredEmojiNames } from '../emoji/data';
+import { getFilteredEmojis } from '../emoji/data';
 import type { RealmEmojiById, Dispatch } from '../types';
 import { connect } from '../react-redux';
 import { getActiveImageEmojiByName } from '../selectors';
@@ -26,7 +26,7 @@ class EmojiAutocomplete extends PureComponent<Props> {
 
   render() {
     const { filter, activeImageEmojiByName } = this.props;
-    const emojiNames = getFilteredEmojiNames(filter, activeImageEmojiByName);
+    const emojiNames = getFilteredEmojis(filter, activeImageEmojiByName);
 
     if (emojiNames.length === 0) {
       return null;
@@ -38,8 +38,8 @@ class EmojiAutocomplete extends PureComponent<Props> {
           keyboardShouldPersistTaps="always"
           initialNumToRender={12}
           data={emojiNames.slice(0, MAX_CHOICES)}
-          keyExtractor={item => item}
-          renderItem={({ item: name }) => <EmojiRow name={name} onPress={this.onAutocomplete} />}
+          keyExtractor={item => item.name}
+          renderItem={({ item }) => <EmojiRow name={item.name} onPress={this.onAutocomplete} />}
         />
       </Popup>
     );

--- a/src/autocomplete/EmojiAutocomplete.js
+++ b/src/autocomplete/EmojiAutocomplete.js
@@ -39,7 +39,14 @@ class EmojiAutocomplete extends PureComponent<Props> {
           initialNumToRender={12}
           data={emojiNames.slice(0, MAX_CHOICES)}
           keyExtractor={item => item.name}
-          renderItem={({ item }) => <EmojiRow name={item.name} onPress={this.onAutocomplete} />}
+          renderItem={({ item }) => (
+            <EmojiRow
+              type={item.emoji_type}
+              code={item.code}
+              name={item.name}
+              onPress={this.onAutocomplete}
+            />
+          )}
         />
       </Popup>
     );

--- a/src/emoji/Emoji.js
+++ b/src/emoji/Emoji.js
@@ -3,21 +3,22 @@ import React, { PureComponent } from 'react';
 import { StyleSheet, Image } from 'react-native';
 import { createIconSet } from 'react-native-vector-icons';
 
-import type { ImageEmojiType, Dispatch } from '../types';
+import type { ImageEmojiType, Dispatch, EmojiType } from '../types';
 import { connect } from '../react-redux';
-import { nameToEmojiMap } from './data';
-import { getAllImageEmojiByName } from './emojiSelectors';
+import { getAllImageEmojiByCode } from './emojiSelectors';
+import { codeToEmojiMap } from './data';
 
-/* $FlowFixMe: `nameToEmojiMap` is mistyped upstream; elements of
+/* $FlowFixMe: `createIconSet` is mistyped upstream; elements of
   `glyphMap` may be either `number` or `string`. */
-const UnicodeEmoji = createIconSet(nameToEmojiMap);
+const UnicodeEmoji = createIconSet(codeToEmojiMap);
 
 type SelectorProps = {|
   imageEmoji: ImageEmojiType | void,
 |};
 
 type Props = $ReadOnly<{|
-  name: string,
+  type: EmojiType,
+  code: string,
 
   dispatch: Dispatch,
   ...SelectorProps,
@@ -29,14 +30,14 @@ class Emoji extends PureComponent<Props> {
   });
 
   render() {
-    const { name, imageEmoji } = this.props;
+    const { code, imageEmoji } = this.props;
     if (imageEmoji) {
       return <Image style={this.styles.image} source={{ uri: imageEmoji.source_url }} />;
     }
-    return <UnicodeEmoji name={name} size={20} />;
+    return <UnicodeEmoji name={code} size={20} />;
   }
 }
 
 export default connect<SelectorProps, _, _>((state, props) => ({
-  imageEmoji: getAllImageEmojiByName(state)[props.name],
+  imageEmoji: props.type === 'image' ? getAllImageEmojiByCode(state)[props.code] : undefined,
 }))(Emoji);

--- a/src/emoji/EmojiPickerScreen.js
+++ b/src/emoji/EmojiPickerScreen.js
@@ -8,7 +8,7 @@ import * as api from '../api';
 import { unicodeCodeByName } from './codePointMap';
 import { Screen } from '../common';
 import EmojiRow from './EmojiRow';
-import { getFilteredEmojiNames } from './data';
+import { getFilteredEmojis } from './data';
 import type { RealmEmojiById, Auth, Dispatch, ReactionType } from '../types';
 import { connect } from '../react-redux';
 import { getAuth, getActiveImageEmojiByName } from '../selectors';
@@ -64,7 +64,7 @@ class EmojiPickerScreen extends PureComponent<Props, State> {
     const { activeImageEmojiByName } = this.props;
     const { filter } = this.state;
 
-    const emojiNames = getFilteredEmojiNames(filter, activeImageEmojiByName);
+    const emojiNames = getFilteredEmojis(filter, activeImageEmojiByName);
 
     return (
       <Screen search scrollEnabled={false} searchBarOnChange={this.handleInputChange}>
@@ -72,8 +72,8 @@ class EmojiPickerScreen extends PureComponent<Props, State> {
           keyboardShouldPersistTaps="always"
           initialNumToRender={20}
           data={emojiNames}
-          keyExtractor={item => item}
-          renderItem={({ item: name }) => <EmojiRow name={name} onPress={this.addReaction} />}
+          keyExtractor={item => item.name}
+          renderItem={({ item }) => <EmojiRow name={item.name} onPress={this.addReaction} />}
         />
       </Screen>
     );

--- a/src/emoji/EmojiPickerScreen.js
+++ b/src/emoji/EmojiPickerScreen.js
@@ -73,7 +73,14 @@ class EmojiPickerScreen extends PureComponent<Props, State> {
           initialNumToRender={20}
           data={emojiNames}
           keyExtractor={item => item.name}
-          renderItem={({ item }) => <EmojiRow name={item.name} onPress={this.addReaction} />}
+          renderItem={({ item }) => (
+            <EmojiRow
+              type={item.emoji_type}
+              code={item.code}
+              name={item.name}
+              onPress={this.addReaction}
+            />
+          )}
         />
       </Screen>
     );

--- a/src/emoji/EmojiRow.js
+++ b/src/emoji/EmojiRow.js
@@ -2,6 +2,7 @@
 import React, { PureComponent } from 'react';
 import { StyleSheet, View } from 'react-native';
 
+import type { EmojiType } from '../types';
 import { RawLabel, Touchable } from '../common';
 import Emoji from './Emoji';
 
@@ -17,6 +18,8 @@ const styles = StyleSheet.create({
 });
 
 type Props = $ReadOnly<{|
+  type: EmojiType,
+  code: string,
   name: string,
   onPress: (name: string) => void,
 |}>;
@@ -28,12 +31,12 @@ export default class EmojiRow extends PureComponent<Props> {
   };
 
   render() {
-    const { name } = this.props;
+    const { code, name, type } = this.props;
 
     return (
       <Touchable onPress={this.handlePress}>
         <View style={styles.emojiRow}>
-          <Emoji name={name} />
+          <Emoji code={code} type={type} />
           <RawLabel style={styles.text} text={name} />
         </View>
       </Touchable>

--- a/src/emoji/__tests__/data-test.js
+++ b/src/emoji/__tests__/data-test.js
@@ -1,3 +1,4 @@
+/* @flow strict-local */
 import { getFilteredEmojiNames, nameToEmojiMap } from '../data';
 
 // Prettier disabled in .prettierignore ; it misparses this file, apparently
@@ -65,11 +66,24 @@ describe('getFilteredEmojiNames', () => {
   });
 
   test('search in realm emojis as well', () => {
-    expect(getFilteredEmojiNames('qwerty', { qwerty: {} })).toEqual(['qwerty']);
+    expect(
+      getFilteredEmojiNames('qwerty', {
+        qwerty: { code: '654', deactivated: false, name: 'qwerty', source_url: 'url' },
+      }),
+    ).toEqual(['qwerty']);
   });
 
   test('remove duplicates', () => {
     expect(getFilteredEmojiNames('dog', {})).toEqual(['dog', 'dogi', 'hotdog']);
-    expect(getFilteredEmojiNames('dog', { dog: {} })).toEqual(['dog', 'dogi', 'hotdog']);
+    expect(
+      getFilteredEmojiNames('dog', {
+        dog: {
+          code: '345',
+          deactivated: false,
+          name: 'dog',
+          source_url: 'url',
+        },
+      }),
+    ).toEqual(['dog', 'dogi', 'hotdog']);
   });
 });

--- a/src/emoji/__tests__/data-test.js
+++ b/src/emoji/__tests__/data-test.js
@@ -1,29 +1,29 @@
 /* @flow strict-local */
-import { getFilteredEmojis, nameToEmojiMap } from '../data';
+import { codeToEmojiMap, getFilteredEmojis } from '../data';
 
 // Prettier disabled in .prettierignore ; it misparses this file, apparently
 // because of the emoji.  (Even if they're tucked away in comments, it still
 // gets it wrong.)
 
 /* eslint-disable no-multi-spaces, spellcheck/spell-checker */
-describe('nameToEmojiMap', () => {
+describe('codeToEmojiMap', () => {
   const check = (name, string1, string2) => {
     expect(string1).toEqual(string2);
-    expect(nameToEmojiMap[name]).toEqual(string1);
+    expect(codeToEmojiMap[name]).toEqual(string1);
   };
 
   test('works for some single-codepoint emoji', () => {
-    check('thumbs_up', '👍', '\u{1f44d}');
-    check('pride',     '🌈', '\u{1f308}');
-    check('rainbow',   '🌈', '\u{1f308}');
+    check('1f44d', '👍', '\u{1f44d}');
+    check('1f308', '🌈', '\u{1f308}');
+    check('1f308', '🌈', '\u{1f308}');
   });
-
   test('works for some multi-codepoint emoji', () => {
-    check('0',        '0⃣', '0\u{20e3}');
-    check('asterisk', '*⃣', '*\u{20e3}');
-    check('hash',     '#⃣', '#\u{20e3}');
+    check('0030-20e3', '0⃣', '0\u{20e3}');
+    check('002a-20e3', '*⃣', '*\u{20e3}');
+    check('0023-20e3', '#⃣', '#\u{20e3}');
   });
 });
+
 
 describe('getFilteredEmojis', () => {
   test('empty query returns all emojis', () => {

--- a/src/emoji/__tests__/data-test.js
+++ b/src/emoji/__tests__/data-test.js
@@ -1,5 +1,5 @@
 /* @flow strict-local */
-import { getFilteredEmojiNames, nameToEmojiMap } from '../data';
+import { getFilteredEmojis, nameToEmojiMap } from '../data';
 
 // Prettier disabled in .prettierignore ; it misparses this file, apparently
 // because of the emoji.  (Even if they're tucked away in comments, it still
@@ -25,58 +25,67 @@ describe('nameToEmojiMap', () => {
   });
 });
 
-describe('getFilteredEmojiNames', () => {
+describe('getFilteredEmojis', () => {
   test('empty query returns all emojis', () => {
-    const list = getFilteredEmojiNames('', {});
+    const list = getFilteredEmojis('', {});
     expect(list).toHaveLength(1560);
   });
 
   test('non existing query returns empty list', () => {
-    const list = getFilteredEmojiNames('qwerty', {});
+    const list = getFilteredEmojis('qwerty', {});
     expect(list).toHaveLength(0);
   });
 
   test('returns a sorted list of emojis starting with query', () => {
-    const list = getFilteredEmojiNames('go', {});
+    const list = getFilteredEmojis('go', {});
     expect(list).toEqual([
-      'go',
-      'goal',
-      'goat',
-      'goblin',
-      'gold',
-      'gold_record',
-      'golf',
-      'gondola',
-      'goodnight',
-      'gooooooooal',
-      'gorilla',
-      'got_it',
-      'agony',
-      'all_good',
-      'dango',
-      'dragon',
-      'dragon_face',
-      'easy_come_easy_go',
-      'heart_of_gold',
-      'merry_go_round',
-      'octagonal_sign',
-      'synagogue',
-      'virgo',
+      { emoji_type: 'unicode', code: '1f3c1',  name: 'go' },
+      { emoji_type: 'unicode', code: '1f945',  name: 'goal' },
+      { emoji_type: 'unicode', code: '1f410',  name: 'goat' },
+      { emoji_type: 'unicode', code: '1f47a',  name: 'goblin' },
+      { emoji_type: 'unicode', code: '1f947',  name: 'gold' },
+      { emoji_type: 'unicode', code: '1f4bd',  name: 'gold_record' },
+      { emoji_type: 'unicode', code: '1f3cc',  name: 'golf' },
+      { emoji_type: 'unicode', code: '1f6a0',  name: 'gondola' },
+      { emoji_type: 'unicode', code: '1f31b',  name: 'goodnight' },
+      { emoji_type: 'unicode', code: '1f945',  name: 'gooooooooal' },
+      { emoji_type: 'unicode', code: '1f98d',  name: 'gorilla' },
+      { emoji_type: 'unicode', code: '1f44c',  name: 'got_it' },
+      { emoji_type: 'unicode', code: '1f616',  name: 'agony' },
+      { emoji_type: 'unicode', code: '2705', name: 'all_good' },
+      { emoji_type: 'unicode', code: '1f361', name: 'dango' },
+      { emoji_type: 'unicode', code: '1f409', name: 'dragon' },
+      { emoji_type: 'unicode', code: '1f432', name: 'dragon_face' },
+      { emoji_type: 'unicode', code: '1f4b8', name: 'easy_come_easy_go' },
+      { emoji_type: 'unicode', code: '1f49b', name: 'heart_of_gold' },
+      { emoji_type: 'unicode', code: '1f3a0', name: 'merry_go_round' },
+      { emoji_type: 'unicode', code: '1f6d1', name: 'octagonal_sign' },
+      { emoji_type: 'unicode', code: '1f54d', name: 'synagogue' },
+      { emoji_type: 'unicode', code: '264d', name: 'virgo' },
     ]);
   });
 
   test('search in realm emojis as well', () => {
     expect(
-      getFilteredEmojiNames('qwerty', {
-        qwerty: { code: '654', deactivated: false, name: 'qwerty', source_url: 'url' },
+      getFilteredEmojis('qwerty', {
+        qwerty: {
+          code: '654',
+          deactivated: false,
+          name: 'qwerty',
+          source_url: 'url',
+        },
       }),
-    ).toEqual(['qwerty']);
+    ).toEqual([{ name: 'qwerty', emoji_type: 'image', code: '654' }]);
   });
 
   test('remove duplicates', () => {
-    expect(getFilteredEmojiNames('dog', {})).toEqual(['dog', 'dogi', 'hotdog']);
+    expect(getFilteredEmojis('dog', {})).toEqual([
+      { emoji_type: 'unicode', code: '1f415', name: 'dog' },
+      { emoji_type: 'unicode', code: '1f94b', name: 'dogi' },
+      { emoji_type: 'unicode', code: '1f32d', name: 'hotdog' },
+    ]);
     expect(
-      getFilteredEmojiNames('dog', {
+      getFilteredEmojis('dog', {
         dog: {
           code: '345',
           deactivated: false,
@@ -84,6 +93,10 @@ describe('getFilteredEmojiNames', () => {
           source_url: 'url',
         },
       }),
-    ).toEqual(['dog', 'dogi', 'hotdog']);
+    ).toEqual([
+      { emoji_type: 'image', code: '345', name: 'dog', },
+      { emoji_type: 'unicode', code: '1f94b', name: 'dogi', },
+      { emoji_type: 'unicode', code: '1f32d', name: 'hotdog' },
+    ]);
   });
 });

--- a/src/emoji/__tests__/emojiSelectors-test.js
+++ b/src/emoji/__tests__/emojiSelectors-test.js
@@ -3,7 +3,7 @@ import {
   getActiveImageEmojiById,
   getAllImageEmojiById,
   getActiveImageEmojiByName,
-  getAllImageEmojiByName,
+  getAllImageEmojiByCode,
 } from '../emojiSelectors';
 
 describe('getActiveImageEmojiById', () => {
@@ -84,17 +84,19 @@ describe('getAllImageEmojiById', () => {
   });
 });
 
-describe('getAllImageEmojiByName', () => {
+describe('getAllImageEmojiByCode', () => {
   test('get realm emoji object with emoji names as the keys', () => {
     const state = {
       accounts: [{ realm: 'https://example.com' }],
       realm: {
         emoji: {
           1: {
+            code: '1',
             name: 'smile',
             source_url: 'https://example.com/static/user_upload/smile.png',
           },
           2: {
+            code: '2',
             name: 'laugh',
             source_url: 'https://example.com/static/user_upload/laugh.png',
           },
@@ -103,11 +105,13 @@ describe('getAllImageEmojiByName', () => {
     };
 
     const expectedResult = {
-      smile: {
+      1: {
+        code: '1',
         name: 'smile',
         source_url: 'https://example.com/static/user_upload/smile.png',
       },
-      laugh: {
+      2: {
+        code: '2',
         name: 'laugh',
         source_url: 'https://example.com/static/user_upload/laugh.png',
       },
@@ -118,7 +122,7 @@ describe('getAllImageEmojiByName', () => {
         source_url: 'https://example.com/static/generated/emoji/images/emoji/unicode/zulip.png',
       },
     };
-    expect(getAllImageEmojiByName(deepFreeze(state))).toEqual(expectedResult);
+    expect(getAllImageEmojiByCode(deepFreeze(state))).toEqual(expectedResult);
   });
 });
 

--- a/src/emoji/data.js
+++ b/src/emoji/data.js
@@ -1,7 +1,7 @@
 /* @flow strict-local */
 import 'string.fromcodepoint'; // eslint-disable-line spellcheck/spell-checker
 
-import type { ImageEmojiType } from '../types';
+import type { ImageEmojiType, EmojiType } from '../types';
 import { objectFromEntries } from '../jsBackport';
 import { unicodeCodeByName, override } from './codePointMap';
 
@@ -28,10 +28,10 @@ export const codeToEmojiMap = objectFromEntries<string, string>(
 /**
  * Names of all emoji matching the query, in an order to offer to the user.
  */
-export const getFilteredEmojiNames = (
+export const getFilteredEmojis = (
   query: string,
   activeImageEmojiByName: $ReadOnly<{ [string]: ImageEmojiType }>,
-): string[] => {
+): $ReadOnlyArray<{| emoji_type: EmojiType, name: string, code: string |}> => {
   // Map from emoji names to 0 for prefix matches, 1 for others.
   // (Nonmatching names are excluded.)
   const nameMap: Map<string, number> = new Map(
@@ -47,5 +47,12 @@ export const getFilteredEmojiNames = (
     return n !== 0 ? n : a < b ? -1 : 1;
   });
 
-  return emoji;
+  return emoji.map(emojiName => {
+    const isImageEmoji = activeImageEmojiByName[emojiName] !== undefined;
+    return {
+      name: emojiName,
+      emoji_type: isImageEmoji ? 'image' : 'unicode',
+      code: isImageEmoji ? activeImageEmojiByName[emojiName].code : unicodeCodeByName[emojiName],
+    };
+  });
 };

--- a/src/emoji/data.js
+++ b/src/emoji/data.js
@@ -7,15 +7,11 @@ import { unicodeCodeByName, override } from './codePointMap';
 
 const unicodeEmojiNames = Object.keys(unicodeCodeByName);
 
-const parseUnicodeEmojiCode = (code: string): string /* force line */ =>
+export const parseUnicodeEmojiCode = (code: string): string /* force line */ =>
   code
     .split('-')
     .map(hex => String.fromCodePoint(parseInt(hex, 16)))
     .join('');
-
-export const nameToEmojiMap = objectFromEntries<string, string>(
-  unicodeEmojiNames.map(name => [name, parseUnicodeEmojiCode(unicodeCodeByName[name])]),
-);
 
 export const codeToEmojiMap = objectFromEntries<string, string>(
   unicodeEmojiNames.map(name => {

--- a/src/emoji/emojiSelectors.js
+++ b/src/emoji/emojiSelectors.js
@@ -37,9 +37,9 @@ export const getActiveImageEmojiById: Selector<RealmEmojiById> = createSelector(
   },
 );
 
-export const getAllImageEmojiByName: Selector<{ [string]: ImageEmojiType }> = createSelector(
+export const getAllImageEmojiByCode: Selector<{ [string]: ImageEmojiType }> = createSelector(
   getAllImageEmojiById,
-  emojis => objectFromEntries(Object.keys(emojis).map(id => [emojis[id].name, emojis[id]])),
+  emojis => objectFromEntries(Object.keys(emojis).map(id => [emojis[id].code, emojis[id]])),
 );
 
 export const getActiveImageEmojiByName: Selector<{ [string]: ImageEmojiType }> = createSelector(

--- a/src/reactions/MessageReactionList.js
+++ b/src/reactions/MessageReactionList.js
@@ -6,7 +6,14 @@ import type { NavigationScreenProp } from 'react-navigation';
 
 import ReactionUserList from './ReactionUserList';
 import { connect } from '../react-redux';
-import type { AggregatedReaction, Dispatch, Message, UserOrBot } from '../types';
+import type {
+  AggregatedReaction,
+  Dispatch,
+  EmojiType,
+  Message,
+  ReactionType,
+  UserOrBot,
+} from '../types';
 import { Screen, Label, RawLabel } from '../common';
 import { getOwnUser } from '../selectors';
 import aggregateReactions from './aggregateReactions';
@@ -15,6 +22,13 @@ import { getAllUsersById } from '../users/userSelectors';
 import tabsOptions from '../styles/tabs';
 import Emoji from '../emoji/Emoji';
 import { objectFromEntries } from '../jsBackport';
+
+const emojiTypeFromReactionType = (reactionType: ReactionType): EmojiType => {
+  if (reactionType === 'unicode_emoji') {
+    return 'unicode';
+  }
+  return 'image';
+};
 
 // Generate tabs for the reaction list.  The tabs depend on the distinct
 // reactions on the message.
@@ -34,7 +48,10 @@ const getReactionsTabs = (
         navigationOptions: {
           tabBarLabel: () => (
             <View style={styles.row}>
-              <Emoji name={aggregatedReaction.name} />
+              <Emoji
+                code={aggregatedReaction.code}
+                type={emojiTypeFromReactionType(aggregatedReaction.type)}
+              />
               <RawLabel style={styles.paddingLeft} text={`${aggregatedReaction.count}`} />
             </View>
           ),

--- a/src/types.js
+++ b/src/types.js
@@ -110,6 +110,8 @@ export type Account = {|
  */
 export type Identity = $Diff<Auth, { apiKey: string }>;
 
+export type EmojiType = 'image' | 'unicode';
+
 /** An aggregate of all the reactions with one emoji to one message. */
 export type AggregatedReaction = {|
   code: string,


### PR DESCRIPTION
Messages contain emoji code with them in reactions. So use them instead
of relying on codes hardcoded in the app. This fixes the issue when
emoji names in app are outdated.

Fixes: #3716