### PR TITLE
group-pm: Improve the text color on group icons

### DIFF
--- a/src/common/GroupAvatar.js
+++ b/src/common/GroupAvatar.js
@@ -4,7 +4,7 @@ import { Text, StyleSheet, View } from 'react-native';
 
 import type { Node as React$Node } from 'react';
 import Touchable from './Touchable';
-import { colorHashFromString } from '../utils/color';
+import { colorHashFromString, foregroundColorFromBackground } from '../utils/color';
 import { initialsFromString } from '../utils/misc';
 
 const styles = StyleSheet.create({
@@ -52,6 +52,7 @@ export default class GroupAvatar extends PureComponent<Props> {
     };
     const textSize = {
       fontSize: size / 3,
+      color: foregroundColorFromBackground(frameSize.backgroundColor),
     };
 
     return (


### PR DESCRIPTION
Determine the color of text on group avatar by using foregroundColorFromBackground() this will help users to read the text properly when the background color is light.
![Screenshot_20200314-130555_Zulip (debug)](https://user-images.githubusercontent.com/31368194/76677793-64767100-65f8-11ea-9e0e-afd5b56602ac.jpg)

Also replace the for loop in colorHashFromString() with a single line equation that will reduce the complexity from O(n) to O(1).
The for loop before resulted in a recursive equation: 
```hash(N) = hash(N-1) * 31 + name.charCodeAt(1)       , hash(0) = 0```
This actually is the sum of the first N terms in a Geometric Progression, for which a mathematical equation is already present.
The for loop ran till ```names.length```, whose value depends on the no.of members in a group. For a certain large value and above, JS wouldn't be able to calculate the value of ```hash``` and returns ```infinity```,  this happens in the equation too, hence the value ```names.length % 100``` was used instead of ```names.length```.