### PR TITLE
Language Pick: Implement exact searching of languages

### DIFF
--- a/src/settings/LanguagePicker.js
+++ b/src/settings/LanguagePicker.js
@@ -46,8 +46,9 @@ export default class LanguagePicker extends PureComponent<Props> {
     return list.filter(item => {
       const itemData = `${item.name.toUpperCase()} ${item.nativeName.toUpperCase()}`;
       const filterData = filter.toUpperCase();
+      const language = itemData.replace(/[()]/g, '').split(' ');
 
-      return itemData.includes(filterData);
+      return language.find(str => str.startsWith(filterData));
     });
   };
 


### PR DESCRIPTION
In language pick screen, search result is produced by
checking if the search term is included in any language-string.
But the user expected result may not be in the top of the list.
Since every language strings are smaller in length we can
implement exact searching for a language.

It will list the languages which begins with or whose
secondary name begins with the search term and eliminates
all other languages even if they contain the search term
in the middle.

Fixes: #4014

![screenshot-2020-04-21_01 36 58 195](https://user-images.githubusercontent.com/23723464/79795218-3875aa80-8371-11ea-9948-2ce9db458f2e.png)
![screenshot-2020-04-21_01 37 11 885](https://user-images.githubusercontent.com/23723464/79795222-39a6d780-8371-11ea-9c4d-fc3e99b07c02.png)
