### PR TITLE
realm screen: Give early error when server URL is an email address.

### DIFF
--- a/src/common/ErrorMsg.js
+++ b/src/common/ErrorMsg.js
@@ -2,13 +2,11 @@
 import React, { PureComponent } from 'react';
 import { StyleSheet, View } from 'react-native';
 
-import { CONTROL_SIZE } from '../styles';
 import Label from './Label';
 
 const styles = StyleSheet.create({
   field: {
     flexDirection: 'row',
-    height: CONTROL_SIZE / 2,
     marginTop: 5,
     marginBottom: 5,
     justifyContent: 'center',

--- a/src/start/RealmScreen.js
+++ b/src/start/RealmScreen.js
@@ -46,7 +46,6 @@ class RealmScreen extends PureComponent<Props, State> {
     const { realm } = this.state;
 
     this.setState({
-      realm,
       progress: true,
       error: null,
     });

--- a/static/translations/messages_en.json
+++ b/static/translations/messages_en.json
@@ -36,6 +36,8 @@
   "Chat": "Chat",
   "Sign in with {method}": "Sign in with {method}",
   "Cannot connect to server": "Cannot connect to server",
+  "Please enter a valid URL": "Please enter a valid URL",
+  "Please enter the server URL, not your email": "Please enter the server URL, not your email",
   "Wrong email or password. Try again.": "Wrong email or password. Try again.",
   "Wrong username or password. Try again.": "Wrong username or password. Try again.",
   "Enter a valid email address": "Enter a valid email address",


### PR DESCRIPTION
Show an error message when the user tries to enter an email in the
server URL input field, even before trying to connect to the
server.

Fixes: #4058
