### PR TITLE
vscode: Add configuration for interactive Jest debugging.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,6 +5,24 @@
     "version": "0.2.0",
     "configurations": [
         {
+            // Start Jest with VSCode's debugger attached.
+            "name": "Debug Jest",
+            "type": "node",
+            "request":"launch",
+            "program": "${workspaceRoot}/node_modules/.bin/jest",
+            "args": [
+                /* To avoid running more tests than necessary, replace this
+                   argument with a pattern matching the name of the test file
+                   you're interested in. */
+                "--onlyChanged",
+
+                /* Run tests serially. */
+                "--runInBand",
+            ],
+            "cwd": "${workspaceFolder}",
+            "console": "internalConsole"
+        },
+        {
             "name": "Debug Android",
             "program": "${workspaceRoot}/.vscode/launchReactNative.js",
             "type": "reactnative",


### PR DESCRIPTION
Add a new VSCode Run-configuration which will start Jest, but allow for stepping through the test code in the interactive debugger.