### PR TITLE
Stop using legacy Context API for styles (continued)

### DIFF
--- a/src/ZulipMobile.js
+++ b/src/ZulipMobile.js
@@ -5,7 +5,7 @@ import 'react-native-url-polyfill/auto';
 import '../vendor/intl/intl';
 import StoreProvider from './boot/StoreProvider';
 import TranslationProvider from './boot/TranslationProvider';
-import StylesProvider from './boot/StylesProvider';
+import ThemeProvider from './boot/ThemeProvider';
 import CompatibilityChecker from './boot/CompatibilityChecker';
 import AppEventHandlers from './boot/AppEventHandlers';
 import AppDataFetcher from './boot/AppDataFetcher';
@@ -26,11 +26,11 @@ export default (): React$Node => (
       <AppEventHandlers>
         <AppDataFetcher>
           <TranslationProvider>
-            <StylesProvider>
+            <ThemeProvider>
               <BackNavigationHandler>
                 <AppWithNavigation />
               </BackNavigationHandler>
-            </StylesProvider>
+            </ThemeProvider>
           </TranslationProvider>
         </AppDataFetcher>
       </AppEventHandlers>

--- a/src/boot/ThemeProvider.js
+++ b/src/boot/ThemeProvider.js
@@ -6,9 +6,7 @@ import type { Node as React$Node } from 'react';
 import type { ThemeName, Dispatch } from '../types';
 import { connect } from '../react-redux';
 import { getSettings } from '../directSelectors';
-import { stylesFromTheme, themeColors, ThemeContext } from '../styles/theme';
-
-const Dummy = props => props.children;
+import { themeColors, ThemeContext } from '../styles/theme';
 
 type Props = $ReadOnly<{|
   dispatch: Dispatch,
@@ -16,32 +14,17 @@ type Props = $ReadOnly<{|
   children: React$Node,
 |}>;
 
-class StylesProvider extends PureComponent<Props> {
-  static childContextTypes = {
-    styles: () => {},
-  };
-
+class ThemeProvider extends PureComponent<Props> {
   static defaultProps = {
     theme: 'default',
   };
 
-  getChildContext() {
-    const { theme } = this.props;
-    const styles = stylesFromTheme(theme);
-    return { styles };
-  }
-
   render() {
     const { children, theme } = this.props;
-
-    return (
-      <ThemeContext.Provider value={themeColors[theme]}>
-        <Dummy key={theme}>{children}</Dummy>
-      </ThemeContext.Provider>
-    );
+    return <ThemeContext.Provider value={themeColors[theme]}>{children}</ThemeContext.Provider>;
   }
 }
 
 export default connect(state => ({
   theme: getSettings(state).theme,
-}))(StylesProvider);
+}))(ThemeProvider);

--- a/src/boot/ThemeProvider.js
+++ b/src/boot/ThemeProvider.js
@@ -6,7 +6,7 @@ import type { Node as React$Node } from 'react';
 import type { ThemeName, Dispatch } from '../types';
 import { connect } from '../react-redux';
 import { getSettings } from '../directSelectors';
-import { themeColors, ThemeContext } from '../styles/theme';
+import { themeData, ThemeContext } from '../styles/theme';
 
 type Props = $ReadOnly<{|
   dispatch: Dispatch,
@@ -21,7 +21,7 @@ class ThemeProvider extends PureComponent<Props> {
 
   render() {
     const { children, theme } = this.props;
-    return <ThemeContext.Provider value={themeColors[theme]}>{children}</ThemeContext.Provider>;
+    return <ThemeContext.Provider value={themeData[theme]}>{children}</ThemeContext.Provider>;
   }
 }
 

--- a/src/boot/TranslationProvider.js
+++ b/src/boot/TranslationProvider.js
@@ -1,5 +1,5 @@
 /* @flow strict-local */
-import React, { PureComponent } from 'react';
+import React, { PureComponent, Component } from 'react';
 import type { ComponentType, ElementConfig, Node as React$Node } from 'react';
 import { Text } from 'react-native';
 import { IntlProvider } from 'react-intl';
@@ -51,9 +51,37 @@ const makeGetText = (intl: IntlShape): GetText => {
  * new API.
  *
  * See https://reactjs.org/docs/context.html
- * vs. https://reactjs.org/docs/legacy-context.html .
+ * vs. https://reactjs.org/docs/legacy-context.html.
+ *
+ * Why do we need this? `IntlProvider` uses React's "legacy context
+ * API", deprecated since React 16.3, of which the docs say:
+ *
+ *   ## Updating Context
+ *
+ *   Don't do it.
+ *
+ *   React has an API to update context, but it is fundamentally
+ *   broken and you should not use it.
+ *
+ * It's broken because a consumer in the old way would never
+ * re-`render` on changes to the context if they, or any of their
+ * ancestors below the provider, implemented `shouldComponentUpdate`
+ * in a way that blocked updates from the context. This meant that
+ * neither the provider nor the consumer had the power to fix many
+ * non-re-`render`ing bugs. A very common context-update-blocking
+ * implementation of `shouldComponentUpdate` is the one
+ * `PureComponent` uses, so the effect is widespread.
+ *
+ * In the new way, `shouldComponentUpdate`s (as implemented by hand or
+ * by using `PureComponent`) in the hierarchy all the way down to the
+ * consumer (inclusive) are ignored when the context updates.
+ *
+ * Consumers should consume `TranslationContext` as it's provided
+ * here, so they don't have to worry about not updating when it
+ * changes.
  */
-class TranslationContextTranslator extends PureComponent<{|
+// This component MUST NOT be a `PureComponent`; see above.
+class TranslationContextTranslator extends Component<{|
   +children: React$Node,
 |}> {
   context: { intl: IntlShape };
@@ -62,11 +90,9 @@ class TranslationContextTranslator extends PureComponent<{|
     intl: () => null,
   };
 
-  _ = makeGetText(this.context.intl);
-
   render() {
     return (
-      <TranslationContext.Provider value={this._}>
+      <TranslationContext.Provider value={makeGetText(this.context.intl)}>
         {this.props.children}
       </TranslationContext.Provider>
     );
@@ -84,21 +110,7 @@ class TranslationProvider extends PureComponent<Props> {
     const { locale, children } = this.props;
 
     return (
-      /* `IntlProvider` uses React's "legacy context API", deprecated since
-       * React 16.3, of which the docs say:
-       *
-       *   ## Updating Context
-       *
-       *   Don't do it.
-       *
-       *   React has an API to update context, but it is fundamentally
-       *   broken and you should not use it.
-       *
-       * To work around that, we set `key={locale}` to force the whole tree
-       * to rerender if the locale changes.  Not cheap, but the locale
-       * changing is rare.
-       */
-      <IntlProvider key={locale} locale={locale} textComponent={Text} messages={messages[locale]}>
+      <IntlProvider locale={locale} textComponent={Text} messages={messages[locale]}>
         <TranslationContextTranslator>{children}</TranslationContextTranslator>
       </IntlProvider>
     );

--- a/src/chat/ChatScreen.js
+++ b/src/chat/ChatScreen.js
@@ -5,7 +5,7 @@ import type { NavigationScreenProp } from 'react-navigation';
 import { ActionSheetProvider } from '@expo/react-native-action-sheet';
 
 import { connect } from '../react-redux';
-import type { ThemeColors } from '../styles';
+import type { ThemeData } from '../styles';
 import styles, { ThemeContext } from '../styles';
 import type { Dispatch, Fetching, Narrow, EditMessage } from '../types';
 import { KeyboardAvoider, OfflineNotice, ZulipStatusBar } from '../common';
@@ -39,7 +39,7 @@ type State = {|
 
 class ChatScreen extends PureComponent<Props, State> {
   static contextType = ThemeContext;
-  context: ThemeColors;
+  context: ThemeData;
 
   state = {
     editMessage: null,

--- a/src/common/Input.js
+++ b/src/common/Input.js
@@ -4,7 +4,7 @@ import { TextInput, Platform } from 'react-native';
 import { FormattedMessage } from 'react-intl';
 
 import type { LocalizableText } from '../types';
-import type { ThemeColors } from '../styles';
+import type { ThemeData } from '../styles';
 import { ThemeContext, HALF_COLOR, BORDER_COLOR } from '../styles';
 
 export type Props = $ReadOnly<{|
@@ -34,7 +34,7 @@ type State = {|
  */
 export default class Input extends PureComponent<Props, State> {
   static contextType = ThemeContext;
-  context: ThemeColors;
+  context: ThemeData;
 
   styles = {
     input: {

--- a/src/common/Label.js
+++ b/src/common/Label.js
@@ -3,7 +3,7 @@ import React, { PureComponent } from 'react';
 import { Text } from 'react-native';
 import TranslatedText from './TranslatedText';
 
-import type { ThemeColors } from '../styles';
+import type { ThemeData } from '../styles';
 import { ThemeContext } from '../styles';
 import type { LocalizableText } from '../types';
 
@@ -26,7 +26,7 @@ type Props = $ReadOnly<{|
  */
 export default class Label extends PureComponent<Props> {
   static contextType = ThemeContext;
-  context: ThemeColors;
+  context: ThemeData;
 
   styles = {
     label: {

--- a/src/common/LineSeparator.js
+++ b/src/common/LineSeparator.js
@@ -2,12 +2,12 @@
 import React, { PureComponent } from 'react';
 import { View } from 'react-native';
 
-import type { ThemeColors } from '../styles';
+import type { ThemeData } from '../styles';
 import { ThemeContext } from '../styles';
 
 export default class LineSeparator extends PureComponent<{||}> {
   static contextType = ThemeContext;
-  context: ThemeColors;
+  context: ThemeData;
 
   styles = {
     lineSeparator: {

--- a/src/common/LoadingBanner.js
+++ b/src/common/LoadingBanner.js
@@ -7,7 +7,7 @@ import type { Dispatch } from '../types';
 import { connect } from '../react-redux';
 import { getLoading } from '../selectors';
 import { Label, LoadingIndicator } from '.';
-import type { ThemeColors } from '../styles';
+import type { ThemeData } from '../styles';
 import { ThemeContext } from '../styles';
 
 const key = 'LoadingBanner';
@@ -40,7 +40,7 @@ type Props = $ReadOnly<{|
  */
 class LoadingBanner extends PureComponent<Props> {
   static contextType = ThemeContext;
-  context: ThemeColors;
+  context: ThemeData;
 
   render() {
     if (!this.props.loading) {

--- a/src/common/OptionButton.js
+++ b/src/common/OptionButton.js
@@ -6,7 +6,7 @@ import Label from './Label';
 import Touchable from './Touchable';
 import { IconRight } from './Icons';
 import type { SpecificIconType } from './Icons';
-import type { ThemeColors } from '../styles';
+import type { ThemeData } from '../styles';
 import styles, { ThemeContext } from '../styles';
 
 type Props = $ReadOnly<{|
@@ -17,7 +17,7 @@ type Props = $ReadOnly<{|
 
 export default class OptionButton extends PureComponent<Props> {
   static contextType = ThemeContext;
-  context: ThemeColors;
+  context: ThemeData;
 
   styles = {
     icon: styles.settingsIcon,

--- a/src/common/OptionDivider.js
+++ b/src/common/OptionDivider.js
@@ -2,12 +2,12 @@
 import React, { PureComponent } from 'react';
 import { View } from 'react-native';
 
-import type { ThemeColors } from '../styles';
+import type { ThemeData } from '../styles';
 import { ThemeContext } from '../styles';
 
 export default class OptionDivider extends PureComponent<{||}> {
   static contextType = ThemeContext;
-  context: ThemeColors;
+  context: ThemeData;
 
   styles = {
     divider: {

--- a/src/common/OptionRow.js
+++ b/src/common/OptionRow.js
@@ -6,7 +6,7 @@ import type { ViewStyleProp } from 'react-native/Libraries/StyleSheet/StyleSheet
 import type { SpecificIconType } from './Icons';
 import Label from './Label';
 import ZulipSwitch from './ZulipSwitch';
-import type { ThemeColors } from '../styles';
+import type { ThemeData } from '../styles';
 import styles, { ThemeContext } from '../styles';
 
 type Props = $ReadOnly<{|
@@ -19,7 +19,7 @@ type Props = $ReadOnly<{|
 
 export default class OptionRow extends PureComponent<Props> {
   static contextType = ThemeContext;
-  context: ThemeColors;
+  context: ThemeData;
 
   styles = {
     icon: styles.settingsIcon,

--- a/src/common/Popup.js
+++ b/src/common/Popup.js
@@ -3,7 +3,7 @@ import React, { PureComponent } from 'react';
 import type { Node as React$Node } from 'react';
 import { View, StyleSheet } from 'react-native';
 
-import type { ThemeColors } from '../styles';
+import type { ThemeData } from '../styles';
 import { ThemeContext } from '../styles';
 
 const styles = StyleSheet.create({
@@ -24,7 +24,7 @@ type Props = $ReadOnly<{|
 
 export default class Popup extends PureComponent<Props> {
   static contextType = ThemeContext;
-  context: ThemeColors;
+  context: ThemeData;
 
   render() {
     return (

--- a/src/common/RawLabel.js
+++ b/src/common/RawLabel.js
@@ -2,7 +2,7 @@
 import React, { PureComponent } from 'react';
 import { Text } from 'react-native';
 
-import type { ThemeColors } from '../styles';
+import type { ThemeData } from '../styles';
 import { ThemeContext } from '../styles';
 
 type Props = $ReadOnly<{|
@@ -23,7 +23,7 @@ type Props = $ReadOnly<{|
  */
 export default class RawLabel extends PureComponent<Props> {
   static contextType = ThemeContext;
-  context: ThemeColors;
+  context: ThemeData;
 
   styles = {
     label: {

--- a/src/common/Screen.js
+++ b/src/common/Screen.js
@@ -5,7 +5,7 @@ import type { Node as React$Node } from 'react';
 import { StyleSheet, View, ScrollView } from 'react-native';
 import type { ViewStyleProp } from 'react-native/Libraries/StyleSheet/StyleSheet';
 
-import type { ThemeColors } from '../styles';
+import type { ThemeData } from '../styles';
 import styles, { ThemeContext } from '../styles';
 import type { Dimensions, LocalizableText, Dispatch } from '../types';
 import { connect } from '../react-redux';
@@ -78,7 +78,7 @@ type Props = $ReadOnly<{|
  */
 class Screen extends PureComponent<Props> {
   static contextType = ThemeContext;
-  context: ThemeColors;
+  context: ThemeData;
 
   static defaultProps = {
     centerContent: false,

--- a/src/common/SectionHeader.js
+++ b/src/common/SectionHeader.js
@@ -2,7 +2,7 @@
 import React, { PureComponent } from 'react';
 import { StyleSheet, View } from 'react-native';
 
-import type { ThemeColors } from '../styles';
+import type { ThemeData } from '../styles';
 import { ThemeContext } from '../styles';
 import Label from './Label';
 
@@ -19,7 +19,7 @@ type Props = $ReadOnly<{|
 
 export default class SectionHeader extends PureComponent<Props> {
   static contextType = ThemeContext;
-  context: ThemeColors;
+  context: ThemeData;
 
   render() {
     const { text } = this.props;

--- a/src/common/SmartUrlInput.js
+++ b/src/common/SmartUrlInput.js
@@ -4,7 +4,7 @@ import { StyleSheet, TextInput, TouchableWithoutFeedback, View } from 'react-nat
 import type { ViewStyleProp } from 'react-native/Libraries/StyleSheet/StyleSheet';
 import type { NavigationEventSubscription, NavigationScreenProp } from 'react-navigation';
 
-import type { ThemeColors } from '../styles';
+import type { ThemeData } from '../styles';
 import { ThemeContext } from '../styles';
 import { autocompleteRealmPieces, autocompleteRealm, fixRealmUrl } from '../utils/url';
 import type { Protocol } from '../utils/url';
@@ -62,7 +62,7 @@ type State = {|
 
 export default class SmartUrlInput extends PureComponent<Props, State> {
   static contextType = ThemeContext;
-  context: ThemeColors;
+  context: ThemeData;
   state = {
     value: '',
   };

--- a/src/compose/ComposeBox.js
+++ b/src/compose/ComposeBox.js
@@ -4,7 +4,7 @@ import { Platform, View, TextInput, findNodeHandle } from 'react-native';
 import type { LayoutEvent } from 'react-native/Libraries/Types/CoreEventTypes';
 import TextInputReset from 'react-native-text-input-reset';
 
-import type { ThemeColors } from '../styles';
+import type { ThemeData } from '../styles';
 import { ThemeContext } from '../styles';
 import type {
   Auth,
@@ -104,7 +104,7 @@ export const updateTextInput = (textInput: ?TextInput, text: string): void => {
 
 class ComposeBox extends PureComponent<Props, State> {
   static contextType = ThemeContext;
-  context: ThemeColors;
+  context: ThemeData;
 
   messageInput: ?TextInput = null;
   topicInput: ?TextInput = null;

--- a/src/main/MainScreenWithTabs.js
+++ b/src/main/MainScreenWithTabs.js
@@ -2,14 +2,14 @@
 import React, { PureComponent } from 'react';
 import { View } from 'react-native';
 
-import type { ThemeColors } from '../styles';
+import type { ThemeData } from '../styles';
 import styles, { ThemeContext } from '../styles';
 import { OfflineNotice, ZulipStatusBar } from '../common';
 import MainTabs from './MainTabs';
 
 export default class MainScreenWithTabs extends PureComponent<{||}> {
   static contextType = ThemeContext;
-  context: ThemeColors;
+  context: ThemeData;
 
   render() {
     return (

--- a/src/nav/ModalNavBar.js
+++ b/src/nav/ModalNavBar.js
@@ -4,7 +4,7 @@ import React, { PureComponent } from 'react';
 import { View } from 'react-native';
 
 import type { Dispatch, LocalizableText } from '../types';
-import type { ThemeColors } from '../styles';
+import type { ThemeData } from '../styles';
 import styles, { ThemeContext, NAVBAR_SIZE } from '../styles';
 import { connect } from '../react-redux';
 
@@ -20,7 +20,7 @@ type Props = $ReadOnly<{|
 
 class ModalNavBar extends PureComponent<Props> {
   static contextType = ThemeContext;
-  context: ThemeColors;
+  context: ThemeData;
 
   render() {
     const { dispatch, canGoBack, title } = this.props;

--- a/src/nav/ModalSearchNavBar.js
+++ b/src/nav/ModalSearchNavBar.js
@@ -3,7 +3,7 @@ import React, { PureComponent } from 'react';
 import { View } from 'react-native';
 
 import type { Dispatch } from '../types';
-import type { ThemeColors } from '../styles';
+import type { ThemeData } from '../styles';
 import { ThemeContext, NAVBAR_SIZE } from '../styles';
 import { connect } from '../react-redux';
 import SearchInput from '../common/SearchInput';
@@ -19,7 +19,7 @@ type Props = $ReadOnly<{|
 
 class ModalSearchNavBar extends PureComponent<Props> {
   static contextType = ThemeContext;
-  context: ThemeColors;
+  context: ThemeData;
 
   static defaultProps = {
     canGoBack: true,

--- a/src/pm-conversations/PmConversationsCard.js
+++ b/src/pm-conversations/PmConversationsCard.js
@@ -3,7 +3,7 @@
 import React, { PureComponent } from 'react';
 import { View, StyleSheet } from 'react-native';
 
-import type { ThemeColors } from '../styles';
+import type { ThemeData } from '../styles';
 import { ThemeContext } from '../styles';
 import type { Dispatch, PmConversationData, UserOrBot } from '../types';
 import { connect } from '../react-redux';
@@ -43,7 +43,7 @@ type Props = $ReadOnly<{|
  * */
 class PmConversationsCard extends PureComponent<Props> {
   static contextType = ThemeContext;
-  context: ThemeColors;
+  context: ThemeData;
 
   render() {
     const { dispatch, conversations, usersByEmail } = this.props;

--- a/src/reduxTypes.js
+++ b/src/reduxTypes.js
@@ -254,6 +254,9 @@ export type RealmState = {|
   isAdmin: boolean,
 |};
 
+// TODO: Stop using the 'default' name. Any 'default' semantics should
+// only apply the device level, not within the app. See
+// https://github.com/zulip/zulip-mobile/issues/4009#issuecomment-619280681.
 export type ThemeName = 'default' | 'night';
 
 export type SettingsState = {|

--- a/src/streams/StreamItem.js
+++ b/src/streams/StreamItem.js
@@ -2,7 +2,7 @@
 import React, { PureComponent } from 'react';
 import { StyleSheet, View } from 'react-native';
 
-import type { ThemeColors } from '../styles';
+import type { ThemeData } from '../styles';
 import styles, { ThemeContext } from '../styles';
 import { RawLabel, Touchable, UnreadCount, ZulipSwitch } from '../common';
 import { foregroundColorFromBackground } from '../utils/color';
@@ -61,7 +61,7 @@ type Props = $ReadOnly<{|
  */
 export default class StreamItem extends PureComponent<Props> {
   static contextType = ThemeContext;
-  context: ThemeColors;
+  context: ThemeData;
 
   static defaultProps = {
     isMuted: false,

--- a/src/styles/index.js
+++ b/src/styles/index.js
@@ -7,7 +7,7 @@ import { statics as navStyles } from './navStyles';
 import utilityStyles from './utilityStyles';
 
 export * from './constants';
-export type { ThemeColors } from './theme';
+export type { ThemeData } from './theme';
 export { ThemeContext } from './theme';
 
 export default StyleSheet.create({

--- a/src/styles/theme.js
+++ b/src/styles/theme.js
@@ -2,6 +2,8 @@
 import React from 'react';
 import type { Context } from 'react';
 
+import type { ThemeName } from '../reduxTypes';
+
 export type ThemeColors = {|
   color: string,
   backgroundColor: string,
@@ -9,7 +11,7 @@ export type ThemeColors = {|
   dividerColor: string,
 |};
 
-export const themeColors: { [string]: ThemeColors } = {
+export const themeColors: { [name: ThemeName | 'light']: ThemeColors } = {
   night: {
     color: 'hsl(210, 11%, 85%)',
     backgroundColor: 'hsl(212, 28%, 18%)',

--- a/src/styles/theme.js
+++ b/src/styles/theme.js
@@ -4,14 +4,14 @@ import type { Context } from 'react';
 
 import type { ThemeName } from '../reduxTypes';
 
-export type ThemeColors = {|
+export type ThemeData = {|
   color: string,
   backgroundColor: string,
   cardColor: string,
   dividerColor: string,
 |};
 
-export const themeColors: { [name: ThemeName | 'light']: ThemeColors } = {
+export const themeData: { [name: ThemeName | 'light']: ThemeData } = {
   night: {
     color: 'hsl(210, 11%, 85%)',
     backgroundColor: 'hsl(212, 28%, 18%)',
@@ -29,6 +29,6 @@ export const themeColors: { [name: ThemeName | 'light']: ThemeColors } = {
     dividerColor: 'hsla(0, 0%, 0%, 0.12)',
   },
 };
-themeColors.default = themeColors.light;
+themeData.default = themeData.light;
 
-export const ThemeContext: Context<ThemeColors> = React.createContext(themeColors.default);
+export const ThemeContext: Context<ThemeData> = React.createContext(themeData.default);

--- a/src/styles/theme.js
+++ b/src/styles/theme.js
@@ -1,9 +1,6 @@
 /* @flow strict-local */
 import React from 'react';
 import type { Context } from 'react';
-import { StyleSheet } from 'react-native';
-
-import type { ThemeName } from '../types';
 
 export type ThemeColors = {|
   color: string,
@@ -11,8 +8,6 @@ export type ThemeColors = {|
   cardColor: string,
   dividerColor: string,
 |};
-
-export type AppStyles = $ReadOnly<{||}>;
 
 export const themeColors: { [string]: ThemeColors } = {
   night: {
@@ -35,5 +30,3 @@ export const themeColors: { [string]: ThemeColors } = {
 themeColors.default = themeColors.light;
 
 export const ThemeContext: Context<ThemeColors> = React.createContext(themeColors.default);
-
-export const stylesFromTheme = (name: ThemeName) => StyleSheet.create({});

--- a/src/subscriptions/__tests__/subscriptionsReducer-test.js
+++ b/src/subscriptions/__tests__/subscriptionsReducer-test.js
@@ -1,46 +1,48 @@
+/* @flow strict-local */
+
 import deepFreeze from 'deep-freeze';
 
 import { EventTypes } from '../../api/eventTypes';
-import { REALM_INIT, EVENT_SUBSCRIPTION, ACCOUNT_SWITCH, EVENT } from '../../actionConstants';
+import { EVENT_SUBSCRIPTION, ACCOUNT_SWITCH, EVENT } from '../../actionConstants';
 import subscriptionsReducer from '../subscriptionsReducer';
+import * as eg from '../../__tests__/lib/exampleData';
 
 describe('subscriptionsReducer', () => {
+  const stream1 = eg.makeStream({ name: 'stream1', description: 'my first stream' });
+  const sub1 = eg.makeSubscription({ stream: stream1 });
+
+  const stream2 = eg.makeStream({ name: 'stream2', description: 'my second stream' });
+  const sub2 = eg.makeSubscription({ stream: stream2 });
+
+  const stream3 = eg.makeStream({ name: 'stream3', description: 'my third stream' });
+  const sub3 = eg.makeSubscription({ stream: stream3 });
+
   describe('REALM_INIT', () => {
     test('when `subscriptions` data is provided init state with it', () => {
       const initialState = deepFreeze([]);
+
       const action = deepFreeze({
-        type: REALM_INIT,
+        ...eg.action.realm_init,
         data: {
-          subscriptions: [
-            {
-              name: 'some stream',
-              stream_id: 1,
-            },
-          ],
+          ...eg.action.realm_init.data,
+          subscriptions: [sub1],
         },
       });
 
       const actualState = subscriptionsReducer(initialState, action);
 
-      expect(actualState).toEqual([
-        {
-          name: 'some stream',
-          stream_id: 1,
-        },
-      ]);
+      expect(actualState).toEqual([sub1]);
     });
 
     test('when `subscriptions` is an empty array, reset state', () => {
-      const initialState = deepFreeze([
-        {
-          name: 'some stream',
-          stream_id: 1,
-        },
-      ]);
+      const initialState = deepFreeze([sub1]);
 
       const action = deepFreeze({
-        type: REALM_INIT,
-        data: { subscriptions: [] },
+        ...eg.action.realm_init,
+        data: {
+          ...eg.action.realm_init.data,
+          subscriptions: [],
+        },
       });
 
       const expectedState = [];
@@ -51,13 +53,6 @@ describe('subscriptionsReducer', () => {
     });
   });
 
-  test('on unrecognized action, returns input state unchanged', () => {
-    const prevState = deepFreeze({ hello: 'world' });
-
-    const newState = subscriptionsReducer(prevState, {});
-    expect(newState).toEqual(prevState);
-  });
-
   describe('EVENT_SUBSCRIPTION -> add', () => {
     test('if new subscriptions do not exist in state, add them', () => {
       const prevState = deepFreeze([]);
@@ -65,28 +60,11 @@ describe('subscriptionsReducer', () => {
       const action = deepFreeze({
         type: EVENT_SUBSCRIPTION,
         op: 'add',
-        subscriptions: [
-          {
-            name: 'some stream',
-            stream_id: 1,
-          },
-          {
-            name: 'some other stream',
-            stream_id: 2,
-          },
-        ],
+        id: 1,
+        subscriptions: [sub1, sub2],
       });
 
-      const expectedState = [
-        {
-          name: 'some stream',
-          stream_id: 1,
-        },
-        {
-          name: 'some other stream',
-          stream_id: 2,
-        },
-      ];
+      const expectedState = [sub1, sub2];
 
       const newState = subscriptionsReducer(prevState, action);
 
@@ -94,41 +72,16 @@ describe('subscriptionsReducer', () => {
     });
 
     test('if some of subscriptions already exist, do not add them', () => {
-      const prevState = deepFreeze([
-        {
-          color: 'red',
-          stream_id: 1,
-          name: 'some stream',
-        },
-      ]);
+      const prevState = deepFreeze([sub1]);
 
       const action = deepFreeze({
         type: EVENT_SUBSCRIPTION,
         op: 'add',
-        subscriptions: [
-          {
-            name: 'some stream',
-            color: 'red',
-            stream_id: 1,
-          },
-          {
-            name: 'some other stream',
-            stream_id: 2,
-          },
-        ],
+        id: 1,
+        subscriptions: [sub1, sub2],
       });
 
-      const expectedState = [
-        {
-          color: 'red',
-          name: 'some stream',
-          stream_id: 1,
-        },
-        {
-          name: 'some other stream',
-          stream_id: 2,
-        },
-      ];
+      const expectedState = [sub1, sub2];
 
       const newState = subscriptionsReducer(prevState, action);
 
@@ -138,46 +91,16 @@ describe('subscriptionsReducer', () => {
 
   describe('EVENT_SUBSCRIPTION -> remove', () => {
     test('removes subscriptions from state', () => {
-      const prevState = deepFreeze([
-        {
-          color: 'red',
-          stream_id: 1,
-          name: 'some stream',
-        },
-        {
-          color: 'green',
-          stream_id: 2,
-          name: 'other stream',
-        },
-        {
-          color: 'blue',
-          stream_id: 3,
-          name: 'third stream',
-        },
-      ]);
+      const prevState = deepFreeze([sub1, sub2, sub3]);
 
       const action = deepFreeze({
         type: EVENT_SUBSCRIPTION,
         op: 'remove',
-        subscriptions: [
-          {
-            name: 'some stream',
-            stream_id: 1,
-          },
-          {
-            name: 'some other stream',
-            stream_id: 2,
-          },
-        ],
+        id: 1,
+        subscriptions: [sub1, sub2],
       });
 
-      const expectedState = [
-        {
-          color: 'blue',
-          stream_id: 3,
-          name: 'third stream',
-        },
-      ];
+      const expectedState = [sub3];
 
       const newState = subscriptionsReducer(prevState, action);
 
@@ -185,26 +108,13 @@ describe('subscriptionsReducer', () => {
     });
 
     test('removes subscriptions that exist, do nothing if not', () => {
-      const prevState = deepFreeze([
-        {
-          name: 'some stream',
-          stream_id: 1,
-        },
-      ]);
+      const prevState = deepFreeze([sub1]);
 
       const action = deepFreeze({
         type: EVENT_SUBSCRIPTION,
         op: 'remove',
-        subscriptions: [
-          {
-            name: 'some stream',
-            stream_id: 1,
-          },
-          {
-            name: 'some other stream',
-            stream_id: 2,
-          },
-        ],
+        id: 1,
+        subscriptions: [sub1, sub2],
       });
 
       const expectedState = [];
@@ -217,54 +127,28 @@ describe('subscriptionsReducer', () => {
 
   describe('EVENT_SUBSCRIPTION -> update', () => {
     test('Change the in_home_view property', () => {
-      const initialState = deepFreeze([
-        {
-          stream_id: 123,
-          name: 'competition',
-          in_home_view: false,
-        },
-        {
-          stream_id: 67,
-          name: 'design',
-          in_home_view: false,
-        },
-        {
-          stream_id: 53,
-          name: 'mobile',
-          in_home_view: true,
-        },
-      ]);
+      const subNotInHomeView = deepFreeze({
+        ...eg.makeSubscription({
+          stream: stream1,
+        }),
+        in_home_view: false,
+      });
+
+      const initialState = deepFreeze([subNotInHomeView, sub2, sub3]);
 
       const action = deepFreeze({
-        stream_id: 123,
         type: EVENT_SUBSCRIPTION,
         op: 'update',
-        eventId: 2,
         id: 2,
-        name: 'competition',
+        email: subNotInHomeView.email_address,
+        stream_id: subNotInHomeView.stream_id,
+        name: subNotInHomeView.name,
         property: 'in_home_view',
         value: true,
       });
 
-      const expectedState = [
-        {
-          stream_id: 123,
-          name: 'competition',
-          in_home_view: true,
-        },
-        {
-          stream_id: 67,
-          name: 'design',
-          in_home_view: false,
-        },
-        {
-          stream_id: 53,
-          name: 'mobile',
-          in_home_view: true,
-        },
-      ];
-
       const actualState = subscriptionsReducer(initialState, action);
+      const expectedState = [{ ...subNotInHomeView, in_home_view: true }, sub2, sub3];
 
       expect(actualState).toEqual(expectedState);
     });
@@ -272,23 +156,14 @@ describe('subscriptionsReducer', () => {
 
   describe('EVENT_STREAM -> delete', () => {
     test('when a stream is delrted but user is not subscribed to it, do not change state', () => {
-      const initialState = deepFreeze([
-        {
-          stream_id: 3,
-          name: 'not subscribed to stream',
-        },
-      ]);
+      const initialState = deepFreeze([sub3]);
       const action = deepFreeze({
         type: EVENT,
         event: {
           type: EventTypes.stream,
+          id: 1,
           op: 'delete',
-          streams: [
-            {
-              name: 'some stream',
-              stream_id: 1,
-            },
-          ],
+          streams: [stream1],
         },
       });
 
@@ -298,27 +173,14 @@ describe('subscriptionsReducer', () => {
     });
 
     test('when a stream is deleted the user is unsubscribed', () => {
-      const initialState = deepFreeze([
-        {
-          stream_id: 1,
-          name: 'some stream',
-        },
-      ]);
+      const initialState = deepFreeze([sub1]);
       const action = deepFreeze({
         type: EVENT,
         event: {
           type: EventTypes.stream,
+          id: 1,
           op: 'delete',
-          streams: [
-            {
-              name: 'some stream',
-              stream_id: 1,
-            },
-            {
-              name: 'some other stream',
-              stream_id: 2,
-            },
-          ],
+          streams: [stream1, stream2],
         },
       });
       const expectedState = [];
@@ -329,31 +191,14 @@ describe('subscriptionsReducer', () => {
     });
 
     test('when multiple streams are deleted the user is unsubscribed from all of them', () => {
-      const initialState = deepFreeze([
-        {
-          stream_id: 1,
-          name: 'some stream',
-        },
-        {
-          name: 'some other stream',
-          stream_id: 2,
-        },
-      ]);
+      const initialState = deepFreeze([sub1, sub2]);
       const action = deepFreeze({
         type: EVENT,
         event: {
           type: EventTypes.stream,
+          id: 1,
           op: 'delete',
-          streams: [
-            {
-              name: 'some stream',
-              stream_id: 1,
-            },
-            {
-              name: 'some other stream',
-              stream_id: 2,
-            },
-          ],
+          streams: [stream1, stream2],
         },
       });
       const expectedState = [];
@@ -366,10 +211,11 @@ describe('subscriptionsReducer', () => {
 
   describe('ACCOUNT_SWITCH', () => {
     test('resets state to initial state', () => {
-      const initialState = deepFreeze(['some_stream']);
+      const initialState = deepFreeze([sub1]);
 
       const action = deepFreeze({
         type: ACCOUNT_SWITCH,
+        index: 2,
       });
 
       const expectedState = [];

--- a/src/subscriptions/__tests__/subscriptionsReducer-test.js
+++ b/src/subscriptions/__tests__/subscriptionsReducer-test.js
@@ -108,6 +108,7 @@ describe('subscriptionsReducer', () => {
         subscriptions: [
           {
             name: 'some stream',
+            color: 'red',
             stream_id: 1,
           },
           {

--- a/src/types.js
+++ b/src/types.js
@@ -3,7 +3,6 @@ import type { IntlShape } from 'react-intl';
 import type { DangerouslyImpreciseStyleProp } from 'react-native/Libraries/StyleSheet/StyleSheet';
 
 import type { Auth, Topic, Message, Reaction, ReactionType, Narrow } from './api/apiTypes';
-import type { AppStyles } from './styles/theme';
 import type { ZulipVersion } from './utils/zulipVersion';
 
 export type * from './reduxTypes';
@@ -145,10 +144,6 @@ export type TopicExtended = {|
   ...$Exact<Topic>,
   isMuted: boolean,
   unreadCount: number,
-|};
-
-export type Context = {|
-  styles: AppStyles,
 |};
 
 /**

--- a/src/user-groups/UserGroupItem.js
+++ b/src/user-groups/UserGroupItem.js
@@ -5,7 +5,7 @@ import { StyleSheet, View } from 'react-native';
 import { IconPeople } from '../common/Icons';
 import { RawLabel, Touchable } from '../common';
 import styles, { ThemeContext } from '../styles';
-import type { ThemeColors } from '../styles';
+import type { ThemeData } from '../styles';
 
 const componentStyles = StyleSheet.create({
   text: {
@@ -28,7 +28,7 @@ type Props = $ReadOnly<{|
 
 export default class UserGroupItem extends PureComponent<Props> {
   static contextType = ThemeContext;
-  context: ThemeColors;
+  context: ThemeData;
 
   handlePress = () => {
     const { name, onPress } = this.props;

--- a/src/webview/MessageList.js
+++ b/src/webview/MessageList.js
@@ -25,7 +25,7 @@ import type {
   UserOrBot,
   EditMessage,
 } from '../types';
-import type { ThemeColors } from '../styles';
+import type { ThemeData } from '../styles';
 import { ThemeContext } from '../styles';
 import { connect } from '../react-redux';
 import {
@@ -144,7 +144,7 @@ const webviewAssetsUrl = new URL('webview/', assetsUrl);
 
 class MessageList extends Component<Props> {
   static contextType = ThemeContext;
-  context: ThemeColors;
+  context: ThemeData;
 
   webview: ?WebView;
   readyRetryInterval: IntervalID | void;


### PR DESCRIPTION
Fixes: #1946 
Fixes: #3994

A continuation of https://github.com/zulip/zulip-mobile/pull/4046, which has gotten cluttered with several unrelated conversations (sorry!). The work being done here isn't as complicated as the length of those conversations might suggest.

Greg has already merged several commits from that older PR, as he lists at https://github.com/zulip/zulip-mobile/pull/4046#issuecomment-622204993:

> I've gone and merged 10 of these commits, along with a small added commit at the end:
> f9caf224c SmartUrlInput: Switch to new React Context API for theme colors.
> a197c9916 StreamItem: Switch to new React Context API for theme colors.
> 64e142226 miscStyles [nfc]: Remove unused `color` in `miscStyles`.
> ecba735a7 StreamItem [nfc]: Readability refactor (no need to repeat object literals).
> aa4f3ad6b StreamItem [nfc]: Refactor textColor to look more like iconColor above it.
> be26c744b StreamItem [nfc]: Remove `isSelected` prop that is never passed.
> 452edbc5e StreamItem: Confirm '' cases are irrelevant, remove check, add JSDoc.
> 2a4d9ee98 StreamAutocomplete [nfc]: Rename `streams` to `matchingSubscriptions`.
> 67be6ac43 subscriptions reducer test: Test for `subscriptions` being empty array.
> 3faf5a4a7 subs reducer: Remove needless check for void `subscriptions` in REALM_INIT.
> 29c22e029 StreamItem [nfc]: Reorder props for logical grouping.
> 
> [...]
> 
> Still reviewing the rest, but this will help move things forward and also reduce the work of future rebases and reviews :slightly_smiling_face: 
