### PR TITLE
Lightbox: Show spinner while image is loading.

### DIFF
--- a/src/lightbox/Lightbox.js
+++ b/src/lightbox/Lightbox.js
@@ -10,7 +10,7 @@ import { connect } from '../react-redux';
 import type { ShowActionSheetWithOptions } from '../message/messageActionSheet';
 import { getAuth } from '../selectors';
 import { getResource } from '../utils/url';
-import { SlideAnimationView } from '../common';
+import { SlideAnimationView, LoadingIndicator } from '../common';
 import LightboxHeader from './LightboxHeader';
 import LightboxFooter from './LightboxFooter';
 import { constructActionSheetButtons, executeActionSheetAction } from './LightboxActionSheet';
@@ -21,6 +21,12 @@ import { navigateBack } from '../actions';
 const styles = StyleSheet.create({
   img: {
     height: 300,
+    flex: 1,
+  },
+  hidden: {
+    display: 'none',
+  },
+  spinner: {
     flex: 1,
   },
   header: {},
@@ -46,16 +52,19 @@ type Props = $ReadOnly<{|
 
 type State = {|
   movement: 'in' | 'out',
+  isLoading: boolean,
 |};
 
 class Lightbox extends PureComponent<Props, State> {
   state = {
     movement: 'out',
+    isLoading: true,
   };
 
   handleImagePress = () => {
-    this.setState(({ movement }, props) => ({
+    this.setState(({ movement, isLoading }, props) => ({
       movement: movement === 'out' ? 'in' : 'out',
+      isLoading,
     }));
   };
 
@@ -98,10 +107,14 @@ class Lightbox extends PureComponent<Props, State> {
 
     return (
       <View style={styles.container}>
+        <View style={this.state.isLoading ? styles.spinner : styles.hidden}>
+          <LoadingIndicator />
+        </View>
         <PhotoView
           source={resource}
-          style={[styles.img, { width }]}
+          style={this.state.isLoading ? styles.hidden : [styles.img, { width }]}
           resizeMode="contain"
+          onLoadEnd={() => this.setState(state => ({ ...state, isLoading: false }))}
           onTap={this.handleImagePress}
         />
         <SlideAnimationView


### PR DESCRIPTION
Show a spinner while image is loading in Lightbox.


![lightbox](https://user-images.githubusercontent.com/7714968/73609532-9b6a6780-45f4-11ea-82e0-1d58708181fd.gif)



**Why did I not use the built-in prop `loadingIndicatorSource`?**
The said prop **does not work** on Android.  It might work for IOS, but I have not tested it.
I replaced `source` with a sample image, which worked, but the same image does not work for `loadingIndicatorSource`, which means that it's not an issue with opening the spinner resource file. A [developer here confrims](https://github.com/alwx/react-native-photo-view/issues/173) that it only works in IOS, as do [other issues in that repository](https://github.com/alwx/react-native-photo-view/issues?utf8=%E2%9C%93&q=is%3Aissue+loadingindicatorsource).

**Another note:**
The library we use, `react-native-photo-view` appears to be unmaintained (
Last  commit on 6 Apr 2018 ) and we should consider replacing it.

Fixes #2896.