### PR TITLE
[WIP] redux: Add transform to keep parsed ZulipVersion in Redux state.

### DIFF
--- a/src/__tests__/lib/exampleData.js
+++ b/src/__tests__/lib/exampleData.js
@@ -112,7 +112,7 @@ export const makeAccount = (
     realm: realmInner,
     email,
     apiKey,
-    zulipVersion: shouldHaveZulipVersion ? zulipVersionInner : undefined,
+    zulipVersion: shouldHaveZulipVersion ? zulipVersionInner : null,
     ackedPushToken,
   });
 };

--- a/src/__tests__/lib/exampleData.js
+++ b/src/__tests__/lib/exampleData.js
@@ -5,6 +5,7 @@ import { createStore } from 'redux';
 import type { CrossRealmBot, Message, PmRecipientUser, Stream, User } from '../../api/modelTypes';
 import type { Action, GlobalState, RealmState } from '../../reduxTypes';
 import type { Auth, Account } from '../../types';
+import { ZulipVersion } from '../../utils/zulipVersion';
 import { ACCOUNT_SWITCH, LOGIN_SUCCESS, REALM_INIT } from '../../actionConstants';
 import rootReducer from '../../boot/reducers';
 import { authOfAccount } from '../../account/accountMisc';
@@ -86,7 +87,7 @@ export const makeCrossRealmBot = (args: { name?: string } = {}): CrossRealmBot =
 
 export const realm = 'https://zulip.example.org';
 
-export const zulipVersion = '2.1.0-234-g7c3acf4';
+export const zulipVersion = new ZulipVersion('2.1.0-234-g7c3acf4');
 
 export const makeAccount = (
   args: {
@@ -95,7 +96,7 @@ export const makeAccount = (
     realm?: string,
     apiKey?: string,
     shouldHaveZulipVersion?: boolean,
-    zulipVersion?: string,
+    zulipVersion?: ZulipVersion,
     ackedPushToken?: string | null,
   } = {},
 ): Account => {

--- a/src/account/__tests__/accountsReducer-test.js
+++ b/src/account/__tests__/accountsReducer-test.js
@@ -10,6 +10,7 @@ import {
   ACCOUNT_REMOVE,
 } from '../../actionConstants';
 import accountsReducer from '../accountsReducer';
+import { ZulipVersion } from '../../utils/zulipVersion';
 
 import * as eg from '../../__tests__/lib/exampleData';
 
@@ -77,7 +78,7 @@ describe('accountsReducer', () => {
 
     test('records zulipVersion on active account', () => {
       const prevState = deepFreeze([account1, account2, account3]);
-      const newZulipVersion = '2.0.0';
+      const newZulipVersion = new ZulipVersion('2.0.0');
       const action = deepFreeze({ ...eg.action.realm_init, zulipVersion: newZulipVersion });
 
       const expectedState = [{ ...account1, zulipVersion: newZulipVersion }, account2, account3];

--- a/src/account/accountActions.js
+++ b/src/account/accountActions.js
@@ -7,13 +7,14 @@ import {
   LOGIN_SUCCESS,
   LOGOUT,
 } from '../actionConstants';
+import type { ZulipVersion } from '../utils/zulipVersion';
 
 export const switchAccount = (index: number): Action => ({
   type: ACCOUNT_SWITCH,
   index,
 });
 
-export const realmAdd = (realm: string, zulipVersion: string): Action => ({
+export const realmAdd = (realm: string, zulipVersion: ZulipVersion): Action => ({
   type: REALM_ADD,
   realm,
   zulipVersion,

--- a/src/account/accountsReducer.js
+++ b/src/account/accountsReducer.js
@@ -65,7 +65,7 @@ const loginSuccess = (state, action) => {
   const { realm, email, apiKey } = action;
   const accountIndex = findAccount(state, { realm, email });
   if (accountIndex === -1) {
-    return [{ realm, email, apiKey, ackedPushToken: null }, ...state];
+    return [{ realm, email, apiKey, ackedPushToken: null, zulipVersion: null }, ...state];
   }
   return [
     { ...state[accountIndex], email, apiKey, ackedPushToken: null },

--- a/src/account/accountsSelectors.js
+++ b/src/account/accountsSelectors.js
@@ -157,10 +157,10 @@ export const getIdentity: Selector<Identity> = createSelector(
  * See the `zulipVersion` property of `Account` for details on how this
  * information is kept up to date.
  */
-export const getServerVersion = (state: GlobalState): ZulipVersion | void => {
+export const getServerVersion = (state: GlobalState): ZulipVersion | null => {
   const activeAccount: Account = getActiveAccount(state);
   if (activeAccount.zulipVersion === null) {
-    return undefined;
+    return null;
   }
   return new ZulipVersion(activeAccount.zulipVersion);
 };

--- a/src/account/accountsSelectors.js
+++ b/src/account/accountsSelectors.js
@@ -159,7 +159,7 @@ export const getIdentity: Selector<Identity> = createSelector(
  */
 export const getServerVersion = (state: GlobalState): ZulipVersion | void => {
   const activeAccount: Account = getActiveAccount(state);
-  if (activeAccount.zulipVersion === undefined) {
+  if (activeAccount.zulipVersion === null) {
     return undefined;
   }
   return new ZulipVersion(activeAccount.zulipVersion);

--- a/src/account/accountsSelectors.js
+++ b/src/account/accountsSelectors.js
@@ -162,5 +162,5 @@ export const getServerVersion = (state: GlobalState): ZulipVersion | null => {
   if (activeAccount.zulipVersion === null) {
     return null;
   }
-  return new ZulipVersion(activeAccount.zulipVersion);
+  return activeAccount.zulipVersion;
 };

--- a/src/account/accountsSelectors.js
+++ b/src/account/accountsSelectors.js
@@ -157,10 +157,5 @@ export const getIdentity: Selector<Identity> = createSelector(
  * See the `zulipVersion` property of `Account` for details on how this
  * information is kept up to date.
  */
-export const getServerVersion = (state: GlobalState): ZulipVersion | null => {
-  const activeAccount: Account = getActiveAccount(state);
-  if (activeAccount.zulipVersion === null) {
-    return null;
-  }
-  return activeAccount.zulipVersion;
-};
+export const getServerVersion = (state: GlobalState): ZulipVersion | null =>
+  getActiveAccount(state).zulipVersion;

--- a/src/actionTypes.js
+++ b/src/actionTypes.js
@@ -86,6 +86,7 @@ import type {
   AlertWordsState,
   UserStatusEvent,
 } from './types';
+import type { ZulipVersion } from './utils/zulipVersion';
 
 export type { NavigationAction } from 'react-navigation';
 
@@ -154,7 +155,7 @@ type AccountSwitchAction = {|
 type RealmAddAction = {|
   type: typeof REALM_ADD,
   realm: string,
-  zulipVersion: string,
+  zulipVersion: ZulipVersion,
 |};
 
 type AccountRemoveAction = {|
@@ -176,7 +177,7 @@ type LogoutAction = {|
 type RealmInitAction = {|
   type: typeof REALM_INIT,
   data: InitialData,
-  zulipVersion: string,
+  zulipVersion: ZulipVersion,
 |};
 
 /** We learned the device token from the system.  See `SessionState`. */

--- a/src/boot/store.js
+++ b/src/boot/store.js
@@ -132,6 +132,15 @@ const migrations: { [string]: (GlobalState) => GlobalState } = {
       },
     };
   },
+
+  // Accounts.zulipVersion is now string | null
+  '11': state => ({
+    ...state,
+    accounts: state.accounts.map(a => ({
+      ...a,
+      zulipVersion: a.zulipVersion !== undefined ? a.zulipVersion : null,
+    })),
+  }),
 };
 
 const reduxPersistConfig: Config = {

--- a/src/message/fetchActions.js
+++ b/src/message/fetchActions.js
@@ -34,6 +34,7 @@ import { addToOutbox, sendOutbox } from '../outbox/outboxActions';
 import { realmInit } from '../realm/realmActions';
 import { startEventPolling } from '../events/eventActions';
 import { logout } from '../account/accountActions';
+import { ZulipVersion } from '../utils/zulipVersion';
 
 const messageFetchStart = (narrow: Narrow, numBefore: number, numAfter: number): Action => ({
   type: MESSAGE_FETCH_START,
@@ -249,7 +250,7 @@ export const doInitialFetch = () => async (dispatch: Dispatch, getState: GetStat
     return;
   }
 
-  dispatch(realmInit(initData, serverSettings.zulip_version));
+  dispatch(realmInit(initData, new ZulipVersion(serverSettings.zulip_version)));
   dispatch(fetchTopMostNarrow());
   dispatch(initialFetchComplete());
   dispatch(startEventPolling(initData.queue_id, initData.last_event_id));

--- a/src/realm/realmActions.js
+++ b/src/realm/realmActions.js
@@ -1,8 +1,9 @@
 /* @flow strict-local */
 import type { InitialData, Action } from '../types';
+import type { ZulipVersion } from '../utils/zulipVersion';
 import { REALM_INIT } from '../actionConstants';
 
-export const realmInit = (data: InitialData, zulipVersion: string): Action => ({
+export const realmInit = (data: InitialData, zulipVersion: ZulipVersion): Action => ({
   type: REALM_INIT,
   data,
   zulipVersion,

--- a/src/start/RealmScreen.js
+++ b/src/start/RealmScreen.js
@@ -3,6 +3,7 @@ import React, { PureComponent } from 'react';
 import { ScrollView, Keyboard } from 'react-native';
 import type { NavigationScreenProp } from 'react-navigation';
 
+import { ZulipVersion } from '../utils/zulipVersion';
 import type { ApiResponseServerSettings, Dispatch } from '../types';
 import { connect } from '../react-redux';
 import { ErrorMsg, Label, SmartUrlInput, Screen, ZulipButton } from '../common';
@@ -54,7 +55,7 @@ class RealmScreen extends PureComponent<Props, State> {
 
     try {
       const serverSettings: ApiResponseServerSettings = await api.getServerSettings(realm);
-      dispatch(realmAdd(realm, serverSettings.zulip_version));
+      dispatch(realmAdd(realm, new ZulipVersion(serverSettings.zulip_version)));
       dispatch(navigateToAuth(serverSettings));
       Keyboard.dismiss();
     } catch (err) {

--- a/src/types.js
+++ b/src/types.js
@@ -92,7 +92,7 @@ export type Account = {|
    *    "crunchy shell" pattern (see docs/architecture/crunchy-shell.md);
    *  * context data in Sentry reports.
    */
-  zulipVersion?: string,
+  zulipVersion: string | null,
 
   /**
    * The last device token value the server has definitely heard from us.

--- a/src/types.js
+++ b/src/types.js
@@ -4,6 +4,7 @@ import type { DangerouslyImpreciseStyleProp } from 'react-native/Libraries/Style
 
 import type { Auth, Topic, Message, Reaction, ReactionType, Narrow } from './api/apiTypes';
 import type { AppStyles } from './styles/theme';
+import type { ZulipVersion } from './utils/zulipVersion';
 
 export type * from './reduxTypes';
 export type * from './api/apiTypes';
@@ -92,7 +93,7 @@ export type Account = {|
    *    "crunchy shell" pattern (see docs/architecture/crunchy-shell.md);
    *  * context data in Sentry reports.
    */
-  zulipVersion: string | null,
+  zulipVersion: ZulipVersion | null,
 
   /**
    * The last device token value the server has definitely heard from us.

--- a/src/users/usersActions.js
+++ b/src/users/usersActions.js
@@ -28,7 +28,7 @@ export const reportPresence = (isActive: boolean = true, newUserInput: boolean =
 
 const typingWorker = (state: GlobalState) => {
   const auth: Auth = getAuth(state);
-  const serverVersion: ZulipVersion | void = getServerVersion(state);
+  const serverVersion: ZulipVersion | null = getServerVersion(state);
 
   // User ID arrays are only supported in server versions >= 2.0.0-rc1
   // (zulip/zulip@2f634f8c0). For versions before this, email arrays


### PR DESCRIPTION
Storing the parsed ZulipVersion instance in Redux makes it easier to
work with, so we don't have to think about constructing a new
instance as part of every server feature check.

The one tricky bit is that our Redux state is serialized with
JSON.stringify by redux-persist so that it can be stored in
ZulipAsyncStorage, but the ZulipVersion instance itself is not
serializable. Thankfully, it can be represented as its raw version
string, which is serializable.

So, on entry into ZulipAsyncStorage, convert the ZulipVersion
instance into the raw version string with .raw(), and on exit, call
the ZulipVersion constructor on that raw version string, with
redux-persist's `createTransform`.

Fixes: #3951