### PR TITLE
Warn on @-mentioning someone who won't see it because not subscribed

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -42,6 +42,7 @@ import subscriptionRemove from './subscriptions/subscriptionRemove';
 import toggleMuteStream from './subscriptions/toggleMuteStream';
 import togglePinStream from './subscriptions/togglePinStream';
 import toggleStreamNotifications from './subscriptions/toggleStreamNotifications';
+import getSubscriptionToStream from './subscriptions/getSubscriptionToStream';
 import unmuteTopic from './subscriptions/unmuteTopic';
 import tryGetFileTemporaryUrl from './tryGetFileTemporaryUrl';
 import createUserGroup from './user_groups/createUserGroup';
@@ -97,6 +98,7 @@ export {
   muteTopic,
   subscriptionAdd,
   subscriptionRemove,
+  getSubscriptionToStream,
   toggleMuteStream,
   togglePinStream,
   toggleStreamNotifications,

--- a/src/api/subscriptions/getSubscriptionToStream.js
+++ b/src/api/subscriptions/getSubscriptionToStream.js
@@ -1,0 +1,21 @@
+/* @flow strict-local */
+import type { Auth, ApiResponseSuccess } from '../transportTypes';
+import { apiGet } from '../apiFetch';
+
+type ApiResponseSubscriptionStatus = {|
+  ...ApiResponseSuccess,
+  is_subscribed: boolean,
+|};
+
+/**
+ * Get whether a user is subscribed to a particular stream.
+ *
+ * See https://zulip.com/api/get-subscription-status for
+ * documentation of this endpoint.
+ */
+export default (
+  auth: Auth,
+  userId: number,
+  streamId: number,
+): Promise<ApiResponseSubscriptionStatus> =>
+  apiGet(auth, `users/${userId}/subscriptions/${streamId}`);

--- a/src/autocomplete/AutocompleteView.js
+++ b/src/autocomplete/AutocompleteView.js
@@ -19,14 +19,24 @@ type Props = $ReadOnly<{|
   isFocused: boolean,
   text: string,
   selection: InputSelection,
-  onAutocomplete: (input: string) => void,
+
+  /**
+   * The callback that is called when the user taps on any of the suggested items.
+   *
+   * @param input The text entered by the user, modified to include the autocompletion.
+   * @param completion The suggestion selected by the user. Includes markdown formatting,
+      but not the prefix. Eg. **FullName**, **StreamName**.
+   * @param lastWordPrefix The type of the autocompletion - valid values are keys of 'prefixToComponent'.
+   */
+  onAutocomplete: (input: string, completion: string, lastWordPrefix: string) => void,
 |}>;
 
 export default class AutocompleteView extends PureComponent<Props> {
   handleAutocomplete = (autocomplete: string) => {
     const { text, onAutocomplete, selection } = this.props;
+    const { lastWordPrefix } = getAutocompleteFilter(text, selection);
     const newText = getAutocompletedText(text, autocomplete, selection);
-    onAutocomplete(newText);
+    onAutocomplete(newText, autocomplete, lastWordPrefix);
   };
 
   render() {

--- a/src/common/ZulipButton.js
+++ b/src/common/ZulipButton.js
@@ -1,7 +1,7 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
 import { StyleSheet, Text, View, ActivityIndicator } from 'react-native';
-import type { ViewStyleProp } from 'react-native/Libraries/StyleSheet/StyleSheet';
+import type { TextStyleProp, ViewStyleProp } from 'react-native/Libraries/StyleSheet/StyleSheet';
 import TranslatedText from './TranslatedText';
 
 import type { LocalizableText } from '../types';
@@ -62,6 +62,7 @@ const styles = StyleSheet.create({
 
 type Props = $ReadOnly<{|
   style?: ViewStyleProp,
+  textStyle?: TextStyleProp,
   progress: boolean,
   disabled: boolean,
   Icon?: SpecificIconType,
@@ -78,6 +79,7 @@ type Props = $ReadOnly<{|
  * have their `secondary` property set to `true`.
  *
  * @prop [style] - Style object applied to the outermost component.
+ * @prop [textStyle] - Style applied to the button text.
  * @prop [progress] - Shows a progress indicator in place of the button text.
  * @prop [disabled] - If set the button is not pressable and visually looks disabled.
  * @prop [Icon] - Icon component to display in front of the button text
@@ -110,6 +112,7 @@ export default class ZulipButton extends PureComponent<Props> {
     const textStyle = [
       styles.text,
       disabled ? styles.disabledText : secondary ? styles.secondaryText : styles.primaryText,
+      this.props.textStyle,
     ];
     const iconStyle = [styles.icon, secondary ? styles.secondaryIcon : styles.primaryIcon];
 

--- a/src/compose/ComposeBox.js
+++ b/src/compose/ComposeBox.js
@@ -196,8 +196,12 @@ class ComposeBox extends PureComponent<Props, State> {
   };
 
   // See JSDoc on 'onAutocomplete' in 'AutocompleteView.js'.
-  handleMessageAutocomplete = (message: string, completion: string, lastWordPrefix: string) => {
-    this.setMessageInputValue(message);
+  handleMessageAutocomplete = (
+    completedText: string,
+    completion: string,
+    lastWordPrefix: string,
+  ) => {
+    this.setMessageInputValue(completedText);
 
     if (lastWordPrefix === '@') {
       if (this.mentionWarnings.current) {

--- a/src/compose/MentionWarnings.js
+++ b/src/compose/MentionWarnings.js
@@ -1,0 +1,186 @@
+/* @flow strict-local */
+
+import React, { PureComponent } from 'react';
+import { connect } from 'react-redux';
+
+import type { Auth, Stream, Dispatch, Narrow, UserOrBot, Subscription, GetText } from '../types';
+import { TranslationContext } from '../boot/TranslationProvider';
+import { getActiveUsersById, getAuth } from '../selectors';
+import { isPrivateNarrow } from '../utils/narrow';
+import * as api from '../api';
+import { showToast } from '../utils/info';
+
+import AnimatedScaleComponent from '../animation/AnimatedScaleComponent';
+import MentionedUserNotSubscribed from '../message/MentionedUserNotSubscribed';
+
+type State = {|
+  unsubscribedMentions: Array<number>,
+|};
+
+type SelectorProps = {|
+  auth: Auth,
+  usersById: Map<number, UserOrBot>,
+|};
+
+type Props = $ReadOnly<{|
+  narrow: Narrow,
+  stream: Subscription | {| ...Stream, in_home_view: boolean |},
+
+  dispatch: Dispatch,
+  ...SelectorProps,
+|}>;
+
+class MentionWarnings extends PureComponent<Props, State> {
+  static contextType = TranslationContext;
+  context: GetText;
+
+  state = {
+    unsubscribedMentions: [],
+  };
+
+  /**
+   * Tries to parse a user object from an @-mention.
+   *
+   * @param completion The autocomplete option chosend by the user.
+      See JSDoc for AutoCompleteView for details.
+   */
+  getUserFromMention = (completion: string): UserOrBot | void => {
+    const { usersById } = this.props;
+
+    const unformattedMessage = completion.split('**')[1];
+    const [userFullName, userIdRaw] = unformattedMessage.split('|');
+
+    // We skip user groups, for which autocompletes are of the form
+    // `*<user_group_name>*`, and therefore, message.split('**')[1]
+    // is undefined.
+    if (unformattedMessage === undefined) {
+      return undefined;
+    }
+
+    if (userIdRaw !== undefined) {
+      const userId = Number.parseInt(userIdRaw, 10);
+      return usersById.get(userId);
+    }
+
+    for (const user of usersById.values()) {
+      if (user.full_name === userFullName) {
+        return user;
+      }
+    }
+
+    return undefined;
+  };
+
+  showSubscriptionStatusLoadError = (mentionedUser: UserOrBot) => {
+    const _ = this.context;
+
+    const alertTitle = _.intl.formatMessage(
+      {
+        id: "Couldn't load information about {fullName}",
+        defaultMessage: "Couldn't load information about {fullName}",
+      },
+      { fullName: mentionedUser.full_name },
+    );
+    showToast(alertTitle);
+  };
+
+  /**
+   * Check whether the message text entered by the user contains
+   * an @-mention to a user unsubscribed to the current stream, and if
+   * so, shows a warning.
+   *
+   * This function is expected to be called by `ComposeBox` using a ref
+   * to this component.
+   *
+   * @param completion The autocomplete option chosend by the user.
+      See JSDoc for AutoCompleteView for details.
+   */
+  handleMentionSubscribedCheck = async (completion: string) => {
+    const { narrow, auth, stream } = this.props;
+    const { unsubscribedMentions } = this.state;
+
+    if (isPrivateNarrow(narrow)) {
+      return;
+    }
+    const mentionedUser = this.getUserFromMention(completion);
+    if (mentionedUser === undefined || unsubscribedMentions.includes(mentionedUser.user_id)) {
+      return;
+    }
+
+    let isSubscribed: boolean;
+    try {
+      isSubscribed = (await api.getSubscriptionToStream(
+        auth,
+        mentionedUser.user_id,
+        stream.stream_id,
+      )).is_subscribed;
+    } catch (err) {
+      this.showSubscriptionStatusLoadError(mentionedUser);
+      return;
+    }
+
+    if (!isSubscribed) {
+      this.setState(prevState => ({
+        unsubscribedMentions: [...prevState.unsubscribedMentions, mentionedUser.user_id],
+      }));
+    }
+  };
+
+  handleMentionWarningDismiss = (user: UserOrBot) => {
+    this.setState(prevState => ({
+      unsubscribedMentions: prevState.unsubscribedMentions.filter(
+        (x: number) => x !== user.user_id,
+      ),
+    }));
+  };
+
+  clearMentionWarnings = () => {
+    this.setState({
+      unsubscribedMentions: [],
+    });
+  };
+
+  render() {
+    const { unsubscribedMentions } = this.state;
+    const { stream, narrow, usersById } = this.props;
+
+    if (isPrivateNarrow(narrow)) {
+      return null;
+    }
+
+    const mentionWarnings = [];
+    for (const userId of unsubscribedMentions) {
+      const user = usersById.get(userId);
+
+      if (user === undefined) {
+        continue;
+      }
+
+      mentionWarnings.push(
+        <MentionedUserNotSubscribed
+          stream={stream}
+          user={user}
+          onDismiss={this.handleMentionWarningDismiss}
+          key={user.user_id}
+        />,
+      );
+    }
+
+    return (
+      <AnimatedScaleComponent visible={mentionWarnings.length !== 0}>
+        {mentionWarnings}
+      </AnimatedScaleComponent>
+    );
+  }
+}
+
+// $FlowFixMe. TODO: Use a type checked connect call.
+export default connect(
+  state => ({
+    auth: getAuth(state),
+    usersById: getActiveUsersById(state),
+  }),
+  null,
+  null,
+  { withRef: true },
+)(MentionWarnings);

--- a/src/message/MentionedUserNotSubscribed.js
+++ b/src/message/MentionedUserNotSubscribed.js
@@ -35,11 +35,14 @@ const styles = StyleSheet.create({
   },
   text: {
     flex: 1,
-    color: 'white',
+    color: 'black',
   },
   button: {
     backgroundColor: 'orange',
     padding: 6,
+  },
+  buttonText: {
+    color: 'black',
   },
 });
 
@@ -68,7 +71,12 @@ class MentionedUserNotSubscribed extends PureComponent<Props> {
             }}
             style={styles.text}
           />
-          <ZulipButton style={styles.button} text="Subscribe" onPress={this.subscribeToStream} />
+          <ZulipButton
+            style={styles.button}
+            textStyle={styles.buttonText}
+            text="Subscribe"
+            onPress={this.subscribeToStream}
+          />
         </TouchableOpacity>
       </View>
     );

--- a/src/message/MentionedUserNotSubscribed.js
+++ b/src/message/MentionedUserNotSubscribed.js
@@ -23,7 +23,7 @@ type Props = $ReadOnly<{|
 |}>;
 
 const styles = StyleSheet.create({
-  mentionedUserNotSubscribed: {
+  outer: {
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'space-around',
@@ -33,11 +33,11 @@ const styles = StyleSheet.create({
     borderTopWidth: 1,
     borderTopColor: 'orange',
   },
-  mentionedUserNotSubscribedText: {
+  text: {
     flex: 1,
     color: 'white',
   },
-  mentionedUserNotSubscribedButton: {
+  button: {
     backgroundColor: 'orange',
     padding: 6,
   },
@@ -60,19 +60,15 @@ class MentionedUserNotSubscribed extends PureComponent<Props> {
 
     return (
       <View>
-        <TouchableOpacity onPress={this.handleDismiss} style={styles.mentionedUserNotSubscribed}>
+        <TouchableOpacity onPress={this.handleDismiss} style={styles.outer}>
           <Label
             text={{
               text: '{username} will not be notified unless you subscribe them to this stream.',
               values: { username: user.full_name },
             }}
-            style={styles.mentionedUserNotSubscribedText}
+            style={styles.text}
           />
-          <ZulipButton
-            style={styles.mentionedUserNotSubscribedButton}
-            text="Subscribe"
-            onPress={this.subscribeToStream}
-          />
+          <ZulipButton style={styles.button} text="Subscribe" onPress={this.subscribeToStream} />
         </TouchableOpacity>
       </View>
     );

--- a/src/message/MentionedUserNotSubscribed.js
+++ b/src/message/MentionedUserNotSubscribed.js
@@ -1,0 +1,84 @@
+/* @flow strict-local */
+
+import React, { PureComponent } from 'react';
+import { View, TouchableOpacity, StyleSheet } from 'react-native';
+
+import type { Auth, Stream, Dispatch, UserOrBot, Subscription } from '../types';
+import { connect } from '../react-redux';
+import * as api from '../api';
+import { ZulipButton, Label } from '../common';
+import { getAuth } from '../selectors';
+
+type SelectorProps = {|
+  auth: Auth,
+|};
+
+type Props = $ReadOnly<{|
+  user: UserOrBot,
+  stream: Subscription | {| ...Stream, in_home_view: boolean |},
+  onDismiss: (user: UserOrBot) => void,
+
+  dispatch: Dispatch,
+  ...SelectorProps,
+|}>;
+
+const styles = StyleSheet.create({
+  mentionedUserNotSubscribed: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-around',
+    backgroundColor: 'hsl(40, 100%, 60%)', // Material warning-color
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+    borderTopWidth: 1,
+    borderTopColor: 'orange',
+  },
+  mentionedUserNotSubscribedText: {
+    flex: 1,
+    color: 'white',
+  },
+  mentionedUserNotSubscribedButton: {
+    backgroundColor: 'orange',
+    padding: 6,
+  },
+});
+
+class MentionedUserNotSubscribed extends PureComponent<Props> {
+  subscribeToStream = () => {
+    const { auth, stream, user } = this.props;
+    api.subscriptionAdd(auth, [{ name: stream.name }], [user.email]);
+    this.handleDismiss();
+  };
+
+  handleDismiss = () => {
+    const { user, onDismiss } = this.props;
+    onDismiss(user);
+  };
+
+  render() {
+    const { user } = this.props;
+
+    return (
+      <View>
+        <TouchableOpacity onPress={this.handleDismiss} style={styles.mentionedUserNotSubscribed}>
+          <Label
+            text={{
+              text: '{username} will not be notified unless you subscribe them to this stream.',
+              values: { username: user.full_name },
+            }}
+            style={styles.mentionedUserNotSubscribedText}
+          />
+          <ZulipButton
+            style={styles.mentionedUserNotSubscribedButton}
+            text="Subscribe"
+            onPress={this.subscribeToStream}
+          />
+        </TouchableOpacity>
+      </View>
+    );
+  }
+}
+
+export default connect<SelectorProps, _, _>((state, props) => ({
+  auth: getAuth(state),
+}))(MentionedUserNotSubscribed);

--- a/static/translations/messages_en.json
+++ b/static/translations/messages_en.json
@@ -106,6 +106,7 @@
   "Enable notifications": "Enable notifications",
   "Jot down something": "Jot down something",
   "Message {recipient}": "Message {recipient}",
+  "{username} will not be notified unless you subscribe them to this stream.": "{username} will not be notified unless you subscribe them to this stream.",
   "Send private message": "Send private message",
   "View private messages": "View private messages",
   "(This user has been deactivated)": "(This user has been deactivated)",

--- a/static/translations/messages_en.json
+++ b/static/translations/messages_en.json
@@ -216,6 +216,7 @@
   "Sending Message...": "Sending Message...",
   "Failed to send message": "Failed to send message",
   "Message sent": "Message sent",
+  "Couldn't load information about {fullName}": "Couldn't load information about {fullName}",
   "What's your status?": "What's your status?",
   "📅 In a meeting": "📅 In a meeting",
   "🚌 Commuting": "🚌 Commuting",


### PR DESCRIPTION
Fixes #3373.

**Summary of Changes**
* We use the endpoint `/users/{user_id}/subscriptions/{stream_id}` to get the subscription status.
* On non-PM screens, we show a warning when someone unsubscribed is mentioned.
* This warning shows up with a nice animation.
* Pressing the subscribe button subscribes the user and dismisses the warning.
* Tapping on the warning dismisses it.
* Multiple warnings can be shown at a time.

![Screenshot_20200512-133929](https://user-images.githubusercontent.com/7714968/81659129-0e3a7880-9457-11ea-943a-35d0bea35256.png)

Web app equivalent, for comparison:
![image](https://user-images.githubusercontent.com/7714968/81660516-7b9ad900-9458-11ea-810b-035fa7ac63de.png)


