### PR TITLE
recipient [nfc]: Split up pm{Ui,Key}RecipientsFromMessage, and start on "unreads" keys.

### DIFF
--- a/src/api/modelTypes.js
+++ b/src/api/modelTypes.js
@@ -372,11 +372,13 @@ export type MessageEdit = $ReadOnly<{|
 
 /** A user, as seen in the `display_recipient` of a PM `Message`. */
 export type PmRecipientUser = {|
+  // These five fields (id, email, full_name, short_name, is_mirror_dummy)
+  // have all been present since server commit 6b13f4a3c, in 2014.
+  id: number,
   email: string,
   full_name: string,
-  id: number,
-  is_mirror_dummy: boolean,
   short_name: string,
+  is_mirror_dummy: boolean,
 |};
 
 /**

--- a/src/message/messageActionSheet.js
+++ b/src/message/messageActionSheet.js
@@ -22,7 +22,7 @@ import * as api from '../api';
 import { showToast } from '../utils/info';
 import { doNarrow, startEditMessage, deleteOutboxMessage, navigateToEmojiPicker } from '../actions';
 import { navigateToMessageReactionScreen } from '../nav/navActions';
-import { filteredRecipientsForPM } from '../utils/recipient';
+import { pmUiRecipientsFromMessage } from '../utils/recipient';
 
 // TODO really this belongs in a libdef.
 export type ShowActionSheetWithOptions = (
@@ -258,7 +258,7 @@ export const constructMessageActionButtons = ({
 /** Returns the title for the action sheet. */
 const getActionSheetTitle = (message: Message | Outbox, ownUser: User): string => {
   if (message.type === 'private') {
-    const recipients = filteredRecipientsForPM(message, ownUser);
+    const recipients = pmUiRecipientsFromMessage(message, ownUser);
     return recipients
       .map(r => r.full_name)
       .sort()

--- a/src/pm-conversations/__tests__/pmConversationsSelectors-test.js
+++ b/src/pm-conversations/__tests__/pmConversationsSelectors-test.js
@@ -30,6 +30,7 @@ describe('getRecentConversations', () => {
       messages: {
         1: {
           id: 1,
+          type: 'private',
           display_recipient: [
             { id: 0, email: 'me@example.com' },
             { id: 1, email: 'john@example.com' },
@@ -37,6 +38,7 @@ describe('getRecentConversations', () => {
         },
         2: {
           id: 2,
+          type: 'private',
           display_recipient: [
             { id: 0, email: 'me@example.com' },
             { id: 2, email: 'mark@example.com' },
@@ -44,6 +46,7 @@ describe('getRecentConversations', () => {
         },
         3: {
           id: 3,
+          type: 'private',
           display_recipient: [
             { id: 0, email: 'me@example.com' },
             { id: 1, email: 'john@example.com' },
@@ -51,10 +54,12 @@ describe('getRecentConversations', () => {
         },
         4: {
           id: 4,
+          type: 'private',
           display_recipient: [{ id: 0, email: 'me@example.com' }],
         },
         0: {
           id: 0,
+          type: 'private',
           display_recipient: [
             { id: 0, email: 'me@example.com' },
             { id: 1, email: 'john@example.com' },
@@ -127,6 +132,7 @@ describe('getRecentConversations', () => {
       messages: {
         2: {
           id: 2,
+          type: 'private',
           display_recipient: [
             { id: 0, email: 'me@example.com' },
             { id: 1, email: 'john@example.com' },
@@ -134,6 +140,7 @@ describe('getRecentConversations', () => {
         },
         1: {
           id: 1,
+          type: 'private',
           display_recipient: [
             { id: 0, email: 'me@example.com' },
             { id: 2, email: 'mark@example.com' },
@@ -141,6 +148,7 @@ describe('getRecentConversations', () => {
         },
         4: {
           id: 4,
+          type: 'private',
           display_recipient: [
             { id: 0, email: 'me@example.com' },
             { id: 1, email: 'john@example.com' },
@@ -148,6 +156,7 @@ describe('getRecentConversations', () => {
         },
         3: {
           id: 3,
+          type: 'private',
           display_recipient: [
             { id: 0, email: 'me@example.com' },
             { id: 2, email: 'mark@example.com' },
@@ -155,6 +164,7 @@ describe('getRecentConversations', () => {
         },
         5: {
           id: 5,
+          type: 'private',
           display_recipient: [
             { id: 0, email: 'me@example.com' },
             { id: 1, email: 'john@example.com' },
@@ -163,6 +173,7 @@ describe('getRecentConversations', () => {
         },
         6: {
           id: 6,
+          type: 'private',
           display_recipient: [{ id: 0, email: 'me@example.com' }],
         },
       },

--- a/src/pm-conversations/pmConversationsSelectors.js
+++ b/src/pm-conversations/pmConversationsSelectors.js
@@ -19,7 +19,7 @@ export const getRecentConversations: Selector<PmConversationData[]> = createSele
     unreadHuddles: { [string]: number },
   ): PmConversationData[] => {
     const recipients = messages.map(msg => ({
-      ids: getRecipientsIds(msg.display_recipient, ownEmail),
+      ids: getRecipientsIds(msg, ownEmail),
       emails: normalizeRecipientsSansMe(msg.display_recipient, ownEmail),
       msgId: msg.id,
     }));

--- a/src/reduxTypes.js
+++ b/src/reduxTypes.js
@@ -277,10 +277,35 @@ export type TypingState = {|
   },
 |};
 
+// These four are fragments of UnreadState; see below.
 export type UnreadStreamsState = StreamUnreadItem[];
 export type UnreadHuddlesState = HuddlesUnreadItem[];
 export type UnreadPmsState = PmsUnreadItem[];
 export type UnreadMentionsState = number[];
+
+/**
+ * A summary of (almost) all unread messages, even those we don't have.
+ *
+ * This data structure contains a variety of sets of message IDs, all of
+ * them unread messages: it has (almost) all unread messages' IDs, broken
+ * out by conversation (stream + topic, or PM thread), plus unread
+ * @-mentions.
+ *
+ * The valuable thing this gives us is that, at `/register` time (aka at
+ * initial fetch), the server looks deep into the user's message history to
+ * give us this data on far more messages, if applicable, than we'd want to
+ * actually fetch up front in full.  (Thanks to the handy PostgreSQL feature
+ * of "partial indexes", it can have the database answer this question quite
+ * efficiently.)
+ *
+ * The "almost" caveat is that there is an upper bound on this summary.  But
+ * it's giant -- starting with server commit 1.9.0-rc1~206, the latest 50000
+ * unread messages are included.
+ *
+ * The initial version the server gives us for this data is `unread_msgs` in
+ * the `/register` initial state, and we largely follow the structure of
+ * that.
+ */
 export type UnreadState = {|
   streams: UnreadStreamsState,
   huddles: UnreadHuddlesState,

--- a/src/unread/unreadHelpers.js
+++ b/src/unread/unreadHelpers.js
@@ -7,19 +7,12 @@ type SomeUnreadItem = { unread_message_ids: number[] };
 export function removeItemsDeeply<T: SomeUnreadItem>(objArray: T[], messageIds: number[]): T[] {
   let changed = false;
   const objWithAddedUnreadIds = objArray.map(obj => {
-    const newIds = removeItemsFromArray(obj.unread_message_ids, messageIds);
-    if (newIds.length === obj.unread_message_ids) {
-      return obj;
-    }
-
     const filteredIds = removeItemsFromArray(obj.unread_message_ids, messageIds);
-
     if (filteredIds.length === obj.unread_message_ids.length) {
       return obj;
     }
 
     changed = true;
-
     return {
       ...obj,
       unread_message_ids: filteredIds,

--- a/src/unread/unreadHelpers.js
+++ b/src/unread/unreadHelpers.js
@@ -33,7 +33,6 @@ function addItemsDeeply<T: SomeUnreadItem>(input: T[], itemsToAdd: number[], ind
   const item = input[index];
 
   const unreadMessageIds = addItemsToArray(item.unread_message_ids, itemsToAdd);
-
   if (item.unread_message_ids === unreadMessageIds) {
     return input;
   }
@@ -42,7 +41,7 @@ function addItemsDeeply<T: SomeUnreadItem>(input: T[], itemsToAdd: number[], ind
     ...input.slice(0, index),
     {
       ...item,
-      unread_message_ids: addItemsToArray(item.unread_message_ids, itemsToAdd),
+      unread_message_ids: unreadMessageIds,
     },
     ...input.slice(index + 1),
   ];

--- a/src/unread/unreadHelpers.js
+++ b/src/unread/unreadHelpers.js
@@ -8,7 +8,7 @@ export function removeItemsDeeply<T: SomeUnreadItem>(objArray: T[], messageIds: 
   let changed = false;
   const objWithAddedUnreadIds = objArray.map(obj => {
     const filteredIds = removeItemsFromArray(obj.unread_message_ids, messageIds);
-    if (filteredIds.length === obj.unread_message_ids.length) {
+    if (filteredIds === obj.unread_message_ids) {
       return obj;
     }
 

--- a/src/unread/unreadHuddlesReducer.js
+++ b/src/unread/unreadHuddlesReducer.js
@@ -27,11 +27,7 @@ const eventNewMessage = (state, action) => {
     return state;
   }
 
-  return addItemsToHuddleArray(
-    state,
-    [action.message.id],
-    getRecipientsIds(action.message.display_recipient),
-  );
+  return addItemsToHuddleArray(state, [action.message.id], getRecipientsIds(action.message));
 };
 
 const eventUpdateMessageFlags = (state, action) => {

--- a/src/utils/recipient.js
+++ b/src/utils/recipient.js
@@ -35,7 +35,7 @@ export const filteredRecipientsForPM = (
   const { display_recipient } = message;
   return display_recipient.length === 1
     ? display_recipient
-    : display_recipient.filter(r => r.email !== ownUser.email);
+    : display_recipient.filter(r => r.id !== ownUser.user_id);
 };
 
 export const getRecipientsIds = (recipients: PmRecipientUser[], ownEmail?: string): string =>

--- a/src/utils/recipient.js
+++ b/src/utils/recipient.js
@@ -1,6 +1,12 @@
 /* @flow strict-local */
 import type { PmRecipientUser, Message, Outbox, User } from '../types';
 
+// Filter a list of PM recipients in the quirky way that we do.
+//
+// This is a module-private helper.  See caller for jsdoc.
+const filterRecipients = (recipients: PmRecipientUser[], ownUserId: number): PmRecipientUser[] =>
+  recipients.length === 1 ? recipients : recipients.filter(r => r.id !== ownUserId);
+
 // TODO types: this union is confusing
 export const normalizeRecipients = (recipients: $ReadOnlyArray<{ email: string }> | string) =>
   !Array.isArray(recipients)
@@ -32,10 +38,7 @@ export const filteredRecipientsForPM = (
   if (message.type !== 'private') {
     throw new Error('filteredRecipientsForPM: expected PM, got stream message');
   }
-  const { display_recipient } = message;
-  return display_recipient.length === 1
-    ? display_recipient
-    : display_recipient.filter(r => r.id !== ownUser.user_id);
+  return filterRecipients(message.display_recipient, ownUser.user_id);
 };
 
 export const getRecipientsIds = (recipients: PmRecipientUser[], ownEmail?: string): string =>

--- a/src/utils/recipient.js
+++ b/src/utils/recipient.js
@@ -80,13 +80,18 @@ export const pmKeyRecipientsFromMessage = (
   return filterRecipients(message.display_recipient, ownUser.user_id);
 };
 
-export const getRecipientsIds = (recipients: PmRecipientUser[], ownEmail?: string): string =>
-  recipients.length === 2
+export const getRecipientsIds = (message: Message, ownEmail?: string): string => {
+  if (message.type !== 'private') {
+    throw new Error('getRecipientsIds: expected PM, got stream message');
+  }
+  const recipients = message.display_recipient;
+  return recipients.length === 2
     ? recipients.filter(r => r.email !== ownEmail)[0].id.toString()
     : recipients
         .map(s => s.id)
         .sort((a, b) => a - b)
         .join(',');
+};
 
 export const isSameRecipient = (
   message1: Message | Outbox,

--- a/src/utils/recipient.js
+++ b/src/utils/recipient.js
@@ -85,12 +85,17 @@ export const getRecipientsIds = (message: Message, ownEmail?: string): string =>
     throw new Error('getRecipientsIds: expected PM, got stream message');
   }
   const recipients = message.display_recipient;
-  return recipients.length === 2
-    ? recipients.filter(r => r.email !== ownEmail)[0].id.toString()
-    : recipients
-        .map(s => s.id)
-        .sort((a, b) => a - b)
-        .join(',');
+  if (recipients.length === 2) {
+    if (ownEmail === undefined) {
+      throw new Error('getRecipientsIds: got 1:1 PM, but ownEmail omitted');
+    }
+    return recipients.filter(r => r.email !== ownEmail)[0].id.toString();
+  } else {
+    return recipients
+      .map(s => s.id)
+      .sort((a, b) => a - b)
+      .join(',');
+  }
 };
 
 export const isSameRecipient = (

--- a/src/utils/recipient.js
+++ b/src/utils/recipient.js
@@ -13,7 +13,7 @@ const filterRecipients = (recipients: PmRecipientUser[], ownUserId: number): PmR
   recipients.length === 1 ? recipients : recipients.filter(r => r.id !== ownUserId);
 
 // TODO types: this union is confusing
-export const normalizeRecipients = (recipients: $ReadOnlyArray<{ email: string }> | string) =>
+export const normalizeRecipients = (recipients: $ReadOnlyArray<{ email: string, ... }> | string) =>
   !Array.isArray(recipients)
     ? recipients
     : recipients
@@ -23,7 +23,7 @@ export const normalizeRecipients = (recipients: $ReadOnlyArray<{ email: string }
         .join(',');
 
 export const normalizeRecipientsSansMe = (
-  recipients: $ReadOnlyArray<{ email: string }>,
+  recipients: $ReadOnlyArray<{ email: string, ... }>,
   ownEmail: string,
 ) =>
   recipients.length === 1

--- a/src/webview/html/messageHeaderAsHtml.js
+++ b/src/webview/html/messageHeaderAsHtml.js
@@ -11,7 +11,7 @@ import {
 } from '../../utils/narrow';
 import { foregroundColorFromBackground } from '../../utils/color';
 import { humanDate } from '../../utils/date';
-import { filteredRecipientsForPM } from '../../utils/recipient';
+import { pmUiRecipientsFromMessage, pmKeyRecipientsFromMessage } from '../../utils/recipient';
 
 const renderSubject = item =>
   // TODO: pin down if '' happens, and what its proper semantics are.
@@ -88,18 +88,19 @@ export default (
   }
 
   if (item.type === 'private' && headerStyle === 'full') {
-    const recipients = filteredRecipientsForPM(item, ownUser);
+    const keyRecipients = pmKeyRecipientsFromMessage(item, ownUser);
     const narrowObj =
-      recipients.length === 1
-        ? privateNarrow(recipients[0].email)
-        : groupNarrow(recipients.map(r => r.email));
+      keyRecipients.length === 1
+        ? privateNarrow(keyRecipients[0].email)
+        : groupNarrow(keyRecipients.map(r => r.email));
     const privateNarrowStr = JSON.stringify(narrowObj);
 
+    const uiRecipients = pmUiRecipientsFromMessage(item, ownUser);
     return template`
 <div class="header-wrapper private-header header"
      data-narrow="${privateNarrowStr}"
      data-msg-id="${item.id}">
-  ${recipients
+  ${uiRecipients
     .map(r => r.full_name)
     .sort()
     .join(', ')}


### PR DESCRIPTION
This is a more substantial follow-up to #3931.

There's still plenty that's confusing about these interfaces, but I think this branch improves the situation a good bit.

I have some draft other changes, including to give `getRecipientsIds` a better name (turns out what it's really about is specifically for the "unread messages" data structure) and some jsdoc; to start cleaning up `normalizeRecipients` and `normalizeRecipientsSansMe`; and even to write down exactly what the story is for what appears in `display_recipient`! Those still require some further polish on a few points before they're ready to merge, though. And this branch is already more than I'd quite planned to do on this today. ;-)
