### PR TITLE
Deduplicate slashes in social auth login endpoints

### DIFF
--- a/src/start/AuthScreen.js
+++ b/src/start/AuthScreen.js
@@ -204,7 +204,10 @@ class AuthScreen extends PureComponent<Props> {
    */
   beginWebAuth = async (url: string) => {
     otp = await webAuth.generateOtp();
-    webAuth.openBrowser(`${this.props.realm}/${url}`, otp);
+    // TODO: Following #4081, use, e.g.,
+    //   `new URL(url, this.props.realm)`
+    const absoluteURL = `${this.props.realm}/${url.replace(/^\/+/, '')}`;
+    webAuth.openBrowser(absoluteURL, otp);
   };
 
   endWebAuth = (event: LinkingEvent) => {

--- a/src/start/AuthScreen.js
+++ b/src/start/AuthScreen.js
@@ -196,6 +196,12 @@ class AuthScreen extends PureComponent<Props> {
     Linking.removeEventListener('url', this.endWebAuth);
   };
 
+  /**
+   * Hand control to the browser for an external auth method.
+   *
+   * @param url The `login_url` string, a relative URL, from an
+   * `external_authentication_method` object from `/server_settings`.
+   */
   beginWebAuth = async (url: string) => {
     otp = await webAuth.generateOtp();
     webAuth.openBrowser(`${this.props.realm}/${url}`, otp);


### PR DESCRIPTION
This fixes an issue noted in https://github.com/zulip/zulip-mobile/issues/3567#issuecomment-622574435 where we're duplicating slashes when we call social auth endpoints.

A better fix depends on https://github.com/zulip/zulip-mobile/issues/4081. The commit messages reflect that issue being blocked by the RN v0.61 upgrade, but Ray points out that we may be able to do it without the available JS library, and instead make a native plugin, in which case the issue is not blocked; discussion is ongoing.