### PR TITLE
emoji search: Search for query-string anywhere in the emoji name.

### DIFF
--- a/src/emoji/__tests__/data-test.js
+++ b/src/emoji/__tests__/data-test.js
@@ -51,16 +51,16 @@ describe('getFilteredEmojiNames', () => {
       'gorilla',
       'got_it',
       'agony',
+      'all_good',
       'dango',
       'dragon',
       'dragon_face',
-      'virgo',
-      'all_good',
+      'easy_come_easy_go',
+      'heart_of_gold',
+      'merry_go_round',
       'octagonal_sign',
       'synagogue',
-      'merry_go_round',
-      'heart_of_gold',
-      'easy_come_easy_go',
+      'virgo',
     ]);
   });
 

--- a/src/emoji/__tests__/data-test.js
+++ b/src/emoji/__tests__/data-test.js
@@ -50,6 +50,17 @@ describe('getFilteredEmojiNames', () => {
       'gooooooooal',
       'gorilla',
       'got_it',
+      'agony',
+      'dango',
+      'dragon',
+      'dragon_face',
+      'virgo',
+      'all_good',
+      'octagonal_sign',
+      'synagogue',
+      'merry_go_round',
+      'heart_of_gold',
+      'easy_come_easy_go',
     ]);
   });
 
@@ -58,7 +69,7 @@ describe('getFilteredEmojiNames', () => {
   });
 
   test('remove duplicates', () => {
-    expect(getFilteredEmojiNames('dog', {})).toEqual(['dog', 'dogi']);
-    expect(getFilteredEmojiNames('dog', { dog: {} })).toEqual(['dog', 'dogi']);
+    expect(getFilteredEmojiNames('dog', {})).toEqual(['dog', 'dogi', 'hotdog']);
+    expect(getFilteredEmojiNames('dog', { dog: {} })).toEqual(['dog', 'dogi', 'hotdog']);
   });
 });

--- a/src/emoji/data.js
+++ b/src/emoji/data.js
@@ -26,26 +26,24 @@ export const codeToEmojiMap = objectFromEntries<string, string>(
 );
 
 /**
- * Given a query-string, report all emoji whose names match that query-string.
- *
- * Names with the query-string earlier in the emoji name are given preference in
- * the returned list's sort-order.
+ * Names of all emoji matching the query, in an order to offer to the user.
  */
 export const getFilteredEmojiNames = (
   query: string,
   activeImageEmojiByName: $ReadOnly<{ [string]: ImageEmojiType }>,
 ): string[] => {
-  // Map from emoji names to the query's match-index. (Nonmatching names are
-  // excluded.)
+  // Map from emoji names to 0 for prefix matches, 1 for others.
+  // (Nonmatching names are excluded.)
   const nameMap: Map<string, number> = new Map(
     [...unicodeEmojiNames, ...Object.keys(activeImageEmojiByName)]
-      .map(x => [x, x.indexOf(query)])
+      .map(x => [x, Math.min(1, x.indexOf(query))])
       .filter(([_, i]) => i !== -1),
   );
 
   const emoji = Array.from(nameMap.keys()).sort((a, b) => {
     // `.get` will never return `undefined` here, but Flow doesn't know that
     const n = +nameMap.get(a) - +nameMap.get(b);
+    // Prefix matches first, then non-prefix, each in lexicographic order.
     return n !== 0 ? n : a < b ? -1 : 1;
   });
 


### PR DESCRIPTION
Previously, emoji queries required an exact initial match. Instead,
match against the query-string's occurrence anywhere in the name.

This imperfectly mimicks the webapp's behavior, in that prefix-matches
are considered better than normal matches. The webapp leaves some
sort-ordering unspecified, however, and also has a set of "popular
emoji" which are always considered a good match if they're considered
a match at all. Properly mimicking the webapp is left as #3833.

Test data has been taken from the original PR #3836 by @sumukhah,
whose choice of sort order is also maintained to simplify tests.

Fixes #3948.

Co-Authored-By: sumukhah <sumukha214@gmail.com>