### PR TITLE
Search Result sorting at different screens

### DIFF
--- a/src/settings/LanguagePicker.js
+++ b/src/settings/LanguagePicker.js
@@ -36,12 +36,11 @@ export default class LanguagePicker extends PureComponent<Props> {
       return list;
     }
 
-    return list.filter(item => {
-      const itemData = `${item.name.toUpperCase()} ${item.nativeName.toUpperCase()}`;
-      const filterData = filter.toUpperCase();
-
-      return itemData.includes(filterData);
-    });
+    return list.filter(
+      item =>
+        item.name.toLowerCase().indexOf(filter.toLowerCase()) === 0
+        || item.nativeName.toLowerCase().indexOf(filter.toLowerCase()) === 0,
+    );
   };
 
   render() {

--- a/src/topics/TopicListScreen.js
+++ b/src/topics/TopicListScreen.js
@@ -49,7 +49,14 @@ class TopicListScreen extends PureComponent<Props, State> {
     const { topics } = this.props;
     const { filter } = this.state;
     const filteredTopics =
-      topics && topics.filter(topic => topic.name.toLowerCase().includes(filter.toLowerCase()));
+      topics
+      && topics
+        .filter(topic => topic.name.toLowerCase().includes(filter.toLowerCase()))
+        .sort(
+          (x, y) =>
+            x.name.toLowerCase().indexOf(filter.toLowerCase())
+            - y.name.toLowerCase().indexOf(filter.toLowerCase()),
+        );
 
     return (
       <Screen title="Topics" centerContent search searchBarOnChange={this.handleFilterChange}>

--- a/src/users/UserItem.js
+++ b/src/users/UserItem.js
@@ -16,7 +16,7 @@ const componentStyles = StyleSheet.create({
     color: 'white',
   },
   textEmail: {
-    fontSize: 10,
+    fontSize: 14,
     color: 'hsl(0, 0%, 60%)',
   },
   textWrapper: {

--- a/src/users/UserList.js
+++ b/src/users/UserList.js
@@ -29,7 +29,7 @@ export default class UserList extends PureComponent<Props> {
 
   render() {
     const { filter, style, users, presences, onPress, selected } = this.props;
-    const shownUsers = sortUserList(filterUserList(users, filter), presences);
+    const shownUsers = sortUserList(filterUserList(users, filter), presences, filter);
 
     if (shownUsers.length === 0) {
       return <SearchEmptyState text="No users found" />;

--- a/src/users/UserList.js
+++ b/src/users/UserList.js
@@ -57,6 +57,7 @@ export default class UserList extends PureComponent<Props> {
             email={item.email}
             onPress={onPress}
             isSelected={!!selected.find(user => user.user_id === item.user_id)}
+            showEmail
           />
         )}
         renderSectionHeader={({ section }) =>

--- a/src/users/userHelpers.js
+++ b/src/users/userHelpers.js
@@ -37,13 +37,43 @@ const statusOrder = (presence: UserPresence): number => {
   }
 };
 
-export const sortUserList = (users: User[], presences: PresenceState): User[] =>
-  [...users].sort(
-    (x1, x2) =>
-      statusOrder(presences[x1.email]) - statusOrder(presences[x2.email])
-      || x1.full_name.toLowerCase().localeCompare(x2.full_name.toLowerCase()),
+export const sortAlphabetically = (users: User[]): User[] =>
+  [...users].sort((x1, x2) => x1.full_name.toLowerCase().localeCompare(x2.full_name.toLowerCase()));
+
+export const filterUserStartWith = (users: User[], filter: string = ''): User[] =>
+  users.filter(user => user.full_name.toLowerCase().startsWith(filter.toLowerCase()));
+
+export const filterUserEmailStartWith = (users: User[], filter: string = ''): User[] =>
+  users.filter(user => user.email.toLowerCase().startsWith(filter.toLowerCase()));
+
+export const filterUserByInitials = (users: User[], filter: string = ''): User[] =>
+  users.filter(user =>
+    user.full_name
+      .replace(/(\s|[a-z])/g, '')
+      .toLowerCase()
+      .startsWith(filter.toLowerCase()),
   );
 
+export const getUniqueUsers = (users: User[]): User[] => uniqby(users, 'email');
+
+export const sortByPositionOfKeyword = (users: User[], filter: string = ''): User[] => {
+  if (filter === '') {
+    return users;
+  }
+  const beginOfUserName = filterUserStartWith(users, filter);
+  const beginOfInitialName = filterUserByInitials(users, filter);
+  const beginOfEmail = filterUserEmailStartWith(users, filter);
+  return getUniqueUsers([...beginOfUserName, ...beginOfEmail, ...beginOfInitialName, ...users]);
+};
+
+export const sortUserList = (
+  users: User[],
+  presences: PresenceState,
+  filter: string = '',
+): User[] =>
+  [...sortByPositionOfKeyword(users, filter)].sort(
+    (x1, x2) => statusOrder(presences[x1.email]) - statusOrder(presences[x2.email]),
+  );
 export const filterUserList = (users: User[], filter: string = '', ownEmail: ?string): User[] =>
   users.length > 0
     ? users.filter(
@@ -54,29 +84,6 @@ export const filterUserList = (users: User[], filter: string = '', ownEmail: ?st
             || user.email.toLowerCase().includes(filter.toLowerCase())),
       )
     : users;
-
-export const sortAlphabetically = (users: User[]): User[] =>
-  [...users].sort((x1, x2) => x1.full_name.toLowerCase().localeCompare(x2.full_name.toLowerCase()));
-
-export const filterUserStartWith = (users: User[], filter: string = '', ownEmail: string): User[] =>
-  users.filter(
-    user =>
-      user.email !== ownEmail && user.full_name.toLowerCase().startsWith(filter.toLowerCase()),
-  );
-
-export const filterUserByInitials = (
-  users: User[],
-  filter: string = '',
-  ownEmail: string,
-): User[] =>
-  users.filter(
-    user =>
-      user.email !== ownEmail
-      && user.full_name
-        .replace(/(\s|[a-z])/g, '')
-        .toLowerCase()
-        .startsWith(filter.toLowerCase()),
-  );
 
 export const filterUserThatContains = (
   users: User[],
@@ -95,8 +102,6 @@ export const filterUserMatchesEmail = (
   users.filter(
     user => user.email !== ownEmail && user.email.toLowerCase().includes(filter.toLowerCase()),
   );
-
-export const getUniqueUsers = (users: User[]): User[] => uniqby(users, 'email');
 
 export const getUsersAndWildcards = (users: User[]) => [
   { ...NULL_USER, full_name: 'all', email: '(Notify everyone)' },

--- a/src/users/userHelpers.js
+++ b/src/users/userHelpers.js
@@ -74,6 +74,7 @@ export const sortUserList = (
   [...sortByPositionOfKeyword(users, filter)].sort(
     (x1, x2) => statusOrder(presences[x1.email]) - statusOrder(presences[x2.email]),
   );
+
 export const filterUserList = (users: User[], filter: string = '', ownEmail: ?string): User[] =>
   users.length > 0
     ? users.filter(
@@ -84,24 +85,6 @@ export const filterUserList = (users: User[], filter: string = '', ownEmail: ?st
             || user.email.toLowerCase().includes(filter.toLowerCase())),
       )
     : users;
-
-export const filterUserThatContains = (
-  users: User[],
-  filter: string = '',
-  ownEmail: string,
-): User[] =>
-  users.filter(
-    user => user.email !== ownEmail && user.full_name.toLowerCase().includes(filter.toLowerCase()),
-  );
-
-export const filterUserMatchesEmail = (
-  users: User[],
-  filter: string = '',
-  ownEmail: string,
-): User[] =>
-  users.filter(
-    user => user.email !== ownEmail && user.email.toLowerCase().includes(filter.toLowerCase()),
-  );
 
 export const getUsersAndWildcards = (users: User[]) => [
   { ...NULL_USER, full_name: 'all', email: '(Notify everyone)' },
@@ -118,11 +101,8 @@ export const getAutocompleteSuggestion = (
     return users;
   }
   const allAutocompleteOptions = getUsersAndWildcards(users);
-  const startWith = filterUserStartWith(allAutocompleteOptions, filter, ownEmail);
-  const initials = filterUserByInitials(allAutocompleteOptions, filter, ownEmail);
-  const contains = filterUserThatContains(allAutocompleteOptions, filter, ownEmail);
-  const matchesEmail = filterUserMatchesEmail(users, filter, ownEmail);
-  return getUniqueUsers([...startWith, ...initials, ...contains, ...matchesEmail]);
+  const filteredUserExcludeSelf = filterUserList(allAutocompleteOptions, filter, ownEmail);
+  return sortByPositionOfKeyword(filteredUserExcludeSelf, filter);
 };
 
 export const getAutocompleteUserGroupSuggestions = (


### PR DESCRIPTION
1. The user list will show **user name** and **email** of every user to avoid confusion. Because the result will be prepared by comparing with their "**email**", "**username**", **"initials"** but while displaying the result it will show only the **full_name** of the user. the user matched with email(but having unmatched user name) may seem odd in the result list for a user.

2. The result of the sort will have priority of **username startswith> email starts with> initial starts with> email/full name contains.**

3. The language search result will match exactly with the search term. It will eliminate a language even if it contains the search term in the middle.
Because all the _language-strings_ are small strings. assuming, generally, every user knows the spellings of their own language.

4. topic search result will be displayed in **increasing order of occurrence of the search term** in every topic.