### PR TITLE
APNs: log invalid device tokens, rather than sending them

### DIFF
--- a/src/notification/index.js
+++ b/src/notification/index.js
@@ -4,6 +4,7 @@ import NotificationsIOS from 'react-native-notifications';
 
 import type { Auth, Dispatch, Identity, Narrow, User } from '../types';
 import { topicNarrow, privateNarrow, groupNarrow } from '../utils/narrow';
+import type { JSONable } from '../utils/jsonable';
 import * as api from '../api';
 import * as logging from '../utils/logging';
 import {
@@ -209,7 +210,16 @@ export class NotificationListener {
   };
 
   /** Private. */
-  handleDeviceToken = async (deviceToken: string) => {
+  handleDeviceToken = async (deviceToken: mixed) => {
+    // A device token should normally be a string of hex digits. Sometimes,
+    // however, we appear to receive objects here. Log this. (See issue #3672.)
+    if (typeof deviceToken !== 'string' || deviceToken === '[Object object]') {
+      // $FlowFixMe: deviceToken probably _is_ JSONable, but we can only hope
+      const token: JSONable = deviceToken;
+      logging.error('Received invalid device token', { token });
+      return;
+    }
+
     this.dispatch(gotPushToken(deviceToken));
     await this.dispatch(sendAllPushToken());
   };


### PR DESCRIPTION
APNs device tokens, as received through out iOS notifications library,
should be a hex string. Unfortunately, they're sometimes being sent to
the server as "[Object object]".

This is most likely due to the argument of `handleDeviceToken`
actually being an object, despite its typing as `string`, and being
improperly stringified by `encodeParamsForUrl`. However, it may
alternatively be the case that someone is mis-stringifying the object
before we get ahold of it, so log that case too.

This is work toward the resolution of #3672.