### PR TITLE
AutoCompleteView: Add zIndex to the component.

### DIFF
--- a/src/autocomplete/AutocompleteView.js
+++ b/src/autocomplete/AutocompleteView.js
@@ -1,5 +1,6 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
+import { StyleSheet } from 'react-native';
 
 import type { InputSelection } from '../types';
 import getAutocompletedText from './getAutocompletedText';
@@ -22,6 +23,12 @@ type Props = $ReadOnly<{|
   onAutocomplete: (input: string) => void,
 |}>;
 
+const styles = StyleSheet.create({
+  animatedScaleComponent: {
+    zIndex: 1,
+  },
+});
+
 export default class AutocompleteView extends PureComponent<Props> {
   handleAutocomplete = (autocomplete: string) => {
     const { text, onAutocomplete, selection } = this.props;
@@ -36,7 +43,7 @@ export default class AutocompleteView extends PureComponent<Props> {
     const shouldShow = isFocused && !!AutocompleteComponent && filter.length > 0;
 
     return (
-      <AnimatedScaleComponent visible={shouldShow}>
+      <AnimatedScaleComponent visible={shouldShow} style={styles.animatedScaleComponent}>
         {shouldShow && (
           <AutocompleteComponent filter={filter} onAutocomplete={this.handleAutocomplete} />
         )}


### PR DESCRIPTION
This is a bite-sized fix that fixes #3924.

**Now:**
![Screenshot from 2020-02-21 21-08-01](https://user-images.githubusercontent.com/7714968/75048771-138ac580-54ef-11ea-8611-7ad009a6363e.png)

**Before:**
![image](https://user-images.githubusercontent.com/7714968/75049147-b2172680-54ef-11ea-9ebd-2b79a5ec7da1.png)

