### PR TITLE
types [nfc]: Add convenience type MessageLike.

### DIFF
--- a/src/webview/html/messageAsHtml.js
+++ b/src/webview/html/messageAsHtml.js
@@ -5,6 +5,7 @@ import type {
   AggregatedReaction,
   FlagsState,
   Message,
+  MessageLike,
   Outbox,
   Reaction,
   ImageEmojiType,
@@ -59,7 +60,7 @@ const messageBody = (
   { alertWords, flags, ownUser, allImageEmojiById }: BackgroundData,
   message: Message | Outbox,
 ) => {
-  const { id, isOutbox, last_edit_timestamp, reactions } = message;
+  const { id, isOutbox, last_edit_timestamp, reactions } = (message: MessageLike);
   const content = message.match_content !== undefined ? message.match_content : message.content;
   return template`
 $!${processAlertWords(content, id, alertWords, flags)}


### PR DESCRIPTION
Replace the hack in `Outbox` (which typed it as having certain fields
which it never possessed in practice) with a slightly more
sophisticated hack in the form of a compatible auxiliary type.

This closes a minor soundness hole (values of type `Outbox` could
incorrectly have been assigned the value `undefined` in those fields).
Perhaps more importantly, it also makes `Outbox` a `JSONable` type.