### PR TITLE
deps: Upgrade Fresco to recommended version for animated GIFs.

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -236,7 +236,7 @@ dependencies {
         implementation jscFlavor
     }
 
-    implementation 'com.facebook.fresco:animated-gif:1.10.0' // For animated GIF support
+    implementation 'com.facebook.fresco:animated-gif:2.0.0' // For animated GIF support
     implementation 'androidx.browser:browser:1.0.0'
     addUnimodulesDependencies()
 


### PR DESCRIPTION
Upgrades the fresco:animated-gif dependency in 'build.gradle' to
2.0.0 recommended by the official docs [1] to fix animated GIF
support in Android, which was broken after the recent React Native
upgrade.

[1] https://reactnative.dev/docs/0.61/image#gif-and-webp-support-on-android

Fixes: #4212