### PR TITLE
api types: `realm_user_groups` is absent prior to v1.8.0.

### DIFF
--- a/src/api/initialDataTypes.js
+++ b/src/api/initialDataTypes.js
@@ -104,7 +104,10 @@ export type InitialDataRealmUser = {|
 |};
 
 export type InitialDataRealmUserGroups = {|
-  realm_user_groups: UserGroup[],
+  /**
+   * Absent in servers prior to v1.8.0-rc1~2711 (or thereabouts).
+   */
+  realm_user_groups?: UserGroup[],
 |};
 
 type NeverSubscribedStream = {|

--- a/src/api/modelTypes.js
+++ b/src/api/modelTypes.js
@@ -155,6 +155,14 @@ export type CrossRealmBot = {|
  */
 export type UserOrBot = User | CrossRealmBot;
 
+/**
+ * For mentioning multiple users at once.
+ *
+ * When you mention a user group, everyone in the group is notified as
+ * though they were individually mentioned.
+ *
+ * This feature is not related to group PMs.
+ */
 export type UserGroup = {|
   description: string,
   id: number,


### PR DESCRIPTION
This bite-size PR is forked from https://github.com/zulip/zulip-mobile/pull/4046#discussion_r414889862.

---------------

api types: `realm_user_groups` is absent prior to v1.8.0.

This was already handled in runtime code, as of d64b7c84b, on
PR #2878, for issue #2859.

On the server, `git log --stat -p --reverse -S realm_user_groups`
reveals that 4c6a376fd, which is v1.8.0-rc1~2711, is the first
occurrence of 'realm_user_groups'.

Also comment on UserGroup type to highlight difference from group
PMs feature.