### PR TITLE
logging: Disregard null device token.

### DIFF
--- a/src/actionTypes.js
+++ b/src/actionTypes.js
@@ -186,7 +186,7 @@ type RealmInitAction = {|
 /** We learned the device token from the system.  See `SessionState`. */
 type GotPushTokenAction = {|
   type: typeof GOT_PUSH_TOKEN,
-  pushToken: string,
+  pushToken: null | string,
 |};
 
 /** We're about to tell the server to forget our device token. */

--- a/src/notification/index.js
+++ b/src/notification/index.js
@@ -210,11 +210,20 @@ export class NotificationListener {
     this.dispatch(narrowToNotification(data));
   };
 
-  /** Private. */
+  /**
+   * Private.
+   *
+   * @param deviceToken This should be a `?string`, but there's no typechecking
+   *   at the registration site to allow us to ensure it. As we've been burned
+   *   by unexpected types here before, we do the validation explicitly.
+   */
   handleDeviceToken = async (deviceToken: mixed) => {
-    // A device token should normally be a string of hex digits. Sometimes,
-    // however, we appear to receive objects here. Log this. (See issue #3672.)
-    if (typeof deviceToken !== 'string' || deviceToken === '[Object object]') {
+    // Null device tokens are known to occur (at least) on Android emulators
+    // without Google Play services, and have been reported in other scenarios.
+    // See https://stackoverflow.com/q/37517860 for relevant discussion.
+    //
+    // String device tokens are the normal and expected case.
+    if (deviceToken !== null && typeof deviceToken !== 'string') {
       // $FlowFixMe: deviceToken probably _is_ JSONable, but we can only hope
       const token: JSONable = deviceToken;
       logging.error('Received invalid device token', { token });

--- a/src/notification/notificationActions.js
+++ b/src/notification/notificationActions.js
@@ -18,7 +18,7 @@ import { doNarrow } from '../message/messagesActions';
 import { switchAccount } from '../account/accountActions';
 import { getIdentities } from '../account/accountsSelectors';
 
-export const gotPushToken = (pushToken: string): Action => ({
+export const gotPushToken = (pushToken: string | null): Action => ({
   type: GOT_PUSH_TOKEN,
   pushToken,
 });

--- a/src/session/sessionReducer.js
+++ b/src/session/sessionReducer.js
@@ -45,14 +45,18 @@ export type SessionState = {|
   /**
    * Our actual device token, as most recently learned from the system.
    *
-   * With FCM/GCM this is the "registration token"; with APNs the "device token".
+   * With FCM/GCM this is the "registration token"; with APNs the "device
+   * token".
    *
-   * This is `null` before we've gotten a token.
+   * This is `null` before we've gotten a token. On Android, we may also receive
+   * an explicit `null` token if the device can't or won't give us a real one.
    *
    * See upstream docs:
    *   https://firebase.google.com/docs/cloud-messaging/android/client#sample-register
    *   https://developers.google.com/cloud-messaging/android/client
    *   https://developer.apple.com/documentation/usernotifications/registering_your_app_with_apns
+   *
+   * See also discussion at https://stackoverflow.com/q/37517860.
    */
   pushToken: string | null,
 


### PR DESCRIPTION
This is normal on (at least) the Android emulator when running without
Google Play services. (Presumably this would also be true on physical
devices without notification services.)