### PR TITLE
Extend exampleData to further clean up messageActionSheet tests

### DIFF
--- a/src/__tests__/lib/exampleData.js
+++ b/src/__tests__/lib/exampleData.js
@@ -186,6 +186,7 @@ export const stream: Stream = makeStream({
   description: 'An example stream.',
 });
 
+/** A subscription, by default to eg.stream. */
 export const makeSubscription = (args: { stream?: Stream } = {}): Subscription => {
   const { stream: streamInner = stream } = args;
   return deepFreeze({
@@ -202,6 +203,7 @@ export const makeSubscription = (args: { stream?: Stream } = {}): Subscription =
   });
 };
 
+/** A subscription to eg.stream. */
 export const subscription: Subscription = makeSubscription();
 
 /* ========================================================================
@@ -267,7 +269,11 @@ const messagePropertiesFromSender = (user: User) => {
 
 const randMessageId: () => number = makeUniqueRandInt('message ID', 10000000);
 
-/** Beware! These values may not be representative. */
+/**
+ * A PM, by default a 1:1 from eg.otherUser to eg.selfUser.
+ *
+ * Beware! These values may not be representative.
+ */
 export const pmMessage = (extra?: $Rest<Message, {}>): Message => {
   const baseMessage: Message = {
     ...messagePropertiesBase,
@@ -296,7 +302,11 @@ const messagePropertiesFromStream = (stream1: Stream) => {
   });
 };
 
-/** Beware! These values may not be representative. */
+/**
+ * A stream message, by default in eg.stream sent by eg.otherUser.
+ *
+ * Beware! These values may not be representative.
+ */
 export const streamMessage = (args?: {| ...$Rest<Message, {}>, stream?: Stream |}): Message => {
   let streamInner: Stream;
   let extra: $Rest<Message, {}>;
@@ -371,6 +381,7 @@ export const makeOutboxMessage = (data: $Shape<$Diff<Outbox, {| id: mixed |}>>):
 
 const privateReduxStore = createStore(rootReducer);
 
+/** The global Redux state, at its initial value. */
 export const baseReduxState: GlobalState = deepFreeze(privateReduxStore.getState());
 
 export const reduxState = (extra?: $Rest<GlobalState, {}>): GlobalState =>

--- a/src/__tests__/lib/exampleData.js
+++ b/src/__tests__/lib/exampleData.js
@@ -2,7 +2,14 @@
 import deepFreeze from 'deep-freeze';
 import { createStore } from 'redux';
 
-import type { CrossRealmBot, Message, PmRecipientUser, Stream, User } from '../../api/modelTypes';
+import type {
+  CrossRealmBot,
+  Message,
+  PmRecipientUser,
+  Stream,
+  Subscription,
+  User,
+} from '../../api/modelTypes';
 import type { Action, GlobalState, RealmState } from '../../reduxTypes';
 import type { Auth, Account, Outbox } from '../../types';
 import { ZulipVersion } from '../../utils/zulipVersion';
@@ -156,7 +163,7 @@ export const otherUser: User = makeUser({ name: 'other' });
 export const crossRealmBot: CrossRealmBot = makeCrossRealmBot({ name: 'bot' });
 
 /* ========================================================================
- * Streams
+ * Streams and subscriptions
  */
 
 const randStreamId: () => number = makeUniqueRandInt('stream IDs', 1000);
@@ -177,6 +184,24 @@ export const stream: Stream = makeStream({
   name: 'a stream',
   description: 'An example stream.',
 });
+
+export const makeSubscription = (args: { stream?: Stream } = {}): Subscription => {
+  const { stream: streamInner = stream } = args;
+  return deepFreeze({
+    ...streamInner,
+    color: '#123456',
+    in_home_view: true,
+    pin_to_top: false,
+    audible_notifications: false,
+    desktop_notifications: false,
+    email_address: '??? make this value representative before using in a test :)',
+    is_old_stream: true,
+    push_notifications: null,
+    stream_weekly_traffic: 84,
+  });
+};
+
+export const subscription: Subscription = makeSubscription();
 
 /* ========================================================================
  * Messages

--- a/src/__tests__/lib/exampleData.js
+++ b/src/__tests__/lib/exampleData.js
@@ -297,11 +297,20 @@ const messagePropertiesFromStream = (stream1: Stream) => {
 };
 
 /** Beware! These values may not be representative. */
-export const streamMessage = (extra?: $Rest<Message, {}>): Message => {
+export const streamMessage = (args?: {| ...$Rest<Message, {}>, stream?: Stream |}): Message => {
+  let streamInner: Stream;
+  let extra: $Rest<Message, {}>;
+
+  if (args) {
+    ({ stream: streamInner = stream, ...extra } = args);
+  } else {
+    streamInner = stream;
+  }
+
   const baseMessage: Message = {
     ...messagePropertiesBase,
     ...messagePropertiesFromSender(otherUser),
-    ...messagePropertiesFromStream(stream),
+    ...messagePropertiesFromStream(streamInner),
 
     content: 'This is an example stream message.',
     content_type: 'text/markdown',

--- a/src/__tests__/lib/exampleData.js
+++ b/src/__tests__/lib/exampleData.js
@@ -6,6 +6,7 @@ import type {
   CrossRealmBot,
   Message,
   PmRecipientUser,
+  Reaction,
   Stream,
   Subscription,
   User,
@@ -206,6 +207,13 @@ export const subscription: Subscription = makeSubscription();
 /* ========================================================================
  * Messages
  */
+
+export const unicodeEmojiReaction: Reaction = deepFreeze({
+  user_id: randUserId(),
+  reaction_type: 'unicode_emoji',
+  emoji_code: '1f44d',
+  emoji_name: 'thumbs_up',
+});
 
 const displayRecipientFromUser = (user: User): PmRecipientUser => {
   const { email, full_name, user_id: id } = user;

--- a/src/__tests__/lib/exampleData.js
+++ b/src/__tests__/lib/exampleData.js
@@ -257,6 +257,8 @@ const messagePropertiesFromSender = (user: User) => {
   });
 };
 
+const randMessageId: () => number = makeUniqueRandInt('message ID', 10000000);
+
 /** Beware! These values may not be representative. */
 export const pmMessage = (extra?: $Rest<Message, {}>): Message => {
   const baseMessage: Message = {
@@ -266,7 +268,7 @@ export const pmMessage = (extra?: $Rest<Message, {}>): Message => {
     content: 'This is an example PM message.',
     content_type: 'text/markdown',
     display_recipient: [displayRecipientFromUser(selfUser)],
-    id: 1234567,
+    id: randMessageId(),
     recipient_id: 2342,
     stream_id: -1,
     subject: '',
@@ -295,7 +297,7 @@ export const streamMessage = (extra?: $Rest<Message, {}>): Message => {
 
     content: 'This is an example stream message.',
     content_type: 'text/markdown',
-    id: 1234789,
+    id: randMessageId(),
     subject: 'example topic',
     timestamp: 1556579727,
     type: 'stream',

--- a/src/message/__tests__/messageActionSheet-test.js
+++ b/src/message/__tests__/messageActionSheet-test.js
@@ -8,27 +8,15 @@ const baseBackgroundData = deepFreeze({
   alertWords: [],
   allImageEmojiById: eg.action.realm_init.data.realm_emoji,
   auth: eg.selfAuth,
-  debug: {
-    doNotMarkMessagesAsRead: false,
-  },
+  debug: eg.baseReduxState.session.debug,
   flags: {
-    read: {},
+    ...eg.baseReduxState.flags,
     starred: {
       // Key has to be number according to the type declaration. $FlowFixMe.
       1: true,
       // Key has to be number according to the type declaration. $FlowFixMe.
       2: true,
     },
-    collapsed: {},
-    mentioned: {},
-    wildcard_mentioned: {},
-    summarize_in_home: {},
-    summarize_in_stream: {},
-    force_expand: {},
-    force_collapse: {},
-    has_alert_word: {},
-    historical: {},
-    is_me_message: {},
   },
   mute: [],
   ownUser: eg.selfUser,

--- a/src/message/__tests__/messageActionSheet-test.js
+++ b/src/message/__tests__/messageActionSheet-test.js
@@ -48,14 +48,7 @@ describe('constructActionButtons', () => {
 
   test('show reactions option if message is has at least one reaction', () => {
     const message = eg.streamMessage({
-      reactions: [
-        {
-          user_id: 12345,
-          emoji_name: 'haha',
-          reaction_type: 'unicode_emoji',
-          emoji_code: '',
-        },
-      ],
+      reactions: [eg.unicodeEmojiReaction],
     });
 
     const buttons = constructMessageActionButtons({

--- a/src/message/__tests__/messageActionSheet-test.js
+++ b/src/message/__tests__/messageActionSheet-test.js
@@ -20,20 +20,7 @@ const baseBackgroundData = deepFreeze({
   },
   mute: [],
   ownUser: eg.selfUser,
-  subscriptions: [
-    {
-      ...eg.makeStream(),
-      color: '#ffffff',
-      in_home_view: false,
-      pin_to_top: false,
-      audible_notifications: false,
-      desktop_notifications: false,
-      email_address: 'stream@email.com',
-      is_old_stream: false,
-      push_notifications: true,
-      stream_weekly_traffic: 2,
-    },
-  ],
+  subscriptions: [],
   theme: 'default',
   twentyFourHourTime: false,
 });
@@ -130,7 +117,7 @@ describe('constructHeaderActionButtons', () => {
 
     const subscriptions = deepFreeze([
       {
-        ...baseBackgroundData.subscriptions[0],
+        ...eg.subscription,
         name: 'electron issues',
         in_home_view: false,
       },
@@ -157,7 +144,7 @@ describe('constructHeaderActionButtons', () => {
 
     const subscriptions = deepFreeze([
       {
-        ...baseBackgroundData.subscriptions[0],
+        ...eg.subscription,
         name: 'electron issues',
         in_home_view: true,
       },

--- a/src/message/__tests__/messageActionSheet-test.js
+++ b/src/message/__tests__/messageActionSheet-test.js
@@ -30,7 +30,7 @@ const baseBackgroundData = deepFreeze({
     historical: {},
     is_me_message: {},
   },
-  mute: [['announce', 'stream events']],
+  mute: [],
   ownUser: eg.selfUser,
   subscriptions: [
     {

--- a/src/message/__tests__/messageActionSheet-test.js
+++ b/src/message/__tests__/messageActionSheet-test.js
@@ -98,17 +98,7 @@ describe('constructHeaderActionButtons', () => {
   });
 
   test('show Unmute stream option if stream is not in home view', () => {
-    const message = eg.streamMessage({
-      display_recipient: 'electron issues',
-    });
-
-    const subscriptions = deepFreeze([
-      {
-        ...eg.subscription,
-        name: 'electron issues',
-        in_home_view: false,
-      },
-    ]);
+    const subscriptions = [{ ...eg.subscription, in_home_view: false }];
 
     const backgroundData = deepFreeze({
       ...baseBackgroundData,
@@ -117,7 +107,7 @@ describe('constructHeaderActionButtons', () => {
 
     const buttons = constructHeaderActionButtons({
       backgroundData,
-      message,
+      message: eg.streamMessage(),
       narrow,
     });
 
@@ -125,17 +115,7 @@ describe('constructHeaderActionButtons', () => {
   });
 
   test('show mute stream option if stream is in home view', () => {
-    const message = eg.streamMessage({
-      display_recipient: 'electron issues',
-    });
-
-    const subscriptions = deepFreeze([
-      {
-        ...eg.subscription,
-        name: 'electron issues',
-        in_home_view: true,
-      },
-    ]);
+    const subscriptions = [{ ...eg.subscription, in_home_view: true }];
 
     const backgroundData = deepFreeze({
       ...baseBackgroundData,
@@ -144,7 +124,7 @@ describe('constructHeaderActionButtons', () => {
 
     const buttons = constructHeaderActionButtons({
       backgroundData,
-      message,
+      message: eg.streamMessage(),
       narrow,
     });
 

--- a/src/message/__tests__/messageActionSheet-test.js
+++ b/src/message/__tests__/messageActionSheet-test.js
@@ -21,10 +21,8 @@ describe('constructActionButtons', () => {
   const narrow = deepFreeze([]);
 
   test('show star message option if message is not starred', () => {
-    const message = eg.streamMessage({ id: 3 });
-    // https://github.com/facebook/flow/issues/380
-    // eslint-disable-next-line no-useless-computed-key
-    const flags = { ...baseBackgroundData.flags, starred: { [1]: true, [2]: true } };
+    const message = eg.streamMessage();
+    const flags = { ...baseBackgroundData.flags, starred: {} };
 
     const buttons = constructMessageActionButtons({
       backgroundData: { ...baseBackgroundData, flags },
@@ -36,10 +34,8 @@ describe('constructActionButtons', () => {
   });
 
   test('show unstar message option if message is starred', () => {
-    const message = eg.streamMessage({ id: 1 });
-    // https://github.com/facebook/flow/issues/380
-    // eslint-disable-next-line no-useless-computed-key
-    const flags = { ...baseBackgroundData.flags, starred: { [1]: true, [2]: true } };
+    const message = eg.streamMessage();
+    const flags = { ...baseBackgroundData.flags, starred: { [message.id]: true } };
 
     const buttons = constructMessageActionButtons({
       backgroundData: { ...baseBackgroundData, flags },

--- a/src/message/__tests__/messageActionSheet-test.js
+++ b/src/message/__tests__/messageActionSheet-test.js
@@ -9,15 +9,7 @@ const baseBackgroundData = deepFreeze({
   allImageEmojiById: eg.action.realm_init.data.realm_emoji,
   auth: eg.selfAuth,
   debug: eg.baseReduxState.session.debug,
-  flags: {
-    ...eg.baseReduxState.flags,
-    starred: {
-      // Key has to be number according to the type declaration. $FlowFixMe.
-      1: true,
-      // Key has to be number according to the type declaration. $FlowFixMe.
-      2: true,
-    },
-  },
+  flags: eg.baseReduxState.flags,
   mute: [],
   ownUser: eg.selfUser,
   subscriptions: [],
@@ -30,9 +22,12 @@ describe('constructActionButtons', () => {
 
   test('show star message option if message is not starred', () => {
     const message = eg.streamMessage({ id: 3 });
+    // https://github.com/facebook/flow/issues/380
+    // eslint-disable-next-line no-useless-computed-key
+    const flags = { ...baseBackgroundData.flags, starred: { [1]: true, [2]: true } };
 
     const buttons = constructMessageActionButtons({
-      backgroundData: baseBackgroundData,
+      backgroundData: { ...baseBackgroundData, flags },
       message,
       narrow,
     });
@@ -42,9 +37,12 @@ describe('constructActionButtons', () => {
 
   test('show unstar message option if message is starred', () => {
     const message = eg.streamMessage({ id: 1 });
+    // https://github.com/facebook/flow/issues/380
+    // eslint-disable-next-line no-useless-computed-key
+    const flags = { ...baseBackgroundData.flags, starred: { [1]: true, [2]: true } };
 
     const buttons = constructMessageActionButtons({
-      backgroundData: baseBackgroundData,
+      backgroundData: { ...baseBackgroundData, flags },
       message,
       narrow,
     });

--- a/src/message/__tests__/messageActionSheet-test.js
+++ b/src/message/__tests__/messageActionSheet-test.js
@@ -1,5 +1,6 @@
 // @flow strict-local
 import deepFreeze from 'deep-freeze';
+
 import * as eg from '../../__tests__/lib/exampleData';
 import { constructMessageActionButtons, constructHeaderActionButtons } from '../messageActionSheet';
 

--- a/src/message/__tests__/messageActionSheet-test.js
+++ b/src/message/__tests__/messageActionSheet-test.js
@@ -23,40 +23,31 @@ describe('constructActionButtons', () => {
   test('show star message option if message is not starred', () => {
     const message = eg.streamMessage();
     const flags = { ...baseBackgroundData.flags, starred: {} };
-
     const buttons = constructMessageActionButtons({
       backgroundData: { ...baseBackgroundData, flags },
       message,
       narrow,
     });
-
     expect(buttons).toContain('starMessage');
   });
 
   test('show unstar message option if message is starred', () => {
     const message = eg.streamMessage();
     const flags = { ...baseBackgroundData.flags, starred: { [message.id]: true } };
-
     const buttons = constructMessageActionButtons({
       backgroundData: { ...baseBackgroundData, flags },
       message,
       narrow,
     });
-
     expect(buttons).toContain('unstarMessage');
   });
 
   test('show reactions option if message is has at least one reaction', () => {
-    const message = eg.streamMessage({
-      reactions: [eg.unicodeEmojiReaction],
-    });
-
     const buttons = constructMessageActionButtons({
       backgroundData: baseBackgroundData,
-      message,
+      message: eg.streamMessage({ reactions: [eg.unicodeEmojiReaction] }),
       narrow,
     });
-
     expect(buttons).toContain('showReactions');
   });
 });
@@ -66,86 +57,54 @@ describe('constructHeaderActionButtons', () => {
 
   test('show Unmute topic option if topic is muted', () => {
     const mute = deepFreeze([['electron issues', 'issue #556']]);
-
-    const backgroundData = deepFreeze({ ...baseBackgroundData, mute });
-
     const message = eg.streamMessage({
       display_recipient: 'electron issues',
       subject: 'issue #556',
     });
-
     const buttons = constructHeaderActionButtons({
-      backgroundData,
+      backgroundData: { ...baseBackgroundData, mute },
       message,
       narrow,
     });
-
     expect(buttons).toContain('unmuteTopic');
   });
 
   test('show mute topic option if topic is not muted', () => {
-    const mute = deepFreeze([]);
-
-    const backgroundData = deepFreeze({ ...baseBackgroundData, mute });
-
     const buttons = constructHeaderActionButtons({
-      backgroundData,
+      backgroundData: { ...baseBackgroundData, mute: [] },
       message: eg.streamMessage(),
       narrow,
     });
-
     expect(buttons).toContain('muteTopic');
   });
 
   test('show Unmute stream option if stream is not in home view', () => {
     const subscriptions = [{ ...eg.subscription, in_home_view: false }];
-
-    const backgroundData = deepFreeze({
-      ...baseBackgroundData,
-      subscriptions,
-    });
-
     const buttons = constructHeaderActionButtons({
-      backgroundData,
+      backgroundData: { ...baseBackgroundData, subscriptions },
       message: eg.streamMessage(),
       narrow,
     });
-
     expect(buttons).toContain('unmuteStream');
   });
 
   test('show mute stream option if stream is in home view', () => {
     const subscriptions = [{ ...eg.subscription, in_home_view: true }];
-
-    const backgroundData = deepFreeze({
-      ...baseBackgroundData,
-      subscriptions,
-    });
-
     const buttons = constructHeaderActionButtons({
-      backgroundData,
+      backgroundData: { ...baseBackgroundData, subscriptions },
       message: eg.streamMessage(),
       narrow,
     });
-
     expect(buttons).toContain('muteStream');
   });
 
   test('show delete topic option if current user is an admin', () => {
-    const backgroundData = deepFreeze({
-      ...baseBackgroundData,
-      ownUser: {
-        ...baseBackgroundData.ownUser,
-        is_admin: true,
-      },
-    });
-
+    const ownUser = { ...eg.selfUser, is_admin: true };
     const buttons = constructHeaderActionButtons({
-      backgroundData,
+      backgroundData: { ...baseBackgroundData, ownUser },
       message: eg.streamMessage(),
       narrow,
     });
-
     expect(buttons).toContain('deleteTopic');
   });
 
@@ -155,7 +114,6 @@ describe('constructHeaderActionButtons', () => {
       message: eg.streamMessage(),
       narrow,
     });
-
     expect(buttons).not.toContain('deleteTopic');
   });
 });


### PR DESCRIPTION
Thanks @agrawal-d for upgrading the message action sheet tests in #3824 / 4670210f8 to be well-typed! And thanks @ray-kraesig for reviewing and merging that PR.

After reading that commit, I saw some ways that that test file could be further improved to reduce boilerplate and also to make the test data more typical and more fully coherent (e.g., stream name and ID properties agreeing with each other.) Some of those involve extending `exampleData` with new features. This PR is the result.

(@agrawal-d , I can't seem to add you as a requested reviewer -- perhaps you're not in the GitHub org? But please do take a look. :slightly_smiling_face: )
