### PR TITLE
[WIP] Consume user IDs rather than emails from typing-status events.

### DIFF
--- a/src/actionTypes.js
+++ b/src/actionTypes.js
@@ -354,7 +354,7 @@ type EventPresenceAction = {|
 
 type EventTypingCommon = {|
   ...ServerEvent,
-  ownEmail: string,
+  ownUserId: number,
   recipients: Array<{
     user_id: number,
     email: string,

--- a/src/events/eventToAction.js
+++ b/src/events/eventToAction.js
@@ -31,7 +31,7 @@ import {
   EVENT_SUBSCRIPTION,
   EVENT,
 } from '../actionConstants';
-import { getOwnEmail } from '../users/userSelectors';
+import { getOwnEmail, getOwnUserId } from '../users/userSelectors';
 
 const opToActionUser = {
   add: EVENT_USER_ADD,
@@ -151,7 +151,7 @@ export default (state: GlobalState, event: $FlowFixMe): EventAction => {
     case 'typing':
       return {
         ...event,
-        ownEmail: getOwnEmail(state),
+        ownUserId: getOwnUserId(state),
         type: opToActionTyping[event.op],
         time: new Date().getTime(),
       };

--- a/src/reduxTypes.js
+++ b/src/reduxTypes.js
@@ -270,12 +270,12 @@ export type TopicsState = {|
   [number]: Topic[],
 |};
 
-export type TypingState = {|
+export type TypingState = {
   [normalizedRecipients: string]: {
     time: number,
     userIds: number[],
   },
-|};
+};
 
 // These four are fragments of UnreadState; see below.
 export type UnreadStreamsState = StreamUnreadItem[];

--- a/src/typing/__tests__/typingReducer-test.js
+++ b/src/typing/__tests__/typingReducer-test.js
@@ -1,3 +1,5 @@
+/* @flow strict-local */
+
 import deepFreeze from 'deep-freeze';
 
 import { EVENT_TYPING_START, EVENT_TYPING_STOP } from '../../actionConstants';
@@ -17,12 +19,13 @@ describe('typingReducer', () => {
           { email: 'john@example.com', user_id: 1 },
           { email: 'me@example.com', user_id: 2 },
         ],
-        ownEmail: 'me@example.com',
+        ownUserId: 2,
         time: 123456789,
+        id: 123,
       });
 
       const expectedState = {
-        'john@example.com': { time: 123456789, userIds: [1] },
+        '1': { time: 123456789, userIds: [1] },
       };
 
       const newState = typingReducer(initialState, action);
@@ -32,7 +35,7 @@ describe('typingReducer', () => {
 
     test('if user is already typing, no change in userIds but update time', () => {
       const initialState = deepFreeze({
-        'john@example.com': { time: 123456789, userIds: [1] },
+        '1': { time: 123456789, userIds: [1] },
       });
 
       const action = deepFreeze({
@@ -43,12 +46,13 @@ describe('typingReducer', () => {
           { email: 'john@example.com', user_id: 1 },
           { email: 'me@example.com', user_id: 2 },
         ],
-        ownEmail: 'me@example.com',
+        ownUserId: 2,
         time: 123456889,
+        id: 123,
       });
 
       const expectedState = {
-        'john@example.com': { time: 123456889, userIds: [1] },
+        '1': { time: 123456889, userIds: [1] },
       };
 
       const newState = typingReducer(initialState, action);
@@ -58,7 +62,7 @@ describe('typingReducer', () => {
 
     test('if other people are typing in other narrows, add, do not affect them', () => {
       const initialState = deepFreeze({
-        'john@example.com': { time: 123489, userIds: [1] },
+        '1': { time: 123489, userIds: [1] },
       });
 
       const action = deepFreeze({
@@ -70,13 +74,14 @@ describe('typingReducer', () => {
           { email: 'mark@example.com', user_id: 2 },
           { email: 'me@example.com', user_id: 3 },
         ],
-        ownEmail: 'me@example.com',
+        ownUserId: 3,
         time: 123456789,
+        id: 123,
       });
 
       const expectedState = {
-        'john@example.com': { time: 123489, userIds: [1] },
-        'john@example.com,mark@example.com': { time: 123456789, userIds: [2] },
+        '1': { time: 123489, userIds: [1] },
+        '1,2': { time: 123456789, userIds: [2] },
       };
 
       const newState = typingReducer(initialState, action);
@@ -86,7 +91,7 @@ describe('typingReducer', () => {
 
     test('if another user is typing already, append new one', () => {
       const initialState = deepFreeze({
-        'john@example.com,mark@example.com': { time: 123489, userIds: [1] },
+        '1,2': { time: 123489, userIds: [1] },
       });
 
       const action = deepFreeze({
@@ -98,12 +103,13 @@ describe('typingReducer', () => {
           { email: 'mark@example.com', user_id: 2 },
           { email: 'me@example.com', user_id: 3 },
         ],
-        ownEmail: 'me@example.com',
+        ownUserId: 3,
         time: 123456789,
+        id: 123,
       });
 
       const expectedState = {
-        'john@example.com,mark@example.com': { time: 123456789, userIds: [1, 2] },
+        '1,2': { time: 123456789, userIds: [1, 2] },
       };
 
       const newState = typingReducer(initialState, action);
@@ -115,8 +121,8 @@ describe('typingReducer', () => {
   describe('EVENT_TYPING_STOP', () => {
     test('if after removing, key is an empty list, key is removed', () => {
       const initialState = deepFreeze({
-        'john@example.com': { time: 123489, userIds: [1] },
-        'mark@example.com': { time: 123489, userIds: [2] },
+        '1': { time: 123489, userIds: [1] },
+        '3': { time: 123489, userIds: [2] },
       });
 
       const action = deepFreeze({
@@ -127,12 +133,13 @@ describe('typingReducer', () => {
           { email: 'john@example.com', user_id: 1 },
           { email: 'me@example.com', user_id: 2 },
         ],
-        ownEmail: 'me@example.com',
+        ownUserId: 2,
         time: 123456789,
+        id: 123,
       });
 
       const expectedState = {
-        'mark@example.com': { time: 123489, userIds: [2] },
+        '3': { time: 123489, userIds: [2] },
       };
 
       const newState = typingReducer(initialState, action);
@@ -142,7 +149,7 @@ describe('typingReducer', () => {
 
     test('if two people are typing, just one is removed', () => {
       const initialState = deepFreeze({
-        'john@example.com': { time: 123489, userIds: [1, 2] },
+        '1': { time: 123489, userIds: [1, 2] },
       });
 
       const action = deepFreeze({
@@ -153,12 +160,13 @@ describe('typingReducer', () => {
           { email: 'john@example.com', user_id: 1 },
           { email: 'me@example.com', user_id: 2 },
         ],
-        ownEmail: 'me@example.com',
+        ownUserId: 2,
         time: 123456789,
+        id: 123,
       });
 
       const expectedState = {
-        'john@example.com': { time: 123456789, userIds: [2] },
+        '1': { time: 123456789, userIds: [2] },
       };
 
       const newState = typingReducer(initialState, action);
@@ -177,8 +185,9 @@ describe('typingReducer', () => {
           { email: 'john@example.com', user_id: 1 },
           { email: 'me@example.com', user_id: 2 },
         ],
-        ownEmail: 'me@example.com',
+        ownUserId: 2,
         time: 123456789,
+        id: 123,
       });
 
       const expectedState = {};

--- a/src/typing/typingReducer.js
+++ b/src/typing/typingReducer.js
@@ -9,18 +9,21 @@ import {
   LOGIN_SUCCESS,
   ACCOUNT_SWITCH,
 } from '../actionConstants';
-import { normalizeRecipientsSansMe } from '../utils/recipient';
+import { normalizeRecipientsAsUserIdsSansMe } from '../utils/recipient';
 import { NULL_OBJECT } from '../nullObjects';
 
 const initialState: TypingState = NULL_OBJECT;
 
 const eventTypingStart = (state, action) => {
-  if (action.sender.email === action.ownEmail) {
+  if (action.sender.user_id === action.ownUserId) {
     // don't change state when self is typing
     return state;
   }
 
-  const normalizedRecipients = normalizeRecipientsSansMe(action.recipients, action.ownEmail);
+  const normalizedRecipients = normalizeRecipientsAsUserIdsSansMe(
+    action.recipients,
+    action.ownUserId,
+  );
   const previousTypingUsers = state[normalizedRecipients] || { userIds: [] };
 
   const isUserAlreadyTyping = previousTypingUsers.userIds.indexOf(action.sender.user_id);
@@ -44,7 +47,10 @@ const eventTypingStart = (state, action) => {
 };
 
 const eventTypingStop = (state, action) => {
-  const normalizedRecipients = normalizeRecipientsSansMe(action.recipients, action.ownEmail);
+  const normalizedRecipients = normalizeRecipientsAsUserIdsSansMe(
+    action.recipients,
+    action.ownUserId,
+  );
   const previousTypingUsers = state[normalizedRecipients];
 
   if (!previousTypingUsers) {

--- a/src/utils/__tests__/recipient-test.js
+++ b/src/utils/__tests__/recipient-test.js
@@ -1,4 +1,10 @@
-import { normalizeRecipients, normalizeRecipientsSansMe, isSameRecipient } from '../recipient';
+import {
+  normalizeRecipients,
+  normalizeRecipientsAsUserIds,
+  normalizeRecipientsSansMe,
+  normalizeRecipientsAsUserIdsSansMe,
+  isSameRecipient,
+} from '../recipient';
 
 describe('normalizeRecipients', () => {
   test('joins emails from recipients, sorted, trimmed, not including missing ones', () => {
@@ -46,6 +52,60 @@ describe('normalizeRecipientsSansMe', () => {
     const expectedResult = 'abc@example.com,def@example.com';
 
     const normalized = normalizeRecipientsSansMe(recipients, ownEmail);
+
+    expect(normalized).toEqual(expectedResult);
+  });
+});
+
+describe('normalizeRecipientsAsUserIds', () => {
+  test('joins user IDs from recipients, sorted', () => {
+    const recipients = [
+      { user_id: 2 },
+      { user_id: 1 },
+      { user_id: 5 },
+      { user_id: 3 },
+      { user_id: 4 },
+    ];
+    const expectedResult = '1,2,3,4,5';
+
+    const normalized = normalizeRecipientsAsUserIds(recipients);
+
+    expect(normalized).toEqual(expectedResult);
+  });
+
+  test('for a single recipient, returns the user ID as string', () => {
+    const recipients = [{ user_id: 1 }];
+    const expectedResult = '1';
+
+    const normalized = normalizeRecipientsAsUserIds(recipients);
+
+    expect(normalized).toEqual(expectedResult);
+  });
+});
+
+describe('normalizeRecipientsAsUserIdsSansMe', () => {
+  test('if only self user ID provided return unmodified', () => {
+    const recipients = [{ user_id: 1 }];
+    const ownUserId = 1;
+    const expectedResult = '1';
+
+    const normalized = normalizeRecipientsAsUserIdsSansMe(recipients, ownUserId);
+
+    expect(normalized).toEqual(expectedResult);
+  });
+
+  test('when more than one user IDs normalize but filter out self user ID', () => {
+    const recipients = [
+      { user_id: 2 },
+      { user_id: 1 },
+      { user_id: 5 },
+      { user_id: 3 },
+      { user_id: 4 },
+    ];
+    const expectedResult = '2,3,4,5';
+    const ownUserId = 1;
+
+    const normalized = normalizeRecipientsAsUserIdsSansMe(recipients, ownUserId);
 
     expect(normalized).toEqual(expectedResult);
   });

--- a/src/utils/recipient.js
+++ b/src/utils/recipient.js
@@ -30,6 +30,22 @@ export const normalizeRecipientsSansMe = (
     ? recipients[0].email
     : normalizeRecipients(recipients.filter(r => r.email !== ownEmail));
 
+export const normalizeRecipientsAsUserIds = (
+  recipients: $ReadOnlyArray<{ user_id: number, ... }>,
+) =>
+  recipients
+    .map(s => s.user_id)
+    .sort()
+    .join(',');
+
+export const normalizeRecipientsAsUserIdsSansMe = (
+  recipients: $ReadOnlyArray<{ user_id: number, ... }>,
+  ownUserId: number,
+) =>
+  recipients.length === 1
+    ? recipients[0].user_id.toString()
+    : normalizeRecipientsAsUserIds(recipients.filter(r => r.user_id !== ownUserId));
+
 /**
  * The set of users to show in the UI to identify a PM conversation.
  *


### PR DESCRIPTION
I also manually tested that typing notifications are working, and the changes are reflected in the Redux state. Relevant tests are also made well-typed.
Closes #3930.
________

Currently, tests are failing due to (I believe) a Flow bug:

The type TypingState is defined as 
```js
export type TypingState = {|
  [normalizedRecipients: string]: {
    time: number,
    userIds: number[],
  },
|};
```

So, `initalState` should be a valid instance of TypingState:
```js
      const initialState = deepFreeze({
        '1': { time: 123456789, userIds: [1] },
      });

      const newState = typingReducer(initialState, action);
```
But Flow complains:
```
Cannot call `typingReducer` with `initialState` bound to `state` because property `1` is missing in  `TypingState` [1] but exists in  object literal [2].Flow(InferError)
```
That's because Flow is able to infer the key, i.e. '1'. But if I change it to something that Flow can not infer, such as:

```js
      const normalizedRecipients = "1".toString();
      const initialState = deepFreeze({
        [normalizedRecipients]: { time: 123456789, userIds: [1] },
      });

      const newState = typingReducer(initialState, action);
```

Flow no longer complains. So I think this is a bug in Flow. So, should I add `FlowFixMe` in each case of the bug? ( in the file `typingReducer-test.js` )
