### PR TITLE
[TESTABLE] Enable react-native-screens.

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -272,6 +272,8 @@ PODS:
     - React
   - RNDeviceInfo (0.21.5):
     - React
+  - RNScreens (1.0.0-alpha.23):
+    - React
   - RNSentry (1.0.9):
     - React
     - Sentry (~> 4.4.0)
@@ -353,6 +355,7 @@ DEPENDENCIES:
   - rn-fetch-blob (from `../node_modules/rn-fetch-blob`)
   - "RNCAsyncStorage (from `../node_modules/@react-native-community/async-storage`)"
   - RNDeviceInfo (from `../node_modules/react-native-device-info`)
+  - RNScreens (from `../node_modules/react-native-screens`)
   - "RNSentry (from `../node_modules/@sentry/react-native`)"
   - RNSound (from `../node_modules/react-native-sound`)
   - RNVectorIcons (from `../node_modules/react-native-vector-icons`)
@@ -466,6 +469,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/@react-native-community/async-storage"
   RNDeviceInfo:
     :path: "../node_modules/react-native-device-info"
+  RNScreens:
+    :path: "../node_modules/react-native-screens"
   RNSentry:
     :path: "../node_modules/@sentry/react-native"
   RNSound:
@@ -547,6 +552,7 @@ SPEC CHECKSUMS:
   rn-fetch-blob: f525a73a78df9ed5d35e67ea65e79d53c15255bc
   RNCAsyncStorage: 3c304d1adfaea02ec732ac218801cb13897aa8c0
   RNDeviceInfo: e7c5fcde13d40e161d8a27f6c5dc69c638936002
+  RNScreens: f28b48b8345f2f5f39ed6195518291515032a788
   RNSentry: 2803ba8c8129dcf26b79e9b4d8c80168be6e4390
   RNSound: da030221e6ac7e8290c6b43f2b5f2133a8e225b0
   RNVectorIcons: 0bb4def82230be1333ddaeee9fcba45f0b288ed4

--- a/react-native.config.js
+++ b/react-native.config.js
@@ -28,14 +28,6 @@ module.exports = {
         android: null,
       },
     },
-    'react-native-screens': {
-      platforms: {
-        // We haven't enabled `react-native-screens` yet, that's
-        // #4111. See 250cde501.
-        android: null,
-        ios: null,
-      },
-    },
     'react-native-vector-icons': {
       platforms: {
         // We're using a setup that doesn't involve linking

--- a/src/ZulipMobile.js
+++ b/src/ZulipMobile.js
@@ -1,5 +1,6 @@
 /* @flow strict-local */
 import React from 'react';
+import { useScreens } from 'react-native-screens';
 
 import '../vendor/intl/intl';
 import StoreProvider from './boot/StoreProvider';
@@ -15,6 +16,7 @@ import './i18n/locale';
 import { initializeSentry } from './sentry';
 
 initializeSentry();
+useScreens();
 
 // $FlowFixMe
 console.disableYellowBox = true; // eslint-disable-line


### PR DESCRIPTION
Fixes: #4111 

This branch contains my current revision of https://github.com/zulip/zulip-mobile/pull/4160. Without that, it's hard to see any performance differences clearly because one has to wait so long for a link to be visible that would add a route to the stack.

I haven't done extensive testing of this yet, and a few trials suggest that the performance difference isn't huge. But nothing seems to break. I thought I'd file this so I'd have something to return to, if we want to do further testing. Or others can check this out and run some tests too. Or, I suppose, we could just merge it and release it knowing that it's theoretically a boost to performance.