### PR TITLE
api types [nfc]: Remove sole reference to deprecated 'pointer' in use…

### DIFF
--- a/src/api/users/getUserProfile.js
+++ b/src/api/users/getUserProfile.js
@@ -10,9 +10,9 @@ type ApiResponseUserProfile = {|
   is_admin: boolean,
   is_bot: boolean,
   max_message_id: number,
-  pointer: number,
   short_name: string,
   user_id: number,
+  // pointer: number, /* deprecated 2020-02; see zulip/zulip#8994 */
 |};
 
 /** See https://zulipchat.com/api/get-profile */


### PR DESCRIPTION
…rs/me response.

See
https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/removing.20the.20pointer/near/818607,
and the corresponding issue
https://github.com/zulip/zulip/issues/8994.

The pointer will no longer be a user-facing concept. Luckily, we
weren't using it, except to describe this type.