### PR TITLE
webview: Fix message list is scrolled when unread notice hides.

### DIFF
--- a/src/webview/js/generatedEs3.js
+++ b/src/webview/js/generatedEs3.js
@@ -139,7 +139,7 @@ var compiledWebviewJs = (function (exports) {
   window.addEventListener('resize', function (event) {
     var difference = viewportHeight - documentBody.clientHeight;
 
-    if (documentBody.scrollHeight !== documentBody.scrollTop + documentBody.clientHeight) {
+    if (Math.abs(difference) > 100 && documentBody.scrollHeight !== documentBody.scrollTop + documentBody.clientHeight) {
       window.scrollBy({
         left: 0,
         top: difference

--- a/src/webview/js/js.js
+++ b/src/webview/js/js.js
@@ -168,7 +168,10 @@ let viewportHeight = documentBody.clientHeight;
 
 window.addEventListener('resize', event => {
   const difference = viewportHeight - documentBody.clientHeight;
-  if (documentBody.scrollHeight !== documentBody.scrollTop + documentBody.clientHeight) {
+  if (
+    Math.abs(difference) > 100 // do not consider resize when unread notice pops in and out
+    && documentBody.scrollHeight !== documentBody.scrollTop + documentBody.clientHeight
+  ) {
     window.scrollBy({ left: 0, top: difference });
   }
   viewportHeight = documentBody.clientHeight;


### PR DESCRIPTION
On webview resize listner, do not scroll if difference is less than 100.
This listner is only meant to sroll list when keyboard pops in or out,
and for such event difference will be > 100.