### PR TITLE
Add feature to view profile on tapping @mention for a user

### DIFF
--- a/src/webview/js/generatedEs3.js
+++ b/src/webview/js/generatedEs3.js
@@ -491,6 +491,17 @@ var compiledWebviewJs = (function (exports) {
     return value;
   };
 
+  var requireNumericAttribute = function requireNumericAttribute(e, name) {
+    var value = requireAttribute(e, name);
+    var parsedValue = parseInt(value, 10);
+
+    if (Number.isNaN(parsedValue)) {
+      throw new Error("Could not parse attribute ".concat(name, " value '").concat(value, "' as integer"));
+    }
+
+    return parsedValue;
+  };
+
   documentBody.addEventListener('click', function (e) {
     e.preventDefault();
     clearTimeout(longPressTimeout);
@@ -514,7 +525,7 @@ var compiledWebviewJs = (function (exports) {
     if (target.matches('.avatar-img')) {
       sendMessage({
         type: 'avatar',
-        fromUserId: requireAttribute(target, 'data-sender-id')
+        fromUserId: requireNumericAttribute(target, 'data-sender-id')
       });
       return;
     }

--- a/src/webview/js/generatedEs3.js
+++ b/src/webview/js/generatedEs3.js
@@ -538,6 +538,14 @@ var compiledWebviewJs = (function (exports) {
       return;
     }
 
+    if (target.matches('.user-mention')) {
+      sendMessage({
+        type: 'mention',
+        userId: requireNumericAttribute(target, 'data-user-id')
+      });
+      return;
+    }
+
     var inlineImageLink = target.closest('.message_inline_image a');
 
     if (inlineImageLink && !inlineImageLink.closest('.youtube-video, .vimeo-video')) {

--- a/src/webview/js/js.js
+++ b/src/webview/js/js.js
@@ -604,6 +604,20 @@ const requireAttribute = (e: Element, name: string): string => {
   return value;
 };
 
+/**
+ * Returns the integer parsed value of a DOM element attribute.
+ *
+ * Throws if parsing fails.
+ */
+const requireNumericAttribute = (e: Element, name: string): number => {
+  const value = requireAttribute(e, name);
+  const parsedValue = parseInt(value, 10);
+  if (Number.isNaN(parsedValue)) {
+    throw new Error(`Could not parse attribute ${name} value '${value}' as integer`);
+  }
+  return parsedValue;
+};
+
 documentBody.addEventListener('click', (e: MouseEvent) => {
   e.preventDefault();
   clearTimeout(longPressTimeout);
@@ -629,7 +643,7 @@ documentBody.addEventListener('click', (e: MouseEvent) => {
   if (target.matches('.avatar-img')) {
     sendMessage({
       type: 'avatar',
-      fromUserId: requireAttribute(target, 'data-sender-id'),
+      fromUserId: requireNumericAttribute(target, 'data-sender-id'),
     });
     return;
   }

--- a/src/webview/js/js.js
+++ b/src/webview/js/js.js
@@ -656,6 +656,14 @@ documentBody.addEventListener('click', (e: MouseEvent) => {
     return;
   }
 
+  if (target.matches('.user-mention')) {
+    sendMessage({
+      type: 'mention',
+      userId: requireNumericAttribute(target, 'data-user-id'),
+    });
+    return;
+  }
+
   /* Should we pull up the lightbox?  For comparison, see the web app's
    * static/js/lightbox.js , starting at the `#main_div` click handler. */
   const inlineImageLink = target.closest('.message_inline_image a');

--- a/src/webview/webViewEventHandlers.js
+++ b/src/webview/webViewEventHandlers.js
@@ -108,6 +108,11 @@ type MessageListEventReactionDetails = {|
   reactionName: string,
 |};
 
+type MessageListEventMention = {|
+  type: 'mention',
+  userId: number,
+|};
+
 export type MessageListEvent =
   | MessageListEventReady
   | MessageListEventScroll
@@ -119,7 +124,8 @@ export type MessageListEvent =
   | MessageListEventLongPress
   | MessageListEventReactionDetails
   | MessageListEventDebug
-  | MessageListEventError;
+  | MessageListEventError
+  | MessageListEventMention;
 
 type Props = $ReadOnly<{
   backgroundData: BackgroundData,
@@ -243,6 +249,12 @@ export const handleMessageListEvent = (props: Props, _: GetText, event: MessageL
         dispatch(navigateToMessageReactionScreen(messageId, reactionName));
       }
       break;
+
+    case 'mention': {
+      const { dispatch } = props;
+      dispatch(navigateToAccountDetails(event.userId));
+      break;
+    }
 
     case 'debug':
       console.debug(props, event); // eslint-disable-line

--- a/src/webview/webViewEventHandlers.js
+++ b/src/webview/webViewEventHandlers.js
@@ -51,7 +51,7 @@ type MessageListEventScroll = {|
 
 type MessageListEventAvatar = {|
   type: 'avatar',
-  fromUserId: string,
+  fromUserId: number,
 |};
 
 type MessageListEventNarrow = {|
@@ -200,11 +200,7 @@ export const handleMessageListEvent = (props: Props, _: GetText, event: MessageL
       break;
 
     case 'avatar': {
-      const userId = parseInt(event.fromUserId, 10);
-      if (Number.isNaN(userId)) {
-        throw new Error(`Failed to parse fromUserId string '${event.fromUserId}' to integer`);
-      }
-      props.dispatch(navigateToAccountDetails(userId));
+      props.dispatch(navigateToAccountDetails(event.fromUserId));
       break;
     }
 


### PR DESCRIPTION
Closes #3879.

This is a common pattern in messaging apps, and a feature I felt was missing.

![ezgif-3-258db77d92e6](https://user-images.githubusercontent.com/7714968/73977313-21b5df00-4950-11ea-81cc-247494ba1dcc.gif)

I also created a selector  - `getUserForId` and wrote tests for it.

Tested that it works in varoius narrows, such as stream narrows, topic narrows, PM narrows, starred messages narow.


