### PR TITLE
typing: Serialize recipients based on server version.

### DIFF
--- a/src/account/accountsSelectors.js
+++ b/src/account/accountsSelectors.js
@@ -150,9 +150,12 @@ export const getIdentity: Selector<Identity> = createSelector(
 );
 
 /**
- * The Zulip server version of the active account, in the parsed form
- * as a ZulipVersion instance, or undefined if we do not know the server
- * version.
+ * The Zulip server version of the active account.
+ *
+ * Throws if no active account; undefined if server version not known.
+ *
+ * See the `zulipVersion` property of `Account` for details on how this
+ * information is kept up to date.
  */
 export const getServerVersion = (state: GlobalState): ZulipVersion | void => {
   const activeAccount: Account = getActiveAccount(state);

--- a/src/account/accountsSelectors.js
+++ b/src/account/accountsSelectors.js
@@ -1,9 +1,9 @@
 /* @flow strict-local */
 import { createSelector } from 'reselect';
-
 import type { Account, Auth, GlobalState, Identity, Selector } from '../types';
 import { getAccounts } from '../directSelectors';
 import { identityOfAccount, keyOfIdentity, identityOfAuth, authOfAccount } from './accountMisc';
+import { ZulipVersion } from '../utils/zulipVersion';
 
 /** See `getAccountStatuses`. */
 export type AccountStatus = {| ...Identity, isLoggedIn: boolean |};
@@ -148,3 +148,16 @@ export const getIdentity: Selector<Identity> = createSelector(
   getAuth,
   auth => identityOfAuth(auth),
 );
+
+/**
+ * The Zulip server version of the active account, in the parsed form
+ * as a ZulipVersion instance, or undefined if we do not know the server
+ * version.
+ */
+export const getServerVersion = (state: GlobalState): ZulipVersion | void => {
+  const activeAccount: Account = getActiveAccount(state);
+  if (activeAccount.zulipVersion === undefined) {
+    return undefined;
+  }
+  return new ZulipVersion(activeAccount.zulipVersion);
+};

--- a/src/types.js
+++ b/src/types.js
@@ -79,10 +79,18 @@ export type Account = {|
   ...Auth,
 
   /**
-   * Use this to affect how we make some API requests, keeping the logic
-   * isolated to the edge, where we communicate with the server, to keep with
-   * the "crunchy shell" pattern (see docs/architecture/crunchy-shell.md), and
-   * for Sentry reports.
+   * The version of the Zulip server.
+   *
+   * We learn the server's version from /server_settings at the start of the
+   * login process, and again from /register when setting up an event queue.
+   * Because a server deploy invalidates event queues, this means the value
+   * is always up to date for a server we have an active event queue on.
+   *
+   * For use in:
+   *  * how we make some API requests, in order to keep the logic isolated
+   *    to the edge, where we communicate with the server, to keep with the
+   *    "crunchy shell" pattern (see docs/architecture/crunchy-shell.md);
+   *  * context data in Sentry reports.
    */
   zulipVersion?: string,
 

--- a/src/users/usersActions.js
+++ b/src/users/usersActions.js
@@ -34,12 +34,7 @@ const typingWorker = (state: GlobalState) => {
   // (zulip/zulip@2f634f8c0). For versions before this, email arrays
   // are used. If current server version is undetermined, user ID
   // arrays are optimistically used.
-  let useEmailArrays: boolean;
-  if (serverVersion === undefined) {
-    useEmailArrays = false;
-  } else {
-    useEmailArrays = !serverVersion.isAtLeast(new ZulipVersion('2.0.0-rc1'));
-  }
+  const useEmailArrays = !!serverVersion && !serverVersion.isAtLeast(new ZulipVersion('2.0.0-rc1'));
 
   const getRecipients = user_ids_array => {
     if (useEmailArrays) {


### PR DESCRIPTION
Zulip server versions >= 2.0.0-rc1 require user ID arrays in the
'to' argument for the typing endpoint, whereas we currently send
email arrays.

Check the Zulip version and use the appropriate format of the
argument, i.e., for versions >= 2.0.0-rc1 or when the Zulip server
version is undetermined, use user ID arrays, otherwise, use email
arrays.

Fixes #3732.