### PR TITLE
Add LaTeX math support (v3)

### DIFF
--- a/android/app/webviewAssets.gradle
+++ b/android/app/webviewAssets.gradle
@@ -66,6 +66,9 @@ gradle.projectsEvaluated {
         // of what went wrong when it changed out from under us.
         def assetsDir = "${buildDir}/intermediates/merged_assets/${variant.name}/out"
 
+        // See above note on Windows compatibility.
+        def destDir = normalizePath(relativizePath("${assetsDir}/webview", repoDir))
+
         def variantTask = tasks.create(
             name: "build${variant.name.capitalize()}StaticWebviewAssets",
             type: Exec
@@ -74,9 +77,7 @@ gradle.projectsEvaluated {
             workingDir repoDir
             executable "bash"
             args "./tools/build-webview",
-                "android", "--destination",
-                // See above note on Windows compatibility.
-                normalizePath(relativizePath("${assetsDir}/webview", repoDir))
+                "android", "--destination", destDir
         }
 
         // Run this task as part of assets merging for this variant.

--- a/android/app/webviewAssets.gradle
+++ b/android/app/webviewAssets.gradle
@@ -76,8 +76,8 @@ gradle.projectsEvaluated {
             // All arguments to our script must be relative to `workingDir`.
             workingDir repoDir
             executable "bash"
-            args "./tools/build-webview",
-                "android", "--destination", destDir
+            args "./tools/build-webview", "android", "--check-path-name",
+                "--destination", destDir
         }
 
         // Run this task as part of assets merging for this variant.

--- a/ios/ZulipMobile.xcodeproj/project.pbxproj
+++ b/ios/ZulipMobile.xcodeproj/project.pbxproj
@@ -1761,7 +1761,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/bash;
-			shellScript = "exec $SRCROOT/../tools/build-webview ios --destination $SRCROOT/webview\n# See this script, or src/webview/static/README.md, for more information.\n";
+			shellScript = "exec $SRCROOT/../tools/build-webview ios --check-path-name --destination $SRCROOT/webview\n# See this script, or src/webview/static/README.md, for more information.\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "blueimp-md5": "^2.10.0",
     "color": "^3.0.0",
     "date-fns": "^1.29.0",
+    "katex": "^0.11.1",
     "lodash.escape": "^4.0.1",
     "lodash.isequal": "^4.4.0",
     "lodash.omit": "^4.5.0",

--- a/src/webview/css/css.js
+++ b/src/webview/css/css.js
@@ -1,8 +1,26 @@
 /* @flow strict-local */
+import { Platform } from 'react-native';
 import type { ThemeName } from '../../types';
 import cssPygments from './cssPygments';
 import cssEmojis from './cssEmojis';
 import cssNight from './cssNight';
+
+/**
+ * Fix KaTeX frac-line elements disappearing.
+ *
+ * This is a hack, but it's probably better than not having fraction lines on
+ * low-resolution phones. It's only known to be useful under Chrome and Android,
+ * so we only include it there.
+ *
+ * See, among others:
+ *   https://github.com/KaTeX/KaTeX/issues/824
+ *   https://github.com/KaTeX/KaTeX/issues/916
+ *   https://github.com/KaTeX/KaTeX/pull/1249
+ *   https://github.com/KaTeX/KaTeX/issues/1775
+ */
+const katexFraclineHackStyle = `<style id="katex-frac-line-hack">
+.katex .mfrac .frac-line { border-bottom-width: 1px !important; }
+</style>`;
 
 export default (theme: ThemeName) => `
 <link rel='stylesheet' type='text/css' href='./base.css'>
@@ -17,5 +35,6 @@ ${cssEmojis}
   display: none;
 }
 </style>
+${Platform.OS === 'android' ? katexFraclineHackStyle : '<!-- Safari -->'}
 <style id="generated-styles"></style>
 `;

--- a/src/webview/css/css.js
+++ b/src/webview/css/css.js
@@ -6,6 +6,7 @@ import cssNight from './cssNight';
 
 export default (theme: ThemeName) => `
 <link rel='stylesheet' type='text/css' href='./base.css'>
+<link rel='stylesheet' type='text/css' href='./katex/katex.min.css'>
 <style>
 ${theme === 'night' ? cssNight : ''}
 ${cssPygments(theme === 'night')}

--- a/tools/build-webview
+++ b/tools/build-webview
@@ -158,8 +158,7 @@ sync() {
 
 # Sync the directory structure, preserving metadata.
 sync "${root}/src/webview/static" "${dest}" <<EOF
-# Ignore files that won't be needed at runtime.
-- README.md
-
-+ *
++ /index.html
++ /base.css
+- *
 EOF

--- a/tools/build-webview
+++ b/tools/build-webview
@@ -138,11 +138,28 @@ fi  # if $check_path_name
 # (Build and) sync
 ################################################################################
 
-# Sync the directory structure, preserving metadata. (We ignore any files named
-# 'README.md'; these should be strictly informative.)
+# Sync files from src to dest, reading rsync filter rules from stdin.
 #
-# We use `rsync` here, as it will skip unchanged files.
-mkdir -p "$dest"
-rsync -a --no-D --delete --delete-excluded \
-      --exclude=README.md \
-      "$root/src/webview/static/." "$dest"
+# Both src and dest should be directories.
+#
+# Files in dest not mentioned will be deleted by default.  A rule
+# like `-,r /foo` will override this to leave `foo` in place.
+#
+# For documentation on rsync filter rules, see `man rsync` or:
+#   https://dyn.manpages.debian.org/testing/rsync/rsync.1.en.html#FILTER_RULES
+sync() {
+    # "_dest" because bash's `readonly` means can't shadow with `local`
+    local src="$1" _dest="$2"
+    mkdir -p "${_dest}"
+    rsync -aR --no-D --delete --delete-excluded \
+          "${src}/./" "${_dest}/." \
+          --filter='. /dev/stdin'
+}
+
+# Sync the directory structure, preserving metadata.
+sync "${root}/src/webview/static" "${dest}" <<EOF
+# Ignore files that won't be needed at runtime.
+- README.md
+
++ *
+EOF

--- a/tools/build-webview
+++ b/tools/build-webview
@@ -57,7 +57,7 @@ readonly root
 # Parse arguments. Sloppy, but sufficient for now.
 unset target
 unset dest
-sanity_checks=1
+check_path_name=0
 while (( $# )); do
     case "$1" in
         --help|-h|help)
@@ -68,9 +68,10 @@ while (( $# )); do
         --destination)
             # note: this doesn't permit an equals sign after `--destination`
             shift; dest="$1"; shift;;
-        --no-sanity-checks)
-            # disables target-directory sanity checks, for testing's sake
-            shift; sanity_checks=0;;
+        --check-path-name)
+            # enable persnickety checks of our caller's choice of paths,
+            # on the assumption it's the actual app build script
+            shift; check_path_name=1;;
         *) usage; exit 2;;
     esac
 done
@@ -86,9 +87,9 @@ fi
 dest=$(readlink -m "$dest")
 
 # Argument parsing has concluded; argument variables are no longer mutable.
-readonly target dest sanity_checks
+readonly target dest check_path_name
 
-if (( sanity_checks )); then
+if (( check_path_name )); then
     case "$target" in
         ios)
             if [ "$(uname)" != "Darwin" ]; then
@@ -127,7 +128,7 @@ if (( sanity_checks )); then
     if [[ "$dest" != *"/webview" ]]; then
         err "unexpected destination directory '$dest' (expected basename \"webview\")"
     fi
-fi  # if $sanity_checks
+fi  # if $check_path_name
 
 # Set $staging. This is our local staging directory; once it's compiled, it will
 # be synced over to $dest.

--- a/tools/build-webview
+++ b/tools/build-webview
@@ -15,13 +15,18 @@ unset CDPATH
 # print usage message; do not die
 usage() {
     cat >&2 <<EOF
-usage: $0 [ios | android] --destination DEST
+usage: $0 [ios | android] --destination DEST [--check-path-name]
 
-Builds a platform-local intermediate directory containing files used by the
-message-list WebView. The target platform (either \`ios\` or \`android\`) must
-be specified, along with the expected destination directory.
+Build our webview assets, into directory DEST.
 
-(This script is usually run automatically by the build system.)
+This script is mainly for internal use by our build scripts.  They
+go on to use the contents of DEST as the webview-assets folder,
+which our message-list WebView relies on for its static assets.
+See src/webview/MessageList.js for details.
+
+With --check-path-name, make some defensive checks that DEST has
+the form expected from the actual build scripts.
+
 EOF
 }
 
@@ -69,8 +74,6 @@ while (( $# )); do
             # note: this doesn't permit an equals sign after `--destination`
             shift; dest="$1"; shift;;
         --check-path-name)
-            # enable persnickety checks of our caller's choice of paths,
-            # on the assumption it's the actual app build script
             shift; check_path_name=1;;
         *) usage; exit 2;;
     esac

--- a/tools/build-webview
+++ b/tools/build-webview
@@ -133,6 +133,11 @@ if (( check_path_name )); then
     fi
 fi  # if $check_path_name
 
+
+################################################################################
+# (Build and) sync
+################################################################################
+
 # Set $staging. This is our local staging directory; once it's compiled, it will
 # be synced over to $dest.
 readonly staging="$root/src/webview/static"
@@ -141,35 +146,9 @@ if [ ! -d "$staging" ]; then
 fi
 
 
-################################################################################
-# Pre-sync: additional build steps
-################################################################################
-
-# Currently none, but this is where they'll go.
-#
-# TODO: Use something like `make -f src/webview/static.Makefile`, to ensure that
-#   complicated build steps are not run unconditionally.
-#
-# TODO: split assets into build-time-generated and build-time-static?
-#   - rsync can sync from multiple directories, but has no collision-detection
-#   - might be too many layers of abstraction
-
-
-################################################################################
-# Sync
-################################################################################
-
 # Sync the directory structure, preserving metadata. (We ignore any files named
 # 'README.md'; these should be strictly informative.)
 #
 # We use `rsync` here, as it will skip unchanged files.
 mkdir -p "$dest"
 rsync -a --no-D --delete --delete-excluded --exclude=README.md "$staging/." "$dest"
-
-
-
-################################################################################
-# Post-sync: additional build steps
-################################################################################
-
-# None yet.

--- a/tools/build-webview
+++ b/tools/build-webview
@@ -138,17 +138,11 @@ fi  # if $check_path_name
 # (Build and) sync
 ################################################################################
 
-# Set $staging. This is our local staging directory; once it's compiled, it will
-# be synced over to $dest.
-readonly staging="$root/src/webview/static"
-if [ ! -d "$staging" ]; then
-    err "cannot find asset staging directory '$staging'";
-fi
-
-
 # Sync the directory structure, preserving metadata. (We ignore any files named
 # 'README.md'; these should be strictly informative.)
 #
 # We use `rsync` here, as it will skip unchanged files.
 mkdir -p "$dest"
-rsync -a --no-D --delete --delete-excluded --exclude=README.md "$staging/." "$dest"
+rsync -a --no-D --delete --delete-excluded \
+      --exclude=README.md \
+      "$root/src/webview/static/." "$dest"

--- a/tools/build-webview
+++ b/tools/build-webview
@@ -156,8 +156,27 @@ sync() {
           --filter='. /dev/stdin'
 }
 
-# Sync the directory structure, preserving metadata.
+# Copy over files from KaTeX.
+sync "${root}/node_modules/katex/dist" "${dest}/katex" <<EOF
++ /katex.min.css
+
+# The KaTeX JS renders LaTeX code into HTML and MathML.
+# Our webview already has HTML and MathML, and just needs to style it.
+#+ /katex.min.js
+
+# The woff2 font format is preferred for browsers that support it,
+# which include Chrome 36+ and Mobile Safari 10+.  So that's all we need.
++ /fonts/
++ /fonts/*.woff2
+
+- *
+EOF
+
+# Copy over our own files.
 sync "${root}/src/webview/static" "${dest}" <<EOF
+# Leave alone the katex directory we just made.
+-,r /katex
+
 + /index.html
 + /base.css
 - *

--- a/yarn.lock
+++ b/yarn.lock
@@ -5660,6 +5660,13 @@ jszip@^3.1.5:
     readable-stream "~2.3.6"
     set-immediate-shim "~1.0.1"
 
+katex@^0.11.1:
+  version "0.11.1"
+  resolved "https://registry.yarnpkg.com/katex/-/katex-0.11.1.tgz#df30ca40c565c9df01a466a00d53e079e84ffaa2"
+  integrity sha512-5oANDICCTX0NqYIyAiFCCwjQ7ERu3DQG2JFHLbYOf+fXaMoH8eg/zOq5WSYJsKMi/QebW+Eh3gSM+oss1H/bww==
+  dependencies:
+    commander "^2.19.0"
+
 katex@^0.7.1:
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/katex/-/katex-0.7.1.tgz#06bb5298efad05e1e7228035ba8e1591f3061b8f"


### PR DESCRIPTION
This is a successor to #3744 and #3679, and fixes #2660.  It sets us up so that the message-list webview now uses KaTeX to show math formulas, just like the webapp does.

The commits that actually set up KaTeX, and then add some fixes to how it displays in certain cases, are @ray-kraesig's and taken from those previous PRs.  The major difference from those PRs is that it doesn't include the complex build-script infrastructure that those PRs added; instead it simplifies our existing `tools/build-webview` script somewhat and then extends it more modestly in order to accomplish what we need for KaTeX.  The approach is based on my [`rsync-refactor`](https://github.com/zulip/zulip-mobile/compare/master...gnprice:rsync-refactor) branch (to commit gnprice/zulip-mobile@6d98d01fb), from the #3679 thread.

Smaller differences include:
 * Updated the KaTeX version.
 * Applied this comment: https://github.com/zulip/zulip-mobile/pull/3679#discussion_r344940954
 * Various changes to commit messages and comments.

I've tested the branch on Android and iOS, and it works in my testing.

I'd appreciate review from @ray-kraesig (and others) on this PR.  Ray and I have discussed exhaustively the strategy question of whether to develop now an infrastructure for complex build scripts, and while he disagrees, I've made the decision that we won't.  But there are plenty of more-specific choices here that I'd be glad to see comments on.

There's one commit toward the end that I still have questions about (left over from #3679), which I'll comment on below.  Up to that point, and including the main commit that fixes #2660, I consider this branch ready to merge.
