### PR TITLE
Remove `connectFlowFixMe`

### DIFF
--- a/src/__tests__/exampleData.js
+++ b/src/__tests__/exampleData.js
@@ -52,7 +52,7 @@ const randString = () => randInt(2 ** 54).toString(36);
 
 const randUserId: () => number = makeUniqueRandInt('user IDs', 10000);
 const userOrBotProperties = ({ name: _name }) => {
-  const name = _name !== undefined ? _name : randString();
+  const name = _name ?? randString();
   const capsName = name.substring(0, 1).toUpperCase() + name.substring(1);
   return deepFreeze({
     avatar_url: `https://zulip.example.org/yo/avatar-${name}.png`,
@@ -108,9 +108,8 @@ export const crossRealmBot: CrossRealmBot = makeCrossRealmBot({ name: 'bot' });
 
 const randStreamId: () => number = makeUniqueRandInt('stream IDs', 1000);
 export const makeStream = (args: { name?: string, description?: string } = {}): Stream => {
-  const name = args.name !== undefined ? args.name : randString();
-  const description =
-    args.description !== undefined ? args.description : `On the ${randString()} of ${name}`;
+  const name = args.name ?? randString();
+  const description = args.description ?? `On the ${randString()} of ${name}`;
   return deepFreeze({
     stream_id: randStreamId(),
     name,

--- a/src/boot/store.js
+++ b/src/boot/store.js
@@ -101,7 +101,7 @@ const migrations: { [string]: (GlobalState) => GlobalState } = {
       ...a,
       // but in the case of `ackedPushToken` let's be a bit more precise,
       // and avoid clobbering it if present.
-      ackedPushToken: a.ackedPushToken !== undefined ? a.ackedPushToken : null,
+      ackedPushToken: a.ackedPushToken ?? null,
     })),
   }),
 

--- a/src/common/ZulipStatusBar.js
+++ b/src/common/ZulipStatusBar.js
@@ -81,10 +81,7 @@ class ZulipStatusBar extends PureComponent<Props> {
 const mapStateToProps = (state: GlobalState, props: RawProps): SelectorProps => ({
   safeAreaInsets: getSession(state).safeAreaInsets,
   theme: getSettings(state).theme,
-  backgroundColor:
-    props.backgroundColor !== undefined
-      ? props.backgroundColor
-      : getTitleBackgroundColor(props.narrow)(state),
+  backgroundColor: props.backgroundColor ?? getTitleBackgroundColor(props.narrow)(state),
   orientation: getSession(state).orientation,
   hidden: props.hidden ?? false,
 });

--- a/src/react-redux.js
+++ b/src/react-redux.js
@@ -74,19 +74,3 @@ export function connect<SP, P, C: ComponentType<P>>(
 ): C => ComponentType<$ReadOnly<OwnProps<C, SP>>> {
   return connectInner(mapStateToProps);
 }
-
-/**
- * DEPRECATED.  Don't add new uses; and PRs to remove existing uses are welcome.
- *
- * This is exactly like `connect` except with type-checking disabled.
- * Any place we use it, it's because there's a type error there.
- * To fix: change the call site to use `connect`; see what error Flow
- * reports; and fix the error.
- *
- * (Backstory: for a long time `connect` had a type that partly defeated
- * type-checking, so we accumulated a number of type errors that that hid.
- * This untyped version lets us fix those errors one by one, while using the
- * new, well-typed `connect` everywhere else.)
- */
-export const connectFlowFixMe = (mapStateToProps: $FlowFixMe) => (c: $FlowFixMe) =>
-  connect(mapStateToProps)(c);

--- a/src/webview/MessageList.js
+++ b/src/webview/MessageList.js
@@ -370,9 +370,7 @@ export default connect<SelectorProps, _, _>((state, props: OuterProps) => {
   return {
     backgroundData,
     initialScrollMessageId:
-      props.initialScrollMessageId !== undefined
-        ? props.initialScrollMessageId
-        : getFirstUnreadIdInNarrow(state, props.narrow),
+      props.initialScrollMessageId ?? getFirstUnreadIdInNarrow(state, props.narrow),
     fetching: props.fetching || getFetchingForNarrow(state, props.narrow),
     messages: props.messages || getShownMessagesForNarrow(state, props.narrow),
     renderedMessages: props.renderedMessages || getRenderedMessages(props.narrow)(state),

--- a/src/webview/html/messageAsHtml.js
+++ b/src/webview/html/messageAsHtml.js
@@ -60,8 +60,8 @@ const messageBody = (
   { alertWords, flags, ownUser, allImageEmojiById }: BackgroundData,
   message: Message | Outbox,
 ) => {
-  const { id, isOutbox, last_edit_timestamp, reactions } = (message: MessageLike);
-  const content = message.match_content !== undefined ? message.match_content : message.content;
+  const { id, isOutbox, last_edit_timestamp, reactions, match_content } = (message: MessageLike);
+  const content = match_content ?? message.content;
   return template`
 $!${processAlertWords(content, id, alertWords, flags)}
 $!${isOutbox ? '<div class="loading-spinner outbox-spinner"></div>' : ''}


### PR DESCRIPTION
Remove the last use of `connectFlowFixMe` from the codebase, followed immediately by `connectFlowFixMe` itself.

Fixes #3451.

(This PR also includes, as mostly-unrelated cleanup in a final [nfc] commit, a handful of `a ? a : b` ⇒ `a ?? b` conversions. This can be omitted if desired.)