### PR TITLE
emoji: Cut misleading ignored reference to an emoji font.

### DIFF
--- a/src/emoji/Emoji.js
+++ b/src/emoji/Emoji.js
@@ -10,7 +10,7 @@ import { getAllImageEmojiByName } from './emojiSelectors';
 
 /* $FlowFixMe: `nameToEmojiMap` is mistyped upstream; elements of
   `glyphMap` may be either `number` or `string`. */
-const UnicodeEmoji = createIconSet(nameToEmojiMap, 'AppleColorEmoji');
+const UnicodeEmoji = createIconSet(nameToEmojiMap);
 
 type SelectorProps = {|
   imageEmoji: ImageEmojiType | void,


### PR DESCRIPTION
Per the docs of the react-native-vector-icons package, this argument
is supposed to be the name of a font.  But there's no sign of a font
by this name actually appearing in the package, so it's hard to see
what passing it could actually mean -- instead, it just misleads the
reader by suggesting that this font is involved somehow.
    
And, empirically, the behavior is the same when this argument is
removed.  Tested in the reaction-list screen, in an emulated Pixel 3
running Android 10 and in an emulated iPhone 8 running iOS 13.
