### PR TITLE
emoji search: Show result for literal emoji search.

### DIFF
--- a/src/emoji/EmojiPickerScreen.js
+++ b/src/emoji/EmojiPickerScreen.js
@@ -33,7 +33,7 @@ class EmojiPickerScreen extends PureComponent<Props, State> {
 
   handleInputChange = (text: string) => {
     this.setState({
-      filter: text.toLowerCase(),
+      filter: text.toLowerCase().trim(),
     });
   };
 

--- a/src/emoji/__tests__/data-test.js
+++ b/src/emoji/__tests__/data-test.js
@@ -57,6 +57,20 @@ describe('getFilteredEmojiNames', () => {
     expect(getFilteredEmojiNames('qwerty', { qwerty: {} })).toEqual(['qwerty']);
   });
 
+  test('returns the emoji name for a literal single-codepoint emoji search', () => {
+    const list = getFilteredEmojiNames('🤔', {});
+    expect(list).toEqual([
+      'thinking',
+    ]);
+  });
+
+  test('returns the emoji name for a literal multi-codepoint emoji search', () => {
+    const list = getFilteredEmojiNames('#️⃣', {});
+    expect(list).toEqual([
+      'hash',
+    ]);
+  });
+
   test('remove duplicates', () => {
     expect(getFilteredEmojiNames('dog', {})).toEqual(['dog', 'dogi']);
     expect(getFilteredEmojiNames('dog', { dog: {} })).toEqual(['dog', 'dogi']);

--- a/src/emoji/data.js
+++ b/src/emoji/data.js
@@ -29,6 +29,32 @@ export const getFilteredEmojiNames = (
   query: string,
   activeImageEmojiByName: $ReadOnly<{ [string]: ImageEmojiType }>,
 ): string[] => {
+  // Check if the query itself is an emoji, and is known to Zulip. If
+  // so, return the emoji name in an array. Emoji with single-codepoint and
+  // multi-codepoint have length 2 and 3 respectively.
+  if (query.length === 2) {
+    const emojiName = unicodeEmojiNames.find(
+      key => unicodeCodeByName[key] === query.codePointAt(0).toString(16),
+    );
+    if (emojiName !== undefined) {
+      return [emojiName];
+    }
+  } else if (query.length === 3) {
+    const emojiName = unicodeEmojiNames.find(
+      key =>
+        unicodeCodeByName[key]
+        === `${query
+          .codePointAt(0)
+          .toString(16)
+          .padStart(4, '0')}-${query
+          .codePointAt(2)
+          .toString(16)
+          .padStart(4, '0')}`,
+    );
+    if (emojiName !== undefined) {
+      return [emojiName];
+    }
+  }
   const names = [...unicodeEmojiNames, ...Object.keys(activeImageEmojiByName)];
   return Array.from(new Set([...names.filter(x => x.indexOf(query) === 0).sort()]));
 };


### PR DESCRIPTION
Works for both single-codepoint (:+1:) and multi-codepoint emoji (:hash:).

![image](https://user-images.githubusercontent.com/7714968/76598146-36296080-6528-11ea-9622-f164504c8569.png)

Fixes https://github.com/zulip/zulip-mobile/issues/3961