### PR TITLE
webview: Add support for displaying spoilers.

### DIFF
--- a/src/webview/js/generatedEs3.js
+++ b/src/webview/js/generatedEs3.js
@@ -297,9 +297,9 @@ var compiledWebviewJs = (function (exports) {
   };
 
   var collapseSpoiler = function collapseSpoiler(spoiler) {
-    var spoilerHeight = spoiler.scrollHeight;
+    var computedHeight = getComputedStyle(spoiler).height;
     requestAnimationFrame(function () {
-      spoiler.style.height = "".concat(spoilerHeight, "px");
+      spoiler.style.height = computedHeight;
       spoiler.classList.remove('spoiler-content-open');
       requestAnimationFrame(function () {
         spoiler.style.height = '0px';

--- a/src/webview/js/generatedEs3.js
+++ b/src/webview/js/generatedEs3.js
@@ -275,7 +275,7 @@ var compiledWebviewJs = (function (exports) {
     });
   };
 
-  var rewriteHTML = function rewriteHTML(auth) {
+  var rewriteHtml = function rewriteHtml(auth) {
     var element = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : document;
     rewriteImageUrls(auth, element);
     rewriteTime(element);
@@ -657,7 +657,7 @@ var compiledWebviewJs = (function (exports) {
     }
 
     documentBody.innerHTML = uevent.content;
-    rewriteHTML(uevent.auth);
+    rewriteHtml(uevent.auth);
     runAfterLayout(function () {
       if (target.type === 'bottom') {
         scrollToBottom();
@@ -683,7 +683,7 @@ var compiledWebviewJs = (function (exports) {
     }
 
     scrollToMessage(scrollMessageId);
-    rewriteHTML(auth);
+    rewriteHtml(auth);
     sendScrollMessageIfListShort();
     scrollEventsDisabled = false;
   };

--- a/src/webview/js/js.js
+++ b/src/webview/js/js.js
@@ -13,6 +13,7 @@ import type {
 import InboundEventLogger from './InboundEventLogger';
 import sendMessage from './sendMessage';
 import rewriteHtml from './rewriteHtml';
+import { toggleSpoiler } from './spoilers';
 
 /*
  * Supported platforms:
@@ -799,6 +800,12 @@ documentBody.addEventListener('click', (e: MouseEvent) => {
       type: 'time',
       originalText,
     });
+  }
+
+  const spoilerHeader = target.closest('.spoiler-header');
+  if (spoilerHeader instanceof HTMLElement) {
+    toggleSpoiler(spoilerHeader);
+    return;
   }
 
   const messageElement = target.closest('.message-brief');

--- a/src/webview/js/rewriteHtml.js
+++ b/src/webview/js/rewriteHtml.js
@@ -87,6 +87,34 @@ const rewriteTime = (element: Element | Document) => {
 };
 
 /**
+ * Add missing elements to spoiler blocks under the given root, inclusive.
+ *
+ * 1. Adds 'Spoiler' header text if missing.
+ * 2. Adds the spoiler expanded arrow indicator. The arrow is rendered using CSS.
+ *
+ * Does what the web app does, only departing as appropriate to adapt
+ * to mobile. The corresponding code is in
+ * static/js/rendered_markdown.js, at the spot you find searching for
+ * "spoiler-header". That's lines 181-192 in zulip/zulip@c5dc9d386.
+ */
+const rewriteSpoilers = (element: Element | Document) => {
+  const spoilerHeaders: NodeList<HTMLElement> = element.querySelectorAll('div.spoiler-header');
+  spoilerHeaders.forEach(e => {
+    // Add the expand/collapse button to spoiler blocks
+    const toggle_button_html =
+      '<span class="spoiler-button" aria-expanded="false"><span class="spoiler-arrow"></span></span>';
+    if (e.innerText === '') {
+      // If a spoiler block has no header content, it should have a default header.
+      // We do this client side to allow for i18n by the client.
+      const header_html = '<p>Spoiler</p>'; // TODO: Localize this text.
+      e.innerHTML = toggle_button_html + header_html;
+    } else {
+      e.innerHTML = toggle_button_html + e.innerHTML;
+    }
+  });
+};
+
+/**
  * Modify relevant parts of the rendered DOM tree under the given root,
  * inclusive, to ensure functionality.
  *
@@ -95,6 +123,7 @@ const rewriteTime = (element: Element | Document) => {
 const rewriteHtml = (auth: Auth, element: Element | Document = document) => {
   rewriteImageUrls(auth, element);
   rewriteTime(element);
+  rewriteSpoilers(element);
 };
 
 export default rewriteHtml;

--- a/src/webview/js/rewriteHtml.js
+++ b/src/webview/js/rewriteHtml.js
@@ -92,9 +92,9 @@ const rewriteTime = (element: Element | Document) => {
  *
  * DEPRECATED: If no root element is specified, the entire document is considered.
  */
-const rewriteHTML = (auth: Auth, element: Element | Document = document) => {
+const rewriteHtml = (auth: Auth, element: Element | Document = document) => {
   rewriteImageUrls(auth, element);
   rewriteTime(element);
 };
 
-export default rewriteHTML;
+export default rewriteHtml;

--- a/src/webview/js/spoilers.js
+++ b/src/webview/js/spoilers.js
@@ -1,0 +1,111 @@
+/* @flow strict-local */
+
+/**
+ * Collapse an open spoiler block with animation.
+ *
+ * Does what `collapse_spoiler` in static/js/spoilers.js in the web
+ * does, only departing as appropriate to adapt to mobile.
+ */
+const collapseSpoiler = (spoiler: HTMLElement) => {
+  const spoilerHeight = spoiler.scrollHeight;
+
+  // Set height to rendered height on next frame, then to zero on following
+  // frame to allow CSS transition animation to work
+  requestAnimationFrame(() => {
+    spoiler.style.height = `${spoilerHeight}px`;
+    spoiler.classList.remove('spoiler-content-open');
+
+    requestAnimationFrame(() => {
+      spoiler.style.height = '0px';
+    });
+  });
+};
+
+/**
+ * Expand a closed spoiler block with animation.
+ *
+ * Does what `expand_spoiler` in static/js/spoilers.js in the web app
+ * does, only departing as appropriate to adapt to mobile.
+ */
+const expandSpoiler = (spoiler: HTMLElement) => {
+  // Normally, the height of the spoiler block is not defined
+  // absolutely on the `spoiler-content-open` class, but just set to
+  // `auto` (i.e. the height of the content). CSS animations do not
+  // work with properties set to `auto`, so we get the actual height
+  // of the content here and temporarily put it explicitly on the
+  // element styling to allow the transition to work.
+  const spoilerHeight = spoiler.scrollHeight;
+  spoiler.style.height = `${spoilerHeight}px`;
+  // The `spoiler-content-open` class has CSS animations defined on it which
+  // will trigger on the frame after this class change.
+  spoiler.classList.add('spoiler-content-open');
+
+  const callback = () => {
+    spoiler.removeEventListener('transitionend', callback);
+    // When the CSS transition is over, reset the height to auto
+    // This keeps things working if, e.g., the viewport is resized
+    spoiler.style.height = '';
+  };
+  spoiler.addEventListener('transitionend', callback);
+};
+
+/**
+ * Toggle the spoiler state - collapsed <-> open.
+ *
+ * Detects the state of the spoiler block and toggles that.
+ */
+// The structure we're handling looks like this:
+//
+// <div class="spoiler-block">
+//   <div class="spoiler-header">
+//     <span class="spoiler-button" aria-expanded="false">
+//       <span class="spoiler-arrow"></span>
+//     </span>
+//     <p>Always visible heading</p>
+//   </div>
+//
+//   <div class="spoiler-content">
+//     <p>This text won't be visible until the user clicks.</p>
+//   </div>
+// </div>
+//
+// The above represents what we get from the server plus some tweaks
+// that have been made client-side, in `rewriteHtml`. (The web app's
+// version of the above can be seen in
+// templates/zerver/app/markdown_help.html, the user-facing Markdown
+// guide, at c5dc9d386.)
+export const toggleSpoiler = (spoilerHeader: HTMLElement) => {
+  const spoilerBlock = spoilerHeader.parentElement;
+  if (!spoilerBlock) {
+    return;
+  }
+
+  const button = spoilerHeader.querySelector('.spoiler-button');
+  const arrow = spoilerBlock.querySelector('.spoiler-arrow');
+  const spoilerContent = spoilerBlock.querySelector('.spoiler-content');
+  if (!arrow || !button || !spoilerContent) {
+    // eslint-disable-next-line no-console
+    console.warn('Malformed spoiler block');
+    return;
+  }
+
+  if (spoilerContent.classList.contains('spoiler-content-open')) {
+    // Content was open, we are collapsing
+    arrow.classList.remove('spoiler-button-open');
+
+    // Modify ARIA roles for screen readers
+    button.setAttribute('aria-expanded', 'false');
+    spoilerContent.setAttribute('aria-hidden', 'true');
+
+    collapseSpoiler(spoilerContent);
+  } else {
+    // Content was closed, we are expanding
+    arrow.classList.add('spoiler-button-open');
+
+    // Modify ARIA roles for screen readers
+    button.setAttribute('aria-expanded', 'true');
+    spoilerContent.setAttribute('aria-hidden', 'false');
+
+    expandSpoiler(spoilerContent);
+  }
+};

--- a/src/webview/js/spoilers.js
+++ b/src/webview/js/spoilers.js
@@ -7,12 +7,15 @@
  * does, only departing as appropriate to adapt to mobile.
  */
 const collapseSpoiler = (spoiler: HTMLElement) => {
-  const spoilerHeight = spoiler.scrollHeight;
+  // Translation of zulip/zulip@f3011d3b7 out of jQuery. We need
+  // `spoiler`'s computed content height, which excludes padding.
+  // Things like `clientHeight` and `offsetHeight` include padding.
+  const computedHeight = getComputedStyle(spoiler).height;
 
   // Set height to rendered height on next frame, then to zero on following
   // frame to allow CSS transition animation to work
   requestAnimationFrame(() => {
-    spoiler.style.height = `${spoilerHeight}px`;
+    spoiler.style.height = computedHeight;
     spoiler.classList.remove('spoiler-content-open');
 
     requestAnimationFrame(() => {

--- a/src/webview/static/base.css
+++ b/src/webview/static/base.css
@@ -569,3 +569,77 @@ hr {
   border: 1px dashed hsla(0, 0%, 50%, 0.5);
   border-radius: 0.5rem;
 }
+
+/* Taken from the `.spoiler-block` section of the webapp's styles, as
+   of zulip/zulip@1cb040647, translated from SCSS to plain CSS. */
+.spoiler-block {
+  border: hsl(0, 0%, 50%) 1px solid;
+  padding: 2px 8px 2px 10px;
+  border-radius: 10px;
+  position: relative;
+  top: 1px;
+  display: block;
+  margin: 5px 0 15px 0;
+}
+.spoiler-block .spoiler-header {
+  padding: 5px;
+  font-weight: bold;
+}
+.spoiler-block .spoiler-content {
+  overflow: hidden;
+  border-top: hsla(0, 0%, 50%,1) 0px solid;
+  transition: height 0.4s ease-in-out, border-top 0.4s step-end, padding 0.4s step-end;
+  padding: 0px;
+  height: 0px;
+}
+.spoiler-block .spoiler-content.spoiler-content-open {
+  border-top: hsla(0, 0%, 50%,1) 1px solid;
+  transition: height 0.4s ease-in-out, border-top 0.4s step-start, padding 0.4s step-start;
+  padding: 5px;
+  height: auto;
+}
+.spoiler-block .spoiler-button {
+  float: right;
+  width: 25px;
+  height: 25px;
+}
+.spoiler-block .spoiler-button:hover .spoiler-arrow::before, .spoiler-block .spoiler-button:hover .spoiler-arrow::after {
+  background-color: hsl(0, 0%, 50%);
+}
+.spoiler-block .spoiler-arrow {
+  float: right;
+  width: 13px;
+  height: 13px;
+  position: relative;
+  bottom: -5px;
+  left: -10px;
+  cursor: pointer;
+  transition: 0.4s ease;
+  margin-top: 2px;
+  text-align: left;
+  transform: rotate(45deg);
+}
+.spoiler-block .spoiler-arrow::before, .spoiler-block .spoiler-arrow::after {
+  position: absolute;
+  content: '';
+  display: inline-block;
+  width: 12px;
+  height: 3px;
+  background-color: hsl(0, 0%, 83%);
+  transition: 0.4s ease;
+}
+.spoiler-block .spoiler-arrow::after {
+  position: absolute;
+  transform: rotate(90deg);
+  top: -5px;
+  left: 5px;
+}
+.spoiler-block .spoiler-arrow.spoiler-button-open {
+  transform: rotate(45deg) translate(-5px, -5px);
+}
+.spoiler-block .spoiler-arrow.spoiler-button-open::before {
+  transform: translate(10px, 0);
+}
+.spoiler-block .spoiler-arrow.spoiler-button-open::after {
+  transform: rotate(90deg) translate(10px, 0);
+}


### PR DESCRIPTION
Support for creating spoilers was recently added to Zulip[1].
Currently, spoilers render as visible by default on the app.

Add functionality to handle spoilers properly - spoilers are
collapsed by default, and can be toggled by tapping on the header.
Also, if a header is missing, the text 'Spoiler' is added as the
header.

The implementation is similar to [1], but the JavaScript was
rewritten to work without jQuery.

[1] https://github.com/zulip/zulip/commit/1cb040647b37f9f2269c2b39ae6495830f49ac4b

Fixes: #4155