### PR TITLE
message reaction list: Hide emails from user list.

### DIFF
--- a/src/reactions/ReactionUserList.js
+++ b/src/reactions/ReactionUserList.js
@@ -42,7 +42,6 @@ class ReactionUserList extends PureComponent<Props> {
               fullName={user.full_name}
               avatarUrl={user.avatar_url}
               email={user.email}
-              showEmail
               onPress={() => {
                 this.handlePress(user.user_id);
               }}


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/7714968/87285060-b1ba0f00-c514-11ea-80ee-c8ef2e84c8f9.png)


Removes user emails from the user list in the message reactions
screen because in this context, the emails mostly feel like
clutter.

As a side effect of this change, we no longer have to worry about
the server 'email_address_visibility' setting.

Fixes: #4188.