### PR TITLE
WIP: Something to play with on iOS, for navigation.

### DIFF
--- a/src/nav/navActions.js
+++ b/src/nav/navActions.js
@@ -10,10 +10,9 @@ import type {
   UserOrBot,
   ApiResponseServerSettings,
 } from '../types';
-import { getSameRoutesCount } from '../selectors';
 
 export const navigateBack = () => (dispatch: Dispatch, getState: GetState): NavigationAction =>
-  dispatch(StackActions.pop({ n: getSameRoutesCount(getState()) }));
+  dispatch(StackActions.pop({}));
 
 // Other stack routes reached through `navReducer`:
 //    StackActions.push({ routeName: 'loading' });
@@ -24,6 +23,8 @@ export const navigateBack = () => (dispatch: Dispatch, getState: GetState): Navi
 /** Only call this via `doNarrow`.  See there for details. */
 export const navigateToChat = (narrow: Narrow): NavigationAction =>
   StackActions.push({ routeName: 'chat', params: { narrow } });
+
+export const navigatePopToTop = (): NavigationAction => StackActions.popToTop({});
 
 export const navigateToUsersScreen = (): NavigationAction =>
   StackActions.push({ routeName: 'users' });

--- a/src/title-buttons/ExtraNavButtonStream.js
+++ b/src/title-buttons/ExtraNavButtonStream.js
@@ -6,7 +6,7 @@ import type { Dispatch, Narrow, Stream } from '../types';
 import { connect } from '../react-redux';
 import { getStreams } from '../selectors';
 import NavButton from '../nav/NavButton';
-import { navigateToTopicList } from '../actions';
+import { navigatePopToTop } from '../nav/navActions';
 
 type Props = $ReadOnly<{|
   dispatch: Dispatch,
@@ -17,17 +17,13 @@ type Props = $ReadOnly<{|
 
 class ExtraNavButtonStream extends PureComponent<Props> {
   handlePress = () => {
-    const { dispatch, narrow, streams } = this.props;
-    const stream = streams.find(x => x.name === narrow[0].operand);
-    if (stream) {
-      dispatch(navigateToTopicList(stream.stream_id));
-    }
+    this.props.dispatch(navigatePopToTop());
   };
 
   render() {
     const { color } = this.props;
 
-    return <NavButton name="list" color={color} onPress={this.handlePress} />;
+    return <NavButton name="home" color={color} onPress={this.handlePress} />;
   }
 }
 

--- a/src/title-buttons/ExtraNavButtonTopic.js
+++ b/src/title-buttons/ExtraNavButtonTopic.js
@@ -5,9 +5,8 @@ import React, { PureComponent } from 'react';
 import type { Dispatch, Narrow, Stream } from '../types';
 import { connect } from '../react-redux';
 import { getStreams } from '../selectors';
-import { streamNarrow } from '../utils/narrow';
 import NavButton from '../nav/NavButton';
-import { doNarrow } from '../actions';
+import { navigatePopToTop } from '../nav/navActions';
 
 type Props = $ReadOnly<{|
   dispatch: Dispatch,
@@ -18,17 +17,13 @@ type Props = $ReadOnly<{|
 
 class ExtraNavButtonTopic extends PureComponent<Props> {
   handlePress = () => {
-    const { dispatch, narrow, streams } = this.props;
-    const stream = streams.find(x => x.name === narrow[0].operand);
-    if (stream) {
-      dispatch(doNarrow(streamNarrow(stream.name)));
-    }
+    this.props.dispatch(navigatePopToTop());
   };
 
   render() {
     const { color } = this.props;
 
-    return <NavButton name="arrow-up" color={color} onPress={this.handlePress} />;
+    return <NavButton name="home" color={color} onPress={this.handlePress} />;
   }
 }
 

--- a/src/title-buttons/InfoNavButtonStream.js
+++ b/src/title-buttons/InfoNavButtonStream.js
@@ -6,7 +6,7 @@ import type { Dispatch, Narrow, Stream } from '../types';
 import { connect } from '../react-redux';
 import { getStreams } from '../selectors';
 import NavButton from '../nav/NavButton';
-import { navigateToStream } from '../actions';
+import { navigateToTopicList } from '../actions';
 
 type Props = $ReadOnly<{|
   dispatch: Dispatch,
@@ -20,14 +20,14 @@ class InfoNavButtonStream extends PureComponent<Props> {
     const { dispatch, narrow, streams } = this.props;
     const stream = streams.find(x => x.name === narrow[0].operand);
     if (stream) {
-      dispatch(navigateToStream(stream.stream_id));
+      dispatch(navigateToTopicList(stream.stream_id));
     }
   };
 
   render() {
     const { color } = this.props;
 
-    return <NavButton name="info" color={color} onPress={this.handlePress} />;
+    return <NavButton name="list" color={color} onPress={this.handlePress} />;
   }
 }
 

--- a/src/title/TitleStream.js
+++ b/src/title/TitleStream.js
@@ -1,7 +1,7 @@
 /* @flow strict-local */
 
 import React, { PureComponent } from 'react';
-import { StyleSheet, Text, View, TouchableWithoutFeedback } from 'react-native';
+import { StyleSheet, Text, View, TouchableWithoutFeedback, TouchableOpacity } from 'react-native';
 
 import type { Narrow, Stream, Subscription, Dispatch } from '../types';
 import { connect } from '../react-redux';
@@ -10,6 +10,7 @@ import { isTopicNarrow } from '../utils/narrow';
 import { getStreamInNarrow } from '../selectors';
 import styles from '../styles';
 import { showToast } from '../utils/info';
+import { navigateToStream } from '../actions';
 
 type SelectorProps = {|
   stream: Subscription | {| ...Stream, in_home_view: boolean |},
@@ -37,11 +38,18 @@ class TitleStream extends PureComponent<Props> {
     },
   });
 
+  handlePress = () => {
+    const { dispatch, stream } = this.props;
+    if (stream) {
+      dispatch(navigateToStream(stream.stream_id));
+    }
+  };
+
   render() {
     const { narrow, stream, color } = this.props;
 
     return (
-      <View style={this.styles.outer}>
+      <TouchableOpacity onPress={this.handlePress} style={this.styles.outer}>
         <View style={this.styles.streamRow}>
           <StreamIcon
             style={styles.halfMarginRight}
@@ -65,7 +73,7 @@ class TitleStream extends PureComponent<Props> {
             </Text>
           </TouchableWithoutFeedback>
         )}
-      </View>
+      </TouchableOpacity>
     );
   }
 }


### PR DESCRIPTION
EDIT: Huh, not sure why I named the branch "notification" ideas instead of "navigation" ones. 🤷 

@gnprice @ray-kraesig

Following discussions [here](https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/redux.20.2F.20navigation) and [here](https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/navigation), here's something concrete to play with, made especially for iOS.

I think it would have been a good idea to settle some of those discussions before I moved the conversation to hypothetical "a -> b -> a -> b" sequences, etc., so hopefully this WIP PR can help toward that. 🙂 I don't think the concerns of a large stack building up are more urgent right now than fixing the unexpected "back" and "up" behaviors, which I still find really confusing and unhelpful after a lot of time with the UI.

I think we've [found](https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/navigation/near/809169) that Apple doesn't have a strong, consistent rule that would require the "up" button/action, so I've left it out here, hopefully without too much controversy. The concern I raised in my [long story](https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/navigation/near/812671) about the #consciousness stream is resolved by putting the topic list button in the topic nav, not just the stream nav.

I think some disagreement remains on the question of the "up" button/action on Android, which I'll quote here.

Greg [said](https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/navigation/near/812610):
> > > * to pop the history stack: Left-arrow nav-bar button.
> > 
> > This is, IIRC, the opposite of the recommended behavior on Android; this button should take you "up", rather than chronologically "back".
>
> > The "back button in a browser" functionality is explicitly [the purpose of the system Back button/gesture.](https://stuff.mit.edu/afs/sipb/project/android/docs/design/patterns/navigation.html)
>
> So, it's absolutely right that that's the doctrine in the Android docs.
>
> I've grown skeptical that that's actually a great UI choice, though. I've also found it hard to locate real examples of apps seriously following that design.
>
> So I think it may be the right choice for us to leave that left-arrow in the nav bar as a "back" navigation. (Like the status quo, and like in the dictionary I described above.)

(See also Greg's example with a diagram.)

Ray [said](https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/navigation/near/812651):
> >Hmm, and with which behavior? Do you mean having it go "back" on iOS, but "up" on Android?>
> Exactly so.
> 
> > I think an "up" icon wouldn't greatly help. Nobody who hasn't been an Android developer knows about the contrasting terms "back" and "up" -- at least I'd never heard of them, or put together the concepts quite that way, in my years as an Android user before starting to develop for it.
> 
> Yes, that's *why* the different icon. :slight_smile: At least on the topic screen, being located next to the stream-name-over-topic-name construct should be a strong hint to its behavior. I'm less sure about the stream screen, though.

Before resuming this directly, I think it may help to return to my analysis of that Japanese dictionary app, and, from it, some guidelines I've offered to help reduce confusion for Zulip users. Greg, it looks like you [agree](https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/navigation/near/812606) with them. Ray, you [responded](https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/navigation/near/812594) to an implementation idea that followed them, but I'm curious to know what you think about the guidelines themselves. They seem broad enough to be a good place to explore any disagreements before moving forward, perhaps in the ["navigation" topic](https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/navigation/near/826490) on CZO.

I [said](https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/navigation/near/812590):
> A) It lets you navigate by the static structure of the pages, which I think you've called "the DAG of the overall navigation."
> B) It lets you navigate back through the user's history as it's created by some (maybe all) A-type navigation actions.
> C) A- and B-type navigation actions have distinct interfaces, so you're never unsure where a button or swipe will take you.

It seems to me that the Android [diagrams](https://stuff.mit.edu/afs/sipb/project/android/docs/design/patterns/navigation.html) we've discussed observe these.

I may have misunderstood, but some of the recent [discussion](https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/redux.20.2F.20navigation/near/824899) on how many (2, N, 2N, etc.) routes would accumulate in the stack may be influenced by differing assumptions, with one being that a single back or up button could fulfill both A and B, which violates C. If I'm jumping to conclusions here, please let me know, but *after* you've responded to the above. 😉