### PR TITLE
password input: Add icon to show and hide password instead of text

### DIFF
--- a/src/common/Icons.js
+++ b/src/common/Icons.js
@@ -70,3 +70,5 @@ export const IconMoreHorizontal: IconType = props => <Feather name="more-horizon
 export const IconEdit: IconType = props => <Feather name="edit" {...props} />;
 export const IconPlusSquare: IconType = props => <Feather name="plus-square" {...props} />;
 export const IconPlus: IconType = props => <Feather name="plus" {...props} />;
+export const IconEye: IconType = props => <Feather name="eye" {...props} />;
+export const IconEyeOff: IconType = props => <Feather name="eye-off" {...props} />;

--- a/src/common/PasswordInput.js
+++ b/src/common/PasswordInput.js
@@ -5,7 +5,7 @@ import { View, TextInput, StyleSheet } from 'react-native';
 import Input from './Input';
 import type { Props as InputProps } from './Input';
 import { BRAND_COLOR } from '../styles';
-import Label from './Label';
+import { IconEye, IconEyeOff } from './Icons';
 import Touchable from './Touchable';
 
 const styles = StyleSheet.create({
@@ -16,8 +16,7 @@ const styles = StyleSheet.create({
     bottom: 0,
     justifyContent: 'center',
   },
-  showPasswordButtonText: {
-    margin: 8,
+  showPasswordButtonIcon: {
     color: BRAND_COLOR,
   },
 });
@@ -63,7 +62,11 @@ export default class PasswordInput extends PureComponent<Props, State> {
           autoCapitalize="none"
         />
         <Touchable style={styles.showPasswordButton} onPress={this.handleShow}>
-          <Label style={styles.showPasswordButtonText} text={isHidden ? 'show' : 'hide'} />
+          {isHidden ? (
+            <IconEye size={20} style={styles.showPasswordButtonIcon} />
+          ) : (
+            <IconEyeOff size={20} style={styles.showPasswordButtonIcon} />
+          )}
         </Touchable>
       </View>
     );


### PR DESCRIPTION
To view the password users had to click on text 'show' / 'hide', this is replaced by using 'eye' / 'eye-off' icons.

![Screenshot-20200503024441-718x224](https://user-images.githubusercontent.com/31368194/80892533-8d59df00-8ce8-11ea-9d82-33f8e61cb0e2.png)
![Screenshot-20200503024520-723x205](https://user-images.githubusercontent.com/31368194/80892535-9054cf80-8ce8-11ea-951e-ffae506eb25b.png)

