### PR TITLE
Refactor constructMessageActionButtons

### DIFF
--- a/src/message/messageActionSheet.js
+++ b/src/message/messageActionSheet.js
@@ -50,8 +50,6 @@ type ButtonDescription = {
   errorMessage: string,
 };
 
-const isAnOutboxMessage = (message: Message | Outbox): boolean => message.isOutbox;
-
 //
 // Options for the action sheet go below: ...
 //
@@ -63,7 +61,7 @@ reply.title = 'Reply';
 reply.errorMessage = 'Failed to reply';
 
 const copyToClipboard = async ({ _, auth, message }) => {
-  const rawMessage = isAnOutboxMessage(message) /* $FlowFixMe: then really type Outbox */
+  const rawMessage = message.isOutbox
     ? message.markdownContent
     : (await api.getRawMessageContent(auth, message.id)).raw_content;
   Clipboard.setString(rawMessage);
@@ -79,7 +77,7 @@ editMessage.title = 'Edit message';
 editMessage.errorMessage = 'Failed to edit message';
 
 const deleteMessage = async ({ auth, message, dispatch }) => {
-  if (isAnOutboxMessage(message)) {
+  if (message.isOutbox) {
     dispatch(deleteOutboxMessage(message.timestamp));
   } else {
     await api.deleteMessage(auth, message.id);

--- a/src/message/messageActionSheet.js
+++ b/src/message/messageActionSheet.js
@@ -224,16 +224,16 @@ type ButtonCode = $Keys<typeof allButtonsRaw>;
 
 const allButtons: { [ButtonCode]: ButtonDescription } = allButtonsRaw;
 
-type ConstructSheetParams = {|
+type ConstructSheetParams<MsgType: Message | Outbox = Message | Outbox> = {|
   backgroundData: BackgroundData,
-  message: Message | Outbox,
+  message: MsgType,
   narrow: Narrow,
 |};
 
 export const constructHeaderActionButtons = ({
   backgroundData: { mute, subscriptions, ownUser },
   message,
-}: ConstructSheetParams): ButtonCode[] => {
+}: ConstructSheetParams<>): ButtonCode[] => {
   const buttons: ButtonCode[] = [];
   if (message.type === 'stream') {
     if (ownUser.is_admin) {
@@ -262,7 +262,7 @@ export const constructMessageActionButtons = ({
   backgroundData: { ownUser, flags },
   message,
   narrow,
-}: ConstructSheetParams): ButtonCode[] => {
+}: ConstructSheetParams<>): ButtonCode[] => {
   const buttons = [];
   if (!isAnOutboxMessage(message) && messageNotDeleted(message)) {
     buttons.push('addReaction');
@@ -318,7 +318,7 @@ export const showActionSheet = (
   dispatch: Dispatch,
   showActionSheetWithOptions: ShowActionSheetWithOptions,
   _: GetText,
-  params: ConstructSheetParams,
+  params: ConstructSheetParams<>,
 ): void => {
   const optionCodes = isHeader
     ? constructHeaderActionButtons(params)


### PR DESCRIPTION
Break `constructMessageActionButtons` up into two functions, depending on whether the message being processed is an Outbox message or not. Type this properly.

Extracted from PR #3978.