### PR TITLE
Fix bogus year-1970 timestamp in how we aggregate user presence

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -56,9 +56,12 @@ rules:
 
   # For more formatting rules, see tools/formatting.eslintrc.yaml .
 
-  # Repeal a rather absurd rule that makes some code impossible to write in
+  # Repeal some rather absurd rules that make some code impossible to write in
   # the most reasonable way.
   no-else-return: off
+  prefer-destructuring:
+  - error
+  - AssignmentExpression: {array: false, object: false}
 
   # Tricky code.  We repeal several bans from the Airbnb style.
   no-bitwise: off

--- a/src/presence/presenceReducer.js
+++ b/src/presence/presenceReducer.js
@@ -10,6 +10,7 @@ import {
 } from '../actionConstants';
 import { NULL_OBJECT } from '../nullObjects';
 import { getAggregatedPresence } from '../utils/presence';
+import objectEntries from '../utils/objectEntries';
 
 const initialState: PresenceState = NULL_OBJECT;
 
@@ -29,7 +30,15 @@ export default (state: PresenceState = initialState, action: Action): PresenceSt
         ...action.presence,
       };
 
-    case EVENT_PRESENCE:
+    case EVENT_PRESENCE: {
+      // A presence event should have either "active" or "idle" status
+      const isPresenceEventValid = !!objectEntries(action.presence).find(
+        ([device, devicePresence]) => ['active', 'idle'].includes(devicePresence.status),
+      );
+      if (!isPresenceEventValid) {
+        return state;
+      }
+
       return {
         ...state,
         [action.email]: {
@@ -38,7 +47,7 @@ export default (state: PresenceState = initialState, action: Action): PresenceSt
           aggregated: getAggregatedPresence({ ...state[action.email], ...action.presence }),
         },
       };
-
+    }
     default:
       return state;
   }

--- a/src/utils/__tests__/presence-test.js
+++ b/src/utils/__tests__/presence-test.js
@@ -23,7 +23,7 @@ describe('getAggregatedPresence', () => {
     const expectedResult = {
       client: 'zulipMobile',
       status: 'active',
-      timestamp: currentTimestamp - 120,
+      timestamp: currentTimestamp - 100,
     };
 
     expect(getAggregatedPresence(presence)).toEqual(expectedResult);
@@ -68,7 +68,7 @@ describe('getAggregatedPresence', () => {
 
     const expectedResult = {
       client: '',
-      timestamp: 0,
+      timestamp: currentTimestamp - 200,
       status: 'offline',
     };
 

--- a/src/utils/presence.js
+++ b/src/utils/presence.js
@@ -54,12 +54,14 @@ export const getAggregatedPresence = (presence: UserPresence): ClientPresence =>
   let client = '';
   let timestamp = 0;
 
+  const dateNow = Date.now();
+
   for (const [device, devicePresence] of objectEntries(presence)) {
     if (device === 'aggregated') {
       continue;
     }
 
-    const age = Date.now() / 1000 - devicePresence.timestamp;
+    const age = dateNow / 1000 - devicePresence.timestamp;
     if (timestamp < devicePresence.timestamp) {
       timestamp = devicePresence.timestamp;
     }

--- a/src/utils/presence.js
+++ b/src/utils/presence.js
@@ -28,7 +28,7 @@ const OFFLINE_THRESHOLD_SECS = 140;
  *   https://zulip.readthedocs.io/en/latest/subsystems/presence.html
  *
  * This logic should match `status_from_timestamp` in the web app's
- * `static/js/presence.js`.
+ * `static/js/presence.js` at 1ae07b93d^.
  */
 export const getAggregatedPresence = (presence: UserPresence): ClientPresence =>
   /* Out of the ClientPresence objects found in `presence`, we consider only


### PR DESCRIPTION
presence: Fix timestamp being Unix zero (50 years ago).

This is a user-visible symptom, but it's kind of a rare case that we
wouldn't expect to see normally. Sometimes, a user is displayed to
be "last active" 50 years ago, which is bogus. It turns out that it
only happens when a presence event is sent from the server (meaning
it should be as up-to-date as possible; we wouldn't expect it to be
more than a few seconds off), but it's more than 140 seconds old.

Presence events coming from the server don't have the `aggregated`
field, like presence objects do in the /register response and
presence report responses. So we have our own function,
getAggregatedPresence, to calculate it for us. This is analogous to
the status_from_timestamp function in the web app.

As suggested in the parent, a bug seems to have been introduced into
this function by a hasty use of `.reduce`, when a `.forEach` would
work perfectly well.

So, to fix:

1) Use .forEach instead of reduce (that's the parent).

2) Assume that there is at least one ClientPresence in `presence`,
and that its timestamp is sane. This is handled by the server; it
seems reasonable that no event would have been emitted if there
weren't sane data to transmit.

3) Make the returned timestamp be whatever the latest timestamp is,
out of all the ClientPresence objects.

4) Maintain `status` as the greatest status reported within
OFFLINE_THRESHOLD_SECS (with `active` > `idle` > `offline`), or
`offline` if none was within the threshold, as explained in the
comment and implemented in the web app.

Note that `#4` surfaced a subtlety in the intent stated in the
comment, and the behavior of the web app, which prompted changing a
test case. The `timestamp` and the `status` fields of the returned
object won't necessarily be sourced from the same ClientPresence
object from the input. Take an example where one object has status
`idle`, and another has status `active`, and both timestamps are
within OFFLINE_THRESHOLD_SECS, but the `idle` one's timestamp is
later than the `active` one's. In that case, the aggregated `status`
would be `active`, but the timestamp would be the timestamp from the
`idle` object. This may or may not be exactly what we want; the
information conveyed is inaccurate.

Also, note that further investigation or broader refactors were
avoided because of https://github.com/zulip/zulip/issues/13734,
"Improve presence system's scalability for large realms", which
signals substantial future changes to the Presence API. See also the
discussion at
https://chat.zulip.org/#narrow/stream/3-backend/topic/presence.20API/near/811593.

Fixes: #2834