### PR TITLE
Set LAST_MESSAGE_ANCHOR to 10000000000000000 (sixteen zeroes).

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -16,4 +16,6 @@ export const FIRST_UNREAD_ANCHOR = 0;
  * want to retrieve the newest messages for a narrow, without actually
  * knowing their IDs.
  */
+// This special value is understood by the server, corresponding to
+// LARGER_THAN_MAX_MESSAGE_ID there.  See #3654.
 export const LAST_MESSAGE_ANCHOR = 10000000000000000; // sixteen zeroes

--- a/src/constants.js
+++ b/src/constants.js
@@ -16,4 +16,4 @@ export const FIRST_UNREAD_ANCHOR = 0;
  * want to retrieve the newest messages for a narrow, without actually
  * knowing their IDs.
  */
-export const LAST_MESSAGE_ANCHOR = Number.MAX_SAFE_INTEGER;
+export const LAST_MESSAGE_ANCHOR = 10000000000000000; // sixteen zeroes


### PR DESCRIPTION
Fixes: #3654.

The server correctly interprets this special number as indicating
that we want the latest messages (0 is used to request the oldest
messages). Later, we can conditionalize on the server version to
support the updated API merged in
https://github.com/zulip/zulip/pull/13747, that use the strings
'oldest' and 'newest' instead of 0 and 10000000000000000.