### PR TITLE
typingSelectors: Fix selecting welcome bot in pm crashes the app

### DIFF
--- a/src/typing/__tests__/typingSelectors-test.js
+++ b/src/typing/__tests__/typingSelectors-test.js
@@ -90,4 +90,30 @@ describe('getCurrentTypingUsers', () => {
 
     expect(typingUsers).toEqual([expectedUser]);
   });
+
+  test('when in a private narrow with a deactivated user, return valid data', () => {
+    const deactivatedUser = eg.makeUser();
+    const state = eg.reduxState({
+      typing: {},
+      realm: eg.realmState({ nonActiveUsers: [deactivatedUser] }),
+    });
+
+    const getTypingUsers = () => getCurrentTypingUsers(state, privateNarrow(deactivatedUser.email));
+
+    expect(getTypingUsers).not.toThrow();
+    expect(getTypingUsers()).toEqual([]);
+  });
+
+  test('when in a private narrow with a cross-realm bot, return valid data', () => {
+    const crossRealmBot = eg.makeCrossRealmBot();
+    const state = eg.reduxState({
+      typing: {},
+      realm: eg.realmState({ crossRealmBots: [crossRealmBot] }),
+    });
+
+    const getTypingUsers = () => getCurrentTypingUsers(state, privateNarrow(crossRealmBot.email));
+
+    expect(getTypingUsers).not.toThrow();
+    expect(getTypingUsers()).toEqual([]);
+  });
 });

--- a/src/typing/typingSelectors.js
+++ b/src/typing/typingSelectors.js
@@ -6,20 +6,20 @@ import { getTyping } from '../directSelectors';
 import { isPrivateOrGroupNarrow } from '../utils/narrow';
 import { normalizeRecipientsAsUserIds } from '../utils/recipient';
 import { NULL_ARRAY, NULL_USER } from '../nullObjects';
-import { getUsersById, getUsersByEmail } from '../users/userSelectors';
+import { getUsersById, getAllUsersByEmail } from '../users/userSelectors';
 
 export const getCurrentTypingUsers: Selector<$ReadOnlyArray<User>, Narrow> = createSelector(
   (state, narrow) => narrow,
   state => getTyping(state),
   state => getUsersById(state),
-  state => getUsersByEmail(state),
-  (narrow, typing, usersById, usersByEmail): User[] => {
+  state => getAllUsersByEmail(state),
+  (narrow, typing, usersById, allUsersByEmail): User[] => {
     if (!isPrivateOrGroupNarrow(narrow)) {
       return NULL_ARRAY;
     }
 
     const recipients = narrow[0].operand.split(',').map(email => {
-      const userId = usersByEmail.get(email)?.user_id;
+      const userId = allUsersByEmail.get(email)?.user_id;
       if (userId === undefined) {
         throw new Error(`Narrow contains email '${email}' that does not map to any user.`);
       }

--- a/src/typing/typingSelectors.js
+++ b/src/typing/typingSelectors.js
@@ -1,19 +1,19 @@
 /* @flow strict-local */
 import { createSelector } from 'reselect';
 
-import type { Narrow, Selector, User } from '../types';
+import type { Narrow, Selector, UserOrBot } from '../types';
 import { getTyping } from '../directSelectors';
 import { isPrivateOrGroupNarrow } from '../utils/narrow';
 import { normalizeRecipientsAsUserIds } from '../utils/recipient';
 import { NULL_ARRAY, NULL_USER } from '../nullObjects';
-import { getUsersById, getAllUsersByEmail } from '../users/userSelectors';
+import { getAllUsersById, getAllUsersByEmail } from '../users/userSelectors';
 
-export const getCurrentTypingUsers: Selector<$ReadOnlyArray<User>, Narrow> = createSelector(
+export const getCurrentTypingUsers: Selector<$ReadOnlyArray<UserOrBot>, Narrow> = createSelector(
   (state, narrow) => narrow,
   state => getTyping(state),
-  state => getUsersById(state),
+  state => getAllUsersById(state),
   state => getAllUsersByEmail(state),
-  (narrow, typing, usersById, allUsersByEmail): User[] => {
+  (narrow, typing, allUsersById, allUsersByEmail): UserOrBot[] => {
     if (!isPrivateOrGroupNarrow(narrow)) {
       return NULL_ARRAY;
     }
@@ -32,6 +32,6 @@ export const getCurrentTypingUsers: Selector<$ReadOnlyArray<User>, Narrow> = cre
       return NULL_ARRAY;
     }
 
-    return currentTyping.userIds.map(userId => usersById.get(userId) || NULL_USER);
+    return currentTyping.userIds.map(userId => allUsersById.get(userId) || NULL_USER);
   },
 );

--- a/src/webview/MessageList.js
+++ b/src/webview/MessageList.js
@@ -22,6 +22,7 @@ import type {
   Subscription,
   ThemeName,
   User,
+  UserOrBot,
 } from '../types';
 import type { ThemeColors } from '../styles';
 import { ThemeContext } from '../styles';
@@ -91,7 +92,7 @@ type SelectorProps = {|
   fetching: Fetching,
   messages: $ReadOnlyArray<Message | Outbox>,
   renderedMessages: RenderedSectionDescriptor[],
-  typingUsers: $ReadOnlyArray<User>,
+  typingUsers: $ReadOnlyArray<UserOrBot>,
 |};
 
 // TODO get a type for `connectActionSheet` so this gets fully type-checked.
@@ -345,7 +346,7 @@ type OuterProps = {|
   /* Passing these three from the parent is kind of a hack; search uses it
      to hard-code some behavior. */
   fetching?: Fetching,
-  typingUsers?: User[],
+  typingUsers?: UserOrBot[],
 |};
 
 export default connect<SelectorProps, _, _>((state, props: OuterProps) => {

--- a/src/webview/html/messageTypingAsHtml.js
+++ b/src/webview/html/messageTypingAsHtml.js
@@ -1,9 +1,9 @@
 /* @flow strict-local */
 import template from './template';
-import type { User } from '../../types';
+import type { UserOrBot } from '../../types';
 import { getAvatarFromUser } from '../../utils/avatar';
 
-const typingAvatar = (realm: string, user: User): string => template`
+const typingAvatar = (realm: string, user: UserOrBot): string => template`
 <div class="avatar">
   <img
     class="avatar-img"
@@ -12,7 +12,7 @@ const typingAvatar = (realm: string, user: User): string => template`
 </div>
 `;
 
-export default (realm: string, users: $ReadOnlyArray<User>): string => template`
+export default (realm: string, users: $ReadOnlyArray<UserOrBot>): string => template`
   $!${users.map(user => typingAvatar(realm, user)).join('')}
   <div class="content">
     <span></span>


### PR DESCRIPTION
Issue was caused beacuse ```getUsersByEmail``` couldn't determine the user-id of Welcome Bot. This is fixed in the PR by making use of ```getAllUsersByEmail``` instead.

Fixes: #4067.