### PR TITLE
ligthbox: Toggle header & footer on tapping the entire view.

### DIFF
--- a/src/lightbox/Lightbox.js
+++ b/src/lightbox/Lightbox.js
@@ -103,6 +103,7 @@ class Lightbox extends PureComponent<Props, State> {
           style={[styles.img, { width }]}
           resizeMode="contain"
           onTap={this.handleImagePress}
+          onViewTap={this.handleImagePress}
         />
         <SlideAnimationView
           property="translateY"


### PR DESCRIPTION
As opposed to only when the visible image is tapped, as we
currently do.
This is done by simply adding another prop `onViewTap` ( for the
black part) in the react-native-photo-view component[1].
Note that `onTap` and `onViewTap` respond mutually exclusive
areas, the union of which makes up the entire component.

Closes #4098.

[1] https://github.com/alwx/react-native-photo-view#properties