### PR TITLE
events: Add support for bulk delete_message events.

### DIFF
--- a/src/actionTypes.js
+++ b/src/actionTypes.js
@@ -298,7 +298,7 @@ type EventSubmessageAction = {|
 
 type EventMessageDeleteAction = {|
   type: typeof EVENT_MESSAGE_DELETE,
-  messageId: number,
+  messageIds: number[],
 |};
 type EventUpdateMessageAction = {|
   ...ServerEvent,

--- a/src/api/registerForEvents.js
+++ b/src/api/registerForEvents.js
@@ -15,6 +15,7 @@ type RegisterForEventsParams = {|
   queue_lifespan_secs?: number,
   client_capabilities?: {|
     notification_settings_null: boolean,
+    bulk_message_deletion: boolean,
   |},
 |};
 

--- a/src/chat/__tests__/narrowsReducer-test.js
+++ b/src/chat/__tests__/narrowsReducer-test.js
@@ -323,7 +323,7 @@ describe('narrowsReducer', () => {
 
       const action = deepFreeze({
         type: EVENT_MESSAGE_DELETE,
-        messageId: 3,
+        messageIds: [3],
       });
 
       const newState = narrowsReducer(initialState, action);
@@ -338,10 +338,29 @@ describe('narrowsReducer', () => {
       });
       const action = deepFreeze({
         type: EVENT_MESSAGE_DELETE,
-        messageId: 2,
+        messageIds: [2],
       });
       const expectedState = deepFreeze({
         [HOME_NARROW_STR]: [1, 3],
+        [privateNarrowStr]: [],
+      });
+
+      const newState = narrowsReducer(initialState, action);
+
+      expect(newState).toEqual(expectedState);
+    });
+
+    test('if multiple messages indicated, delete the ones that exist', () => {
+      const initialState = deepFreeze({
+        [HOME_NARROW_STR]: [1, 2, 3],
+        [privateNarrowStr]: [2],
+      });
+      const action = deepFreeze({
+        type: EVENT_MESSAGE_DELETE,
+        messageIds: [2, 3, 4],
+      });
+      const expectedState = deepFreeze({
+        [HOME_NARROW_STR]: [1],
         [privateNarrowStr]: [],
       });
 

--- a/src/chat/narrowsReducer.js
+++ b/src/chat/narrowsReducer.js
@@ -63,7 +63,7 @@ const eventMessageDelete = (state, action) => {
   let stateChange = false;
   const newState: NarrowsState = {};
   Object.keys(state).forEach(key => {
-    newState[key] = state[key].filter(id => id !== action.messageId);
+    newState[key] = state[key].filter(id => !action.messageIds.includes(id));
     stateChange = stateChange || newState[key].length < state[key].length;
   });
   return stateChange ? newState : state;

--- a/src/events/eventToAction.js
+++ b/src/events/eventToAction.js
@@ -88,10 +88,13 @@ export default (state: GlobalState, event: $FlowFixMe): EventAction => {
         ownEmail: getOwnEmail(state),
       };
 
+    // Before server feature level 13, or if we don't specify the
+    // `bulk_message_deletion` client capability (which we do) this
+    // event has `message_id` instead of `message_ids`.
     case 'delete_message':
       return {
         type: EVENT_MESSAGE_DELETE,
-        messageId: event.message_id,
+        messageIds: event.message_ids ?? [event.message_id],
       };
 
     case EventTypes.stream:

--- a/src/message/__tests__/messagesReducer-test.js
+++ b/src/message/__tests__/messagesReducer-test.js
@@ -90,7 +90,7 @@ describe('messagesReducer', () => {
       const initialState = deepFreeze({ 1: { id: 1 } });
       const action = deepFreeze({
         type: EVENT_MESSAGE_DELETE,
-        messageId: 2,
+        messageIds: [2],
       });
       const newState = messagesReducer(initialState, action);
       expect(newState).toEqual(initialState);
@@ -101,7 +101,19 @@ describe('messagesReducer', () => {
 
       const action = deepFreeze({
         type: EVENT_MESSAGE_DELETE,
-        messageId: 2,
+        messageIds: [2],
+      });
+      const expectedState = deepFreeze({ 1: { id: 1 } });
+      const newState = messagesReducer(initialState, action);
+      expect(newState).toEqual(expectedState);
+    });
+
+    test('if multiple messages indicated, delete the ones that exist', () => {
+      const initialState = deepFreeze({ 1: { id: 1 }, 2: { id: 2 }, 3: { id: 3 } });
+
+      const action = deepFreeze({
+        type: EVENT_MESSAGE_DELETE,
+        messageIds: [2, 3, 4],
       });
       const expectedState = deepFreeze({ 1: { id: 1 } });
       const newState = messagesReducer(initialState, action);

--- a/src/message/fetchActions.js
+++ b/src/message/fetchActions.js
@@ -253,6 +253,7 @@ export const doInitialFetch = () => async (dispatch: Dispatch, getState: GetStat
           client_gravatar: true,
           client_capabilities: {
             notification_settings_null: true,
+            bulk_message_deletion: true,
           },
         }),
       ),

--- a/src/message/messagesReducer.js
+++ b/src/message/messagesReducer.js
@@ -91,10 +91,10 @@ const eventSubmessage = (state, action) => {
 };
 
 const eventMessageDelete = (state, action) => {
-  if (!state[action.messageId]) {
+  if (action.messageIds.every(messageId => !state[messageId])) {
     return state;
   }
-  return omit(state, action.messageId);
+  return omit(state, action.messageIds);
 };
 
 const eventUpdateMessage = (state, action) => {

--- a/src/unread/unreadHuddlesReducer.js
+++ b/src/unread/unreadHuddlesReducer.js
@@ -61,7 +61,7 @@ export default (state: UnreadHuddlesState = initialState, action: Action): Unrea
       return eventNewMessage(state, action);
 
     case EVENT_MESSAGE_DELETE:
-      return removeItemsDeeply(state, [action.messageId]);
+      return removeItemsDeeply(state, action.messageIds);
 
     case EVENT_UPDATE_MESSAGE_FLAGS:
       return eventUpdateMessageFlags(state, action);

--- a/src/unread/unreadMentionsReducer.js
+++ b/src/unread/unreadMentionsReducer.js
@@ -52,7 +52,7 @@ export default (state: UnreadMentionsState = initialState, action: Action): Unre
     }
 
     case EVENT_MESSAGE_DELETE:
-      return removeItemsFromArray(state, [action.messageId]);
+      return removeItemsFromArray(state, action.messageIds);
 
     case EVENT_UPDATE_MESSAGE_FLAGS:
       return eventUpdateMessageFlags(state, action);

--- a/src/unread/unreadPmsReducer.js
+++ b/src/unread/unreadPmsReducer.js
@@ -60,7 +60,7 @@ export default (state: UnreadPmsState = initialState, action: Action): UnreadPms
       return eventNewMessage(state, action);
 
     case EVENT_MESSAGE_DELETE:
-      return removeItemsDeeply(state, [action.messageId]);
+      return removeItemsDeeply(state, action.messageIds);
 
     case EVENT_UPDATE_MESSAGE_FLAGS:
       return eventUpdateMessageFlags(state, action);

--- a/src/unread/unreadStreamsReducer.js
+++ b/src/unread/unreadStreamsReducer.js
@@ -61,7 +61,7 @@ export default (state: UnreadStreamsState = initialState, action: Action): Unrea
       return eventNewMessage(state, action);
 
     case EVENT_MESSAGE_DELETE:
-      return removeItemsDeeply(state, [action.messageId]);
+      return removeItemsDeeply(state, action.messageIds);
 
     case EVENT_UPDATE_MESSAGE_FLAGS:
       return eventUpdateMessageFlags(state, action);


### PR DESCRIPTION
I haven't yet tested end-to-end an actual bulk delete; I'm still looking for a way to do that in the UI on CZO. Maybe it's an admin feature, or it's not accessible through the UI yet?

Fixes: #4158