### PR TITLE
msglist [nfc]: Warn about passing non-corresponding messages and rend…

### DIFF
--- a/src/webview/MessageList.js
+++ b/src/webview/MessageList.js
@@ -339,6 +339,13 @@ type OuterProps = {|
 
   /* Remaining props are derived from `narrow` by default. */
 
+  // `messages` and `renderedMessages` SHOULD correspond to the same set of
+  // messages, but `messages` MUST be a subset of `renderedMessages`, or
+  // scrolling will wrongly mark out-of-view messages as read! `startMessageId`
+  // and `endMessageId` in MessageListEventScroll are derived from
+  // `renderedMessages`, but are used as bounds on `messages`; see markRead in
+  // webViewEventHandlers.js. For the same reason, both arrays MUST be ordered
+  // by messageId.
   messages?: Message[],
   renderedMessages?: RenderedSectionDescriptor[],
   initialScrollMessageId?: number | null,


### PR DESCRIPTION
…erMessages.

I mentioned maybe last week that I'd seen a case where out-of-view messages were being marked as read. Looking through the code, though, I actually didn't see how this could be happening; the warning this commit adds is already being heeded, as far as I can tell. I'll do more testing soon, but I at least wanted to add this warning in the code.