### PR TITLE
UI tweaks on mention-unsubscribed warning

### DIFF
--- a/src/common/ZulipButton.js
+++ b/src/common/ZulipButton.js
@@ -89,6 +89,7 @@ type Props = $ReadOnly<{|
       paddingRight?: mixed,
       height?: mixed,
       width?: mixed,
+      borderWidth?: mixed,
       borderRadius?: mixed,
       flex?: mixed,
       alignSelf?: mixed,

--- a/src/compose/MentionWarnings.js
+++ b/src/compose/MentionWarnings.js
@@ -10,7 +10,6 @@ import { isPrivateNarrow } from '../utils/narrow';
 import * as api from '../api';
 import { showToast } from '../utils/info';
 
-import AnimatedScaleComponent from '../animation/AnimatedScaleComponent';
 import MentionedUserNotSubscribed from '../message/MentionedUserNotSubscribed';
 
 type State = {|
@@ -162,11 +161,7 @@ class MentionWarnings extends PureComponent<Props, State> {
       );
     }
 
-    return (
-      <AnimatedScaleComponent visible={mentionWarnings.length !== 0}>
-        {mentionWarnings}
-      </AnimatedScaleComponent>
-    );
+    return mentionWarnings;
   }
 }
 

--- a/src/message/MentionedUserNotSubscribed.js
+++ b/src/message/MentionedUserNotSubscribed.js
@@ -34,13 +34,24 @@ const styles = createStyleSheet({
     borderTopWidth: 1,
     borderTopColor: 'orange',
   },
+
   text: {
     flex: 1,
     color: 'black',
   },
+
   button: {
     backgroundColor: 'orange',
-    padding: 6,
+
+    // Based on MarkUnreadButton.
+    // TODO make these less ad hoc.
+    // TODO also make the actual touch target taller, like 48px.
+    //   (Can extend beyond the visual representation of the button itself.)
+    borderWidth: 0,
+    borderRadius: 16,
+    height: 32,
+    paddingLeft: 12,
+    paddingRight: 12,
   },
   buttonText: {
     color: 'black',

--- a/src/message/MentionedUserNotSubscribed.js
+++ b/src/message/MentionedUserNotSubscribed.js
@@ -31,8 +31,6 @@ const styles = createStyleSheet({
     backgroundColor: 'hsl(40, 100%, 60%)', // Material warning-color
     paddingHorizontal: 16,
     paddingVertical: 8,
-    borderTopWidth: 1,
-    borderTopColor: 'orange',
   },
 
   text: {


### PR DESCRIPTION
This follows up on some of the UI points I noted in this comment before merging #4101: https://github.com/zulip/zulip-mobile/pull/4101#issuecomment-669764675

Specifically, going through that comment in order:
- [x] button shape/size in visual appearance -- done here
- [ ] button touch target to 48px (extending beyond visual button) -- still TODO
- [x] no border -- done here
- [ ] background color -- still TODO
- [x] text/background color contrast, for legibility -- done in #4101 before merge
- [x] cut animation -- done here
- [ ] use a nice slide-in animation instead -- still TODO
