### PR TITLE
group-pm: fix colorHashFromString

### DIFF
--- a/src/utils/__tests__/color-test.js
+++ b/src/utils/__tests__/color-test.js
@@ -17,13 +17,21 @@ describe('foregroundColorFromBackground', () => {
 
 describe('colorHashFromString', () => {
   test('returns a 6 digit hex number to use as a color ', () => {
-    const hash = colorHashFromString('John Doe');
-    expect(hash).toHaveLength(7);
+    expect(colorHashFromString('')).toHaveLength(7);
+    expect(colorHashFromString('😃')).toHaveLength(7);
+    expect(colorHashFromString('John Doe')).toHaveLength(7);
+    expect(colorHashFromString('abcdefghijklmnopqrstuvwxyz'.repeat(50))).toHaveLength(7);
   });
 
   test('produces the same output for the same input', () => {
     const hash1 = colorHashFromString('John Doe');
     const hash2 = colorHashFromString('John Doe');
     expect(hash1).toEqual(hash2);
+  });
+
+  test('produces different output for similar inputs', () => {
+    const hash1 = colorHashFromString('John Doe, Juan Pérez');
+    const hash2 = colorHashFromString('John Doe, Jean Dupont');
+    expect(hash1).not.toEqual(hash2);
   });
 });

--- a/src/utils/color.js
+++ b/src/utils/color.js
@@ -8,11 +8,9 @@ export const foregroundColorFromBackground = (color: ColorValue): 'black' | 'whi
 export const colorHashFromString = (name: string): string => {
   let hash = 0;
   for (let i = 0; i < name.length; i++) {
-    hash = hash * 31 + name.charCodeAt(1);
+    hash = hash * 31 + name.charCodeAt(i);
+    hash %= 0x1000000;
   }
-  let colorHash = hash % 0xffffff;
-  if (colorHash < 0x100000) {
-    colorHash += 0x100000;
-  }
-  return `#${colorHash.toString(16)}`;
+
+  return `#${hash.toString(16).padStart(6, '0')}`;
 };


### PR DESCRIPTION
colorHashFromString() now considers all charecters in the string it can also now return colors with red component in it. Also fixed the cases where the function returned #NaN for very long or empty strings.

Fixes: #3985