### PR TITLE
Remove `objectToParams`

### DIFF
--- a/src/api/__tests__/apiFetch-test.js
+++ b/src/api/__tests__/apiFetch-test.js
@@ -1,48 +1,6 @@
-import { objectToParams, getFetchParams } from '../apiFetch';
+import { getFetchParams } from '../apiFetch';
 
 global.FormData = jest.fn();
-
-describe('objectToParams', () => {
-  test('object consisting of numbers, strings or booleans is not changed', () => {
-    const obj = {
-      numKey: 123,
-      strKey: 'str',
-      boolKey: true,
-    };
-    const result = objectToParams(obj);
-    expect(result).toEqual(obj);
-  });
-
-  test('keys with values of "undefined" are skipped, "null" keys are left as-is', () => {
-    const obj = {
-      strKey: 'str',
-      nullKey: null,
-      undefinedKey: undefined,
-    };
-    const expected = {
-      strKey: 'str',
-      nullKey: null,
-    };
-    const result = objectToParams(obj);
-    expect(result).toEqual(expected);
-    expect(result).toHaveProperty('strKey');
-    expect(result).toHaveProperty('nullKey');
-    expect(result).not.toHaveProperty('undefinedKey');
-  });
-
-  test('arrays are JSON-stringified', () => {
-    const obj = {
-      numKey: 123,
-      arrKey: [1, 2, 3],
-    };
-    const expected = {
-      numKey: 123,
-      arrKey: '[1,2,3]',
-    };
-    const result = objectToParams(obj);
-    expect(result).toEqual(expected);
-  });
-});
 
 describe('getFetchParams', () => {
   test('creates a `header` key with authorization data', () => {

--- a/src/api/apiFetch.js
+++ b/src/api/apiFetch.js
@@ -10,20 +10,6 @@ import { makeErrorFromApi } from './apiErrors';
 
 const apiVersion = 'api/v1';
 
-export const objectToParams = (obj: {}) => {
-  const newObj = {};
-  Object.keys(obj).forEach(key => {
-    if (Array.isArray(obj[key])) {
-      newObj[key] = JSON.stringify(obj[key]);
-    } else if (obj[key] === undefined) {
-      // do nothing, skip key
-    } else {
-      newObj[key] = obj[key];
-    }
-  });
-  return newObj;
-};
-
 export const getFetchParams = (auth: Auth, params: { ... } = {}): { ... } => {
   // $FlowFixMe This is purely a no-op, and Flow even knows that. :-/
   const { body } = (params: { body?: mixed });

--- a/src/api/registerForEvents.js
+++ b/src/api/registerForEvents.js
@@ -2,7 +2,7 @@
 import type { InitialData } from './initialDataTypes';
 import type { Auth } from './transportTypes';
 import type { Narrow } from './apiTypes';
-import { apiPost, objectToParams } from './apiFetch';
+import { apiPost } from './apiFetch';
 
 type RegisterForEventsParams = {|
   apply_markdown?: boolean,
@@ -19,9 +19,15 @@ type RegisterForEventsParams = {|
 |};
 
 /** See https://zulipchat.com/api/register-queue */
-export default async (auth: Auth, params: RegisterForEventsParams): Promise<InitialData> =>
-  apiPost(
-    auth,
-    'register',
-    objectToParams({ ...params, client_capabilities: JSON.stringify(params.client_capabilities) }),
-  );
+export default async (auth: Auth, params: RegisterForEventsParams): Promise<InitialData> => {
+  // The use of `...rest` here (rather than just using `...params` below) is to
+  // work around a Flow object-spread bug fixed in v0.111.0.
+  const { narrow, event_types, fetch_event_types, client_capabilities, ...rest } = params;
+  return apiPost(auth, 'register', {
+    ...rest,
+    narrow: JSON.stringify(narrow),
+    event_types: JSON.stringify(event_types),
+    fetch_event_types: JSON.stringify(fetch_event_types),
+    client_capabilities: JSON.stringify(client_capabilities),
+  });
+};

--- a/src/api/users/updateUserStatus.js
+++ b/src/api/users/updateUserStatus.js
@@ -1,6 +1,6 @@
 /* @flow strict-local */
 import type { ApiResponseSuccess, Auth } from '../transportTypes';
-import { apiPost, objectToParams } from '../apiFetch';
+import { apiPost } from '../apiFetch';
 
 type UserStatusParams = {|
   away?: boolean,
@@ -8,4 +8,4 @@ type UserStatusParams = {|
 |};
 
 export default (auth: Auth, params: UserStatusParams): Promise<ApiResponseSuccess> =>
-  apiPost(auth, 'users/me/status', objectToParams(params));
+  apiPost(auth, 'users/me/status', params);

--- a/src/lightbox/downloadImage.js
+++ b/src/lightbox/downloadImage.js
@@ -4,7 +4,6 @@ import RNFetchBlob from 'rn-fetch-blob';
 
 import type { Auth } from '../api/transportTypes';
 import { getAuthHeaders } from '../api/transport';
-import { objectToParams } from '../api/apiFetch';
 import { getFullUrl } from '../utils/url';
 import userAgent from '../utils/userAgent';
 
@@ -54,13 +53,9 @@ export default async (src: string, auth: Auth): Promise<mixed> => {
       title: src.split('/').pop(),
       notification: true,
     },
-  }).fetch(
-    'GET',
-    absoluteUrl,
-    objectToParams({
-      'Content-Type': 'application/x-www-form-urlencoded; charset=utf-8',
-      'User-Agent': userAgent,
-      ...getAuthHeaders(auth),
-    }),
-  );
+  }).fetch('GET', absoluteUrl, {
+    'Content-Type': 'application/x-www-form-urlencoded; charset=utf-8',
+    'User-Agent': userAgent,
+    ...getAuthHeaders(auth),
+  });
 };


### PR DESCRIPTION
This function did both less and more than it really needed to.

Pulled out of plumbing work for #4086.