### PR TITLE
Store server feature level in Redux

### DIFF
--- a/src/__tests__/lib/exampleData.js
+++ b/src/__tests__/lib/exampleData.js
@@ -127,6 +127,8 @@ export const realm = 'https://zulip.example.org';
 
 export const zulipVersion = new ZulipVersion('2.1.0-234-g7c3acf4');
 
+export const zulipFeatureLevel = 1;
+
 export const makeAccount = (
   args: {
     user?: User,

--- a/src/__tests__/lib/exampleData.js
+++ b/src/__tests__/lib/exampleData.js
@@ -473,6 +473,7 @@ export const action = deepFreeze({
       realm_uri: selfAccount.realm,
       realm_video_chat_provider: 1,
       realm_waiting_period_threshold: 3,
+      zulip_feature_level: 1,
       realm_emoji: {},
       realm_filters: [],
       avatar_source: 'G',

--- a/src/__tests__/lib/exampleData.js
+++ b/src/__tests__/lib/exampleData.js
@@ -135,6 +135,7 @@ export const makeAccount = (
     email?: string,
     realm?: string,
     apiKey?: string,
+    zulipFeatureLevel?: number | null,
     zulipVersion?: ZulipVersion | null,
     ackedPushToken?: string | null,
   } = {},
@@ -144,6 +145,7 @@ export const makeAccount = (
     email = user.email,
     realm: realmInner = realm,
     apiKey = randString() + randString(),
+    zulipFeatureLevel: zulipFeatureLevelInner = zulipFeatureLevel,
     zulipVersion: zulipVersionInner = zulipVersion,
     ackedPushToken = null,
   } = args;
@@ -151,6 +153,7 @@ export const makeAccount = (
     realm: realmInner,
     email,
     apiKey,
+    zulipFeatureLevel: zulipFeatureLevelInner,
     zulipVersion: zulipVersionInner,
     ackedPushToken,
   });

--- a/src/account/__tests__/accountsReducer-test.js
+++ b/src/account/__tests__/accountsReducer-test.js
@@ -228,6 +228,7 @@ describe('accountsReducer', () => {
         email: 'newaccount@example.com',
         realm: 'https://new.realm.org',
         zulipVersion: null,
+        zulipFeatureLevel: null,
       });
 
       const action = deepFreeze({

--- a/src/account/__tests__/accountsReducer-test.js
+++ b/src/account/__tests__/accountsReducer-test.js
@@ -26,33 +26,27 @@ describe('accountsReducer', () => {
     });
 
     test('if no account with this realm exists, prepend new one, with empty email/apiKey', () => {
-      const newAccount = eg.makeAccount({
-        realm: 'https://new.realm.org',
-        email: '',
-        apiKey: '',
-      });
+      const newRealm = 'https://new.realm.org';
 
       const action = deepFreeze({
         ...baseAction,
-        realm: newAccount.realm,
+        realm: newRealm,
       });
 
-      expect(accountsReducer(prevState, action)).toEqual([newAccount, account1, account2]);
+      expect(accountsReducer(prevState, action)).toEqual([
+        eg.makeAccount({ realm: newRealm, email: '', apiKey: '' }),
+        account1,
+        account2,
+      ]);
     });
 
     test('if account with this realm exists, move to front of list', () => {
-      const newAccount = eg.makeAccount({
-        realm: account2.realm,
-        email: account2.email,
-        apiKey: '',
-      });
-
       const action = deepFreeze({
         ...baseAction,
-        realm: newAccount.realm,
+        realm: account2.realm,
       });
 
-      expect(accountsReducer(prevState, action)).toEqual([newAccount, account1]);
+      expect(accountsReducer(prevState, action)).toEqual([account2, account1]);
     });
 
     describe('if an account with this realm exists', () => {

--- a/src/account/__tests__/accountsReducer-test.js
+++ b/src/account/__tests__/accountsReducer-test.js
@@ -162,6 +162,28 @@ describe('accountsReducer', () => {
       expect(newState).toEqual(expectedState);
       expect(newState).not.toBe(prevState);
     });
+
+    test('records zulipFeatureLevel on active account', () => {
+      const prevState = deepFreeze([account1, account2, account3]);
+      const newZulipFeatureLevel = 6;
+      const action = deepFreeze({
+        ...eg.action.realm_init,
+        data: {
+          ...eg.action.realm_init.data,
+          zulip_feature_level: newZulipFeatureLevel,
+        },
+      });
+
+      const expectedState = [
+        { ...account1, zulipFeatureLevel: newZulipFeatureLevel },
+        account2,
+        account3,
+      ];
+
+      const newState = accountsReducer(prevState, action);
+
+      expect(newState).toEqual(expectedState);
+    });
   });
 
   describe('ACCOUNT_SWITCH', () => {

--- a/src/account/__tests__/accountsReducer-test.js
+++ b/src/account/__tests__/accountsReducer-test.js
@@ -107,38 +107,26 @@ describe('accountsReducer', () => {
     const account3 = eg.makeAccount();
 
     test('records zulipVersion on active account', () => {
-      const prevState = deepFreeze([account1, account2, account3]);
       const newZulipVersion = new ZulipVersion('2.0.0');
-      const action = deepFreeze({ ...eg.action.realm_init, zulipVersion: newZulipVersion });
-
-      const expectedState = [{ ...account1, zulipVersion: newZulipVersion }, account2, account3];
-
-      const newState = accountsReducer(prevState, action);
-
-      expect(newState).toEqual(expectedState);
-      expect(newState).not.toBe(prevState);
+      expect(
+        accountsReducer(
+          deepFreeze([account1, account2, account3]),
+          deepFreeze({ ...eg.action.realm_init, zulipVersion: newZulipVersion }),
+        ),
+      ).toEqual([{ ...account1, zulipVersion: newZulipVersion }, account2, account3]);
     });
 
     test('records zulipFeatureLevel on active account', () => {
-      const prevState = deepFreeze([account1, account2, account3]);
       const newZulipFeatureLevel = 6;
-      const action = deepFreeze({
-        ...eg.action.realm_init,
-        data: {
-          ...eg.action.realm_init.data,
-          zulip_feature_level: newZulipFeatureLevel,
-        },
-      });
-
-      const expectedState = [
-        { ...account1, zulipFeatureLevel: newZulipFeatureLevel },
-        account2,
-        account3,
-      ];
-
-      const newState = accountsReducer(prevState, action);
-
-      expect(newState).toEqual(expectedState);
+      expect(
+        accountsReducer(
+          deepFreeze([account1, account2, account3]),
+          deepFreeze({
+            ...eg.action.realm_init,
+            data: { ...eg.action.realm_init.data, zulip_feature_level: newZulipFeatureLevel },
+          }),
+        ),
+      ).toEqual([{ ...account1, zulipFeatureLevel: newZulipFeatureLevel }, account2, account3]);
     });
   });
 

--- a/src/account/__tests__/accountsReducer-test.js
+++ b/src/account/__tests__/accountsReducer-test.js
@@ -16,16 +16,15 @@ import * as eg from '../../__tests__/lib/exampleData';
 
 describe('accountsReducer', () => {
   describe('REALM_ADD', () => {
-    const accountWithZulipVersion = eg.makeAccount({
+    const account1 = eg.makeAccount({
       apiKey: '',
       realm: 'https://realm.one.org',
     });
-    const accountWithoutZulipVersion = eg.makeAccount({
+    const account2 = eg.makeAccount({
       apiKey: '',
-      zulipVersion: null,
       realm: 'https://realm.two.org',
     });
-    const prevState = deepFreeze([accountWithZulipVersion, accountWithoutZulipVersion]);
+    const prevState = deepFreeze([account1, account2]);
 
     test('if no account with this realm exists, prepend new one, with empty email/apiKey', () => {
       const newAccount = eg.makeAccount({
@@ -40,18 +39,33 @@ describe('accountsReducer', () => {
         zulipVersion: eg.zulipVersion,
       });
 
-      const expectedState = [newAccount, accountWithZulipVersion, accountWithoutZulipVersion];
+      const expectedState = [newAccount, account1, account2];
 
-      const newState = accountsReducer(prevState, action);
-
-      expect(newState).toEqual(expectedState);
-      expect(newState).not.toBe(prevState);
+      expect(accountsReducer(prevState, action)).toEqual(expectedState);
     });
 
     test('if account with this realm exists, move to front of list', () => {
       const newAccount = eg.makeAccount({
-        email: accountWithoutZulipVersion.email,
-        realm: accountWithoutZulipVersion.realm,
+        email: account2.email,
+        realm: account2.realm,
+        apiKey: '',
+      });
+
+      const action = deepFreeze({
+        type: REALM_ADD,
+        realm: newAccount.realm,
+        zulipVersion: eg.zulipVersion,
+      });
+
+      const expectedState = [newAccount, account1];
+
+      expect(accountsReducer(prevState, action)).toEqual(expectedState);
+    });
+
+    test('if account with this realm exists and zulipVersion is non-null, move to front of list', () => {
+      const newAccount = eg.makeAccount({
+        email: account2.email,
+        realm: account2.realm,
         apiKey: '',
         zulipVersion: eg.zulipVersion,
       });
@@ -62,12 +76,28 @@ describe('accountsReducer', () => {
         zulipVersion: eg.zulipVersion,
       });
 
-      const expectedState = [newAccount, accountWithZulipVersion];
+      const expectedState = [newAccount, account1];
 
-      const newState = accountsReducer(prevState, action);
+      expect(accountsReducer(prevState, action)).toEqual(expectedState);
+    });
 
-      expect(newState).toEqual(expectedState);
-      expect(newState).not.toBe(prevState);
+    test('if account exists and zulipVersion is null, move to front of list and include zulipVersion', () => {
+      const newAccount = eg.makeAccount({
+        email: account2.email,
+        realm: account2.realm,
+        apiKey: '',
+        zulipVersion: null,
+      });
+
+      const action = deepFreeze({
+        type: REALM_ADD,
+        realm: newAccount.realm,
+        zulipVersion: eg.zulipVersion,
+      });
+
+      const expectedState = [account2, account1];
+
+      expect(accountsReducer(prevState, action)).toEqual(expectedState);
     });
   });
 

--- a/src/account/__tests__/accountsReducer-test.js
+++ b/src/account/__tests__/accountsReducer-test.js
@@ -36,6 +36,7 @@ describe('accountsReducer', () => {
       const action = deepFreeze({
         type: REALM_ADD,
         realm: newAccount.realm,
+        zulipFeatureLevel: eg.zulipFeatureLevel,
         zulipVersion: eg.zulipVersion,
       });
 
@@ -54,6 +55,7 @@ describe('accountsReducer', () => {
       const action = deepFreeze({
         type: REALM_ADD,
         realm: newAccount.realm,
+        zulipFeatureLevel: eg.zulipFeatureLevel,
         zulipVersion: eg.zulipVersion,
       });
 
@@ -73,6 +75,7 @@ describe('accountsReducer', () => {
       const action = deepFreeze({
         type: REALM_ADD,
         realm: newAccount.realm,
+        zulipFeatureLevel: eg.zulipFeatureLevel,
         zulipVersion: eg.zulipVersion,
       });
 
@@ -92,10 +95,51 @@ describe('accountsReducer', () => {
       const action = deepFreeze({
         type: REALM_ADD,
         realm: newAccount.realm,
+        zulipFeatureLevel: eg.zulipFeatureLevel,
         zulipVersion: eg.zulipVersion,
       });
 
       const expectedState = [account2, account1];
+
+      expect(accountsReducer(prevState, action)).toEqual(expectedState);
+    });
+
+    test('if no account with this realm exists and account has zulipFeatureLevel, prepend new one, with empty email/apiKey', () => {
+      const newAccount = eg.makeAccount({
+        email: '',
+        apiKey: '',
+        realm: 'https://new.realm.org',
+        zulipFeatureLevel: eg.zulipFeatureLevel,
+      });
+
+      const action = deepFreeze({
+        type: REALM_ADD,
+        realm: newAccount.realm,
+        zulipFeatureLevel: eg.zulipFeatureLevel,
+        zulipVersion: eg.zulipVersion,
+      });
+
+      const expectedState = [newAccount, account1, account2];
+
+      expect(accountsReducer(prevState, action)).toEqual(expectedState);
+    });
+
+    test('if account with this realm exists and account has zulipFeatureLevel, move to front of list', () => {
+      const newAccount = eg.makeAccount({
+        email: account2.email,
+        realm: account2.realm,
+        apiKey: '',
+        zulipFeatureLevel: eg.zulipFeatureLevel,
+      });
+
+      const action = deepFreeze({
+        type: REALM_ADD,
+        realm: newAccount.realm,
+        zulipFeatureLevel: eg.zulipFeatureLevel,
+        zulipVersion: eg.zulipVersion,
+      });
+
+      const expectedState = [newAccount, account1];
 
       expect(accountsReducer(prevState, action)).toEqual(expectedState);
     });

--- a/src/account/__tests__/accountsReducer-test.js
+++ b/src/account/__tests__/accountsReducer-test.js
@@ -16,52 +16,43 @@ import * as eg from '../../__tests__/lib/exampleData';
 
 describe('accountsReducer', () => {
   describe('REALM_ADD', () => {
-    const account1 = eg.makeAccount({
-      apiKey: '',
-      realm: 'https://realm.one.org',
-    });
-    const account2 = eg.makeAccount({
-      apiKey: '',
-      realm: 'https://realm.two.org',
-    });
+    const account1 = eg.makeAccount({ realm: 'https://realm.one.org', apiKey: '' });
+    const account2 = eg.makeAccount({ realm: 'https://realm.two.org', apiKey: '' });
     const prevState = deepFreeze([account1, account2]);
+    const baseAction = deepFreeze({
+      type: REALM_ADD,
+      zulipFeatureLevel: eg.zulipFeatureLevel,
+      zulipVersion: eg.zulipVersion,
+    });
 
     test('if no account with this realm exists, prepend new one, with empty email/apiKey', () => {
       const newAccount = eg.makeAccount({
+        realm: 'https://new.realm.org',
         email: '',
         apiKey: '',
-        realm: 'https://new.realm.org',
       });
 
       const action = deepFreeze({
-        type: REALM_ADD,
+        ...baseAction,
         realm: newAccount.realm,
-        zulipFeatureLevel: eg.zulipFeatureLevel,
-        zulipVersion: eg.zulipVersion,
       });
 
-      const expectedState = [newAccount, account1, account2];
-
-      expect(accountsReducer(prevState, action)).toEqual(expectedState);
+      expect(accountsReducer(prevState, action)).toEqual([newAccount, account1, account2]);
     });
 
     test('if account with this realm exists, move to front of list', () => {
       const newAccount = eg.makeAccount({
-        email: account2.email,
         realm: account2.realm,
+        email: account2.email,
         apiKey: '',
       });
 
       const action = deepFreeze({
-        type: REALM_ADD,
+        ...baseAction,
         realm: newAccount.realm,
-        zulipFeatureLevel: eg.zulipFeatureLevel,
-        zulipVersion: eg.zulipVersion,
       });
 
-      const expectedState = [newAccount, account1];
-
-      expect(accountsReducer(prevState, action)).toEqual(expectedState);
+      expect(accountsReducer(prevState, action)).toEqual([newAccount, account1]);
     });
 
     describe('if an account with this realm exists', () => {
@@ -71,9 +62,8 @@ describe('accountsReducer', () => {
         const newZulipVersion = new ZulipVersion('4.0.0');
 
         const action = deepFreeze({
-          type: REALM_ADD,
+          ...baseAction,
           realm: existingAccountBase.realm,
-          zulipFeatureLevel: eg.zulipFeatureLevel,
           zulipVersion: newZulipVersion,
         });
 
@@ -97,10 +87,9 @@ describe('accountsReducer', () => {
         const newZulipFeatureLevel = 6;
 
         const action = deepFreeze({
-          type: REALM_ADD,
+          ...baseAction,
           realm: existingAccountBase.realm,
           zulipFeatureLevel: newZulipFeatureLevel,
-          zulipVersion: eg.zulipVersion,
         });
 
         test('when its zulipFeatureLevel started out non-null', () => {

--- a/src/account/__tests__/accountsReducer-test.js
+++ b/src/account/__tests__/accountsReducer-test.js
@@ -64,84 +64,57 @@ describe('accountsReducer', () => {
       expect(accountsReducer(prevState, action)).toEqual(expectedState);
     });
 
-    test('if account with this realm exists and zulipVersion is non-null, move to front of list', () => {
-      const newAccount = eg.makeAccount({
-        email: account2.email,
-        realm: account2.realm,
-        apiKey: '',
-        zulipVersion: eg.zulipVersion,
+    describe('if an account with this realm exists', () => {
+      const existingAccountBase = eg.makeAccount({});
+
+      describe('update its zulipVersion', () => {
+        const newZulipVersion = new ZulipVersion('4.0.0');
+
+        const action = deepFreeze({
+          type: REALM_ADD,
+          realm: existingAccountBase.realm,
+          zulipFeatureLevel: eg.zulipFeatureLevel,
+          zulipVersion: newZulipVersion,
+        });
+
+        test('when its zulipVersion started out non-null', () => {
+          expect(
+            accountsReducer(
+              [{ ...existingAccountBase, zulipVersion: new ZulipVersion('3.0.0') }],
+              action,
+            ),
+          ).toEqual([{ ...existingAccountBase, zulipVersion: newZulipVersion }]);
+        });
+
+        test('when its zulipVersion started out null', () => {
+          expect(accountsReducer([{ ...existingAccountBase, zulipVersion: null }], action)).toEqual(
+            [{ ...existingAccountBase, zulipVersion: newZulipVersion }],
+          );
+        });
       });
 
-      const action = deepFreeze({
-        type: REALM_ADD,
-        realm: newAccount.realm,
-        zulipFeatureLevel: eg.zulipFeatureLevel,
-        zulipVersion: eg.zulipVersion,
+      describe('update its zulipFeatureLevel', () => {
+        const newZulipFeatureLevel = 6;
+
+        const action = deepFreeze({
+          type: REALM_ADD,
+          realm: existingAccountBase.realm,
+          zulipFeatureLevel: newZulipFeatureLevel,
+          zulipVersion: eg.zulipVersion,
+        });
+
+        test('when its zulipFeatureLevel started out non-null', () => {
+          expect(
+            accountsReducer([{ ...existingAccountBase, zulipFeatureLevel: 5 }], action),
+          ).toEqual([{ ...existingAccountBase, zulipFeatureLevel: newZulipFeatureLevel }]);
+        });
+
+        test('when its zulipVersion started out null', () => {
+          expect(
+            accountsReducer([{ ...existingAccountBase, zulipFeatureLevel: null }], action),
+          ).toEqual([{ ...existingAccountBase, zulipFeatureLevel: newZulipFeatureLevel }]);
+        });
       });
-
-      const expectedState = [newAccount, account1];
-
-      expect(accountsReducer(prevState, action)).toEqual(expectedState);
-    });
-
-    test('if account exists and zulipVersion is null, move to front of list and include zulipVersion', () => {
-      const newAccount = eg.makeAccount({
-        email: account2.email,
-        realm: account2.realm,
-        apiKey: '',
-        zulipVersion: null,
-      });
-
-      const action = deepFreeze({
-        type: REALM_ADD,
-        realm: newAccount.realm,
-        zulipFeatureLevel: eg.zulipFeatureLevel,
-        zulipVersion: eg.zulipVersion,
-      });
-
-      const expectedState = [account2, account1];
-
-      expect(accountsReducer(prevState, action)).toEqual(expectedState);
-    });
-
-    test('if no account with this realm exists and account has zulipFeatureLevel, prepend new one, with empty email/apiKey', () => {
-      const newAccount = eg.makeAccount({
-        email: '',
-        apiKey: '',
-        realm: 'https://new.realm.org',
-        zulipFeatureLevel: eg.zulipFeatureLevel,
-      });
-
-      const action = deepFreeze({
-        type: REALM_ADD,
-        realm: newAccount.realm,
-        zulipFeatureLevel: eg.zulipFeatureLevel,
-        zulipVersion: eg.zulipVersion,
-      });
-
-      const expectedState = [newAccount, account1, account2];
-
-      expect(accountsReducer(prevState, action)).toEqual(expectedState);
-    });
-
-    test('if account with this realm exists and account has zulipFeatureLevel, move to front of list', () => {
-      const newAccount = eg.makeAccount({
-        email: account2.email,
-        realm: account2.realm,
-        apiKey: '',
-        zulipFeatureLevel: eg.zulipFeatureLevel,
-      });
-
-      const action = deepFreeze({
-        type: REALM_ADD,
-        realm: newAccount.realm,
-        zulipFeatureLevel: eg.zulipFeatureLevel,
-        zulipVersion: eg.zulipVersion,
-      });
-
-      const expectedState = [newAccount, account1];
-
-      expect(accountsReducer(prevState, action)).toEqual(expectedState);
     });
   });
 

--- a/src/account/__tests__/accountsReducer-test.js
+++ b/src/account/__tests__/accountsReducer-test.js
@@ -16,50 +16,44 @@ import * as eg from '../../__tests__/lib/exampleData';
 
 describe('accountsReducer', () => {
   describe('REALM_ADD', () => {
-    const account1 = eg.makeAccount({ realm: 'https://realm.one.org', apiKey: '' });
-    const account2 = eg.makeAccount({ realm: 'https://realm.two.org', apiKey: '' });
-    const prevState = deepFreeze([account1, account2]);
-    const baseAction = deepFreeze({
-      type: REALM_ADD,
-      zulipFeatureLevel: eg.zulipFeatureLevel,
-      zulipVersion: eg.zulipVersion,
-    });
-
-    test('if no account with this realm exists, prepend new one, with empty email/apiKey', () => {
-      const newRealm = 'https://new.realm.org';
-
-      const action = deepFreeze({
-        ...baseAction,
-        realm: newRealm,
+    describe('on list of identities', () => {
+      const account1 = eg.makeAccount({ realm: 'https://realm.one.org', apiKey: '' });
+      const account2 = eg.makeAccount({ realm: 'https://realm.two.org', apiKey: '' });
+      const prevState = deepFreeze([account1, account2]);
+      const baseAction = deepFreeze({
+        type: REALM_ADD,
+        zulipFeatureLevel: eg.zulipFeatureLevel,
+        zulipVersion: eg.zulipVersion,
       });
 
-      expect(accountsReducer(prevState, action)).toEqual([
-        eg.makeAccount({ realm: newRealm, email: '', apiKey: '' }),
-        account1,
-        account2,
-      ]);
-    });
-
-    test('if account with this realm exists, move to front of list', () => {
-      const action = deepFreeze({
-        ...baseAction,
-        realm: account2.realm,
+      test('if no account with this realm exists, prepend new one, with empty email/apiKey', () => {
+        const newRealm = 'https://new.realm.org';
+        const action = deepFreeze({ ...baseAction, realm: newRealm });
+        expect(accountsReducer(prevState, action)).toEqual([
+          eg.makeAccount({ realm: newRealm, email: '', apiKey: '' }),
+          account1,
+          account2,
+        ]);
       });
 
-      expect(accountsReducer(prevState, action)).toEqual([account2, account1]);
+      test('if account with this realm exists, move to front of list', () => {
+        const action = deepFreeze({ ...baseAction, realm: account2.realm });
+        expect(accountsReducer(prevState, action)).toEqual([account2, account1]);
+      });
     });
 
     describe('if an account with this realm exists', () => {
       const existingAccountBase = eg.makeAccount({});
+      const baseAction = deepFreeze({
+        type: REALM_ADD,
+        realm: existingAccountBase.realm,
+        zulipFeatureLevel: eg.zulipFeatureLevel,
+        zulipVersion: eg.zulipVersion,
+      });
 
       describe('update its zulipVersion', () => {
         const newZulipVersion = new ZulipVersion('4.0.0');
-
-        const action = deepFreeze({
-          ...baseAction,
-          realm: existingAccountBase.realm,
-          zulipVersion: newZulipVersion,
-        });
+        const action = deepFreeze({ ...baseAction, zulipVersion: newZulipVersion });
 
         test('when its zulipVersion started out non-null', () => {
           expect(
@@ -79,12 +73,7 @@ describe('accountsReducer', () => {
 
       describe('update its zulipFeatureLevel', () => {
         const newZulipFeatureLevel = 6;
-
-        const action = deepFreeze({
-          ...baseAction,
-          realm: existingAccountBase.realm,
-          zulipFeatureLevel: newZulipFeatureLevel,
-        });
+        const action = deepFreeze({ ...baseAction, zulipFeatureLevel: newZulipFeatureLevel });
 
         test('when its zulipFeatureLevel started out non-null', () => {
           expect(

--- a/src/account/accountActions.js
+++ b/src/account/accountActions.js
@@ -14,9 +14,14 @@ export const switchAccount = (index: number): Action => ({
   index,
 });
 
-export const realmAdd = (realm: string, zulipVersion: ZulipVersion): Action => ({
+export const realmAdd = (
+  realm: string,
+  zulipFeatureLevel: number,
+  zulipVersion: ZulipVersion,
+): Action => ({
   type: REALM_ADD,
   realm,
+  zulipFeatureLevel,
   zulipVersion,
 });
 

--- a/src/account/accountsReducer.js
+++ b/src/account/accountsReducer.js
@@ -21,6 +21,7 @@ const realmAdd = (state, action) => {
   if (accountIndex !== -1) {
     const newAccount = {
       ...state[accountIndex],
+      zulipFeatureLevel: action.zulipFeatureLevel,
       zulipVersion: action.zulipVersion,
     };
     return [newAccount, ...state.slice(0, accountIndex), ...state.slice(accountIndex + 1)];
@@ -32,6 +33,7 @@ const realmAdd = (state, action) => {
       apiKey: '',
       email: '',
       ackedPushToken: null,
+      zulipFeatureLevel: action.zulipFeatureLevel,
       zulipVersion: action.zulipVersion,
     },
     ...state,
@@ -41,6 +43,7 @@ const realmAdd = (state, action) => {
 const realmInit = (state, action) => [
   {
     ...state[0],
+    zulipFeatureLevel: action.data.zulip_feature_level ?? 0,
     zulipVersion: action.zulipVersion,
   },
   ...state.slice(1),
@@ -65,7 +68,10 @@ const loginSuccess = (state, action) => {
   const { realm, email, apiKey } = action;
   const accountIndex = findAccount(state, { realm, email });
   if (accountIndex === -1) {
-    return [{ realm, email, apiKey, ackedPushToken: null, zulipVersion: null }, ...state];
+    return [
+      { realm, email, apiKey, ackedPushToken: null, zulipVersion: null, zulipFeatureLevel: null },
+      ...state,
+    ];
   }
   return [
     { ...state[accountIndex], email, apiKey, ackedPushToken: null },

--- a/src/actionTypes.js
+++ b/src/actionTypes.js
@@ -143,6 +143,7 @@ type AccountSwitchAction = {|
 type RealmAddAction = {|
   type: typeof REALM_ADD,
   realm: string,
+  zulipFeatureLevel: number,
   zulipVersion: ZulipVersion,
 |};
 

--- a/src/api/initialDataTypes.js
+++ b/src/api/initialDataTypes.js
@@ -83,6 +83,13 @@ export type InitialDataRealm = {|
   realm_uri: string,
   realm_video_chat_provider: number,
   realm_waiting_period_threshold: number,
+
+  /**
+   * Added in server version 2.2, feature level 1.
+   * Same meaning as in the server_settings response:
+   * https://zulipchat.com/api/server-settings
+   */
+  zulip_feature_level?: number,
 |};
 
 export type InitialDataRealmEmoji = {|

--- a/src/api/settings/getServerSettings.js
+++ b/src/api/settings/getServerSettings.js
@@ -35,6 +35,10 @@ export type ApiResponseServerSettings = {|
   realm_uri: string,
   require_email_format_usernames: boolean,
   zulip_version: string,
+
+  // zulip_feature_level added for server v2.2, feature level 1
+  // See https://zulipchat.com/api/server-settings
+  zulip_feature_level?: number,
 |};
 
 /** See https://zulip.com/api/server-settings */

--- a/src/boot/store.js
+++ b/src/boot/store.js
@@ -178,6 +178,15 @@ const migrations: { [string]: (GlobalState) => GlobalState } = {
     })),
   }),
 
+  // Added Accounts.zulipFeatureLevel as number | null
+  '14': state => ({
+    ...state,
+    accounts: state.accounts.map(a => ({
+      ...a,
+      zulipFeatureLevel: null,
+    })),
+  }),
+
   // TIP: When adding a migration, consider just using `dropCache`.
 };
 

--- a/src/boot/store.js
+++ b/src/boot/store.js
@@ -118,7 +118,8 @@ const migrations: { [string]: (GlobalState) => GlobalState } = {
     accounts: state.accounts.map(a => ({
       ...a,
       // but in the case of `ackedPushToken` let's be a bit more precise,
-      // and avoid clobbering it if present.
+      // and avoid clobbering it if present.  (Don't copy this pattern for a
+      // normal migration; this uncertainty is specific to recovering from #3553.)
       ackedPushToken: a.ackedPushToken !== undefined ? a.ackedPushToken : null,
     })),
   }),
@@ -159,26 +160,25 @@ const migrations: { [string]: (GlobalState) => GlobalState } = {
     })),
   }),
 
-  // Accounts.zulipVersion is now string | null
+  // Add Accounts.zulipVersion, as string | null.
   '12': state => ({
     ...state,
     accounts: state.accounts.map(a => ({
       ...a,
-      zulipVersion: a.zulipVersion !== undefined ? a.zulipVersion : null,
+      zulipVersion: null,
     })),
   }),
 
-  // Accounts.zulipVersion is now ZulipVersion | null
+  // Convert Accounts.zulipVersion from `string | null` to `ZulipVersion | null`.
   '13': state => ({
     ...state,
     accounts: state.accounts.map(a => ({
       ...a,
-      zulipVersion:
-        typeof a.zulipVersion === 'string' ? new ZulipVersion(a.zulipVersion) : a.zulipVersion,
+      zulipVersion: typeof a.zulipVersion === 'string' ? new ZulipVersion(a.zulipVersion) : null,
     })),
   }),
 
-  // Added Accounts.zulipFeatureLevel as number | null
+  // Add Accounts.zulipFeatureLevel, as number | null.
   '14': state => ({
     ...state,
     accounts: state.accounts.map(a => ({

--- a/src/start/RealmScreen.js
+++ b/src/start/RealmScreen.js
@@ -65,7 +65,7 @@ class RealmScreen extends PureComponent<Props, State> {
       dispatch(
         realmAdd(
           realm,
-          serverSettings.zulip_feature_level === undefined ? 0 : serverSettings.zulip_feature_level,
+          serverSettings.zulip_feature_level ?? 0,
           new ZulipVersion(serverSettings.zulip_version),
         ),
       );

--- a/src/start/RealmScreen.js
+++ b/src/start/RealmScreen.js
@@ -62,7 +62,13 @@ class RealmScreen extends PureComponent<Props, State> {
     });
     try {
       const serverSettings: ApiResponseServerSettings = await api.getServerSettings(realm);
-      dispatch(realmAdd(realm, new ZulipVersion(serverSettings.zulip_version)));
+      dispatch(
+        realmAdd(
+          realm,
+          serverSettings.zulip_feature_level === undefined ? 0 : serverSettings.zulip_feature_level,
+          new ZulipVersion(serverSettings.zulip_version),
+        ),
+      );
       dispatch(navigateToAuth(serverSettings));
       Keyboard.dismiss();
     } catch (err) {

--- a/src/types.js
+++ b/src/types.js
@@ -57,6 +57,9 @@ export type Account = {|
    * Because a server deploy invalidates event queues, this means the value
    * is always up to date for a server we have an active event queue on.
    *
+   * This is `null` just when representing an account which was last used on
+   * a version of the app which didn't record this information.
+   *
    * For use in:
    *  * how we make some API requests, in order to keep the logic isolated
    *    to the edge, where we communicate with the server, to keep with the
@@ -72,6 +75,9 @@ export type Account = {|
    * server supports all API features introduced before feature level N.
    * This is designed to provide a simple way for mobile apps to decide
    * whether the server supports a given feature or API change.
+   *
+   * This is `null` just when representing an account which was last used on
+   * a version of the app which didn't record this information.
    *
    * Like zulipVersion, we learn the feature level from /server_settings
    * at the start of the login process, and again from /register when

--- a/src/types.js
+++ b/src/types.js
@@ -66,6 +66,20 @@ export type Account = {|
   zulipVersion: ZulipVersion | null,
 
   /**
+   * An integer indicating what features are available on the server.
+   *
+   * The feature level increases monotonically; a value of N means the
+   * server supports all API features introduced before feature level N.
+   * This is designed to provide a simple way for mobile apps to decide
+   * whether the server supports a given feature or API change.
+   *
+   * Like zulipVersion, we learn the feature level from /server_settings
+   * at the start of the login process, and again from /register when
+   * setting up an event queue.
+   */
+  zulipFeatureLevel: number | null,
+
+  /**
    * The last device token value the server has definitely heard from us.
    *
    * This is `null` until we make a successful request to the server to


### PR DESCRIPTION
Following [#14658](https://github.com/zulip/zulip/pull/14658), we now obtain `feature level` from Zulip server and store it in Redux. This is designed to provide a simple way for mobile apps to decide whether the server supports a given feature or API change.

Closes #4049.