### PR TITLE
webview, js: Only scroll on resize when !isNearBottom().

### DIFF
--- a/src/webview/js/generatedEs3.js
+++ b/src/webview/js/generatedEs3.js
@@ -135,15 +135,21 @@ var compiledWebviewJs = (function (exports) {
     }
   };
 
+  var isNearBottom = function isNearBottom() {
+    return documentBody.scrollHeight - 100 < documentBody.scrollTop + documentBody.clientHeight;
+  };
+
   var viewportHeight = documentBody.clientHeight;
   window.addEventListener('resize', function (event) {
     var difference = viewportHeight - documentBody.clientHeight;
 
     if (documentBody.scrollHeight !== documentBody.scrollTop + documentBody.clientHeight) {
-      window.scrollBy({
-        left: 0,
-        top: difference
-      });
+      if (isNearBottom() && difference > 0 || !isNearBottom()) {
+        window.scrollBy({
+          left: 0,
+          top: difference
+        });
+      }
     }
 
     viewportHeight = documentBody.clientHeight;
@@ -323,10 +329,6 @@ var compiledWebviewJs = (function (exports) {
       top: documentBody.scrollHeight,
       behavior: 'smooth'
     });
-  };
-
-  var isNearBottom = function isNearBottom() {
-    return documentBody.scrollHeight - 100 < documentBody.scrollTop + documentBody.clientHeight;
   };
 
   var scrollToBottomIfNearEnd = function scrollToBottomIfNearEnd() {

--- a/src/webview/js/js.js
+++ b/src/webview/js/js.js
@@ -163,13 +163,18 @@ const showHideElement = (elementId: string, show: boolean) => {
   }
 };
 
+const isNearBottom = (): boolean =>
+  documentBody.scrollHeight - 100 < documentBody.scrollTop + documentBody.clientHeight;
+
 /* Cached to avoid re-looking it up all the time. */
 let viewportHeight = documentBody.clientHeight;
 
 window.addEventListener('resize', event => {
   const difference = viewportHeight - documentBody.clientHeight;
   if (documentBody.scrollHeight !== documentBody.scrollTop + documentBody.clientHeight) {
-    window.scrollBy({ left: 0, top: difference });
+    if ((isNearBottom() && difference > 0) || !isNearBottom()) {
+      window.scrollBy({ left: 0, top: difference });
+    }
   }
   viewportHeight = documentBody.clientHeight;
 });
@@ -430,9 +435,6 @@ type ScrollTarget =
 const scrollToBottom = () => {
   window.scroll({ left: 0, top: documentBody.scrollHeight, behavior: 'smooth' });
 };
-
-const isNearBottom = (): boolean =>
-  documentBody.scrollHeight - 100 < documentBody.scrollTop + documentBody.clientHeight;
 
 const scrollToBottomIfNearEnd = () => {
   if (isNearBottom()) {


### PR DESCRIPTION
So that when unread notice hides, webview doesn't scroll up.
This also seems to work fine when keyboard pops in/out.

Fixes: #3301