### PR TITLE
message actions [nfc]: Clarify which narrows offer "edit message".

### DIFF
--- a/src/message/messageActionSheet.js
+++ b/src/message/messageActionSheet.js
@@ -4,9 +4,8 @@ import type { Auth, Dispatch, GetText, Message, Narrow, Outbox, Subscription } f
 import type { BackgroundData } from '../webview/MessageList';
 import {
   getNarrowFromMessage,
-  isHomeNarrow,
   isPrivateOrGroupNarrow,
-  isSpecialNarrow,
+  isStreamOrTopicNarrow,
   isTopicNarrow,
 } from '../utils/narrow';
 import { isTopicMuted } from '../utils/message';
@@ -227,8 +226,8 @@ export const constructMessageActionButtons = ({
   if (
     !isAnOutboxMessage(message)
     && message.sender_email === ownUser.email
-    && !isHomeNarrow(narrow)
-    && !isSpecialNarrow(narrow)
+    // Our "edit message" UI only works in certain kinds of narrows.
+    && (isStreamOrTopicNarrow(narrow) || isPrivateOrGroupNarrow(narrow))
   ) {
     buttons.push('editMessage');
   }


### PR DESCRIPTION
This conditional does not mean the same thing as the old version!
The old version produced true for search narrows.

That would have been a bug, but... when we show a search narrow,
we actually pass `narrow={HOME_NARROW}` to `MessageList` (in
`SearchMessagesCard.js`), and so the `narrow` value that makes it
here is the home narrow.  So the bug is only latent, and this
commit makes no functional change.  Still good to fix latent bugs,
and to be explicit about the narrows where we *are* prepared to
offer the edit-message UI rather than try to list where we aren't.