### PR TITLE
about: Request navless versions of /terms and /privacy.

### DIFF
--- a/src/settings/LegalScreen.js
+++ b/src/settings/LegalScreen.js
@@ -17,12 +17,12 @@ type Props = $ReadOnly<{|
 class LegalScreen extends PureComponent<Props> {
   openTermsOfService = () => {
     const { realm } = this.props;
-    openLink(getFullUrl('/terms/', realm));
+    openLink(getFullUrl('/terms/?nav=no', realm));
   };
 
   openPrivacyPolicy = () => {
     const { realm } = this.props;
-    openLink(getFullUrl('/privacy/', realm));
+    openLink(getFullUrl('/privacy/?nav=no', realm));
   };
 
   render() {


### PR DESCRIPTION
This option causes the server (since zulip/zulip#13758) to render
these pages' content alone, without the navigation header or footer
linking to other pages.

Older servers without this feature simply ignore the extra query
parameter, so this is a no-op there.