### PR TITLE
no-messages [nfc]: Clean up "fetching" selectors and "No Messages" UI logic.

### DIFF
--- a/src/chat/Chat.js
+++ b/src/chat/Chat.js
@@ -16,7 +16,7 @@ import { getShownMessagesForNarrow } from './narrowsSelectors';
 
 type SelectorProps = {|
   fetching: Fetching,
-  noMessages: boolean,
+  haveNoMessages: boolean,
 |};
 
 type Props = $ReadOnly<{|
@@ -37,16 +37,17 @@ const componentStyles = StyleSheet.create({
 
 class Chat extends PureComponent<Props> {
   render() {
-    const { fetching, noMessages, narrow } = this.props;
+    const { fetching, haveNoMessages, narrow } = this.props;
 
-    const showMessagePlaceholders = (fetching.older || fetching.newer) && noMessages;
+    const showMessagePlaceholders = (fetching.older || fetching.newer) && haveNoMessages;
+    const sayNoMessages = haveNoMessages && !showMessagePlaceholders;
     const showComposeBox = canSendToNarrow(narrow) && !showMessagePlaceholders;
     return (
       <KeyboardAvoider style={styles.flexed} behavior="padding">
         <View style={styles.flexed}>
           <View style={componentStyles.reverse}>
             <MessageList narrow={narrow} showMessagePlaceholders={showMessagePlaceholders} />
-            {noMessages && !showMessagePlaceholders && <NoMessages narrow={narrow} />}
+            {sayNoMessages && <NoMessages narrow={narrow} />}
             <UnreadNotice narrow={narrow} />
           </View>
           {showComposeBox && <ComposeBox narrow={narrow} />}
@@ -58,5 +59,5 @@ class Chat extends PureComponent<Props> {
 
 export default connect<SelectorProps, _, _>((state, props) => ({
   fetching: getFetchingForNarrow(state, props.narrow),
-  noMessages: getShownMessagesForNarrow(state, props.narrow).length === 0,
+  haveNoMessages: getShownMessagesForNarrow(state, props.narrow).length === 0,
 }))(Chat);

--- a/src/chat/Chat.js
+++ b/src/chat/Chat.js
@@ -12,7 +12,7 @@ import UnreadNotice from './UnreadNotice';
 import styles from '../styles';
 import { canSendToNarrow } from '../utils/narrow';
 import { getFetchingForNarrow } from './fetchingSelectors';
-import { getIfNoMessages } from './narrowsSelectors';
+import { getShownMessagesForNarrow } from './narrowsSelectors';
 
 type SelectorProps = {|
   fetching: Fetching,
@@ -62,5 +62,5 @@ class Chat extends PureComponent<Props> {
 
 export default connect<SelectorProps, _, _>((state, props) => ({
   fetching: getFetchingForNarrow(state, props.narrow),
-  noMessages: getIfNoMessages(props.narrow)(state),
+  noMessages: getShownMessagesForNarrow(state, props.narrow).length === 0,
 }))(Chat);

--- a/src/chat/Chat.js
+++ b/src/chat/Chat.js
@@ -2,7 +2,7 @@
 import React, { PureComponent } from 'react';
 import { View, StyleSheet } from 'react-native';
 
-import type { Narrow, Dispatch } from '../types';
+import type { Fetching, Narrow, Dispatch } from '../types';
 import { connect } from '../react-redux';
 import { KeyboardAvoider } from '../common';
 import MessageList from '../webview/MessageList';
@@ -11,10 +11,12 @@ import ComposeBox from '../compose/ComposeBox';
 import UnreadNotice from './UnreadNotice';
 import styles from '../styles';
 import { canSendToNarrow } from '../utils/narrow';
-import { getShowMessagePlaceholders } from '../selectors';
+import { getFetchingForNarrow } from './fetchingSelectors';
+import { getIfNoMessages } from './narrowsSelectors';
 
 type SelectorProps = {|
-  showMessagePlaceholders: boolean,
+  fetching: Fetching,
+  noMessages: boolean,
 |};
 
 type Props = $ReadOnly<{|
@@ -35,8 +37,9 @@ const componentStyles = StyleSheet.create({
 
 class Chat extends PureComponent<Props> {
   render() {
-    const { showMessagePlaceholders, narrow } = this.props;
+    const { fetching, noMessages, narrow } = this.props;
 
+    const showMessagePlaceholders = (fetching.older || fetching.newer) && noMessages;
     const showComposeBox = canSendToNarrow(narrow) && !showMessagePlaceholders;
     return (
       <KeyboardAvoider style={styles.flexed} behavior="padding">
@@ -54,5 +57,6 @@ class Chat extends PureComponent<Props> {
 }
 
 export default connect<SelectorProps, _, _>((state, props) => ({
-  showMessagePlaceholders: getShowMessagePlaceholders(props.narrow)(state),
+  fetching: getFetchingForNarrow(state, props.narrow),
+  noMessages: getIfNoMessages(props.narrow)(state),
 }))(Chat);

--- a/src/chat/Chat.js
+++ b/src/chat/Chat.js
@@ -46,11 +46,7 @@ class Chat extends PureComponent<Props> {
         <View style={styles.flexed}>
           <View style={componentStyles.reverse}>
             <MessageList narrow={narrow} showMessagePlaceholders={showMessagePlaceholders} />
-            <NoMessages
-              narrow={narrow}
-              noMessages={noMessages}
-              showMessagePlaceholders={showMessagePlaceholders}
-            />
+            {noMessages && !showMessagePlaceholders && <NoMessages narrow={narrow} />}
             <UnreadNotice narrow={narrow} />
           </View>
           {showComposeBox && <ComposeBox narrow={narrow} />}

--- a/src/chat/Chat.js
+++ b/src/chat/Chat.js
@@ -42,8 +42,8 @@ class Chat extends PureComponent<Props> {
       <KeyboardAvoider style={styles.flexed} behavior="padding">
         <View style={styles.flexed}>
           <View style={componentStyles.reverse}>
-            <MessageList narrow={narrow} />
-            <NoMessages narrow={narrow} />
+            <MessageList narrow={narrow} showMessagePlaceholders={showMessagePlaceholders} />
+            <NoMessages narrow={narrow} showMessagePlaceholders={showMessagePlaceholders} />
             <UnreadNotice narrow={narrow} />
           </View>
           {showComposeBox && <ComposeBox narrow={narrow} />}

--- a/src/chat/Chat.js
+++ b/src/chat/Chat.js
@@ -39,8 +39,9 @@ class Chat extends PureComponent<Props> {
   render() {
     const { fetching, haveNoMessages, narrow } = this.props;
 
-    const showMessagePlaceholders = (fetching.older || fetching.newer) && haveNoMessages;
-    const sayNoMessages = haveNoMessages && !showMessagePlaceholders;
+    const isFetching = fetching.older || fetching.newer;
+    const showMessagePlaceholders = haveNoMessages && isFetching;
+    const sayNoMessages = haveNoMessages && !isFetching;
     const showComposeBox = canSendToNarrow(narrow) && !showMessagePlaceholders;
     return (
       <KeyboardAvoider style={styles.flexed} behavior="padding">

--- a/src/chat/Chat.js
+++ b/src/chat/Chat.js
@@ -46,7 +46,11 @@ class Chat extends PureComponent<Props> {
         <View style={styles.flexed}>
           <View style={componentStyles.reverse}>
             <MessageList narrow={narrow} showMessagePlaceholders={showMessagePlaceholders} />
-            <NoMessages narrow={narrow} showMessagePlaceholders={showMessagePlaceholders} />
+            <NoMessages
+              narrow={narrow}
+              noMessages={noMessages}
+              showMessagePlaceholders={showMessagePlaceholders}
+            />
             <UnreadNotice narrow={narrow} />
           </View>
           {showComposeBox && <ComposeBox narrow={narrow} />}

--- a/src/chat/Chat.js
+++ b/src/chat/Chat.js
@@ -14,7 +14,7 @@ import { canSendToNarrow } from '../utils/narrow';
 import { getShowMessagePlaceholders } from '../selectors';
 
 type SelectorProps = {|
-  canSend: boolean,
+  showMessagePlaceholders: boolean,
 |};
 
 type Props = $ReadOnly<{|
@@ -35,8 +35,9 @@ const componentStyles = StyleSheet.create({
 
 class Chat extends PureComponent<Props> {
   render() {
-    const { canSend, narrow } = this.props;
+    const { showMessagePlaceholders, narrow } = this.props;
 
+    const showComposeBox = canSendToNarrow(narrow) && !showMessagePlaceholders;
     return (
       <KeyboardAvoider style={styles.flexed} behavior="padding">
         <View style={styles.flexed}>
@@ -45,7 +46,7 @@ class Chat extends PureComponent<Props> {
             <NoMessages narrow={narrow} />
             <UnreadNotice narrow={narrow} />
           </View>
-          {canSend && <ComposeBox narrow={narrow} />}
+          {showComposeBox && <ComposeBox narrow={narrow} />}
         </View>
       </KeyboardAvoider>
     );
@@ -53,5 +54,5 @@ class Chat extends PureComponent<Props> {
 }
 
 export default connect<SelectorProps, _, _>((state, props) => ({
-  canSend: canSendToNarrow(props.narrow) && !getShowMessagePlaceholders(props.narrow)(state),
+  showMessagePlaceholders: getShowMessagePlaceholders(props.narrow)(state),
 }))(Chat);

--- a/src/chat/__tests__/fetchingSelectors-test.js
+++ b/src/chat/__tests__/fetchingSelectors-test.js
@@ -1,6 +1,6 @@
 import deepFreeze from 'deep-freeze';
 
-import { getFetchingForNarrow, getIsFetching } from '../fetchingSelectors';
+import { getFetchingForNarrow } from '../fetchingSelectors';
 import { HOME_NARROW, HOME_NARROW_STR } from '../../utils/narrow';
 
 describe('getFetchingForNarrow', () => {
@@ -26,41 +26,5 @@ describe('getFetchingForNarrow', () => {
     const actualResult = getFetchingForNarrow(HOME_NARROW)(state);
 
     expect(actualResult).toEqual(expectedResult);
-  });
-});
-
-describe('getIsFetching', () => {
-  test('when no initial fetching required and fetching is empty returns false', () => {
-    const state = deepFreeze({
-      fetching: {},
-    });
-
-    const result = getIsFetching(HOME_NARROW)(state);
-
-    expect(result).toEqual(false);
-  });
-
-  test('if fetching older for current narrow returns true', () => {
-    const state = deepFreeze({
-      fetching: {
-        [HOME_NARROW_STR]: { older: true, newer: false },
-      },
-    });
-
-    const result = getIsFetching(HOME_NARROW)(state);
-
-    expect(result).toEqual(true);
-  });
-
-  test('if fetching newer for current narrow returns true', () => {
-    const state = deepFreeze({
-      fetching: {
-        [HOME_NARROW_STR]: { older: false, newer: true },
-      },
-    });
-
-    const result = getIsFetching(HOME_NARROW)(state);
-
-    expect(result).toEqual(true);
   });
 });

--- a/src/chat/__tests__/fetchingSelectors-test.js
+++ b/src/chat/__tests__/fetchingSelectors-test.js
@@ -10,7 +10,7 @@ describe('getFetchingForNarrow', () => {
     });
     const expectedResult = { older: false, newer: false };
 
-    const actualResult = getFetchingForNarrow(HOME_NARROW)(state);
+    const actualResult = getFetchingForNarrow(state, HOME_NARROW);
 
     expect(actualResult).toEqual(expectedResult);
   });
@@ -23,7 +23,7 @@ describe('getFetchingForNarrow', () => {
     });
     const expectedResult = { older: true, newer: true };
 
-    const actualResult = getFetchingForNarrow(HOME_NARROW)(state);
+    const actualResult = getFetchingForNarrow(state, HOME_NARROW);
 
     expect(actualResult).toEqual(expectedResult);
   });

--- a/src/chat/fetchingSelectors.js
+++ b/src/chat/fetchingSelectors.js
@@ -1,14 +1,9 @@
 /* @flow strict-local */
-import { createSelector } from 'reselect';
-
-import type { Fetching, Selector, Narrow } from '../types';
+import type { Fetching, GlobalState, Narrow } from '../types';
 import { getFetching } from '../directSelectors';
 
 /** The value implicitly represented by a missing entry in FetchingState. */
 export const DEFAULT_FETCHING = { older: false, newer: false };
 
-export const getFetchingForNarrow = (narrow: Narrow): Selector<Fetching> =>
-  createSelector(
-    getFetching,
-    fetching => fetching[JSON.stringify(narrow)] || DEFAULT_FETCHING,
-  );
+export const getFetchingForNarrow = (state: GlobalState, narrow: Narrow): Fetching =>
+  getFetching(state)[JSON.stringify(narrow)] || DEFAULT_FETCHING;

--- a/src/chat/fetchingSelectors.js
+++ b/src/chat/fetchingSelectors.js
@@ -12,9 +12,3 @@ export const getFetchingForNarrow = (narrow: Narrow): Selector<Fetching> =>
     getFetching,
     fetching => fetching[JSON.stringify(narrow)] || DEFAULT_FETCHING,
   );
-
-export const getIsFetching = (narrow: Narrow): Selector<boolean> =>
-  createSelector(
-    getFetchingForNarrow(narrow),
-    (fetching: Fetching): boolean => fetching.older || fetching.newer,
-  );

--- a/src/chat/narrowsSelectors.js
+++ b/src/chat/narrowsSelectors.js
@@ -22,7 +22,6 @@ import {
 } from '../directSelectors';
 import { getCaughtUpForNarrow } from '../caughtup/caughtUpSelectors';
 import { getAllUsersByEmail } from '../users/userSelectors';
-import { getFetchingForNarrow } from './fetchingSelectors';
 import {
   isPrivateNarrow,
   isStreamOrTopicNarrow,
@@ -135,11 +134,6 @@ export const getStreamInNarrow = (
 
 export const getIfNoMessages = (narrow: Narrow) => (state: GlobalState): boolean =>
   getShownMessagesForNarrow(state, narrow).length === 0;
-
-export const getShowMessagePlaceholders = (narrow: Narrow) => (state: GlobalState): boolean => {
-  const fetching = getFetchingForNarrow(state, narrow);
-  return (fetching.older || fetching.newer) && getIfNoMessages(narrow)(state);
-};
 
 export const isNarrowValid = (narrow: Narrow): Selector<boolean> =>
   createSelector(

--- a/src/chat/narrowsSelectors.js
+++ b/src/chat/narrowsSelectors.js
@@ -137,7 +137,7 @@ export const getIfNoMessages = (narrow: Narrow) => (state: GlobalState): boolean
   getShownMessagesForNarrow(state, narrow).length === 0;
 
 export const getShowMessagePlaceholders = (narrow: Narrow) => (state: GlobalState): boolean => {
-  const fetching = getFetchingForNarrow(narrow)(state);
+  const fetching = getFetchingForNarrow(state, narrow);
   return (fetching.older || fetching.newer) && getIfNoMessages(narrow)(state);
 };
 

--- a/src/chat/narrowsSelectors.js
+++ b/src/chat/narrowsSelectors.js
@@ -22,7 +22,7 @@ import {
 } from '../directSelectors';
 import { getCaughtUpForNarrow } from '../caughtup/caughtUpSelectors';
 import { getAllUsersByEmail } from '../users/userSelectors';
-import { getIsFetching } from './fetchingSelectors';
+import { getFetchingForNarrow } from './fetchingSelectors';
 import {
   isPrivateNarrow,
   isStreamOrTopicNarrow,
@@ -142,8 +142,8 @@ export const getIfNoMessages = (narrow: Narrow): Selector<boolean> =>
 export const getShowMessagePlaceholders = (narrow: Narrow): Selector<boolean> =>
   createSelector(
     getIfNoMessages(narrow),
-    getIsFetching(narrow),
-    (noMessages, isFetching) => isFetching && noMessages,
+    getFetchingForNarrow(narrow),
+    (noMessages, fetching) => (fetching.older || fetching.newer) && noMessages,
   );
 
 export const isNarrowValid = (narrow: Narrow): Selector<boolean> =>

--- a/src/chat/narrowsSelectors.js
+++ b/src/chat/narrowsSelectors.js
@@ -132,9 +132,6 @@ export const getStreamInNarrow = (
     },
   );
 
-export const getIfNoMessages = (narrow: Narrow) => (state: GlobalState): boolean =>
-  getShownMessagesForNarrow(state, narrow).length === 0;
-
 export const isNarrowValid = (narrow: Narrow): Selector<boolean> =>
   createSelector(
     getStreams,

--- a/src/chat/narrowsSelectors.js
+++ b/src/chat/narrowsSelectors.js
@@ -133,18 +133,13 @@ export const getStreamInNarrow = (
     },
   );
 
-export const getIfNoMessages = (narrow: Narrow): Selector<boolean> =>
-  createSelector(
-    state => getShownMessagesForNarrow(state, narrow),
-    messages => messages.length === 0,
-  );
+export const getIfNoMessages = (narrow: Narrow) => (state: GlobalState): boolean =>
+  getShownMessagesForNarrow(state, narrow).length === 0;
 
-export const getShowMessagePlaceholders = (narrow: Narrow): Selector<boolean> =>
-  createSelector(
-    getIfNoMessages(narrow),
-    getFetchingForNarrow(narrow),
-    (noMessages, fetching) => (fetching.older || fetching.newer) && noMessages,
-  );
+export const getShowMessagePlaceholders = (narrow: Narrow) => (state: GlobalState): boolean => {
+  const fetching = getFetchingForNarrow(narrow)(state);
+  return (fetching.older || fetching.newer) && getIfNoMessages(narrow)(state);
+};
 
 export const isNarrowValid = (narrow: Narrow): Selector<boolean> =>
   createSelector(

--- a/src/message/NoMessages.js
+++ b/src/message/NoMessages.js
@@ -3,9 +3,7 @@
 import React, { PureComponent } from 'react';
 import { StyleSheet, View } from 'react-native';
 
-import type { Narrow, Dispatch } from '../types';
-import { connect } from '../react-redux';
-import { getIfNoMessages } from '../selectors';
+import type { Narrow } from '../types';
 import { Label } from '../common';
 
 import {
@@ -47,19 +45,13 @@ const messages: EmptyMessage[] = [
   { isFunc: isSearchNarrow, text: 'No messages' },
 ];
 
-type SelectorProps = {|
-  noMessages: boolean,
-|};
-
 type Props = $ReadOnly<{|
   narrow: Narrow,
+  noMessages: boolean,
   showMessagePlaceholders: boolean,
-
-  dispatch: Dispatch,
-  ...SelectorProps,
 |}>;
 
-class NoMessages extends PureComponent<Props> {
+export default class NoMessages extends PureComponent<Props> {
   render() {
     const { noMessages, showMessagePlaceholders, narrow } = this.props;
 
@@ -77,7 +69,3 @@ class NoMessages extends PureComponent<Props> {
     );
   }
 }
-
-export default connect<SelectorProps, _, _>((state, props) => ({
-  noMessages: getIfNoMessages(props.narrow)(state),
-}))(NoMessages);

--- a/src/message/NoMessages.js
+++ b/src/message/NoMessages.js
@@ -5,7 +5,7 @@ import { StyleSheet, View } from 'react-native';
 
 import type { Narrow, Dispatch } from '../types';
 import { connect } from '../react-redux';
-import { getIfNoMessages, getShowMessagePlaceholders } from '../selectors';
+import { getIfNoMessages } from '../selectors';
 import { Label } from '../common';
 
 import {
@@ -48,12 +48,12 @@ const messages: EmptyMessage[] = [
 ];
 
 type SelectorProps = {|
-  showMessagePlaceholders: boolean,
   noMessages: boolean,
 |};
 
 type Props = $ReadOnly<{|
   narrow: Narrow,
+  showMessagePlaceholders: boolean,
 
   dispatch: Dispatch,
   ...SelectorProps,
@@ -79,6 +79,5 @@ class NoMessages extends PureComponent<Props> {
 }
 
 export default connect<SelectorProps, _, _>((state, props) => ({
-  showMessagePlaceholders: getShowMessagePlaceholders(props.narrow)(state),
   noMessages: getIfNoMessages(props.narrow)(state),
 }))(NoMessages);

--- a/src/message/NoMessages.js
+++ b/src/message/NoMessages.js
@@ -47,17 +47,11 @@ const messages: EmptyMessage[] = [
 
 type Props = $ReadOnly<{|
   narrow: Narrow,
-  noMessages: boolean,
-  showMessagePlaceholders: boolean,
 |}>;
 
 export default class NoMessages extends PureComponent<Props> {
   render() {
-    const { noMessages, showMessagePlaceholders, narrow } = this.props;
-
-    if (!noMessages || showMessagePlaceholders) {
-      return null;
-    }
+    const { narrow } = this.props;
 
     const message = messages.find(x => x.isFunc(narrow)) || {};
 

--- a/src/message/fetchActions.js
+++ b/src/message/fetchActions.js
@@ -79,7 +79,7 @@ export const fetchOlder = (narrow: Narrow) => (dispatch: Dispatch, getState: Get
   const state = getState();
   const firstMessageId = getFirstMessageId(state, narrow);
   const caughtUp = getCaughtUpForNarrow(state, narrow);
-  const fetching = getFetchingForNarrow(narrow)(state);
+  const fetching = getFetchingForNarrow(state, narrow);
   const { needsInitialFetch } = getSession(state);
 
   if (!needsInitialFetch && !fetching.older && !caughtUp.older && firstMessageId !== undefined) {
@@ -91,7 +91,7 @@ export const fetchNewer = (narrow: Narrow) => (dispatch: Dispatch, getState: Get
   const state = getState();
   const lastMessageId = getLastMessageId(state, narrow);
   const caughtUp = getCaughtUpForNarrow(state, narrow);
-  const fetching = getFetchingForNarrow(narrow)(state);
+  const fetching = getFetchingForNarrow(state, narrow);
   const { needsInitialFetch } = getSession(state);
 
   if (!needsInitialFetch && !fetching.newer && !caughtUp.newer && lastMessageId !== undefined) {

--- a/src/reduxTypes.js
+++ b/src/reduxTypes.js
@@ -73,6 +73,11 @@ export type Fetching = {|
   newer: boolean,
 |};
 
+/**
+ * Info about which narrows we're actively fetching more messages from.
+ *
+ * See also: `CaughtUpState`, `NarrowsState`.
+ */
 export type FetchingState = {
   [narrow: string]: Fetching,
 };
@@ -155,10 +160,12 @@ export type MuteState = MuteTuple[];
  * Keys are `JSON.stringify`-encoded `Narrow` objects.
  * Values are sorted lists of message IDs.
  *
- * See also `MessagesState`, which stores the message data indexed by ID.
- * See also `CaughtUpState` for information about where this data *is*
- * complete for a given narrow, and `FetchingState` for information about
- * which narrows we're actively fetching more messages from.
+ * See also:
+ *  * `MessagesState`, which stores the message data indexed by ID;
+ *  * `CaughtUpState` for information about where this data *is*
+ *    complete for a given narrow;
+ *  * `FetchingState` for information about which narrows we're actively
+ *    fetching more messages from.
  */
 export type NarrowsState = {
   [narrow: string]: number[],

--- a/src/webview/MessageList.js
+++ b/src/webview/MessageList.js
@@ -39,7 +39,6 @@ import {
   getOwnUser,
   getSettings,
   getSubscriptions,
-  getShowMessagePlaceholders,
   getShownMessagesForNarrow,
   getRealm,
 } from '../selectors';
@@ -92,13 +91,13 @@ type SelectorProps = {|
   fetching: Fetching,
   messages: $ReadOnlyArray<Message | Outbox>,
   renderedMessages: RenderedSectionDescriptor[],
-  showMessagePlaceholders: boolean,
   typingUsers: $ReadOnlyArray<User>,
 |};
 
 // TODO get a type for `connectActionSheet` so this gets fully type-checked.
 export type Props = $ReadOnly<{|
   narrow: Narrow,
+  showMessagePlaceholders: boolean,
 
   dispatch: Dispatch,
   ...SelectorProps,
@@ -336,6 +335,7 @@ class MessageList extends Component<Props> {
 
 type OuterProps = {|
   narrow: Narrow,
+  showMessagePlaceholders: boolean,
 
   /* Remaining props are derived from `narrow` by default. */
 
@@ -346,7 +346,6 @@ type OuterProps = {|
   /* Passing these three from the parent is kind of a hack; search uses it
      to hard-code some behavior. */
   fetching?: Fetching,
-  showMessagePlaceholders?: boolean,
   typingUsers?: User[],
 |};
 
@@ -377,10 +376,6 @@ export default connect<SelectorProps, _, _>((state, props: OuterProps) => {
     fetching: props.fetching || getFetchingForNarrow(props.narrow)(state),
     messages: props.messages || getShownMessagesForNarrow(state, props.narrow),
     renderedMessages: props.renderedMessages || getRenderedMessages(props.narrow)(state),
-    showMessagePlaceholders:
-      props.showMessagePlaceholders !== undefined
-        ? props.showMessagePlaceholders
-        : getShowMessagePlaceholders(props.narrow)(state),
     typingUsers: props.typingUsers || getCurrentTypingUsers(state, props.narrow),
   };
 })(connectActionSheet(withGetText(MessageList)));

--- a/src/webview/MessageList.js
+++ b/src/webview/MessageList.js
@@ -373,7 +373,7 @@ export default connect<SelectorProps, _, _>((state, props: OuterProps) => {
       props.initialScrollMessageId !== undefined
         ? props.initialScrollMessageId
         : getFirstUnreadIdInNarrow(state, props.narrow),
-    fetching: props.fetching || getFetchingForNarrow(props.narrow)(state),
+    fetching: props.fetching || getFetchingForNarrow(state, props.narrow),
     messages: props.messages || getShownMessagesForNarrow(state, props.narrow),
     renderedMessages: props.renderedMessages || getRenderedMessages(props.narrow)(state),
     typingUsers: props.typingUsers || getCurrentTypingUsers(state, props.narrow),


### PR DESCRIPTION
I sat down this afternoon to look at #3822 and #3802, and found I wasn't 100% sure under what conditions we show that "No Messages" message, and that it wasn't immediate to find out.

I dug into the code to answer that question, and this series of changes is the result. :slightly_smiling_face: They're all NFC refactors, and each step is simple; at the end, I think it's appreciably easier to reason about what's going on in this part of our UI.
