### PR TITLE
narrow [nfc]: Cut `Narrow` from the `Outbox` type.

### DIFF
--- a/src/chat/narrowsSelectors.js
+++ b/src/chat/narrowsSelectors.js
@@ -26,7 +26,7 @@ import {
   isPrivateNarrow,
   isStreamOrTopicNarrow,
   emailsOfGroupNarrow,
-  narrowContains,
+  narrowContainsOutbox,
 } from '../utils/narrow';
 import { shouldBeMuted } from '../utils/message';
 import { NULL_ARRAY, NULL_SUBSCRIPTION } from '../nullObjects';
@@ -39,7 +39,7 @@ export const outboxMessagesForNarrow: Selector<Outbox[], Narrow> = createSelecto
     if (!caughtUp.newer) {
       return NULL_ARRAY;
     }
-    const filtered = outboxMessages.filter(item => narrowContains(narrow, item.narrow));
+    const filtered = outboxMessages.filter(item => narrowContainsOutbox(narrow, item));
     return isEqual(filtered, outboxMessages) ? outboxMessages : filtered;
   },
 );

--- a/src/outbox/outboxActions.js
+++ b/src/outbox/outboxActions.js
@@ -163,7 +163,6 @@ export const addToOutbox = (narrow: Narrow, content: string) => async (
   const localTime = Math.round(new Date().getTime() / 1000);
   dispatch(
     messageSendStart({
-      narrow,
       isSent: false,
       ...extractTypeToAndSubjectFromNarrow(narrow, getUsersByEmail(state), userDetail),
       markdownContent: content,

--- a/src/outbox/outboxActions.js
+++ b/src/outbox/outboxActions.js
@@ -64,17 +64,13 @@ export const trySendMessages = (dispatch: Dispatch, getState: GetState): boolean
         return; // i.e., continue
       }
 
-      const to = ((): string => {
-        const { narrow } = item;
-        // TODO: can this test be `if (item.type === private)`?
-        if (isPrivateOrGroupNarrow(narrow)) {
-          return narrow[0].operand;
-        } else {
-          // HACK: the server attempts to interpret this argument as JSON, then
-          // CSV, then a literal. To avoid misparsing, always use JSON.
-          return JSON.stringify([item.display_recipient]);
-        }
-      })();
+      // prettier-ignore
+      const to =
+        item.type === 'private'
+          ? item.narrow[0].operand
+            // HACK: the server attempts to interpret this argument as JSON, then
+            // CSV, then a literal. To avoid misparsing, always use JSON.
+          : JSON.stringify([item.display_recipient]);
 
       await api.sendMessage(auth, {
         type: item.type,

--- a/src/outbox/outboxActions.js
+++ b/src/outbox/outboxActions.js
@@ -67,7 +67,10 @@ export const trySendMessages = (dispatch: Dispatch, getState: GetState): boolean
       // prettier-ignore
       const to =
         item.type === 'private'
-          ? item.narrow[0].operand
+            // This will include the self user, possibly twice.  That's
+            // fine; on send, the server (since at least 2013) drops dupes
+            // and normalizes whether to include the sender.
+          ? item.display_recipient.map(r => r.email).join(',')
             // HACK: the server attempts to interpret this argument as JSON, then
             // CSV, then a literal. To avoid misparsing, always use JSON.
           : JSON.stringify([item.display_recipient]);

--- a/src/types.js
+++ b/src/types.js
@@ -2,7 +2,7 @@
 import type { IntlShape } from 'react-intl';
 import type { DangerouslyImpreciseStyleProp } from 'react-native/Libraries/StyleSheet/StyleSheet';
 
-import type { Auth, Topic, Message, Reaction, ReactionType, Narrow } from './api/apiTypes';
+import type { Auth, Topic, Message, Reaction, ReactionType } from './api/apiTypes';
 import type { ZulipVersion } from './utils/zulipVersion';
 
 export type * from './generics';
@@ -171,10 +171,9 @@ export type Outbox = {|
    */
   isSent: boolean,
 
-  // These fields don't exist in `Message`.
-  // They're used for sending the message to the server.
+  // `markdownContent` doesn't exist in `Message`.
+  // It's used for sending the message to the server.
   markdownContent: string,
-  narrow: Narrow,
 
   // These fields are modeled on `Message`.
   avatar_url: string | null,

--- a/src/utils/logging.js
+++ b/src/utils/logging.js
@@ -124,14 +124,14 @@ const makeLogFunction = ({ consoleMethod, severity }: LogParams): LogFunction =>
  * represents a bug.  For conditions that can happen without a bug (e.g. a
  * failure to reach the server), consider `logging.warn`.
  *
+ * See also:
+ *  * `logging.warn` for logging at lower severity
+ *
  * @param event A string describing the nature of the event to be logged, or an
  *   exception whose `.message` is such a string. Related events should have
  *   identical such strings, when feasible.
  * @param extras Diagnostic data which may differ between separate occurrences
  *   of the event.
- *
- * See also:
- *  * `logging.warn` for logging at lower severity
  */
 export const error: (event: string | Error, extras?: Extras) => void = makeLogFunction({
   consoleMethod: console.error,
@@ -148,14 +148,14 @@ export const error: (event: string | Error, extras?: Extras) => void = makeLogFu
  * which have an inevitable background rate.  For conditions which
  * definitely represent a bug in the app, consider `logging.error` instead.
  *
+ * See also:
+ *  * `logging.error` for logging at higher severity
+ *
  * @param event A string describing the nature of the event to be logged, or an
  *   exception whose `.message` is such a string. Related events should have
  *   identical such strings, when feasible.
  * @param extras Diagnostic data which may differ between separate occurrences
  *   of the event.
- *
- * See also:
- *  * `logging.error` for logging at higher severity
  */
 export const warn: (event: string | Error, extras?: Extras) => void = makeLogFunction({
   consoleMethod: console.warn,


### PR DESCRIPTION
Our `Narrow` type is kind of a mess: it's defined as just an array of operator/operand string pairs, but in practice most of our code assumes it has a lot more structure than that. There's also a lot of scattered places where we parse that structure, and so express a variety of those assumptions. Separately, it's a major source of #3764 in that it identifies users by email, not ID, for PM threads (as well as streams by name, not ID); and the many scattered places we parse its implicit structure are each obstacles to fixing that.

I spent some time last week sketching out what it would look like to migrate `Narrow` to something that would use IDs rather than emails or stream names, and also be more explicitly structured so that e.g. after conditioning on being a PM conversation we'd have something like `userIds: number[]` rather than having to parse a string. I found it actually seems surprisingly doable, and I have a rough draft in a branch.

One piece is that there are places where we just shouldn't be using a "narrow" value at all, because we're not actually talking about a feed of messages or a possible message list -- we're talking about one message and who it goes to. The cleanest way to migrate those is to just get them off `Narrow` entirely. One of those places is a property on `Outbox`; this branch fixes that.
