### PR TITLE
webview, css: Apply font: -apple-system-body; to body.

### DIFF
--- a/src/webview/static/base.css
+++ b/src/webview/static/base.css
@@ -5,6 +5,7 @@ html {
   user-select: none; /* Standard syntax */
   -khtml-user-select: none;
   -webkit-touch-callout: none;
+  font: -apple-system-body;
 }
 body {
   font-family: sans-serif;


### PR DESCRIPTION
Fixes: #4042

This is based on https://www.interactiveaccessibility.com/blog/text-resizing-web-pages-ios-using-dynamic-type#.XqVIvpMzZ25

- Change font size in iOS setting to test this PR, Setting -> General -> Accessibility -> Larger text
- After changing text size, reload the webview. Changes are only effective when webview is re-rendered.
- It only works for text whose html element doesn't override `font-size` (like `.code`) and rely on parent (`body`) css styles.

Screenshots (iPhone X), when `font: -apple-system-body;` is applied to body:
- Max font size (Larger accessibility toggle is off)
![image](https://user-images.githubusercontent.com/18511177/80518037-9292f300-89a3-11ea-9eaa-6f32e4a41598.png)

- Min font size (Larger accessibility toggle is off)
![image](https://user-images.githubusercontent.com/18511177/80517818-40ea6880-89a3-11ea-93aa-237e47598478.png)

Also works fine when Larger accessibility toggle is on
![image](https://user-images.githubusercontent.com/18511177/80517773-2e702f00-89a3-11ea-8691-c7b81ccc1daf.png)
