### PR TITLE
composeBox: Limit maxHeight to '50%' of parent.

### DIFF
--- a/src/compose/ComposeBox.js
+++ b/src/compose/ComposeBox.js
@@ -295,6 +295,7 @@ class ComposeBox extends PureComponent<Props, State> {
   styles = {
     wrapper: {
       flexShrink: 1,
+      maxHeight: '60%',
     },
     autocompleteWrapper: {
       position: 'absolute',


### PR DESCRIPTION
- Provide max height in percentage so that it works in split screen mode,
and even when keyboards appears.

Fixes: #3977