### PR TITLE
Use recent_private_conversations on PMs screen, when available

### DIFF
--- a/src/__tests__/lib/exampleData.js
+++ b/src/__tests__/lib/exampleData.js
@@ -509,5 +509,6 @@ export const eventNewMessageActionBase /* \: $Diff<EventNewMessageAction, {| mes
   type: EVENT_NEW_MESSAGE,
   id: 1001,
   caughtUp: {},
+  ownId: selfUser.user_id,
   ownEmail: selfAccount.email,
 };

--- a/src/__tests__/lib/exampleData.js
+++ b/src/__tests__/lib/exampleData.js
@@ -188,16 +188,17 @@ export const stream: Stream = makeStream({
  * Messages
  */
 
-const displayRecipientFromUser = (user: User): PmRecipientUser => {
-  const { email, full_name, user_id: id } = user;
-  return deepFreeze({
-    email,
-    full_name,
-    id,
-    is_mirror_dummy: false,
-    short_name: '', // what is this, anyway?
+const displayRecipientFromUsers = (users: User[]): PmRecipientUser[] =>
+  users.map(user => {
+    const { email, full_name, user_id: id } = user;
+    return deepFreeze({
+      email,
+      full_name,
+      id,
+      is_mirror_dummy: false,
+      short_name: '', // what is this, anyway?
+    });
   });
-};
 
 /** Boring properties common to all example Message objects. */
 const messagePropertiesBase = deepFreeze({
@@ -239,14 +240,14 @@ const messagePropertiesFromSender = (user: User) => {
 };
 
 /** Beware! These values may not be representative. */
-export const pmMessage = (extra?: $Rest<Message, {}>): Message => {
+export const pmMessageFromTo = (from: User, to: User[], extra?: $Rest<Message, {}>): Message => {
   const baseMessage: Message = {
     ...messagePropertiesBase,
-    ...messagePropertiesFromSender(otherUser),
+    ...messagePropertiesFromSender(from),
 
     content: 'This is an example PM message.',
     content_type: 'text/markdown',
-    display_recipient: [displayRecipientFromUser(selfUser)],
+    display_recipient: displayRecipientFromUsers([from, ...to]),
     id: 1234567,
     recipient_id: 2342,
     stream_id: -1,
@@ -257,6 +258,9 @@ export const pmMessage = (extra?: $Rest<Message, {}>): Message => {
 
   return deepFreeze({ ...baseMessage, ...extra });
 };
+
+export const pmMessage = (extra?: $Rest<Message, {}>): Message =>
+  pmMessageFromTo(selfUser, [otherUser], extra);
 
 const messagePropertiesFromStream = (stream1: Stream) => {
   const { stream_id, name: display_recipient } = stream1;

--- a/src/__tests__/lib/exampleData.js
+++ b/src/__tests__/lib/exampleData.js
@@ -3,7 +3,7 @@ import deepFreeze from 'deep-freeze';
 import { createStore } from 'redux';
 
 import type { CrossRealmBot, Message, PmRecipientUser, Stream, User } from '../../api/modelTypes';
-import type { Action, GlobalState, RealmState } from '../../reduxTypes';
+import type { Action, GlobalState, MessagesState, RealmState } from '../../reduxTypes';
 import type { Auth, Account, Outbox } from '../../types';
 import { ZulipVersion } from '../../utils/zulipVersion';
 import {
@@ -17,6 +17,7 @@ import rootReducer from '../../boot/reducers';
 import { authOfAccount } from '../../account/accountMisc';
 import { HOME_NARROW } from '../../utils/narrow';
 import { NULL_OBJECT } from '../../nullObjects';
+import { objectFromEntries } from '../../jsBackport';
 
 /* ========================================================================
  * Utilities
@@ -287,6 +288,13 @@ export const streamMessage = (extra?: $Rest<Message, {}>): Message => {
   };
 
   return deepFreeze({ ...baseMessage, ...extra });
+};
+
+/**  Construct a MessagesState from a list of messages. */
+export const makeMessagesState = (messages: Message[]): MessagesState => {
+  const state: { [id: number]: Message } = objectFromEntries(messages.map(m => [m.id, m]));
+  // exact object + indexer properties issue; fixed in v0.111.0
+  return (state: $FlowFixMe);
 };
 
 /* ========================================================================

--- a/src/__tests__/lib/exampleData.js
+++ b/src/__tests__/lib/exampleData.js
@@ -16,6 +16,7 @@ import {
 import rootReducer from '../../boot/reducers';
 import { authOfAccount } from '../../account/accountMisc';
 import { HOME_NARROW } from '../../utils/narrow';
+import { NULL_OBJECT } from '../../nullObjects';
 
 /* ========================================================================
  * Utilities
@@ -73,8 +74,13 @@ export const randString = () => randInt(2 ** 54).toString(36);
  * Users and bots
  */
 
+type UserOrBotPropertiesArgs = {|
+  name?: string,
+  user_id?: number,
+|};
+
 const randUserId: () => number = makeUniqueRandInt('user IDs', 10000);
-const userOrBotProperties = ({ name: _name }) => {
+const userOrBotProperties = ({ name: _name, user_id }: UserOrBotPropertiesArgs) => {
   const name = _name ?? randString();
   const capsName = name.substring(0, 1).toUpperCase() + name.substring(1);
   return deepFreeze({
@@ -88,12 +94,12 @@ const userOrBotProperties = ({ name: _name }) => {
     full_name: `${capsName} User`,
     is_admin: false,
     timezone: 'UTC',
-    user_id: randUserId(),
+    user_id: user_id ?? randUserId(),
   });
 };
 
 /** Beware! These values may not be representative. */
-export const makeUser = (args: { name?: string } = {}): User =>
+export const makeUser = (args: UserOrBotPropertiesArgs = NULL_OBJECT): User =>
   deepFreeze({
     ...userOrBotProperties(args),
 
@@ -107,7 +113,7 @@ export const makeUser = (args: { name?: string } = {}): User =>
   });
 
 /** Beware! These values may not be representative. */
-export const makeCrossRealmBot = (args: { name?: string } = {}): CrossRealmBot =>
+export const makeCrossRealmBot = (args: UserOrBotPropertiesArgs = NULL_OBJECT): CrossRealmBot =>
   deepFreeze({
     ...userOrBotProperties(args),
     is_bot: true,

--- a/src/__tests__/lib/exampleData.js
+++ b/src/__tests__/lib/exampleData.js
@@ -442,6 +442,7 @@ export const action = deepFreeze({
       realm_users: [],
       user_id: 4,
       realm_user_groups: [],
+      recent_private_conversations: [],
       streams: [],
       never_subscribed: [],
       subscriptions: [],

--- a/src/actionTypes.js
+++ b/src/actionTypes.js
@@ -301,6 +301,7 @@ type EventNewMessageAction = {|
   ...$Diff<MessageEvent, { flags: mixed }>,
   type: typeof EVENT_NEW_MESSAGE,
   caughtUp: CaughtUpState,
+  ownId: number,
   ownEmail: string,
 |};
 

--- a/src/api/initialDataTypes.js
+++ b/src/api/initialDataTypes.js
@@ -4,6 +4,7 @@ import type {
   CrossRealmBot,
   RealmEmojiById,
   RealmFilter,
+  RecentPrivateConversation,
   Stream,
   Subscription,
   User,
@@ -108,6 +109,11 @@ export type InitialDataRealmUserGroups = {|
    * Absent in servers prior to v1.8.0-rc1~2711 (or thereabouts).
    */
   realm_user_groups?: UserGroup[],
+|};
+
+export type InitialDataRecentPmConversations = {|
+  // Added in server commit 2.1-dev-384-g4c3c669b41.
+  recent_private_conversations?: RecentPrivateConversation[],
 |};
 
 type NeverSubscribedStream = {|
@@ -287,6 +293,7 @@ export type InitialData = {|
   ...InitialDataRealmFilters,
   ...InitialDataRealmUser,
   ...InitialDataRealmUserGroups,
+  ...InitialDataRecentPmConversations,
   ...InitialDataStream,
   ...InitialDataSubscription,
   ...InitialDataUpdateDisplaySettings,

--- a/src/api/initialDataTypes.js
+++ b/src/api/initialDataTypes.js
@@ -112,7 +112,10 @@ export type InitialDataRealmUserGroups = {|
 |};
 
 export type InitialDataRecentPmConversations = {|
-  // Added in server commit 2.1-dev-384-g4c3c669b41.
+  // * Added in server commit 2.1-dev-384-g4c3c669b41.
+  // * `user_id` fields are sorted as of commit 2.2-dev-53-g405a529340, which
+  //    was backported to 2.1.1-50-gd452ad31e0 -- meaning that they are _not_
+  //    sorted in either v2.1.0 or v2.1.1.
   recent_private_conversations?: RecentPrivateConversation[],
 |};
 

--- a/src/api/modelTypes.js
+++ b/src/api/modelTypes.js
@@ -545,3 +545,26 @@ export type Message = $ReadOnly<{
   subject: string,
   subject_links: $ReadOnlyArray<string>,
 }>;
+
+//
+//
+//
+// ===================================================================
+// Summaries of messages and conversations.
+//
+//
+
+/**
+ * Describes a single recent PM conversation.
+ *
+ * For the structure of this type and the meaning of its properties, see:
+ * https://github.com/zulip/zulip/blob/4c3c669b41/zerver/lib/events.py#L283-L290
+ *
+ * `user_ids` does not contain the `user_id` of the current user. Consequently,
+ * a user's conversation with themselves will be listed here as [], which is
+ * unlike the behaviour found in some other parts of the codebase.
+ */
+export type RecentPrivateConversation = {|
+  max_message_id: number,
+  user_ids: number[],
+|};

--- a/src/api/modelTypes.js
+++ b/src/api/modelTypes.js
@@ -566,5 +566,7 @@ export type Message = $ReadOnly<{
  */
 export type RecentPrivateConversation = {|
   max_message_id: number,
+  // When received from the server, these are guaranteed to be sorted only after
+  // 2.2-dev-53-g405a529340. To be safe, we always sort them on receipt.
   user_ids: number[],
 |};

--- a/src/boot/reducers.js
+++ b/src/boot/reducers.js
@@ -21,6 +21,7 @@ import nav from '../nav/navReducer';
 import outbox from '../outbox/outboxReducer';
 import presence from '../presence/presenceReducer';
 import realm from '../realm/realmReducer';
+import recentPrivateConversations from '../pm-conversations/recentPmConversationsReducer';
 import session from '../session/sessionReducer';
 import settings from '../settings/settingsReducer';
 import streams from '../streams/streamsReducer';
@@ -50,6 +51,7 @@ const reducers = {
   outbox,
   presence,
   realm,
+  recentPrivateConversations,
   session,
   settings,
   streams,

--- a/src/boot/store.js
+++ b/src/boot/store.js
@@ -47,9 +47,9 @@ export const storeKeys: Array<$Keys<GlobalState>> = [
  * don't have to re-download it.
  */
 // prettier-ignore
-export const cacheKeys: Array<$Keys<GlobalState>> = [
-  'flags', 'messages', 'mute', 'narrows', 'realm', 'streams',
-  'subscriptions', 'unread', 'userGroups', 'users',
+export const cacheKeys = [
+  'flags', 'messages', 'mute', 'narrows', 'realm', 'recentPrivateConversations',
+  'streams', 'subscriptions', 'unread', 'userGroups', 'users',
 ];
 
 /**

--- a/src/config.js
+++ b/src/config.js
@@ -32,6 +32,7 @@ const config: Config = {
     'realm_filters',
     'realm_user',
     'realm_user_groups',
+    'recent_private_conversations',
     'stream',
     'subscription',
     'update_display_settings',

--- a/src/directSelectors.js
+++ b/src/directSelectors.js
@@ -23,6 +23,7 @@ import type {
   Subscription,
   Stream,
   Outbox,
+  RecentPrivateConversation,
   User,
   UserGroup,
   UserStatusState,
@@ -82,6 +83,9 @@ export const getSubscriptions = (state: GlobalState): Subscription[] => state.su
  * or `getStreamsById` instead.
  */
 export const getStreams = (state: GlobalState): Stream[] => state.streams;
+
+export const getRecentPrivateConversations = (state: GlobalState): RecentPrivateConversation[] =>
+  state.recentPrivateConversations;
 
 export const getPresence = (state: GlobalState): PresenceState => state.presence;
 

--- a/src/events/eventToAction.js
+++ b/src/events/eventToAction.js
@@ -85,6 +85,8 @@ export default (state: GlobalState, event: $FlowFixMe): EventAction => {
         ...event,
         type: EVENT_NEW_MESSAGE,
         caughtUp: state.caughtUp,
+        ownId: getOwnUserId(state),
+        // deprecated; avoid adding new uses (#3764)
         ownEmail: getOwnEmail(state),
       };
 

--- a/src/pm-conversations/__tests__/pmConversationsSelectors-test.js
+++ b/src/pm-conversations/__tests__/pmConversationsSelectors-test.js
@@ -181,3 +181,158 @@ describe('getRecentConversations: legacy', () => {
     expect(actual).toEqual(expectedResult);
   });
 });
+
+describe('getRecentConversations: modern', () => {
+  const zulipVersion = new ZulipVersion('2.2.0');
+
+  test('when no recent conversations, return no conversations', () => {
+    const state = eg.reduxState({
+      accounts: [eg.makeAccount({ user: eg.selfUser, zulipVersion })],
+      realm: eg.realmState({ email: eg.selfUser.email }),
+      users: [eg.selfUser],
+    });
+
+    expect(getRecentConversations(state)).toEqual([]);
+  });
+
+  test('returns unique list of recipients, includes conversations with self', () => {
+    const users = [eg.selfUser, eg.makeUser({ name: 'john' }), eg.makeUser({ name: 'mark' })];
+    const recentPrivateConversations = [
+      { max_message_id: 4, user_ids: [] },
+      { max_message_id: 3, user_ids: [users[1].user_id] },
+      { max_message_id: 2, user_ids: [users[2].user_id] },
+      { max_message_id: 0, user_ids: [users[1].user_id, users[2].user_id] },
+    ];
+    const unread = {
+      ...eg.baseReduxState.unread,
+      huddles: [
+        {
+          user_ids_string: [eg.selfUser.user_id, users[1].user_id, users[2].user_id]
+            .sort((a, b) => a - b)
+            .join(),
+          unread_message_ids: [5],
+        },
+      ],
+      pms: [
+        {
+          sender_id: eg.selfUser.user_id,
+          unread_message_ids: [4],
+        },
+        {
+          sender_id: users[1].user_id,
+          unread_message_ids: [1, 3],
+        },
+        {
+          sender_id: users[2].user_id,
+          unread_message_ids: [2],
+        },
+      ],
+    };
+
+    const state = eg.reduxState({
+      accounts: [eg.makeAccount({ user: eg.selfUser, zulipVersion })],
+      realm: eg.realmState({ email: eg.selfUser.email }),
+      users,
+      recentPrivateConversations,
+      unread,
+    });
+
+    expect(getRecentConversations(state)).toEqual([
+      {
+        ids: eg.selfUser.user_id.toString(),
+        recipients: eg.selfUser.email,
+        msgId: 4,
+        unread: 1,
+      },
+      {
+        ids: users[1].user_id.toString(),
+        recipients: users[1].email,
+        msgId: 3,
+        unread: 2,
+      },
+      {
+        ids: users[2].user_id.toString(),
+        recipients: users[2].email,
+        msgId: 2,
+        unread: 1,
+      },
+      {
+        ids: [eg.selfUser.user_id, users[1].user_id, users[2].user_id].sort((a, b) => a - b).join(),
+        recipients: [users[1].email, users[2].email].join(),
+        msgId: 0,
+        unread: 1,
+      },
+    ]);
+  });
+
+  test('returns recipients sorted by last activity', () => {
+    const users = [eg.selfUser, eg.makeUser({ name: 'john' }), eg.makeUser({ name: 'mark' })];
+    const recentPrivateConversations = [
+      { max_message_id: 6, user_ids: [] },
+      { max_message_id: 5, user_ids: [users[1].user_id, users[2].user_id] },
+      { max_message_id: 4, user_ids: [users[1].user_id] },
+      { max_message_id: 3, user_ids: [users[2].user_id] },
+    ];
+    const unread = {
+      streams: [],
+      huddles: [
+        {
+          user_ids_string: [eg.selfUser.user_id, users[1].user_id, users[2].user_id]
+            .sort((a, b) => a - b)
+            .join(),
+          unread_message_ids: [5],
+        },
+      ],
+      pms: [
+        {
+          sender_id: eg.selfUser.user_id,
+          unread_message_ids: [4],
+        },
+        {
+          sender_id: users[1].user_id,
+          unread_message_ids: [1, 3],
+        },
+        {
+          sender_id: users[2].user_id,
+          unread_message_ids: [2],
+        },
+      ],
+      mentions: [],
+    };
+
+    const state = eg.reduxState({
+      accounts: [eg.makeAccount({ user: eg.selfUser, zulipVersion })],
+      realm: eg.realmState({ email: eg.selfUser.email }),
+      users,
+      recentPrivateConversations,
+      unread,
+    });
+
+    expect(getRecentConversations(state)).toEqual([
+      {
+        ids: eg.selfUser.user_id.toString(),
+        recipients: eg.selfUser.email,
+        msgId: 6,
+        unread: 1,
+      },
+      {
+        ids: [eg.selfUser.user_id, users[1].user_id, users[2].user_id].sort((a, b) => a - b).join(),
+        recipients: [users[1].email, users[2].email].join(),
+        msgId: 5,
+        unread: 1,
+      },
+      {
+        ids: users[1].user_id.toString(),
+        recipients: users[1].email,
+        msgId: 4,
+        unread: 2,
+      },
+      {
+        ids: users[2].user_id.toString(),
+        recipients: users[2].email,
+        msgId: 3,
+        unread: 1,
+      },
+    ]);
+  });
+});

--- a/src/pm-conversations/__tests__/pmConversationsSelectors-test.js
+++ b/src/pm-conversations/__tests__/pmConversationsSelectors-test.js
@@ -3,10 +3,14 @@
 import * as eg from '../../__tests__/lib/exampleData';
 import { getRecentConversations } from '../pmConversationsSelectors';
 import { ALL_PRIVATE_NARROW_STR } from '../../utils/narrow';
+import { ZulipVersion } from '../../utils/zulipVersion';
 
-describe('getRecentConversations', () => {
+describe('getRecentConversations: legacy', () => {
+  const zulipVersion = new ZulipVersion('2.0.0');
+
   test('when no messages, return no conversations', () => {
     const state = eg.reduxState({
+      accounts: [eg.makeAccount({ user: eg.selfUser, zulipVersion })],
       realm: eg.realmState({ email: eg.selfUser.email }),
       users: [eg.selfUser],
       narrows: {
@@ -30,6 +34,7 @@ describe('getRecentConversations', () => {
     const mark = eg.makeUser({ user_id: 2, name: 'mark' });
 
     const state = eg.reduxState({
+      accounts: [eg.makeAccount({ user: me, zulipVersion })],
       realm: eg.realmState({ email: me.email }),
       users: [me, john, mark],
       narrows: {
@@ -105,6 +110,7 @@ describe('getRecentConversations', () => {
     const mark = eg.makeUser({ user_id: 2, name: 'mark' });
 
     const state = eg.reduxState({
+      accounts: [eg.makeAccount({ user: me, zulipVersion })],
       realm: eg.realmState({ email: me.email }),
       users: [me, john, mark],
       narrows: {

--- a/src/pm-conversations/__tests__/recentPmConversationsReducer-test.js
+++ b/src/pm-conversations/__tests__/recentPmConversationsReducer-test.js
@@ -1,0 +1,28 @@
+/* @flow strict-local */
+import deepFreeze from 'deep-freeze';
+
+import recentPmConversationsReducer from '../recentPmConversationsReducer';
+import * as eg from '../../__tests__/lib/exampleData';
+
+describe('recentPmConversationsReducer', () => {
+  describe('EVENT_NEW_MESSAGE', () => {
+    test('reorder correctly upon receiving a new message', () => {
+      const users = [eg.makeUser({ name: 'john' }), eg.makeUser({ name: 'mark' })];
+      const newMessage = eg.pmMessageFromTo(users[1], [eg.selfUser], { id: 2 });
+      const initialState = deepFreeze([
+        { max_message_id: 1, user_ids: [users[0].user_id] },
+        { max_message_id: 0, user_ids: [users[1].user_id] },
+      ]);
+
+      const action = deepFreeze({
+        ...eg.eventNewMessageActionBase,
+        message: newMessage,
+      });
+
+      expect(recentPmConversationsReducer(initialState, action)).toEqual([
+        { max_message_id: 2, user_ids: [users[1].user_id] },
+        { max_message_id: 1, user_ids: [users[0].user_id] },
+      ]);
+    });
+  });
+});

--- a/src/pm-conversations/pmConversationsSelectors.js
+++ b/src/pm-conversations/pmConversationsSelectors.js
@@ -7,36 +7,46 @@ import { getOwnUser } from '../users/userSelectors';
 import { getUnreadByPms, getUnreadByHuddles } from '../unread/unreadSelectors';
 import { normalizeRecipientsSansMe, pmUnreadsKeyFromMessage } from '../utils/recipient';
 
-export const getRecentConversations: Selector<PmConversationData[]> = createSelector(
-  getOwnUser,
-  getPrivateMessages,
+/**
+ * Given a list of PmConversationPartial or PmConversationData, trim it down to
+ * contain only the most recent message from any conversation, and return them
+ * sorted by recency.
+ */
+const collateByRecipient = <T: { recipients: string, msgId: number }>(
+  items: $ReadOnlyArray<T>,
+): T[] => {
+  const latestByRecipient = new Map();
+  items.forEach(item => {
+    const prev = latestByRecipient.get(item.recipients);
+    if (!prev || item.msgId > prev.msgId) {
+      latestByRecipient.set(item.recipients, item);
+    }
+  });
+
+  const sortedByMostRecent = Array.from(latestByRecipient.values()).sort(
+    (a, b) => +b.msgId - +a.msgId,
+  );
+
+  return sortedByMostRecent;
+};
+
+type PmConversationPartial = $Diff<PmConversationData, {| unread: mixed |}>;
+type UnreadAttacher = ($ReadOnlyArray<PmConversationPartial>) => PmConversationData[];
+
+/**
+ * Auxiliary function: fragment of the selector(s) for PmConversationData.
+ * Transforms PmConversationPartial[] to PmConversationData[].
+ *
+ * Note that, since this will only ever be called by other selectors, the inner
+ * function doesn't need to do any memoization of its own.
+ */
+const getAttachUnread: Selector<UnreadAttacher> = createSelector(
   getUnreadByPms,
   getUnreadByHuddles,
-  (
-    ownUser: User,
-    messages: Message[],
-    unreadPms: { [number]: number },
-    unreadHuddles: { [string]: number },
-  ): PmConversationData[] => {
-    const items = messages.map(msg => ({
-      ids: pmUnreadsKeyFromMessage(msg, ownUser.user_id),
-      recipients: normalizeRecipientsSansMe(msg.display_recipient, ownUser.email),
-      msgId: msg.id,
-    }));
-
-    const latestByRecipient = new Map();
-    items.forEach(item => {
-      const prev = latestByRecipient.get(item.recipients);
-      if (!prev || item.msgId > prev.msgId) {
-        latestByRecipient.set(item.recipients, item);
-      }
-    });
-
-    const sortedByMostRecent = Array.from(latestByRecipient.values()).sort(
-      (a, b) => +b.msgId - +a.msgId,
-    );
-
-    return sortedByMostRecent.map(recipient => ({
+  (unreadPms: { [number]: number }, unreadHuddles: { [string]: number }) => (
+    partials: $ReadOnlyArray<PmConversationPartial>,
+  ) =>
+    partials.map(recipient => ({
       ...recipient,
       unread:
         // This business of looking in one place and then the other is kind
@@ -47,7 +57,23 @@ export const getRecentConversations: Selector<PmConversationData[]> = createSele
          end up converted to strings, so this access with string keys works.  We should probably use
          a Map for this and similar maps. */
         unreadPms[recipient.ids] || unreadHuddles[recipient.ids],
+    })),
+);
+
+export const getRecentConversations: Selector<PmConversationData[]> = createSelector(
+  getOwnUser,
+  getPrivateMessages,
+  getAttachUnread,
+  (ownUser: User, messages: Message[], attachUnread: UnreadAttacher): PmConversationData[] => {
+    const items = messages.map(msg => ({
+      ids: pmUnreadsKeyFromMessage(msg, ownUser.user_id),
+      recipients: normalizeRecipientsSansMe(msg.display_recipient, ownUser.email),
+      msgId: msg.id,
     }));
+
+    const sortedByMostRecent = collateByRecipient(items);
+
+    return attachUnread(sortedByMostRecent);
   },
 );
 

--- a/src/pm-conversations/pmConversationsSelectors.js
+++ b/src/pm-conversations/pmConversationsSelectors.js
@@ -18,21 +18,17 @@ export const getRecentConversations: Selector<PmConversationData[]> = createSele
     unreadPms: { [number]: number },
     unreadHuddles: { [string]: number },
   ): PmConversationData[] => {
-    const recipients = messages.map(msg => ({
+    const items = messages.map(msg => ({
       ids: pmUnreadsKeyFromMessage(msg, ownUser.user_id),
-      emails: normalizeRecipientsSansMe(msg.display_recipient, ownUser.email),
+      recipients: normalizeRecipientsSansMe(msg.display_recipient, ownUser.email),
       msgId: msg.id,
     }));
 
     const latestByRecipient = new Map();
-    recipients.forEach(recipient => {
-      const prev = latestByRecipient.get(recipient.emails);
-      if (!prev || recipient.msgId > prev.msgId) {
-        latestByRecipient.set(recipient.emails, {
-          ids: recipient.ids,
-          recipients: recipient.emails,
-          msgId: recipient.msgId,
-        });
+    items.forEach(item => {
+      const prev = latestByRecipient.get(item.recipients);
+      if (!prev || item.msgId > prev.msgId) {
+        latestByRecipient.set(item.recipients, item);
       }
     });
 

--- a/src/pm-conversations/recentPmConversationsReducer.js
+++ b/src/pm-conversations/recentPmConversationsReducer.js
@@ -5,13 +5,28 @@ import { NULL_ARRAY } from '../nullObjects';
 
 const initialState: RecentPrivateConversationsState = NULL_ARRAY;
 
+const realmInit = (state, action) => {
+  // If this is a pre-2.1 server, we'll have to get by without.
+  if (action.data.recent_private_conversations === undefined) {
+    return initialState;
+  }
+
+  // `user_id`s are not guaranteed to be sorted prior to v2.1.2.
+  // (Take care not to mutate the input.)
+  return action.data.recent_private_conversations.map(({ user_ids, ...rest }) => ({
+    ...rest,
+    user_ids: [...user_ids].sort((a, b) => a - b),
+  }));
+};
+
 export default (
   state: RecentPrivateConversationsState = initialState,
   action: Action,
 ): RecentPrivateConversationsState => {
   switch (action.type) {
     case REALM_INIT:
-      return /* action.data.recent_private_conversations || */ initialState;
+      return realmInit(state, action);
+
     default:
       return state;
   }

--- a/src/pm-conversations/recentPmConversationsReducer.js
+++ b/src/pm-conversations/recentPmConversationsReducer.js
@@ -1,0 +1,18 @@
+/* @flow strict-local */
+import type { Action, RecentPrivateConversationsState } from '../types';
+import { REALM_INIT } from '../actionConstants';
+import { NULL_ARRAY } from '../nullObjects';
+
+const initialState: RecentPrivateConversationsState = NULL_ARRAY;
+
+export default (
+  state: RecentPrivateConversationsState = initialState,
+  action: Action,
+): RecentPrivateConversationsState => {
+  switch (action.type) {
+    case REALM_INIT:
+      return /* action.data.recent_private_conversations || */ initialState;
+    default:
+      return state;
+  }
+};

--- a/src/reduxTypes.js
+++ b/src/reduxTypes.js
@@ -22,6 +22,7 @@ import type {
   RealmEmojiById,
   RealmFilter,
   Narrow,
+  RecentPrivateConversation,
   Stream,
   StreamUnreadItem,
   Subscription,
@@ -252,6 +253,13 @@ export type RealmState = {|
   isAdmin: boolean,
 |};
 
+/**
+ * The PM conversations (group or 1:1) found in the last 1000 PMs.
+ *
+ * Sorted by `max_message_id` descending.
+ */
+export type RecentPrivateConversationsState = RecentPrivateConversation[];
+
 export type ThemeName = 'default' | 'night';
 
 export type SettingsState = {|
@@ -339,6 +347,7 @@ export type GlobalState = {|
   outbox: OutboxState,
   presence: PresenceState,
   realm: RealmState,
+  recentPrivateConversations: RecentPrivateConversationsState,
   session: SessionState,
   settings: SettingsState,
   streams: StreamsState,


### PR DESCRIPTION
Attempt to acquire `recent_private_conversations` from the server (zulip/zulip#11946). Add a new implementation for `getRecentConversations` which will use the data provided therein.

Since there are many Zulip servers still active which predate this server-side feature, we continue to use the old implementation when connecting to those servers, to avoid a significant regression.

This PR is intended to supersede PR #3535, with which it shares some code and history. Notable functional differences include:
 * *(the first two paragraphs, above)*
 * Incoming IDs for recent conversations are always sorted (per [this comment](https://github.com/zulip/zulip-mobile/pull/3535#issuecomment-626071303)).
 * New functions added have been to `exampleData` to ease test construction.
 * The new `EVENT_NEW_MESSAGE` reducer now properly filters `display_recipient`. (Noticed while converting its tests to use the new functions.)

Fixes #3133.