### PR TITLE
eslint [nfc]: Give comments more room to breathe; regularize indentation.

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -112,8 +112,6 @@ rules:
 
   camelcase: off
 
-  no-await-in-loop: off # Promise.all is not always desirable
-
   # Permit dangling underscores in class property names, to denote "private"
   # fields. (These should be replaced with true private fields per the TC39
   # class fields proposal [1], once that's available to us.)
@@ -139,6 +137,7 @@ rules:
   # Repeal some rather absurd rules that make some code impossible to write in
   # the most reasonable way.
   no-else-return: off
+  no-await-in-loop: off # Promise.all is not always desirable
   prefer-destructuring:
   - error
   - AssignmentExpression: {array: false, object: false}

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -28,10 +28,12 @@ settings:
     node:
       extensions: [.js, .ios.js, .android.js, .json]
 
+
 rules:
 
   #
-  # Airbnb rule repeals / adjustments
+  # ================================================================
+  # Airbnb rule repeals / adjustments.
   #
   # Our settings for a rule supersede Airbnb's, so we duplicate some
   # of Airbnb's settings where we don't want a full repeal.
@@ -106,20 +108,11 @@ rules:
   # which we choose, instead of this circumlocution.
   no-with: error
 
-  #
-  # Formatting and naming
-  #
 
-  camelcase: off
-
-  # Permit dangling underscores in class property names, to denote "private"
-  # fields. (These should be replaced with true private fields per the TC39
-  # class fields proposal [1], once that's available to us.)
   #
-  # [1]: https://github.com/tc39/proposal-class-fields
-  no-underscore-dangle: ["error", { allowAfterThis: true } ]
-  # Disallow double underscores and trailing underscores.
-  id-match: ["error", "^_?([a-zA-Z0-9$]+_?)*$", { "properties": true }]
+  # ================================================================
+  # Formatting.
+  #
 
   # Disable a bunch of rules that should be taken care of by prettier.
   arrow-parens: off
@@ -133,6 +126,30 @@ rules:
   quote-props: off
 
   # For more formatting rules, see tools/formatting.eslintrc.yaml .
+
+
+  #
+  # ================================================================
+  # Naming.
+  #
+
+  camelcase: off
+
+  # Permit dangling underscores in class property names, to denote "private"
+  # fields. (These should be replaced with true private fields per the TC39
+  # class fields proposal [1], once that's available to us.)
+  #
+  # [1]: https://github.com/tc39/proposal-class-fields
+  no-underscore-dangle: ["error", { allowAfterThis: true } ]
+
+  # Disallow double underscores and trailing underscores.
+  id-match: ["error", "^_?([a-zA-Z0-9$]+_?)*$", { "properties": true }]
+
+
+  #
+  # ================================================================
+  # Language syntax, operators, control flow.
+  #
 
   # Repeal some rather absurd rules that make some code impossible to write in
   # the most reasonable way.
@@ -148,18 +165,30 @@ rules:
   # of Array#reduce.  Too noisy.
   no-param-reassign: off
 
-  # Imports
+
+  #
+  # ================================================================
+  # Imports; plugin `import`.
+  #
+
   import/prefer-default-export: off
+
   import/no-extraneous-dependencies:
   - error
   - devDependencies: ['**/__tests__/**/*.js', tools/**]
   no-restricted-imports:
   - error
   - patterns: ['**/__tests__/**']
+
   import/no-cycle: off  # This would be nice to fix; but isn't easy.
   import/export: off  # This is redundant with Flow, and buggy.
 
-  # Jest
+
+  #
+  # ================================================================
+  # Jest; plugin `jest`.
+  #
+
   # This rule could be useful if it fired only on new instances; but we
   # don't have a way to do that, and it doesn't make sense to keep these
   # out of the repo.
@@ -189,31 +218,51 @@ rules:
   # [2] https://github.com/zulip/zulip-mobile/pull/4235#discussion_r489984717
   jest/no-standalone-expect: off
 
-  # React
+
+  #
+  # ================================================================
+  # React; plugin `react`.
+  #
+
   react/jsx-filename-extension: off  # Like RN upstream, we call the files *.js.
+
   react/destructuring-assignment: off  # The opposite is often much cleaner.
   react/no-multi-comp: off  # This often just forces making code worse.
   react/no-unused-prop-types: off  # This can be perfectly appropriate.
+
   react/default-props-match-prop-types: off  # We handle this better with types.
   react/prop-types: off  # We handle this better with types.
   react/require-default-props: off  # We handle this better with types.
+
   # These two could be good to fix.
   react/prefer-stateless-function: off
   react/sort-comp: off
 
-  # React Native.
+
   #
+  # ================================================================
+  # React Native; plugin `react-native`.
+  #
+
   # This plugin isn't included in the airbnb config, and it doesn't
   # itself enable any rules by default, so this config is it.
-  #
+
   # (From the docs as of 2020-03, these are the rules we'd like to use.
   # Plugin disabled only because the rules are; bring it back when
   # reviving either of them.)
-  #
-  # react-native/no-unused-styles: error  # This is buggy on the `this.styles` pattern.
-  # react-native/no-color-literals: error  # TODO eliminate these and enable.
 
-  # Flow
+  # This is buggy on the `this.styles` pattern.
+  # react-native/no-unused-styles: error
+
+  # TODO eliminate these and enable.
+  # react-native/no-color-literals: error
+
+
+  #
+  # ================================================================
+  # Flow; plugin `flowtype`.
+  #
+
   flowtype/boolean-style: [error, boolean]
   flowtype/define-flow-type: warn
   flowtype/delimiter-dangle: off
@@ -234,6 +283,7 @@ rules:
   flowtype/union-intersection-spacing: [error, always]
   flowtype/use-flow-type: warn
   flowtype/valid-syntax: warn
+
 
 overrides:
 

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -173,6 +173,7 @@ rules:
 
   import/prefer-default-export: off
 
+  # Compare these two rules with the override below.
   import/no-extraneous-dependencies:
     - error
     - devDependencies: ['**/__tests__/**/*.js', tools/**]
@@ -287,12 +288,18 @@ rules:
 
 overrides:
 
-  # Test file overrides
+  #
+  # ================================================================
+  # Our test suite.
   - files: ['**/__tests__/**']
     rules:
       no-restricted-imports: off
 
-  # Maintain code style of redux-persist as we received it.
+  #
+  # ================================================================
+  # Third-party code: redux-persist.
+  #
+  # We leave this code in the style we received it in.
   - files: ['src/third/redux-persist/**']
     rules:
       semi: off # semicolons are omitted

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -1,3 +1,25 @@
+# Our main ESLint config.
+
+# Tips for developing on this file:
+#
+#  * To see what config currently applies, try a command like:
+#
+#      $ npx eslint --print-config src/types.js | less
+#
+#    or for a specific rule:
+#
+#      $ npx eslint --print-config src/types.js | jq '.rules["no-continue"]'
+#
+#    Especially handy for seeing the default or base setting, when we don't
+#    configure a rule ourselves.
+#
+#  * A variation to canonicalize the config output for comparison:
+#
+#     $ npx eslint --print-config src/foo.js | jq . --sorted >/tmp/foo.json
+#     $ npx eslint --print-config src/bar.js | jq . --sorted >/tmp/bar.json
+#     $ git diff --no-index /tmp/{foo,bar}.json
+
+
 parser: babel-eslint
 
 extends:

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -6,9 +6,9 @@ extends:
   - ./tools/formatting.eslintrc.yaml
 
 plugins:
- - jest
- - flowtype
- # - react-native  # see commented-out rules config below
+  - jest
+  - flowtype
+  # - react-native  # see commented-out rules config below
 
 env:
   browser: true
@@ -64,48 +64,48 @@ rules:
 
   # Enforce `static` class property syntax.
   react/static-property-placement:
-  - error
-  - static public field
+    - error
+    - static public field
 
   # Enforce state initialization style (never in constructor)
   react/state-in-constructor:
-  - error
-  - never
+    - error
+    - never
 
   # Airbnb uses four selectors under 'no-restricted-syntax':
   #
   # ForInStatement, ForOfStatement, LabeledStatement, WithStatement.
   # https://github.com/airbnb/javascript/blob/dee4f17/packages/eslint-config-airbnb-base/rules/style.js#L334.
   no-restricted-syntax:
-  - error
+    - error
 
-  # ForInStatement: We agree to forbid 'for..in' loops.
-  - selector: ForInStatement
-    message: 'for..in loops iterate over the entire prototype chain, which
-      is virtually never what you want. Use Object.{keys,values,entries}, and
-      iterate over the resulting array.'
-      # Further to Airbnb's explanation: They're also slightly buggy
-      # in JSC [1], on which react-native is built... and,
-      # surprisingly, their semantics weren't fully nailed down until
-      # as late as 2019-12 [2]. But the above is reason enough.
-      # [1]: https://bugs.webkit.org/show_bug.cgi?id=38970
-      # [2]: https://github.com/tc39/proposals/commit/cb9c6e50
+    # ForInStatement: We agree to forbid 'for..in' loops.
+    - selector: ForInStatement
+      message: 'for..in loops iterate over the entire prototype chain, which
+        is virtually never what you want. Use Object.{keys,values,entries}, and
+        iterate over the resulting array.'
+        # Further to Airbnb's explanation: They're also slightly buggy
+        # in JSC [1], on which react-native is built... and,
+        # surprisingly, their semantics weren't fully nailed down until
+        # as late as 2019-12 [2]. But the above is reason enough.
+        # [1]: https://bugs.webkit.org/show_bug.cgi?id=38970
+        # [2]: https://github.com/tc39/proposals/commit/cb9c6e50
 
-  # ForOfStatement: We don't agree to forbid 'for..of' loops.
-  #
-  # Airbnb's style guide discourages language-level loops in favor of
-  # array iterations. We don't share this controversial view; see it
-  # expressed at https://github.com/airbnb/javascript/issues/1103.
+    # ForOfStatement: We don't agree to forbid 'for..of' loops.
+    #
+    # Airbnb's style guide discourages language-level loops in favor of
+    # array iterations. We don't share this controversial view; see it
+    # expressed at https://github.com/airbnb/javascript/issues/1103.
 
-  # LabeledStatement: We don't agree to forbid labeled statements.
-  #
-  # We don't really use them, but Airbnb's reasoning flows from their
-  # anti-loop position, mentioned above, which we don't share.
+    # LabeledStatement: We don't agree to forbid labeled statements.
+    #
+    # We don't really use them, but Airbnb's reasoning flows from their
+    # anti-loop position, mentioned above, which we don't share.
 
-  # WithStatement: Agree to forbid with statements, but not this way.
-  #
-  # ESLint provides a built-in `no-with` rule with the same effect,
-  # which we choose, instead of this circumlocution.
+    # WithStatement: Agree to forbid with statements, but not this way.
+    # Instead, ...
+
+  # ... use ESLint's built-in `no-with` rule to do the same thing more simply.
   no-with: error
 
 
@@ -156,8 +156,8 @@ rules:
   no-else-return: off
   no-await-in-loop: off # Promise.all is not always desirable
   prefer-destructuring:
-  - error
-  - AssignmentExpression: {array: false, object: false}
+    - error
+    - AssignmentExpression: {array: false, object: false}
 
   # Likely-wrong code
   no-unused-vars: [warn, {vars: local, args: none}]
@@ -174,11 +174,11 @@ rules:
   import/prefer-default-export: off
 
   import/no-extraneous-dependencies:
-  - error
-  - devDependencies: ['**/__tests__/**/*.js', tools/**]
+    - error
+    - devDependencies: ['**/__tests__/**/*.js', tools/**]
   no-restricted-imports:
-  - error
-  - patterns: ['**/__tests__/**']
+    - error
+    - patterns: ['**/__tests__/**']
 
   import/no-cycle: off  # This would be nice to fix; but isn't easy.
   import/export: off  # This is redundant with Flow, and buggy.
@@ -287,45 +287,45 @@ rules:
 
 overrides:
 
-# Test file overrides
-- files: ['**/__tests__/**']
-  rules:
-    no-restricted-imports: off
+  # Test file overrides
+  - files: ['**/__tests__/**']
+    rules:
+      no-restricted-imports: off
 
-# Maintain code style of redux-persist as we received it.
-- files: ['src/third/redux-persist/**']
-  rules:
-    semi: off # semicolons are omitted
-    curly: off # one-line `if`s and `else`s without semicolons
-    nonblock-statement-body-position: off # same reason as `curly`
-    space-before-function-paren: off # `function myFunc (arg1) { ... }`
-    arrow-body-style: off # `() => { return 1; }` used over `() => 1`
-    object-curly-spacing: off # `{foo: 'bar'}` used over { foo: 'bar' }
-    no-underscore-dangle: off # various identifiers beginning with '_'
-    import/order: off # imports not ordered a particular way
-    func-names: off # anonymous non-arrow functions sometimes used
-    object-shorthand: off # ES6 object method syntax not used
+  # Maintain code style of redux-persist as we received it.
+  - files: ['src/third/redux-persist/**']
+    rules:
+      semi: off # semicolons are omitted
+      curly: off # one-line `if`s and `else`s without semicolons
+      nonblock-statement-body-position: off # same reason as `curly`
+      space-before-function-paren: off # `function myFunc (arg1) { ... }`
+      arrow-body-style: off # `() => { return 1; }` used over `() => 1`
+      object-curly-spacing: off # `{foo: 'bar'}` used over { foo: 'bar' }
+      no-underscore-dangle: off # various identifiers beginning with '_'
+      import/order: off # imports not ordered a particular way
+      func-names: off # anonymous non-arrow functions sometimes used
+      object-shorthand: off # ES6 object method syntax not used
 
-    # function declarations are made (we favor function expressions
-    # with `const`), so these functions may be used above the
-    # declaration because they are hoisted. Don't change them to our
-    # style without addressing this!
-    no-use-before-define: off
+      # function declarations are made (we favor function expressions
+      # with `const`), so these functions may be used above the
+      # declaration because they are hoisted. Don't change them to our
+      # style without addressing this!
+      no-use-before-define: off
 
-    no-console: off
-    prefer-const: off # `let` is sometimes used unnecessarily
-    consistent-return: off # defense against accidental `undefined` return
-    no-unused-expressions: off # `myFn && myFn()` used
-    no-var: off # var is rarely, but sometimes, used (avoid new uses)
+      no-console: off
+      prefer-const: off # `let` is sometimes used unnecessarily
+      consistent-return: off # defense against accidental `undefined` return
+      no-unused-expressions: off # `myFn && myFn()` used
+      no-var: off # var is rarely, but sometimes, used (avoid new uses)
 
-    # a few `var`s not *quite* at the top of function scope (they're
-    # very near to it); no bugs known to result from this
-    vars-on-top: off
+      # a few `var`s not *quite* at the top of function scope (they're
+      # very near to it); no bugs known to result from this
+      vars-on-top: off
 
-    # a few variables already declared in upper scope; no bugs known
-    # to result from this
-    no-shadow: off
+      # a few variables already declared in upper scope; no bugs known
+      # to result from this
+      no-shadow: off
 
-    # foo.hasOwnProperty("bar") used instead of
-    # Object.prototype.hasOwnProperty.call(foo, "bar")
-    no-prototype-builtins: off
+      # foo.hasOwnProperty("bar") used instead of
+      # Object.prototype.hasOwnProperty.call(foo, "bar")
+      no-prototype-builtins: off

--- a/tools/formatting.eslintrc.yaml
+++ b/tools/formatting.eslintrc.yaml
@@ -5,7 +5,7 @@
 parser: babel-eslint
 
 plugins:
- - flowtype
+  - flowtype
 
 rules:
   # Disallow tucking a condition or loop body in at the end of a line, like
@@ -17,16 +17,16 @@ rules:
   # at the start of a line, not the end.  This makes it much more
   # conspicuous whether we're using e.g. `&&` or `||`.
   operator-linebreak:
-  - error
-  - before
-  - overrides:
-      # Assignment operators are a very different beast, which it would make
-      # no sense to format this way.
-      "=": after
-      "+=": after
-      "-=": after
-      # ... There are 10 other assignment operators in JavaScript;
-      # if they come up, add them.
+    - error
+    - before
+    - overrides:
+        # Assignment operators are a very different beast, which it would make
+        # no sense to format this way.
+        "=": after
+        "+=": after
+        "-=": after
+        # ... There are 10 other assignment operators in JavaScript;
+        # if they come up, add them.
 
   # This *would* overrule Prettier, and in particular run roughshod over
   # line-length limits.  Let Prettier take care of it.


### PR DESCRIPTION
Things I noticed in the course of making the edits in 88cafe4df, that can perhaps make future edits to this config a little easier.

This is `eslint [nfc]` because it makes no functional changes even *to* the ESLint config; it just touches comments and whitespace.
