### PR TITLE
Fix last `connectFlowFixMe`; and delete it!

### DIFF
--- a/src/common/ZulipStatusBar.js
+++ b/src/common/ZulipStatusBar.js
@@ -24,13 +24,20 @@ export const getStatusBarStyle = (statusBarColor: string): BarStyle =>
     ? 'light-content'
     : 'dark-content';
 
-type Props = $ReadOnly<{
-  dispatch: Dispatch,
-  hidden: boolean,
+type SelectorProps = $ReadOnly<{|
+  safeAreaInsets: Dimensions,
   theme: ThemeName,
   backgroundColor: string,
-  safeAreaInsets: Dimensions,
   orientation: Orientation,
+|}>;
+
+type Props = $ReadOnly<{
+  backgroundColor?: string,
+  narrow?: Narrow,
+  hidden: boolean,
+
+  dispatch: Dispatch,
+  ...SelectorProps,
 }>;
 
 /**
@@ -67,7 +74,7 @@ class ZulipStatusBar extends PureComponent<Props> {
 }
 
 export default connectFlowFixMe(
-  (state: GlobalState, props: { backgroundColor?: string, narrow?: Narrow }) => ({
+  (state: GlobalState, props: { backgroundColor?: string, narrow?: Narrow }): SelectorProps => ({
     safeAreaInsets: getSession(state).safeAreaInsets,
     theme: getSettings(state).theme,
     backgroundColor:

--- a/src/common/ZulipStatusBar.js
+++ b/src/common/ZulipStatusBar.js
@@ -4,8 +4,8 @@ import React, { PureComponent } from 'react';
 import { Platform, StatusBar, View } from 'react-native';
 import Color from 'color';
 
-import type { Dimensions, GlobalState, Narrow, Orientation, ThemeName, Dispatch } from '../types';
-import { connectFlowFixMe } from '../react-redux';
+import type { Dimensions, Narrow, Orientation, ThemeName, Dispatch } from '../types';
+import { connect } from '../react-redux';
 import { DEFAULT_TITLE_BACKGROUND_COLOR, getTitleBackgroundColor } from '../title/titleSelectors';
 import { foregroundColorFromBackground } from '../utils/color';
 import { getSession, getSettings } from '../selectors';
@@ -27,7 +27,7 @@ export const getStatusBarStyle = (statusBarColor: string): BarStyle =>
 type SelectorProps = $ReadOnly<{|
   safeAreaInsets: Dimensions,
   theme: ThemeName,
-  backgroundColor: string,
+  narrowTitleBackgroundColor: string,
   orientation: Orientation,
 |}>;
 
@@ -54,7 +54,8 @@ class ZulipStatusBar extends PureComponent<Props> {
   };
 
   render() {
-    const { theme, backgroundColor, hidden, safeAreaInsets, orientation } = this.props;
+    const { theme, hidden, safeAreaInsets, orientation } = this.props;
+    const backgroundColor = this.props.backgroundColor ?? this.props.narrowTitleBackgroundColor;
     const style = { height: hidden ? 0 : safeAreaInsets.top, backgroundColor };
     const statusBarColor = getStatusBarColor(backgroundColor, theme);
     return (
@@ -73,14 +74,9 @@ class ZulipStatusBar extends PureComponent<Props> {
   }
 }
 
-export default connectFlowFixMe(
-  (state: GlobalState, props: { backgroundColor?: string, narrow?: Narrow }): SelectorProps => ({
-    safeAreaInsets: getSession(state).safeAreaInsets,
-    theme: getSettings(state).theme,
-    backgroundColor:
-      props.backgroundColor !== undefined
-        ? props.backgroundColor
-        : getTitleBackgroundColor(state, props.narrow),
-    orientation: getSession(state).orientation,
-  }),
-)(ZulipStatusBar);
+export default connect<SelectorProps, _, _>((state, props) => ({
+  safeAreaInsets: getSession(state).safeAreaInsets,
+  theme: getSettings(state).theme,
+  narrowTitleBackgroundColor: getTitleBackgroundColor(state, props.narrow),
+  orientation: getSession(state).orientation,
+}))(ZulipStatusBar);

--- a/src/common/ZulipStatusBar.js
+++ b/src/common/ZulipStatusBar.js
@@ -73,7 +73,7 @@ export default connectFlowFixMe(
     backgroundColor:
       props.backgroundColor !== undefined
         ? props.backgroundColor
-        : getTitleBackgroundColor(props.narrow)(state),
+        : getTitleBackgroundColor(state, props.narrow),
     orientation: getSession(state).orientation,
   }),
 )(ZulipStatusBar);

--- a/src/nav/ChatNavBar.js
+++ b/src/nav/ChatNavBar.js
@@ -50,5 +50,5 @@ class ChatNavBar extends PureComponent<Props> {
 }
 
 export default connect<SelectorProps, _, _>((state, props) => ({
-  backgroundColor: getTitleBackgroundColor(props.narrow)(state),
+  backgroundColor: getTitleBackgroundColor(state, props.narrow),
 }))(ChatNavBar);

--- a/src/react-redux.js
+++ b/src/react-redux.js
@@ -74,19 +74,3 @@ export function connect<SP, P, C: ComponentType<P>>(
 ): C => ComponentType<$ReadOnly<OwnProps<C, SP>>> {
   return connectInner(mapStateToProps);
 }
-
-/**
- * DEPRECATED.  Don't add new uses; and PRs to remove existing uses are welcome.
- *
- * This is exactly like `connect` except with type-checking disabled.
- * Any place we use it, it's because there's a type error there.
- * To fix: change the call site to use `connect`; see what error Flow
- * reports; and fix the error.
- *
- * (Backstory: for a long time `connect` had a type that partly defeated
- * type-checking, so we accumulated a number of type errors that that hid.
- * This untyped version lets us fix those errors one by one, while using the
- * new, well-typed `connect` everywhere else.)
- */
-export const connectFlowFixMe = (mapStateToProps: $FlowFixMe) => (c: $FlowFixMe) =>
-  connect(mapStateToProps)(c);

--- a/src/subscriptions/subscriptionSelectors.js
+++ b/src/subscriptions/subscriptionSelectors.js
@@ -27,6 +27,11 @@ export const getSubscriptionsById: Selector<Map<number, Subscription>> = createS
     new Map(subscriptions.map(subscription => [subscription.stream_id, subscription])),
 );
 
+export const getSubscriptionsByName: Selector<Map<string, Subscription>> = createSelector(
+  getSubscriptions,
+  subscriptions => new Map(subscriptions.map(subscription => [subscription.name, subscription])),
+);
+
 export const getIsActiveStreamSubscribed: Selector<boolean, Narrow> = createSelector(
   (state, narrow) => narrow,
   state => getSubscriptions(state),

--- a/src/title/__tests__/titleSelectors-test.js
+++ b/src/title/__tests__/titleSelectors-test.js
@@ -13,7 +13,7 @@ describe('getTitleBackgroundColor', () => {
       subscriptions,
     });
 
-    expect(getTitleBackgroundColor(undefined)(state)).toEqual(DEFAULT_TITLE_BACKGROUND_COLOR);
+    expect(getTitleBackgroundColor(state, undefined)).toEqual(DEFAULT_TITLE_BACKGROUND_COLOR);
   });
 
   test('return stream color for stream and topic narrow', () => {
@@ -22,7 +22,7 @@ describe('getTitleBackgroundColor', () => {
       subscriptions,
     });
 
-    expect(getTitleBackgroundColor(streamNarrow('all'))(state)).toEqual('#fff');
+    expect(getTitleBackgroundColor(state, streamNarrow('all'))).toEqual('#fff');
   });
 
   test('return null stream color for invalid stream or unknown subscriptions', () => {
@@ -31,7 +31,7 @@ describe('getTitleBackgroundColor', () => {
       subscriptions,
     });
 
-    expect(getTitleBackgroundColor(streamNarrow('feedback'))(state)).toEqual('gray');
+    expect(getTitleBackgroundColor(state, streamNarrow('feedback'))).toEqual('gray');
   });
 
   test('return default for non topic/stream narrow', () => {
@@ -40,10 +40,10 @@ describe('getTitleBackgroundColor', () => {
       subscriptions,
     });
 
-    expect(getTitleBackgroundColor(privateNarrow('abc@zulip.com'))(state)).toEqual(
+    expect(getTitleBackgroundColor(state, privateNarrow('abc@zulip.com'))).toEqual(
       DEFAULT_TITLE_BACKGROUND_COLOR,
     );
-    expect(getTitleBackgroundColor(groupNarrow(['abc@zulip.com', 'def@zulip.com']))(state)).toEqual(
+    expect(getTitleBackgroundColor(state, groupNarrow(['abc@zulip.com', 'def@zulip.com']))).toEqual(
       DEFAULT_TITLE_BACKGROUND_COLOR,
     );
   });

--- a/src/title/titleSelectors.js
+++ b/src/title/titleSelectors.js
@@ -2,9 +2,9 @@
 import { createSelector } from 'reselect';
 
 import type { Narrow, Selector } from '../types';
-import { getSubscriptions } from '../directSelectors';
 import { isStreamOrTopicNarrow } from '../utils/narrow';
 import { NULL_SUBSCRIPTION } from '../nullObjects';
+import { getSubscriptionsByName } from '../subscriptions/subscriptionSelectors';
 
 export const DEFAULT_TITLE_BACKGROUND_COLOR = 'transparent';
 
@@ -16,12 +16,12 @@ export const DEFAULT_TITLE_BACKGROUND_COLOR = 'transparent';
  */
 export const getTitleBackgroundColor = (narrow?: Narrow): Selector<string> =>
   createSelector(
-    getSubscriptions,
-    subscriptions => {
+    getSubscriptionsByName,
+    subscriptionsByName => {
       if (!narrow || !isStreamOrTopicNarrow(narrow)) {
         return DEFAULT_TITLE_BACKGROUND_COLOR;
       }
       const streamName = narrow[0].operand;
-      return (subscriptions.find(sub => streamName === sub.name) || NULL_SUBSCRIPTION).color;
+      return (subscriptionsByName.get(streamName) ?? NULL_SUBSCRIPTION).color;
     },
   );

--- a/src/title/titleSelectors.js
+++ b/src/title/titleSelectors.js
@@ -1,7 +1,5 @@
 /* @flow strict-local */
-import { createSelector } from 'reselect';
-
-import type { Narrow, Selector } from '../types';
+import type { Narrow, GlobalState } from '../types';
 import { isStreamOrTopicNarrow } from '../utils/narrow';
 import { NULL_SUBSCRIPTION } from '../nullObjects';
 import { getSubscriptionsByName } from '../subscriptions/subscriptionSelectors';
@@ -14,14 +12,11 @@ export const DEFAULT_TITLE_BACKGROUND_COLOR = 'transparent';
  * If `narrow` is a stream or topic narrow, this is based on the stream color.
  * Otherwise, it takes a default value.
  */
-export const getTitleBackgroundColor = (narrow?: Narrow): Selector<string> =>
-  createSelector(
-    getSubscriptionsByName,
-    subscriptionsByName => {
-      if (!narrow || !isStreamOrTopicNarrow(narrow)) {
-        return DEFAULT_TITLE_BACKGROUND_COLOR;
-      }
-      const streamName = narrow[0].operand;
-      return (subscriptionsByName.get(streamName) ?? NULL_SUBSCRIPTION).color;
-    },
-  );
+export const getTitleBackgroundColor = (state: GlobalState, narrow?: Narrow) => {
+  const subscriptionsByName = getSubscriptionsByName(state);
+  if (!narrow || !isStreamOrTopicNarrow(narrow)) {
+    return DEFAULT_TITLE_BACKGROUND_COLOR;
+  }
+  const streamName = narrow[0].operand;
+  return (subscriptionsByName.get(streamName) ?? NULL_SUBSCRIPTION).color;
+};

--- a/src/title/titleSelectors.js
+++ b/src/title/titleSelectors.js
@@ -1,7 +1,6 @@
 /* @flow strict-local */
 import type { Narrow, GlobalState } from '../types';
 import { isStreamOrTopicNarrow } from '../utils/narrow';
-import { NULL_SUBSCRIPTION } from '../nullObjects';
 import { getSubscriptionsByName } from '../subscriptions/subscriptionSelectors';
 
 export const DEFAULT_TITLE_BACKGROUND_COLOR = 'transparent';
@@ -18,5 +17,5 @@ export const getTitleBackgroundColor = (state: GlobalState, narrow?: Narrow) => 
     return DEFAULT_TITLE_BACKGROUND_COLOR;
   }
   const streamName = narrow[0].operand;
-  return (subscriptionsByName.get(streamName) ?? NULL_SUBSCRIPTION).color;
+  return subscriptionsByName.get(streamName)?.color ?? 'gray';
 };


### PR DESCRIPTION
Fixes #3451, as the final cleanup after most call sites were resolved in #3789.

The commit message on the most interesting step is:

---

status bar [nfc]: Fix connectFlowFixMe.

The thing that had made it gnarly to use our well-typed `connect` here was that we both took `backgroundColor` in as a prop of the outer component and then returned a `backgroundColor` from the `mapStateToProps` callback, to override the former as a prop on the inner component.

The same fact is also a source of complexity and surprise when trying to read the code as a human, because we're giving the same name to two slightly different things right next to each other.  Doubly so because those two things are a prop of a component passed to `connect` and the same-named prop of the resulting component -- and it's routine across the rest of our codebase that when a prop exists on both, it's passed straight through verbatim.

So, disentangle that by introducing a distinct name.  And then lift the fixme!

This whole "title background color" logic is still rather tanglier than I'd like: in how `narrow` and a forced `backgroundColor` are implicitly mutually exclusive as props to `ZulipStatusBar`; in the use of DEFAULT_TITLE_BACKGROUND_COLOR aka `'transparent'` both as a value with its own substantive meaning and as a sentinel meaning "no stream here"; in how this component and `ChatNavBar` share this bit of UI logic, but under the covers via a putative selector.  It'd be good to disentangle those.  But now at least we have types here.


