### PR TITLE
group-pm: Fix profile icon breaking for large no.of recepients

### DIFF
--- a/src/common/GroupAvatar.js
+++ b/src/common/GroupAvatar.js
@@ -5,7 +5,6 @@ import { Text, StyleSheet, View } from 'react-native';
 import type { Node as React$Node } from 'react';
 import Touchable from './Touchable';
 import { colorHashFromString, foregroundColorFromBackground } from '../utils/color';
-import { initialsFromString } from '../utils/misc';
 
 const styles = StyleSheet.create({
   frame: {
@@ -18,12 +17,23 @@ const styles = StyleSheet.create({
 });
 
 type Props = $ReadOnly<{|
-  names: string,
+  names: string[],
   size: number,
   shape: 'rounded' | 'square',
   children?: React$Node,
   onPress?: () => void,
 |}>;
+
+/** Private; exported only for tests. */
+export const initialsForGroupIcon = (names: string[]): string => {
+  const initials = names.map(item =>
+    item === '' ? '' : String.fromCodePoint(item.codePointAt(0)).toUpperCase(),
+  );
+  if (initials.length > 4) {
+    initials[3] = '…';
+  }
+  return initials.slice(0, 4).join('');
+};
 
 /**
  * Renders a text avatar based on a single or multiple user's
@@ -48,7 +58,7 @@ export default class GroupAvatar extends PureComponent<Props> {
       height: size,
       width: size,
       borderRadius: shape === 'rounded' ? size / 8 : 0,
-      backgroundColor: colorHashFromString(names),
+      backgroundColor: colorHashFromString(names.join(', ')),
     };
     const textSize = {
       fontSize: size / 3,
@@ -58,7 +68,7 @@ export default class GroupAvatar extends PureComponent<Props> {
     return (
       <Touchable onPress={onPress}>
         <View style={[styles.frame, frameSize]}>
-          <Text style={[styles.text, textSize]}>{initialsFromString(names)}</Text>
+          <Text style={[styles.text, textSize]}>{initialsForGroupIcon(names)}</Text>
           {children}
         </View>
       </Touchable>

--- a/src/common/__tests__/initialsForGroupIcon-test.js
+++ b/src/common/__tests__/initialsForGroupIcon-test.js
@@ -1,0 +1,37 @@
+/* @flow strict-local */
+import { initialsForGroupIcon } from '../GroupAvatar';
+
+describe('initialsForGroupIcon', () => {
+  test('empty string returns empty strings of initials', () => {
+    expect(initialsForGroupIcon([''])).toEqual('');
+  });
+
+  test('a single name has a single letter initial', () => {
+    expect(initialsForGroupIcon(['John'])).toEqual('J');
+    expect(initialsForGroupIcon(['John Doe'])).toEqual('J');
+    expect(initialsForGroupIcon(['Ruby Donald Johnny Doe'])).toEqual('R');
+  });
+
+  test('initials are always upper case', () => {
+    expect(initialsForGroupIcon(['small caps'])).toEqual('S');
+    expect(initialsForGroupIcon(['john', 'doe'])).toEqual('JD');
+  });
+
+  test('double names produce one initial', () => {
+    expect(initialsForGroupIcon(['Jean-Pierre'])).toEqual('J');
+    expect(initialsForGroupIcon(["Mc'Donald"])).toEqual('M');
+  });
+
+  test('four names or less should produce the respective names initials', () => {
+    expect(initialsForGroupIcon(['John', 'Doe', 'Ruby', 'Mathew'])).toEqual('JDRM');
+    expect(initialsForGroupIcon(['Doe', 'Ruby'])).toEqual('DR');
+  });
+
+  test("more than four names should have a '…' charector after the first 3 initials", () => {
+    expect(initialsForGroupIcon(['John', 'Doe', 'Ruby', 'Mat', 'Sam'])).toEqual('JDR…');
+  });
+
+  test('should work on emojis', () => {
+    expect(initialsForGroupIcon(['😁Me', 'test'])).toEqual('😁T');
+  });
+});

--- a/src/pm-conversations/GroupPmConversationItem.js
+++ b/src/pm-conversations/GroupPmConversationItem.js
@@ -41,7 +41,7 @@ export default class GroupPmConversationItem extends PureComponent<Props> {
     }
 
     // $FlowFixMe Flow doesn't see the `every` check above.
-    const allNames = allUsers.map(user => user.full_name).join(', ');
+    const allNames = allUsers.map(user => user.full_name);
 
     return (
       <Touchable onPress={this.handlePress}>
@@ -51,7 +51,7 @@ export default class GroupPmConversationItem extends PureComponent<Props> {
             style={componentStyles.text}
             numberOfLines={2}
             ellipsizeMode="tail"
-            text={allNames}
+            text={allNames.join(', ')}
           />
           <UnreadCount count={unreadCount} />
         </View>

--- a/src/utils/__tests__/misc-test.js
+++ b/src/utils/__tests__/misc-test.js
@@ -1,5 +1,5 @@
 /* @flow strict-local */
-import { initialsFromString, isValidEmailFormat, numberWithSeparators, deeperMerge } from '../misc';
+import { isValidEmailFormat, numberWithSeparators, deeperMerge } from '../misc';
 
 describe('numberWithSeparators', () => {
   test('do not change a small number', () => {
@@ -69,33 +69,6 @@ describe('deeperMerge', () => {
     const result = deeperMerge(a, b);
 
     expect(result).toEqual(expectedResult);
-  });
-});
-
-describe('initialsFromString', () => {
-  test('empty string returns empty strings of initials', () => {
-    const initials = initialsFromString('');
-    expect(initials).toEqual('');
-  });
-
-  test('a single name has a single letter initial', () => {
-    const initials = initialsFromString('John');
-    expect(initials).toEqual('J');
-  });
-
-  test('two names result in two initials', () => {
-    const initials = initialsFromString('John Doe');
-    expect(initials).toEqual('JD');
-  });
-
-  test('initials are always upper case', () => {
-    const initials = initialsFromString('small caps');
-    expect(initials).toEqual('SC');
-  });
-
-  test('double names produce one initial', () => {
-    expect(initialsFromString('Jean-Pierre')).toEqual('J');
-    expect(initialsFromString("Mc'Donald")).toEqual('M');
   });
 });
 

--- a/src/utils/misc.js
+++ b/src/utils/misc.js
@@ -24,9 +24,6 @@ export function deeperMerge<K, V>(obj1: { [K]: V }, obj2: { [K]: V }): { [K]: V 
   );
 }
 
-export const initialsFromString = (name: string): string =>
-  (name.match(/\S+\s*/g) || []).map(x => x[0].toUpperCase()).join('');
-
 export function groupItemsById<T: { +id: number }>(items: T[]): { [id: number]: T } {
   return objectFromEntries(items.map(item => [item.id, item]));
 }


### PR DESCRIPTION
When there are large no.of recipients or people with large
no.of initials in their names, the profile Icon is overflowed
with letters. This PR fixes this by taking only the first Initial
from each name and if no.of recipients is > 4 adding a '+'
charector to the end.

Fixes: #3939