### PR TITLE
StyleSheet.create and other refactors

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -158,6 +158,7 @@ rules:
   - error
   - patterns: ['**/__tests__/**']
   import/no-cycle: off  # This would be nice to fix; but isn't easy.
+  import/export: off  # This is redundant with Flow, and buggy.
 
   # Jest
   # This rule could be useful if it fired only on new instances; but we

--- a/src/account-info/AccountDetails.js
+++ b/src/account-info/AccountDetails.js
@@ -1,8 +1,9 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
-import { View, StyleSheet } from 'react-native';
+import { View } from 'react-native';
 
 import type { UserOrBot, Dispatch } from '../types';
+import styles, { createStyleSheet } from '../styles';
 import { connect } from '../react-redux';
 import { UserAvatar, ComponentList, RawLabel } from '../common';
 import { getCurrentRealm, getUserStatusTextForUser } from '../selectors';
@@ -10,9 +11,8 @@ import PresenceStatusIndicator from '../common/PresenceStatusIndicator';
 import ActivityText from '../title/ActivityText';
 import { getAvatarFromUser } from '../utils/avatar';
 import { nowInTimeZone } from '../utils/date';
-import styles from '../styles';
 
-const componentStyles = StyleSheet.create({
+const componentStyles = createStyleSheet({
   componentListItem: {
     alignItems: 'center',
   },

--- a/src/account-info/AccountDetailsScreen.js
+++ b/src/account-info/AccountDetailsScreen.js
@@ -1,9 +1,9 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
-import { StyleSheet } from 'react-native';
 
 import type { NavigationScreenProp } from 'react-navigation';
 import type { Dispatch, UserOrBot } from '../types';
+import { createStyleSheet } from '../styles';
 import { connect } from '../react-redux';
 import { Screen, ZulipButton, Label } from '../common';
 import { IconPrivateChat } from '../common/Icons';
@@ -12,7 +12,7 @@ import AccountDetails from './AccountDetails';
 import { doNarrow } from '../actions';
 import { getUserIsActive, getUserForId } from '../users/userSelectors';
 
-const styles = StyleSheet.create({
+const styles = createStyleSheet({
   pmButton: {
     marginHorizontal: 16,
   },

--- a/src/account-info/ProfileCard.js
+++ b/src/account-info/ProfileCard.js
@@ -1,8 +1,9 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
-import { ScrollView, StyleSheet, View } from 'react-native';
+import { ScrollView, View } from 'react-native';
 
 import type { Dispatch, User } from '../types';
+import { createStyleSheet } from '../styles';
 import { connect } from '../react-redux';
 import { getSelfUserDetail } from '../selectors';
 import { ZulipButton } from '../common';
@@ -15,7 +16,7 @@ import {
 import AccountDetails from './AccountDetails';
 import AwayStatusSwitch from './AwayStatusSwitch';
 
-const styles = StyleSheet.create({
+const styles = createStyleSheet({
   buttonRow: {
     flexDirection: 'row',
     marginHorizontal: 8,

--- a/src/account/AccountItem.js
+++ b/src/account/AccountItem.js
@@ -1,12 +1,12 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { View } from 'react-native';
 
-import { BRAND_COLOR } from '../styles';
+import { BRAND_COLOR, createStyleSheet } from '../styles';
 import { RawLabel, Touchable } from '../common';
 import { IconDone, IconTrash } from '../common/Icons';
 
-const styles = StyleSheet.create({
+const styles = createStyleSheet({
   wrapper: {
     justifyContent: 'space-between',
   },

--- a/src/autocomplete/TopicAutocomplete.js
+++ b/src/autocomplete/TopicAutocomplete.js
@@ -1,15 +1,16 @@
 /* @flow strict-local */
 
 import React, { PureComponent } from 'react';
-import { FlatList, StyleSheet } from 'react-native';
+import { FlatList } from 'react-native';
 
 import type { Dispatch, Narrow } from '../types';
+import { createStyleSheet } from '../styles';
 import { connect } from '../react-redux';
 import { getTopicsForNarrow } from '../selectors';
 import { Popup, RawLabel, Touchable } from '../common';
 import AnimatedScaleComponent from '../animation/AnimatedScaleComponent';
 
-const styles = StyleSheet.create({
+const styles = createStyleSheet({
   topic: {
     padding: 10,
   },

--- a/src/boot/AppEventHandlers.js
+++ b/src/boot/AppEventHandlers.js
@@ -1,13 +1,14 @@
 /* @flow strict-local */
 
 import React, { PureComponent } from 'react';
-import { AppState, View, StyleSheet, Platform, NativeModules } from 'react-native';
+import { AppState, View, Platform, NativeModules } from 'react-native';
 import NetInfo from '@react-native-community/netinfo';
 import SafeArea from 'react-native-safe-area';
 import * as ScreenOrientation from 'expo-screen-orientation';
 
 import type { Node as React$Node } from 'react';
 import type { Dispatch, Orientation as OrientationT } from '../types';
+import { createStyleSheet } from '../styles';
 import { connect } from '../react-redux';
 import { getUnreadByHuddlesMentionsAndPMs } from '../selectors';
 import {
@@ -56,7 +57,7 @@ type NetInfoState = {
   details: null | NetInfoConnectedDetails,
 };
 
-const styles = StyleSheet.create({
+const styles = createStyleSheet({
   wrapper: {
     flex: 1,
     flexDirection: 'column',

--- a/src/chat/MarkUnreadButton.js
+++ b/src/chat/MarkUnreadButton.js
@@ -1,16 +1,16 @@
 /* @flow strict-local */
 
 import React, { PureComponent } from 'react';
-import { StyleSheet } from 'react-native';
 
 import type { Auth, Narrow, Stream, Dispatch } from '../types';
+import { createStyleSheet } from '../styles';
 import { connect } from '../react-redux';
 import { ZulipButton } from '../common';
 import * as api from '../api';
 import { getAuth, getStreams } from '../selectors';
 import { isHomeNarrow, isStreamNarrow, isTopicNarrow } from '../utils/narrow';
 
-const styles = StyleSheet.create({
+const styles = createStyleSheet({
   button: {
     borderRadius: 16,
     height: 32,

--- a/src/chat/UnreadNotice.js
+++ b/src/chat/UnreadNotice.js
@@ -1,16 +1,17 @@
 /* @flow strict-local */
 
 import React, { PureComponent } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { View } from 'react-native';
 
 import type { Narrow, Dispatch } from '../types';
+import { createStyleSheet } from '../styles';
 import { connect } from '../react-redux';
 import { getUnreadCountForNarrow } from '../selectors';
 import { Label, RawLabel } from '../common';
 import MarkUnreadButton from './MarkUnreadButton';
 import AnimatedScaleComponent from '../animation/AnimatedScaleComponent';
 
-const styles = StyleSheet.create({
+const styles = createStyleSheet({
   unreadContainer: {
     paddingHorizontal: 8,
     paddingVertical: 4,

--- a/src/common/Centerer.js
+++ b/src/common/Centerer.js
@@ -1,12 +1,12 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { View } from 'react-native';
 import type { ViewStyleProp } from 'react-native/Libraries/StyleSheet/StyleSheet';
 
 import type { Node as React$Node } from 'react';
-import styles from '../styles';
+import styles, { createStyleSheet } from '../styles';
 
-const componentStyles = StyleSheet.create({
+const componentStyles = createStyleSheet({
   centerer: {
     flex: 1,
     flexDirection: 'row',

--- a/src/common/ComponentWithOverlay.js
+++ b/src/common/ComponentWithOverlay.js
@@ -1,11 +1,12 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { View } from 'react-native';
 import type { ViewStyleProp } from 'react-native/Libraries/StyleSheet/StyleSheet';
-
 import type { Node as React$Node } from 'react';
 
-const styles = StyleSheet.create({
+import { createStyleSheet } from '../styles';
+
+const styles = createStyleSheet({
   wrapper: {
     justifyContent: 'center',
     alignItems: 'center',

--- a/src/common/CountOverlay.js
+++ b/src/common/CountOverlay.js
@@ -1,12 +1,12 @@
 /* @flow strict-local */
 
 import React, { PureComponent } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { View } from 'react-native';
 
 import { ComponentWithOverlay, UnreadCount } from '.';
-import { BRAND_COLOR } from '../styles';
+import { BRAND_COLOR, createStyleSheet } from '../styles';
 
-const styles = StyleSheet.create({
+const styles = createStyleSheet({
   button: {
     flex: 1,
   },

--- a/src/common/ErrorMsg.js
+++ b/src/common/ErrorMsg.js
@@ -1,10 +1,11 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { View } from 'react-native';
 
 import Label from './Label';
+import { createStyleSheet } from '../styles';
 
-const styles = StyleSheet.create({
+const styles = createStyleSheet({
   field: {
     flexDirection: 'row',
     marginTop: 5,

--- a/src/common/FloatingActionButton.js
+++ b/src/common/FloatingActionButton.js
@@ -1,13 +1,13 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { View } from 'react-native';
 import type { ViewStyleProp } from 'react-native/Libraries/StyleSheet/StyleSheet';
 
 import type { SpecificIconType } from './Icons';
-import { BRAND_COLOR } from '../styles';
+import { BRAND_COLOR, createStyleSheet } from '../styles';
 import Touchable from './Touchable';
 
-const styles = StyleSheet.create({
+const styles = createStyleSheet({
   wrapper: {
     justifyContent: 'center',
     alignItems: 'center',

--- a/src/common/GroupAvatar.js
+++ b/src/common/GroupAvatar.js
@@ -1,12 +1,13 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
-import { Text, StyleSheet, View } from 'react-native';
+import { Text, View } from 'react-native';
 
 import type { Node as React$Node } from 'react';
 import Touchable from './Touchable';
+import { createStyleSheet } from '../styles';
 import { colorHashFromString, foregroundColorFromBackground } from '../utils/color';
 
-const styles = StyleSheet.create({
+const styles = createStyleSheet({
   frame: {
     justifyContent: 'center',
     alignItems: 'center',

--- a/src/common/InputWithClearButton.js
+++ b/src/common/InputWithClearButton.js
@@ -1,13 +1,13 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
-import { View, TextInput, StyleSheet } from 'react-native';
+import { View, TextInput } from 'react-native';
 
 import Input from './Input';
 import type { Props as InputProps } from './Input';
-import styles, { BRAND_COLOR } from '../styles';
+import styles, { createStyleSheet, BRAND_COLOR } from '../styles';
 import { Icon } from './Icons';
 
-const componentStyles = StyleSheet.create({
+const componentStyles = createStyleSheet({
   clearButtonIcon: {
     color: BRAND_COLOR,
     paddingRight: 16,

--- a/src/common/LoadingBanner.js
+++ b/src/common/LoadingBanner.js
@@ -1,18 +1,18 @@
 /* @flow strict-local */
 
 import React, { PureComponent } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { View } from 'react-native';
 
 import type { Dispatch } from '../types';
 import { connect } from '../react-redux';
 import { getLoading } from '../selectors';
 import { Label, LoadingIndicator } from '.';
 import type { ThemeData } from '../styles';
-import { ThemeContext } from '../styles';
+import { ThemeContext, createStyleSheet } from '../styles';
 
 const key = 'LoadingBanner';
 
-const styles = StyleSheet.create({
+const styles = createStyleSheet({
   block: {
     flexDirection: 'row',
     justifyContent: 'center',

--- a/src/common/LoadingIndicator.js
+++ b/src/common/LoadingIndicator.js
@@ -1,11 +1,12 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
-import { Image, StyleSheet, View } from 'react-native';
+import { Image, View } from 'react-native';
 
 import SpinningProgress from './SpinningProgress';
+import { createStyleSheet } from '../styles';
 import messageLoadingImg from '../../static/img/message-loading.png';
 
-const styles = StyleSheet.create({
+const styles = createStyleSheet({
   wrapper: {
     flex: 1,
     padding: 4,

--- a/src/common/Logo.js
+++ b/src/common/Logo.js
@@ -1,10 +1,11 @@
 /* @flow strict-local */
 import React from 'react';
-import { Image, StyleSheet } from 'react-native';
+import { Image } from 'react-native';
 
 import logoImg from '../../static/img/logo.png';
+import { createStyleSheet } from '../styles';
 
-const styles = StyleSheet.create({
+const styles = createStyleSheet({
   logo: {
     width: 40,
     height: 40,

--- a/src/common/OfflineNotice.js
+++ b/src/common/OfflineNotice.js
@@ -1,16 +1,17 @@
 /* @flow strict-local */
 
 import React, { PureComponent } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { View } from 'react-native';
 
 import type { Dispatch } from '../types';
+import { createStyleSheet } from '../styles';
 import { connect } from '../react-redux';
 import { getSession } from '../selectors';
 import Label from './Label';
 
 const key = 'OfflineNotice';
 
-const styles = StyleSheet.create({
+const styles = createStyleSheet({
   block: {
     flexDirection: 'row',
     justifyContent: 'center',

--- a/src/common/PasswordInput.js
+++ b/src/common/PasswordInput.js
@@ -1,14 +1,14 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
-import { View, TextInput, StyleSheet } from 'react-native';
+import { View, TextInput } from 'react-native';
 
 import Input from './Input';
 import type { Props as InputProps } from './Input';
-import { BRAND_COLOR } from '../styles';
+import { BRAND_COLOR, createStyleSheet } from '../styles';
 import Label from './Label';
 import Touchable from './Touchable';
 
-const styles = StyleSheet.create({
+const styles = createStyleSheet({
   showPasswordButton: {
     position: 'absolute',
     right: 0,

--- a/src/common/Popup.js
+++ b/src/common/Popup.js
@@ -1,12 +1,12 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
 import type { Node as React$Node } from 'react';
-import { View, StyleSheet } from 'react-native';
+import { View } from 'react-native';
 
 import type { ThemeData } from '../styles';
-import { ThemeContext } from '../styles';
+import { ThemeContext, createStyleSheet } from '../styles';
 
-const styles = StyleSheet.create({
+const styles = createStyleSheet({
   popup: {
     marginHorizontal: 16,
     marginVertical: 8,

--- a/src/common/PresenceStatusIndicator.js
+++ b/src/common/PresenceStatusIndicator.js
@@ -1,16 +1,17 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { View } from 'react-native';
 import type { ViewStyleProp } from 'react-native/Libraries/StyleSheet/StyleSheet';
 
 import type { PresenceState, User, UserStatusMapObject, Dispatch } from '../types';
+import { createStyleSheet } from '../styles';
 import { connect } from '../react-redux';
 import { statusFromPresenceAndUserStatus } from '../utils/presence';
 import { getPresence, getUserStatus } from '../selectors';
 import { getUsersByEmail } from '../users/userSelectors';
 import { ensureUnreachable } from '../types';
 
-const styles = StyleSheet.create({
+const styles = createStyleSheet({
   common: {
     width: 12,
     height: 12,

--- a/src/common/Screen.js
+++ b/src/common/Screen.js
@@ -2,11 +2,11 @@
 
 import React, { PureComponent } from 'react';
 import type { Node as React$Node } from 'react';
-import { StyleSheet, View, ScrollView } from 'react-native';
+import { View, ScrollView } from 'react-native';
 import type { ViewStyleProp } from 'react-native/Libraries/StyleSheet/StyleSheet';
 
 import type { ThemeData } from '../styles';
-import styles, { ThemeContext } from '../styles';
+import styles, { createStyleSheet, ThemeContext } from '../styles';
 import type { Dimensions, LocalizableText, Dispatch } from '../types';
 import { connect } from '../react-redux';
 import KeyboardAvoider from './KeyboardAvoider';
@@ -17,7 +17,7 @@ import { getSession } from '../selectors';
 import ModalNavBar from '../nav/ModalNavBar';
 import ModalSearchNavBar from '../nav/ModalSearchNavBar';
 
-const componentStyles = StyleSheet.create({
+const componentStyles = createStyleSheet({
   screen: {
     flex: 1,
     flexDirection: 'column',

--- a/src/common/SearchEmptyState.js
+++ b/src/common/SearchEmptyState.js
@@ -1,10 +1,11 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { View } from 'react-native';
 
 import Label from './Label';
+import { createStyleSheet } from '../styles';
 
-const styles = StyleSheet.create({
+const styles = createStyleSheet({
   container: {
     flex: 1,
     padding: 16,

--- a/src/common/SearchInput.js
+++ b/src/common/SearchInput.js
@@ -1,9 +1,10 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
-import { View, StyleSheet } from 'react-native';
+import { View } from 'react-native';
 import InputWithClearButton from './InputWithClearButton';
+import { createStyleSheet } from '../styles';
 
-const styles = StyleSheet.create({
+const styles = createStyleSheet({
   wrapper: {
     flex: 1,
     flexDirection: 'row',

--- a/src/common/SectionHeader.js
+++ b/src/common/SectionHeader.js
@@ -1,12 +1,12 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { View } from 'react-native';
 
 import type { ThemeData } from '../styles';
-import { ThemeContext } from '../styles';
+import { ThemeContext, createStyleSheet } from '../styles';
 import Label from './Label';
 
-const styles = StyleSheet.create({
+const styles = createStyleSheet({
   header: {
     padding: 10,
     backgroundColor: 'hsla(0, 0%, 50%, 0.75)',

--- a/src/common/SectionSeparator.js
+++ b/src/common/SectionSeparator.js
@@ -1,8 +1,10 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { View } from 'react-native';
 
-const styles = StyleSheet.create({
+import { createStyleSheet } from '../styles';
+
+const styles = createStyleSheet({
   separator: {
     height: 1,
     margin: 10,

--- a/src/common/SmartUrlInput.js
+++ b/src/common/SmartUrlInput.js
@@ -1,16 +1,16 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
-import { StyleSheet, TextInput, TouchableWithoutFeedback, View } from 'react-native';
+import { TextInput, TouchableWithoutFeedback, View } from 'react-native';
 import type { ViewStyleProp } from 'react-native/Libraries/StyleSheet/StyleSheet';
 import type { NavigationEventSubscription, NavigationScreenProp } from 'react-navigation';
 
 import type { ThemeData } from '../styles';
-import { ThemeContext } from '../styles';
+import { ThemeContext, createStyleSheet } from '../styles';
 import { autocompleteRealmPieces, autocompleteRealm, fixRealmUrl } from '../utils/url';
 import type { Protocol } from '../utils/url';
 import RawLabel from './RawLabel';
 
-const styles = StyleSheet.create({
+const styles = createStyleSheet({
   wrapper: {
     flexDirection: 'row',
     opacity: 0.8,

--- a/src/common/UnreadCount.js
+++ b/src/common/UnreadCount.js
@@ -1,12 +1,12 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
-import { StyleSheet, Text, View } from 'react-native';
+import { Text, View } from 'react-native';
 import type { ViewStyleProp } from 'react-native/Libraries/StyleSheet/StyleSheet';
 
-import { BRAND_COLOR } from '../styles';
+import { BRAND_COLOR, createStyleSheet } from '../styles';
 import { foregroundColorFromBackground } from '../utils/color';
 
-const styles = StyleSheet.create({
+const styles = createStyleSheet({
   frame: {
     paddingTop: 2,
     paddingRight: 4,

--- a/src/common/UserAvatarWithPresence.js
+++ b/src/common/UserAvatarWithPresence.js
@@ -1,16 +1,16 @@
 /* @flow strict-local */
 
 import React, { PureComponent } from 'react';
-import { StyleSheet } from 'react-native';
 
 import type { Dispatch } from '../types';
+import { createStyleSheet } from '../styles';
 import { connect } from '../react-redux';
 import { getCurrentRealm } from '../selectors';
 import UserAvatar from './UserAvatar';
 import { getAvatarUrl } from '../utils/avatar';
 import PresenceStatusIndicator from './PresenceStatusIndicator';
 
-const styles = StyleSheet.create({
+const styles = createStyleSheet({
   status: {
     bottom: 0,
     right: 0,

--- a/src/common/WebLink.js
+++ b/src/common/WebLink.js
@@ -1,7 +1,6 @@
 /* @flow strict-local */
 
 import React, { PureComponent } from 'react';
-import { StyleSheet } from 'react-native';
 
 import type { Dispatch } from '../types';
 import { connect } from '../react-redux';
@@ -9,7 +8,7 @@ import Label from './Label';
 import { getFullUrl } from '../utils/url';
 import openLink from '../utils/openLink';
 import { getCurrentRealm } from '../selectors';
-import { BRAND_COLOR } from '../styles';
+import { BRAND_COLOR, createStyleSheet } from '../styles';
 
 type Props = $ReadOnly<{|
   dispatch: Dispatch,
@@ -31,7 +30,7 @@ class WebLink extends PureComponent<Props> {
     openLink(getFullUrl(href, realm));
   };
 
-  styles = StyleSheet.create({
+  styles = createStyleSheet({
     link: {
       marginTop: 10,
       fontSize: 15,

--- a/src/common/ZulipButton.js
+++ b/src/common/ZulipButton.js
@@ -10,12 +10,6 @@ import { BRAND_COLOR } from '../styles';
 import Touchable from './Touchable';
 
 const styles = StyleSheet.create({
-  buttonContent: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'center',
-    height: 44,
-  },
   frame: {
     height: 44,
     justifyContent: 'center',
@@ -29,16 +23,21 @@ const styles = StyleSheet.create({
     borderWidth: 1.5,
     borderColor: BRAND_COLOR,
   },
-  text: {
-    color: 'hsl(0, 0%, 100%)',
-    fontSize: 16,
+  disabledPrimaryFrame: {
+    backgroundColor: 'hsla(0, 0%, 50%, 0.4)',
   },
-  primaryText: {
-    color: 'white',
+  disabledSecondaryFrame: {
+    borderWidth: 1.5,
+    borderColor: 'hsla(0, 0%, 50%, 0.4)',
   },
-  secondaryText: {
-    color: BRAND_COLOR,
+
+  buttonContent: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    height: 44,
   },
+
   icon: {
     marginRight: 8,
   },
@@ -48,12 +47,16 @@ const styles = StyleSheet.create({
   secondaryIcon: {
     color: BRAND_COLOR,
   },
-  disabledPrimaryFrame: {
-    backgroundColor: 'hsla(0, 0%, 50%, 0.4)',
+
+  text: {
+    color: 'hsl(0, 0%, 100%)',
+    fontSize: 16,
   },
-  disabledSecondaryFrame: {
-    borderWidth: 1.5,
-    borderColor: 'hsla(0, 0%, 50%, 0.4)',
+  primaryText: {
+    color: 'white',
+  },
+  secondaryText: {
+    color: BRAND_COLOR,
   },
   disabledText: {
     color: 'hsla(0, 0%, 50%, 0.8)',

--- a/src/common/ZulipButton.js
+++ b/src/common/ZulipButton.js
@@ -1,15 +1,15 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
-import { StyleSheet, Text, View, ActivityIndicator } from 'react-native';
+import { Text, View, ActivityIndicator } from 'react-native';
 import type { TextStyleProp, ViewStyleProp } from 'react-native/Libraries/StyleSheet/StyleSheet';
 import TranslatedText from './TranslatedText';
 
 import type { LocalizableText } from '../types';
 import type { SpecificIconType } from './Icons';
-import { BRAND_COLOR } from '../styles';
+import { BRAND_COLOR, createStyleSheet } from '../styles';
 import Touchable from './Touchable';
 
-const styles = StyleSheet.create({
+const styles = createStyleSheet({
   frame: {
     height: 44,
     justifyContent: 'center',

--- a/src/common/ZulipButton.js
+++ b/src/common/ZulipButton.js
@@ -49,7 +49,6 @@ const styles = StyleSheet.create({
   },
 
   text: {
-    color: 'hsl(0, 0%, 100%)',
     fontSize: 16,
   },
   primaryText: {

--- a/src/common/ZulipButton.js
+++ b/src/common/ZulipButton.js
@@ -1,10 +1,11 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
 import { Text, View, ActivityIndicator } from 'react-native';
-import type { TextStyleProp, ViewStyleProp } from 'react-native/Libraries/StyleSheet/StyleSheet';
+import type { TextStyle, ViewStyle } from 'react-native/Libraries/StyleSheet/StyleSheet';
 import TranslatedText from './TranslatedText';
 
 import type { LocalizableText } from '../types';
+import type { SubsetProperties } from '../generics';
 import type { SpecificIconType } from './Icons';
 import { BRAND_COLOR, createStyleSheet } from '../styles';
 import Touchable from './Touchable';
@@ -63,8 +64,38 @@ const styles = createStyleSheet({
 });
 
 type Props = $ReadOnly<{|
-  style?: ViewStyleProp,
-  textStyle?: TextStyleProp,
+  /* eslint-disable flowtype/generic-spacing */
+  style?: SubsetProperties<
+    ViewStyle,
+    {|
+      // The use of specific style properties for callers to micromanage the
+      // layout of the button is pretty chaotic and fragile, introducing
+      // implicit dependencies on details of the ZulipButton implementation.
+      // TODO: Assimilate those usages into a more coherent set of options
+      //   provided by the ZulipButton interface explicitly.
+      //
+      // Until then, by listing here the properties we do use, we at least
+      // make it possible when working on the ZulipButton implementation to
+      // know the scope of different ways that callers can mess with the
+      // styles.  If you need one not listed here and it's in the same
+      // spirit as others that are, feel free to add it.
+      margin?: mixed,
+      marginTop?: mixed,
+      marginBottom?: mixed,
+      marginHorizontal?: mixed,
+      // (... e.g., go ahead and add more variations on margin.)
+      padding?: mixed,
+      paddingLeft?: mixed,
+      paddingRight?: mixed,
+      height?: mixed,
+      width?: mixed,
+      borderRadius?: mixed,
+      flex?: mixed,
+      alignSelf?: mixed,
+      backgroundColor?: mixed,
+    |},
+  >,
+  textStyle?: SubsetProperties<TextStyle, {| color?: mixed |}>,
   progress: boolean,
   disabled: boolean,
   Icon?: SpecificIconType,

--- a/src/compose/ComposeMenu.js
+++ b/src/compose/ComposeMenu.js
@@ -1,13 +1,13 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
-import { Platform, StyleSheet, View } from 'react-native';
+import { Platform, View } from 'react-native';
 import type { DocumentPickerResponse } from 'react-native-document-picker';
 import ImagePicker from 'react-native-image-picker';
 
 import type { Dispatch, Narrow } from '../types';
 import { connect } from '../react-redux';
 import { showErrorAlert } from '../utils/info';
-import { BRAND_COLOR } from '../styles';
+import { BRAND_COLOR, createStyleSheet } from '../styles';
 import {
   IconPlusCircle,
   IconLeft,
@@ -135,7 +135,7 @@ class ComposeMenu extends PureComponent<Props> {
     this.uploadFile(response.uri, response.name);
   };
 
-  styles = StyleSheet.create({
+  styles = createStyleSheet({
     composeMenu: {
       flexDirection: 'row',
       overflow: 'hidden',

--- a/src/diagnostics/DiagnosticsScreen.js
+++ b/src/diagnostics/DiagnosticsScreen.js
@@ -1,11 +1,11 @@
 /* @flow strict-local */
 
 import React, { PureComponent } from 'react';
-import { StyleSheet } from 'react-native';
 
 import { nativeApplicationVersion } from 'expo-application';
 
 import type { Dispatch } from '../types';
+import { createStyleSheet } from '../styles';
 import { connect } from '../react-redux';
 import { OptionButton, OptionDivider, Screen, RawLabel } from '../common';
 import {
@@ -15,7 +15,7 @@ import {
   navigateToVariables,
 } from '../actions';
 
-const styles = StyleSheet.create({
+const styles = createStyleSheet({
   versionLabel: {
     textAlign: 'center',
     padding: 8,

--- a/src/diagnostics/InfoItem.js
+++ b/src/diagnostics/InfoItem.js
@@ -1,11 +1,12 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { View } from 'react-native';
 
 import { RawLabel } from '../common';
+import { createStyleSheet } from '../styles';
 import type { JSONable } from '../utils/jsonable';
 
-const styles = StyleSheet.create({
+const styles = createStyleSheet({
   item: {
     padding: 16,
     borderBottomWidth: 1,

--- a/src/diagnostics/SizeItem.js
+++ b/src/diagnostics/SizeItem.js
@@ -1,11 +1,12 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { View } from 'react-native';
 
 import { RawLabel } from '../common';
+import { createStyleSheet } from '../styles';
 import { numberWithSeparators } from '../utils/misc';
 
-const styles = StyleSheet.create({
+const styles = createStyleSheet({
   item: {
     flexDirection: 'row',
     justifyContent: 'space-between',

--- a/src/diagnostics/TimeItem.js
+++ b/src/diagnostics/TimeItem.js
@@ -1,13 +1,14 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { View } from 'react-native';
 import format from 'date-fns/format';
 import type { TimingItemType } from '../types';
+import { createStyleSheet } from '../styles';
 
 import { RawLabel } from '../common';
 import { numberWithSeparators } from '../utils/misc';
 
-const styles = StyleSheet.create({
+const styles = createStyleSheet({
   item: {
     padding: 16,
     borderBottomWidth: 1,

--- a/src/emoji/Emoji.js
+++ b/src/emoji/Emoji.js
@@ -1,9 +1,10 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
-import { StyleSheet, Image } from 'react-native';
+import { Image } from 'react-native';
 import { createIconSet } from 'react-native-vector-icons';
 
 import type { ImageEmojiType, Dispatch, EmojiType } from '../types';
+import { createStyleSheet } from '../styles';
 import { connect } from '../react-redux';
 import { getAllImageEmojiByCode } from './emojiSelectors';
 import { codeToEmojiMap } from './data';
@@ -25,7 +26,7 @@ type Props = $ReadOnly<{|
 |}>;
 
 class Emoji extends PureComponent<Props> {
-  styles = StyleSheet.create({
+  styles = createStyleSheet({
     image: { width: 20, height: 20 },
   });
 

--- a/src/emoji/EmojiRow.js
+++ b/src/emoji/EmojiRow.js
@@ -1,12 +1,13 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { View } from 'react-native';
 
 import type { EmojiType } from '../types';
+import { createStyleSheet } from '../styles';
 import { RawLabel, Touchable } from '../common';
 import Emoji from './Emoji';
 
-const styles = StyleSheet.create({
+const styles = createStyleSheet({
   emojiRow: {
     flexDirection: 'row',
     padding: 8,

--- a/src/generics.js
+++ b/src/generics.js
@@ -1,0 +1,80 @@
+/* @flow strict-local */
+/**
+ * Tools for manipulating generic types in the Flow type system.
+ */
+
+/* eslint-disable flowtype/generic-spacing */
+
+/**
+ * The type `S`, plus a check that `S` is a supertype of `T`.
+ *
+ * Gives an error unless `S` is a supertype of `T` -- i.e., a `T` can always
+ * be used where an `S` is required.
+ */
+export type IsSupertype<+S, +T: S> = S; // eslint-disable-line no-unused-vars
+
+/**
+ * An inverse of the operation `(A, B) => {| ...A, ...B |}`, with checking.
+ *
+ * Similar to `$Diff`, but checks that the subtraction makes sense.
+ * Also always subtracts a given property completely, even if its type on
+ * `L` happens to be more specific than on `U`.
+ *
+ * Assumes both U and L are exact object types.  (If not, behavior unknown.)
+ * Returns a solution, where possible, to the type equation
+ *   `U == {| ...D, ...L |}`
+ * with an (inexact) object type `D`.
+ *
+ * More generally, returns the most general solution `D` to the relation
+ *   `{| ...D, ...L |}: U`  (read "subtype of")
+ * I.e., the most general type `D` such that `{| ...D, ...L |}` can be used
+ * where a `U` is expected.  If there is no such `D`, causes a type error.
+ *
+ * In particular, this means:
+ *  * Error if `L` has any extra properties that aren't in `U`.
+ *  * Error unless each property of `L` has the same type as in `U`, or a subtype
+ *    (i.e., the property's values in `L` are valid for `U`).
+ *  * `D` has exactly the properties in `U` that aren't in `L`.
+ *  * Each property of `D` has the same type as in `U`.
+ */
+// Oddly, Flow accepts this declaration with <-U, -L> but also with <+U, +L>.
+export type BoundedDiff<-U, -L> = $Diff<
+  // This `IsSupertype` is the part that checks that all of L's properties
+  // (a) are present on U and (b) have appropriate types to use on U.
+  IsSupertype<U, $ReadOnly<{| ...U, ...L |}>>,
+  // This `$ObjMap` makes a variant of `L` that `$Diff` treats as more
+  // powerful, ensuring that all properties in `L` are removed completely.
+  $ObjMap<L, () => mixed>,
+>;
+
+/**
+ * Assert a contradiction, statically.  Do nothing at runtime.
+ *
+ * The `empty` type is the type with no values.  So, apart from certain bugs
+ * in Flow, the only way a call to this function can ever be valid is when
+ * the type-checker can actually prove the call site is unreachable.
+ *
+ * Especially useful for statically asserting that a `switch` statement is
+ * exhaustive:
+ *
+ *     type Foo =
+ *       | {| type: 'frob', ... |}
+ *       | {| type: 'twiddle', ... |};
+ *
+ *
+ *     const foo: Foo = ...;
+ *     switch (foo.type) {
+ *       case 'frob': ...; break;
+ *
+ *       case 'twiddle': ...; break;
+ *
+ *       default:
+ *         ensureUnreachable(foo); // Asserts no possible cases for `foo` remain.
+ *         break;
+ *     }
+ *
+ * In this example if by mistake a case is omitted, or if another case is
+ * added to the type without a corresponding `case` statement here, then
+ * Flow will report a type error at the `ensureUnreachable` call.
+ */
+export function ensureUnreachable(x: empty) {}

--- a/src/generics.js
+++ b/src/generics.js
@@ -48,6 +48,41 @@ export type BoundedDiff<-U, -L> = $Diff<
 >;
 
 /**
+ * An object type with a subset of T's properties, namely those in U.
+ *
+ * Gives an error unless all properties of U also appear in T.  Each
+ * property's type in the result is the type of the same property in T.
+ *
+ * Handy when T is something like an options object and you want a type
+ * representing a subset of the options in T.  Write e.g.
+ * `SubsetProperties<T, {| frobMode?: mixed |}>` for an object type that
+ * permits only the `frobMode` option, with the exact same type T allows,
+ * but without having to repeat the details of that type.
+ *
+ * A limitation: this implementation can't tell which properties are
+ * *optional* in T, i.e. spelled with `?:`, as in `foo?: number`.  Instead,
+ * properties in the result will be optional or required based on how they
+ * are in U.  To avoid confusion, be sure to make the same properties
+ * optional in U as are optional in T.  (In the "options object" use case,
+ * typically all the properties are optional.)
+ */
+// Implementation note: You might think to write this as something like
+// $Diff<T, $Diff<T, U>>.  Or $Diff<T, $ObjMap<$Diff<T, U>, () => mixed>>.
+// In particular you might hope for this to avoid the limitation mentioned
+// above.
+//
+// Sadly that doesn't work (as of Flow v0.130) when T has any optional
+// properties not found in U: the first diff type will still have them
+// optional, this will still be true after the $ObjMap, and so the second
+// diff won't remove them and they'll all wind up in the resulting type.
+//
+// Possibly this will get better after a project to fix the handling of
+// $Diff and other "type destructors", which as of 2020-08 the Flow team is
+// taking up as a priority:
+//   https://github.com/facebook/flow/issues/7886#issuecomment-669977952
+export type SubsetProperties<T, U> = $ObjMapi<U, <K, V>(K) => $ElementType<T, K>>;
+
+/**
  * Assert a contradiction, statically.  Do nothing at runtime.
  *
  * The `empty` type is the type with no values.  So, apart from certain bugs

--- a/src/lightbox/Lightbox.js
+++ b/src/lightbox/Lightbox.js
@@ -1,7 +1,7 @@
 /* @flow strict-local */
 
 import React, { PureComponent } from 'react';
-import { View, StyleSheet, Dimensions, Easing } from 'react-native';
+import { View, Dimensions, Easing } from 'react-native';
 import PhotoView from 'react-native-photo-view';
 import { connectActionSheet } from '@expo/react-native-action-sheet';
 
@@ -14,11 +14,11 @@ import { SlideAnimationView } from '../common';
 import LightboxHeader from './LightboxHeader';
 import LightboxFooter from './LightboxFooter';
 import { constructActionSheetButtons, executeActionSheetAction } from './LightboxActionSheet';
-import { NAVBAR_SIZE } from '../styles';
+import { NAVBAR_SIZE, createStyleSheet } from '../styles';
 import { getAvatarFromMessage } from '../utils/avatar';
 import { navigateBack } from '../actions';
 
-const styles = StyleSheet.create({
+const styles = createStyleSheet({
   img: {
     height: 300,
     flex: 1,

--- a/src/lightbox/LightboxFooter.js
+++ b/src/lightbox/LightboxFooter.js
@@ -1,11 +1,12 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
-import { Text, StyleSheet, View } from 'react-native';
+import { Text, View } from 'react-native';
 import type { ViewStyleProp } from 'react-native/Libraries/StyleSheet/StyleSheet';
 
 import { Icon } from '../common/Icons';
+import { createStyleSheet } from '../styles';
 
-const styles = StyleSheet.create({
+const styles = createStyleSheet({
   wrapper: {
     height: 44,
     flexDirection: 'row',

--- a/src/lightbox/LightboxHeader.js
+++ b/src/lightbox/LightboxHeader.js
@@ -1,12 +1,13 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
-import { View, Text, StyleSheet } from 'react-native';
+import { View, Text } from 'react-native';
 
 import { shortTime, humanDate } from '../utils/date';
+import { createStyleSheet } from '../styles';
 import { UserAvatarWithPresence, Touchable } from '../common';
 import { Icon } from '../common/Icons';
 
-const styles = StyleSheet.create({
+const styles = createStyleSheet({
   text: {
     flex: 1,
     justifyContent: 'space-between',

--- a/src/lightbox/LightboxScreen.js
+++ b/src/lightbox/LightboxScreen.js
@@ -1,14 +1,15 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
-import { View, StyleSheet } from 'react-native';
+import { View } from 'react-native';
 import type { NavigationScreenProp } from 'react-navigation';
 import { ActionSheetProvider } from '@expo/react-native-action-sheet';
 
 import { ZulipStatusBar } from '../common';
+import { createStyleSheet } from '../styles';
 import Lightbox from './Lightbox';
 import type { Message } from '../types';
 
-const styles = StyleSheet.create({
+const styles = createStyleSheet({
   screen: {
     flex: 1,
     flexDirection: 'column',

--- a/src/main/HomeTab.js
+++ b/src/main/HomeTab.js
@@ -1,7 +1,7 @@
 /* @flow strict-local */
 
 import React, { PureComponent } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { View } from 'react-native';
 
 import type { Dispatch } from '../types';
 import { connect } from '../react-redux';
@@ -11,10 +11,10 @@ import NavButtonGeneral from '../nav/NavButtonGeneral';
 import UnreadCards from '../unread/UnreadCards';
 import { doNarrow, navigateToSearch } from '../actions';
 import IconUnreadMentions from '../nav/IconUnreadMentions';
-import { BRAND_COLOR } from '../styles';
+import { BRAND_COLOR, createStyleSheet } from '../styles';
 import { LoadingBanner } from '../common';
 
-const styles = StyleSheet.create({
+const styles = createStyleSheet({
   wrapper: {
     flex: 1,
     flexDirection: 'column',

--- a/src/main/StreamTabs.js
+++ b/src/main/StreamTabs.js
@@ -1,15 +1,16 @@
 /* @flow strict-local */
 import React from 'react';
-import { StyleSheet, Text } from 'react-native';
+import { Text } from 'react-native';
 import { FormattedMessage } from 'react-intl';
 import { createMaterialTopTabNavigator } from 'react-navigation-tabs';
 
 import type { TabNavigationOptionsPropsType } from '../types';
+import { createStyleSheet } from '../styles';
 import tabsOptions from '../styles/tabs';
 import SubscriptionsCard from '../streams/SubscriptionsCard';
 import StreamListCard from '../subscriptions/StreamListCard';
 
-const styles = StyleSheet.create({
+const styles = createStyleSheet({
   tab: {
     padding: 8,
     fontSize: 16,

--- a/src/message/MentionedUserNotSubscribed.js
+++ b/src/message/MentionedUserNotSubscribed.js
@@ -1,9 +1,10 @@
 /* @flow strict-local */
 
 import React, { PureComponent } from 'react';
-import { View, TouchableOpacity, StyleSheet } from 'react-native';
+import { View, TouchableOpacity } from 'react-native';
 
 import type { Auth, Stream, Dispatch, UserOrBot, Subscription } from '../types';
+import { createStyleSheet } from '../styles';
 import { connect } from '../react-redux';
 import * as api from '../api';
 import { ZulipButton, Label } from '../common';
@@ -22,7 +23,7 @@ type Props = $ReadOnly<{|
   ...SelectorProps,
 |}>;
 
-const styles = StyleSheet.create({
+const styles = createStyleSheet({
   outer: {
     flexDirection: 'row',
     alignItems: 'center',

--- a/src/message/NoMessages.js
+++ b/src/message/NoMessages.js
@@ -1,9 +1,10 @@
 /* @flow strict-local */
 
 import React, { PureComponent } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { View } from 'react-native';
 
 import type { Narrow } from '../types';
+import { createStyleSheet } from '../styles';
 import { Label } from '../common';
 
 import {
@@ -17,7 +18,7 @@ import {
   canSendToNarrow,
 } from '../utils/narrow';
 
-const styles = StyleSheet.create({
+const styles = createStyleSheet({
   container: {
     flex: 1,
     alignItems: 'center',

--- a/src/nav/NavButton.js
+++ b/src/nav/NavButton.js
@@ -1,9 +1,8 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
-import { StyleSheet } from 'react-native';
 import type { TextStyleProp } from 'react-native/Libraries/StyleSheet/StyleSheet';
 
-import { BRAND_COLOR } from '../styles';
+import { BRAND_COLOR, createStyleSheet } from '../styles';
 import { Icon } from '../common/Icons';
 import type { IconNames } from '../common/Icons';
 import NavButtonGeneral from './NavButtonGeneral';
@@ -20,7 +19,7 @@ export default class NavButton extends PureComponent<Props> {
     color: BRAND_COLOR,
   };
 
-  styles = StyleSheet.create({
+  styles = createStyleSheet({
     navButtonIcon: {
       textAlign: 'center',
       fontSize: 26,

--- a/src/nav/NavButtonGeneral.js
+++ b/src/nav/NavButtonGeneral.js
@@ -1,9 +1,9 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { View } from 'react-native';
 import type { Node as React$Node } from 'react';
 
-import { NAVBAR_SIZE } from '../styles';
+import { NAVBAR_SIZE, createStyleSheet } from '../styles';
 import { Touchable } from '../common';
 
 type Props = $ReadOnly<{|
@@ -12,7 +12,7 @@ type Props = $ReadOnly<{|
 |}>;
 
 export default class NavButtonGeneral extends PureComponent<Props> {
-  styles = StyleSheet.create({
+  styles = createStyleSheet({
     navButtonFrame: {
       width: NAVBAR_SIZE,
       height: NAVBAR_SIZE,

--- a/src/pm-conversations/GroupPmConversationItem.js
+++ b/src/pm-conversations/GroupPmConversationItem.js
@@ -1,12 +1,12 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { View } from 'react-native';
 
 import type { UserOrBot } from '../types';
+import styles, { createStyleSheet } from '../styles';
 import { GroupAvatar, RawLabel, Touchable, UnreadCount } from '../common';
-import styles from '../styles';
 
-const componentStyles = StyleSheet.create({
+const componentStyles = createStyleSheet({
   text: {
     flex: 1,
     marginLeft: 16,

--- a/src/pm-conversations/PmConversationList.js
+++ b/src/pm-conversations/PmConversationList.js
@@ -1,14 +1,15 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
-import { FlatList, StyleSheet } from 'react-native';
+import { FlatList } from 'react-native';
 
 import type { Dispatch, PmConversationData, UserOrBot } from '../types';
+import { createStyleSheet } from '../styles';
 import { privateNarrow, groupNarrow } from '../utils/narrow';
 import UserItem from '../users/UserItem';
 import GroupPmConversationItem from './GroupPmConversationItem';
 import { doNarrow } from '../actions';
 
-const styles = StyleSheet.create({
+const styles = createStyleSheet({
   list: {
     flex: 1,
     flexDirection: 'column',

--- a/src/pm-conversations/PmConversationsCard.js
+++ b/src/pm-conversations/PmConversationsCard.js
@@ -1,10 +1,10 @@
 /* @flow strict-local */
 
 import React, { PureComponent } from 'react';
-import { View, StyleSheet } from 'react-native';
+import { View } from 'react-native';
 
 import type { ThemeData } from '../styles';
-import { ThemeContext } from '../styles';
+import { ThemeContext, createStyleSheet } from '../styles';
 import type { Dispatch, PmConversationData, UserOrBot } from '../types';
 import { connect } from '../react-redux';
 import { Label, ZulipButton, LoadingBanner } from '../common';
@@ -13,7 +13,7 @@ import PmConversationList from './PmConversationList';
 import { getRecentConversations, getAllUsersByEmail } from '../selectors';
 import { navigateToCreateGroup, navigateToUsersScreen } from '../actions';
 
-const styles = StyleSheet.create({
+const styles = createStyleSheet({
   container: {
     flex: 1,
   },

--- a/src/react-redux.js
+++ b/src/react-redux.js
@@ -3,50 +3,9 @@ import type { ComponentType, ElementConfig } from 'react';
 import { connect as connectInner } from 'react-redux';
 
 import type { GlobalState, Dispatch } from './types';
+import type { BoundedDiff } from './generics';
 
 /* eslint-disable flowtype/generic-spacing */
-
-/**
- * The type `S`, plus a check that `S` is a supertype of `T`.
- *
- * Gives an error unless `S` is a supertype of `T` -- i.e., a `T` can always
- * be used where an `S` is required.
- */
-type IsSupertype<+S, +T: S> = S; // eslint-disable-line no-unused-vars
-
-/**
- * An inverse of the operation `(A, B) => {| ...A, ...B |}`, with checking.
- *
- * Similar to `$Diff`, but checks that the subtraction makes sense.
- * Also always subtracts a given property completely, even if its type on
- * `L` happens to be more specific than on `U`.
- *
- * Assumes both U and L are exact object types.  (If not, behavior unknown.)
- * Returns a solution, where possible, to the type equation
- *   `U == {| ...D, ...L |}`
- * with an (inexact) object type `D`.
- *
- * More generally, returns the most general solution `D` to the relation
- *   `{| ...D, ...L |}: U`  (read "subtype of")
- * I.e., the most general type `D` such that `{| ...D, ...L |}` can be used
- * where a `U` is expected.  If there is no such `D`, causes a type error.
- *
- * In particular, this means:
- *  * Error if `L` has any extra properties that aren't in `U`.
- *  * Error unless each property of `L` has the same type as in `U`, or a subtype
- *    (i.e., the property's values in `L` are valid for `U`).
- *  * `D` has exactly the properties in `U` that aren't in `L`.
- *  * Each property of `D` has the same type as in `U`.
- */
-// Oddly, Flow accepts this declaration with <-U, -L> but also with <+U, +L>.
-export type BoundedDiff<-U, -L> = $Diff<
-  // This `IsSupertype` is the part that checks that all of L's properties
-  // (a) are present on U and (b) have appropriate types to use on U.
-  IsSupertype<U, $ReadOnly<{| ...U, ...L |}>>,
-  // This `$ObjMap` makes a variant of `L` that `$Diff` treats as more
-  // powerful, ensuring that all properties in `L` are removed completely.
-  $ObjMap<L, () => mixed>,
->;
 
 export type OwnProps<-C, -SP> = $Diff<
   BoundedDiff<$Exact<ElementConfig<C>>, SP>,

--- a/src/search/SearchMessagesCard.js
+++ b/src/search/SearchMessagesCard.js
@@ -1,17 +1,18 @@
 /* @flow strict-local */
 
 import React, { PureComponent } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { View } from 'react-native';
 import { ActionSheetProvider } from '@expo/react-native-action-sheet';
 
 import type { Message } from '../types';
+import { createStyleSheet } from '../styles';
 import { LoadingIndicator, SearchEmptyState } from '../common';
 import { HOME_NARROW } from '../utils/narrow';
 import MessageList from '../webview/MessageList';
 import renderMessages from '../message/renderMessages';
 import { NULL_ARRAY } from '../nullObjects';
 
-const styles = StyleSheet.create({
+const styles = createStyleSheet({
   results: {
     flex: 1,
   },

--- a/src/settings/LanguagePickerItem.js
+++ b/src/settings/LanguagePickerItem.js
@@ -1,12 +1,12 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { View } from 'react-native';
 
 import { RawLabel, Touchable } from '../common';
-import { BRAND_COLOR } from '../styles';
+import { BRAND_COLOR, createStyleSheet } from '../styles';
 import { IconDone } from '../common/Icons';
 
-const styles = StyleSheet.create({
+const styles = createStyleSheet({
   languageWrapper: {
     flex: 1,
     flexDirection: 'column',

--- a/src/settings/SettingsCard.js
+++ b/src/settings/SettingsCard.js
@@ -1,9 +1,10 @@
 /* @flow strict-local */
 
 import React, { PureComponent } from 'react';
-import { StyleSheet, ScrollView } from 'react-native';
+import { ScrollView } from 'react-native';
 
 import type { Dispatch } from '../types';
+import { createStyleSheet } from '../styles';
 import { connect } from '../react-redux';
 import { getSettings } from '../selectors';
 import { OptionButton, OptionRow } from '../common';
@@ -23,7 +24,7 @@ import {
   navigateToLegal,
 } from '../actions';
 
-const styles = StyleSheet.create({
+const styles = createStyleSheet({
   optionWrapper: {
     flex: 1,
   },

--- a/src/sharing/ShareToPm.js
+++ b/src/sharing/ShareToPm.js
@@ -1,8 +1,9 @@
 /* @flow strict-local */
 import React from 'react';
-import { View, StyleSheet, Image, ScrollView, Modal, BackHandler } from 'react-native';
+import { View, Image, ScrollView, Modal, BackHandler } from 'react-native';
 import { type NavigationNavigatorProps } from 'react-navigation';
 import type { Dispatch, SharedData, User, Auth, GetText } from '../types';
+import { createStyleSheet } from '../styles';
 import { TranslationContext } from '../boot/TranslationProvider';
 
 import { connect } from '../react-redux';
@@ -13,7 +14,7 @@ import { navigateBack } from '../nav/navActions';
 import ChooseRecipientsScreen from './ChooseRecipientsScreen';
 import { handleSend } from './send';
 
-const styles = StyleSheet.create({
+const styles = createStyleSheet({
   wrapper: {
     flex: 1,
     padding: 10,

--- a/src/sharing/ShareToStream.js
+++ b/src/sharing/ShareToStream.js
@@ -1,8 +1,9 @@
 /* @flow strict-local */
 import React from 'react';
-import { View, StyleSheet, Image, ScrollView, BackHandler } from 'react-native';
+import { View, Image, ScrollView, BackHandler } from 'react-native';
 import { type NavigationNavigatorProps } from 'react-navigation';
 import type { Dispatch, SharedData, Subscription, Auth, GetText } from '../types';
+import { createStyleSheet } from '../styles';
 import { TranslationContext } from '../boot/TranslationProvider';
 import { connect } from '../react-redux';
 import { ZulipButton, Input } from '../common';
@@ -16,7 +17,7 @@ import { navigateBack } from '../nav/navActions';
 import { fetchTopicsForStream } from '../topics/topicActions';
 import { handleSend } from './send';
 
-const styles = StyleSheet.create({
+const styles = createStyleSheet({
   wrapper: {
     flex: 1,
     padding: 10,

--- a/src/sharing/SharingScreen.js
+++ b/src/sharing/SharingScreen.js
@@ -1,10 +1,11 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
-import { StyleSheet, Text } from 'react-native';
+import { Text } from 'react-native';
 import type { NavigationScreenProp } from 'react-navigation';
 import { createMaterialTopTabNavigator } from 'react-navigation-tabs';
 import { FormattedMessage } from 'react-intl';
 import type { Dispatch, SharedData, Auth, TabNavigationOptionsPropsType } from '../types';
+import { createStyleSheet } from '../styles';
 import tabsOptions from '../styles/tabs';
 import { connect } from '../react-redux';
 import { Screen } from '../common';
@@ -19,7 +20,7 @@ type Props = $ReadOnly<{|
   dispatch: Dispatch,
 |}>;
 
-const styles = StyleSheet.create({
+const styles = createStyleSheet({
   tab: {
     padding: 8,
     fontSize: 16,

--- a/src/start/CompatibilityScreen.js
+++ b/src/start/CompatibilityScreen.js
@@ -1,13 +1,13 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
-import { StyleSheet, Image, Text, View, Platform, Linking } from 'react-native';
+import { Image, Text, View, Platform, Linking } from 'react-native';
 
 import { Touchable } from '../common';
-import { BRAND_COLOR } from '../styles';
+import { BRAND_COLOR, createStyleSheet } from '../styles';
 import appStoreBadgePNG from '../../static/img/app-store-badge.png';
 import googlePlayBadgePNG from '../../static/img/google-play-badge.png';
 
-const styles = StyleSheet.create({
+const styles = createStyleSheet({
   appStoreBadge: {
     width: 180,
     height: 60,

--- a/src/start/DevAuthScreen.js
+++ b/src/start/DevAuthScreen.js
@@ -1,17 +1,17 @@
 /* @flow strict-local */
 
 import React, { PureComponent } from 'react';
-import { ActivityIndicator, View, StyleSheet, FlatList } from 'react-native';
+import { ActivityIndicator, View, FlatList } from 'react-native';
 
 import type { Auth, DevUser, Dispatch } from '../types';
+import styles, { createStyleSheet } from '../styles';
 import { connect } from '../react-redux';
 import { ErrorMsg, Label, Screen, ZulipButton } from '../common';
 import * as api from '../api';
 import { getPartialAuth } from '../selectors';
 import { loginSuccess } from '../actions';
-import styles from '../styles';
 
-const componentStyles = StyleSheet.create({
+const componentStyles = createStyleSheet({
   accountItem: { height: 10 },
   heading: { flex: 0 },
   heading2: {

--- a/src/start/IosCompliantAppleAuthButton/Custom.js
+++ b/src/start/IosCompliantAppleAuthButton/Custom.js
@@ -1,14 +1,15 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
-import { StyleSheet, Text, View, Image, TouchableWithoutFeedback } from 'react-native';
+import { Text, View, Image, TouchableWithoutFeedback } from 'react-native';
 import type { ViewStyleProp } from 'react-native/Libraries/StyleSheet/StyleSheet';
 
 import type { ThemeName } from '../../reduxTypes';
+import { createStyleSheet } from '../../styles';
 import TranslatedText from '../../common/TranslatedText';
 import appleLogoBlackImg from '../../../static/img/apple-logo-black.png';
 import appleLogoWhiteImg from '../../../static/img/apple-logo-white.png';
 
-const styles = StyleSheet.create({
+const styles = createStyleSheet({
   buttonContent: {
     flexDirection: 'row',
     alignItems: 'center',

--- a/src/start/LoadingScreen.js
+++ b/src/start/LoadingScreen.js
@@ -1,11 +1,11 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { View } from 'react-native';
 
-import { BRAND_COLOR } from '../styles';
+import { BRAND_COLOR, createStyleSheet } from '../styles';
 import { LoadingIndicator, ZulipStatusBar } from '../common';
 
-const styles = StyleSheet.create({
+const styles = createStyleSheet({
   center: {
     flex: 1,
     justifyContent: 'center',

--- a/src/start/PasswordAuthScreen.js
+++ b/src/start/PasswordAuthScreen.js
@@ -1,9 +1,10 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
-import { View, StyleSheet } from 'react-native';
+import { View } from 'react-native';
 import type { NavigationScreenProp } from 'react-navigation';
 
 import type { Auth, Dispatch } from '../types';
+import { createStyleSheet } from '../styles';
 import { connect } from '../react-redux';
 import * as api from '../api';
 import {
@@ -19,7 +20,7 @@ import { getPartialAuth } from '../selectors';
 import { isValidEmailFormat } from '../utils/misc';
 import { loginSuccess } from '../actions';
 
-const styles = StyleSheet.create({
+const styles = createStyleSheet({
   linksTouchable: {
     alignItems: 'flex-end',
   },

--- a/src/start/RealmInfo.js
+++ b/src/start/RealmInfo.js
@@ -1,10 +1,11 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
-import { View, Image, StyleSheet } from 'react-native';
+import { View, Image } from 'react-native';
 
 import { RawLabel } from '../common';
+import { createStyleSheet } from '../styles';
 
-const styles = StyleSheet.create({
+const styles = createStyleSheet({
   description: {
     flexDirection: 'row',
     justifyContent: 'center',

--- a/src/streams/EditStreamCard.js
+++ b/src/streams/EditStreamCard.js
@@ -1,12 +1,12 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { View } from 'react-native';
 
 import { Input, Label, OptionRow, ZulipButton } from '../common';
-import styles from '../styles';
+import styles, { createStyleSheet } from '../styles';
 import { IconPrivate } from '../common/Icons';
 
-const componentStyles = StyleSheet.create({
+const componentStyles = createStyleSheet({
   optionRow: {
     paddingLeft: 8,
     paddingRight: 8,

--- a/src/streams/StreamCard.js
+++ b/src/streams/StreamCard.js
@@ -1,14 +1,14 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { View } from 'react-native';
 
 import type { Stream, Subscription } from '../types';
+import styles, { createStyleSheet } from '../styles';
 import { RawLabel } from '../common';
 import StreamIcon from './StreamIcon';
 import { NULL_SUBSCRIPTION } from '../nullObjects';
-import styles from '../styles';
 
-const componentStyles = StyleSheet.create({
+const componentStyles = createStyleSheet({
   streamRow: {
     flexDirection: 'row',
     alignItems: 'center',

--- a/src/streams/StreamItem.js
+++ b/src/streams/StreamItem.js
@@ -1,14 +1,14 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { View } from 'react-native';
 
 import type { ThemeData } from '../styles';
-import styles, { ThemeContext } from '../styles';
+import styles, { createStyleSheet, ThemeContext } from '../styles';
 import { RawLabel, Touchable, UnreadCount, ZulipSwitch } from '../common';
 import { foregroundColorFromBackground } from '../utils/color';
 import StreamIcon from './StreamIcon';
 
-const componentStyles = StyleSheet.create({
+const componentStyles = createStyleSheet({
   description: {
     opacity: 0.75,
     fontSize: 12,

--- a/src/streams/StreamList.js
+++ b/src/streams/StreamList.js
@@ -1,13 +1,14 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
-import { SectionList, StyleSheet } from 'react-native';
+import { SectionList } from 'react-native';
 
 import type { Stream, Subscription } from '../types';
+import { createStyleSheet } from '../styles';
 import { caseInsensitiveCompareFunc } from '../utils/misc';
 import StreamItem from './StreamItem';
 import { SectionSeparatorBetween, SearchEmptyState } from '../common';
 
-const styles = StyleSheet.create({
+const styles = createStyleSheet({
   list: {
     flex: 1,
     flexDirection: 'column',

--- a/src/streams/SubscriptionsCard.js
+++ b/src/streams/SubscriptionsCard.js
@@ -1,9 +1,10 @@
 /* @flow strict-local */
 
 import React, { PureComponent } from 'react';
-import { View, StyleSheet } from 'react-native';
+import { View } from 'react-native';
 
 import type { Dispatch, Subscription } from '../types';
+import { createStyleSheet } from '../styles';
 import { connect } from '../react-redux';
 import StreamList from './StreamList';
 import { LoadingBanner } from '../common';
@@ -12,7 +13,7 @@ import { getUnreadByStream } from '../selectors';
 import { getSubscribedStreams } from '../subscriptions/subscriptionSelectors';
 import { doNarrow } from '../actions';
 
-const styles = StyleSheet.create({
+const styles = createStyleSheet({
   container: {
     flex: 1,
     flexDirection: 'column',

--- a/src/streams/TopicItem.js
+++ b/src/streams/TopicItem.js
@@ -1,12 +1,12 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { View } from 'react-native';
 
-import styles, { BRAND_COLOR } from '../styles';
+import styles, { BRAND_COLOR, createStyleSheet } from '../styles';
 import { RawLabel, Touchable, UnreadCount } from '../common';
 import { showToast } from '../utils/info';
 
-const componentStyles = StyleSheet.create({
+const componentStyles = createStyleSheet({
   selectedRow: {
     backgroundColor: BRAND_COLOR,
   },

--- a/src/styles/index.js
+++ b/src/styles/index.js
@@ -1,5 +1,4 @@
 /* @flow strict-local */
-import { StyleSheet } from 'react-native';
 /* eslint-disable id-match */
 import type { ____Styles_Internal } from 'react-native/Libraries/StyleSheet/StyleSheetTypes';
 
@@ -44,7 +43,7 @@ export function createStyleSheet<+S: ____Styles_Internal>(obj: S): S {
   return Object.freeze(obj);
 }
 
-export default StyleSheet.create({
+export default createStyleSheet({
   ...composeBoxStyles,
   ...miscStyles,
   ...navStyles,

--- a/src/styles/index.js
+++ b/src/styles/index.js
@@ -1,5 +1,7 @@
 /* @flow strict-local */
 import { StyleSheet } from 'react-native';
+/* eslint-disable id-match */
+import type { ____Styles_Internal } from 'react-native/Libraries/StyleSheet/StyleSheetTypes';
 
 import composeBoxStyles from './composeBoxStyles';
 import { statics as miscStyles } from './miscStyles';
@@ -9,6 +11,38 @@ import utilityStyles from './utilityStyles';
 export * from './constants';
 export type { ThemeData } from './theme';
 export { ThemeContext } from './theme';
+
+/**
+ * Use instead of StyleSheet.create.
+ *
+ * The upstream StyleSheet.create does precisely nothing in release mode.
+ * In debug mode it does some runtime checks that are redundant with the
+ * type-checker, and applies Object.freeze.  The useful things it does are
+ * entirely at the source-code level:
+ *  * It makes explicit that this is supposed to be a bunch of styles.
+ *  * It tells Flow up front that this is supposed to be a bunch of styles.
+ *    In most cases we'll go on to use the styles someplace with an
+ *    appropriate type and so Flow would give an error just fine without
+ *    using any function like this, but it can be handy if the style is
+ *    passed someplace with an unfortunate `any` type.
+ *
+ * Unfortunately the upstream StyleSheet.create also defeats all
+ * type-checking on the styles it returns, marking them all as type `any`.
+ *
+ * This function does the useful things from StyleSheet.create, plus
+ * unconditionally applies Object.freeze.  And then it passes through the
+ * styles' actual types unchanged.
+ */
+// The name ____Styles_Internal is kind of hilarious, yes.  The type it
+// actually refers to is: an object where each property's type is a certain
+// object type, an exact object type with all properties optional.  That
+// type has the also-hilarious name ____DangerouslyImpreciseStyle_Internal;
+// but it's just what you get by spreading together all the different style
+// types.  Which makes it also the least upper bound, among plain object
+// types (i.e. not including union types), of all the different style types.
+export function createStyleSheet<+S: ____Styles_Internal>(obj: S): S {
+  return Object.freeze(obj);
+}
 
 export default StyleSheet.create({
   ...composeBoxStyles,

--- a/src/subscriptions/StreamListCard.js
+++ b/src/subscriptions/StreamListCard.js
@@ -1,9 +1,10 @@
 /* @flow strict-local */
 
 import React, { PureComponent } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { View } from 'react-native';
 
 import type { Auth, Dispatch, Stream, Subscription } from '../types';
+import { createStyleSheet } from '../styles';
 import { connect } from '../react-redux';
 import { ZulipButton, LoadingBanner } from '../common';
 import * as api from '../api';
@@ -13,7 +14,7 @@ import StreamList from '../streams/StreamList';
 import { getAuth, getCanCreateStreams, getStreams, getSubscriptions } from '../selectors';
 import { doNarrow, navigateToCreateStream } from '../actions';
 
-const styles = StyleSheet.create({
+const styles = createStyleSheet({
   wrapper: {
     flex: 1,
   },

--- a/src/title/TitleGroup.js
+++ b/src/title/TitleGroup.js
@@ -1,13 +1,13 @@
 /* @flow strict-local */
 
 import React, { PureComponent } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { View } from 'react-native';
 
 import type { Dispatch, UserOrBot, Narrow } from '../types';
+import styles, { createStyleSheet } from '../styles';
 import { connect } from '../react-redux';
 import { UserAvatarWithPresence } from '../common';
 import { getRecipientsInGroupNarrow } from '../selectors';
-import styles from '../styles';
 import { navigateToAccountDetails } from '../nav/navActions';
 
 type SelectorProps = $ReadOnly<{|
@@ -27,7 +27,7 @@ class TitleGroup extends PureComponent<Props> {
     dispatch(navigateToAccountDetails(user.user_id));
   };
 
-  styles = StyleSheet.create({
+  styles = createStyleSheet({
     titleAvatar: {
       marginRight: 16,
     },

--- a/src/title/TitlePrivate.js
+++ b/src/title/TitlePrivate.js
@@ -1,14 +1,14 @@
 /* @flow strict-local */
 
 import React, { PureComponent } from 'react';
-import { StyleSheet, Text, View } from 'react-native';
+import { Text, View } from 'react-native';
 
 import type { Dispatch, UserOrBot } from '../types';
+import styles, { createStyleSheet } from '../styles';
 import { connect } from '../react-redux';
 import { Touchable, UserAvatarWithPresence, ViewPlaceholder } from '../common';
 import ActivityText from './ActivityText';
 import { getAllUsersByEmail } from '../users/userSelectors';
-import styles from '../styles';
 import { navigateToAccountDetails } from '../nav/navActions';
 import * as logging from '../utils/logging';
 
@@ -33,7 +33,7 @@ class TitlePrivate extends PureComponent<Props> {
     dispatch(navigateToAccountDetails(user.user_id));
   };
 
-  styles = StyleSheet.create({
+  styles = createStyleSheet({
     outer: { flex: 1 },
     inner: { flexDirection: 'row', alignItems: 'center' },
   });

--- a/src/title/TitleStream.js
+++ b/src/title/TitleStream.js
@@ -1,14 +1,14 @@
 /* @flow strict-local */
 
 import React, { PureComponent } from 'react';
-import { StyleSheet, Text, View, TouchableWithoutFeedback } from 'react-native';
+import { Text, View, TouchableWithoutFeedback } from 'react-native';
 
 import type { Narrow, Stream, Subscription, Dispatch } from '../types';
+import styles, { createStyleSheet } from '../styles';
 import { connect } from '../react-redux';
 import StreamIcon from '../streams/StreamIcon';
 import { isTopicNarrow } from '../utils/narrow';
 import { getStreamInNarrow } from '../selectors';
-import styles from '../styles';
 import { showToast } from '../utils/info';
 
 type SelectorProps = {|
@@ -24,7 +24,7 @@ type Props = $ReadOnly<{|
 |}>;
 
 class TitleStream extends PureComponent<Props> {
-  styles = StyleSheet.create({
+  styles = createStyleSheet({
     outer: {
       flex: 1,
       flexDirection: 'column',

--- a/src/topics/TopicList.js
+++ b/src/topics/TopicList.js
@@ -1,12 +1,13 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
-import { FlatList, StyleSheet } from 'react-native';
+import { FlatList } from 'react-native';
 
 import type { TopicExtended } from '../types';
+import { createStyleSheet } from '../styles';
 import TopicItem from '../streams/TopicItem';
 import { LoadingIndicator, SearchEmptyState } from '../common';
 
-const styles = StyleSheet.create({
+const styles = createStyleSheet({
   list: {
     flex: 1,
     flexDirection: 'column',

--- a/src/types.js
+++ b/src/types.js
@@ -5,40 +5,11 @@ import type { DangerouslyImpreciseStyleProp } from 'react-native/Libraries/Style
 import type { Auth, Topic, Message, Reaction, ReactionType, Narrow } from './api/apiTypes';
 import type { ZulipVersion } from './utils/zulipVersion';
 
+export type * from './generics';
 export type * from './reduxTypes';
 export type * from './api/apiTypes';
 
-/**
- * Assert a contradiction, statically.  Do nothing at runtime.
- *
- * The `empty` type is the type with no values.  So, apart from certain bugs
- * in Flow, the only way a call to this function can ever be valid is when
- * the type-checker can actually prove the call site is unreachable.
- *
- * Especially useful for statically asserting that a `switch` statement is
- * exhaustive:
- *
- *     type Foo =
- *       | {| type: 'frob', ... |}
- *       | {| type: 'twiddle', ... |};
- *
- *
- *     const foo: Foo = ...;
- *     switch (foo.type) {
- *       case 'frob': ...; break;
- *
- *       case 'twiddle': ...; break;
- *
- *       default:
- *         ensureUnreachable(foo); // Asserts no possible cases for `foo` remain.
- *         break;
- *     }
- *
- * In this example if by mistake a case is omitted, or if another case is
- * added to the type without a corresponding `case` statement here, then
- * Flow will report a type error at the `ensureUnreachable` call.
- */
-export function ensureUnreachable(x: empty) {}
+export { ensureUnreachable } from './generics';
 
 /*
  * TODO as the name suggests, this should be broken down more specifically.

--- a/src/user-groups/UserGroupItem.js
+++ b/src/user-groups/UserGroupItem.js
@@ -1,13 +1,13 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { View } from 'react-native';
 
 import { IconPeople } from '../common/Icons';
 import { RawLabel, Touchable } from '../common';
-import styles, { ThemeContext } from '../styles';
+import styles, { createStyleSheet, ThemeContext } from '../styles';
 import type { ThemeData } from '../styles';
 
-const componentStyles = StyleSheet.create({
+const componentStyles = createStyleSheet({
   text: {
     marginLeft: 8,
   },

--- a/src/user-picker/AvatarItem.js
+++ b/src/user-picker/AvatarItem.js
@@ -1,11 +1,12 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
-import { Animated, Easing, StyleSheet, View } from 'react-native';
+import { Animated, Easing, View } from 'react-native';
 
 import { UserAvatarWithPresence, ComponentWithOverlay, RawLabel, Touchable } from '../common';
+import { createStyleSheet } from '../styles';
 import { IconCancel } from '../common/Icons';
 
-const styles = StyleSheet.create({
+const styles = createStyleSheet({
   wrapper: {
     flexDirection: 'column',
     marginLeft: 8,

--- a/src/user-picker/UserPickerCard.js
+++ b/src/user-picker/UserPickerCard.js
@@ -1,9 +1,10 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { View } from 'react-native';
 import type { FlatList } from 'react-native';
 
 import type { User, PresenceState, Dispatch } from '../types';
+import { createStyleSheet } from '../styles';
 import { connect } from '../react-redux';
 import { FloatingActionButton, LineSeparator } from '../common';
 import { IconDone } from '../common/Icons';
@@ -12,7 +13,7 @@ import AvatarList from './AvatarList';
 import AnimatedScaleComponent from '../animation/AnimatedScaleComponent';
 import { getPresence, getUsersSansMe, getUsersByEmail } from '../selectors';
 
-const styles = StyleSheet.create({
+const styles = createStyleSheet({
   wrapper: {
     flex: 1,
   },

--- a/src/user-status/UserStatusScreen.js
+++ b/src/user-status/UserStatusScreen.js
@@ -1,7 +1,8 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
-import { FlatList, StyleSheet, View } from 'react-native';
+import { FlatList, View } from 'react-native';
 import { TranslationContext } from '../boot/TranslationProvider';
+import { createStyleSheet } from '../styles';
 
 import type { GetText, Dispatch } from '../types';
 import { connect } from '../react-redux';
@@ -12,7 +13,7 @@ import statusSuggestions from './userStatusTextSuggestions';
 import { updateUserStatusText } from './userStatusActions';
 import { navigateBack } from '../nav/navActions';
 
-const styles = StyleSheet.create({
+const styles = createStyleSheet({
   statusTextInput: {
     margin: 16,
   },

--- a/src/users/UserItem.js
+++ b/src/users/UserItem.js
@@ -1,11 +1,11 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { View } from 'react-native';
 
 import { UserAvatarWithPresence, RawLabel, Touchable, UnreadCount } from '../common';
-import styles, { BRAND_COLOR } from '../styles';
+import styles, { createStyleSheet, BRAND_COLOR } from '../styles';
 
-const componentStyles = StyleSheet.create({
+const componentStyles = createStyleSheet({
   selectedRow: {
     backgroundColor: BRAND_COLOR,
   },

--- a/src/users/UserList.js
+++ b/src/users/UserList.js
@@ -1,13 +1,14 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
-import { StyleSheet, SectionList } from 'react-native';
+import { SectionList } from 'react-native';
 
 import type { PresenceState, Style, User } from '../types';
+import { createStyleSheet } from '../styles';
 import { SectionHeader, SearchEmptyState } from '../common';
 import UserItem from './UserItem';
 import { sortUserList, filterUserList, groupUsersByStatus } from './userHelpers';
 
-const styles = StyleSheet.create({
+const styles = createStyleSheet({
   list: {
     flex: 1,
   },


### PR DESCRIPTION
This is the other set of followups from https://github.com/zulip/zulip-mobile/pull/4101#issuecomment-669814479 where I merged #4101: some small refactors to the ZulipButton component, and then that led me to some digging into StyleSheet.create and responding to an unpleasant discovery there, and to a bit of Flow metaprogramming.

(I actually still have some further changes following up on these, going deeper into tools for the Flow metaprogramming with some of the things I learned while writing this `SubsetProperties`. Those aren't quite ready and I'll send them separately.)
