### PR TITLE
Migrate navigateToAccountDetails and getUserIsActive to user IDs

### DIFF
--- a/src/account-info/AccountDetailsScreen.js
+++ b/src/account-info/AccountDetailsScreen.js
@@ -5,7 +5,7 @@ import { StyleSheet } from 'react-native';
 import type { NavigationScreenProp } from 'react-navigation';
 import type { Dispatch, UserOrBot } from '../types';
 import { connect } from '../react-redux';
-import { getAccountDetailsUserForEmail } from '../selectors';
+import { getUserForEmail } from '../selectors';
 import { Screen, ZulipButton, Label } from '../common';
 import { IconPrivateChat } from '../common/Icons';
 import { privateNarrow } from '../utils/narrow';
@@ -71,6 +71,6 @@ class AccountDetailsScreen extends PureComponent<Props> {
 }
 
 export default connect<SelectorProps, _, _>((state, props) => ({
-  user: getAccountDetailsUserForEmail(state, props.navigation.state.params.email),
+  user: getUserForEmail(state, props.navigation.state.params.email),
   isActive: getUserIsActive(state, props.navigation.state.params.email),
 }))(AccountDetailsScreen);

--- a/src/account-info/AccountDetailsScreen.js
+++ b/src/account-info/AccountDetailsScreen.js
@@ -5,13 +5,12 @@ import { StyleSheet } from 'react-native';
 import type { NavigationScreenProp } from 'react-navigation';
 import type { Dispatch, UserOrBot } from '../types';
 import { connect } from '../react-redux';
-import { getUserForEmail } from '../selectors';
 import { Screen, ZulipButton, Label } from '../common';
 import { IconPrivateChat } from '../common/Icons';
 import { privateNarrow } from '../utils/narrow';
 import AccountDetails from './AccountDetails';
 import { doNarrow } from '../actions';
-import { getUserIsActive } from '../users/userSelectors';
+import { getUserIsActive, getUserForId } from '../users/userSelectors';
 
 const styles = StyleSheet.create({
   pmButton: {
@@ -31,7 +30,7 @@ type SelectorProps = $ReadOnly<{|
 |}>;
 
 type Props = $ReadOnly<{|
-  navigation: NavigationScreenProp<{ params: {| email: string |} }>,
+  navigation: NavigationScreenProp<{ params: {| userId: number |} }>,
 
   dispatch: Dispatch,
   ...SelectorProps,
@@ -70,7 +69,9 @@ class AccountDetailsScreen extends PureComponent<Props> {
   }
 }
 
-export default connect<SelectorProps, _, _>((state, props) => ({
-  user: getUserForEmail(state, props.navigation.state.params.email),
-  isActive: getUserIsActive(state, props.navigation.state.params.email),
-}))(AccountDetailsScreen);
+export default connect<SelectorProps, _, _>((state, props) => {
+  const { userId } = props.navigation.state.params;
+  const user: UserOrBot = getUserForId(state, userId);
+  const isActive: boolean = getUserIsActive(state, user.email);
+  return { user, isActive };
+})(AccountDetailsScreen);

--- a/src/account-info/AccountDetailsScreen.js
+++ b/src/account-info/AccountDetailsScreen.js
@@ -69,9 +69,7 @@ class AccountDetailsScreen extends PureComponent<Props> {
   }
 }
 
-export default connect<SelectorProps, _, _>((state, props) => {
-  const { userId } = props.navigation.state.params;
-  const user: UserOrBot = getUserForId(state, userId);
-  const isActive: boolean = getUserIsActive(state, user.email);
-  return { user, isActive };
-})(AccountDetailsScreen);
+export default connect<SelectorProps, _, _>((state, props) => ({
+  user: getUserForId(state, props.navigation.state.params.userId),
+  isActive: getUserIsActive(state, props.navigation.state.params.userId),
+}))(AccountDetailsScreen);

--- a/src/chat/GroupDetailsScreen.js
+++ b/src/chat/GroupDetailsScreen.js
@@ -15,8 +15,8 @@ type Props = $ReadOnly<{|
 |}>;
 
 class GroupDetailsScreen extends PureComponent<Props> {
-  handlePress = (email: string) => {
-    this.props.dispatch(navigateToAccountDetails(email));
+  handlePress = (userId: number) => {
+    this.props.dispatch(navigateToAccountDetails(userId));
   };
 
   render() {
@@ -34,7 +34,9 @@ class GroupDetailsScreen extends PureComponent<Props> {
               avatarUrl={item.avatar_url}
               email={item.email}
               showEmail
-              onPress={this.handlePress}
+              onPress={() => {
+                this.handlePress(item.user_id);
+              }}
             />
           )}
         />

--- a/src/nav/navActions.js
+++ b/src/nav/navActions.js
@@ -44,8 +44,8 @@ export const navigateToPassword = (requireEmailFormat: boolean): NavigationActio
 export const navigateToAccountPicker = (): NavigationAction =>
   StackActions.push({ routeName: 'account' });
 
-export const navigateToAccountDetails = (email: string): NavigationAction =>
-  StackActions.push({ routeName: 'account-details', params: { email } });
+export const navigateToAccountDetails = (userId: number): NavigationAction =>
+  StackActions.push({ routeName: 'account-details', params: { userId } });
 
 export const navigateToGroupDetails = (recipients: UserOrBot[]): NavigationAction =>
   StackActions.push({ routeName: 'group-details', params: { recipients } });

--- a/src/reactions/ReactionUserList.js
+++ b/src/reactions/ReactionUserList.js
@@ -19,9 +19,9 @@ type Props = $ReadOnly<{|
  * Used within `MessageReactionList`.
  */
 class ReactionUserList extends PureComponent<Props> {
-  handlePress = (email: string) => {
+  handlePress = (userId: number) => {
     const { dispatch } = this.props;
-    dispatch(navigateToAccountDetails(email));
+    dispatch(navigateToAccountDetails(userId));
   };
 
   render() {
@@ -43,7 +43,9 @@ class ReactionUserList extends PureComponent<Props> {
               avatarUrl={user.avatar_url}
               email={user.email}
               showEmail
-              onPress={this.handlePress}
+              onPress={() => {
+                this.handlePress(user.user_id);
+              }}
             />
           );
         }}

--- a/src/title-buttons/InfoNavButtonPrivate.js
+++ b/src/title-buttons/InfoNavButtonPrivate.js
@@ -6,17 +6,23 @@ import type { Dispatch, Narrow } from '../types';
 import { connect } from '../react-redux';
 import NavButton from '../nav/NavButton';
 import { navigateToAccountDetails } from '../actions';
+import { getUserForEmail } from '../users/userSelectors';
+
+type SelectorProps = $ReadOnly<{|
+  userId: number,
+|}>;
 
 type Props = $ReadOnly<{|
   dispatch: Dispatch,
   narrow: Narrow,
   color: string,
+  ...SelectorProps,
 |}>;
 
 class InfoNavButtonPrivate extends PureComponent<Props> {
   handlePress = () => {
-    const { dispatch, narrow } = this.props;
-    dispatch(navigateToAccountDetails(narrow[0].operand));
+    const { dispatch, userId } = this.props;
+    dispatch(navigateToAccountDetails(userId));
   };
 
   render() {
@@ -26,4 +32,6 @@ class InfoNavButtonPrivate extends PureComponent<Props> {
   }
 }
 
-export default connect()(InfoNavButtonPrivate);
+export default connect<SelectorProps, _, _>((state, props) => ({
+  userId: getUserForEmail(state, props.narrow[0].operand).user_id,
+}))(InfoNavButtonPrivate);

--- a/src/title/TitleGroup.js
+++ b/src/title/TitleGroup.js
@@ -24,7 +24,7 @@ type Props = $ReadOnly<{|
 class TitleGroup extends PureComponent<Props> {
   handlePress = (user: UserOrBot) => {
     const { dispatch } = this.props;
-    dispatch(navigateToAccountDetails(user.email));
+    dispatch(navigateToAccountDetails(user.user_id));
   };
 
   styles = StyleSheet.create({

--- a/src/title/TitlePrivate.js
+++ b/src/title/TitlePrivate.js
@@ -30,7 +30,7 @@ class TitlePrivate extends PureComponent<Props> {
     if (!user) {
       return;
     }
-    dispatch(navigateToAccountDetails(user.email));
+    dispatch(navigateToAccountDetails(user.user_id));
   };
 
   styles = StyleSheet.create({

--- a/src/users/__tests__/userSelectors-test.js
+++ b/src/users/__tests__/userSelectors-test.js
@@ -6,6 +6,7 @@ import {
   getAllUsersById,
   getUsersById,
   getUsersSansMe,
+  getUserForId,
   getUserIsActive,
 } from '../userSelectors';
 import * as eg from '../../__tests__/exampleData';
@@ -123,6 +124,33 @@ describe('getUsersSansMe', () => {
       realm: eg.realmState({ email: eg.selfUser.email }),
     });
     expect(getUsersSansMe(state)).toEqual([eg.otherUser]);
+  });
+});
+
+describe('getUserForId', () => {
+  const state = eg.reduxState({
+    users: [eg.selfUser],
+    realm: {
+      ...eg.baseReduxState.realm,
+      crossRealmBots: [eg.crossRealmBot],
+      nonActiveUsers: [eg.makeUser(), eg.makeUser()],
+    },
+  });
+
+  test('returns the user if it has not been deactivated', () => {
+    expect(getUserForId(state, state.users[0].user_id)).toEqual(state.users[0]);
+  });
+
+  test('returns the user if it has been deactivated', () => {
+    expect(getUserForId(state, state.realm.nonActiveUsers[0].user_id)).toEqual(
+      state.realm.nonActiveUsers[0],
+    );
+  });
+
+  test('returns the user if it is a cross realm bot', () => {
+    expect(getUserForId(state, state.realm.crossRealmBots[0].user_id)).toEqual(
+      state.realm.crossRealmBots[0],
+    );
   });
 });
 

--- a/src/users/__tests__/userSelectors-test.js
+++ b/src/users/__tests__/userSelectors-test.js
@@ -7,6 +7,7 @@ import {
   getUsersById,
   getUsersSansMe,
   getUserForId,
+  getUserForEmail,
   getUserIsActive,
 } from '../userSelectors';
 import * as eg from '../../__tests__/exampleData';
@@ -149,6 +150,33 @@ describe('getUserForId', () => {
 
   test('returns the user if it is a cross realm bot', () => {
     expect(getUserForId(state, state.realm.crossRealmBots[0].user_id)).toEqual(
+      state.realm.crossRealmBots[0],
+    );
+  });
+});
+
+describe('getUserForEmail', () => {
+  const state = eg.reduxState({
+    users: [eg.selfUser],
+    realm: {
+      ...eg.baseReduxState.realm,
+      crossRealmBots: [eg.crossRealmBot],
+      nonActiveUsers: [eg.makeUser(), eg.makeUser()],
+    },
+  });
+
+  test('returns the user if it has not been deactivated', () => {
+    expect(getUserForEmail(state, state.users[0].email)).toEqual(state.users[0]);
+  });
+
+  test('returns the user if it has been deactivated', () => {
+    expect(getUserForEmail(state, state.realm.nonActiveUsers[0].email)).toEqual(
+      state.realm.nonActiveUsers[0],
+    );
+  });
+
+  test('returns the user if it is a cross realm bot', () => {
+    expect(getUserForEmail(state, state.realm.crossRealmBots[0].email)).toEqual(
       state.realm.crossRealmBots[0],
     );
   });

--- a/src/users/__tests__/userSelectors-test.js
+++ b/src/users/__tests__/userSelectors-test.js
@@ -1,6 +1,5 @@
 /* @flow strict-local */
 import {
-  getAccountDetailsUserForEmail,
   getActiveUsersByEmail,
   getAllUsersByEmail,
   getAllUsersById,
@@ -11,28 +10,6 @@ import {
   getUserIsActive,
 } from '../userSelectors';
 import * as eg from '../../__tests__/exampleData';
-
-describe('getAccountDetailsUserForEmail', () => {
-  test('return user for the account details screen', () => {
-    const state = eg.reduxState({
-      users: [eg.selfUser, eg.otherUser],
-    });
-    expect(getAccountDetailsUserForEmail(state, eg.otherUser.email)).toEqual(eg.otherUser);
-  });
-
-  test('if user does not exist return a user with the same email and no details', () => {
-    const state = eg.reduxState();
-    expect(getAccountDetailsUserForEmail(state, 'b@a.com')).toEqual({
-      email: 'b@a.com',
-      full_name: 'b@a.com',
-      avatar_url: '',
-      timezone: '',
-      user_id: -1,
-      is_admin: false,
-      is_bot: false,
-    });
-  });
-});
 
 describe('getActiveUsers', () => {
   test('return users, bots, map by email and do not include inactive users', () => {

--- a/src/users/__tests__/userSelectors-test.js
+++ b/src/users/__tests__/userSelectors-test.js
@@ -170,14 +170,14 @@ describe('getUserIsActive', () => {
   });
 
   test('returns false for a user that has been deactivated', () => {
-    expect(getUserIsActive(state, state.realm.nonActiveUsers[0].email)).toBeFalse();
+    expect(getUserIsActive(state, state.realm.nonActiveUsers[0].user_id)).toBeFalse();
   });
 
   test('returns true for a user that has not been deactivated', () => {
-    expect(getUserIsActive(state, state.users[0].email)).toBeTrue();
+    expect(getUserIsActive(state, state.users[0].user_id)).toBeTrue();
   });
 
   test('returns true for a cross realm bot', () => {
-    expect(getUserIsActive(state, state.realm.crossRealmBots[0].email)).toBeTrue();
+    expect(getUserIsActive(state, state.realm.crossRealmBots[0].user_id)).toBeTrue();
   });
 });

--- a/src/users/userSelectors.js
+++ b/src/users/userSelectors.js
@@ -206,6 +206,23 @@ export const getUserForId = (state: GlobalState, userId: number): UserOrBot => {
 };
 
 /**
+ * The user with the given email.
+ *
+ * In particular, returns the user for:
+ * * i) cross-realm bots
+ * * ii) deactivated users (`is_active` false; see `User` and the linked docs)
+ *
+ * Throws if none exists for the given email.
+ */
+export const getUserForEmail = (state: GlobalState, email: string): UserOrBot => {
+  const user = getAllUsersByEmail(state).get(email);
+  if (!user) {
+    throw new Error(`getUserForEmail: missing user: email ${email}`);
+  }
+  return user;
+};
+
+/**
  * The value of `is_active` for the given user.
  *
  * For a normal user, this is true unless the user or an admin has

--- a/src/users/userSelectors.js
+++ b/src/users/userSelectors.js
@@ -41,7 +41,12 @@ export const getAllUsersById: Selector<Map<number, UserOrBot>> = createSelector(
   allUsers => new Map(allUsers.map(user => [user.user_id, user])),
 );
 
-/** See `getAllUsers` for discussion. */
+/**
+ * See `getAllUsers` for discussion.
+ *
+ * Prefer `getAllUsersById`; see #3764.
+ *
+ */
 export const getAllUsersByEmail: Selector<Map<string, UserOrBot>> = createSelector(
   getAllUsers,
   allUsers => new Map(allUsers.map(user => [user.email, user])),
@@ -59,6 +64,8 @@ export const getUsersById: Selector<Map<number, User>> = createSelector(
 
 /**
  * WARNING: despite the name, only (a) `is_active` users (b) excluding cross-realm bots.
+ *
+ * Prefer `getUsersById`; see #3764.
  *
  * See `getAllUsersByEmail`, and `getAllUsers` for discussion.
  */
@@ -102,7 +109,7 @@ export const getOwnUserId = (state: GlobalState): number => {
  *
  * Throws if we have no data from the server.
  *
- * See also `getOwnUserId` and `getOwnUser`.
+ * Prefer using `getOwnUserId` or `getOwnUser`; see #3764.
  */
 export const getOwnEmail = (state: GlobalState): string => {
   const { email } = state.realm;
@@ -153,7 +160,11 @@ export const getUsersSansMe: Selector<User[]> = createSelector(
   (users, ownEmail) => users.filter(user => user.email !== ownEmail),
 );
 
-/** Excludes deactivated users.  See `getAllUsers` for discussion. */
+/**
+ * Excludes deactivated users.  See `getAllUsers` for discussion.
+ *
+ * Prefer `getActiveUsersById`; see #3764.
+ */
 export const getActiveUsersByEmail: Selector<Map<string, UserOrBot>> = createSelector(
   getUsers,
   getCrossRealmBots,
@@ -187,6 +198,8 @@ export const getUserForId = (state: GlobalState, userId: number): UserOrBot => {
 
 /**
  * The user with the given email.
+ *
+ * Prefer `getUserForId` where a user ID is available; see #3764.
  *
  * This works for any user in this Zulip org/realm, including deactivated
  * users and cross-realm bots.  See `getAllUsers` for details.

--- a/src/users/userSelectors.js
+++ b/src/users/userSelectors.js
@@ -214,9 +214,5 @@ export const getUserForEmail = (state: GlobalState, email: string): UserOrBot =>
  */
 // To understand this implementation, see the comment about `is_active` in
 // the `User` type definition.
-export const getUserIsActive = (state: GlobalState, email: string): boolean => {
-  if (!email) {
-    return false;
-  }
-  return getActiveUsersByEmail(state).has(email);
-};
+export const getUserIsActive = (state: GlobalState, userId: number): boolean =>
+  !!getActiveUsersById(state).get(userId);

--- a/src/users/userSelectors.js
+++ b/src/users/userSelectors.js
@@ -161,6 +161,14 @@ export const getActiveUsersByEmail: Selector<Map<string, UserOrBot>> = createSel
     new Map([...users, ...crossRealmBots].map(user => [user.email, user])),
 );
 
+/** Excludes deactivated users.  See `getAllUsers` for discussion. */
+export const getActiveUsersById: Selector<Map<number, UserOrBot>> = createSelector(
+  getUsers,
+  getCrossRealmBots,
+  (users = [], crossRealmBots = []) =>
+    new Map([...users, ...crossRealmBots].map(user => [user.user_id, user])),
+);
+
 /**
  * The user with the given user ID.
  *

--- a/src/users/userSelectors.js
+++ b/src/users/userSelectors.js
@@ -201,14 +201,9 @@ export const getAccountDetailsUserForEmail: Selector<UserOrBot, string> = create
  */
 // To understand this implementation, see the comment about `is_active` in
 // the `User` type definition.
-export const getUserIsActive: Selector<boolean, string> = createSelector(
-  (state, email) => email,
-  state => getActiveUsersByEmail(state),
-  (email, usersByEmail) => {
-    if (!email) {
-      return false;
-    } else {
-      return usersByEmail.has(email);
-    }
-  },
-);
+export const getUserIsActive = (state: GlobalState, email: string): boolean => {
+  if (!email) {
+    return false;
+  }
+  return getActiveUsersByEmail(state).has(email);
+};

--- a/src/users/userSelectors.js
+++ b/src/users/userSelectors.js
@@ -189,13 +189,12 @@ export const getAccountDetailsUserForEmail: Selector<UserOrBot, string> = create
 );
 
 /**
- * The user with the given user Id.
+ * The user with the given user ID.
  *
- * In particular, returns the user for:
- * * i) cross-realm bots
- * * ii) deactivated users (`is_active` false; see `User` and the linked docs)
+ * This works for any user in this Zulip org/realm, including deactivated
+ * users and cross-realm bots.  See `getAllUsers` for details.
  *
- * Throws if none exists for the given ID.
+ * Throws if no such user exists.
  */
 export const getUserForId = (state: GlobalState, userId: number): UserOrBot => {
   const user = getAllUsersById(state).get(userId);
@@ -208,11 +207,10 @@ export const getUserForId = (state: GlobalState, userId: number): UserOrBot => {
 /**
  * The user with the given email.
  *
- * In particular, returns the user for:
- * * i) cross-realm bots
- * * ii) deactivated users (`is_active` false; see `User` and the linked docs)
+ * This works for any user in this Zulip org/realm, including deactivated
+ * users and cross-realm bots.  See `getAllUsers` for details.
  *
- * Throws if none exists for the given email.
+ * Throws if no such user exists.
  */
 export const getUserForEmail = (state: GlobalState, email: string): UserOrBot => {
   const user = getAllUsersByEmail(state).get(email);

--- a/src/users/userSelectors.js
+++ b/src/users/userSelectors.js
@@ -189,6 +189,23 @@ export const getAccountDetailsUserForEmail: Selector<UserOrBot, string> = create
 );
 
 /**
+ * The user with the given user Id.
+ *
+ * In particular, returns the user for:
+ * * i) cross-realm bots
+ * * ii) deactivated users (`is_active` false; see `User` and the linked docs)
+ *
+ * Throws if none exists for the given ID.
+ */
+export const getUserForId = (state: GlobalState, userId: number): UserOrBot => {
+  const user = getAllUsersById(state).get(userId);
+  if (!user) {
+    throw new Error(`getUserForId: missing user: id ${userId}`);
+  }
+  return user;
+};
+
+/**
  * The value of `is_active` for the given user.
  *
  * For a normal user, this is true unless the user or an admin has

--- a/src/users/userSelectors.js
+++ b/src/users/userSelectors.js
@@ -162,33 +162,6 @@ export const getActiveUsersByEmail: Selector<Map<string, UserOrBot>> = createSel
 );
 
 /**
- * DEPRECATED; don't add new uses.  Generally, use `getAllUsersByEmail` instead.
- *
- * (Better yet, use `getAllUsersById`; see #3764.)
- *
- * PRs to eliminate the remaining use of this are welcome.
- *
- * For discussion, see `nullObjects.js`.
- */
-export const getAccountDetailsUserForEmail: Selector<UserOrBot, string> = createSelector(
-  (state, email) => email,
-  state => getAllUsersByEmail(state),
-  (email, allUsersByEmail) => {
-    if (!email) {
-      return NULL_USER;
-    }
-
-    return (
-      allUsersByEmail.get(email) || {
-        ...NULL_USER,
-        email,
-        full_name: email,
-      }
-    );
-  },
-);
-
-/**
  * The user with the given user ID.
  *
  * This works for any user in this Zulip org/realm, including deactivated

--- a/src/webview/html/messageAsHtml.js
+++ b/src/webview/html/messageAsHtml.js
@@ -116,7 +116,8 @@ $!${divOpenHtml}
 `;
   }
 
-  const { sender_full_name, sender_email } = message;
+  const { sender_full_name } = message;
+  const sender_id = message.isOutbox ? backgroundData.ownUser.user_id : message.sender_id;
   const avatarUrl = getAvatarFromMessage(message, backgroundData.auth.realm);
   const subheaderHtml = template`
 <div class="subheader">
@@ -130,7 +131,7 @@ $!${divOpenHtml}
   return template`
 $!${divOpenHtml}
   <div class="avatar">
-    <img src="${avatarUrl}" alt="${sender_full_name}" class="avatar-img" data-email="${sender_email}">
+    <img src="${avatarUrl}" alt="${sender_full_name}" class="avatar-img" data-sender-id="${sender_id}">
   </div>
   <div class="content">
     $!${subheaderHtml}

--- a/src/webview/html/messageTypingAsHtml.js
+++ b/src/webview/html/messageTypingAsHtml.js
@@ -7,7 +7,7 @@ const typingAvatar = (realm: string, user: User): string => template`
 <div class="avatar">
   <img
     class="avatar-img"
-    data-email="${user.email}"
+    data-sender-id="${user.user_id}"
     src="${getAvatarFromUser(user, realm)}">
 </div>
 `;

--- a/src/webview/js/generatedEs3.js
+++ b/src/webview/js/generatedEs3.js
@@ -514,7 +514,7 @@ var compiledWebviewJs = (function (exports) {
     if (target.matches('.avatar-img')) {
       sendMessage({
         type: 'avatar',
-        fromEmail: requireAttribute(target, 'data-email')
+        fromUserId: requireAttribute(target, 'data-sender-id')
       });
       return;
     }

--- a/src/webview/js/js.js
+++ b/src/webview/js/js.js
@@ -629,7 +629,7 @@ documentBody.addEventListener('click', (e: MouseEvent) => {
   if (target.matches('.avatar-img')) {
     sendMessage({
       type: 'avatar',
-      fromEmail: requireAttribute(target, 'data-email'),
+      fromUserId: requireAttribute(target, 'data-sender-id'),
     });
     return;
   }

--- a/src/webview/webViewEventHandlers.js
+++ b/src/webview/webViewEventHandlers.js
@@ -51,7 +51,7 @@ type MessageListEventScroll = {|
 
 type MessageListEventAvatar = {|
   type: 'avatar',
-  fromEmail: string,
+  fromUserId: string,
 |};
 
 type MessageListEventNarrow = {|
@@ -199,9 +199,14 @@ export const handleMessageListEvent = (props: Props, _: GetText, event: MessageL
       markRead(props, event);
       break;
 
-    case 'avatar':
-      props.dispatch(navigateToAccountDetails(event.fromEmail));
+    case 'avatar': {
+      const userId = parseInt(event.fromUserId, 10);
+      if (Number.isNaN(userId)) {
+        throw new Error(`Failed to parse fromUserId string '${event.fromUserId}' to integer`);
+      }
+      props.dispatch(navigateToAccountDetails(userId));
       break;
+    }
 
     case 'narrow':
       props.dispatch(doNarrow(parseNarrowString(event.narrow)));


### PR DESCRIPTION
This is a rough initial PR. Feedback is appreciated. This was done to make pull #3878 mergeable, as per https://github.com/zulip/zulip-mobile/pull/3878#issuecomment-589911019.

This PR will partially address https://github.com/zulip/zulip-mobile/issues/3764.