### PR TITLE
chatNavBar: fix gap between navBar and topmost header

### DIFF
--- a/src/nav/ChatNavBar.js
+++ b/src/nav/ChatNavBar.js
@@ -2,6 +2,7 @@
 
 import React, { PureComponent } from 'react';
 import { View } from 'react-native';
+import Color from 'color';
 
 import type { Dispatch, Narrow } from '../types';
 import { LoadingBanner } from '../common';
@@ -40,7 +41,10 @@ class ChatNavBar extends PureComponent<Props> {
     return (
       <View
         style={{
-          borderColor: 'hsla(0, 0%, 50%, 0.25)',
+          borderColor:
+            backgroundColor === 'transparent'
+              ? 'hsla(0, 0%, 50%, 0.25)'
+              : Color(backgroundColor).darken(0.1),
           borderBottomWidth: 1,
         }}
       >


### PR DESCRIPTION
There is a gap of 1px between navigation Bar and the top header in chat screen. This is caused by applying  bottomBorder on navBar. This PR removes this.

![Screenshot-20200407015649-881x318](https://user-images.githubusercontent.com/31368194/78601871-1e1cd680-7873-11ea-8797-c528dfbcfa9c.png)
---------------------Before-----------------------------------------------------------------------After----------------------------