### PR TITLE
[REVIEWABLE] Stop using legacy Context API for styles

### DIFF
--- a/docs/architecture/react.md
+++ b/docs/architecture/react.md
@@ -100,27 +100,6 @@ long as the code adheres to core Redux principles:
   Redux reducers and treating every `state` value (and hence all its
   elements' elements, etc.) as immutable.
 
-### Context
-
-Our "Pure Component Principle" says `render` is a pure function of props,
-state, *and context*.  But `PureComponent` only checks for changes to props
-and state, and skips re-render when just those two are unchanged.  Doesn't
-that open up bugs if just `this.context` changes?
-
-[Yes, it
-would](https://reactjs.org/docs/legacy-context.html#updating-context).  For
-this reason, when something provided in context is updated, we force the
-entire React component tree under that point (in our usage of `context`,
-this is nearly the entire tree) to re-render.  This means we use `context`
-sparingly -- only for things where its benefit for code readability is very
-large, and where updates are rare so we're OK with that global re-render.
-
-In `StylesProvider`, for example, this is done with a `key`.
-
-Relatedly, the `this.context` API we use is a legacy API.  Recent React
-versions offer a [new context API](https://reactjs.org/docs/context.html)
-that works much more like Redux and `connect`, above.
-
 ### The exception: `MessageList`
 
 We have one React component that we wrote (beyond `connect` calls) that

--- a/src/ZulipMobile.js
+++ b/src/ZulipMobile.js
@@ -4,7 +4,7 @@ import React from 'react';
 import '../vendor/intl/intl';
 import StoreProvider from './boot/StoreProvider';
 import TranslationProvider from './boot/TranslationProvider';
-import StylesProvider from './boot/StylesProvider';
+import ThemeProvider from './boot/ThemeProvider';
 import CompatibilityChecker from './boot/CompatibilityChecker';
 import AppEventHandlers from './boot/AppEventHandlers';
 import AppDataFetcher from './boot/AppDataFetcher';
@@ -25,11 +25,11 @@ export default () => (
       <AppEventHandlers>
         <AppDataFetcher>
           <TranslationProvider>
-            <StylesProvider>
+            <ThemeProvider>
               <BackNavigationHandler>
                 <AppWithNavigation />
               </BackNavigationHandler>
-            </StylesProvider>
+            </ThemeProvider>
           </TranslationProvider>
         </AppDataFetcher>
       </AppEventHandlers>

--- a/src/boot/AppEventHandlers.js
+++ b/src/boot/AppEventHandlers.js
@@ -15,8 +15,48 @@ import {
   NotificationListener,
   notificationOnAppActive,
 } from '../notification';
-import { appOnline, appOrientation, initSafeAreaInsets } from '../actions';
+import { appOnline, appOrientation, initSafeAreaInsets, settingsChange } from '../actions';
+import { sleep } from '../utils/async';
 import PresenceHeartbeat from '../presence/PresenceHeartbeat';
+
+class ThemeClockUC extends PureComponent<{| +dispatch: Dispatch |}> {
+  running = false;
+
+  async run() {
+    if (this.running) {
+      return;
+    }
+    try {
+      while (true) {
+        await sleep(2500);
+        if (this.running) {
+          break;
+        }
+        await this.props.dispatch(settingsChange({ theme: 'night' }));
+        await sleep(2500);
+        if (this.running) {
+          break;
+        }
+        await this.props.dispatch(settingsChange({ theme: 'default' }));
+      }
+    } finally {
+      this.running = false;
+    }
+  }
+
+  componentDidMount() {
+    this.run();
+  }
+  componentWillUnmount() {
+    this.running = false;
+  }
+
+  render() {
+    return null;
+  }
+}
+
+const ThemeClock = connect()(ThemeClockUC);
 
 /**
  * Part of the interface from react-native-netinfo.
@@ -134,6 +174,7 @@ class AppEventHandlers extends PureComponent<Props> {
     return (
       <>
         <PresenceHeartbeat />
+        <ThemeClock />
         <View style={styles.wrapper}>{this.props.children}</View>
       </>
     );

--- a/src/boot/ThemeProvider.js
+++ b/src/boot/ThemeProvider.js
@@ -6,9 +6,7 @@ import type { Node as React$Node } from 'react';
 import type { ThemeName, Dispatch } from '../types';
 import { connect } from '../react-redux';
 import { getSettings } from '../directSelectors';
-import { stylesFromTheme, themeColors, ThemeContext } from '../styles/theme';
-
-const Dummy = props => props.children;
+import { themeColors, ThemeContext } from '../styles/theme';
 
 type Props = $ReadOnly<{|
   dispatch: Dispatch,
@@ -16,32 +14,17 @@ type Props = $ReadOnly<{|
   children: React$Node,
 |}>;
 
-class StylesProvider extends PureComponent<Props> {
-  static childContextTypes = {
-    styles: () => {},
-  };
-
+class ThemeProvider extends PureComponent<Props> {
   static defaultProps = {
     theme: 'default',
   };
 
-  getChildContext() {
-    const { theme } = this.props;
-    const styles = stylesFromTheme(theme);
-    return { styles };
-  }
-
   render() {
     const { children, theme } = this.props;
-
-    return (
-      <ThemeContext.Provider value={themeColors[theme]}>
-        <Dummy key={theme}>{children}</Dummy>
-      </ThemeContext.Provider>
-    );
+    return <ThemeContext.Provider value={themeColors[theme]}>{children}</ThemeContext.Provider>;
   }
 }
 
 export default connect(state => ({
   theme: getSettings(state).theme,
-}))(StylesProvider);
+}))(ThemeProvider);

--- a/src/boot/ThemeProvider.js
+++ b/src/boot/ThemeProvider.js
@@ -6,7 +6,7 @@ import type { Node as React$Node } from 'react';
 import type { ThemeName, Dispatch } from '../types';
 import { connect } from '../react-redux';
 import { getSettings } from '../directSelectors';
-import { themeColors, ThemeContext } from '../styles/theme';
+import { themeData, ThemeContext } from '../styles/theme';
 
 type Props = $ReadOnly<{|
   dispatch: Dispatch,
@@ -21,7 +21,7 @@ class ThemeProvider extends PureComponent<Props> {
 
   render() {
     const { children, theme } = this.props;
-    return <ThemeContext.Provider value={themeColors[theme]}>{children}</ThemeContext.Provider>;
+    return <ThemeContext.Provider value={themeData[theme]}>{children}</ThemeContext.Provider>;
   }
 }
 

--- a/src/chat/ChatScreen.js
+++ b/src/chat/ChatScreen.js
@@ -5,7 +5,9 @@ import type { NavigationScreenProp } from 'react-navigation';
 import { ActionSheetProvider } from '@expo/react-native-action-sheet';
 
 import { connect } from '../react-redux';
-import type { Context, Dispatch, Fetching, Narrow } from '../types';
+import type { ThemeColors } from '../styles';
+import styles, { ThemeContext } from '../styles';
+import type { Dispatch, Fetching, Narrow } from '../types';
 import { KeyboardAvoider, OfflineNotice, ZulipStatusBar } from '../common';
 import ChatNavBar from '../nav/ChatNavBar';
 
@@ -13,7 +15,7 @@ import MessageList from '../webview/MessageList';
 import NoMessages from '../message/NoMessages';
 import ComposeBox from '../compose/ComposeBox';
 import UnreadNotice from './UnreadNotice';
-import styles from '../styles';
+
 import { canSendToNarrow } from '../utils/narrow';
 import { getLoading } from '../directSelectors';
 import { getFetchingForNarrow } from './fetchingSelectors';
@@ -33,14 +35,17 @@ type Props = $ReadOnly<{|
 |}>;
 
 class ChatScreen extends PureComponent<Props> {
-  context: Context;
+  static contextType = ThemeContext;
+  context: ThemeColors;
 
-  static contextTypes = {
-    styles: () => null,
+  styles = {
+    screen: {
+      flex: 1,
+      flexDirection: 'column',
+    },
   };
 
   render() {
-    const { styles: contextStyles } = this.context;
     const { fetching, haveNoMessages, loading, navigation } = this.props;
     const { narrow } = navigation.state.params;
 
@@ -51,7 +56,7 @@ class ChatScreen extends PureComponent<Props> {
 
     return (
       <ActionSheetProvider>
-        <View style={contextStyles.screen}>
+        <View style={[this.styles.screen, { backgroundColor: this.context.backgroundColor }]}>
           <KeyboardAvoider style={styles.flexed} behavior="padding">
             <ZulipStatusBar narrow={narrow} />
             <ChatNavBar narrow={narrow} />

--- a/src/chat/ChatScreen.js
+++ b/src/chat/ChatScreen.js
@@ -5,7 +5,7 @@ import type { NavigationScreenProp } from 'react-navigation';
 import { ActionSheetProvider } from '@expo/react-native-action-sheet';
 
 import { connect } from '../react-redux';
-import type { ThemeColors } from '../styles';
+import type { ThemeData } from '../styles';
 import styles, { ThemeContext } from '../styles';
 import type { Dispatch, Fetching, Narrow } from '../types';
 import { KeyboardAvoider, OfflineNotice, ZulipStatusBar } from '../common';
@@ -36,7 +36,7 @@ type Props = $ReadOnly<{|
 
 class ChatScreen extends PureComponent<Props> {
   static contextType = ThemeContext;
-  context: ThemeColors;
+  context: ThemeData;
 
   styles = {
     screen: {

--- a/src/common/Input.js
+++ b/src/common/Input.js
@@ -4,7 +4,7 @@ import { TextInput, Platform } from 'react-native';
 import { FormattedMessage } from 'react-intl';
 
 import type { LocalizableText } from '../types';
-import type { ThemeColors } from '../styles';
+import type { ThemeData } from '../styles';
 import { ThemeContext, HALF_COLOR, BORDER_COLOR } from '../styles';
 
 export type Props = $ReadOnly<{|
@@ -34,7 +34,7 @@ type State = {|
  */
 export default class Input extends PureComponent<Props, State> {
   static contextType = ThemeContext;
-  context: ThemeColors;
+  context: ThemeData;
 
   styles = {
     input: {

--- a/src/common/Input.js
+++ b/src/common/Input.js
@@ -1,10 +1,11 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
-import { TextInput } from 'react-native';
+import { TextInput, Platform } from 'react-native';
 import { FormattedMessage } from 'react-intl';
 
-import type { Context, LocalizableText } from '../types';
-import { HALF_COLOR, BORDER_COLOR } from '../styles';
+import type { LocalizableText } from '../types';
+import type { ThemeColors } from '../styles';
+import { ThemeContext, HALF_COLOR, BORDER_COLOR } from '../styles';
 
 export type Props = $ReadOnly<{|
   ...$PropertyType<TextInput, 'props'>,
@@ -32,15 +33,26 @@ type State = {|
  *   See upstream: https://facebook.github.io/react-native/docs/textinput
  */
 export default class Input extends PureComponent<Props, State> {
-  context: Context;
+  static contextType = ThemeContext;
+  context: ThemeColors;
+
+  styles = {
+    input: {
+      ...Platform.select({
+        ios: {
+          borderWidth: 1,
+          borderColor: BORDER_COLOR,
+          borderRadius: 2,
+          padding: 8,
+        },
+      }),
+    },
+  };
+
   state = {
     isFocused: false,
   };
   textInput: ?TextInput;
-
-  static contextTypes = {
-    styles: () => null,
-  };
 
   handleClear = () => {
     const { onChangeText } = this.props;
@@ -65,7 +77,6 @@ export default class Input extends PureComponent<Props, State> {
   };
 
   render() {
-    const { styles: contextStyles } = this.context;
     const { style, placeholder, textInputRef, ...restProps } = this.props;
     const { isFocused } = this.state;
     const fullPlaceholder =
@@ -81,7 +92,7 @@ export default class Input extends PureComponent<Props, State> {
       >
         {(text: string) => (
           <TextInput
-            style={[contextStyles.input, style]}
+            style={[this.styles.input, { color: this.context.color }, style]}
             placeholder={text}
             placeholderTextColor={HALF_COLOR}
             underlineColorAndroid={isFocused ? BORDER_COLOR : HALF_COLOR}

--- a/src/common/Label.js
+++ b/src/common/Label.js
@@ -3,7 +3,7 @@ import React, { PureComponent } from 'react';
 import { Text } from 'react-native';
 import TranslatedText from './TranslatedText';
 
-import type { ThemeColors } from '../styles';
+import type { ThemeData } from '../styles';
 import { ThemeContext } from '../styles';
 import type { LocalizableText } from '../types';
 
@@ -26,7 +26,7 @@ type Props = $ReadOnly<{|
  */
 export default class Label extends PureComponent<Props> {
   static contextType = ThemeContext;
-  context: ThemeColors;
+  context: ThemeData;
 
   styles = {
     label: {

--- a/src/common/Label.js
+++ b/src/common/Label.js
@@ -3,7 +3,9 @@ import React, { PureComponent } from 'react';
 import { Text } from 'react-native';
 import TranslatedText from './TranslatedText';
 
-import type { Context, LocalizableText } from '../types';
+import type { ThemeColors } from '../styles';
+import { ThemeContext } from '../styles';
+import type { LocalizableText } from '../types';
 
 type Props = $ReadOnly<{|
   ...$Exact<$PropertyType<Text, 'props'>>,
@@ -23,18 +25,20 @@ type Props = $ReadOnly<{|
  *   See upstream: https://facebook.github.io/react-native/docs/text
  */
 export default class Label extends PureComponent<Props> {
-  context: Context;
+  static contextType = ThemeContext;
+  context: ThemeColors;
 
-  static contextTypes = {
-    styles: () => null,
+  styles = {
+    label: {
+      fontSize: 15,
+    },
   };
 
   render() {
-    const { styles: contextStyles } = this.context;
     const { text, style, ...restProps } = this.props;
 
     return (
-      <Text style={[contextStyles.label, style]} {...restProps}>
+      <Text style={[this.styles.label, { color: this.context.color }, style]} {...restProps}>
         <TranslatedText text={text} />
       </Text>
     );

--- a/src/common/LineSeparator.js
+++ b/src/common/LineSeparator.js
@@ -2,12 +2,12 @@
 import React, { PureComponent } from 'react';
 import { View } from 'react-native';
 
-import type { ThemeColors } from '../styles';
+import type { ThemeData } from '../styles';
 import { ThemeContext } from '../styles';
 
 export default class LineSeparator extends PureComponent<{||}> {
   static contextType = ThemeContext;
-  context: ThemeColors;
+  context: ThemeData;
 
   styles = {
     lineSeparator: {

--- a/src/common/LineSeparator.js
+++ b/src/common/LineSeparator.js
@@ -12,12 +12,13 @@ export default class LineSeparator extends PureComponent<{||}> {
   styles = {
     lineSeparator: {
       height: 1,
-      backgroundColor: this.context.cardColor,
       margin: 4,
     },
   };
 
   render() {
-    return <View style={this.styles.lineSeparator} />;
+    return (
+      <View style={[this.styles.lineSeparator, { backgroundColor: this.context.cardColor }]} />
+    );
   }
 }

--- a/src/common/LoadingBanner.js
+++ b/src/common/LoadingBanner.js
@@ -7,7 +7,7 @@ import type { Dispatch } from '../types';
 import { connect } from '../react-redux';
 import { getLoading } from '../selectors';
 import { Label, LoadingIndicator } from '.';
-import type { ThemeColors } from '../styles';
+import type { ThemeData } from '../styles';
 import { ThemeContext } from '../styles';
 
 const key = 'LoadingBanner';
@@ -40,7 +40,7 @@ type Props = $ReadOnly<{|
  */
 class LoadingBanner extends PureComponent<Props> {
   static contextType = ThemeContext;
-  context: ThemeColors;
+  context: ThemeData;
 
   render() {
     if (!this.props.loading) {

--- a/src/common/OptionButton.js
+++ b/src/common/OptionButton.js
@@ -20,10 +20,7 @@ export default class OptionButton extends PureComponent<Props> {
   context: ThemeColors;
 
   styles = {
-    icon: {
-      ...styles.settingsIcon,
-      color: this.context.color,
-    },
+    icon: styles.settingsIcon,
   };
 
   render() {
@@ -32,10 +29,10 @@ export default class OptionButton extends PureComponent<Props> {
     return (
       <Touchable onPress={onPress}>
         <View style={styles.listItem}>
-          {!!Icon && <Icon size={18} style={this.styles.icon} />}
+          {!!Icon && <Icon size={18} style={[this.styles.icon, { color: this.context.color }]} />}
           <Label text={label} />
           <View style={styles.rightItem}>
-            <IconRight size={18} style={this.styles.icon} />
+            <IconRight size={18} style={[this.styles.icon, { color: this.context.color }]} />
           </View>
         </View>
       </Touchable>

--- a/src/common/OptionButton.js
+++ b/src/common/OptionButton.js
@@ -6,7 +6,7 @@ import Label from './Label';
 import Touchable from './Touchable';
 import { IconRight } from './Icons';
 import type { IconType } from './Icons';
-import type { ThemeColors } from '../styles';
+import type { ThemeData } from '../styles';
 import styles, { ThemeContext } from '../styles';
 
 type Props = $ReadOnly<{|
@@ -17,7 +17,7 @@ type Props = $ReadOnly<{|
 
 export default class OptionButton extends PureComponent<Props> {
   static contextType = ThemeContext;
-  context: ThemeColors;
+  context: ThemeData;
 
   styles = {
     icon: styles.settingsIcon,

--- a/src/common/OptionDivider.js
+++ b/src/common/OptionDivider.js
@@ -12,11 +12,10 @@ export default class OptionDivider extends PureComponent<{||}> {
   styles = {
     divider: {
       borderBottomWidth: 1,
-      borderBottomColor: this.context.dividerColor,
     },
   };
 
   render() {
-    return <View style={this.styles.divider} />;
+    return <View style={[this.styles.divider, { borderBottomColor: this.context.dividerColor }]} />;
   }
 }

--- a/src/common/OptionDivider.js
+++ b/src/common/OptionDivider.js
@@ -2,12 +2,12 @@
 import React, { PureComponent } from 'react';
 import { View } from 'react-native';
 
-import type { ThemeColors } from '../styles';
+import type { ThemeData } from '../styles';
 import { ThemeContext } from '../styles';
 
 export default class OptionDivider extends PureComponent<{||}> {
   static contextType = ThemeContext;
-  context: ThemeColors;
+  context: ThemeData;
 
   styles = {
     divider: {

--- a/src/common/OptionRow.js
+++ b/src/common/OptionRow.js
@@ -22,10 +22,7 @@ export default class OptionRow extends PureComponent<Props> {
   context: ThemeColors;
 
   styles = {
-    icon: {
-      ...styles.settingsIcon,
-      color: this.context.color,
-    },
+    icon: styles.settingsIcon,
   };
 
   render() {
@@ -33,7 +30,7 @@ export default class OptionRow extends PureComponent<Props> {
 
     return (
       <View style={[styles.listItem, style]}>
-        {!!Icon && <Icon size={18} style={this.styles.icon} />}
+        {!!Icon && <Icon size={18} style={[this.styles.icon, { color: this.context.color }]} />}
         <Label text={label} style={styles.flexed} />
         <View style={styles.rightItem}>
           <ZulipSwitch value={value} onValueChange={onValueChange} />

--- a/src/common/OptionRow.js
+++ b/src/common/OptionRow.js
@@ -6,7 +6,7 @@ import type { ViewStyleProp } from 'react-native/Libraries/StyleSheet/StyleSheet
 import type { IconType } from './Icons';
 import Label from './Label';
 import ZulipSwitch from './ZulipSwitch';
-import type { ThemeColors } from '../styles';
+import type { ThemeData } from '../styles';
 import styles, { ThemeContext } from '../styles';
 
 type Props = $ReadOnly<{|
@@ -19,7 +19,7 @@ type Props = $ReadOnly<{|
 
 export default class OptionRow extends PureComponent<Props> {
   static contextType = ThemeContext;
-  context: ThemeColors;
+  context: ThemeData;
 
   styles = {
     icon: styles.settingsIcon,

--- a/src/common/Popup.js
+++ b/src/common/Popup.js
@@ -3,7 +3,7 @@ import React, { PureComponent } from 'react';
 import type { Node as React$Node } from 'react';
 import { View, StyleSheet } from 'react-native';
 
-import type { ThemeColors } from '../styles';
+import type { ThemeData } from '../styles';
 import { ThemeContext } from '../styles';
 
 const styles = StyleSheet.create({
@@ -24,7 +24,7 @@ type Props = $ReadOnly<{|
 
 export default class Popup extends PureComponent<Props> {
   static contextType = ThemeContext;
-  context: ThemeColors;
+  context: ThemeData;
 
   render() {
     return (

--- a/src/common/Popup.js
+++ b/src/common/Popup.js
@@ -3,7 +3,8 @@ import React, { PureComponent } from 'react';
 import type { Node as React$Node } from 'react';
 import { View, StyleSheet } from 'react-native';
 
-import type { Context } from '../types';
+import type { ThemeColors } from '../styles';
+import { ThemeContext } from '../styles';
 
 const styles = StyleSheet.create({
   popup: {
@@ -22,15 +23,14 @@ type Props = $ReadOnly<{|
 |}>;
 
 export default class Popup extends PureComponent<Props> {
-  context: Context;
-
-  static contextTypes = {
-    styles: () => null,
-  };
+  static contextType = ThemeContext;
+  context: ThemeColors;
 
   render() {
     return (
-      <View style={[this.context.styles.backgroundColor, styles.popup]}>{this.props.children}</View>
+      <View style={[{ backgroundColor: this.context.backgroundColor }, styles.popup]}>
+        {this.props.children}
+      </View>
     );
   }
 }

--- a/src/common/RawLabel.js
+++ b/src/common/RawLabel.js
@@ -2,7 +2,7 @@
 import React, { PureComponent } from 'react';
 import { Text } from 'react-native';
 
-import type { ThemeColors } from '../styles';
+import type { ThemeData } from '../styles';
 import { ThemeContext } from '../styles';
 
 type Props = $ReadOnly<{|
@@ -23,7 +23,7 @@ type Props = $ReadOnly<{|
  */
 export default class RawLabel extends PureComponent<Props> {
   static contextType = ThemeContext;
-  context: ThemeColors;
+  context: ThemeData;
 
   styles = {
     label: {

--- a/src/common/RawLabel.js
+++ b/src/common/RawLabel.js
@@ -2,7 +2,8 @@
 import React, { PureComponent } from 'react';
 import { Text } from 'react-native';
 
-import type { Context } from '../types';
+import type { ThemeColors } from '../styles';
+import { ThemeContext } from '../styles';
 
 type Props = $ReadOnly<{|
   ...$Exact<$PropertyType<Text, 'props'>>,
@@ -21,18 +22,20 @@ type Props = $ReadOnly<{|
  *   See upstream: https://facebook.github.io/react-native/docs/text
  */
 export default class RawLabel extends PureComponent<Props> {
-  context: Context;
+  static contextType = ThemeContext;
+  context: ThemeColors;
 
-  static contextTypes = {
-    styles: () => null,
+  styles = {
+    label: {
+      fontSize: 15,
+    },
   };
 
   render() {
-    const styles = this.context.styles || {};
     const { text, style, ...restProps } = this.props;
 
     return (
-      <Text style={[styles.label, style]} {...restProps}>
+      <Text style={[this.styles.label, { color: this.context.color }, style]} {...restProps}>
         {text}
       </Text>
     );

--- a/src/common/Screen.js
+++ b/src/common/Screen.js
@@ -5,7 +5,7 @@ import type { Node as React$Node } from 'react';
 import { StyleSheet, View, ScrollView } from 'react-native';
 import type { ViewStyleProp } from 'react-native/Libraries/StyleSheet/StyleSheet';
 
-import type { ThemeColors } from '../styles';
+import type { ThemeData } from '../styles';
 import styles, { ThemeContext } from '../styles';
 import type { Dimensions, LocalizableText, Dispatch } from '../types';
 import { connect } from '../react-redux';
@@ -78,7 +78,7 @@ type Props = $ReadOnly<{|
  */
 class Screen extends PureComponent<Props> {
   static contextType = ThemeContext;
-  context: ThemeColors;
+  context: ThemeData;
 
   static defaultProps = {
     centerContent: false,

--- a/src/common/Screen.js
+++ b/src/common/Screen.js
@@ -5,7 +5,9 @@ import type { Node as React$Node } from 'react';
 import { StyleSheet, View, ScrollView } from 'react-native';
 import type { ViewStyleProp } from 'react-native/Libraries/StyleSheet/StyleSheet';
 
-import type { Context, Dimensions, LocalizableText, Dispatch } from '../types';
+import type { ThemeColors } from '../styles';
+import styles, { ThemeContext } from '../styles';
+import type { Dimensions, LocalizableText, Dispatch } from '../types';
 import { connect } from '../react-redux';
 import KeyboardAvoider from './KeyboardAvoider';
 import OfflineNotice from './OfflineNotice';
@@ -14,9 +16,12 @@ import ZulipStatusBar from './ZulipStatusBar';
 import { getSession } from '../selectors';
 import ModalNavBar from '../nav/ModalNavBar';
 import ModalSearchNavBar from '../nav/ModalSearchNavBar';
-import styles from '../styles';
 
 const componentStyles = StyleSheet.create({
+  screen: {
+    flex: 1,
+    flexDirection: 'column',
+  },
   wrapper: {
     flex: 1,
     justifyContent: 'center',
@@ -72,11 +77,8 @@ type Props = $ReadOnly<{|
  *                 Required unless `search` is true.
  */
 class Screen extends PureComponent<Props> {
-  context: Context;
-
-  static contextTypes = {
-    styles: () => null,
-  };
+  static contextType = ThemeContext;
+  context: ThemeColors;
 
   static defaultProps = {
     centerContent: false,
@@ -109,10 +111,15 @@ class Screen extends PureComponent<Props> {
       title,
       shouldShowLoadingBanner,
     } = this.props;
-    const { styles: contextStyles } = this.context;
 
     return (
-      <View style={[contextStyles.screen, { paddingBottom: safeAreaInsets.bottom }]}>
+      <View
+        style={[
+          componentStyles.screen,
+          { backgroundColor: this.context.backgroundColor },
+          { paddingBottom: safeAreaInsets.bottom },
+        ]}
+      >
         <ZulipStatusBar />
         {search ? (
           <ModalSearchNavBar autoFocus={autoFocus} searchBarOnChange={searchBarOnChange} />

--- a/src/common/SectionHeader.js
+++ b/src/common/SectionHeader.js
@@ -2,7 +2,8 @@
 import React, { PureComponent } from 'react';
 import { StyleSheet, View } from 'react-native';
 
-import type { Context } from '../types';
+import type { ThemeColors } from '../styles';
+import { ThemeContext } from '../styles';
 import Label from './Label';
 
 const styles = StyleSheet.create({
@@ -17,16 +18,13 @@ type Props = $ReadOnly<{|
 |}>;
 
 export default class SectionHeader extends PureComponent<Props> {
-  context: Context;
-
-  static contextTypes = {
-    styles: () => null,
-  };
+  static contextType = ThemeContext;
+  context: ThemeColors;
 
   render() {
     const { text } = this.props;
     return (
-      <View style={[styles.header, this.context.styles.backgroundColor]}>
+      <View style={[styles.header, { backgroundColor: this.context.backgroundColor }]}>
         <Label text={text} />
       </View>
     );

--- a/src/common/SectionHeader.js
+++ b/src/common/SectionHeader.js
@@ -2,7 +2,7 @@
 import React, { PureComponent } from 'react';
 import { StyleSheet, View } from 'react-native';
 
-import type { ThemeColors } from '../styles';
+import type { ThemeData } from '../styles';
 import { ThemeContext } from '../styles';
 import Label from './Label';
 
@@ -19,7 +19,7 @@ type Props = $ReadOnly<{|
 
 export default class SectionHeader extends PureComponent<Props> {
   static contextType = ThemeContext;
-  context: ThemeColors;
+  context: ThemeData;
 
   render() {
     const { text } = this.props;

--- a/src/common/SmartUrlInput.js
+++ b/src/common/SmartUrlInput.js
@@ -4,7 +4,7 @@ import { StyleSheet, TextInput, TouchableWithoutFeedback, View } from 'react-nat
 import type { ViewStyleProp } from 'react-native/Libraries/StyleSheet/StyleSheet';
 import type { NavigationEventSubscription, NavigationScreenProp } from 'react-navigation';
 
-import type { ThemeColors } from '../styles';
+import type { ThemeData } from '../styles';
 import { ThemeContext } from '../styles';
 import { autocompleteRealmPieces, autocompleteRealm, fixRealmUrl } from '../utils/url';
 import type { Protocol } from '../utils/url';
@@ -62,7 +62,7 @@ type State = {|
 
 export default class SmartUrlInput extends PureComponent<Props, State> {
   static contextType = ThemeContext;
-  context: ThemeColors;
+  context: ThemeData;
   state = {
     value: '',
   };

--- a/src/compose/ComposeBox.js
+++ b/src/compose/ComposeBox.js
@@ -4,7 +4,7 @@ import { Platform, View, TextInput, findNodeHandle } from 'react-native';
 import type { LayoutEvent } from 'react-native/Libraries/Types/CoreEventTypes';
 import TextInputReset from 'react-native-text-input-reset';
 
-import type { ThemeColors } from '../styles';
+import type { ThemeData } from '../styles';
 import { ThemeContext } from '../styles';
 import type {
   Auth,
@@ -104,7 +104,7 @@ export const updateTextInput = (textInput: ?TextInput, text: string): void => {
 
 class ComposeBox extends PureComponent<Props, State> {
   static contextType = ThemeContext;
-  context: ThemeColors;
+  context: ThemeData;
 
   messageInput: ?TextInput = null;
   topicInput: ?TextInput = null;

--- a/src/compose/ComposeBox.js
+++ b/src/compose/ComposeBox.js
@@ -4,9 +4,10 @@ import { Platform, View, TextInput, findNodeHandle } from 'react-native';
 import type { LayoutEvent } from 'react-native/Libraries/Types/CoreEventTypes';
 import TextInputReset from 'react-native-text-input-reset';
 
+import type { ThemeColors } from '../styles';
+import { ThemeContext } from '../styles';
 import type {
   Auth,
-  Context,
   Narrow,
   EditMessage,
   InputSelection,
@@ -102,16 +103,13 @@ export const updateTextInput = (textInput: ?TextInput, text: string): void => {
 };
 
 class ComposeBox extends PureComponent<Props, State> {
-  context: Context;
+  static contextType = ThemeContext;
+  context: ThemeColors;
 
   messageInput: ?TextInput = null;
   topicInput: ?TextInput = null;
 
   inputBlurTimeoutId: ?TimeoutID = null;
-
-  static contextTypes = {
-    styles: () => null,
-  };
 
   state = {
     isMessageFocused: false,
@@ -319,7 +317,6 @@ class ComposeBox extends PureComponent<Props, State> {
       borderRadius: 5,
       marginBottom: 8,
       ...this.inputMarginPadding,
-      ...this.context.styles.backgroundColor,
     },
     composeTextInput: {
       borderWidth: 0,
@@ -327,7 +324,6 @@ class ComposeBox extends PureComponent<Props, State> {
       fontSize: 15,
       flexShrink: 1,
       ...this.inputMarginPadding,
-      ...this.context.styles.backgroundColor,
     },
   };
 
@@ -381,7 +377,7 @@ class ComposeBox extends PureComponent<Props, State> {
           <View style={this.styles.composeText}>
             {this.getCanSelectTopic() && (
               <Input
-                style={this.styles.topicInput}
+                style={[this.styles.topicInput, { backgroundColor: this.context.backgroundColor }]}
                 underlineColorAndroid="transparent"
                 placeholder="Topic"
                 defaultValue={topic}
@@ -397,7 +393,10 @@ class ComposeBox extends PureComponent<Props, State> {
             )}
             <Input
               multiline={!isMenuExpanded}
-              style={this.styles.composeTextInput}
+              style={[
+                this.styles.composeTextInput,
+                { backgroundColor: this.context.backgroundColor },
+              ]}
               underlineColorAndroid="transparent"
               placeholder={placeholder}
               defaultValue={message}

--- a/src/main/MainScreenWithTabs.js
+++ b/src/main/MainScreenWithTabs.js
@@ -2,14 +2,14 @@
 import React, { PureComponent } from 'react';
 import { View } from 'react-native';
 
-import type { ThemeColors } from '../styles';
+import type { ThemeData } from '../styles';
 import styles, { ThemeContext } from '../styles';
 import { OfflineNotice, ZulipStatusBar } from '../common';
 import MainTabs from './MainTabs';
 
 export default class MainScreenWithTabs extends PureComponent<{||}> {
   static contextType = ThemeContext;
-  context: ThemeColors;
+  context: ThemeData;
 
   render() {
     return (

--- a/src/main/MainScreenWithTabs.js
+++ b/src/main/MainScreenWithTabs.js
@@ -2,23 +2,18 @@
 import React, { PureComponent } from 'react';
 import { View } from 'react-native';
 
-import type { Context } from '../types';
+import type { ThemeColors } from '../styles';
+import styles, { ThemeContext } from '../styles';
 import { OfflineNotice, ZulipStatusBar } from '../common';
 import MainTabs from './MainTabs';
-import styles from '../styles';
 
 export default class MainScreenWithTabs extends PureComponent<{||}> {
-  context: Context;
-
-  static contextTypes = {
-    styles: () => null,
-  };
+  static contextType = ThemeContext;
+  context: ThemeColors;
 
   render() {
-    const { styles: contextStyles } = this.context;
-
     return (
-      <View style={[styles.flexed, contextStyles.backgroundColor]}>
+      <View style={[styles.flexed, { backgroundColor: this.context.backgroundColor }]}>
         <ZulipStatusBar />
         <OfflineNotice />
         <MainTabs />

--- a/src/nav/ModalNavBar.js
+++ b/src/nav/ModalNavBar.js
@@ -4,7 +4,7 @@ import React, { PureComponent } from 'react';
 import { View } from 'react-native';
 
 import type { Dispatch, LocalizableText } from '../types';
-import type { ThemeColors } from '../styles';
+import type { ThemeData } from '../styles';
 import styles, { ThemeContext, NAVBAR_SIZE } from '../styles';
 import { connect } from '../react-redux';
 
@@ -20,7 +20,7 @@ type Props = $ReadOnly<{|
 
 class ModalNavBar extends PureComponent<Props> {
   static contextType = ThemeContext;
-  context: ThemeColors;
+  context: ThemeData;
 
   render() {
     const { dispatch, canGoBack, title } = this.props;

--- a/src/nav/ModalSearchNavBar.js
+++ b/src/nav/ModalSearchNavBar.js
@@ -3,7 +3,7 @@ import React, { PureComponent } from 'react';
 import { View } from 'react-native';
 
 import type { Dispatch } from '../types';
-import type { ThemeColors } from '../styles';
+import type { ThemeData } from '../styles';
 import { ThemeContext, NAVBAR_SIZE } from '../styles';
 import { connect } from '../react-redux';
 import SearchInput from '../common/SearchInput';
@@ -18,7 +18,7 @@ type Props = $ReadOnly<{|
 
 class ModalSearchNavBar extends PureComponent<Props> {
   static contextType = ThemeContext;
-  context: ThemeColors;
+  context: ThemeData;
 
   render() {
     const { dispatch, autoFocus, searchBarOnChange } = this.props;

--- a/src/pm-conversations/PmConversationsCard.js
+++ b/src/pm-conversations/PmConversationsCard.js
@@ -3,7 +3,7 @@
 import React, { PureComponent } from 'react';
 import { View, StyleSheet } from 'react-native';
 
-import type { ThemeColors } from '../styles';
+import type { ThemeData } from '../styles';
 import { ThemeContext } from '../styles';
 import type { Dispatch, PmConversationData, UserOrBot } from '../types';
 import { connect } from '../react-redux';
@@ -43,7 +43,7 @@ type Props = $ReadOnly<{|
  * */
 class PmConversationsCard extends PureComponent<Props> {
   static contextType = ThemeContext;
-  context: ThemeColors;
+  context: ThemeData;
 
   render() {
     const { dispatch, conversations, usersByEmail } = this.props;

--- a/src/pm-conversations/PmConversationsCard.js
+++ b/src/pm-conversations/PmConversationsCard.js
@@ -3,7 +3,9 @@
 import React, { PureComponent } from 'react';
 import { View, StyleSheet } from 'react-native';
 
-import type { Context, Dispatch, PmConversationData, UserOrBot } from '../types';
+import type { ThemeColors } from '../styles';
+import { ThemeContext } from '../styles';
+import type { Dispatch, PmConversationData, UserOrBot } from '../types';
 import { connect } from '../react-redux';
 import { Label, ZulipButton, LoadingBanner } from '../common';
 import { IconPeople, IconSearch } from '../common/Icons';
@@ -40,18 +42,14 @@ type Props = $ReadOnly<{|
  * The "PMs" page in the main tabs navigation.
  * */
 class PmConversationsCard extends PureComponent<Props> {
-  context: Context;
-
-  static contextTypes = {
-    styles: () => null,
-  };
+  static contextType = ThemeContext;
+  context: ThemeColors;
 
   render() {
-    const { styles: contextStyles } = this.context;
     const { dispatch, conversations, usersByEmail } = this.props;
 
     return (
-      <View style={[styles.container, contextStyles.background]}>
+      <View style={[styles.container, { backgroundColor: this.context.backgroundColor }]}>
         <View style={styles.row}>
           <ZulipButton
             secondary

--- a/src/streams/StreamItem.js
+++ b/src/streams/StreamItem.js
@@ -2,7 +2,7 @@
 import React, { PureComponent } from 'react';
 import { StyleSheet, View } from 'react-native';
 
-import type { ThemeColors } from '../styles';
+import type { ThemeData } from '../styles';
 import styles, { ThemeContext } from '../styles';
 import { RawLabel, Touchable, UnreadCount, ZulipSwitch } from '../common';
 import { foregroundColorFromBackground } from '../utils/color';
@@ -61,7 +61,7 @@ type Props = $ReadOnly<{|
  */
 export default class StreamItem extends PureComponent<Props> {
   static contextType = ThemeContext;
-  context: ThemeColors;
+  context: ThemeData;
 
   static defaultProps = {
     isMuted: false,

--- a/src/styles/index.js
+++ b/src/styles/index.js
@@ -7,7 +7,7 @@ import { statics as navStyles } from './navStyles';
 import utilityStyles from './utilityStyles';
 
 export * from './constants';
-export type { ThemeColors } from './theme';
+export type { ThemeData } from './theme';
 export { ThemeContext } from './theme';
 
 export default StyleSheet.create({

--- a/src/styles/miscStyles.js
+++ b/src/styles/miscStyles.js
@@ -62,8 +62,4 @@ export default ({ color, backgroundColor }: ThemeColors) => ({
   background: {
     backgroundColor,
   },
-  label: {
-    color,
-    fontSize: 15,
-  },
 });

--- a/src/styles/miscStyles.js
+++ b/src/styles/miscStyles.js
@@ -82,7 +82,6 @@ export default ({ color, backgroundColor }: ThemeColors) => ({
   screen: {
     flex: 1,
     flexDirection: 'column',
-    // alignItems: 'stretch',
     backgroundColor,
   },
 });

--- a/src/styles/miscStyles.js
+++ b/src/styles/miscStyles.js
@@ -1,5 +1,4 @@
 /* @flow strict-local */
-import type { ThemeColors } from './theme';
 import { CONTROL_SIZE } from './constants';
 
 export const statics = {
@@ -54,12 +53,3 @@ export const statics = {
     justifyContent: 'flex-end',
   },
 };
-
-export default ({ color, backgroundColor }: ThemeColors) => ({
-  backgroundColor: {
-    backgroundColor,
-  },
-  background: {
-    backgroundColor,
-  },
-});

--- a/src/styles/miscStyles.js
+++ b/src/styles/miscStyles.js
@@ -79,9 +79,4 @@ export default ({ color, backgroundColor }: ThemeColors) => ({
     color,
     fontSize: 15,
   },
-  screen: {
-    flex: 1,
-    flexDirection: 'column',
-    backgroundColor,
-  },
 });

--- a/src/styles/miscStyles.js
+++ b/src/styles/miscStyles.js
@@ -1,8 +1,6 @@
 /* @flow strict-local */
-import { Platform } from 'react-native';
-
 import type { ThemeColors } from './theme';
-import { BORDER_COLOR, CONTROL_SIZE } from './constants';
+import { CONTROL_SIZE } from './constants';
 
 export const statics = {
   largerText: {
@@ -60,17 +58,6 @@ export const statics = {
 export default ({ color, backgroundColor }: ThemeColors) => ({
   backgroundColor: {
     backgroundColor,
-  },
-  input: {
-    color,
-    ...Platform.select({
-      ios: {
-        borderWidth: 1,
-        borderColor: BORDER_COLOR,
-        borderRadius: 2,
-        padding: 8,
-      },
-    }),
   },
   background: {
     backgroundColor,

--- a/src/styles/theme.js
+++ b/src/styles/theme.js
@@ -2,6 +2,8 @@
 import React from 'react';
 import type { Context } from 'react';
 
+import type { ThemeName } from '../reduxTypes';
+
 export type ThemeColors = {|
   color: string,
   backgroundColor: string,
@@ -9,7 +11,7 @@ export type ThemeColors = {|
   dividerColor: string,
 |};
 
-export const themeColors: { [string]: ThemeColors } = {
+export const themeColors: { [name: ThemeName | 'light']: ThemeColors } = {
   night: {
     color: 'hsl(210, 11%, 85%)',
     backgroundColor: 'hsl(212, 28%, 18%)',

--- a/src/styles/theme.js
+++ b/src/styles/theme.js
@@ -4,7 +4,6 @@ import type { Context } from 'react';
 import { StyleSheet } from 'react-native';
 
 import type { ThemeName } from '../types';
-import miscStyles from './miscStyles';
 
 export type ThemeColors = {|
   color: string,
@@ -13,9 +12,7 @@ export type ThemeColors = {|
   dividerColor: string,
 |};
 
-export type AppStyles = $ReadOnly<{|
-  ...$Call<typeof miscStyles, ThemeColors>,
-|}>;
+export type AppStyles = $ReadOnly<{||}>;
 
 export const themeColors: { [string]: ThemeColors } = {
   night: {
@@ -39,9 +36,4 @@ themeColors.default = themeColors.light;
 
 export const ThemeContext: Context<ThemeColors> = React.createContext(themeColors.default);
 
-export const stylesFromTheme = (name: ThemeName) => {
-  const colors = themeColors[name];
-  return StyleSheet.create({
-    ...miscStyles(colors),
-  });
-};
+export const stylesFromTheme = (name: ThemeName) => StyleSheet.create({});

--- a/src/styles/theme.js
+++ b/src/styles/theme.js
@@ -4,14 +4,14 @@ import type { Context } from 'react';
 
 import type { ThemeName } from '../reduxTypes';
 
-export type ThemeColors = {|
+export type ThemeData = {|
   color: string,
   backgroundColor: string,
   cardColor: string,
   dividerColor: string,
 |};
 
-export const themeColors: { [name: ThemeName | 'light']: ThemeColors } = {
+export const themeData: { [name: ThemeName | 'light']: ThemeData } = {
   night: {
     color: 'hsl(210, 11%, 85%)',
     backgroundColor: 'hsl(212, 28%, 18%)',
@@ -29,6 +29,6 @@ export const themeColors: { [name: ThemeName | 'light']: ThemeColors } = {
     dividerColor: 'hsla(0, 0%, 0%, 0.12)',
   },
 };
-themeColors.default = themeColors.light;
+themeData.default = themeData.light;
 
-export const ThemeContext: Context<ThemeColors> = React.createContext(themeColors.default);
+export const ThemeContext: Context<ThemeData> = React.createContext(themeData.default);

--- a/src/styles/theme.js
+++ b/src/styles/theme.js
@@ -1,9 +1,6 @@
 /* @flow strict-local */
 import React from 'react';
 import type { Context } from 'react';
-import { StyleSheet } from 'react-native';
-
-import type { ThemeName } from '../types';
 
 export type ThemeColors = {|
   color: string,
@@ -11,8 +8,6 @@ export type ThemeColors = {|
   cardColor: string,
   dividerColor: string,
 |};
-
-export type AppStyles = $ReadOnly<{||}>;
 
 export const themeColors: { [string]: ThemeColors } = {
   night: {
@@ -35,5 +30,3 @@ export const themeColors: { [string]: ThemeColors } = {
 themeColors.default = themeColors.light;
 
 export const ThemeContext: Context<ThemeColors> = React.createContext(themeColors.default);
-
-export const stylesFromTheme = (name: ThemeName) => StyleSheet.create({});

--- a/src/types.js
+++ b/src/types.js
@@ -3,7 +3,6 @@ import type { IntlShape } from 'react-intl';
 import type { DangerouslyImpreciseStyleProp } from 'react-native/Libraries/StyleSheet/StyleSheet';
 
 import type { Auth, Topic, Message, Reaction, ReactionType, Narrow } from './api/apiTypes';
-import type { AppStyles } from './styles/theme';
 
 export type * from './reduxTypes';
 export type * from './api/apiTypes';
@@ -144,10 +143,6 @@ export type TopicExtended = {|
   ...$Exact<Topic>,
   isMuted: boolean,
   unreadCount: number,
-|};
-
-export type Context = {|
-  styles: AppStyles,
 |};
 
 /**

--- a/src/user-groups/UserGroupItem.js
+++ b/src/user-groups/UserGroupItem.js
@@ -5,7 +5,7 @@ import { StyleSheet, View } from 'react-native';
 import { IconPeople } from '../common/Icons';
 import { RawLabel, Touchable } from '../common';
 import styles, { ThemeContext } from '../styles';
-import type { ThemeColors } from '../styles';
+import type { ThemeData } from '../styles';
 
 const componentStyles = StyleSheet.create({
   text: {
@@ -28,7 +28,7 @@ type Props = $ReadOnly<{|
 
 export default class UserGroupItem extends PureComponent<Props> {
   static contextType = ThemeContext;
-  context: ThemeColors;
+  context: ThemeData;
 
   handlePress = () => {
     const { name, onPress } = this.props;

--- a/src/webview/MessageList.js
+++ b/src/webview/MessageList.js
@@ -23,7 +23,7 @@ import type {
   ThemeName,
   User,
 } from '../types';
-import type { ThemeColors } from '../styles';
+import type { ThemeData } from '../styles';
 import { ThemeContext } from '../styles';
 import { connect } from '../react-redux';
 import {
@@ -152,7 +152,7 @@ const assetsPath = Platform.OS === 'ios' ? './webview' : 'file:///android_asset/
 
 class MessageList extends Component<Props> {
   static contextType = ThemeContext;
-  context: ThemeColors;
+  context: ThemeData;
 
   webview: ?WebView;
   readyRetryInterval: IntervalID | void;


### PR DESCRIPTION
Fixes: #1946
Fixes: #3994

If you get to the commit "StreamItem: Defend against empty strings for `color` on Subscription." and you're wondering how I might approach testing for this in `subscriptionsReducer-test.js`, let me know, and let's chat on CZO or video. It's pretty tangential to this PR, but I have a local branch exploring a way to thoroughly test that bad/unexpected server data in an `Action` doesn't fool a reducer into corrupting its piece of state — without having to repeat a lot of code from the existing _n_ tests, where _n_ is the minimum number of tests required to establish correct output *given expected input* in the `Action`. Basically, it uses [`jest.spyOn`](https://jestjs.io/docs/en/jest-object#jestspyonobject-methodname) to replay all the calls to the reducer from those _n_ tests, but with the passed `Action` transformed into a bad one (with a function you define once), and checks that the resulting state is clean (with a function you define once). A whole new interface like this will be less welcome where _n_ is small, obviously.