### PR TITLE
prettier: use Babylon (babel-flow) as the parser

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,6 +1,6 @@
 {
   "printWidth": 100,
-  "parser": "flow",
+  "parser": "babel-flow",
   "singleQuote": true,
   "trailingComma": "all",
 }


### PR DESCRIPTION
The `babel-flow` and `flow` parsers produce subtly different ASTs, and Prettier's support for the latter is relatively poor.

In particular, when using the `flow` parser:
  * ~~prettier/prettier#&zwj;5288: the private field sigil `#` is stripped.~~ *(Resolved.)*
  * prettier/prettier#2597: type-declaration comments are promoted to inline type declarations.

This commit will enable some simple uses of private fields, but not all. See our commit 86a42582aace1b13f1e250b0a34835866b794e4a and its associated PR (#3725) for more detail.

The more important fix (and the one that can't be obtained by updating Prettier, at least not yet) is the second. This will allow us to rely on Flow's typechecking in scripts which will be executed directly by Node without a preliminary Babel run -- e.g., scripts residing in `tools/`, or plugins for support tools such as Jest or ESLint.