### PR TITLE
msglist: Make background transparent.

### DIFF
--- a/src/webview/MessageList.js
+++ b/src/webview/MessageList.js
@@ -1,6 +1,6 @@
 /* @flow strict-local */
 import React, { Component } from 'react';
-import { Platform, View } from 'react-native';
+import { Platform } from 'react-native';
 import { WebView } from 'react-native-webview';
 import type { WebViewNavigation } from 'react-native-webview';
 import { connectActionSheet } from '@expo/react-native-action-sheet';
@@ -221,15 +221,6 @@ class MessageList extends Component<Props> {
     return false;
   };
 
-  renderLoading = () => {
-    const style = {
-      backgroundColor: 'transparent',
-      width: '100%',
-      height: '100%',
-    };
-    return <View style={style} />;
-  };
-
   render() {
     const {
       backgroundData,
@@ -318,12 +309,10 @@ class MessageList extends Component<Props> {
     // https://github.com/react-native-community/react-native-webview/pull/697
     return (
       <WebView
-        startInLoadingState
-        renderLoading={this.renderLoading}
         source={{ baseUrl, html }}
         originWhitelist={['file://']}
         onShouldStartLoadWithRequest={onShouldStartLoadWithRequest}
-        style={{ backgroundColor: this.context.backgroundColor }}
+        style={{ backgroundColor: 'transparent' }}
         ref={webview => {
           this.webview = webview;
         }}


### PR DESCRIPTION
The resolution of #2914 in b0fc3177b was to show a "loading view"
(which was really just a blank rectangle of the appropriate theme
color) during the initial load of the WebView. During some debugging
of extremely long displays of this loading view, we found [1] that
it doesn't count as finished loading until all images have loaded,
which will regularly take quite a long time, and no content shows
until it's finished.

Instead, forget the "loading view" and just make the background
color of the WebView transparent. Empirically, this solution
wouldn't have worked work on iOS with `react-native-webview` v5.0.0
(where we were at b0fc3177b), but it does on v8.0.4, which we're on
now. It seems to work on Android at either version.

[1]: https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/WebView.20.22LOADING.22.20state/near/903385