### PR TITLE
accountsReducer: Remove unhelpful test.

### DIFF
--- a/src/account/__tests__/accountsReducer-test.js
+++ b/src/account/__tests__/accountsReducer-test.js
@@ -88,21 +88,6 @@ describe('accountsReducer', () => {
       expect(newState).toEqual(expectedState);
       expect(newState).not.toBe(prevState);
     });
-
-    test('records undefined for zulipVersion on active account if not present in action', () => {
-      const prevState = deepFreeze([account1, account2, account3]);
-      const action = deepFreeze({
-        ...eg.action.realm_init,
-        zulipVersion: undefined,
-      });
-
-      const expectedState = [{ ...account1, zulipVersion: undefined }, account2, account3];
-
-      const newState = accountsReducer(prevState, action);
-
-      expect(newState).toEqual(expectedState);
-      expect(newState).not.toBe(prevState);
-    });
   });
 
   describe('ACCOUNT_SWITCH', () => {


### PR DESCRIPTION
With Flow v0.113.0, which we'll get in the RN v0.61 -> v0.62 upgrade
(#3782), red flags are raised about this test. Strangely, the test
was allowed to expect the `zulipVersion` on an Account to be
undefined. In fact, the type for it is `ZulipVersion | null`.

The test is based on the false premise that a REALM_INIT action
might not have a `zulipVersion` property. `RealmInitAction` states
that it will always be there, as a ZulipVersion instance. So, delete
the test. If we ever find that there's a legitimate case where it is
missing, we'll fix the RealmInitAction type accordingly, and a new
test can proceed from there.