### PR TITLE
lightbox: Download images with correct names and MIME types.

### DIFF
--- a/src/lightbox/LightboxActionSheet.js
+++ b/src/lightbox/LightboxActionSheet.js
@@ -42,8 +42,9 @@ const tryToDownloadImage = async ({ src, auth }: DownloadImageType) => {
     return;
   }
 
+  const fileName = src.split('/').pop();
   try {
-    await downloadImage(tempUrl, auth);
+    await downloadImage(tempUrl, fileName, auth);
     showToast('Download complete');
   } catch (error) {
     showToast(error.message);

--- a/src/lightbox/shareImage.js
+++ b/src/lightbox/shareImage.js
@@ -18,12 +18,13 @@ export default async (url: string, auth: Auth) => {
     return;
   }
 
+  const fileName = url.split('/').pop();
   if (Platform.OS === 'android') {
-    const res: $FlowFixMe = await downloadImage(tempUrl, auth);
+    const res: $FlowFixMe = await downloadImage(tempUrl, fileName, auth);
     await ShareImageAndroid.shareImage(res.path());
   } else {
     try {
-      const uri = await downloadImage(tempUrl, auth);
+      const uri = await downloadImage(tempUrl, fileName, auth);
       try {
         await Share.share({ url: uri, message: url });
       } catch (error) {


### PR DESCRIPTION
Currently, the `downloadImage` function saves images with the
wrong names, extensions and MIME types. This commit fixes that
by introducing a new argument for the function - `fileName`,
and by determining the MIME type from the file extension.

Simply having the proper extension does not fix the issue, as the file is still interpreted as a text file by Android. The proper MIME type is still required.


Fixes: #4138
Fixes: #4137 