### PR TITLE
Local notification fixes

### DIFF
--- a/android/app/src/main/java/com/zulipmobile/notifications/FcmMessage.kt
+++ b/android/app/src/main/java/com/zulipmobile/notifications/FcmMessage.kt
@@ -107,7 +107,7 @@ data class MessageFcmMessage(
      * All the data our React code needs on opening the notification.
      *
      * For the corresponding type definition on the JS side, see `Notification`
-     * in `notification/index.js`.
+     * in `src/notification/types.js`.
      */
     fun dataForOpen(): Bundle = Bundle().apply {
         // NOTE: Keep the JS-side type definition in sync with this code.

--- a/src/actionTypes.js
+++ b/src/actionTypes.js
@@ -188,7 +188,7 @@ type RealmInitAction = {|
 /** We learned the device token from the system.  See `SessionState`. */
 type GotPushTokenAction = {|
   type: typeof GOT_PUSH_TOKEN,
-  pushToken: string,
+  pushToken: null | string,
 |};
 
 /** We're about to tell the server to forget our device token. */

--- a/src/notification/__tests__/notification-test.js
+++ b/src/notification/__tests__/notification-test.js
@@ -3,7 +3,7 @@ import deepFreeze from 'deep-freeze';
 
 import type { User } from '../../api/modelTypes';
 import type { JSONableDict } from '../../utils/jsonable';
-import { getNarrowFromNotificationData, extractNotificationData } from '..';
+import { getNarrowFromNotificationData } from '..';
 import { topicNarrow, privateNarrow, groupNarrow } from '../../utils/narrow';
 
 import * as eg from '../../__tests__/exampleData';
@@ -65,24 +65,6 @@ describe('getNarrowFromNotificationData', () => {
     const narrow = getNarrowFromNotificationData(notification, usersById);
 
     expect(narrow).toBe(null);
-  });
-});
-
-describe('extractNotificationData', () => {
-  test('if input value is not as expected, returns null', () => {
-    expect(extractNotificationData()).toBe(null);
-    // $FlowFixMe
-    expect(extractNotificationData({})).toBe(null);
-    // $FlowFixMe
-    expect(extractNotificationData({ getData: undefined })).toBe(null);
-  });
-
-  test('if some data is passed, returns it', () => {
-    const data = {};
-    // $FlowFixMe
-    expect(extractNotificationData({ getData: () => data })).toBe(data);
-    // $FlowFixMe
-    expect(extractNotificationData({ getData: () => ({ zulip: data }) })).toBe(data);
   });
 });
 

--- a/src/notification/__tests__/notification-test.js
+++ b/src/notification/__tests__/notification-test.js
@@ -1,9 +1,14 @@
 // @flow strict-local
+import deepFreeze from 'deep-freeze';
+
+import type { User } from '../../api/modelTypes';
+import type { JSONableDict } from '../../utils/jsonable';
 import { getNarrowFromNotificationData, extractNotificationData } from '..';
 import { topicNarrow, privateNarrow, groupNarrow } from '../../utils/narrow';
 
-import type { User } from '../../api/modelTypes';
 import * as eg from '../../__tests__/exampleData';
+import { fromAPNsImpl as extractIosNotificationData } from '../extract';
+import objectEntries from '../../utils/objectEntries';
 
 describe('getNarrowFromNotificationData', () => {
   const DEFAULT_MAP = new Map<number, User>();
@@ -78,5 +83,102 @@ describe('extractNotificationData', () => {
     expect(extractNotificationData({ getData: () => data })).toBe(data);
     // $FlowFixMe
     expect(extractNotificationData({ getData: () => ({ zulip: data }) })).toBe(data);
+  });
+});
+
+describe('extract iOS notification data', () => {
+  const barebones = deepFreeze({
+    stream: { recipient_type: 'stream', stream: 'announce', topic: 'New channel' },
+    private: {
+      recipient_type: 'private',
+      sender_email: 'nobody@example.com',
+    },
+    'group PM': {
+      recipient_type: 'private',
+      sender_email: 'nobody@example.com',
+    },
+  });
+
+  describe('success', () => {
+    /** Helper function: test data immediately. */
+    const verify = (data: JSONableDict) => extractIosNotificationData({ zulip: data });
+
+    for (const [type, data] of objectEntries(barebones)) {
+      test(`${type} notification`, () => {
+        // barebones 1.8.0-style message is accepted
+        const msg = data;
+        expect(verify(msg)).toEqual(msg);
+
+        // unused fields are not copied
+        const msg2 = { ...msg, realm_id: 8675309 };
+        expect(verify(msg2)).toEqual(msg);
+
+        // unknown fields are ignored and not copied
+        const msg2a = { ...msg, unknown_data: ['unknown_data'] };
+        expect(verify(msg2a)).toEqual(msg);
+
+        // realm_uri is copied if present
+        const msg3 = { ...msg, realm_uri: 'https://zulip.example.org' };
+        expect(verify(msg3)).toEqual(msg3);
+      });
+    }
+  });
+
+  /** Helper function: test raw data after another call. */
+  const makeRaw = (data: JSONableDict) => () => extractIosNotificationData(data);
+  /** Helper function: test wrapped data after another call. */
+  const make = (data: JSONableDict) => () => extractIosNotificationData({ zulip: data });
+
+  describe('failure', () => {
+    test('completely malformed or inappropriate messages', () => {
+      expect(makeRaw({})).toThrow();
+      expect(makeRaw({ message_ids: [1] })).toThrow();
+      expect(makeRaw({ initechData: 'everything' })).toThrow(/alien/);
+    });
+
+    test('very-old-style messages', () => {
+      expect(make({ message_ids: [123] })).toThrow(/archaic/);
+    });
+
+    test('broken or partial messages', () => {
+      expect(make({ recipient_type: 'huddle' })).toThrow(/invalid/);
+      expect(make({ recipient_type: 'stream' })).toThrow(/invalid/);
+      expect(make({ recipient_type: 'stream', stream: 'stream name' })).toThrow(/invalid/);
+      expect(make({ recipient_type: 'stream', subject: 'topic' })).toThrow(/invalid/);
+      expect(make({ recipient_type: 'private', subject: 'topic' })).toThrow(/invalid/);
+    });
+
+    test('values of incorrect type', () => {
+      expect(make({ recipient_type: 'private', pm_users: [1, 2, 3] })).toThrow(/invalid/);
+      expect(make({ recipient_type: 'stream', stream: [], topic: 'yes' })).toThrow(/invalid/);
+      expect(
+        make({
+          recipient_type: 'stream',
+          stream: { name: 'somewhere' },
+          topic: 'no',
+        }),
+      ).toThrow(/invalid/);
+    });
+
+    test('optional data is typechecked', () => {
+      expect(
+        make({
+          realm_uri: null,
+          ...barebones.stream,
+        }),
+      ).toThrow(/invalid/);
+
+      expect(
+        make({
+          realm_uri: ['array', 'of', 'string'],
+          ...barebones['group PM'],
+        }),
+      ).toThrow(/invalid/);
+    });
+
+    test('hypothetical future: different event types', () => {
+      expect(make({ event: 'remove' })()).toBeUndefined();
+      expect(make({ event: 'unknown type' })()).toBeUndefined();
+    });
   });
 });

--- a/src/notification/extract.js
+++ b/src/notification/extract.js
@@ -1,0 +1,219 @@
+/* @flow strict-local */
+import type { Notification } from './types';
+import type { JSONable, JSONableDict, JSONableInput, JSONableInputDict } from '../utils/jsonable';
+import * as logging from '../utils/logging';
+
+/** Confirm (or disprove) that a JSONableInput object is a dictionary. */
+const asDict = (obj: JSONableInput | void): JSONableInputDict | void => {
+  if (typeof obj !== 'object') {
+    return undefined;
+  }
+  if (obj === null || obj instanceof Array) {
+    return undefined;
+  }
+  return obj;
+};
+
+/*
+    The Zulip APNs message format, as far back as 2013-03-23 [0], has always
+    been some subtype of the following:
+
+        type Data = { zulip: { ... } }
+
+    (Comments in `zerver/lib/push_notifications.py` may appear to indicate
+    otherwise, but these refer only to the format of inter-server messages for
+    the Zulip-hosted push-notification bouncer service. Messages sent over APNs
+    itself have always had a `zulip` field.)
+
+    [0] GitHub commit 410ee44eb6e40bac4099d1851d949533026fe4b3.
+
+    The original payload was merely `{ message_ids: [number] }`, but this has
+    been expanded incrementally over the years. As of 2020-02, commit
+    2.2-dev-775-g10e7e15088, the current form of APNs messages is as follows:
+
+    ```
+    type StreamData = {
+        // added 1.7.0-1351-g98943a8333, release 1.8.0+
+        recipient_type: 'stream',
+        stream: string,
+        topic: string,
+    };
+
+    type PmData = {
+        // added 1.7.0-1351-g98943a8333, release 1.8.0+
+        recipient_type: 'private',
+
+        // added 1.7.0-2360-g693a9a5e70, release 1.8.0+
+        // present only on group PMs
+        pm_users?: string,  // CSV of int (user ids)
+    };
+
+    type Data = { zulip: {
+        // present since antiquity
+        message_ids: [number],  // single-element tuple!
+
+        // added 1.7.0-1351-g98943a8333, release 1.8.0+
+        sender_email: string,
+        sender_id: number,
+        server: string,     // settings.EXTERNAL_HOST
+        realm_id: number,   // server-internal realm identifier
+
+        // added 1.8.0-2150-g5f8d193bb7, release 1.9.0+
+        realm_uri: string,  // as in `/server_settings` response
+
+        // added 2.1-dev-540-g447a517e6f, release 2.1.0+
+        user_id: number,    // recipient id
+
+        ...(StreamData | PmData),
+    } };
+    ```
+
+    Note that prior to 1.7.0-1351-g98943a8333, we only received the
+    `message_ids` field. Messages of this form are not useful.
+
+    The pair `(server, realm_id)`, added in the same commit, uniquely identifies
+    a Zulip realm, and was originally intended to permit the client to associate
+    a notification with its associated realm. Unfortunately, there is no way to
+    get either of these from a server via the API, so this would not be possible
+    until the addition of `realm_uri` in 1.8.0-2150-g5f8d193bb7...
+
+    ... which still didn't permit differentiating between multiple accounts on
+    the same realm. This was only made possible by the addition of the `user_id`
+    field, in 2.1-dev-540-g447a517e6f.
+*/
+
+/** Local error type. */
+class ApnsMsgValidationError extends Error {
+  extras: JSONable;
+  constructor(message, extras: JSONable) {
+    super(message);
+    this.extras = extras;
+  }
+}
+
+/** Private. Exported only for tests. */
+//
+// Extract Zulip notification data from a JSONable dictionary imported from an
+// APNs notification.
+//
+// @returns A `Notification` on success, `undefined` on suppressible failure.
+// @throws An ApnsMsgValidationError on interesting failure.
+//
+export const fromAPNsImpl = (rawData: JSONableDict): Notification | void => {
+  /** Helper function: fail. */
+  const err = (style: string) =>
+    new ApnsMsgValidationError(`Received ${style} APNs notification`, { data: rawData });
+
+  // APNs messages are JSON dictionaries. The `aps` entry of this dictionary is
+  // required, with a structure defined by Apple; all other entries are
+  // available to the application.
+  //
+  // The react-native-notifications library filters out `aps`, parses it, and
+  // hands us the rest as "data". Pretty much any iOS notifications library
+  // should do the same, but we don't rely on that.
+
+  const data: JSONableInputDict = (() => {
+    if ('aps' in rawData) {
+      // eslint-disable-next-line no-unused-vars
+      const { aps, ...rest } = rawData;
+      return rest;
+    } else {
+      return rawData;
+    }
+  })();
+
+  // Always present; see historical type definition, above.
+  const zulip: JSONableInputDict | void = asDict(data.zulip);
+  if (!zulip) {
+    throw err('alien');
+  }
+
+  // On Android, we also receive "remove" notification messages, tagged with an
+  // `event` field with value 'remove'. As of 2.2-dev-775-g10e7e15088, however,
+  // these are not yet sent to iOS devices, and we don't have a way to handle
+  // them even if they were.
+  //
+  // The messages we currently do receive, and can handle, are analogous to
+  // Android notification messages of event type 'message'. On the assumption
+  // that some future version of the Zulip server will send explicit event types
+  // in APNs messages, accept messages with that `event` value, but no other.
+  const { event: eventType } = zulip;
+  if (eventType !== 'message' && eventType !== undefined) {
+    return undefined;
+  }
+
+  // At this point we can begin trying to construct our `Notification`.
+
+  const { recipient_type } = zulip;
+  if (recipient_type === undefined) {
+    // Arguably not a real error, but we'd like to know when there are no longer
+    // any of these servers left in the wild.
+    throw err('archaic (pre-1.8.x)');
+  }
+  if (typeof recipient_type !== 'string') {
+    throw err('invalid');
+  }
+  if (recipient_type !== 'stream' && recipient_type !== 'private') {
+    throw err('invalid');
+  }
+
+  const { realm_uri } = zulip;
+  if (realm_uri !== undefined && typeof realm_uri !== 'string') {
+    throw err('invalid');
+  }
+  const realm_uri_obj = Object.freeze(realm_uri === undefined ? {} : { realm_uri });
+
+  if (recipient_type === 'stream') {
+    const { stream, topic } = zulip;
+    if (typeof stream !== 'string' || typeof topic !== 'string') {
+      throw err('invalid');
+    }
+    return {
+      recipient_type: 'stream',
+      stream,
+      topic,
+      ...realm_uri_obj,
+    };
+  } else {
+    /* recipient_type === 'private' */
+    const { sender_email, pm_users } = zulip;
+
+    if (pm_users !== undefined) {
+      if (typeof pm_users !== 'string') {
+        throw err('invalid');
+      }
+      if (pm_users.split(',').some(s => Number.isNaN(parseInt(s, 10)))) {
+        throw err('invalid');
+      }
+      return { recipient_type: 'private', pm_users, ...realm_uri_obj };
+    }
+
+    if (typeof sender_email !== 'string') {
+      throw err('invalid');
+    }
+    return { recipient_type: 'private', sender_email, ...realm_uri_obj };
+  }
+
+  /* unreachable */
+};
+
+/**
+ * Extract Zulip notification data from a JSONable dictionary imported from an
+ * APNs notification. Logs validation errors as warnings.
+ *
+ * @returns A `Notification` on success; `undefined` on failure.
+ */
+export const fromAPNs = (data: JSONableDict): Notification | void => {
+  try {
+    return fromAPNsImpl(data);
+  } catch (err) {
+    if (err instanceof ApnsMsgValidationError) {
+      logging.warn(err.message, err.extras);
+      return undefined;
+    }
+    throw err;
+  }
+};
+
+// Despite the name `fromAPNs`, there is no parallel Android-side `fromFCM`
+// function here; the relevant task is performed in `FcmMessage.kt`.

--- a/src/notification/index.js
+++ b/src/notification/index.js
@@ -106,22 +106,6 @@ export const getNarrowFromNotificationData = (
   return groupNarrow(emails);
 };
 
-type NotificationMuddle =
-  | Notification
-  | null
-  | void
-  | { getData: () => Notification | { zulip: Notification } };
-
-/** Extract the actual notification data from the wix library's wrapping (iOS only). */
-// exported for tests
-export const extractNotificationData = (notification: NotificationMuddle): Notification | null => {
-  if (!notification || !notification.getData) {
-    return null;
-  }
-  const data = notification.getData();
-  return data && data.zulip ? data.zulip : data;
-};
-
 const getInitialNotification = async (): Promise<Notification | null> => {
   if (Platform.OS === 'android') {
     const { Notifications } = NativeModules;

--- a/src/notification/index.js
+++ b/src/notification/index.js
@@ -2,6 +2,7 @@
 import { DeviceEventEmitter, NativeModules, Platform, PushNotificationIOS } from 'react-native';
 import NotificationsIOS from 'react-native-notifications';
 
+import type { Notification } from './types';
 import type { Auth, Dispatch, Identity, Narrow, User } from '../types';
 import { topicNarrow, privateNarrow, groupNarrow } from '../utils/narrow';
 import type { JSONable } from '../utils/jsonable';
@@ -14,32 +15,6 @@ import {
   narrowToNotification,
 } from './notificationActions';
 import { identityOfAuth } from '../account/accountMisc';
-
-/**
- * The data we need in JS/React code for acting on a notification.
- *
- * The actual objects we describe with these types may have a bunch more
- * fields.  So, properly, these object types aren't really exact.  But
- * pretending they are seems to be the least unpleasant way to get Flow to
- * recognize the effect of refinements like `data.pm_users === undefined`.
- *
- * Currently:
- *
- *  * On iOS, these objects are translated directly, field by field, from
- *    the blobs of key/value pairs sent by the Zulip server in the
- *    "payload".  The set of fields therefore varies by server version.
- *
- *  * On Android, our platform-native code constructs the exact data to
- *    send; see `MessageFcmMessage#dataForOpen` in `FcmMessage.kt`.
- *    That should be kept in sync with this type definition, in which case
- *    these types really are exact.
- */
-export type Notification =
-  | {| recipient_type: 'stream', stream: string, topic: string, realm_uri?: string |}
-  // Group PM messages have `pm_users`, which is comma-separated IDs.
-  | {| recipient_type: 'private', pm_users: string, realm_uri?: string |}
-  // 1:1 PM messages lack `pm_users`.
-  | {| recipient_type: 'private', sender_email: string, realm_uri?: string |};
 
 /**
  * Identify the account the notification is for, if possible.

--- a/src/notification/index.js
+++ b/src/notification/index.js
@@ -210,14 +210,25 @@ export class NotificationListener {
     this.dispatch(narrowToNotification(data));
   };
 
-  /** Private. */
+  /**
+   * Private.
+   *
+   * @param deviceToken This should be a `?string`, but there's no typechecking
+   *   at the registration site to allow us to ensure it. As we've been burned
+   *   by unexpected types here before, we do the validation explicitly.
+   */
   handleDeviceToken = async (deviceToken: mixed) => {
-    // A device token should be some (platform-dependent and largely
+    // Null device tokens are known to occur (at least) on Android emulators
+    // without Google Play services, and have been reported in other scenarios.
+    // See https://stackoverflow.com/q/37517860 for relevant discussion.
+    //
+    // Otherwise, a device token should be some (platform-dependent and largely
     // unspecified) flavor of string.
-    if (typeof deviceToken !== 'string') {
+    if (deviceToken !== null && typeof deviceToken !== 'string') {
       // $FlowFixMe: deviceToken probably _is_ JSONable, but we can only hope
       const token: JSONable = deviceToken;
       logging.error('Received invalid device token', { token });
+      // Take no further action.
       return;
     }
 

--- a/src/notification/index.js
+++ b/src/notification/index.js
@@ -212,9 +212,9 @@ export class NotificationListener {
 
   /** Private. */
   handleDeviceToken = async (deviceToken: mixed) => {
-    // A device token should normally be a string of hex digits. Sometimes,
-    // however, we appear to receive objects here. Log this. (See issue #3672.)
-    if (typeof deviceToken !== 'string' || deviceToken === '[Object object]') {
+    // A device token should be some (platform-dependent and largely
+    // unspecified) flavor of string.
+    if (typeof deviceToken !== 'string') {
       // $FlowFixMe: deviceToken probably _is_ JSONable, but we can only hope
       const token: JSONable = deviceToken;
       logging.error('Received invalid device token', { token });

--- a/src/notification/index.js
+++ b/src/notification/index.js
@@ -5,7 +5,7 @@ import NotificationsIOS from 'react-native-notifications';
 import type { Notification } from './types';
 import type { Auth, Dispatch, Identity, Narrow, User } from '../types';
 import { topicNarrow, privateNarrow, groupNarrow } from '../utils/narrow';
-import type { JSONable } from '../utils/jsonable';
+import type { JSONable, JSONableDict } from '../utils/jsonable';
 import * as api from '../api';
 import * as logging from '../utils/logging';
 import {
@@ -15,6 +15,7 @@ import {
   narrowToNotification,
 } from './notificationActions';
 import { identityOfAuth } from '../account/accountMisc';
+import { fromAPNs } from './extract';
 
 /**
  * Identify the account the notification is for, if possible.
@@ -225,8 +226,8 @@ export class NotificationListener {
       // On iOS, `note` should be an IOSNotifications object. The notification
       // data it returns from `getData` is unvalidated -- it comes almost
       // straight off the wire from the server.
-      this.listen('notificationOpened', (note: NotificationMuddle) => {
-        const data = extractNotificationData(note);
+      this.listen('notificationOpened', (note: { getData(): JSONableDict }) => {
+        const data = fromAPNs(note.getData());
         if (data) {
           this.handleNotificationOpen(data);
         }

--- a/src/notification/index.js
+++ b/src/notification/index.js
@@ -252,8 +252,9 @@ export class NotificationListener {
       // straight off the wire from the server.
       this.listen('notificationOpened', (note: NotificationMuddle) => {
         const data = extractNotificationData(note);
-        // $FlowFixMe
-        this.handleNotificationOpen(data);
+        if (data) {
+          this.handleNotificationOpen(data);
+        }
       });
     }
 

--- a/src/notification/notificationActions.js
+++ b/src/notification/notificationActions.js
@@ -8,7 +8,7 @@ import {
   getNarrowFromNotificationData,
   getAccountFromNotificationData,
 } from '.';
-import type { Notification } from '.';
+import type { Notification } from './types';
 import { getAuth, getActiveAccount } from '../selectors';
 import { getSession, getAccounts } from '../directSelectors';
 import { GOT_PUSH_TOKEN, ACK_PUSH_TOKEN, UNACK_PUSH_TOKEN } from '../actionConstants';

--- a/src/notification/notificationActions.js
+++ b/src/notification/notificationActions.js
@@ -18,7 +18,7 @@ import { doNarrow } from '../message/messagesActions';
 import { switchAccount } from '../account/accountActions';
 import { getIdentities } from '../account/accountsSelectors';
 
-export const gotPushToken = (pushToken: string): Action => ({
+export const gotPushToken = (pushToken: string | null): Action => ({
   type: GOT_PUSH_TOKEN,
   pushToken,
 });

--- a/src/notification/types.js
+++ b/src/notification/types.js
@@ -3,15 +3,15 @@
 /**
  * The data we need in JS/React code for acting on a notification.
  *
- * Currently:
- *  * On iOS, these objects are reconstructed in React Native from the APNs
- *    payload; the exactness of these type definitions is checked by Flow. (See
- *    `fromAPNs` in `src/notifications/extract.js`.)
+ * On iOS, these objects are constructed by our JS code from the data the
+ * Zulip server sends in the APNs payload.  See `fromAPNs` in
+ * `src/notifications/extract.js`.
  *
- *  * On Android, these objects are constructed by casting JSON objects from our
- *    platform-native code; they are exact iff that code is kept in sync. (See
- *    `MessageFcmMessage#dataForOpen` in `FcmMessage.kt`.)
+ * On Android, these objects are sent to JS from our platform-native code,
+ * constructed there by `MessageFcmMessage#dataForOpen` in `FcmMessage.kt`.
+ * The correspondence of that code with this type isn't type-checked.
  */
+// NOTE: Keep the Android-side code in sync with this type definition.
 export type Notification =
   | {| recipient_type: 'stream', stream: string, topic: string, realm_uri?: string |}
   // Group PM messages have `pm_users`, which is comma-separated IDs.

--- a/src/notification/types.js
+++ b/src/notification/types.js
@@ -1,0 +1,27 @@
+// @flow strict-local
+
+/**
+ * The data we need in JS/React code for acting on a notification.
+ *
+ * The actual objects we describe with these types may have a bunch more
+ * fields.  So, properly, these object types aren't really exact.  But
+ * pretending they are seems to be the least unpleasant way to get Flow to
+ * recognize the effect of refinements like `data.pm_users === undefined`.
+ *
+ * Currently:
+ *
+ *  * On iOS, these objects are translated directly, field by field, from
+ *    the blobs of key/value pairs sent by the Zulip server in the
+ *    "payload".  The set of fields therefore varies by server version.
+ *
+ *  * On Android, our platform-native code constructs the exact data to
+ *    send; see `MessageFcmMessage#dataForOpen` in `FcmMessage.kt`.
+ *    That should be kept in sync with this type definition, in which case
+ *    these types really are exact.
+ */
+export type Notification =
+  | {| recipient_type: 'stream', stream: string, topic: string, realm_uri?: string |}
+  // Group PM messages have `pm_users`, which is comma-separated IDs.
+  | {| recipient_type: 'private', pm_users: string, realm_uri?: string |}
+  // 1:1 PM messages lack `pm_users`.
+  | {| recipient_type: 'private', sender_email: string, realm_uri?: string |};

--- a/src/notification/types.js
+++ b/src/notification/types.js
@@ -3,21 +3,14 @@
 /**
  * The data we need in JS/React code for acting on a notification.
  *
- * The actual objects we describe with these types may have a bunch more
- * fields.  So, properly, these object types aren't really exact.  But
- * pretending they are seems to be the least unpleasant way to get Flow to
- * recognize the effect of refinements like `data.pm_users === undefined`.
- *
  * Currently:
+ *  * On iOS, these objects are reconstructed in React Native from the APNs
+ *    payload; the exactness of these type definitions is checked by Flow. (See
+ *    `fromAPNs` in `src/notifications/extract.js`.)
  *
- *  * On iOS, these objects are translated directly, field by field, from
- *    the blobs of key/value pairs sent by the Zulip server in the
- *    "payload".  The set of fields therefore varies by server version.
- *
- *  * On Android, our platform-native code constructs the exact data to
- *    send; see `MessageFcmMessage#dataForOpen` in `FcmMessage.kt`.
- *    That should be kept in sync with this type definition, in which case
- *    these types really are exact.
+ *  * On Android, these objects are constructed by casting JSON objects from our
+ *    platform-native code; they are exact iff that code is kept in sync. (See
+ *    `MessageFcmMessage#dataForOpen` in `FcmMessage.kt`.)
  */
 export type Notification =
   | {| recipient_type: 'stream', stream: string, topic: string, realm_uri?: string |}

--- a/src/session/sessionReducer.js
+++ b/src/session/sessionReducer.js
@@ -45,14 +45,18 @@ export type SessionState = {|
   /**
    * Our actual device token, as most recently learned from the system.
    *
-   * With FCM/GCM this is the "registration token"; with APNs the "device token".
+   * With FCM/GCM this is the "registration token"; with APNs the "device
+   * token".
    *
-   * This is `null` before we've gotten a token.
+   * This is `null` before we've gotten a token. On Android, we may also receive
+   * an explicit `null` token if the device can't or won't give us a real one.
    *
    * See upstream docs:
    *   https://firebase.google.com/docs/cloud-messaging/android/client#sample-register
    *   https://developers.google.com/cloud-messaging/android/client
    *   https://developer.apple.com/documentation/usernotifications/registering_your_app_with_apns
+   *
+   * See also discussion at https://stackoverflow.com/q/37517860.
    */
   pushToken: string | null,
 

--- a/src/utils/jsonable.js
+++ b/src/utils/jsonable.js
@@ -1,4 +1,5 @@
 /* @flow strict */
+/* eslint-disable flowtype/type-id-match */
 
 /**
  * Type of a round-trip-capable JSONable object.
@@ -11,16 +12,23 @@
  *
  * which of course will not be equal to the original object after parsing.
  */
-// eslint-disable-next-line flowtype/type-id-match
 export type JSONable =
   | null
   | string
   | number
   | boolean
-  | { +[string]: JSONable } /* [α] */
+  | { +[string]: JSONable } // [α]
   | $ReadOnlyArray<JSONable>;
+// [α] This should just be `JSONableDict`, but Flow doesn't handle
+//     mutually-recursive types very well.
 
-// [α]: This should really be an exact type, `{| +[string]: JSONable |}`.
+/**
+ * Type of a round-trip-capable JSONable dictionary.
+ *
+ * See documentation of `JSONable` for caveats.
+ */
+export type JSONableDict = { +[string]: JSONable };
+// This should really be an exact type, `{| +[string]: JSONable |}`.
 // Unfortunately, it can't yet be.
 //
 // Prior to Flow v0.111.0 (i.e., prior to React Native v0.62.0), exact object


### PR DESCRIPTION
* Correctly hook up to `react-native-notifications`. (Fixes #3672.)
* Verify (including by typechecking) the contents of APNs notification data.
* Remove some muddled [_sic_], now-unnecessary rectification code.

N.B.: The first commit here is a duplicate of the current #3906, and should be considered there.