### PR TITLE
i18n [nfc]: Add interpolation support to our `_` wrapper.

### DIFF
--- a/src/boot/TranslationProvider.js
+++ b/src/boot/TranslationProvider.js
@@ -38,7 +38,8 @@ export function withGetText<P: { +_: GetText, ... }, C: ComponentType<P>>(
 }
 
 const makeGetText = (intl: IntlShape): GetText => {
-  const _ = value => intl.formatMessage({ id: value });
+  const _ = (message, values) =>
+    intl.formatMessage({ id: message, defaultMessage: message }, values);
   _.intl = intl;
   return _;
 };

--- a/src/compose/MentionWarnings.js
+++ b/src/compose/MentionWarnings.js
@@ -74,13 +74,9 @@ class MentionWarnings extends PureComponent<Props, State> {
   showSubscriptionStatusLoadError = (mentionedUser: UserOrBot) => {
     const _ = this.context;
 
-    const alertTitle = _.intl.formatMessage(
-      {
-        id: "Couldn't load information about {fullName}",
-        defaultMessage: "Couldn't load information about {fullName}",
-      },
-      { fullName: mentionedUser.full_name },
-    );
+    const alertTitle = _("Couldn't load information about {fullName}", {
+      fullName: mentionedUser.full_name,
+    });
     showToast(alertTitle);
   };
 

--- a/src/message/messageActionSheet.js
+++ b/src/message/messageActionSheet.js
@@ -112,13 +112,9 @@ muteTopic.title = 'Mute topic';
 muteTopic.errorMessage = 'Failed to mute topic';
 
 const deleteTopic = async ({ auth, message, dispatch, ownEmail, _ }) => {
-  const alertTitle = _.intl.formatMessage(
-    {
-      id: "Are you sure you want to delete the topic '{topic}'?",
-      defaultMessage: "Are you sure you want to delete the topic '{topic}'?",
-    },
-    { topic: message.subject },
-  );
+  const alertTitle = _("Are you sure you want to delete the topic '{topic}'?", {
+    topic: message.subject,
+  });
   const AsyncAlert = async (): Promise<boolean> =>
     new Promise((resolve, reject) => {
       Alert.alert(

--- a/src/types.js
+++ b/src/types.js
@@ -257,7 +257,7 @@ export type LocalizableText =
  * @prop intl - The full react-intl API, for more complex situations.
  */
 export type GetText = {
-  (string): string,
+  (message: string, values?: { [string]: IntlMessageFormatValue }): string,
   intl: IntlShape,
 };
 

--- a/src/types.js
+++ b/src/types.js
@@ -234,7 +234,12 @@ export type MessageLike =
       ...Outbox,
     }>;
 
-export type LocalizableText = string | { text: string, values?: { [string]: string } };
+// From docs: https://formatjs.io/docs/react-intl/api/#formatmessage
+type IntlMessageFormatValue = string | number | boolean | null | void;
+
+export type LocalizableText =
+  | string
+  | { text: string, values?: { [string]: IntlMessageFormatValue } };
 
 /**
  * Usually called `_`, and invoked like `_('Message')` -> `'Nachricht'`.

--- a/src/webview/webViewEventHandlers.js
+++ b/src/webview/webViewEventHandlers.js
@@ -273,13 +273,9 @@ export const handleMessageListEvent = (props: Props, _: GetText, event: MessageL
     }
 
     case 'time': {
-      const alertText = _.intl.formatMessage(
-        {
-          id: "This time is in your timezone. Original text was '{originalText}'.",
-          defaultMessage: "This time is in your timezone. Original text was '{originalText}'.",
-        },
-        { originalText: event.originalText },
-      );
+      const alertText = _("This time is in your timezone. Original text was '{originalText}'.", {
+        originalText: event.originalText,
+      });
       Alert.alert('', alertText);
       break;
     }


### PR DESCRIPTION
This allows us to stop using the `intl.formatMessage` API in its most extra-verbose form.  (When there are variables to interpolate, both `defaultMessage` and `id` are required, even though for us they're the same thing -- because while react-intl will fall back to `id` as the message when a translation isn't available, it will do so literally, without any interpolation. @agrawal-d pointed this out at https://github.com/zulip/zulip-mobile/pull/4175#discussion_r459261420 .)
