### PR TITLE
Prep commits for new `avatar_url` handling (#4157)

### DIFF
--- a/src/api/messages/__tests__/migrateMessages-test.js
+++ b/src/api/messages/__tests__/migrateMessages-test.js
@@ -1,12 +1,53 @@
+/* @flow strict-local */
+import omit from 'lodash.omit';
+
 import { migrateMessages } from '../getMessages';
+import * as eg from '../../../__tests__/lib/exampleData';
+import type { ServerMessage, ServerReaction } from '../getMessages';
+import type { Message } from '../../modelTypes';
 
 describe('migrateMessages', () => {
-  test('Replace user object with `user_id`', () => {
-    const messages = [
-      { reactions: [{ user: { id: 1, full_name: 'name', email: 'a@a.com' }, code: 'code' }] },
-    ];
-    const expectedOutput = [{ reactions: [{ user_id: 1, code: 'code' }] }];
+  const reactingUser = eg.makeUser();
 
-    expect(migrateMessages(messages)).toEqual(expectedOutput);
+  const serverReaction: ServerReaction = {
+    emoji_name: '+1',
+    reaction_type: 'unicode_emoji',
+    emoji_code: '1f44d',
+    user: {
+      email: reactingUser.email,
+      full_name: reactingUser.full_name,
+      id: reactingUser.user_id,
+    },
+  };
+
+  const serverMessage: ServerMessage = {
+    // The `omit` shouldn't be necessary with Flow v0.111: "Spreads
+    // now overwrite properties instead of inferring unions"
+    // (https://medium.com/flow-type/spreads-common-errors-fixes-9701012e9d58).
+    ...(omit(eg.streamMessage(), 'reactions'): $Diff<Message, { reactions: mixed }>),
+    reactions: [serverReaction],
+  };
+
+  const input: ServerMessage[] = [serverMessage];
+
+  const expectedOutput: Message[] = [
+    {
+      // The `omit` shouldn't be necessary with Flow v0.111.
+      ...(omit(serverMessage, 'reactions'): $Diff<ServerMessage, { reactions: mixed }>),
+      reactions: [
+        {
+          user_id: reactingUser.user_id,
+          emoji_name: serverReaction.emoji_name,
+          reaction_type: serverReaction.reaction_type,
+          emoji_code: serverReaction.emoji_code,
+        },
+      ],
+    },
+  ];
+
+  const actualOutput: Message[] = migrateMessages(input);
+
+  test('Replace user object with `user_id`', () => {
+    expect(actualOutput.map(m => m.reactions)).toEqual(expectedOutput.map(m => m.reactions));
   });
 });

--- a/src/api/messages/getMessages.js
+++ b/src/api/messages/getMessages.js
@@ -19,7 +19,7 @@ type ApiResponseMessages = {|
  * Note that reaction events have a *different* variation; see their
  * handling in `eventToAction`.
  */
-type ServerReaction = $ReadOnly<{|
+export type ServerReaction = $ReadOnly<{|
   ...$Diff<Reaction, {| user_id: mixed |}>,
   user: $ReadOnly<{|
     email: string,
@@ -28,7 +28,7 @@ type ServerReaction = $ReadOnly<{|
   |}>,
 |}>;
 
-type ServerMessage = $ReadOnly<{|
+export type ServerMessage = $ReadOnly<{|
   ...$Exact<Message>,
   reactions: $ReadOnlyArray<ServerReaction>,
 |}>;

--- a/src/webview/html/__tests__/render-test.js
+++ b/src/webview/html/__tests__/render-test.js
@@ -1,14 +1,16 @@
+/* @flow strict-local */
 import messageTypingAsHtml from '../messageTypingAsHtml';
+import * as eg from '../../../__tests__/lib/exampleData';
 
 describe('typing', () => {
-  it('escapes values', () => {
-    expect(
-      messageTypingAsHtml('&<r', [
-        {
-          avatar_url: '&<av',
-          email: '&<e',
-        },
-      ]),
-    ).not.toContain('&<');
+  it('escapes &< (e.g., in `avatar_url` and `email`', () => {
+    const name = '&<name';
+    const user = {
+      ...eg.makeUser({ name }),
+      avatar_url: `https://zulip.example.org/yo/avatar-${name}.png`,
+      email: `${name}@example.com`,
+    };
+
+    expect(messageTypingAsHtml('&<r', [user])).not.toContain('&<');
   });
 });


### PR DESCRIPTION
In a revision of my work for #4157, I noticed that there were some necessary changes to some test files, and some of these files haven't been type-checked or taken advantage of the work we've put into `src/__tests__/lib/exampleData.js`.

Rather than continue editing these files in this unstable state, pave the way for better edits by type-checking them and using that example data. 🙂  And fix a few bugs I've noticed.

The revision that informed these changes was one where the type for `avatar_url` on the `Message` type (not just that field on the `User` type) was changed. I *think* this might be a direction we'll go in (e.g., the type might be a union of all subclasses of `AvatarURL` except `IdleAvatarURL`); I'm thinking of the discussion around [here](https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/Mobile.20API.20changes/near/912176). In any case, that explains why `fetchActions-test.js` was touched (`fetchMessages` is in there).

There will be some more of this; I know at least `src/webview/__tests__/webViewHandleUpdates-test.js` has some stuff that I'm still figuring out.