### PR TITLE
MessageList: Fix white flicker in dark mode on iOS while WebView is i…

### DIFF
--- a/src/styles/miscStyles.js
+++ b/src/styles/miscStyles.js
@@ -88,8 +88,4 @@ export default ({ color, backgroundColor }: ThemeColors) => ({
     // alignItems: 'stretch',
     backgroundColor,
   },
-  webview: {
-    borderWidth: 0,
-    backgroundColor,
-  },
 });

--- a/src/webview/MessageList.js
+++ b/src/webview/MessageList.js
@@ -1,6 +1,6 @@
 /* @flow strict-local */
 import React, { Component } from 'react';
-import { Platform } from 'react-native';
+import { Platform, View } from 'react-native';
 import { WebView } from 'react-native-webview';
 import type { WebViewNavigation } from 'react-native-webview';
 
@@ -199,6 +199,15 @@ class MessageList extends Component<Props> {
     return false;
   };
 
+  renderLoading = () => {
+    const style = {
+      backgroundColor: 'transparent',
+      width: '100%',
+      height: '100%',
+    };
+    return <View style={style} />;
+  };
+
   render() {
     const { styles: contextStyles } = this.context;
     const {
@@ -290,6 +299,8 @@ class MessageList extends Component<Props> {
     return (
       <WebView
         useWebKit
+        startInLoadingState
+        renderLoading={this.renderLoading}
         source={{ baseUrl, html }}
         originWhitelist={['file://']}
         onShouldStartLoadWithRequest={onShouldStartLoadWithRequest}

--- a/src/webview/MessageList.js
+++ b/src/webview/MessageList.js
@@ -3,7 +3,6 @@ import React, { Component } from 'react';
 import { Platform, View } from 'react-native';
 import { WebView } from 'react-native-webview';
 import type { WebViewNavigation } from 'react-native-webview';
-
 import { connectActionSheet } from '@expo/react-native-action-sheet';
 
 import type {
@@ -46,7 +45,6 @@ import {
   getRealm,
 } from '../selectors';
 import { withGetText } from '../boot/TranslationProvider';
-
 import type { ShowActionSheetWithOptions } from '../message/messageActionSheet';
 import type { WebViewUpdateEvent } from './webViewHandleUpdates';
 import type { MessageListEvent } from './webViewEventHandlers';

--- a/src/webview/MessageList.js
+++ b/src/webview/MessageList.js
@@ -9,7 +9,6 @@ import { connectActionSheet } from '@expo/react-native-action-sheet';
 import type {
   AlertWordsState,
   Auth,
-  Context,
   Debug,
   Dispatch,
   Fetching,
@@ -25,6 +24,8 @@ import type {
   ThemeName,
   User,
 } from '../types';
+import type { ThemeColors } from '../styles';
+import { ThemeContext } from '../styles';
 import { connect } from '../react-redux';
 import {
   getAuth,
@@ -137,15 +138,12 @@ const assetsPath = Platform.OS === 'ios' ? './webview' : 'file:///android_asset/
 // [3] https://github.com/facebook/react-native/blob/0.59-stable/React/Base/RCTConvert.m#L85
 
 class MessageList extends Component<Props> {
-  context: Context;
+  static contextType = ThemeContext;
+  context: ThemeColors;
+
   webview: ?WebView;
   sendUpdateEventsIsReady: boolean;
   unsentUpdateEvents: WebViewUpdateEvent[] = [];
-
-  static contextTypes = {
-    styles: () => null,
-    theme: () => null,
-  };
 
   componentDidMount() {
     this.setupSendUpdateEvents();
@@ -209,7 +207,6 @@ class MessageList extends Component<Props> {
   };
 
   render() {
-    const { styles: contextStyles } = this.context;
     const {
       backgroundData,
       renderedMessages,
@@ -304,7 +301,8 @@ class MessageList extends Component<Props> {
         source={{ baseUrl, html }}
         originWhitelist={['file://']}
         onShouldStartLoadWithRequest={onShouldStartLoadWithRequest}
-        style={contextStyles.webview}
+        /* eslint-disable react-native/no-inline-styles */
+        style={{ backgroundColor: this.context.backgroundColor, borderWidth: 0 }}
         ref={webview => {
           this.webview = webview;
         }}

--- a/src/webview/MessageList.js
+++ b/src/webview/MessageList.js
@@ -300,7 +300,7 @@ class MessageList extends Component<Props> {
         originWhitelist={['file://']}
         onShouldStartLoadWithRequest={onShouldStartLoadWithRequest}
         /* eslint-disable react-native/no-inline-styles */
-        style={{ backgroundColor: this.context.backgroundColor, borderWidth: 0 }}
+        style={{ backgroundColor: this.context.backgroundColor }}
         ref={webview => {
           this.webview = webview;
         }}


### PR DESCRIPTION
Fixes: #2914.

Use startInLoadingState and renderLoading props to present a blank,
transparent View, during the first load.

react-native-webview does not specify exactly what work is being
done during this "first load," but it's fairly clear
(https://github.com/react-native-community/react-native-webview/blob/master/docs/Reference.md#startinloadingstate)
that it only happens (and our blank View will only show) on the
first load of the WebView, and not during API calls, etc.