### PR TITLE
streams: Add functionality to create and edit stream with stream post policy.

### DIFF
--- a/src/__tests__/lib/exampleData.js
+++ b/src/__tests__/lib/exampleData.js
@@ -169,6 +169,7 @@ export const makeStream = (args: { name?: string, description?: string } = {}): 
     invite_only: false,
     is_announcement_only: false,
     history_public_to_subscribers: true,
+    stream_post_policy: 1,
   });
 };
 

--- a/src/api/modelTypes.js
+++ b/src/api/modelTypes.js
@@ -242,6 +242,7 @@ export type Stream = {|
   invite_only: boolean,
   is_announcement_only: boolean,
   history_public_to_subscribers: boolean,
+  stream_post_policy: number,
 |};
 
 export type Subscription = {|

--- a/src/api/streams/createStream.js
+++ b/src/api/streams/createStream.js
@@ -9,11 +9,13 @@ export default (
   description?: string = '',
   principals?: string[] = [],
   inviteOnly?: boolean = false,
+  streamPostPolicy?: number = 1,
   announce?: boolean = false,
 ): Promise<ApiResponse> =>
   apiPost(auth, 'users/me/subscriptions', {
     subscriptions: JSON.stringify([{ name, description }]),
     principals: JSON.stringify(principals),
     invite_only: inviteOnly,
+    stream_post_policy: streamPostPolicy,
     announce,
   });

--- a/src/api/streams/updateStream.js
+++ b/src/api/streams/updateStream.js
@@ -6,7 +6,7 @@ export default (
   auth: Auth,
   id: number,
   property: string,
-  value: string | boolean,
+  value: string | boolean | number,
 ): Promise<ApiResponse> =>
   apiPatch(auth, `streams/${id}`, {
     [property]: value,

--- a/src/common/SelectionList.js
+++ b/src/common/SelectionList.js
@@ -1,0 +1,155 @@
+/* @flow strict-local */
+import React, { PureComponent } from 'react';
+import { FlatList, StyleSheet, View } from 'react-native';
+import type { ViewStyleProp } from 'react-native/Libraries/StyleSheet/StyleSheet';
+import type { NavigationScreenProp } from 'react-navigation';
+
+import type { Dispatch } from '../types';
+import type { ThemeColors } from '../styles';
+import { connect } from '../react-redux';
+import Label from './Label';
+import { IconDone, IconRight } from './Icons';
+import Touchable from './Touchable';
+import { BRAND_COLOR, ThemeContext } from '../styles';
+import { navigateToZulipPickerOptionsScreen, navigateBack } from '../nav/navActions';
+import OptionDivider from './OptionDivider';
+import Screen from './Screen';
+
+const componentStyles = StyleSheet.create({
+  selectorWrapper: {
+    marginTop: 4,
+  },
+  selectorRow: {
+    flex: 1,
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+  },
+  selectorValue: {
+    color: 'gray',
+    marginTop: 4,
+  },
+  selectorIcon: {
+    alignSelf: 'center',
+  },
+  selectorLabel: {
+    fontWeight: '400',
+  },
+  optionItem: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingTop: 12,
+    paddingBottom: 12,
+    paddingLeft: 16,
+    paddingRight: 16,
+  },
+  optionSelectedValue: { color: BRAND_COLOR },
+});
+
+type OptionsScreenProps = $ReadOnly<{|
+  dispatch: Dispatch,
+  navigation: NavigationScreenProp<{
+    params: {|
+      label: string,
+      options: $ReadOnlyArray<{| key: number, value: string |}>,
+      selectedIndex: number,
+      onOptionSelect: (value: number) => void,
+    |},
+  }>,
+|}>;
+
+/**
+ * A selector option list component.
+ *
+ * @prop label - label for selectionl list.
+ * @prop options - all available options to select from.
+ * @prop selectedIndex - index of currently selected option.
+ * @prop onOptionSelect - Event called when any option is selected.
+ */
+class OptionsScreen extends PureComponent<OptionsScreenProps> {
+  onOptionSelect = (index: number) => {
+    const { dispatch, navigation } = this.props;
+    const { onOptionSelect } = navigation.state.params;
+    onOptionSelect(index);
+    dispatch(navigateBack());
+  };
+
+  render() {
+    const { label, options, selectedIndex } = this.props.navigation.state.params;
+
+    return (
+      <Screen title={label}>
+        <FlatList
+          ItemSeparatorComponent={OptionDivider}
+          data={options}
+          keyExtractor={item => `${item.key}`}
+          renderItem={({ item, index }) => (
+            <Touchable onPress={() => this.onOptionSelect(index)}>
+              <View style={componentStyles.optionItem}>
+                <Label
+                  style={selectedIndex === index && componentStyles.optionSelectedValue}
+                  text={item.value}
+                />
+                {selectedIndex === index && <IconDone size={16} color={BRAND_COLOR} />}
+              </View>
+            </Touchable>
+          )}
+        />
+      </Screen>
+    );
+  }
+}
+
+type SelectorProps = $ReadOnly<{|
+  dispatch: Dispatch,
+  label: string,
+  options: $ReadOnlyArray<{| key: number, value: string |}>,
+  selectedIndex: number,
+  style?: ViewStyleProp,
+  onOptionSelect: (value: number) => void,
+|}>;
+
+/**
+ * An selector component, which shows the the label and selected value
+ *
+ * @prop [style] - Style object applied to the outermost component.
+ * @prop label - label of the picker.
+ * @prop options - all available options to select from.
+ * @prop selectedIndex - index of currently selected option.
+ * @prop onOptionSelect - Event called when any option is selected.
+ */
+class Selector extends PureComponent<SelectorProps> {
+  static contextType = ThemeContext;
+  context: ThemeColors;
+
+  styles = { icon: { color: this.context.color } };
+
+  navigateToZulipPickerOptions = () => {
+    const { dispatch, options, label, selectedIndex, onOptionSelect } = this.props;
+    dispatch(navigateToZulipPickerOptionsScreen(label, options, selectedIndex, onOptionSelect));
+  };
+
+  render() {
+    const { label, options, selectedIndex, style } = this.props;
+
+    return (
+      <Touchable
+        style={[style, componentStyles.selectorWrapper]}
+        onPress={this.navigateToZulipPickerOptions}
+      >
+        <View style={componentStyles.selectorRow}>
+          <View>
+            <Label style={componentStyles.selectorLabel} text={label} />
+            <Label style={componentStyles.selectorValue} text={options[selectedIndex].value} />
+          </View>
+          <IconRight size={24} style={[this.styles.icon, componentStyles.selectorIcon]} />
+        </View>
+      </Touchable>
+    );
+  }
+}
+
+export default {
+  Selector: connect()(Selector),
+  OptionsScreen: connect()(OptionsScreen),
+};

--- a/src/common/index.js
+++ b/src/common/index.js
@@ -42,4 +42,5 @@ export { default as ViewPlaceholder } from './ViewPlaceholder';
 export { default as WebLink } from './WebLink';
 export { default as ZulipButton } from './ZulipButton';
 export { default as ZulipStatusBar } from './ZulipStatusBar';
+export { default as SelectionList } from './SelectionList';
 export { default as ZulipSwitch } from './ZulipSwitch';

--- a/src/nav/AppNavigator.js
+++ b/src/nav/AppNavigator.js
@@ -31,6 +31,7 @@ import TopicListScreen from '../topics/TopicListScreen';
 import EmojiPickerScreen from '../emoji/EmojiPickerScreen';
 import LegalScreen from '../settings/LegalScreen';
 import UserStatusScreen from '../user-status/UserStatusScreen';
+import SelectionList from '../common/SelectionList';
 
 export default createStackNavigator(
   // $FlowFixMe react-navigation types :-/ -- see a36814e80
@@ -65,6 +66,7 @@ export default createStackNavigator(
     notifications: { screen: NotificationsScreen },
     legal: { screen: LegalScreen },
     'user-status': { screen: UserStatusScreen },
+    'selection-list-options': { screen: SelectionList.OptionsScreen },
   },
   {
     initialRouteName: 'main',

--- a/src/nav/navActions.js
+++ b/src/nav/navActions.js
@@ -103,3 +103,14 @@ export const navigateToLegal = (): NavigationAction => StackActions.push({ route
 
 export const navigateToUserStatus = (): NavigationAction =>
   StackActions.push({ routeName: 'user-status' });
+
+export const navigateToZulipPickerOptionsScreen = (
+  label: string,
+  options: $ReadOnlyArray<{| key: number, value: string |}>,
+  selectedIndex: number,
+  onOptionSelect: (value: number) => void,
+): NavigationAction =>
+  StackActions.push({
+    routeName: 'selection-list-options',
+    params: { label, options, selectedIndex, onOptionSelect },
+  });

--- a/src/nullObjects.js
+++ b/src/nullObjects.js
@@ -57,4 +57,5 @@ export const NULL_SUBSCRIPTION: Subscription = {
   is_old_stream: false,
   is_announcement_only: false,
   history_public_to_subscribers: false,
+  stream_post_policy: 1,
 };

--- a/src/streams/CreateStreamScreen.js
+++ b/src/streams/CreateStreamScreen.js
@@ -14,10 +14,15 @@ type Props = $ReadOnly<{|
 |}>;
 
 class CreateStreamScreen extends PureComponent<Props> {
-  handleComplete = (name: string, description: string, isPrivate: boolean) => {
+  handleComplete = (
+    name: string,
+    description: string,
+    isPrivate: boolean,
+    streamPostPolicy: number,
+  ) => {
     const { dispatch, ownEmail } = this.props;
 
-    dispatch(createNewStream(name, description, [ownEmail], isPrivate));
+    dispatch(createNewStream(name, description, [ownEmail], isPrivate, streamPostPolicy));
     dispatch(navigateBack());
   };
 
@@ -26,7 +31,12 @@ class CreateStreamScreen extends PureComponent<Props> {
       <Screen title="Create new stream" padding>
         <EditStreamCard
           isNewStream
-          initialValues={{ name: '', description: '', invite_only: false }}
+          initialValues={{
+            name: '',
+            description: '',
+            invite_only: false,
+            stream_post_policy: 1,
+          }}
           onComplete={this.handleComplete}
         />
       </Screen>

--- a/src/streams/EditStreamScreen.js
+++ b/src/streams/EditStreamScreen.js
@@ -21,10 +21,22 @@ type Props = $ReadOnly<{|
 |}>;
 
 class EditStreamScreen extends PureComponent<Props> {
-  handleComplete = (name: string, description: string, isPrivate: boolean) => {
+  handleComplete = (
+    name: string,
+    description: string,
+    isPrivate: boolean,
+    streamPostPolicy: number,
+  ) => {
     const { dispatch, stream } = this.props;
 
-    dispatch(updateExistingStream(stream.stream_id, stream, { name, description, isPrivate }));
+    dispatch(
+      updateExistingStream(stream.stream_id, stream, {
+        name,
+        description,
+        isPrivate,
+        streamPostPolicy,
+      }),
+    );
     dispatch(navigateBack());
   };
 

--- a/src/streams/streamsActions.js
+++ b/src/streams/streamsActions.js
@@ -8,14 +8,27 @@ export const createNewStream = (
   description: string,
   principals: string[],
   isPrivate: boolean,
+  streamPostPolicy: number,
 ) => async (dispatch: Dispatch, getState: GetState) => {
-  await api.createStream(getAuth(getState()), name, description, principals, isPrivate);
+  await api.createStream(
+    getAuth(getState()),
+    name,
+    description,
+    principals,
+    isPrivate,
+    streamPostPolicy,
+  );
 };
 
 export const updateExistingStream = (
   id: number,
   initialValues: Stream,
-  newValues: {| name: string, description: string, isPrivate: boolean |},
+  newValues: {|
+    name: string,
+    description: string,
+    isPrivate: boolean,
+    streamPostPolicy: number,
+  |},
 ) => async (dispatch: Dispatch, getState: GetState) => {
   if (initialValues.name !== newValues.name) {
     // Stream names might contain unsafe characters so we must encode it first.
@@ -32,6 +45,15 @@ export const updateExistingStream = (
   }
   if (initialValues.invite_only !== newValues.isPrivate) {
     await api.updateStream(getAuth(getState()), id, 'is_private', newValues.isPrivate);
+  }
+
+  if (initialValues.stream_post_policy !== newValues.streamPostPolicy) {
+    await api.updateStream(
+      getAuth(getState()),
+      id,
+      'stream_post_policy',
+      newValues.streamPostPolicy,
+    );
   }
 };
 

--- a/static/translations/messages_en.json
+++ b/static/translations/messages_en.json
@@ -212,5 +212,8 @@
   "🤒 Out sick": "🤒 Out sick",
   "🌴 Vacationing": "🌴 Vacationing",
   "🏠 Working remotely": "🏠 Working remotely",
-  "Restrict posting to organization administrators": "Restrict posting to organization administrators"
+  "Who can post to the stream?": "Who can post to the stream?",
+  "All stream members": "All stream members",
+  "Only organization administrators": "Only organization administrators",
+  "Only organization full members": "Only organization full members"
 }

--- a/static/translations/messages_en.json
+++ b/static/translations/messages_en.json
@@ -211,5 +211,6 @@
   "🚌 Commuting": "🚌 Commuting",
   "🤒 Out sick": "🤒 Out sick",
   "🌴 Vacationing": "🌴 Vacationing",
-  "🏠 Working remotely": "🏠 Working remotely"
+  "🏠 Working remotely": "🏠 Working remotely",
+  "Restrict posting to organization administrators": "Restrict posting to organization administrators"
 }


### PR DESCRIPTION
Continuing from [pervious PR](https://github.com/zulip/zulip-mobile/pull/3140#issuecomment-617976221)


- now it uses the same option text as web, just trimmed the  "can post" part to save some space. 

![image](https://user-images.githubusercontent.com/18511177/80277090-51cc7d00-870a-11ea-8fa5-b12e4ba3a786.png)

![image](https://user-images.githubusercontent.com/18511177/80277086-4a0cd880-870a-11ea-9180-efeaf62ea9fe.png)
