### PR TITLE
eslint: Stop using react-native plugin.

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -6,7 +6,7 @@ extends:
   - ./tools/formatting.eslintrc.yaml
 
 plugins:
- - react-native
+# - react-native
  - jest
  - flowtype
 

--- a/package.json
+++ b/package.json
@@ -97,7 +97,6 @@
     "eslint-plugin-jsx-a11y": "^6.2.3",
     "eslint-plugin-prettier": "^3.1.0",
     "eslint-plugin-react": "^7.14.2",
-    "eslint-plugin-react-native": "^3.7.0",
     "eslint-plugin-spellcheck": "0.0.14",
     "flow-bin": "^0.92.0",
     "flow-coverage-report": "^0.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3344,18 +3344,6 @@ eslint-plugin-prettier@^3.1.0:
   dependencies:
     prettier-linter-helpers "^1.0.0"
 
-eslint-plugin-react-native-globals@^0.1.1:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-react-native-globals/-/eslint-plugin-react-native-globals-0.1.2.tgz#ee1348bc2ceb912303ce6bdbd22e2f045ea86ea2"
-  integrity sha512-9aEPf1JEpiTjcFAmmyw8eiIXmcNZOqaZyHO77wgm0/dWfT/oxC1SrIq8ET38pMxHYrcB6Uew+TzUVsBeczF88g==
-
-eslint-plugin-react-native@^3.7.0:
-  version "3.7.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-react-native/-/eslint-plugin-react-native-3.7.0.tgz#7e2cc1f3cf24919c4c0ea7fac13301e7444e105f"
-  integrity sha512-krLtQmGih/uJDPxF8DBpnU8J3kRUsDm/Dey5yEhOO8LN1I3Wesbk4PGCg8Zah57azKFU+9YtGooFjJcDJWUs+g==
-  dependencies:
-    eslint-plugin-react-native-globals "^0.1.1"
-
 eslint-plugin-react@^7.14.2:
   version "7.14.3"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.14.3.tgz#911030dd7e98ba49e1b2208599571846a66bdf13"


### PR DESCRIPTION
In abc043253, we disabled the only rule that remained enabled from
this plugin. So, remove the plugin. Leave the two existing
commented-out lines to enable other rules, which describe how we'd
like to potentially use them in the future. See:
  https://github.com/zulip/zulip-mobile/pull/3901#discussion_r388026654

----------------

From https://github.com/zulip/zulip-mobile/pull/3901#issuecomment-596799693, where Greg said:

> I've also dropped the new commit that removes the eslint react-native plugin, because I realized that it doesn't yet remove it from package.json and yarn.lock 🙂 -- only from the eslintrc. That can be a good quick followup.