### PR TITLE
js [nfc]: Simplify expressions using `??`.

### DIFF
--- a/src/__tests__/exampleData.js
+++ b/src/__tests__/exampleData.js
@@ -52,7 +52,7 @@ const randString = () => randInt(2 ** 54).toString(36);
 
 const randUserId: () => number = makeUniqueRandInt('user IDs', 10000);
 const userOrBotProperties = ({ name: _name }) => {
-  const name = _name !== undefined ? _name : randString();
+  const name = _name ?? randString();
   const capsName = name.substring(0, 1).toUpperCase() + name.substring(1);
   return deepFreeze({
     avatar_url: `https://zulip.example.org/yo/avatar-${name}.png`,
@@ -108,9 +108,8 @@ export const crossRealmBot: CrossRealmBot = makeCrossRealmBot({ name: 'bot' });
 
 const randStreamId: () => number = makeUniqueRandInt('stream IDs', 1000);
 export const makeStream = (args: { name?: string, description?: string } = {}): Stream => {
-  const name = args.name !== undefined ? args.name : randString();
-  const description =
-    args.description !== undefined ? args.description : `On the ${randString()} of ${name}`;
+  const name = args.name ?? randString();
+  const description = args.description ?? `On the ${randString()} of ${name}`;
   return deepFreeze({
     stream_id: randStreamId(),
     name,

--- a/src/webview/html/messageAsHtml.js
+++ b/src/webview/html/messageAsHtml.js
@@ -60,8 +60,8 @@ const messageBody = (
   { alertWords, flags, ownUser, allImageEmojiById }: BackgroundData,
   message: Message | Outbox,
 ) => {
-  const { id, isOutbox, last_edit_timestamp, reactions } = (message: MessageLike);
-  const content = message.match_content !== undefined ? message.match_content : message.content;
+  const { id, isOutbox, last_edit_timestamp, match_content, reactions } = (message: MessageLike);
+  const content = match_content ?? message.content;
   return template`
 $!${processAlertWords(content, id, alertWords, flags)}
 $!${isOutbox ? '<div class="loading-spinner outbox-spinner"></div>' : ''}


### PR DESCRIPTION
Originally part of #3912, in which this was performed manually. Candidate expressions were identified with a multiline search for `/==\s*undefined\s*\?/` and manually checked. (`null` was also checked for, but no simplifiable expressions using it were found.)

This revised commit was generated in part automatically, with a
temporary installation of jscodeshift. The resultant script:

 * correctly excluded one item (`initialScrollMessageId`) noted to be incorrect in #3912;
 * arguably correctly excluded another item (`ackedPushToken`) *not* noted to be incorrect;
 * converted one item (`match_content`) in a technically-semantically-correct fashion that caused Flow to complain and required manual adjustment to fix;
 * had to repeatedly reinvoke Flow via the shell to get type information; and
 * was ~140 lines of ugly code (more, if properly cleaned up) that doesn't belong anywhere in our repo.