### PR TITLE
unreadNotice: Shrink height to 0 when compose box expands.

### DIFF
--- a/src/chat/UnreadNotice.js
+++ b/src/chat/UnreadNotice.js
@@ -50,17 +50,15 @@ class UnreadNotice extends PureComponent<Props> {
     const { narrow, unreadCount } = this.props;
 
     return (
-      <AnimatedScaleComponent visible={unreadCount > 0}>
-        <View style={styles.unreadContainer}>
-          <View style={styles.unreadTextWrapper}>
-            <RawLabel style={styles.unreadNumber} text={unreadCount.toString()} />
-            <Label
-              style={styles.unreadText}
-              text={unreadCount === 1 ? 'unread message' : 'unread messages'}
-            />
-          </View>
-          <MarkUnreadButton narrow={narrow} />
+      <AnimatedScaleComponent visible={unreadCount > 0} style={styles.unreadContainer}>
+        <View style={styles.unreadTextWrapper}>
+          <RawLabel style={styles.unreadNumber} text={unreadCount.toString()} />
+          <Label
+            style={styles.unreadText}
+            text={unreadCount === 1 ? 'unread message' : 'unread messages'}
+          />
         </View>
+        <MarkUnreadButton narrow={narrow} />
       </AnimatedScaleComponent>
     );
   }


### PR DESCRIPTION
The height of UnreadNotice which was stucked on the top was
equal to the `paddingVertical` applied to it. So when it comes to shrink
RN was persisting padding.

Actually, this `View` wrapper is just a add on, not required. Styles can
be directly applied to `Animated.View`. So remove whis extra wrapper
from UnreadNotice, which fixes the issue.

Fixes: #3857

On this PR
![image](https://user-images.githubusercontent.com/18511177/73594918-9e078700-4538-11ea-8e94-a81c70a0cda0.png)
