### PR TITLE
[WIP?] Add cyclomatic complexity lint (+ various refactors)

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -65,7 +65,7 @@ rules:
   no-plusplus: off
   no-nested-ternary: off
 
-  complexity: ["error", {max: 20}]
+  complexity: ["error", {max: 15}]
 
   # We also partly repeal AirBnB's forbidden-syntax subrules. (This must be done
   # in the `overrides:` section.)

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -65,6 +65,8 @@ rules:
   no-plusplus: off
   no-nested-ternary: off
 
+  complexity: ["error", {max: 20}]
+
   # We also partly repeal AirBnB's forbidden-syntax subrules. (This must be done
   # in the `overrides:` section.)
   #

--- a/src/events/eventToAction.js
+++ b/src/events/eventToAction.js
@@ -33,31 +33,31 @@ import {
 } from '../actionConstants';
 import { getOwnEmail } from '../users/userSelectors';
 
-const opToActionUser = {
+const opToActionUser = Object.freeze({
   add: EVENT_USER_ADD,
   remove: EVENT_USER_REMOVE,
   update: EVENT_USER_UPDATE,
-};
+});
 
-const opToActionUserGroup = {
+const opToActionUserGroup = Object.freeze({
   add: EVENT_USER_GROUP_ADD,
   remove: EVENT_USER_GROUP_REMOVE,
   update: EVENT_USER_GROUP_UPDATE,
   add_members: EVENT_USER_GROUP_ADD_MEMBERS,
   remove_members: EVENT_USER_GROUP_REMOVE_MEMBERS,
-};
+});
 
-const opToActionReaction = {
+const opToActionReaction = Object.freeze({
   add: EVENT_REACTION_ADD,
   remove: EVENT_REACTION_REMOVE,
-};
+});
 
-const opToActionTyping = {
+const opToActionTyping = Object.freeze({
   start: EVENT_TYPING_START,
   stop: EVENT_TYPING_STOP,
-};
+});
 
-const actionTypeOfEventType = {
+const actionTypeOfEventType = Object.freeze({
   update_message: EVENT_UPDATE_MESSAGE,
   subscription: EVENT_SUBSCRIPTION,
   presence: EVENT_PRESENCE,
@@ -68,7 +68,7 @@ const actionTypeOfEventType = {
   update_global_notifications: EVENT_UPDATE_GLOBAL_NOTIFICATIONS_SETTINGS,
   update_display_settings: EVENT_UPDATE_DISPLAY_SETTINGS,
   user_status: EVENT_USER_STATUS_UPDATE,
-};
+});
 
 // This FlowFixMe is because this function encodes a large number of
 // assumptions about the events the server sends, and doesn't check them.

--- a/src/events/eventToAction.js
+++ b/src/events/eventToAction.js
@@ -73,6 +73,14 @@ const actionTypeOfEventType = Object.freeze({
 // This FlowFixMe is because this function encodes a large number of
 // assumptions about the events the server sends, and doesn't check them.
 export default (state: GlobalState, event: $FlowFixMe): EventAction => {
+  // simple case: conversion by lookup-table
+  const actionType: $Values<typeof actionTypeOfEventType> | void =
+    actionTypeOfEventType[event.type];
+  if (actionType !== undefined) {
+    return { ...event, type: actionType };
+  }
+
+  // complicated case: additional event translation needed
   switch (event.type) {
     case 'alert_words':
       return {
@@ -98,21 +106,6 @@ export default (state: GlobalState, event: $FlowFixMe): EventAction => {
       return {
         type: EVENT,
         event,
-      };
-
-    case 'update_message':
-    case 'subscription':
-    case 'presence':
-    case 'muted_topics':
-    case 'realm_emoji':
-    case 'realm_filters':
-    case 'submessage':
-    case 'update_global_notifications':
-    case 'update_display_settings':
-    case 'user_status':
-      return {
-        ...event,
-        type: actionTypeOfEventType[event.type],
       };
 
     case 'realm_user':

--- a/src/message/messageActionSheet.js
+++ b/src/message/messageActionSheet.js
@@ -50,8 +50,6 @@ type ButtonDescription = {
   errorMessage: string,
 };
 
-const isAnOutboxMessage = (message: Message | Outbox): boolean => message.isOutbox;
-
 //
 // Options for the action sheet go below: ...
 //
@@ -63,7 +61,7 @@ reply.title = 'Reply';
 reply.errorMessage = 'Failed to reply';
 
 const copyToClipboard = async ({ _, auth, message }) => {
-  const rawMessage = isAnOutboxMessage(message) /* $FlowFixMe: then really type Outbox */
+  const rawMessage = message.isOutbox
     ? message.markdownContent
     : (await api.getRawMessageContent(auth, message.id)).raw_content;
   Clipboard.setString(rawMessage);
@@ -79,7 +77,7 @@ editMessage.title = 'Edit message';
 editMessage.errorMessage = 'Failed to edit message';
 
 const deleteMessage = async ({ auth, message, dispatch }) => {
-  if (isAnOutboxMessage(message)) {
+  if (message.isOutbox) {
     dispatch(deleteOutboxMessage(message.timestamp));
   } else {
     await api.deleteMessage(auth, message.id);

--- a/src/message/messageActionSheet.js
+++ b/src/message/messageActionSheet.js
@@ -224,16 +224,16 @@ type ButtonCode = $Keys<typeof allButtonsRaw>;
 
 const allButtons: { [ButtonCode]: ButtonDescription } = allButtonsRaw;
 
-type ConstructSheetParams = {|
+type ConstructSheetParams<MsgType: Message | Outbox = Message | Outbox> = {|
   backgroundData: BackgroundData,
-  message: Message | Outbox,
+  message: MsgType,
   narrow: Narrow,
 |};
 
 export const constructHeaderActionButtons = ({
   backgroundData: { mute, subscriptions, ownUser },
   message,
-}: ConstructSheetParams): ButtonCode[] => {
+}: ConstructSheetParams<>): ButtonCode[] => {
   const buttons: ButtonCode[] = [];
   if (message.type === 'stream') {
     if (ownUser.is_admin) {
@@ -262,7 +262,7 @@ export const constructMessageActionButtons = ({
   backgroundData: { ownUser, flags },
   message,
   narrow,
-}: ConstructSheetParams): ButtonCode[] => {
+}: ConstructSheetParams<>): ButtonCode[] => {
   const buttons = [];
   if (!isAnOutboxMessage(message) && messageNotDeleted(message)) {
     buttons.push('addReaction');
@@ -318,7 +318,7 @@ export const showActionSheet = (
   dispatch: Dispatch,
   showActionSheetWithOptions: ShowActionSheetWithOptions,
   _: GetText,
-  params: ConstructSheetParams,
+  params: ConstructSheetParams<>,
 ): void => {
   const optionCodes = isHeader
     ? constructHeaderActionButtons(params)

--- a/src/message/messageActionSheet.js
+++ b/src/message/messageActionSheet.js
@@ -255,6 +255,18 @@ export const constructHeaderActionButtons = ({
   return buttons;
 };
 
+export const constructOutboxActionButtons = ({
+  backgroundData,
+  message,
+  narrow,
+}: ConstructSheetParams<Outbox>): ButtonCode[] => {
+  const buttons = [];
+  buttons.push('copyToClipboard');
+  buttons.push('deleteMessage');
+  buttons.push('cancel');
+  return buttons;
+};
+
 const messageNotDeleted = (message: Message | Outbox): boolean =>
   message.content !== '<p>(deleted)</p>';
 
@@ -262,15 +274,15 @@ export const constructMessageActionButtons = ({
   backgroundData: { ownUser, flags },
   message,
   narrow,
-}: ConstructSheetParams<>): ButtonCode[] => {
+}: ConstructSheetParams<Message>): ButtonCode[] => {
   const buttons = [];
-  if (!isAnOutboxMessage(message) && messageNotDeleted(message)) {
+  if (messageNotDeleted(message)) {
     buttons.push('addReaction');
   }
   if (message.reactions.length > 0) {
     buttons.push('showReactions');
   }
-  if (!isAnOutboxMessage(message) && !isTopicNarrow(narrow) && !isPrivateOrGroupNarrow(narrow)) {
+  if (!isTopicNarrow(narrow) && !isPrivateOrGroupNarrow(narrow)) {
     buttons.push('reply');
   }
   if (messageNotDeleted(message)) {
@@ -278,8 +290,7 @@ export const constructMessageActionButtons = ({
     buttons.push('shareMessage');
   }
   if (
-    !isAnOutboxMessage(message)
-    && message.sender_email === ownUser.email
+    message.sender_email === ownUser.email
     // Our "edit message" UI only works in certain kinds of narrows.
     && (isStreamOrTopicNarrow(narrow) || isPrivateOrGroupNarrow(narrow))
   ) {
@@ -288,15 +299,25 @@ export const constructMessageActionButtons = ({
   if (message.sender_email === ownUser.email && messageNotDeleted(message)) {
     buttons.push('deleteMessage');
   }
-  if (!isAnOutboxMessage(message)) {
-    if (message.id in flags.starred) {
-      buttons.push('unstarMessage');
-    } else {
-      buttons.push('starMessage');
-    }
+  if (message.id in flags.starred) {
+    buttons.push('unstarMessage');
+  } else {
+    buttons.push('starMessage');
   }
   buttons.push('cancel');
   return buttons;
+};
+
+export const constructNonHeaderActionButtons = ({
+  backgroundData,
+  message,
+  narrow,
+}: ConstructSheetParams<>): ButtonCode[] => {
+  if (message.isOutbox) {
+    return constructOutboxActionButtons({ backgroundData, message, narrow });
+  } else {
+    return constructMessageActionButtons({ backgroundData, message, narrow });
+  }
 };
 
 /** Returns the title for the action sheet. */
@@ -322,7 +343,7 @@ export const showActionSheet = (
 ): void => {
   const optionCodes = isHeader
     ? constructHeaderActionButtons(params)
-    : constructMessageActionButtons(params);
+    : constructNonHeaderActionButtons(params);
   const callback = buttonIndex => {
     (async () => {
       const pressedButton: ButtonDescription = allButtons[optionCodes[buttonIndex]];

--- a/src/message/messageUpdates.js
+++ b/src/message/messageUpdates.js
@@ -25,6 +25,8 @@ export type UpdateStrategy =
   | 'scroll-to-anchor'
   | 'scroll-to-bottom-if-near-bottom';
 
+// (the complexity here is mostly illusory, but consider refactoring anyway)
+// eslint-disable-next-line complexity
 export const getMessageTransitionProps = (prevProps: Props, nextProps: Props): TransitionProps => {
   const sameNarrow = isEqual(prevProps.narrow, nextProps.narrow);
   const noMessages = nextProps.messages.length === 0;

--- a/src/notification/__tests__/notification-test.js
+++ b/src/notification/__tests__/notification-test.js
@@ -143,17 +143,20 @@ describe('extract iOS notification data', () => {
     });
 
     test('optional data is typechecked', () => {
+      // arbitrary; any of the three will do
+      const base = barebones.stream;
+
       expect(
         make({
+          ...base,
           realm_uri: null,
-          ...barebones.stream,
         }),
       ).toThrow(/invalid/);
 
       expect(
         make({
+          ...base,
           realm_uri: ['array', 'of', 'string'],
-          ...barebones['group PM'],
         }),
       ).toThrow(/invalid/);
     });

--- a/src/session/sessionReducer.js
+++ b/src/session/sessionReducer.js
@@ -108,6 +108,8 @@ const rehydrate = (state, action) => {
   };
 };
 
+// TODO: refactor, probably by breaking up SessionState
+// eslint-disable-next-line complexity
 export default (state: SessionState = initialState, action: Action): SessionState => {
   switch (action.type) {
     case DEAD_QUEUE:

--- a/src/streams/StreamItem.js
+++ b/src/streams/StreamItem.js
@@ -66,6 +66,8 @@ export default class StreamItem extends PureComponent<Props> {
     }
   };
 
+  // TODO: refactor
+  // eslint-disable-next-line complexity
   render() {
     const { styles: contextStyles } = this.context;
     const {

--- a/src/subscriptions/subscriptionsReducer.js
+++ b/src/subscriptions/subscriptionsReducer.js
@@ -46,6 +46,35 @@ const eventSubscription = (state, action) => {
   }
 };
 
+// the systematic name for this handler would unfortunately be "event"
+const eventEvent = (state, action) => {
+  const { event } = action;
+  switch (event.type) {
+    case EventTypes.stream:
+      switch (event.op) {
+        case 'update':
+          return updateSubscription(state, event);
+
+        case 'delete':
+          return filterArray(
+            state,
+            sub => !event.streams.find(stream => sub.stream_id === stream.stream_id),
+          );
+
+        case 'create':
+        case 'occupy':
+        case 'vacate':
+          return state;
+
+        default:
+          ensureUnreachable(event);
+          return state;
+      }
+    default:
+      return state;
+  }
+};
+
 export default (state: SubscriptionsState = initialState, action: Action): SubscriptionsState => {
   switch (action.type) {
     case LOGOUT:
@@ -59,33 +88,9 @@ export default (state: SubscriptionsState = initialState, action: Action): Subsc
     case EVENT_SUBSCRIPTION:
       return eventSubscription(state, action);
 
-    case EVENT: {
-      const { event } = action;
-      switch (event.type) {
-        case EventTypes.stream:
-          switch (event.op) {
-            case 'update':
-              return updateSubscription(state, event);
+    case EVENT:
+      return eventEvent(state, action);
 
-            case 'delete':
-              return filterArray(
-                state,
-                sub => !event.streams.find(stream => sub.stream_id === stream.stream_id),
-              );
-
-            case 'create':
-            case 'occupy':
-            case 'vacate':
-              return state;
-
-            default:
-              ensureUnreachable(event);
-              return state;
-          }
-        default:
-          return state;
-      }
-    }
     default:
       return state;
   }

--- a/src/utils/internalLinks.js
+++ b/src/utils/internalLinks.js
@@ -29,6 +29,8 @@ export const isMessageLink = (url: string, realm: string): boolean =>
 
 type LinkType = 'external' | 'home' | 'pm' | 'topic' | 'stream' | 'special';
 
+// TODO: refactor
+// eslint-disable-next-line complexity
 export const getLinkType = (url: string, realm: string): LinkType => {
   if (!isInternalLink(url, realm)) {
     return 'external';


### PR DESCRIPTION
Refactor a few large functions, and add a lint to prevent future functions from getting too unwieldy. (In particular, this refactors the already-problematic `constructMessageActionButtons` to split the Outbox and Message cases, fixing a bug.)

The cyclomatic complexity lint has a few arguable false positives and a few items that would just be nontrivial to do. These have just been marked with exhortative `TODO` markers for now.

This PR should not be merged as-is; some decisions need to be made first.

 - [ ] Should `fromAPNsImpl` actually be broken up?
   * The right way to remove it from lint-consideration is probably to make a generalized typechecked validator (via [ajv](https://github.com/epoberezkin/ajv) or the like). That's going to involve some code generation somewhere, though, if we want to keep it Flow-checked.
   * Breaking it up doesn't actually make it clearer or more testable; it might be better just to tag it with a marker.
-  [ ] What exactly should the limit be?
   * ESLint defaults to 20. That's high enough that nothing we have hits it (at least after the refactors), but I'm of the opinion that this is far too high.
   * 15 (my preference) is doable, but requires either tagging a few functions with `// eslint-disable`s or doing some less trivial refactoring.
   * [The original study suggested 10.](https://en.wikipedia.org/wiki/Cyclomatic_complexity#Limiting_complexity_during_development) This is technically reachable, but would either take a lot of questionably-productive effort or would require throwing around sufficiently many `// eslint-disable`s that, I think, we run the risk of becoming cavalier with them.