### PR TITLE
Break up handlers for native events

### DIFF
--- a/src/boot/AppEventHandlers.js
+++ b/src/boot/AppEventHandlers.js
@@ -32,6 +32,10 @@ type Props = $ReadOnly<{|
   unreadCount: number,
 |}>;
 
+// TODO: After upgrading or replacing our iOS notifications library, look into
+//   organizing NotificationListener and the notification-related components of
+//   this file into another event-handler component.
+
 class AppEventHandlers extends PureComponent<Props> {
   /** For the type, see docs: https://facebook.github.io/react-native/docs/appstate */
   handleAppStateChange = (state: 'active' | 'background' | 'inactive') => {

--- a/src/boot/AppEventHandlers.js
+++ b/src/boot/AppEventHandlers.js
@@ -51,16 +51,11 @@ class AppEventHandlers extends PureComponent<Props> {
 
   notificationListener = new NotificationListener(this.props.dispatch);
 
-  handleMemoryWarning = () => {
-    // Release memory here
-  };
-
   componentDidMount() {
     const { dispatch } = this.props;
     handleInitialNotification(dispatch);
 
     AppState.addEventListener('change', this.handleAppStateChange);
-    AppState.addEventListener('memoryWarning', this.handleMemoryWarning);
     SafeArea.getSafeAreaInsetsForRootView().then(params =>
       dispatch(initSafeAreaInsets(params.safeAreaInsets)),
     );
@@ -71,7 +66,6 @@ class AppEventHandlers extends PureComponent<Props> {
 
   componentWillUnmount() {
     AppState.removeEventListener('change', this.handleAppStateChange);
-    AppState.removeEventListener('memoryWarning', this.handleMemoryWarning);
     // $FlowFixMe: libdef wrongly says callback's parameter is optional
     Orientation.removeOrientationListener(this.handleOrientationChange);
     this.notificationListener.stop();

--- a/src/boot/AppEventHandlers.js
+++ b/src/boot/AppEventHandlers.js
@@ -3,7 +3,6 @@
 import React, { PureComponent } from 'react';
 import { AppState, View, StyleSheet, Platform, NativeModules } from 'react-native';
 import SafeArea from 'react-native-safe-area';
-import Orientation, { type Orientations } from 'react-native-orientation';
 
 import type { Node as React$Node } from 'react';
 import type { Dispatch } from '../types';
@@ -14,9 +13,10 @@ import {
   NotificationListener,
   notificationOnAppActive,
 } from '../notification';
-import { appOrientation, initSafeAreaInsets } from '../actions';
+import { initSafeAreaInsets } from '../actions';
 import PresenceHeartbeat from '../presence/PresenceHeartbeat';
 import NetworkStateHandler from './event-handlers/NetworkStateHandler';
+import OrientationStateHandler from './event-handlers/OrientationHandler';
 
 const styles = StyleSheet.create({
   wrapper: {
@@ -33,26 +33,6 @@ type Props = $ReadOnly<{|
 |}>;
 
 class AppEventHandlers extends PureComponent<Props> {
-  // The libdef says that this parameter is optional. The docs disagree.
-  handleOrientationChange = (orientation?: Orientations) => {
-    if (!orientation) {
-      return;
-    }
-
-    // Lookup table. More elaborate than a simple 'orientation !== LANDSCAPE'
-    // test to ensure robustness against future additions to the enumeration.
-    const converter = {
-      LANDSCAPE: 'LANDSCAPE',
-      PORTRAIT: 'PORTRAIT',
-      PORTRAITUPSIDEDOWN: 'PORTRAIT',
-      UNKNOWN: 'PORTRAIT',
-    };
-    const converted = converter[orientation];
-
-    const { dispatch } = this.props;
-    dispatch(appOrientation(converted));
-  };
-
   /** For the type, see docs: https://facebook.github.io/react-native/docs/appstate */
   handleAppStateChange = (state: 'active' | 'background' | 'inactive') => {
     const { unreadCount } = this.props;
@@ -74,13 +54,11 @@ class AppEventHandlers extends PureComponent<Props> {
     SafeArea.getSafeAreaInsetsForRootView().then(params =>
       dispatch(initSafeAreaInsets(params.safeAreaInsets)),
     );
-    Orientation.addOrientationListener(this.handleOrientationChange);
     this.notificationListener.start();
   }
 
   componentWillUnmount() {
     AppState.removeEventListener('change', this.handleAppStateChange);
-    Orientation.removeOrientationListener(this.handleOrientationChange);
     this.notificationListener.stop();
   }
 
@@ -88,6 +66,7 @@ class AppEventHandlers extends PureComponent<Props> {
     return (
       <>
         <NetworkStateHandler />
+        <OrientationStateHandler />
         <PresenceHeartbeat />
         <View style={styles.wrapper}>{this.props.children}</View>
       </>

--- a/src/boot/event-handlers/NetworkStateHandler.js
+++ b/src/boot/event-handlers/NetworkStateHandler.js
@@ -1,0 +1,61 @@
+// @flow strict-local
+
+import { useEffect } from 'react';
+import NetInfo from '@react-native-community/netinfo';
+
+import { connect } from '../../react-redux';
+import { appOnline } from '../../actions';
+import type { Dispatch } from '../../types';
+
+/**
+ * Part of the interface from react-native-netinfo.
+ * https://github.com/react-native-community/react-native-netinfo/tree/v3.2.1
+ */
+// TODO: upgrade to 4.x.x so that we can use the `flow-typed` versions.
+// Requires RN 0.60+.
+type NetInfoStateType =
+  | 'unknown'
+  | 'none'
+  | 'cellular'
+  | 'wifi'
+  | 'bluetooth'
+  | 'ethernet'
+  | 'wimax'
+  | 'vpn'
+  | 'other';
+
+type NetInfoConnectedDetails = {
+  isConnectionExpensive: boolean,
+};
+
+type NetInfoState = {
+  /** The type of the current connection. */
+  type: NetInfoStateType,
+
+  /** Whether there is an active network connection. Note that this DOES NOT
+      mean that the Internet is reachable. */
+  isConnected: boolean,
+
+  /**
+   * This actually has a more complicated type whose exact shape is dependent on
+   * the value of `type`, above. (Flow could describe it, but we don't have a
+   * use for it yet.)
+   */
+  details: null | NetInfoConnectedDetails,
+};
+
+const NetworkStateHandler = ({ dispatch }: {| dispatch: Dispatch |}) => {
+  useEffect(() => {
+    const handleConnectivityChange = (netInfoState: NetInfoState) => {
+      const { type: connectionType } = netInfoState;
+      const isConnected = connectionType !== 'none' && connectionType !== 'unknown';
+      dispatch(appOnline(isConnected));
+    };
+
+    return NetInfo.addEventListener(handleConnectivityChange);
+  }, [dispatch]);
+
+  return null;
+};
+
+export default connect()(NetworkStateHandler);

--- a/src/boot/event-handlers/OrientationHandler.js
+++ b/src/boot/event-handlers/OrientationHandler.js
@@ -1,0 +1,37 @@
+// @flow strict-local
+import { useEffect } from 'react';
+import Orientation, { type Orientations } from 'react-native-orientation';
+
+import { connect } from '../../react-redux';
+import { appOrientation } from '../../actions';
+import type { Dispatch, Orientation as OrientationT } from '../../types';
+
+const OrientationHandler = ({ dispatch }: {| dispatch: Dispatch |}) => {
+  useEffect(() => {
+    // The libdef says that this parameter is optional. The docs disagree.
+    const handleOrientationChange = (orientation?: Orientations) => {
+      if (!orientation) {
+        return;
+      }
+
+      // Lookup table. More elaborate than a simple 'orientation !== LANDSCAPE'
+      // test to ensure robustness against future additions to the enumeration.
+      const converter = {
+        LANDSCAPE: 'LANDSCAPE',
+        PORTRAIT: 'PORTRAIT',
+        PORTRAITUPSIDEDOWN: 'PORTRAIT',
+        UNKNOWN: 'PORTRAIT',
+      };
+      const converted: OrientationT = converter[orientation];
+
+      dispatch(appOrientation(converted));
+    };
+
+    Orientation.addOrientationListener(handleOrientationChange);
+    return () => Orientation.removeOrientationListener(handleOrientationChange);
+  }, [dispatch]);
+
+  return null;
+};
+
+export default connect()(OrientationHandler);


### PR DESCRIPTION
Separate some more bits of the `AppEventHandlers` component into null-rendering subcomponents. Followup from https://github.com/zulip/zulip-mobile/pull/3704#discussion_r358403848.

Yet more remains to be done – in particular, the code interacting with notifications – but the partial factoring is still an improvement.

(This PR also flushes out and fixes a `$FlowFixMe`-concealed orientation-handling bug.)