### PR TITLE
outbox: Show outbox messages when 'caughtUp.newer' is false.

### DIFF
--- a/src/chat/__tests__/narrowsSelectors-test.js
+++ b/src/chat/__tests__/narrowsSelectors-test.js
@@ -75,7 +75,7 @@ describe('getMessagesForNarrow', () => {
     expect(anchor).toEqual(expectedState);
   });
 
-  test('do not combine messages and outbox if not caught up', () => {
+  test('combine messages and outbox if not caught up', () => {
     const state = deepFreeze({
       narrows: {
         [HOME_NARROW_STR]: [123],
@@ -94,7 +94,7 @@ describe('getMessagesForNarrow', () => {
       ],
     });
 
-    const expectedState = deepFreeze([state.messages[123]]);
+    const expectedState = deepFreeze([state.messages[123], ...state.outbox]);
 
     const anchor = getMessagesForNarrow(state, HOME_NARROW);
 

--- a/src/chat/narrowsSelectors.js
+++ b/src/chat/narrowsSelectors.js
@@ -36,9 +36,6 @@ export const outboxMessagesForNarrow: Selector<Outbox[], Narrow> = createSelecto
   getCaughtUpForNarrow,
   state => getOutbox(state),
   (narrow, caughtUp, outboxMessages) => {
-    if (!caughtUp.newer) {
-      return NULL_ARRAY;
-    }
     const filtered = outboxMessages.filter(item => narrowContains(narrow, item.narrow));
     return isEqual(filtered, outboxMessages) ? outboxMessages : filtered;
   },

--- a/src/topics/__tests__/topicsSelectors-test.js
+++ b/src/topics/__tests__/topicsSelectors-test.js
@@ -30,6 +30,7 @@ describe('getLastMessageTopic', () => {
   test('when no messages in narrow return an empty string', () => {
     const state = deepFreeze({
       narrows: {},
+      outbox: [],
     });
 
     const topic = getLastMessageTopic(state, HOME_NARROW);
@@ -50,6 +51,7 @@ describe('getLastMessageTopic', () => {
         1: { id: 1 },
         2: { id: 2, subject: 'some topic' },
       },
+      outbox: [],
     });
 
     const topic = getLastMessageTopic(state, narrow);


### PR DESCRIPTION
Currently, we return a NULL_ARRAY in outboxMessagesForNarrow when
'caughtUp.newer' is false - but there is no reason to do this. We
should always show outbox messages regardless of the caughtUp state
because there can always be unsent messages for various reasons.

So, remove the conditional that causes this.

Fixes: #3800.