### PR TITLE
compose box: Show error on sending message when not caught up.

### DIFF
--- a/src/compose/ComposeBox.js
+++ b/src/compose/ComposeBox.js
@@ -265,7 +265,7 @@ class ComposeBox extends PureComponent<Props, State> {
   };
 
   handleEdit = () => {
-    const { auth, editMessage, completeEditMessage } = this.props;
+    const { auth, editMessage, completeEditMessage, _ } = this.props;
     if (!editMessage) {
       throw new Error('expected editMessage');
     }
@@ -274,7 +274,7 @@ class ComposeBox extends PureComponent<Props, State> {
     const subject = topic !== editMessage.topic ? topic : undefined;
     if ((content !== undefined && content !== '') || (subject !== undefined && subject !== '')) {
       api.updateMessage(auth, { content, subject }, editMessage.id).catch(error => {
-        showErrorAlert(error.message, 'Failed to edit message');
+        showErrorAlert(error.message, _('Failed to edit message'));
       });
     }
     completeEditMessage();

--- a/src/compose/ComposeBox.js
+++ b/src/compose/ComposeBox.js
@@ -254,7 +254,7 @@ class ComposeBox extends PureComponent<Props, State> {
     const { message } = this.state;
 
     if (!caughtUp.newer) {
-      showErrorAlert(undefined, _('Failed to send message'));
+      showErrorAlert(_('Failed to send message'));
       return;
     }
 
@@ -274,7 +274,7 @@ class ComposeBox extends PureComponent<Props, State> {
     const subject = topic !== editMessage.topic ? topic : undefined;
     if ((content !== undefined && content !== '') || (subject !== undefined && subject !== '')) {
       api.updateMessage(auth, { content, subject }, editMessage.id).catch(error => {
-        showErrorAlert(error.message, _('Failed to edit message'));
+        showErrorAlert(_('Failed to edit message'), error.message);
       });
     }
     completeEditMessage();

--- a/src/compose/ComposeBox.js
+++ b/src/compose/ComposeBox.js
@@ -254,7 +254,7 @@ class ComposeBox extends PureComponent<Props, State> {
     const { message } = this.state;
 
     if (!caughtUp.newer) {
-      showErrorAlert(_('Please try again after some time'), _('Failed to send message'));
+      showErrorAlert(undefined, _('Failed to send message'));
       return;
     }
 

--- a/src/compose/ComposeMenu.js
+++ b/src/compose/ComposeMenu.js
@@ -83,7 +83,7 @@ class ComposeMenu extends PureComponent<Props> {
     // $FlowFixMe sketchy falsiness check, because upstream API is unclear
     const error: string | null = response.error || null;
     if (error !== null) {
-      showErrorAlert(error, 'Error');
+      showErrorAlert('Error', error);
       return;
     }
 
@@ -127,7 +127,7 @@ class ComposeMenu extends PureComponent<Props> {
       }): DocumentPickerResponse);
     } catch (e) {
       if (!DocumentPicker.isCancel(e)) {
-        showErrorAlert(e, 'Error');
+        showErrorAlert('Error', e);
       }
       return;
     }

--- a/src/utils/info.js
+++ b/src/utils/info.js
@@ -6,5 +6,5 @@ export const showToast = (message: string) => {
   Toast.show(message);
 };
 
-export const showErrorAlert = (message?: string, title: string) =>
+export const showErrorAlert = (title: string, message?: string) =>
   Alert.alert(title, message, [{ text: 'OK', onPress: () => {} }], { cancelable: true });

--- a/src/utils/info.js
+++ b/src/utils/info.js
@@ -6,5 +6,5 @@ export const showToast = (message: string) => {
   Toast.show(message);
 };
 
-export const showErrorAlert = (message: string, title: string) =>
+export const showErrorAlert = (message?: string, title: string) =>
   Alert.alert(title, message, [{ text: 'OK', onPress: () => {} }], { cancelable: true });

--- a/static/translations/messages_en.json
+++ b/static/translations/messages_en.json
@@ -213,7 +213,6 @@
   "Narrow": "Narrow",
   "Sending Message...": "Sending Message...",
   "Failed to send message": "Failed to send message",
-  "Please try again after some time": "Please try again after some time",
   "Message sent": "Message sent",
   "What's your status?": "What's your status?",
   "📅 In a meeting": "📅 In a meeting",

--- a/static/translations/messages_en.json
+++ b/static/translations/messages_en.json
@@ -213,6 +213,7 @@
   "Narrow": "Narrow",
   "Sending Message...": "Sending Message...",
   "Failed to send message": "Failed to send message",
+  "Please try again after some time": "Please try again after some time",
   "Message sent": "Message sent",
   "What's your status?": "What's your status?",
   "📅 In a meeting": "📅 In a meeting",


### PR DESCRIPTION
Check if we are caught up in the current narrow, and if so, show an
error when trying to send a message asking the user to try again
after some time.

This prevents the user from possibly responding to a very old
message when the messages after it have not been loaded yet - this
can lead to the reply being out of context without the sender
realizing it.

Fixes: #3800
