### PR TITLE
UnreadCards: Avoid collision between strings from users and a magic string

### DIFF
--- a/src/unread/__tests__/unreadSelectors-test.js
+++ b/src/unread/__tests__/unreadSelectors-test.js
@@ -363,7 +363,7 @@ describe('getUnreadStreamsAndTopics', () => {
           },
         ],
         isMuted: true,
-        key: 'stream 0',
+        key: 'stream:stream 0',
         streamName: 'stream 0',
         unread: 5,
       },
@@ -379,7 +379,7 @@ describe('getUnreadStreamsAndTopics', () => {
           },
         ],
         isMuted: true,
-        key: 'stream 2',
+        key: 'stream:stream 2',
         streamName: 'stream 2',
         unread: 2,
       },
@@ -431,7 +431,7 @@ describe('getUnreadStreamsAndTopics', () => {
         ],
         isMuted: false,
         isPrivate: undefined,
-        key: 'stream 0',
+        key: 'stream:stream 0',
         streamName: 'stream 0',
         unread: 2,
       },
@@ -447,7 +447,7 @@ describe('getUnreadStreamsAndTopics', () => {
           },
         ],
         isMuted: false,
-        key: 'stream 2',
+        key: 'stream:stream 2',
         streamName: 'stream 2',
         unread: 2,
       },
@@ -480,7 +480,7 @@ describe('getUnreadStreamsAndTopics', () => {
 
     expect(unreadCount).toEqual([
       {
-        key: 'stream 0',
+        key: 'stream:stream 0',
         streamName: 'stream 0',
         color: 'red',
         unread: 5,
@@ -497,7 +497,7 @@ describe('getUnreadStreamsAndTopics', () => {
         ],
       },
       {
-        key: 'stream 2',
+        key: 'stream:stream 2',
         streamName: 'stream 2',
         color: 'blue',
         unread: 2,
@@ -584,7 +584,7 @@ describe('getUnreadStreamsAndTopics', () => {
 
     expect(unreadCount).toEqual([
       {
-        key: 'xyz stream',
+        key: 'stream:xyz stream',
         streamName: 'xyz stream',
         color: 'blue',
         isMuted: false,
@@ -597,7 +597,7 @@ describe('getUnreadStreamsAndTopics', () => {
         ],
       },
       {
-        key: 'abc stream',
+        key: 'stream:abc stream',
         streamName: 'abc stream',
         color: 'red',
         isMuted: false,
@@ -610,7 +610,7 @@ describe('getUnreadStreamsAndTopics', () => {
         ],
       },
       {
-        key: 'def stream',
+        key: 'stream:def stream',
         streamName: 'def stream',
         color: 'green',
         isMuted: false,
@@ -686,7 +686,7 @@ describe('getUnreadStreamsAndTopicsSansMuted', () => {
         ],
         isMuted: false,
         isPrivate: undefined,
-        key: 'stream 0',
+        key: 'stream:stream 0',
         streamName: 'stream 0',
         unread: 2,
       },

--- a/src/unread/unreadSelectors.js
+++ b/src/unread/unreadSelectors.js
@@ -148,7 +148,7 @@ export const getUnreadStreamsAndTopics: Selector<UnreadStreamItem[]> = createSel
       let total = totals.get(stream.stream_id);
       if (!total) {
         total = {
-          key: name,
+          key: `stream:${name}`,
           streamName: name,
           isMuted: !in_home_view,
           isPrivate: invite_only,


### PR DESCRIPTION
We'd like to clarify and untangle most of the UI code in
UnreadCards, StreamItem, and elsewhere (part of that is #3767), but
the most pressing task is to minimally fix an issue where a stream
named "private" causes bugs for other users who are subscribed to it
and are viewing UnreadCards on mobile.

So, fix it at the source, where the `key` in the data is first
assigned, by adding a prefix. Fortunately, consumers of this data
don't ever expect that the `key` will be equal to the stream's name.

The magic string should never have been introduced in the first
place, and it should be removed as part of those larger refactors.
But the temptation to use it would probably not have existed, if
more careful thought had gone into the UI semantics here.

In particular, private messages and stream/topic messages are not
organized the same way, and they have different semantics. It looks
like the magic string was added to deal with those differences in a
world where both kinds of messages must coexist in a single
SectionList. The cleaner solution would have been to use two
separate lists; for example, a FlatList for PMs, and a SectionList
for the stream/topic messages. PMs just don't fit in a heading–item
structure, like streams and topics do, much less one with the same
semantics.