### PR TITLE
[WIP] fetch actions: Retry on message fetch failure.

### DIFF
--- a/src/message/fetchActions.js
+++ b/src/message/fetchActions.js
@@ -62,13 +62,8 @@ export const fetchMessages = (
 ) => async (dispatch: Dispatch, getState: GetState) => {
   const useFirstUnread = anchor === FIRST_UNREAD_ANCHOR;
   dispatch(messageFetchStart(narrow, numBefore, numAfter));
-  const { messages, found_newest, found_oldest } = await api.getMessages(
-    getAuth(getState()),
-    narrow,
-    anchor,
-    numBefore,
-    numAfter,
-    useFirstUnread,
+  const { messages, found_newest, found_oldest } = await tryUntilSuccessful(() =>
+    api.getMessages(getAuth(getState()), narrow, anchor, numBefore, numAfter, useFirstUnread),
   );
   dispatch(
     messageFetchComplete(messages, narrow, anchor, numBefore, numAfter, found_newest, found_oldest),


### PR DESCRIPTION
Code is exactly the same as https://github.com/zulip/zulip-mobile/pull/3288.

It previously broke Jest tests. The problem was, as @gnprice mentions [here](https://github.com/zulip/zulip-mobile/commit/abc781457935135559560f6d619ffb15bf18e87e)
>After this change, Jest would hang after all tests had completed.

This appears to have been fixed in upstream PR https://github.com/facebook/jest/pull/1870. I ran `/tools/test jest --full`, and Jest is no longer hanging; here's the tail of the output:
```js
[...]
Test Suites: 90 passed, 90 total
Tests:       787 passed, 787 total
Snapshots:   0 total
Time:        11.84s, estimated 16s
Ran all test suites.
Passed!
```