### PR TITLE
notifications: Correctly stringify pmUsers to fix navigation to group…

### DIFF
--- a/android/app/src/main/java/com/zulipmobile/notifications/FcmMessage.kt
+++ b/android/app/src/main/java/com/zulipmobile/notifications/FcmMessage.kt
@@ -51,7 +51,7 @@ sealed class Recipient {
      * pmUsers: the user IDs of all users in the conversation.
      */
     data class GroupPm(val pmUsers: Set<Int>) : Recipient() {
-        fun getPmUsersString() = pmUsers.sorted().joinToString { toString() }
+        fun getPmUsersString() = pmUsers.sorted().joinToString { it.toString() }
     }
 
     /** A stream message. */

--- a/android/app/src/main/java/com/zulipmobile/notifications/FcmMessage.kt
+++ b/android/app/src/main/java/com/zulipmobile/notifications/FcmMessage.kt
@@ -51,7 +51,7 @@ sealed class Recipient {
      * pmUsers: the user IDs of all users in the conversation.
      */
     data class GroupPm(val pmUsers: Set<Int>) : Recipient() {
-        fun getPmUsersString() = pmUsers.sorted().joinToString { it.toString() }
+        fun getPmUsersString() = pmUsers.sorted().joinToString(separator=",") { it.toString() }
     }
 
     /** A stream message. */

--- a/android/app/src/test/java/com/zulipmobile/notifications/FcmMessageTest.kt
+++ b/android/app/src/test/java/com/zulipmobile/notifications/FcmMessageTest.kt
@@ -52,6 +52,19 @@ class FcmMessageTest : FcmMessageTestBase() {
     }
 }
 
+class RecipientTest : FcmMessageTestBase() {
+    @Test
+    fun `GroupPm#getPmUsersString gives the correct string`() {
+        expect.that(Recipient.GroupPm(pmUsers = setOf(123, 234, 345)).getPmUsersString())
+            .isEqualTo("123, 234, 345")
+    }
+    @Test
+    fun `GroupPm#getPmUsersString correctly reorders user ids`() {
+        expect.that(Recipient.GroupPm(pmUsers = setOf(234, 123, 23, 345)).getPmUsersString())
+            .isEqualTo("23, 123, 234, 345")
+    }
+}
+
 class MessageFcmMessageTest : FcmMessageTestBase() {
     object Example {
         val base = FcmMessageTestBase.Example.base.plus(sequenceOf(

--- a/android/app/src/test/java/com/zulipmobile/notifications/FcmMessageTest.kt
+++ b/android/app/src/test/java/com/zulipmobile/notifications/FcmMessageTest.kt
@@ -55,13 +55,13 @@ class FcmMessageTest : FcmMessageTestBase() {
 class RecipientTest : FcmMessageTestBase() {
     @Test
     fun `GroupPm#getPmUsersString gives the correct string`() {
-        expect.that(Recipient.GroupPm(pmUsers = setOf(123, 234, 345)).getPmUsersString())
-            .isEqualTo("123, 234, 345")
+        expect.that(Recipient.GroupPm(pmUsers = setOf(123,234,345)).getPmUsersString())
+            .isEqualTo("123,234,345")
     }
     @Test
     fun `GroupPm#getPmUsersString correctly reorders user ids`() {
-        expect.that(Recipient.GroupPm(pmUsers = setOf(234, 123, 23, 345)).getPmUsersString())
-            .isEqualTo("23, 123, 234, 345")
+        expect.that(Recipient.GroupPm(pmUsers = setOf(234,123,23,345)).getPmUsersString())
+            .isEqualTo("23,123,234,345")
     }
 }
 

--- a/src/notification/__tests__/notification-test.js
+++ b/src/notification/__tests__/notification-test.js
@@ -45,7 +45,7 @@ describe('getNarrowFromNotificationData', () => {
 
     const notification = {
       recipient_type: 'private',
-      pm_users: users.map(u => u.user_id).join(','),
+      pm_users: users.map(u => u.user_id).join(', '),
     };
 
     const expectedNarrow = groupNarrow(users.map(u => u.email));
@@ -58,7 +58,7 @@ describe('getNarrowFromNotificationData', () => {
   test('do not throw when users are not found; return null', () => {
     const notification = {
       recipient_type: 'private',
-      pm_users: '1,2,4',
+      pm_users: '1, 2, 4',
     };
     const usersById = new Map();
 

--- a/src/notification/__tests__/notification-test.js
+++ b/src/notification/__tests__/notification-test.js
@@ -45,7 +45,7 @@ describe('getNarrowFromNotificationData', () => {
 
     const notification = {
       recipient_type: 'private',
-      pm_users: users.map(u => u.user_id).join(', '),
+      pm_users: users.map(u => u.user_id).join(','),
     };
 
     const expectedNarrow = groupNarrow(users.map(u => u.email));
@@ -58,7 +58,7 @@ describe('getNarrowFromNotificationData', () => {
   test('do not throw when users are not found; return null', () => {
     const notification = {
       recipient_type: 'private',
-      pm_users: '1, 2, 4',
+      pm_users: '1,2,4',
     };
     const usersById = new Map();
 

--- a/src/notification/index.js
+++ b/src/notification/index.js
@@ -97,7 +97,8 @@ export const getNarrowFromNotificationData = (
   const emails = [];
   const idStrs = data.pm_users.split(',');
   for (let i = 0; i < idStrs.length; ++i) {
-    const user = usersById.get(+idStrs[i]);
+    const id = parseInt(idStrs[i], 10);
+    const user = usersById.get(id);
     if (!user) {
       return null;
     }


### PR DESCRIPTION
… PMs.

Navigation to a group PM on pressing a notification was broken
because pmUsers was incorrectly stringified in
GroupPm.getPmUsersString. Fix, and add a test for it.