### PR TITLE
Fix scroll-on-resize to avoid jumping from bottom

### DIFF
--- a/src/webview/js/generatedEs3.js
+++ b/src/webview/js/generatedEs3.js
@@ -141,7 +141,7 @@ var compiledWebviewJs = (function (exports) {
     viewportHeight = documentBody.clientHeight;
     var maxScrollTop = documentBody.scrollHeight - documentBody.clientHeight;
 
-    if (documentBody.scrollTop === maxScrollTop) {
+    if (documentBody.scrollTop >= maxScrollTop - 1) {
       return;
     }
 

--- a/src/webview/js/generatedEs3.js
+++ b/src/webview/js/generatedEs3.js
@@ -137,12 +137,12 @@ var compiledWebviewJs = (function (exports) {
 
   var viewportHeight = documentBody.clientHeight;
   window.addEventListener('resize', function (event) {
-    var difference = viewportHeight - documentBody.clientHeight;
+    var heightChange = documentBody.clientHeight - viewportHeight;
 
     if (documentBody.scrollHeight !== documentBody.scrollTop + documentBody.clientHeight) {
       window.scrollBy({
         left: 0,
-        top: difference
+        top: -heightChange
       });
     }
 

--- a/src/webview/js/generatedEs3.js
+++ b/src/webview/js/generatedEs3.js
@@ -138,6 +138,7 @@ var compiledWebviewJs = (function (exports) {
   var viewportHeight = documentBody.clientHeight;
   window.addEventListener('resize', function (event) {
     var heightChange = documentBody.clientHeight - viewportHeight;
+    viewportHeight = documentBody.clientHeight;
 
     if (documentBody.scrollHeight !== documentBody.scrollTop + documentBody.clientHeight) {
       window.scrollBy({
@@ -145,8 +146,6 @@ var compiledWebviewJs = (function (exports) {
         top: -heightChange
       });
     }
-
-    viewportHeight = documentBody.clientHeight;
   });
 
   function midMessagePeer(top, bottom) {

--- a/src/webview/js/generatedEs3.js
+++ b/src/webview/js/generatedEs3.js
@@ -139,8 +139,9 @@ var compiledWebviewJs = (function (exports) {
   window.addEventListener('resize', function (event) {
     var heightChange = documentBody.clientHeight - viewportHeight;
     viewportHeight = documentBody.clientHeight;
+    var maxScrollTop = documentBody.scrollHeight - documentBody.clientHeight;
 
-    if (documentBody.scrollHeight === documentBody.scrollTop + documentBody.clientHeight) {
+    if (documentBody.scrollTop === maxScrollTop) {
       return;
     }
 

--- a/src/webview/js/generatedEs3.js
+++ b/src/webview/js/generatedEs3.js
@@ -140,12 +140,14 @@ var compiledWebviewJs = (function (exports) {
     var heightChange = documentBody.clientHeight - viewportHeight;
     viewportHeight = documentBody.clientHeight;
 
-    if (documentBody.scrollHeight !== documentBody.scrollTop + documentBody.clientHeight) {
-      window.scrollBy({
-        left: 0,
-        top: -heightChange
-      });
+    if (documentBody.scrollHeight === documentBody.scrollTop + documentBody.clientHeight) {
+      return;
     }
+
+    window.scrollBy({
+      left: 0,
+      top: -heightChange
+    });
   });
 
   function midMessagePeer(top, bottom) {

--- a/src/webview/js/js.js
+++ b/src/webview/js/js.js
@@ -167,9 +167,9 @@ const showHideElement = (elementId: string, show: boolean) => {
 let viewportHeight = documentBody.clientHeight;
 
 window.addEventListener('resize', event => {
-  const difference = viewportHeight - documentBody.clientHeight;
+  const heightChange = documentBody.clientHeight - viewportHeight;
   if (documentBody.scrollHeight !== documentBody.scrollTop + documentBody.clientHeight) {
-    window.scrollBy({ left: 0, top: difference });
+    window.scrollBy({ left: 0, top: -heightChange });
   }
   viewportHeight = documentBody.clientHeight;
 });

--- a/src/webview/js/js.js
+++ b/src/webview/js/js.js
@@ -184,8 +184,9 @@ window.addEventListener('resize', event => {
   //
   // If that happened, we'll be at the very bottom now.
   const maxScrollTop = documentBody.scrollHeight - documentBody.clientHeight;
-  if (documentBody.scrollTop === maxScrollTop) {
-    // We're at the very bottom of the content.  Don't scroll.
+  if (documentBody.scrollTop >= maxScrollTop - 1) {
+    // We're at (or within a px of, or beyond) the very bottom of the
+    // content.  Don't scroll.
     //
     // This does mean if you're near the bottom, and then the viewport grows
     // by more than that distance, you'll wind up at the very bottom instead

--- a/src/webview/js/js.js
+++ b/src/webview/js/js.js
@@ -168,10 +168,18 @@ let viewportHeight = documentBody.clientHeight;
 
 window.addEventListener('resize', event => {
   const heightChange = documentBody.clientHeight - viewportHeight;
+  viewportHeight = documentBody.clientHeight;
+
+  // Now we try to scroll to keep the bottom edge of the viewport aligned to
+  // the same content it was before the resize.  We assume the browser tried
+  // to keep the top edge aligned instead.
+  //
+  // Mostly, that means if the viewport grew, then the bottom moved down, so
+  // we'll scroll back up by the same amount; and vice versa if it shrank.
+
   if (documentBody.scrollHeight !== documentBody.scrollTop + documentBody.clientHeight) {
     window.scrollBy({ left: 0, top: -heightChange });
   }
-  viewportHeight = documentBody.clientHeight;
 });
 
 /*

--- a/src/webview/js/js.js
+++ b/src/webview/js/js.js
@@ -174,12 +174,28 @@ window.addEventListener('resize', event => {
   // the same content it was before the resize.  We assume the browser tried
   // to keep the top edge aligned instead.
   //
-  // Mostly, that means if the viewport grew, then the bottom moved down, so
-  // we'll scroll back up by the same amount; and vice versa if it shrank.
+  // Mostly, that means if the viewport grew, then the bottom edge moved down,
+  // so we'll scroll back up by the same amount; vice versa if it shrank.
 
-  if (documentBody.scrollHeight !== documentBody.scrollTop + documentBody.clientHeight) {
-    window.scrollBy({ left: 0, top: -heightChange });
+  // But if we were near the bottom pre-resize, and grew, then there may not
+  // have been room for the bottom edge to move that far down, and we
+  // shouldn't try to compensate -- if we do, we could end up scrolling up
+  // higher than we started.
+  //
+  // If that happened, we'll be at the very bottom now.
+  if (documentBody.scrollHeight === documentBody.scrollTop + documentBody.clientHeight) {
+    // We're at the very bottom of the content.  Don't scroll.
+    //
+    // This does mean if you're near the bottom, and then the viewport grows
+    // by more than that distance, you'll wind up at the very bottom instead
+    // of where you were.  That's not our ideal behavior.  OTOH it's
+    // mitigated by the fact that in this situation everything that was in
+    // view is still in view.
+    return;
   }
+
+  // Scrolling by a positive `top` scrolls down; negative scrolls up.
+  window.scrollBy({ left: 0, top: -heightChange });
 });
 
 /*

--- a/src/webview/js/js.js
+++ b/src/webview/js/js.js
@@ -183,7 +183,8 @@ window.addEventListener('resize', event => {
   // higher than we started.
   //
   // If that happened, we'll be at the very bottom now.
-  if (documentBody.scrollHeight === documentBody.scrollTop + documentBody.clientHeight) {
+  const maxScrollTop = documentBody.scrollHeight - documentBody.clientHeight;
+  if (documentBody.scrollTop === maxScrollTop) {
     // We're at the very bottom of the content.  Don't scroll.
     //
     // This does mean if you're near the bottom, and then the viewport grows


### PR DESCRIPTION
When the message list's viewport grows, we generally want to scroll up to keep its bottom edge aligned within the content, but we want to skip that when we're at the very bottom. We have logic to do all that, but it's pretty cryptic; this series starts by unpacking it.

If we're at the bottom and scroll up anyway, the effect would be exactly the symptoms in #3301.

Then it turns out that when we're at the bottom, the `scrollTop` value may not actually quite line up with where you'd think it should be. Empirically:
 * On iOS (in Safari), it tends to be 1px beyond the bottom.
 * On Android (in Chrome), it's not an integer, and can be a fraction of a px either beyond or short of the bottom.

So, allow for that when checking to see if we're at the bottom. We'd been testing for exact numerical equality.

Thanks to @jainkuniya for suggesting a related direction in #4003.

Fixes: #3301
