### PR TITLE
Support `zh-Hant`

### DIFF
--- a/src/boot/store.js
+++ b/src/boot/store.js
@@ -118,6 +118,20 @@ const migrations: { [string]: (GlobalState) => GlobalState } = {
       ackedPushToken: null,
     })),
   }),
+
+  // Convert old locale names to new, more-specific locale names.
+  '10': state => {
+    const newLocaleNames = { zh: 'zh-Hans', id: 'id-ID' };
+    const { locale } = state.settings;
+    const newLocale = newLocaleNames[locale] ?? locale;
+    return {
+      ...state,
+      settings: {
+        ...state.settings,
+        locale: newLocale,
+      },
+    };
+  },
 };
 
 const reduxPersistConfig: Config = {

--- a/src/i18n/messages.js
+++ b/src/i18n/messages.js
@@ -1,5 +1,5 @@
-/* eslint-disable spellcheck/spell-checker */
 /* @flow strict-local */
+/* eslint-disable spellcheck/spell-checker */
 
 import ar from '../../static/translations/messages_ar.json';
 import bg from '../../static/translations/messages_bg.json';
@@ -17,7 +17,7 @@ import gl from '../../static/translations/messages_gl.json';
 import hi from '../../static/translations/messages_hi.json';
 import hr from '../../static/translations/messages_hr.json';
 import hu from '../../static/translations/messages_hu.json';
-import id from '../../static/translations/messages_id_ID.json';
+import id_ID from '../../static/translations/messages_id_ID.json';
 import it from '../../static/translations/messages_it.json';
 import ja from '../../static/translations/messages_ja.json';
 import ko from '../../static/translations/messages_ko.json';
@@ -35,7 +35,7 @@ import tr from '../../static/translations/messages_tr.json';
 import uk from '../../static/translations/messages_uk.json';
 import uz from '../../static/translations/messages_uz.json';
 import vi from '../../static/translations/messages_vi.json';
-import zh from '../../static/translations/messages_zh-Hans.json';
+import zh_Hans from '../../static/translations/messages_zh-Hans.json';
 
 export default {
   ar,
@@ -54,7 +54,7 @@ export default {
   hi,
   hr,
   hu,
-  id,
+  'id-ID': id_ID,
   it,
   ja,
   ko,
@@ -72,5 +72,5 @@ export default {
   uk,
   uz,
   vi,
-  zh,
+  'zh-Hans': zh_Hans,
 };

--- a/src/i18n/messages.js
+++ b/src/i18n/messages.js
@@ -36,6 +36,7 @@ import uk from '../../static/translations/messages_uk.json';
 import uz from '../../static/translations/messages_uz.json';
 import vi from '../../static/translations/messages_vi.json';
 import zh_Hans from '../../static/translations/messages_zh-Hans.json';
+import zh_Hant from '../../static/translations/messages_zh-Hant.json';
 
 export default {
   ar,
@@ -73,4 +74,5 @@ export default {
   uz,
   vi,
   'zh-Hans': zh_Hans,
+  'zh-Hant': zh_Hant,
 };

--- a/src/settings/languages.js
+++ b/src/settings/languages.js
@@ -36,6 +36,7 @@ const languages: $ReadOnlyArray<Language> = [
   { locale: 'bg', name: 'Bulgarian', nativeName: 'Български' },
   { locale: 'ca', name: 'Catalan', nativeName: 'Català' },
   { locale: 'zh-Hans', name: 'Chinese (Simplified)', nativeName: '中文（简体）' },
+  { locale: 'zh-Hant', name: 'Chinese (Traditional)', nativeName: '中文 (繁体)' },
   { locale: 'cs', name: 'Czech', nativeName: 'Čeština' },
   { locale: 'nl', name: 'Dutch', nativeName: 'Nederlands' },
   // TODO: add `en_GB` -- it's "100% translated", though that just means

--- a/src/settings/languages.js
+++ b/src/settings/languages.js
@@ -35,8 +35,7 @@ const languages: $ReadOnlyArray<Language> = [
   { locale: 'en', name: 'English', nativeName: 'English' },
   { locale: 'bg', name: 'Bulgarian', nativeName: 'Български' },
   { locale: 'ca', name: 'Catalan', nativeName: 'Català' },
-  { locale: 'zh', name: 'Chinese (Simplified)', nativeName: '中文 (简体)' },
-  // TODO: migrate `zh` to `zh-Hans`, and add `zh-Hant`
+  { locale: 'zh-Hans', name: 'Chinese (Simplified)', nativeName: '中文（简体）' },
   { locale: 'cs', name: 'Czech', nativeName: 'Čeština' },
   { locale: 'nl', name: 'Dutch', nativeName: 'Nederlands' },
   // TODO: add `en_GB` -- it's "100% translated", though that just means
@@ -47,7 +46,7 @@ const languages: $ReadOnlyArray<Language> = [
   { locale: 'de', name: 'German', nativeName: 'Deutsch' },
   { locale: 'hi', name: 'Hindi', nativeName: 'हिन्दी' },
   { locale: 'hu', name: 'Hungarian', nativeName: 'Magyar' },
-  { locale: 'id', name: 'Indonesian', nativeName: 'Bahasa Indonesia' },
+  { locale: 'id-ID', name: 'Indonesian', nativeName: 'Bahasa Indonesia' },
   { locale: 'it', name: 'Italian', nativeName: 'Italiano' },
   { locale: 'ja', name: 'Japanese', nativeName: '日本語' },
   { locale: 'ko', name: 'Korean', nativeName: '한국어' },


### PR DESCRIPTION
Migrate `zh` to `zh-Hans`, and add support for `zh-Hant`.

Extracted from existing PR #3915.