### PR TITLE
Improve long-loading logging code from the WebView.

### DIFF
--- a/src/webview/js/InboundEventLogger.js
+++ b/src/webview/js/InboundEventLogger.js
@@ -1,0 +1,159 @@
+/* @flow strict-local */
+import type {
+  WebViewUpdateEvent as WebViewInboundEvent,
+  WebViewUpdateEventContent as WebViewInboundEventContent,
+  WebViewUpdateEventFetching as WebViewInboundEventFetching,
+  WebViewUpdateEventTyping as WebViewInboundEventTyping,
+  WebViewUpdateEventReady as WebViewInboundEventReady,
+  WebViewUpdateEventMessagesRead as WebViewInboundEventMessagesRead,
+} from '../webViewHandleUpdates';
+import type { JSONable } from '../../utils/jsonable';
+import sendMessage from './sendMessage';
+import { ensureUnreachable } from '../../types';
+
+// TODO: Make exact (see note in jsonable.js).
+type Scrub<E: WebViewInboundEvent> = { [key: $Keys<E>]: JSONable };
+
+type ScrubbedInboundEvent =
+  | Scrub<WebViewInboundEventContent>
+  | Scrub<WebViewInboundEventFetching>
+  | Scrub<WebViewInboundEventTyping>
+  | Scrub<WebViewInboundEventReady>
+  | Scrub<WebViewInboundEventMessagesRead>;
+
+type ScrubbedInboundEventItem = {|
+  timestamp: number,
+  type: 'inbound',
+  scrubbedEvent: ScrubbedInboundEvent,
+|};
+
+/**
+ * Grab interesting but not privacy-sensitive message-loading state.
+ *
+ * Takes the "content" from an inbound WebView event, an HTML string,
+ * and returns the opening div#message-loading tag, so we know whether
+ * it's visible.
+ */
+const placeholdersDivTagFromContent = (content: string): string | null => {
+  const match = new RegExp('<div id="message-loading" class="(?:hidden)?">').exec(content);
+  return match !== null ? match[0] : null;
+};
+
+export default class InboundEventLogger {
+  _captureStartTime: number | void;
+  _captureEndTime: number | void;
+  _isCapturing: boolean;
+  _capturedInboundEventItems: ScrubbedInboundEventItem[];
+
+  /**
+   * Minimally transform an inbound event to remove sensitive data.
+   */
+  static scrubInboundEvent(event: WebViewInboundEvent): ScrubbedInboundEvent {
+    // Don't spread the event (e.g., `...event`); instead, rebuild it.
+    // That way, a new property, when added, won't automatically be
+    // sent to Sentry un-scrubbed.
+    switch (event.type) {
+      case 'content': {
+        return {
+          type: event.type,
+          scrollMessageId: event.scrollMessageId,
+          auth: 'redacted',
+          content: placeholdersDivTagFromContent(event.content),
+          updateStrategy: event.updateStrategy,
+        };
+      }
+      case 'fetching': {
+        return {
+          type: event.type,
+          showMessagePlaceholders: event.showMessagePlaceholders,
+          fetchingOlder: event.fetchingOlder,
+          fetchingNewer: event.fetchingNewer,
+        };
+      }
+      case 'typing': {
+        return {
+          type: event.type,
+          // Empty if no one is typing; otherwise, has avatar URLs.
+          content: event.content !== '',
+        };
+      }
+      case 'ready': {
+        return {
+          type: event.type,
+        };
+      }
+      case 'read': {
+        return {
+          type: event.type,
+          messageIds: event.messageIds,
+        };
+      }
+      default: {
+        ensureUnreachable(event);
+        return {
+          type: event.type,
+        };
+      }
+    }
+  }
+
+  constructor() {
+    this._isCapturing = false;
+    this._capturedInboundEventItems = [];
+  }
+
+  startCapturing() {
+    if (this._isCapturing) {
+      throw new Error('InboundEventLogger: Tried to call startCapturing while already capturing.');
+    } else if (this._capturedInboundEventItems.length > 0 || this._captureEndTime !== undefined) {
+      throw new Error('InboundEventLogger: Tried to call startCapturing before resetting.');
+    }
+    this._isCapturing = true;
+    this._captureStartTime = Date.now();
+  }
+
+  stopCapturing() {
+    if (!this._isCapturing) {
+      throw new Error('InboundEventLogger: Tried to call stopCapturing while not capturing.');
+    }
+    this._isCapturing = false;
+    this._captureEndTime = Date.now();
+  }
+
+  send() {
+    if (this._isCapturing) {
+      throw new Error('InboundEventLogger: Tried to send captured events while still capturing.');
+    }
+    sendMessage({
+      type: 'warn',
+      details: {
+        startTime: this._captureStartTime ?? null,
+        endTime: this._captureEndTime ?? null,
+        inboundEventItems: this._capturedInboundEventItems,
+      },
+    });
+  }
+
+  reset() {
+    this._captureStartTime = undefined;
+    this._captureEndTime = undefined;
+    this._capturedInboundEventItems = [];
+    this._isCapturing = false;
+  }
+
+  maybeCaptureInboundEvent(event: WebViewInboundEvent) {
+    if (this._isCapturing) {
+      const item = {
+        type: 'inbound',
+        timestamp: Date.now(),
+        // Scrubbing up front, rather than just before sending, means
+        // it might be a waste of work -- we may never send. But it's
+        // not a *ton* of work, and it's currently the case that
+        // scrubbed events are much lighter than unscrubbed ones
+        // (unscrubbed events can have very long `content` strings).
+        scrubbedEvent: InboundEventLogger.scrubInboundEvent(event),
+      };
+      this._capturedInboundEventItems.push(item);
+    }
+  }
+}

--- a/src/webview/js/generatedEs3.js
+++ b/src/webview/js/generatedEs3.js
@@ -46,6 +46,10 @@ var compiledWebviewJs = (function (exports) {
     });
   };
 
+  var sendMessage = (function (msg) {
+    window.ReactNativeWebView.postMessage(JSON.stringify(msg));
+  });
+
   if (!Array.from) {
     Array.from = function from(arr) {
       return Array.prototype.slice.call(arr);
@@ -88,10 +92,6 @@ var compiledWebviewJs = (function (exports) {
     var element = document.createElement('div');
     element.innerText = text;
     return element.innerHTML;
-  };
-
-  var sendMessage = function sendMessage(msg) {
-    window.ReactNativeWebView.postMessage(JSON.stringify(msg));
   };
 
   window.onerror = function (message, source, line, column, error) {

--- a/src/webview/js/generatedEs3.js
+++ b/src/webview/js/generatedEs3.js
@@ -14,91 +14,6 @@ export default `
 var compiledWebviewJs = (function (exports) {
   'use strict';
 
-  function _defineProperty(obj, key, value) {
-    if (key in obj) {
-      Object.defineProperty(obj, key, {
-        value: value,
-        enumerable: true,
-        configurable: true,
-        writable: true
-      });
-    } else {
-      obj[key] = value;
-    }
-
-    return obj;
-  }
-
-  function ownKeys(object, enumerableOnly) {
-    var keys = Object.keys(object);
-
-    if (Object.getOwnPropertySymbols) {
-      var symbols = Object.getOwnPropertySymbols(object);
-      if (enumerableOnly) symbols = symbols.filter(function (sym) {
-        return Object.getOwnPropertyDescriptor(object, sym).enumerable;
-      });
-      keys.push.apply(keys, symbols);
-    }
-
-    return keys;
-  }
-
-  function _objectSpread2(target) {
-    for (var i = 1; i < arguments.length; i++) {
-      var source = arguments[i] != null ? arguments[i] : {};
-
-      if (i % 2) {
-        ownKeys(Object(source), true).forEach(function (key) {
-          _defineProperty(target, key, source[key]);
-        });
-      } else if (Object.getOwnPropertyDescriptors) {
-        Object.defineProperties(target, Object.getOwnPropertyDescriptors(source));
-      } else {
-        ownKeys(Object(source)).forEach(function (key) {
-          Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key));
-        });
-      }
-    }
-
-    return target;
-  }
-
-  function _objectWithoutPropertiesLoose(source, excluded) {
-    if (source == null) return {};
-    var target = {};
-    var sourceKeys = Object.keys(source);
-    var key, i;
-
-    for (i = 0; i < sourceKeys.length; i++) {
-      key = sourceKeys[i];
-      if (excluded.indexOf(key) >= 0) continue;
-      target[key] = source[key];
-    }
-
-    return target;
-  }
-
-  function _objectWithoutProperties(source, excluded) {
-    if (source == null) return {};
-
-    var target = _objectWithoutPropertiesLoose(source, excluded);
-
-    var key, i;
-
-    if (Object.getOwnPropertySymbols) {
-      var sourceSymbolKeys = Object.getOwnPropertySymbols(source);
-
-      for (i = 0; i < sourceSymbolKeys.length; i++) {
-        key = sourceSymbolKeys[i];
-        if (excluded.indexOf(key) >= 0) continue;
-        if (!Object.prototype.propertyIsEnumerable.call(source, key)) continue;
-        target[key] = source[key];
-      }
-    }
-
-    return target;
-  }
-
   var inlineApiRoutes = ['^/user_uploads/', '^/thumbnail$', '^/avatar/'].map(function (r) {
     return new RegExp(r);
   });
@@ -211,73 +126,6 @@ var compiledWebviewJs = (function (exports) {
     });
     return true;
   };
-
-  var isTrackingLongLoad = true;
-  var eventsDuringLongLoad = [];
-
-  var logLongLoad = function logLongLoad() {
-    if (eventsDuringLongLoad === null) {
-      throw new Error();
-    }
-
-    var loggableEvents = eventsDuringLongLoad.map(function (eventWithTimestamp) {
-      var placeholdersDivTagFromContent = function placeholdersDivTagFromContent(content) {
-        var match = new RegExp('<div id="message-loading" class="(?:hidden)?">').exec(content);
-        return match !== null ? match[0] : null;
-      };
-
-      var content = eventWithTimestamp.content,
-          auth = eventWithTimestamp.auth,
-          rest = _objectWithoutProperties(eventWithTimestamp, ["content", "auth"]);
-
-      switch (eventWithTimestamp.type) {
-        case 'content':
-          {
-            return _objectSpread2(_objectSpread2({}, rest), {}, {
-              auth: 'redacted',
-              content: placeholdersDivTagFromContent(eventWithTimestamp.content)
-            });
-          }
-
-        case 'read':
-        case 'ready':
-        case 'fetching':
-          return rest;
-
-        case 'typing':
-          {
-            return _objectSpread2(_objectSpread2({}, rest), {}, {
-              content: placeholdersDivTagFromContent(eventWithTimestamp.content)
-            });
-          }
-
-        default:
-          return {
-            type: eventWithTimestamp.type,
-            timestamp: eventWithTimestamp.timestamp
-          };
-      }
-    });
-    sendMessage({
-      type: 'warn',
-      details: {
-        loggableEvents: loggableEvents
-      }
-    });
-  };
-
-  var maybeLogLongLoad = function maybeLogLongLoad() {
-    var placeholdersDiv = document.getElementById('message-loading');
-
-    if (placeholdersDiv && !placeholdersDiv.classList.contains('hidden')) {
-      logLongLoad();
-    }
-
-    isTrackingLongLoad = false;
-    eventsDuringLongLoad = null;
-  };
-
-  setTimeout(maybeLogLongLoad, 10000);
 
   var showHideElement = function showHideElement(elementId, show) {
     var element = document.getElementById(elementId);
@@ -631,12 +479,6 @@ var compiledWebviewJs = (function (exports) {
     var updateEvents = JSON.parse(decodedData);
     updateEvents.forEach(function (uevent) {
       eventUpdateHandlers[uevent.type](uevent);
-
-      if (isTrackingLongLoad && eventsDuringLongLoad !== null) {
-        eventsDuringLongLoad.push(_objectSpread2(_objectSpread2({}, uevent), {}, {
-          timestamp: Date.now()
-        }));
-      }
     });
     scrollEventsDisabled = false;
   };

--- a/src/webview/js/js.js
+++ b/src/webview/js/js.js
@@ -9,9 +9,9 @@ import type {
   WebViewUpdateEventReady,
   WebViewUpdateEventMessagesRead,
 } from '../webViewHandleUpdates';
-import type { MessageListEvent } from '../webViewEventHandlers';
 
 import rewriteImageUrls from './rewriteImageUrls';
+import sendMessage from './sendMessage';
 
 /*
  * Supported platforms:
@@ -102,10 +102,6 @@ const escapeHtml = (text: string): string => {
   const element = document.createElement('div');
   element.innerText = text;
   return element.innerHTML;
-};
-
-const sendMessage = (msg: MessageListEvent) => {
-  window.ReactNativeWebView.postMessage(JSON.stringify(msg));
 };
 
 window.onerror = (message: string, source: string, line: number, column: number, error: Error) => {

--- a/src/webview/js/js.js
+++ b/src/webview/js/js.js
@@ -1,7 +1,6 @@
 /* @flow strict-local */
 /* eslint-disable no-useless-return */
 import type { Auth } from '../../types';
-import type { JSONable } from '../../utils/jsonable';
 import type {
   WebViewUpdateEvent,
   WebViewUpdateEventContent,
@@ -11,7 +10,6 @@ import type {
   WebViewUpdateEventMessagesRead,
 } from '../webViewHandleUpdates';
 import type { MessageListEvent } from '../webViewEventHandlers';
-import { ensureUnreachable } from '../../types';
 
 import rewriteImageUrls from './rewriteImageUrls';
 
@@ -157,66 +155,6 @@ window.onerror = (message: string, source: string, line: number, column: number,
 
   return true;
 };
-
-let isTrackingLongLoad = true;
-let eventsDuringLongLoad: Array<{ ...WebViewUpdateEvent, timestamp: number }> | null = [];
-
-const logLongLoad = () => {
-  if (eventsDuringLongLoad === null) {
-    throw new Error();
-  }
-  const loggableEvents: JSONable[] = eventsDuringLongLoad.map(eventWithTimestamp => {
-    const placeholdersDivTagFromContent = (content: string) => {
-      const match = new RegExp('<div id="message-loading" class="(?:hidden)?">').exec(content);
-      return match !== null ? match[0] : null;
-    };
-    // $FlowFixMe (some events don't have content or auth)
-    const { content, auth, ...rest } = eventWithTimestamp; /* eslint-disable-line no-unused-vars */
-    switch (eventWithTimestamp.type) {
-      case 'content': {
-        return {
-          ...rest,
-          auth: 'redacted',
-          content: placeholdersDivTagFromContent(eventWithTimestamp.content),
-        };
-      }
-      case 'read':
-      case 'ready':
-      case 'fetching':
-        return rest;
-      case 'typing': {
-        return {
-          ...rest,
-          content: placeholdersDivTagFromContent(eventWithTimestamp.content),
-        };
-      }
-      default:
-        ensureUnreachable(eventWithTimestamp);
-        return {
-          type: eventWithTimestamp.type,
-          timestamp: eventWithTimestamp.timestamp,
-        };
-    }
-  });
-
-  sendMessage({
-    type: 'warn',
-    details: {
-      loggableEvents,
-    },
-  });
-};
-
-const maybeLogLongLoad = () => {
-  const placeholdersDiv = document.getElementById('message-loading');
-  if (placeholdersDiv && !placeholdersDiv.classList.contains('hidden')) {
-    logLongLoad();
-  }
-  isTrackingLongLoad = false;
-  eventsDuringLongLoad = null;
-};
-
-setTimeout(maybeLogLongLoad, 10000);
 
 const showHideElement = (elementId: string, show: boolean) => {
   const element = document.getElementById(elementId);
@@ -671,13 +609,6 @@ const handleMessageEvent: MessageEventListener = e => {
   updateEvents.forEach((uevent: WebViewUpdateEvent) => {
     // $FlowFixMe
     eventUpdateHandlers[uevent.type](uevent);
-    if (isTrackingLongLoad && eventsDuringLongLoad !== null) {
-      // $FlowFixMe the spread seems to confuse Flow, but this is likely correct
-      eventsDuringLongLoad.push({
-        ...uevent,
-        timestamp: Date.now(),
-      });
-    }
   });
   scrollEventsDisabled = false;
 };

--- a/src/webview/js/sendMessage.js
+++ b/src/webview/js/sendMessage.js
@@ -1,0 +1,6 @@
+/* @flow strict-local */
+import type { MessageListEvent } from '../webViewEventHandlers';
+
+export default (msg: MessageListEvent) => {
+  window.ReactNativeWebView.postMessage(JSON.stringify(msg));
+};


### PR DESCRIPTION
Prompted by Greg's suggestions at https://github.com/zulip/zulip-mobile/pull/4180#issuecomment-654466175.

There are a few differences to call out. If they're problematic, I'll fix them right away, of course!

> The log-long-load state and all the logic referring to that state could be encapsulated in a class

Since I was making a class anyway, and putting it in its own JS file, I didn't want to entangle that class with the DOM detail of whether the `message-loading` div was visible. Instead, I made it so you can call "start" and "stop" methods on the class. I think this will also be useful if we want to log based on other, unrelated states. The code added in `js.js` is still much smaller than in the old way.

> The `map` callback that produces `loggableEvents` could be pulled out and given a name like `scrubUpdateEvent` -- then `logLongLoad` would be much shorter.

Makes sense. I've pulled out the "scrubbing" logic into its own function, but the difference is: I don't use it in a `map`. As soon as the class instance becomes aware of the event, it scrubs it right away, before pushing it to the array.