### PR TITLE
Enable Scrolling in Pick account list to show "Add account" button

### DIFF
--- a/src/account/AccountPickScreen.js
+++ b/src/account/AccountPickScreen.js
@@ -49,13 +49,7 @@ class AccountPickScreen extends PureComponent<Props> {
     const { accounts, dispatch } = this.props;
 
     return (
-      <Screen
-        title="Pick account"
-        centerContent
-        padding
-        canGoBack={this.canGoBack}
-        verticalScrollIndicatorEnabled={false}
-      >
+      <Screen title="Pick account" centerContent padding canGoBack={this.canGoBack}>
         <Centerer>
           {accounts.length === 0 && <Logo />}
           <AccountList

--- a/src/account/AccountPickScreen.js
+++ b/src/account/AccountPickScreen.js
@@ -49,7 +49,13 @@ class AccountPickScreen extends PureComponent<Props> {
     const { accounts, dispatch } = this.props;
 
     return (
-      <Screen title="Pick account" centerContent padding canGoBack={this.canGoBack}>
+      <Screen
+        title="Pick account"
+        centerContent
+        padding
+        canGoBack={this.canGoBack}
+        verticalScrollIndicatorEnabled={false}
+      >
         <Centerer>
           {accounts.length === 0 && <Logo />}
           <AccountList

--- a/src/common/Screen.js
+++ b/src/common/Screen.js
@@ -38,6 +38,7 @@ type Props = $ReadOnly<{|
   keyboardShouldPersistTaps: 'never' | 'always' | 'handled',
   padding: boolean,
   scrollEnabled: boolean,
+  verticalScrollIndicatorEnabled: boolean,
   style?: ViewStyleProp,
 
   search: boolean,
@@ -59,6 +60,7 @@ type Props = $ReadOnly<{|
  * @prop [keyboardShouldPersistTaps] - Passed through to ScrollView.
  * @prop [padding] - Should padding be added to the contents of the screen.
  * @prop [scrollEnabled] - Passed through to ScrollView.
+ * @prop [verticalScrollIndicatorEnabled] - Passed through to ScrollView
  * @prop [style] - Additional style for the ScrollView.
  *
  * @prop [search] - If 'true' show a search box in place of the title.
@@ -81,6 +83,7 @@ class Screen extends PureComponent<Props> {
     keyboardShouldPersistTaps: 'handled',
     padding: false,
     scrollEnabled: true,
+    verticalScrollIndicatorEnabled: true,
 
     search: false,
     autoFocus: false,
@@ -100,6 +103,7 @@ class Screen extends PureComponent<Props> {
       padding,
       safeAreaInsets,
       scrollEnabled,
+      verticalScrollIndicatorEnabled,
       search,
       searchBarOnChange,
       style,
@@ -126,6 +130,7 @@ class Screen extends PureComponent<Props> {
             style={componentStyles.childrenWrapper}
             keyboardShouldPersistTaps={keyboardShouldPersistTaps}
             scrollEnabled={scrollEnabled}
+            showsVerticalScrollIndicator={verticalScrollIndicatorEnabled}
           >
             {children}
           </ScrollView>

--- a/src/common/Screen.js
+++ b/src/common/Screen.js
@@ -60,7 +60,6 @@ type Props = $ReadOnly<{|
  * @prop [keyboardShouldPersistTaps] - Passed through to ScrollView.
  * @prop [padding] - Should padding be added to the contents of the screen.
  * @prop [scrollEnabled] - Passed through to ScrollView.
- * @prop [verticalScrollIndicatorEnabled] - Passed through to ScrollView
  * @prop [style] - Additional style for the ScrollView.
  *
  * @prop [search] - If 'true' show a search box in place of the title.
@@ -83,7 +82,6 @@ class Screen extends PureComponent<Props> {
     keyboardShouldPersistTaps: 'handled',
     padding: false,
     scrollEnabled: true,
-    verticalScrollIndicatorEnabled: true,
 
     search: false,
     autoFocus: false,
@@ -103,7 +101,6 @@ class Screen extends PureComponent<Props> {
       padding,
       safeAreaInsets,
       scrollEnabled,
-      verticalScrollIndicatorEnabled,
       search,
       searchBarOnChange,
       style,
@@ -130,7 +127,6 @@ class Screen extends PureComponent<Props> {
             style={componentStyles.childrenWrapper}
             keyboardShouldPersistTaps={keyboardShouldPersistTaps}
             scrollEnabled={scrollEnabled}
-            showsVerticalScrollIndicator={verticalScrollIndicatorEnabled}
           >
             {children}
           </ScrollView>

--- a/src/common/Screen.js
+++ b/src/common/Screen.js
@@ -38,6 +38,7 @@ type Props = $ReadOnly<{|
   keyboardShouldPersistTaps: 'never' | 'always' | 'handled',
   padding: boolean,
   scrollEnabled: boolean,
+  verticalScrollIndicatorEnabled: boolean,
   style?: ViewStyleProp,
 
   search: boolean,
@@ -59,6 +60,7 @@ type Props = $ReadOnly<{|
  * @prop [keyboardShouldPersistTaps] - Passed through to ScrollView.
  * @prop [padding] - Should padding be added to the contents of the screen.
  * @prop [scrollEnabled] - Passed through to ScrollView.
+ * @prop [verticalScrollIndicatorEnabled] - Passed through to ScrollView
  * @prop [style] - Additional style for the ScrollView.
  *
  * @prop [search] - If 'true' show a search box in place of the title.
@@ -81,6 +83,7 @@ class Screen extends PureComponent<Props> {
     keyboardShouldPersistTaps: 'handled',
     padding: false,
     scrollEnabled: true,
+    verticalScrollIndicatorEnabled: true,
 
     search: false,
     autoFocus: false,
@@ -100,6 +103,7 @@ class Screen extends PureComponent<Props> {
       padding,
       safeAreaInsets,
       scrollEnabled,
+      verticalScrollIndicatorEnabled,
       search,
       searchBarOnChange,
       style,
@@ -122,10 +126,11 @@ class Screen extends PureComponent<Props> {
           contentContainerStyle={[padding && styles.padding]}
         >
           <ScrollView
-            contentContainerStyle={[styles.flexed, centerContent && componentStyles.content, style]}
+            contentContainerStyle={[centerContent && componentStyles.content, style]}
             style={componentStyles.childrenWrapper}
             keyboardShouldPersistTaps={keyboardShouldPersistTaps}
             scrollEnabled={scrollEnabled}
+            showsVerticalScrollIndicator={verticalScrollIndicatorEnabled}
           >
             {children}
           </ScrollView>

--- a/src/common/Screen.js
+++ b/src/common/Screen.js
@@ -64,6 +64,7 @@ type Props = $ReadOnly<{|
  * @prop [search] - If 'true' show a search box in place of the title.
  * @prop [autoFocus] - If search bar enabled, should it be focused initially.
  * @prop [searchBarOnChange] - Event called on search query change.
+
  * @prop [canGoBack] - If true (the default), show UI for "navigate back".
  * @prop [title] - Text shown as the title of the screen.
  *                 Required unless `search` is true.

--- a/src/common/Screen.js
+++ b/src/common/Screen.js
@@ -64,7 +64,7 @@ type Props = $ReadOnly<{|
  * @prop [search] - If 'true' show a search box in place of the title.
  * @prop [autoFocus] - If search bar enabled, should it be focused initially.
  * @prop [searchBarOnChange] - Event called on search query change.
-
+ *
  * @prop [canGoBack] - If true (the default), show UI for "navigate back".
  * @prop [title] - Text shown as the title of the screen.
  *                 Required unless `search` is true.

--- a/src/common/Screen.js
+++ b/src/common/Screen.js
@@ -38,7 +38,6 @@ type Props = $ReadOnly<{|
   keyboardShouldPersistTaps: 'never' | 'always' | 'handled',
   padding: boolean,
   scrollEnabled: boolean,
-  verticalScrollIndicatorEnabled: boolean,
   style?: ViewStyleProp,
 
   search: boolean,
@@ -65,7 +64,6 @@ type Props = $ReadOnly<{|
  * @prop [search] - If 'true' show a search box in place of the title.
  * @prop [autoFocus] - If search bar enabled, should it be focused initially.
  * @prop [searchBarOnChange] - Event called on search query change.
- *
  * @prop [canGoBack] - If true (the default), show UI for "navigate back".
  * @prop [title] - Text shown as the title of the screen.
  *                 Required unless `search` is true.


### PR DESCRIPTION
 Scrolling is enabled in the Account Pick Screen.
![after_1_commit](https://user-images.githubusercontent.com/23723464/74468181-6695c480-4ec0-11ea-81b6-c50ec2dbbc2c.gif)
