### PR TITLE
compose box: Trim leading and trailing whitespace in topic.

### DIFF
--- a/src/compose/ComposeBox.js
+++ b/src/compose/ComposeBox.js
@@ -228,7 +228,7 @@ class ComposeBox extends PureComponent<Props, State> {
 
   getDestinationNarrow = (): Narrow => {
     const { narrow } = this.props;
-    const { topic } = this.state;
+    const topic = this.state.topic.trim();
     return isStreamNarrow(narrow) ? topicNarrow(narrow[0].operand, topic || '(no topic)') : narrow;
   };
 


### PR DESCRIPTION
Fixes #3743.

Trim the leading and trailing whitespace from topic when it is used by `getDestinationNarrow()` in `ComposeBox`. A consequence of this is that a whitespace-only topic gets converted to `(no topic)`.

Tested that:
- It works as expected.
- This mirrors the webapp behaviour, so it wont break things.
- Send button does not break in PM or group PM screens.