### PR TITLE
ui: fix the visibility of dividers in dark mode

### DIFF
--- a/src/settings/LanguagePicker.js
+++ b/src/settings/LanguagePicker.js
@@ -1,20 +1,13 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
-import { FlatList, StyleSheet, View } from 'react-native';
+import { FlatList } from 'react-native';
 
 import type { GetText } from '../types';
 import { TranslationContext } from '../boot/TranslationProvider';
-
+import { OptionDivider } from '../common';
 import languages from './languages';
 import type { Language } from './languages';
 import LanguagePickerItem from './LanguagePickerItem';
-
-const styles = StyleSheet.create({
-  separator: {
-    height: 1,
-    backgroundColor: 'hsla(0, 0%, 0%, 0.1)',
-  },
-});
 
 type Props = $ReadOnly<{|
   value: string,
@@ -57,7 +50,7 @@ export default class LanguagePicker extends PureComponent<Props> {
 
     return (
       <FlatList
-        ItemSeparatorComponent={() => <View style={styles.separator} />}
+        ItemSeparatorComponent={OptionDivider}
         initialNumToRender={languages.length}
         data={data}
         keyboardShouldPersistTaps="always"


### PR DESCRIPTION
Dividers in the language picker screen isn't visible in night mode since they are black in color. Use OptionDivider instead. OptionDivider changes it's color with respect to the appropriate theme.

![Screenshot_20200320-111158_Zulip (debug)](https://user-images.githubusercontent.com/31368194/77140650-413c3d80-6aa0-11ea-983e-b1cdfd828933.jpg)

Fixes: #3986