### PR TITLE
Fix instance of #3457, "Narrow sometimes lands far in the past", for muted streams.

### DIFF
--- a/src/message/messageSelectors.js
+++ b/src/message/messageSelectors.js
@@ -12,7 +12,6 @@ import {
 import * as logging from '../utils/logging';
 import { getShownMessagesForNarrow } from '../chat/narrowsSelectors';
 import renderMessages from './renderMessages';
-import { findFirstUnread } from '../utils/message';
 import type { JSONable } from '../utils/jsonable';
 import { ALL_PRIVATE_NARROW_STR } from '../utils/narrow';
 import { NULL_ARRAY } from '../nullObjects';
@@ -73,6 +72,8 @@ export const getFirstUnreadIdInNarrow: Selector<number | null, Narrow> = createS
   getFlags,
   getSubscriptions,
   getMute,
-  (messages, flags, subscriptions, mute) =>
-    findFirstUnread(messages, flags, subscriptions, mute)?.id ?? null,
+  (messages, flags, subscriptions, mute) => {
+    const firstUnread = messages.find(msg => !flags.read[msg.id]);
+    return firstUnread?.id ?? null;
+  },
 );

--- a/src/utils/__tests__/message-test.js
+++ b/src/utils/__tests__/message-test.js
@@ -1,4 +1,4 @@
-import { shouldBeMuted, isMessageRead, findFirstUnread } from '../message';
+import { shouldBeMuted, findFirstUnread } from '../message';
 import { HOME_NARROW, topicNarrow } from '../narrow';
 
 describe('shouldBeMuted', () => {
@@ -66,27 +66,6 @@ describe('shouldBeMuted', () => {
     const isMuted = shouldBeMuted(message, HOME_NARROW, subscriptions, mutes);
 
     expect(isMuted).toBe(true);
-  });
-});
-
-describe('isMessageRead', () => {
-  test('message with no flags entry is considered not read', () => {
-    const message = { id: 0, display_recipient: 'testStream', type: 'stream' };
-    const flags = { read: {} };
-    const subscriptions = [{ name: 'testStream', in_home_view: true }];
-
-    const result = isMessageRead(message, flags, subscriptions);
-
-    expect(result).toEqual(false);
-  });
-
-  test('message with flags entry is considered read', () => {
-    const message = { id: 123 };
-    const flags = { read: { 123: true } };
-
-    const result = isMessageRead(message, flags);
-
-    expect(result).toEqual(true);
   });
 });
 

--- a/src/utils/__tests__/message-test.js
+++ b/src/utils/__tests__/message-test.js
@@ -1,4 +1,4 @@
-import { shouldBeMuted, findFirstUnread } from '../message';
+import { shouldBeMuted } from '../message';
 import { HOME_NARROW, topicNarrow } from '../narrow';
 
 describe('shouldBeMuted', () => {
@@ -66,50 +66,5 @@ describe('shouldBeMuted', () => {
     const isMuted = shouldBeMuted(message, HOME_NARROW, subscriptions, mutes);
 
     expect(isMuted).toBe(true);
-  });
-});
-
-describe('findFirstUnread', () => {
-  test('returns first message not flagged "read"', () => {
-    const messages = [
-      { id: 0, display_recipient: 'testStream', type: 'stream' },
-      { id: 1, display_recipient: 'testStream', type: 'stream' },
-      { id: 2, display_recipient: 'testStream', type: 'stream' },
-      { id: 3, display_recipient: 'testStream', type: 'stream' },
-    ];
-    const flags = {
-      read: {
-        0: true,
-        1: true,
-      },
-    };
-    const subscriptions = [{ name: 'testStream', in_home_view: true }];
-
-    const result = findFirstUnread(messages, flags, subscriptions);
-
-    expect(result).toEqual(messages[2]);
-  });
-
-  test('if all are read return undefined', () => {
-    const messages = [{ id: 0 }, { id: 1 }, { id: 2 }];
-    const flags = {
-      read: {
-        0: true,
-        1: true,
-        2: true,
-      },
-    };
-
-    const result = findFirstUnread(messages, flags);
-
-    expect(result).toEqual(undefined);
-  });
-
-  test('if no messages returns undefined', () => {
-    const messages = [];
-
-    const result = findFirstUnread(messages);
-
-    expect(result).toEqual(undefined);
   });
 });

--- a/src/utils/__tests__/message-test.js
+++ b/src/utils/__tests__/message-test.js
@@ -88,45 +88,6 @@ describe('isMessageRead', () => {
 
     expect(result).toEqual(true);
   });
-
-  test('a message in a muted stream is considered read', () => {
-    const message = {
-      id: 0,
-      display_recipient: 'muted stream',
-      subject: 'topic',
-    };
-    const flags = { read: {} };
-    const subscriptions = [
-      {
-        name: 'muted stream',
-        in_home_view: false,
-      },
-    ];
-
-    const result = isMessageRead(message, flags, subscriptions);
-
-    expect(result).toEqual(true);
-  });
-
-  test('a message in a muted topic is considered read', () => {
-    const message = {
-      id: 0,
-      display_recipient: 'stream',
-      subject: 'muted topic',
-    };
-    const flags = { read: {} };
-    const subscriptions = [
-      {
-        name: 'stream',
-        in_home_view: false,
-      },
-    ];
-    const mute = [['stream', 'muted topic']];
-
-    const result = isMessageRead(message, flags, subscriptions, mute);
-
-    expect(result).toEqual(true);
-  });
 });
 
 describe('findFirstUnread', () => {
@@ -171,38 +132,5 @@ describe('findFirstUnread', () => {
     const result = findFirstUnread(messages);
 
     expect(result).toEqual(undefined);
-  });
-
-  test('a message in muted stream or topic is considered read', () => {
-    const messageInMutedStream = {
-      id: 0,
-      display_recipient: 'muted stream',
-      subject: 'topic',
-      type: 'stream',
-    };
-    const messageInMutedTopic = {
-      id: 1,
-      display_recipient: 'stream',
-      subject: 'muted topic',
-      type: 'stream',
-    };
-    const unreadMessage = { id: 2, display_recipient: 'stream', type: 'stream' };
-    const flags = { read: {} };
-    const messages = [messageInMutedStream, messageInMutedTopic, unreadMessage];
-    const subscriptions = [
-      {
-        name: 'stream',
-        in_home_view: true,
-      },
-      {
-        name: 'muted stream',
-        in_home_view: false,
-      },
-    ];
-    const mute = [['stream', 'muted topic']];
-
-    const result = findFirstUnread(messages, flags, subscriptions, mute);
-
-    expect(result).toEqual(unreadMessage);
   });
 });

--- a/src/utils/message.js
+++ b/src/utils/message.js
@@ -1,6 +1,6 @@
 /* @flow strict-local */
 import type { FlagsState, Narrow, Message, MuteState, Outbox, Subscription } from '../types';
-import { HOME_NARROW, isTopicNarrow } from './narrow';
+import { isTopicNarrow } from './narrow';
 
 export const isTopicMuted = (stream: string, topic: string, mute: MuteState = []): boolean =>
   mute.some(x => x[0] === stream && x[1] === topic);
@@ -34,7 +34,7 @@ export const isMessageRead = (
   flags: FlagsState,
   subscriptions: Subscription[],
   mute: MuteState,
-): boolean => shouldBeMuted(message, HOME_NARROW, subscriptions, mute) || !!flags.read[message.id];
+): boolean => !!flags.read[message.id];
 
 export const findFirstUnread = (
   messages: $ReadOnlyArray<Message | Outbox>,

--- a/src/utils/message.js
+++ b/src/utils/message.js
@@ -29,16 +29,9 @@ export const shouldBeMuted = (
   return mutes.some(x => x[0] === message.display_recipient && x[1] === message.subject);
 };
 
-export const isMessageRead = (
-  message: Message | Outbox,
-  flags: FlagsState,
-  subscriptions: Subscription[],
-  mute: MuteState,
-): boolean => !!flags.read[message.id];
-
 export const findFirstUnread = (
   messages: $ReadOnlyArray<Message | Outbox>,
   flags: FlagsState,
   subscriptions: Subscription[],
   mute: MuteState,
-) => messages.find(msg => !isMessageRead(msg, flags, subscriptions, mute));
+) => messages.find(msg => !flags.read[msg.id]);

--- a/src/utils/message.js
+++ b/src/utils/message.js
@@ -1,5 +1,5 @@
 /* @flow strict-local */
-import type { FlagsState, Narrow, Message, MuteState, Outbox, Subscription } from '../types';
+import type { Narrow, Message, MuteState, Outbox, Subscription } from '../types';
 import { isTopicNarrow } from './narrow';
 
 export const isTopicMuted = (stream: string, topic: string, mute: MuteState = []): boolean =>
@@ -28,10 +28,3 @@ export const shouldBeMuted = (
 
   return mutes.some(x => x[0] === message.display_recipient && x[1] === message.subject);
 };
-
-export const findFirstUnread = (
-  messages: $ReadOnlyArray<Message | Outbox>,
-  flags: FlagsState,
-  subscriptions: Subscription[],
-  mute: MuteState,
-) => messages.find(msg => !flags.read[msg.id]);


### PR DESCRIPTION
Please see the motivation for this at https://github.com/zulip/zulip-mobile/pull/3913#issuecomment-597910545, and in the commit message.

The second and third commits are marked [don't merge]. In removing these single-use helpers, I'm not sure whether the advantage of immediately simplifying the code (no more flipping back and forth between files, mainly) outweighs the concerns of a) losses in test coverage and b) future reusability, especially since a) the core logic of each is simple, and b) we haven't opted to reuse them since they were introduced over two years ago.