### PR TITLE
ui: Fix color of statusbar in loading screen.

### DIFF
--- a/src/start/LoadingScreen.js
+++ b/src/start/LoadingScreen.js
@@ -3,7 +3,7 @@ import React, { PureComponent } from 'react';
 import { StyleSheet, View } from 'react-native';
 
 import { BRAND_COLOR } from '../styles';
-import { LoadingIndicator } from '../common';
+import { LoadingIndicator, ZulipStatusBar } from '../common';
 
 const styles = StyleSheet.create({
   center: {
@@ -18,6 +18,7 @@ export default class LoadingScreen extends PureComponent<{||}> {
   render() {
     return (
       <View style={styles.center}>
+        <ZulipStatusBar backgroundColor={BRAND_COLOR} />
         <LoadingIndicator color="0, 0, 0" size={80} showLogo />
       </View>
     );


### PR DESCRIPTION
fix the status bar color in loading screen issue in https://github.com/zulip/zulip-mobile/issues/3860
![Screenshot_20200202-014022_Zulip (debug)](https://user-images.githubusercontent.com/31368194/73598336-11bb8b00-455d-11ea-980c-9aef9420f5bf.jpg)
