### PR TITLE
Block imports of files via a whitelist

### DIFF
--- a/.eslintplugin/index.js
+++ b/.eslintplugin/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+  rules: {},
+};

--- a/.eslintplugin/index.js
+++ b/.eslintplugin/index.js
@@ -1,3 +1,5 @@
 module.exports = {
-  rules: {},
+  rules: {
+    'zulip-disallow-imports': require('./zulip-disallow-imports'),
+  },
 };

--- a/.eslintplugin/zulip-disallow-imports.js
+++ b/.eslintplugin/zulip-disallow-imports.js
@@ -1,0 +1,379 @@
+/* @flow strict-local */
+
+// This is an almost complete rewrite of ESLint's `no-restricted-imports` rule.
+//
+// At present, this is not a full replacement for all uses of that rule:
+// `no-restricted-imports` allows blacklisting patterns of identifiers as well.
+// This has not been reimplemented, but the facilities used by the original to
+// do so have been left in place, in expectation of future requirements.
+//
+// The original is available at:
+//
+//   github.com/eslint/eslint/blob/0243549db4/lib/rules/no-restricted-imports.js
+
+'use strict';
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+// $FlowFixMe: `ignore` has no flow-typed typedef file
+const ignore = require('ignore');
+
+// from node.js; Flow provides these types in core
+const path = require('path');
+
+/**
+ * Trivial wrapper around `ignore` library. Partly this is for type-checking,
+ * but mostly it's because "ignores" is a terrible way to spell "matches".
+ */
+class Matcher {
+  /*:: _ignore; */
+  constructor(items /*: $ReadOnlyArray<string>*/) {
+    this._ignore = ignore().add(items);
+  }
+  matches(s /*: string*/) /*: boolean*/ {
+    return this._ignore.ignores(s);
+  }
+}
+
+/* ::
+
+/**
+ * Type of the options we receive from the .eslintrc file.
+ *
+ * The .eslintrc file may specify any number of these rules; each is considered
+ * independently, and may forbid an import independently of the others.
+ *-/
+type OptionsRecord = $ReadOnly<{|
+  /**
+   * patterns: A .gitignore-style pattern set describing the set of restricted
+   *   files. These files cannot be imported, unless the import is explicitly
+   *   allowed by another rule in this options-set, *and* not explicitly
+   *   disallowed by any.
+   *-/
+  patterns: $ReadOnlyArray<string>,
+
+  /**
+   * importerWhitelist: A .gitignore-style pattern set describing the set of
+   *   files which may import from a restricted file.
+   *
+   * If this option is specified, it is total: no other files may perform
+   *   an import. If omitted, it has no effect.
+   *
+   * This can be used as a blacklist by explicitly allowing all files, then
+   *   revoking permissions on certain files with !-prefixed rules. See the
+   *   Git documentation on .gitignore [0] for details.
+   *
+   * [0] https://git-scm.com/docs/gitignore#_pattern_format
+   *-/
+  importerWhitelist?: $ReadOnlyArray<string>,
+
+  // Regexes. Not yet implemented.
+  identifierWhitelist?: $ReadOnlyArray<string>,
+  identifierBlacklist?: $ReadOnlyArray<string>,
+
+  // Just a human-readable string.
+  message?: string,
+|}>;
+
+/**
+ * Type of a check function.
+ *
+ * A check function's responsibility is to report, as a side effect, whether a
+ * given import is legal. The parameters are based on those provided by the
+ * original scaffolding taken from ESLint's `no-restricted-imports` rule.
+ *
+ * The current filename (that is, the filename of the _importing_ file) is not
+ * currently provided as a parameter; instead it's assumed to be available in
+ * the local environment.
+ *
+ * @param {importedFile} The file being imported from.
+ * @param {importedIdsMap} A map containing all imported identifiers, or '*' if
+ *   that was imported.
+ * @param {node} The AST node of the import statement being checked.
+ *-/
+type CheckFunction = (
+  importedFile: string,
+  importedIdsMap: Map<string, mixed[]>,
+  node: $FlowFixMe,
+) => void;
+*/
+
+/**
+ * Distinguished trivial check-function.
+ *
+ * Used to explicitly identify checks that don't need to be performed.
+ */
+const DO_NOTHING /*: CheckFunction*/ = (importedFile, importedIdsMap, node) => {};
+
+/**
+ * Basic set of error messages.
+ *
+ * These error messages also have automatically-generated versions with a
+ * trailing `{{customMessage}}`; see `messages`, below.
+ */
+const baseMessages = {
+  fileImport: "'{{importee}}' may not be imported.",
+  fileWhitelist: "'{{importer}}' may not import '{{importee}}' (not whitelisted).",
+  fileBlacklist: "'{{importer}}' may not import '{{importee}}' (blacklisted).",
+};
+
+/*:: type MessageID = $Keys<typeof baseMessages>; */
+
+// Ponyfill for object.fromEntries.
+const objectFromEntries = (arr /*: $ReadOnlyArray<[string, string]>*/) =>
+  arr.reduce((obj, [key, val]) => {
+    obj[key] = val;
+    return obj;
+  }, {});
+
+/** Full set of error messages. */
+const messages = {
+  // without custom message
+  ...baseMessages,
+  // with custom message
+  ...objectFromEntries(
+    Object.entries(baseMessages).map(([key, val]) => [
+      key + '-custom',
+      // $FlowFixMe: Object.entries returns [string, mixed][] even for exact types
+      val + '{{customMessage}}',
+    ]),
+  ),
+};
+
+module.exports = {
+  meta: {
+    type: 'problem',
+
+    docs: {
+      description: 'disallow imports of files from other files',
+      category: 'ECMAScript 6',
+      recommended: false,
+    },
+
+    messages: messages,
+
+    schema: {
+      /* ===== Schema definitions ======================================== */
+      definitions: {
+        /** Convenience alias. */
+        arrayOfStrings: {
+          type: 'array',
+          items: { type: 'string' },
+          uniqueItems: true,
+        },
+
+        /** This should match the Flow type `OptionsRecord`, above. */
+        OptionsRecord: {
+          type: 'object',
+          properties: {
+            patterns: { $ref: '#/definitions/arrayOfStrings' },
+            importerWhitelist: { $ref: '#/definitions/arrayOfStrings' },
+            /* not yet implemented! */
+            // identifierWhitelist: { $ref: '#/definitions/arrayOfStrings' },
+            // identifierBlacklist: { $ref: '#/definitions/arrayOfStrings' },
+            message: { type: 'string' },
+          },
+          additionalProperties: false,
+          required: ['patterns'],
+        },
+      },
+
+      /* ===== Schema: `OptionsRecord[]` ================================= */
+      type: 'array',
+      items: [{ $ref: '#/definitions/OptionsRecord' }],
+    },
+  },
+
+  /**
+   * Rule entry point.
+   *
+   * https://eslint.org/docs/developer-guide/working-with-rules#rule-basics
+   */
+  create(context /*: $FlowFixMe */) {
+    const sourceCode = context.getSourceCode();
+
+    const sourceFile /*: string */ = path.relative(process.cwd(), context.getFilename());
+
+    const options /*: $ReadOnlyArray<OptionsRecord> */ = context.options || [];
+
+    /**
+     * Given a message name and a custom message, create a reporter function.
+     *
+     * A reporter function is a kind of check-function which always reports.
+     * Reporting is complicated by the need to use the `context.report` API,
+     * which requires the caller to have an explicitly-enumerated selection of
+     * messages for internationalization purposes.
+     */
+    const makeReporter = (
+      messageName /*: MessageID */,
+      customMessage /*: string | void */,
+    ) /*: CheckFunction */ => {
+      const messageId = customMessage === undefined ? messageName : messageName + '-custom';
+
+      return (importedFile, importedIdsMap, node) => {
+        context.report({
+          node,
+          messageId,
+          data: {
+            importer: sourceFile,
+            importee: importedFile,
+            customMessage, // (OK even if undef)
+          },
+        });
+      };
+    };
+
+    /**
+     * Given a .gitignore-style pattern-set, return a check-function that
+     * reports if the imported file is present within it.
+     */
+    const makePatternOnlyCheck = (patterns /*: Matcher*/, customMessage) /*: CheckFunction*/ => {
+      const report = makeReporter('fileImport', customMessage);
+      return (importedFile, importedIdsMap, node) => {
+        if (patterns.matches(importedFile)) {
+          report(importedFile, importedIdsMap, node);
+        }
+      };
+    };
+
+    /**
+     * Given a .gitignore-style list, return a check-function that reports
+     * if the current source file's path is present/absent, as desired.
+     *
+     * Underlying implementation function.
+     */
+    const makeImporterListCheck = (
+      importerList /*: $ReadOnlyArray<string> | void */,
+      shouldBePresent /*: boolean */,
+      messageName /*: MessageID */,
+      customMessage /*: string | void */,
+    ) /*: CheckFunction */ => {
+      if (!importerList) return DO_NOTHING;
+
+      // As it happens, we can always evaluate this condition ahead of time.
+      const isPresent = ignore()
+        .add(importerList)
+        .ignores(sourceFile);
+      return isPresent === shouldBePresent ? DO_NOTHING : makeReporter(messageName, customMessage);
+    };
+
+    /**
+     * Given a .gitignore-style whitelist, return a check-function that reports
+     * if the current source file's path is within it.
+     */
+    const makeImporterWhitelistCheck = (
+      importerWhitelist /*: $ReadOnlyArray<string> | void */,
+      customMessage /*: string | void */,
+    ) /*: CheckFunction */ => {
+      return makeImporterListCheck(importerWhitelist, true, 'fileWhitelist', customMessage);
+    };
+
+    /**
+     * Sequence of all check-functions for all OptionRecords.
+     */
+    const allChecks /*: $ReadOnlyArray<CheckFunction> */ = options
+      .map(record => {
+        const { patterns } = record;
+        if (patterns.length == 0) return DO_NOTHING;
+
+        const patternsMatcher = new Matcher(patterns);
+
+        const {
+          message: customMessage,
+          importerWhitelist,
+          // identifierWhitelist,
+          // identifierBlacklist,
+        } = record;
+
+        // If no permission-rules are specified, the pattern-specification is
+        // absolute.
+        if (
+          !importerWhitelist // &&
+          // !identifierWhitelist &&
+          // !identifierBlacklist
+        ) {
+          // patterns only
+          return makePatternOnlyCheck(patternsMatcher, customMessage);
+        }
+
+        // Check function: is this file explicitly allowed to import from here?
+        const fileWhitelistCheck = makeImporterWhitelistCheck(
+          record.importerWhitelist,
+          record.message,
+        );
+
+        // All check functions for this record.
+        const checks = [
+          fileWhitelistCheck,
+          // idWhitelistCheck,
+          // idBlacklistCheck,
+        ].filter(f => f !== DO_NOTHING);
+        if (checks.length === 0) return DO_NOTHING;
+
+        return (importedFile, importedIdsMap, node) => {
+          if (patternsMatcher.matches(importedFile)) {
+            checks.forEach(f => f(importedFile, importedIdsMap, node));
+          }
+        };
+      })
+      .filter(f => f !== DO_NOTHING);
+
+    /**
+     * Checks a node to see if any problems should be reported.
+     * @param {ASTNode} node The node to check.
+     * @returns {void}
+     * @private
+     */
+    // Taken from the original ESLint `no-restricted-imports` rule.
+    function checkNode(node /*: $FlowFixMe */) {
+      const importSource = node.source.value.trim();
+      const importNames /*: Map<string, mixed[]> */ = new Map();
+
+      if (node.type === 'ExportAllDeclaration') {
+        const starToken = sourceCode.getFirstToken(node, 1);
+
+        importNames.set('*', [{ loc: starToken.loc }]);
+      } else if (node.specifiers) {
+        for (const specifier of node.specifiers) {
+          let name;
+          const specifierData = { loc: specifier.loc };
+
+          if (specifier.type === 'ImportDefaultSpecifier') {
+            name = 'default';
+          } else if (specifier.type === 'ImportNamespaceSpecifier') {
+            name = '*';
+          } else if (specifier.imported) {
+            name = specifier.imported.name;
+          } else if (specifier.local) {
+            name = specifier.local.name;
+          }
+
+          if (name) {
+            if (importNames.has(name)) {
+              // $FlowFixMe upsert
+              importNames.get(name).push(specifierData);
+            } else {
+              importNames.set(name, [specifierData]);
+            }
+          }
+        }
+      }
+
+      const importedFile = path.relative(process.cwd(), path.resolve(sourceFile, importSource));
+
+      allChecks.forEach(f => f(importedFile, importNames, node));
+    }
+
+    return {
+      ImportDeclaration: checkNode,
+      ExportNamedDeclaration(node /*: $FlowFixMe*/) {
+        if (node.source) {
+          checkNode(node);
+        }
+      },
+      ExportAllDeclaration: checkNode,
+    };
+  },
+};

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -9,6 +9,7 @@ plugins:
  - jest
  - flowtype
  # - react-native  # see commented-out rules config below
+ - local
 
 env:
   browser: true
@@ -81,9 +82,11 @@ rules:
   import/no-extraneous-dependencies:
   - error
   - devDependencies: ['**/__tests__/**/*.js', tools/**]
-  no-restricted-imports:
+  local/zulip-disallow-imports:
   - error
   - patterns: ['**/__tests__/**']
+    importerWhitelist: ['**/__tests__/**']
+    # message: "non-test files can't import test files"
   import/no-cycle: off  # This would be nice to fix; but isn't easy.
 
   # Jest
@@ -179,8 +182,3 @@ overrides:
         # [2]: https://github.com/tc39/proposals/commit/cb9c6e50
 
     no-with: error
-
-# Test file overrides
-- files: ['**/__tests__/**']
-  rules:
-    no-restricted-imports: off

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "flow-bin": "^0.92.0",
     "flow-coverage-report": "^0.6.0",
     "flow-typed": "^2.4.0",
+    "ignore": "^5.1.4",
     "jest": "^24.9.0",
     "jest-cli": "^24.9.0",
     "jest-environment-jsdom": "^24.9.0",

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "eslint-plugin-import": "^2.18.1",
     "eslint-plugin-jest": "^22.11.1",
     "eslint-plugin-jsx-a11y": "^6.2.3",
+    "eslint-plugin-local": "^1.0.0",
     "eslint-plugin-prettier": "^3.1.0",
     "eslint-plugin-react": "^7.14.2",
     "eslint-plugin-spellcheck": "0.0.14",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4559,10 +4559,10 @@ ignore@^4.0.6:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
 
-ignore@^5.1.2:
-  version "5.1.2"
-  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.2.tgz#e28e584d43ad7e92f96995019cc43b9e1ac49558"
-  integrity sha512-vdqWBp7MyzdmHkkRWV5nY+PfGRbYbahfuvsBCh277tq+w9zyNi7h5CYJCK0kmzti9kU+O/cB7sE8HvKv6aXAKQ==
+ignore@^5.1.2, ignore@^5.1.4:
+  version "5.1.4"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.4.tgz#84b7b3dbe64552b6ef0eca99f6743dbec6d97adf"
+  integrity sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==
 
 image-size@^0.6.0:
   version "0.6.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3337,6 +3337,11 @@ eslint-plugin-jsx-a11y@^6.2.3:
     has "^1.0.3"
     jsx-ast-utils "^2.2.1"
 
+eslint-plugin-local@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-local/-/eslint-plugin-local-1.0.0.tgz#f0c07011c95fec42bfb4d909debb6ea035f3b2a4"
+  integrity sha1-8MBwEclf7EK/tNkJ3rtuoDXzsqQ=
+
 eslint-plugin-prettier@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.0.tgz#8695188f95daa93b0dc54b249347ca3b79c4686d"


### PR DESCRIPTION
Add and use a custom ESLint plugin to prevent certain files from being imported unless they're on a whitelist.

This also sets up a minimal framework for other custom ESLint rules.