### PR TITLE
Fix Button Position: Options position in Message Actions

### DIFF
--- a/src/message/messageActionSheet.js
+++ b/src/message/messageActionSheet.js
@@ -210,11 +210,11 @@ export const constructMessageActionButtons = ({
   narrow,
 }: ConstructSheetParams): ButtonCode[] => {
   const buttons = [];
-  if (message.reactions.length > 0) {
-    buttons.push('showReactions');
-  }
   if (!isAnOutboxMessage(message) && messageNotDeleted(message)) {
     buttons.push('addReaction');
+  }
+  if (message.reactions.length > 0) {
+    buttons.push('showReactions');
   }
   if (!isAnOutboxMessage(message) && !isTopicNarrow(narrow) && !isPrivateOrGroupNarrow(narrow)) {
     buttons.push('reply');


### PR DESCRIPTION
"See who reacted" option was listed first in message action options. then "Add reaction" was listed. This wasnt convinient for users. so interchanged their postions for the reason (i.e 'Add reaction'-'See who reacted').

Fixes: zulip#3871