### PR TITLE
ios notifs: Consume "background queue" so notifs navigate from backgr…

### DIFF
--- a/src/boot/AppEventHandlers.js
+++ b/src/boot/AppEventHandlers.js
@@ -10,7 +10,11 @@ import type { Node as React$Node } from 'react';
 import type { Dispatch, Orientation as OrientationT } from '../types';
 import { connect } from '../react-redux';
 import { getUnreadByHuddlesMentionsAndPMs } from '../selectors';
-import { handleInitialNotification, NotificationListener } from '../notification';
+import {
+  handleInitialNotification,
+  NotificationListener,
+  notificationOnAppActive,
+} from '../notification';
 import { appOnline, appOrientation, appState, initSafeAreaInsets } from '../actions';
 import PresenceHeartbeat from '../presence/PresenceHeartbeat';
 
@@ -88,6 +92,9 @@ class AppEventHandlers extends PureComponent<Props> {
     dispatch(appState(state === 'active'));
     if (state === 'background' && Platform.OS === 'android') {
       NativeModules.BadgeCountUpdaterModule.setBadgeCount(unreadCount);
+    }
+    if (state === 'active') {
+      notificationOnAppActive();
     }
   };
 

--- a/src/notification/index.js
+++ b/src/notification/index.js
@@ -132,6 +132,29 @@ export const handleInitialNotification = async (dispatch: Dispatch) => {
   dispatch(narrowToNotification(data));
 };
 
+export const notificationOnAppActive = () => {
+  if (Platform.OS === 'ios') {
+    try {
+      // Allow 'notificationOpened' events to be emitted when pressing
+      // a notification when the app is in the background.
+      //
+      // TODO: This API is deprecated in react-native-notifications release
+      // 2.0.6-snapshot.8; see #3647.
+      //
+      // We don't know the behavior if this is called before
+      // NotificationsIOS.requestPermissions(), so, catch any errors
+      // silently. Ray's investigation shows that it *shouldn't*
+      // throw, but may (https://github.com/zulip/zulip-mobile/pull/3947#discussion_r389192513).
+      NotificationsIOS.consumeBackgroundQueue();
+    } catch (e) {
+      logging.warn(e, {
+        message:
+          'Call to NotificationsIOS.consumeBackgroundQueue failed; pressed notification failed to navigate',
+      });
+    }
+  }
+};
+
 /**
  * From rn-notifications@1.5.0's RNNotifications.m.
  */


### PR DESCRIPTION
…ound.

This is a short-term fix that relies on a deprecated API. We should
upgrade to a newer version of react-native-notifications or use
@react-native-community/push-notification-ios instead.

For now-outdated docs on this, see
https://github.com/wix/react-native-notifications/commit/fe30ae5e03990eb46dc7c04a9ebe86ae0338c7d6#diff-d455ef90f34ba49d565c96e9f2cc8b98R53-R58.
The API was removed in release 2.0.6-shapshot-8 with commit
https://github.com/wix/react-native-notifications/commit/800669120bb7d5f5220ad821a323c3ab7f94342f,
presumably in response to
https://github.com/wix/react-native-notifications/issues/339.

Process an opened notification from the "background queue" so our
handleNotificationOpen will run, and the app will navigate, for a
notification opened while the app was in the background.

Fixes: #3647