### PR TITLE
Crunchify shell for avatar URLs, handle `user_avatar_url_field_optional` client capability

### DIFF
--- a/src/__tests__/lib/exampleData.js
+++ b/src/__tests__/lib/exampleData.js
@@ -15,6 +15,7 @@ import type {
 import type { Action, GlobalState, RealmState } from '../../reduxTypes';
 import type { Auth, Account, Outbox } from '../../types';
 import { ZulipVersion } from '../../utils/zulipVersion';
+import { AvatarURL } from '../../utils/avatar';
 import {
   ACCOUNT_SWITCH,
   LOGIN_SUCCESS,
@@ -266,12 +267,18 @@ const messagePropertiesBase = deepFreeze({
 });
 
 const messagePropertiesFromSender = (user: User) => {
-  const { avatar_url, user_id: sender_id, email: sender_email, full_name: sender_full_name } = user;
+  const { user_id: sender_id, email: sender_email, full_name: sender_full_name } = user;
 
   return deepFreeze({
     sender_domain: '',
 
-    avatar_url,
+    // In the next commit, we'll just use `user.avatar_url`, since
+    // it'll already be an `AvatarURL`.
+    avatar_url: AvatarURL.fromUserOrBotData({
+      rawAvatarUrl: user.avatar_url,
+      email: user.email,
+      realm,
+    }),
     client: 'ExampleClient',
     gravatar_hash: 'd3adb33f',
     sender_email,
@@ -367,7 +374,13 @@ const outboxMessageBase: $Diff<Outbox, {| id: mixed, timestamp: mixed |}> = deep
   isOutbox: true,
   isSent: false,
 
-  avatar_url: selfUser.avatar_url,
+  // In the next commit, we'll just use `selfUser.avatar_url`, since
+  // it'll already be an `AvatarURL`.
+  avatar_url: AvatarURL.fromUserOrBotData({
+    rawAvatarUrl: selfUser.avatar_url,
+    email: selfUser.email,
+    realm,
+  }),
   content: '<p>Test.</p>',
   display_recipient: stream.name,
   // id: ...,

--- a/src/__tests__/lib/exampleData.js
+++ b/src/__tests__/lib/exampleData.js
@@ -14,8 +14,8 @@ import type {
 } from '../../api/modelTypes';
 import type { Action, GlobalState, RealmState } from '../../reduxTypes';
 import type { Auth, Account, Outbox } from '../../types';
+import { UploadedAvatarURL } from '../../utils/avatar';
 import { ZulipVersion } from '../../utils/zulipVersion';
-import { AvatarURL } from '../../utils/avatar';
 import {
   ACCOUNT_SWITCH,
   LOGIN_SUCCESS,
@@ -89,7 +89,10 @@ const userOrBotProperties = ({ name: _name }) => {
   const name = _name ?? randString();
   const capsName = name.substring(0, 1).toUpperCase() + name.substring(1);
   return deepFreeze({
-    avatar_url: `https://zulip.example.org/yo/avatar-${name}.png`,
+    avatar_url: UploadedAvatarURL.validateAndConstructInstance({
+      realm: new URL('https://zulip.example.org'),
+      absoluteOrRelativeUrl: `/yo/avatar-${name}.png`,
+    }),
 
     date_joined: `2014-04-${randInt(30)
       .toString()
@@ -271,14 +274,7 @@ const messagePropertiesFromSender = (user: User) => {
 
   return deepFreeze({
     sender_domain: '',
-
-    // In the next commit, we'll just use `user.avatar_url`, since
-    // it'll already be an `AvatarURL`.
-    avatar_url: AvatarURL.fromUserOrBotData({
-      rawAvatarUrl: user.avatar_url,
-      email: user.email,
-      realm,
-    }),
+    avatar_url: user.avatar_url,
     client: 'ExampleClient',
     gravatar_hash: 'd3adb33f',
     sender_email,
@@ -373,14 +369,7 @@ export const streamMessage = (args?: {|
 const outboxMessageBase: $Diff<Outbox, {| id: mixed, timestamp: mixed |}> = deepFreeze({
   isOutbox: true,
   isSent: false,
-
-  // In the next commit, we'll just use `selfUser.avatar_url`, since
-  // it'll already be an `AvatarURL`.
-  avatar_url: AvatarURL.fromUserOrBotData({
-    rawAvatarUrl: selfUser.avatar_url,
-    email: selfUser.email,
-    realm,
-  }),
+  avatar_url: selfUser.avatar_url,
   content: '<p>Test.</p>',
   display_recipient: stream.name,
   // id: ...,

--- a/src/account-info/AccountDetails.js
+++ b/src/account-info/AccountDetails.js
@@ -58,7 +58,7 @@ class AccountDetails extends PureComponent<Props> {
     return (
       <ComponentList outerSpacing itemStyle={componentStyles.componentListItem}>
         <View>
-          <UserAvatar avatarUrl={user.avatar_url} email={user.email} size={200} />
+          <UserAvatar avatarUrl={user.avatar_url} size={200} />
         </View>
         <View style={componentStyles.statusWrapper}>
           <PresenceStatusIndicator

--- a/src/account-info/AccountDetails.js
+++ b/src/account-info/AccountDetails.js
@@ -29,8 +29,6 @@ const componentStyles = createStyleSheet({
   },
 });
 
-const AVATAR_SIZE = 200;
-
 type SelectorProps = {|
   userStatusText: string | void,
 |};
@@ -60,7 +58,7 @@ class AccountDetails extends PureComponent<Props> {
     return (
       <ComponentList outerSpacing itemStyle={componentStyles.componentListItem}>
         <View>
-          <UserAvatar avatarUrl={user.avatar_url} email={user.email} size={AVATAR_SIZE} />
+          <UserAvatar avatarUrl={user.avatar_url} email={user.email} size={200} />
         </View>
         <View style={componentStyles.statusWrapper}>
           <PresenceStatusIndicator

--- a/src/account-info/AccountDetails.js
+++ b/src/account-info/AccountDetails.js
@@ -1,6 +1,6 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
-import { View } from 'react-native';
+import { View, PixelRatio } from 'react-native';
 
 import type { UserOrBot, Dispatch } from '../types';
 import styles, { createStyleSheet } from '../styles';
@@ -62,7 +62,14 @@ class AccountDetails extends PureComponent<Props> {
     return (
       <ComponentList outerSpacing itemStyle={componentStyles.componentListItem}>
         <View>
-          <UserAvatar avatarUrl={getAvatarFromUser(user, realm, AVATAR_SIZE)} size={AVATAR_SIZE} />
+          <UserAvatar
+            avatarUrl={getAvatarFromUser(
+              user,
+              realm,
+              PixelRatio.getPixelSizeForLayoutSize(AVATAR_SIZE),
+            )}
+            size={AVATAR_SIZE}
+          />
         </View>
         <View style={componentStyles.statusWrapper}>
           <PresenceStatusIndicator

--- a/src/account-info/AccountDetails.js
+++ b/src/account-info/AccountDetails.js
@@ -1,15 +1,14 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
-import { View, PixelRatio } from 'react-native';
+import { View } from 'react-native';
 
 import type { UserOrBot, Dispatch } from '../types';
 import styles, { createStyleSheet } from '../styles';
 import { connect } from '../react-redux';
 import { UserAvatar, ComponentList, RawLabel } from '../common';
-import { getCurrentRealm, getUserStatusTextForUser } from '../selectors';
+import { getUserStatusTextForUser } from '../selectors';
 import PresenceStatusIndicator from '../common/PresenceStatusIndicator';
 import ActivityText from '../title/ActivityText';
-import { getAvatarFromUser } from '../utils/avatar';
 import { nowInTimeZone } from '../utils/date';
 
 const componentStyles = createStyleSheet({
@@ -33,7 +32,6 @@ const componentStyles = createStyleSheet({
 const AVATAR_SIZE = 200;
 
 type SelectorProps = {|
-  realm: URL,
   userStatusText: string | void,
 |};
 
@@ -46,7 +44,7 @@ type Props = $ReadOnly<{|
 
 class AccountDetails extends PureComponent<Props> {
   render() {
-    const { realm, user, userStatusText } = this.props;
+    const { user, userStatusText } = this.props;
 
     let localTime: string | null = null;
     // See comments at CrossRealmBot and User at src/api/modelTypes.js.
@@ -62,14 +60,7 @@ class AccountDetails extends PureComponent<Props> {
     return (
       <ComponentList outerSpacing itemStyle={componentStyles.componentListItem}>
         <View>
-          <UserAvatar
-            avatarUrl={getAvatarFromUser(
-              user,
-              realm,
-              PixelRatio.getPixelSizeForLayoutSize(AVATAR_SIZE),
-            )}
-            size={AVATAR_SIZE}
-          />
+          <UserAvatar avatarUrl={user.avatar_url} email={user.email} size={AVATAR_SIZE} />
         </View>
         <View style={componentStyles.statusWrapper}>
           <PresenceStatusIndicator
@@ -96,6 +87,5 @@ class AccountDetails extends PureComponent<Props> {
 }
 
 export default connect<SelectorProps, _, _>((state, props) => ({
-  realm: getCurrentRealm(state),
   userStatusText: getUserStatusTextForUser(state, props.user.user_id),
 }))(AccountDetails);

--- a/src/actionTypes.js
+++ b/src/actionTypes.js
@@ -414,9 +414,11 @@ type EventUserRemoveAction = {|
 |};
 
 type EventUserUpdateAction = {|
+  ...ServerEvent,
   type: typeof EVENT_USER_UPDATE,
-  // In reality there's more -- but this will prevent accidentally using
-  // the type before going and adding those other properties here properly.
+  userId: number,
+  // Include only the fields that should be overwritten.
+  person: $Shape<User>,
 |};
 
 type EventMutedTopicsAction = {|

--- a/src/api/initialDataTypes.js
+++ b/src/api/initialDataTypes.js
@@ -110,8 +110,8 @@ export type RawInitialDataRealmUser = {|
   enter_sends: boolean,
   full_name: string,
   is_admin: boolean,
-  realm_users: Array<{| ...User, avatar_url: string | null |}>,
-  realm_non_active_users: Array<{| ...User, avatar_url: string | null |}>,
+  realm_users: Array<{| ...User, avatar_url?: string | null |}>,
+  realm_non_active_users: Array<{| ...User, avatar_url?: string | null |}>,
   user_id: number,
 |};
 

--- a/src/api/initialDataTypes.js
+++ b/src/api/initialDataTypes.js
@@ -100,19 +100,26 @@ export type InitialDataRealmFilters = {|
   realm_filters: RealmFilter[],
 |};
 
-export type InitialDataRealmUser = {|
+export type RawInitialDataRealmUser = {|
   avatar_source: 'G',
   avatar_url: string | null,
   avatar_url_medium: string,
   can_create_streams: boolean,
-  cross_realm_bots: CrossRealmBot[],
+  cross_realm_bots: Array<{| ...CrossRealmBot, avatar_url?: string | null |}>,
   email: string,
   enter_sends: boolean,
   full_name: string,
   is_admin: boolean,
+  realm_users: Array<{| ...User, avatar_url: string | null |}>,
+  realm_non_active_users: Array<{| ...User, avatar_url: string | null |}>,
+  user_id: number,
+|};
+
+export type InitialDataRealmUser = {|
+  ...RawInitialDataRealmUser,
+  cross_realm_bots: CrossRealmBot[],
   realm_non_active_users: User[],
   realm_users: User[],
-  user_id: number,
 |};
 
 export type InitialDataRealmUserGroups = {|
@@ -280,7 +287,8 @@ export type InitialDataUserStatus = {|
   user_status?: UserStatusMapObject,
 |};
 
-// Initial data snapshot sent in response to a `/register` request.
+// Initial data snapshot sent in response to a `/register` request,
+// after validation and transformation.
 export type InitialData = {|
   // The server sends different subsets of the full available data,
   // depending on what event types the client subscribes to with the
@@ -305,4 +313,11 @@ export type InitialData = {|
   ...InitialDataUpdateGlobalNotifications,
   ...InitialDataUpdateMessageFlags,
   ...InitialDataUserStatus,
+|};
+
+// Initial data snapshot sent in response to a `/register` request,
+// before validation and transformation.
+export type RawInitialData = {|
+  ...InitialData,
+  ...RawInitialDataRealmUser,
 |};

--- a/src/api/messages/__tests__/migrateMessages-test.js
+++ b/src/api/messages/__tests__/migrateMessages-test.js
@@ -4,6 +4,7 @@ import { identityOfAuth } from '../../../account/accountMisc';
 import * as eg from '../../../__tests__/lib/exampleData';
 import type { ServerMessage, ServerReaction } from '../getMessages';
 import type { Message } from '../../modelTypes';
+import { GravatarURL } from '../../../utils/avatar';
 
 describe('migrateMessages', () => {
   const reactingUser = eg.makeUser();
@@ -22,6 +23,7 @@ describe('migrateMessages', () => {
   const serverMessage: ServerMessage = {
     ...eg.streamMessage(),
     reactions: [serverReaction],
+    avatar_url: null,
   };
 
   const input: ServerMessage[] = [serverMessage];
@@ -37,12 +39,17 @@ describe('migrateMessages', () => {
           emoji_code: serverReaction.emoji_code,
         },
       ],
+      avatar_url: GravatarURL.validateAndConstructInstance({ email: serverMessage.sender_email }),
     },
   ];
 
   const actualOutput: Message[] = migrateMessages(input, identityOfAuth(eg.selfAuth));
 
-  test('Replace user object with `user_id`', () => {
+  test('In reactions, replace user object with `user_id`', () => {
     expect(actualOutput.map(m => m.reactions)).toEqual(expectedOutput.map(m => m.reactions));
+  });
+
+  test('Converts avatar_url correctly', () => {
+    expect(actualOutput.map(m => m.avatar_url)).toEqual(expectedOutput.map(m => m.avatar_url));
   });
 });

--- a/src/api/messages/getMessages.js
+++ b/src/api/messages/getMessages.js
@@ -54,6 +54,7 @@ export const migrateMessages = (messages: ServerMessage[], identity: Identity): 
       avatar_url: AvatarURL.fromUserOrBotData({
         rawAvatarUrl,
         email: message.sender_email,
+        userId: message.sender_id,
         realm: identity.realm,
       }),
       reactions: reactions.map(reaction => {

--- a/src/api/messages/getMessages.js
+++ b/src/api/messages/getMessages.js
@@ -100,6 +100,7 @@ export default async (
     num_after: numAfter,
     apply_markdown: true,
     use_first_unread_anchor: useFirstUnread,
+    client_gravatar: true,
   });
   return migrateResponse(response, identityOfAuth(auth));
 };

--- a/src/api/modelTypes.js
+++ b/src/api/modelTypes.js
@@ -12,6 +12,8 @@
 //
 //
 
+import type { AvatarURL } from '../utils/avatar';
+
 export type ImageEmojiType = $ReadOnly<{|
   author?: $ReadOnly<{|
     email: string,
@@ -480,10 +482,18 @@ export type Message = $ReadOnly<{|
    */
   flags?: $ReadOnlyArray<string>,
 
-  //
+  /**
+   * Present under EVENT_NEW_MESSAGE and under MESSAGE_FETCH_COMPLETE,
+   * and in `state.messages`, all as an AvatarURL, because we
+   * translate into that form at the edge.
+   *
+   * For how it appears at the edge (and how we translate) see
+   * AvatarURL.fromUserOrBotData.
+   */
+  avatar_url: AvatarURL,
+
   // The rest are believed to really appear in `message` events.
 
-  avatar_url: string | null,
   client: string,
   content: string,
   content_type: 'text/html' | 'text/markdown',

--- a/src/api/modelTypes.js
+++ b/src/api/modelTypes.js
@@ -108,8 +108,22 @@ export type User = {|
   // instead of an empty string.
   timezone?: string,
 
-  // avatar_url is synthesized on the server by `get_avatar_field`.
-  avatar_url: string | null,
+  /**
+   * Present under EVENT_USER_ADD, EVENT_USER_UPDATE (if change
+   * indicated), under REALM_INIT, and in `state.users`, all as an
+   * AvatarURL, because we translate into that form at the edge.
+   *
+   * For how it appears at the edge (and how we translate) see
+   * AvatarURL.fromUserOrBotData.
+   */
+  avatar_url: AvatarURL,
+
+  // These properties appear in data from the server, but we ignore
+  // them. If we add these, we should try to avoid `avatar_url`
+  // falling out of sync with them.
+  // avatar_source: mixed,
+  // avatar_url_medium: mixed,
+  // avatar_version: mixed,
 
   // profile_data added in commit 02b845336 (in 1.8.0);
   // see also e3aed0f7b (in 2.0.0)
@@ -130,9 +144,10 @@ export type User = {|
  *  * `UserOrBot`, a convenience union
  */
 export type CrossRealmBot = {|
-  // avatar_url included since commit 58ee3fa8c (in 1.9.0)
-  // TODO(crunchy): convert missing -> null
-  avatar_url?: string | null,
+  /**
+   * See note for this property on User.
+   */
+  avatar_url: AvatarURL,
 
   // date_joined included since commit 58ee3fa8c (in 1.9.0)
   date_joined?: string,

--- a/src/api/registerForEvents.js
+++ b/src/api/registerForEvents.js
@@ -18,27 +18,33 @@ type RegisterForEventsParams = {|
   client_capabilities?: {|
     notification_settings_null: boolean,
     bulk_message_deletion: boolean,
+    user_avatar_url_field_optional: boolean,
   |},
 |};
 
-const transformUser = (rawUser: {| ...User, avatar_url: string | null |}, realm: URL): User => {
+const transformUser = (rawUser: {| ...User, avatar_url?: string | null |}, realm: URL): User => {
   const { avatar_url: rawAvatarUrl, email } = rawUser;
 
   return {
     ...rawUser,
-    avatar_url: AvatarURL.fromUserOrBotData({ rawAvatarUrl, email, realm }),
+    avatar_url: AvatarURL.fromUserOrBotData({
+      rawAvatarUrl,
+      email,
+      userId: rawUser.user_id,
+      realm,
+    }),
   };
 };
 
 const transformCrossRealmBot = (
-  rawCrossRealmBot: {| ...CrossRealmBot, avatar_url: string | void | null |},
+  rawCrossRealmBot: {| ...CrossRealmBot, avatar_url?: string | null |},
   realm: URL,
 ): CrossRealmBot => {
-  const { avatar_url: rawAvatarUrl, email } = rawCrossRealmBot;
+  const { avatar_url: rawAvatarUrl, user_id: userId, email } = rawCrossRealmBot;
 
   return {
     ...rawCrossRealmBot,
-    avatar_url: AvatarURL.fromUserOrBotData({ rawAvatarUrl, email, realm }),
+    avatar_url: AvatarURL.fromUserOrBotData({ rawAvatarUrl, userId, email, realm }),
   };
 };
 

--- a/src/api/registerForEvents.js
+++ b/src/api/registerForEvents.js
@@ -1,7 +1,8 @@
 /* @flow strict-local */
-import type { InitialData } from './initialDataTypes';
+import type { RawInitialData, InitialData } from './initialDataTypes';
 import type { Auth } from './transportTypes';
 import type { Narrow } from './apiTypes';
+import type { CrossRealmBot, User } from './modelTypes';
 import { apiPost } from './apiFetch';
 
 type RegisterForEventsParams = {|
@@ -19,14 +20,39 @@ type RegisterForEventsParams = {|
   |},
 |};
 
+const transformUser = (rawUser: {| ...User, avatar_url: string | null |}, realm: URL): User =>
+  // In an upcoming commit, we'll convert the raw-data `avatar_url`
+  // field to an AvatarURL instance.
+  rawUser;
+
+const transformCrossRealmBot = (
+  rawCrossRealmBot: {| ...CrossRealmBot, avatar_url: string | void | null |},
+  realm: URL,
+): CrossRealmBot =>
+  // In an upcoming commit, we'll convert the raw-data `avatar_url`
+  // field to an AvatarURL instance.
+  rawCrossRealmBot;
+
+const transform = (rawInitialData: RawInitialData, auth: Auth): InitialData => ({
+  ...rawInitialData,
+  realm_users: rawInitialData.realm_users.map(rawUser => transformUser(rawUser, auth.realm)),
+  realm_non_active_users: rawInitialData.realm_non_active_users.map(rawNonActiveUser =>
+    transformUser(rawNonActiveUser, auth.realm),
+  ),
+  cross_realm_bots: rawInitialData.cross_realm_bots.map(rawCrossRealmBot =>
+    transformCrossRealmBot(rawCrossRealmBot, auth.realm),
+  ),
+});
+
 /** See https://zulip.com/api/register-queue */
 export default async (auth: Auth, params: RegisterForEventsParams): Promise<InitialData> => {
   const { narrow, event_types, fetch_event_types, client_capabilities } = params;
-  return apiPost(auth, 'register', {
+  const rawInitialData = await apiPost(auth, 'register', {
     ...params,
     narrow: JSON.stringify(narrow),
     event_types: JSON.stringify(event_types),
     fetch_event_types: JSON.stringify(fetch_event_types),
     client_capabilities: JSON.stringify(client_capabilities),
   });
+  return transform(rawInitialData, auth);
 };

--- a/src/api/registerForEvents.js
+++ b/src/api/registerForEvents.js
@@ -4,6 +4,7 @@ import type { Auth } from './transportTypes';
 import type { Narrow } from './apiTypes';
 import type { CrossRealmBot, User } from './modelTypes';
 import { apiPost } from './apiFetch';
+import { AvatarURL } from '../utils/avatar';
 
 type RegisterForEventsParams = {|
   apply_markdown?: boolean,
@@ -20,18 +21,26 @@ type RegisterForEventsParams = {|
   |},
 |};
 
-const transformUser = (rawUser: {| ...User, avatar_url: string | null |}, realm: URL): User =>
-  // In an upcoming commit, we'll convert the raw-data `avatar_url`
-  // field to an AvatarURL instance.
-  rawUser;
+const transformUser = (rawUser: {| ...User, avatar_url: string | null |}, realm: URL): User => {
+  const { avatar_url: rawAvatarUrl, email } = rawUser;
+
+  return {
+    ...rawUser,
+    avatar_url: AvatarURL.fromUserOrBotData({ rawAvatarUrl, email, realm }),
+  };
+};
 
 const transformCrossRealmBot = (
   rawCrossRealmBot: {| ...CrossRealmBot, avatar_url: string | void | null |},
   realm: URL,
-): CrossRealmBot =>
-  // In an upcoming commit, we'll convert the raw-data `avatar_url`
-  // field to an AvatarURL instance.
-  rawCrossRealmBot;
+): CrossRealmBot => {
+  const { avatar_url: rawAvatarUrl, email } = rawCrossRealmBot;
+
+  return {
+    ...rawCrossRealmBot,
+    avatar_url: AvatarURL.fromUserOrBotData({ rawAvatarUrl, email, realm }),
+  };
+};
 
 const transform = (rawInitialData: RawInitialData, auth: Auth): InitialData => ({
   ...rawInitialData,

--- a/src/api/users/getUsers.js
+++ b/src/api/users/getUsers.js
@@ -5,8 +5,12 @@ import { apiGet } from '../apiFetch';
 
 type ApiResponseUsers = {|
   ...ApiResponseSuccess,
-  members: User[],
+  members: $ReadOnlyArray<{| ...User, avatar_url: string | null |}>,
 |};
+
+// TODO: If we start to use this, we need to convert `.avatar_url` to
+// an AvatarURL instance, like we do in `registerForEvents` and
+// `EVENT_USER_ADD` and `EVENT_USER_UPDATE`.
 
 /** See https://zulip.com/api/get-all-users */
 export default (auth: Auth): Promise<ApiResponseUsers> =>

--- a/src/boot/store.js
+++ b/src/boot/store.js
@@ -10,6 +10,7 @@ import { persistStore, autoRehydrate } from '../third/redux-persist';
 import type { Config } from '../third/redux-persist';
 
 import { ZulipVersion } from '../utils/zulipVersion';
+import { GravatarURL, UploadedAvatarURL } from '../utils/avatar';
 import type { Action, GlobalState } from '../types';
 import config from '../config';
 import { REHYDRATE } from '../actionConstants';
@@ -303,6 +304,13 @@ const customReplacer = (key, value, defaultReplacer) => {
     return { data: value.raw(), [SERIALIZED_TYPE_FIELD_NAME]: 'ZulipVersion' };
   } else if (value instanceof URL) {
     return { data: value.toString(), [SERIALIZED_TYPE_FIELD_NAME]: 'URL' };
+  } else if (value instanceof GravatarURL) {
+    return { data: GravatarURL.serialize(value), [SERIALIZED_TYPE_FIELD_NAME]: 'GravatarURL' };
+  } else if (value instanceof UploadedAvatarURL) {
+    return {
+      data: UploadedAvatarURL.serialize(value),
+      [SERIALIZED_TYPE_FIELD_NAME]: 'UploadedAvatarURL',
+    };
   }
   return defaultReplacer(key, value);
 };
@@ -315,6 +323,10 @@ const customReviver = (key, value, defaultReviver) => {
         return new ZulipVersion(data);
       case 'URL':
         return new URL(data);
+      case 'GravatarURL':
+        return GravatarURL.deserialize(data);
+      case 'UploadedAvatarURL':
+        return UploadedAvatarURL.deserialize(data);
       default:
       // Fall back to defaultReviver, below
     }

--- a/src/boot/store.js
+++ b/src/boot/store.js
@@ -10,7 +10,7 @@ import { persistStore, autoRehydrate } from '../third/redux-persist';
 import type { Config } from '../third/redux-persist';
 
 import { ZulipVersion } from '../utils/zulipVersion';
-import { GravatarURL, UploadedAvatarURL } from '../utils/avatar';
+import { GravatarURL, UploadedAvatarURL, FallbackAvatarURL } from '../utils/avatar';
 import type { Action, GlobalState } from '../types';
 import config from '../config';
 import { REHYDRATE } from '../actionConstants';
@@ -318,6 +318,11 @@ const customReplacer = (key, value, defaultReplacer) => {
       data: UploadedAvatarURL.serialize(value),
       [SERIALIZED_TYPE_FIELD_NAME]: 'UploadedAvatarURL',
     };
+  } else if (value instanceof FallbackAvatarURL) {
+    return {
+      data: FallbackAvatarURL.serialize(value),
+      [SERIALIZED_TYPE_FIELD_NAME]: 'FallbackAvatarURL',
+    };
   }
   return defaultReplacer(key, value);
 };
@@ -334,6 +339,8 @@ const customReviver = (key, value, defaultReviver) => {
         return GravatarURL.deserialize(data);
       case 'UploadedAvatarURL':
         return UploadedAvatarURL.deserialize(data);
+      case 'FallbackAvatarURL':
+        return FallbackAvatarURL.deserialize(data);
       default:
       // Fall back to defaultReviver, below
     }

--- a/src/boot/store.js
+++ b/src/boot/store.js
@@ -221,6 +221,10 @@ const migrations: { [string]: (GlobalState) => GlobalState } = {
   // Convert messages[].avatar_url from `string | null` to `AvatarURL`.
   '17': dropCache,
 
+  // Convert `UserOrBot.avatar_url` from raw server data to
+  // `AvatarURL`.
+  '18': dropCache,
+
   // TIP: When adding a migration, consider just using `dropCache`.
 };
 

--- a/src/boot/store.js
+++ b/src/boot/store.js
@@ -218,6 +218,9 @@ const migrations: { [string]: (GlobalState) => GlobalState } = {
     narrows: Immutable.Map(state.narrows),
   }),
 
+  // Convert messages[].avatar_url from `string | null` to `AvatarURL`.
+  '17': dropCache,
+
   // TIP: When adding a migration, consider just using `dropCache`.
 };
 

--- a/src/common/GroupAvatar.js
+++ b/src/common/GroupAvatar.js
@@ -42,7 +42,7 @@ export const initialsForGroupIcon = (names: string[]): string => {
  * We are currently using it only for group chats.
  *
  * @prop names - The name of one or more users, used to extract their initials.
- * @prop size - Sets width and height in pixels.
+ * @prop size - Sets width and height in logical pixels.
  * @prop [shape]
  * @prop children - If provided, will render inside the component body.
  * @prop onPress - Event fired on pressing the component.

--- a/src/common/OwnAvatar.js
+++ b/src/common/OwnAvatar.js
@@ -1,5 +1,6 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
+import { PixelRatio } from 'react-native';
 
 import type { User, Dispatch } from '../types';
 import { connect } from '../react-redux';
@@ -17,12 +18,16 @@ type Props = $ReadOnly<{|
 /**
  * Renders an image of the current user's avatar
  *
- * @prop size - Sets width and height in pixels.
+ * @prop size - Sets width and height in logical pixels.
  */
 class OwnAvatar extends PureComponent<Props> {
   render() {
     const { user, size, realm } = this.props;
-    const fullAvatarUrl = getAvatarFromUser(user, realm, size);
+    const fullAvatarUrl = getAvatarFromUser(
+      user,
+      realm,
+      PixelRatio.getPixelSizeForLayoutSize(size),
+    );
     return <UserAvatar avatarUrl={fullAvatarUrl} size={size} />;
   }
 }

--- a/src/common/OwnAvatar.js
+++ b/src/common/OwnAvatar.js
@@ -20,7 +20,7 @@ type Props = $ReadOnly<{|
 class OwnAvatar extends PureComponent<Props> {
   render() {
     const { user, size } = this.props;
-    return <UserAvatar avatarUrl={user.avatar_url} email={user.email} size={size} />;
+    return <UserAvatar avatarUrl={user.avatar_url} size={size} />;
   }
 }
 

--- a/src/common/OwnAvatar.js
+++ b/src/common/OwnAvatar.js
@@ -1,18 +1,15 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
-import { PixelRatio } from 'react-native';
 
 import type { User, Dispatch } from '../types';
 import { connect } from '../react-redux';
-import { getCurrentRealm, getSelfUserDetail } from '../selectors';
+import { getSelfUserDetail } from '../selectors';
 import UserAvatar from './UserAvatar';
-import { getAvatarFromUser } from '../utils/avatar';
 
 type Props = $ReadOnly<{|
   dispatch: Dispatch,
   user: User,
   size: number,
-  realm: URL,
 |}>;
 
 /**
@@ -22,17 +19,11 @@ type Props = $ReadOnly<{|
  */
 class OwnAvatar extends PureComponent<Props> {
   render() {
-    const { user, size, realm } = this.props;
-    const fullAvatarUrl = getAvatarFromUser(
-      user,
-      realm,
-      PixelRatio.getPixelSizeForLayoutSize(size),
-    );
-    return <UserAvatar avatarUrl={fullAvatarUrl} size={size} />;
+    const { user, size } = this.props;
+    return <UserAvatar avatarUrl={user.avatar_url} email={user.email} size={size} />;
   }
 }
 
 export default connect(state => ({
-  realm: getCurrentRealm(state),
   user: getSelfUserDetail(state),
 }))(OwnAvatar);

--- a/src/common/UserAvatar.js
+++ b/src/common/UserAvatar.js
@@ -1,34 +1,47 @@
 /* @flow strict-local */
-import React, { PureComponent } from 'react';
-import { ImageBackground, View } from 'react-native';
+import React, { PureComponent, type Node as React$Node } from 'react';
+import { ImageBackground, View, PixelRatio } from 'react-native';
+import { connect } from '../react-redux';
 
-import type { Node as React$Node } from 'react';
+import { getCurrentRealm } from '../selectors';
+import { getAvatarUrl } from '../utils/avatar';
 import Touchable from './Touchable';
+import type { Dispatch, Message, User, CrossRealmBot } from '../types';
+
+type SelectorProps = {|
+  realm: URL,
+|};
 
 type Props = $ReadOnly<{|
-  avatarUrl: string,
+  avatarUrl: | $PropertyType<Message, 'avatar_url'>
+    | $PropertyType<User, 'avatar_url'>
+    | $PropertyType<CrossRealmBot, 'avatar_url'>,
+  email: string,
   size: number,
   shape: 'rounded' | 'square',
   children?: React$Node,
   onPress?: () => void,
+
+  dispatch: Dispatch,
+  ...SelectorProps,
 |}>;
 
 /**
  * Renders an image of the user's avatar.
  *
- * @prop avatarUrl - Absolute or relative url to an avatar image.
+ * @prop avatarUrl - `.avatar_url` on a `Message` or a `UserOrBot`
  * @prop size - Sets width and height in logical pixels.
  * @prop [shape] - 'rounded' (default) means a square with rounded corners.
  * @prop [children] - If provided, will render inside the component body.
  * @prop [onPress] - Event fired on pressing the component.
  */
-export default class UserAvatar extends PureComponent<Props> {
+class UserAvatar extends PureComponent<Props> {
   static defaultProps = {
     shape: 'rounded',
   };
 
   render() {
-    const { avatarUrl, children, size, shape, onPress } = this.props;
+    const { avatarUrl, email, realm, children, size, shape, onPress } = this.props;
     const borderRadius = shape === 'rounded' ? size / 8 : 0;
     const style = {
       height: size,
@@ -41,7 +54,14 @@ export default class UserAvatar extends PureComponent<Props> {
         <Touchable onPress={onPress} style={style}>
           <ImageBackground
             style={style}
-            source={{ uri: avatarUrl }}
+            source={{
+              uri: getAvatarUrl(
+                avatarUrl,
+                email,
+                realm,
+                PixelRatio.getPixelSizeForLayoutSize(size),
+              ),
+            }}
             resizeMode="cover"
             /* ImageBackground seems to ignore `style.borderRadius`. */
             borderRadius={borderRadius}
@@ -53,3 +73,7 @@ export default class UserAvatar extends PureComponent<Props> {
     );
   }
 }
+
+export default connect(state => ({
+  realm: getCurrentRealm(state),
+}))(UserAvatar);

--- a/src/common/UserAvatar.js
+++ b/src/common/UserAvatar.js
@@ -4,7 +4,7 @@ import { ImageBackground, View, PixelRatio } from 'react-native';
 import { connect } from '../react-redux';
 
 import { getCurrentRealm } from '../selectors';
-import { getAvatarUrl } from '../utils/avatar';
+import { getAvatarUrl, AvatarURL } from '../utils/avatar';
 import Touchable from './Touchable';
 import type { Dispatch, Message, User, CrossRealmBot } from '../types';
 
@@ -55,12 +55,18 @@ class UserAvatar extends PureComponent<Props> {
           <ImageBackground
             style={style}
             source={{
-              uri: getAvatarUrl(
-                avatarUrl,
-                email,
-                realm,
-                PixelRatio.getPixelSizeForLayoutSize(size),
-              ),
+              uri:
+                // If `avatarUrl` is from a Message, it will be an AvatarURL.
+                // Soon, it will also be an AvatarURL if it's from a UserOrBot,
+                // and we won't need the conditional.
+                avatarUrl instanceof AvatarURL
+                  ? avatarUrl.get(PixelRatio.getPixelSizeForLayoutSize(size)).toString()
+                  : getAvatarUrl(
+                      avatarUrl,
+                      email,
+                      realm,
+                      PixelRatio.getPixelSizeForLayoutSize(size),
+                    ),
             }}
             resizeMode="cover"
             /* ImageBackground seems to ignore `style.borderRadius`. */

--- a/src/common/UserAvatar.js
+++ b/src/common/UserAvatar.js
@@ -1,29 +1,18 @@
 /* @flow strict-local */
 import React, { PureComponent, type Node as React$Node } from 'react';
 import { ImageBackground, View, PixelRatio } from 'react-native';
-import { connect } from '../react-redux';
 
-import { getCurrentRealm } from '../selectors';
-import { getAvatarUrl, AvatarURL } from '../utils/avatar';
 import Touchable from './Touchable';
-import type { Dispatch, Message, User, CrossRealmBot } from '../types';
-
-type SelectorProps = {|
-  realm: URL,
-|};
+import type { Message, User, CrossRealmBot } from '../types';
 
 type Props = $ReadOnly<{|
   avatarUrl: | $PropertyType<Message, 'avatar_url'>
     | $PropertyType<User, 'avatar_url'>
     | $PropertyType<CrossRealmBot, 'avatar_url'>,
-  email: string,
   size: number,
   shape: 'rounded' | 'square',
   children?: React$Node,
   onPress?: () => void,
-
-  dispatch: Dispatch,
-  ...SelectorProps,
 |}>;
 
 /**
@@ -35,13 +24,13 @@ type Props = $ReadOnly<{|
  * @prop [children] - If provided, will render inside the component body.
  * @prop [onPress] - Event fired on pressing the component.
  */
-class UserAvatar extends PureComponent<Props> {
+export default class UserAvatar extends PureComponent<Props> {
   static defaultProps = {
     shape: 'rounded',
   };
 
   render() {
-    const { avatarUrl, email, realm, children, size, shape, onPress } = this.props;
+    const { avatarUrl, children, size, shape, onPress } = this.props;
     const borderRadius = shape === 'rounded' ? size / 8 : 0;
     const style = {
       height: size,
@@ -55,18 +44,7 @@ class UserAvatar extends PureComponent<Props> {
           <ImageBackground
             style={style}
             source={{
-              uri:
-                // If `avatarUrl` is from a Message, it will be an AvatarURL.
-                // Soon, it will also be an AvatarURL if it's from a UserOrBot,
-                // and we won't need the conditional.
-                avatarUrl instanceof AvatarURL
-                  ? avatarUrl.get(PixelRatio.getPixelSizeForLayoutSize(size)).toString()
-                  : getAvatarUrl(
-                      avatarUrl,
-                      email,
-                      realm,
-                      PixelRatio.getPixelSizeForLayoutSize(size),
-                    ),
+              uri: avatarUrl.get(PixelRatio.getPixelSizeForLayoutSize(size)).toString(),
             }}
             resizeMode="cover"
             /* ImageBackground seems to ignore `style.borderRadius`. */
@@ -79,7 +57,3 @@ class UserAvatar extends PureComponent<Props> {
     );
   }
 }
-
-export default connect(state => ({
-  realm: getCurrentRealm(state),
-}))(UserAvatar);

--- a/src/common/UserAvatar.js
+++ b/src/common/UserAvatar.js
@@ -17,7 +17,7 @@ type Props = $ReadOnly<{|
  * Renders an image of the user's avatar.
  *
  * @prop avatarUrl - Absolute or relative url to an avatar image.
- * @prop size - Sets width and height in pixels.
+ * @prop size - Sets width and height in logical pixels.
  * @prop [shape] - 'rounded' (default) means a square with rounded corners.
  * @prop [children] - If provided, will render inside the component body.
  * @prop [onPress] - Event fired on pressing the component.

--- a/src/common/UserAvatar.js
+++ b/src/common/UserAvatar.js
@@ -3,12 +3,10 @@ import React, { PureComponent, type Node as React$Node } from 'react';
 import { ImageBackground, View, PixelRatio } from 'react-native';
 
 import Touchable from './Touchable';
-import type { Message, User, CrossRealmBot } from '../types';
+import { AvatarURL } from '../utils/avatar';
 
 type Props = $ReadOnly<{|
-  avatarUrl: | $PropertyType<Message, 'avatar_url'>
-    | $PropertyType<User, 'avatar_url'>
-    | $PropertyType<CrossRealmBot, 'avatar_url'>,
+  avatarUrl: AvatarURL,
   size: number,
   shape: 'rounded' | 'square',
   children?: React$Node,
@@ -18,7 +16,7 @@ type Props = $ReadOnly<{|
 /**
  * Renders an image of the user's avatar.
  *
- * @prop avatarUrl - `.avatar_url` on a `Message` or a `UserOrBot`
+ * @prop avatarUrl
  * @prop size - Sets width and height in logical pixels.
  * @prop [shape] - 'rounded' (default) means a square with rounded corners.
  * @prop [children] - If provided, will render inside the component body.

--- a/src/common/UserAvatarWithPresence.js
+++ b/src/common/UserAvatarWithPresence.js
@@ -1,6 +1,7 @@
 /* @flow strict-local */
 
 import React, { PureComponent } from 'react';
+import { PixelRatio } from 'react-native';
 
 import type { Dispatch, Message, User, CrossRealmBot } from '../types';
 import { createStyleSheet } from '../styles';
@@ -35,7 +36,7 @@ type Props = $ReadOnly<{|
  *
  * @prop [avatarUrl] - `.avatar_url` on a `Message` or a `UserOrBot`
  * @prop [email] - User's' email address, to calculate Gravatar URL if not given `avatarUrl`.
- * @prop [size] - Sets width and height in pixels.
+ * @prop [size] - Sets width and height in logical pixels.
  * @prop [realm] - Current realm url, used if avatarUrl is relative.
  * @prop [shape] - 'rounded' (default) means a square with rounded corners.
  * @prop [onPress] - Event fired on pressing the component.
@@ -49,7 +50,12 @@ class UserAvatarWithPresence extends PureComponent<Props> {
 
   render() {
     const { avatarUrl, email, size, onPress, realm, shape } = this.props;
-    const fullAvatarUrl = getAvatarUrl(avatarUrl, email, realm, 80);
+    const fullAvatarUrl = getAvatarUrl(
+      avatarUrl,
+      email,
+      realm,
+      PixelRatio.getPixelSizeForLayoutSize(size),
+    );
 
     return (
       <UserAvatar avatarUrl={fullAvatarUrl} size={size} onPress={onPress} shape={shape}>

--- a/src/common/UserAvatarWithPresence.js
+++ b/src/common/UserAvatarWithPresence.js
@@ -49,7 +49,7 @@ class UserAvatarWithPresence extends PureComponent<Props> {
 
   render() {
     const { avatarUrl, email, size, onPress, realm, shape } = this.props;
-    const fullAvatarUrl = getAvatarUrl(avatarUrl, email, realm);
+    const fullAvatarUrl = getAvatarUrl(avatarUrl, email, realm, 80);
 
     return (
       <UserAvatar avatarUrl={fullAvatarUrl} size={size} onPress={onPress} shape={shape}>

--- a/src/common/UserAvatarWithPresence.js
+++ b/src/common/UserAvatarWithPresence.js
@@ -2,7 +2,7 @@
 
 import React, { PureComponent } from 'react';
 
-import type { Dispatch } from '../types';
+import type { Dispatch, Message, User, CrossRealmBot } from '../types';
 import { createStyleSheet } from '../styles';
 import { connect } from '../react-redux';
 import { getCurrentRealm } from '../selectors';
@@ -20,7 +20,9 @@ const styles = createStyleSheet({
 
 type Props = $ReadOnly<{|
   dispatch: Dispatch,
-  avatarUrl: ?string,
+  avatarUrl: | $PropertyType<Message, 'avatar_url'>
+    | $PropertyType<User, 'avatar_url'>
+    | $PropertyType<CrossRealmBot, 'avatar_url'>,
   email: string,
   size: number,
   realm: URL,
@@ -31,7 +33,7 @@ type Props = $ReadOnly<{|
 /**
  * Renders a user avatar with a PresenceStatusIndicator in the corner
  *
- * @prop [avatarUrl] - Absolute or relative url to an avatar image.
+ * @prop [avatarUrl] - `.avatar_url` on a `Message` or a `UserOrBot`
  * @prop [email] - User's' email address, to calculate Gravatar URL if not given `avatarUrl`.
  * @prop [size] - Sets width and height in pixels.
  * @prop [realm] - Current realm url, used if avatarUrl is relative.

--- a/src/common/UserAvatarWithPresence.js
+++ b/src/common/UserAvatarWithPresence.js
@@ -1,14 +1,10 @@
 /* @flow strict-local */
 
 import React, { PureComponent } from 'react';
-import { PixelRatio } from 'react-native';
 
-import type { Dispatch, Message, User, CrossRealmBot } from '../types';
+import type { Message, User, CrossRealmBot } from '../types';
 import { createStyleSheet } from '../styles';
-import { connect } from '../react-redux';
-import { getCurrentRealm } from '../selectors';
 import UserAvatar from './UserAvatar';
-import { getAvatarUrl } from '../utils/avatar';
 import PresenceStatusIndicator from './PresenceStatusIndicator';
 
 const styles = createStyleSheet({
@@ -20,13 +16,11 @@ const styles = createStyleSheet({
 });
 
 type Props = $ReadOnly<{|
-  dispatch: Dispatch,
   avatarUrl: | $PropertyType<Message, 'avatar_url'>
     | $PropertyType<User, 'avatar_url'>
     | $PropertyType<CrossRealmBot, 'avatar_url'>,
   email: string,
   size: number,
-  realm: URL,
   shape: 'rounded' | 'square',
   onPress?: () => void,
 |}>;
@@ -35,13 +29,12 @@ type Props = $ReadOnly<{|
  * Renders a user avatar with a PresenceStatusIndicator in the corner
  *
  * @prop [avatarUrl] - `.avatar_url` on a `Message` or a `UserOrBot`
- * @prop [email] - User's' email address, to calculate Gravatar URL if not given `avatarUrl`.
+ * @prop [email] - Sender's / user's email address, for the presence dot.
  * @prop [size] - Sets width and height in logical pixels.
- * @prop [realm] - Current realm url, used if avatarUrl is relative.
  * @prop [shape] - 'rounded' (default) means a square with rounded corners.
  * @prop [onPress] - Event fired on pressing the component.
  */
-class UserAvatarWithPresence extends PureComponent<Props> {
+export default class UserAvatarWithPresence extends PureComponent<Props> {
   static defaultProps = {
     avatarUrl: '',
     email: '',
@@ -49,22 +42,12 @@ class UserAvatarWithPresence extends PureComponent<Props> {
   };
 
   render() {
-    const { avatarUrl, email, size, onPress, realm, shape } = this.props;
-    const fullAvatarUrl = getAvatarUrl(
-      avatarUrl,
-      email,
-      realm,
-      PixelRatio.getPixelSizeForLayoutSize(size),
-    );
+    const { avatarUrl, email, size, onPress, shape } = this.props;
 
     return (
-      <UserAvatar avatarUrl={fullAvatarUrl} size={size} onPress={onPress} shape={shape}>
+      <UserAvatar avatarUrl={avatarUrl} email={email} size={size} onPress={onPress} shape={shape}>
         <PresenceStatusIndicator style={styles.status} email={email} hideIfOffline />
       </UserAvatar>
     );
   }
 }
-
-export default connect(state => ({
-  realm: getCurrentRealm(state),
-}))(UserAvatarWithPresence);

--- a/src/common/UserAvatarWithPresence.js
+++ b/src/common/UserAvatarWithPresence.js
@@ -36,7 +36,8 @@ type Props = $ReadOnly<{|
  */
 export default class UserAvatarWithPresence extends PureComponent<Props> {
   static defaultProps = {
-    avatarUrl: '',
+    // TODO: An empty-string `email` is probably up to no good. Remove
+    // this default.
     email: '',
     shape: 'rounded',
   };

--- a/src/common/UserAvatarWithPresence.js
+++ b/src/common/UserAvatarWithPresence.js
@@ -44,7 +44,6 @@ class UserAvatarWithPresence extends PureComponent<Props> {
   static defaultProps = {
     avatarUrl: '',
     email: '',
-    size: 32,
     shape: 'rounded',
   };
 

--- a/src/common/UserAvatarWithPresence.js
+++ b/src/common/UserAvatarWithPresence.js
@@ -2,10 +2,10 @@
 
 import React, { PureComponent } from 'react';
 
-import type { Message, User, CrossRealmBot } from '../types';
 import { createStyleSheet } from '../styles';
 import UserAvatar from './UserAvatar';
 import PresenceStatusIndicator from './PresenceStatusIndicator';
+import { AvatarURL } from '../utils/avatar';
 
 const styles = createStyleSheet({
   status: {
@@ -16,9 +16,7 @@ const styles = createStyleSheet({
 });
 
 type Props = $ReadOnly<{|
-  avatarUrl: | $PropertyType<Message, 'avatar_url'>
-    | $PropertyType<User, 'avatar_url'>
-    | $PropertyType<CrossRealmBot, 'avatar_url'>,
+  avatarUrl: AvatarURL,
   email: string,
   size: number,
   shape: 'rounded' | 'square',
@@ -28,7 +26,7 @@ type Props = $ReadOnly<{|
 /**
  * Renders a user avatar with a PresenceStatusIndicator in the corner
  *
- * @prop [avatarUrl] - `.avatar_url` on a `Message` or a `UserOrBot`
+ * @prop [avatarUrl]
  * @prop [email] - Sender's / user's email address, for the presence dot.
  * @prop [size] - Sets width and height in logical pixels.
  * @prop [shape] - 'rounded' (default) means a square with rounded corners.

--- a/src/common/UserAvatarWithPresence.js
+++ b/src/common/UserAvatarWithPresence.js
@@ -46,7 +46,7 @@ export default class UserAvatarWithPresence extends PureComponent<Props> {
     const { avatarUrl, email, size, onPress, shape } = this.props;
 
     return (
-      <UserAvatar avatarUrl={avatarUrl} email={email} size={size} onPress={onPress} shape={shape}>
+      <UserAvatar avatarUrl={avatarUrl} size={size} onPress={onPress} shape={shape}>
         <PresenceStatusIndicator style={styles.status} email={email} hideIfOffline />
       </UserAvatar>
     );

--- a/src/emoji/__tests__/data-test.js
+++ b/src/emoji/__tests__/data-test.js
@@ -7,7 +7,7 @@ import { codeToEmojiMap, getFilteredEmojis } from '../data';
 
 /* eslint-disable no-multi-spaces */
 describe('codeToEmojiMap', () => {
-  // Tell Jest to recognize `check` as a helper function that runs
+  // Tell ESLint to recognize `check` as a helper function that runs
   // assertions.
   /* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["expect", "check"] }] */
   const check = (name, string1, string2) => {

--- a/src/events/eventToAction.js
+++ b/src/events/eventToAction.js
@@ -33,6 +33,8 @@ import {
   EVENT,
 } from '../actionConstants';
 import { getOwnUser, getOwnUserId, getAllUsersById } from '../users/userSelectors';
+import { AvatarURL } from '../utils/avatar';
+import { getCurrentRealm } from '../account/accountsSelectors';
 
 const opToActionUserGroup = {
   add: EVENT_USER_GROUP_ADD,
@@ -84,6 +86,11 @@ export default (state: GlobalState, event: $FlowFixMe): EventAction => {
           // Move `flags` key from `event` to `event.message` for consistency, and
           // default to an empty array if `event.flags` is not set.
           flags: event.message.flags ?? event.flags ?? [],
+          avatar_url: AvatarURL.fromUserOrBotData({
+            rawAvatarUrl: event.message.avatar_url,
+            email: event.message.sender_email,
+            realm: getCurrentRealm(state),
+          }),
         },
         local_message_id: event.local_message_id,
         caughtUp: state.caughtUp,

--- a/src/events/eventToAction.js
+++ b/src/events/eventToAction.js
@@ -128,18 +128,27 @@ export default (state: GlobalState, event: $FlowFixMe): EventAction => {
       };
 
     case 'realm_user': {
+      const realm = getCurrentRealm(state);
+
       switch (event.op) {
-        case 'add':
+        case 'add': {
+          const { avatar_url: rawAvatarUrl, email } = event.person;
           return {
             type: EVENT_USER_ADD,
             id: event.id,
             // TODO: Validate and rebuild `event.person`.
-            person: event.person,
+            person: {
+              ...event.person,
+              avatar_url: AvatarURL.fromUserOrBotData({
+                rawAvatarUrl,
+                email,
+                realm,
+              }),
+            },
           };
+        }
 
         case 'update': {
-          // We'll use this in an upcoming commit.
-          // eslint-disable-next-line no-unused-vars
           const existingUser = getAllUsersById(state).get(event.person.user_id);
           if (!existingUser) {
             // If we get one of these events and don't have
@@ -163,7 +172,13 @@ export default (state: GlobalState, event: $FlowFixMe): EventAction => {
               // currently use them: `avatar_source`,
               // `avatar_url_medium`, and `avatar_version`.
               ...(event.person.avatar_url !== undefined
-                ? { avatar_url: event.person.avatar_url }
+                ? {
+                    avatar_url: AvatarURL.fromUserOrBotData({
+                      rawAvatarUrl: event.person.avatar_url,
+                      email: existingUser.email,
+                      realm,
+                    }),
+                  }
                 : undefined),
             },
           };
@@ -181,6 +196,9 @@ export default (state: GlobalState, event: $FlowFixMe): EventAction => {
     }
 
     case 'realm_bot':
+      // If implementing, don't forget to convert `avatar_url` on
+      // `op: 'add'`, and (where `avatar_url` is present) on
+      // `op: 'update'`.
       return { type: 'ignore' };
 
     case 'reaction':

--- a/src/lightbox/Lightbox.js
+++ b/src/lightbox/Lightbox.js
@@ -16,7 +16,6 @@ import LightboxHeader from './LightboxHeader';
 import LightboxFooter from './LightboxFooter';
 import { constructActionSheetButtons, executeActionSheetAction } from './LightboxActionSheet';
 import { NAVBAR_SIZE, createStyleSheet } from '../styles';
-import { getAvatarFromMessage } from '../utils/avatar';
 import { navigateBack } from '../actions';
 import { streamNameOfStreamMessage } from '../utils/recipient';
 
@@ -118,7 +117,7 @@ class Lightbox extends PureComponent<Props, State> {
           <LightboxHeader
             onPressBack={this.handlePressBack}
             timestamp={message.timestamp}
-            avatarUrl={getAvatarFromMessage(message, auth.realm)}
+            avatarUrl={message.avatar_url}
             senderName={message.sender_full_name}
           />
         </SlideAnimationView>

--- a/src/lightbox/LightboxHeader.js
+++ b/src/lightbox/LightboxHeader.js
@@ -2,6 +2,7 @@
 import React, { PureComponent } from 'react';
 import { View, Text } from 'react-native';
 
+import type { Message, User, CrossRealmBot } from '../types';
 import { shortTime, humanDate } from '../utils/date';
 import { createStyleSheet } from '../styles';
 import { UserAvatarWithPresence, Touchable } from '../common';
@@ -41,10 +42,20 @@ const styles = createStyleSheet({
 type Props = $ReadOnly<{|
   senderName: string,
   timestamp: number,
-  avatarUrl: string,
+  avatarUrl: | $PropertyType<Message, 'avatar_url'>
+    | $PropertyType<User, 'avatar_url'>
+    | $PropertyType<CrossRealmBot, 'avatar_url'>,
   onPressBack: () => void,
 |}>;
 
+/**
+ * Shows sender's name and date of photo being displayed.
+ *
+ * @prop [senderName] - The sender's full name.
+ * @prop [avatarUrl] - `.avatar_url` on a `Message` or a `UserOrBot`
+ * @prop [timestamp]
+ * @prop [onPressBack]
+ */
 export default class LightboxHeader extends PureComponent<Props> {
   render() {
     const { onPressBack, senderName, timestamp, avatarUrl } = this.props;

--- a/src/lightbox/LightboxHeader.js
+++ b/src/lightbox/LightboxHeader.js
@@ -2,11 +2,11 @@
 import React, { PureComponent } from 'react';
 import { View, Text } from 'react-native';
 
-import type { Message, User, CrossRealmBot } from '../types';
 import { shortTime, humanDate } from '../utils/date';
 import { createStyleSheet } from '../styles';
 import { UserAvatarWithPresence, Touchable } from '../common';
 import { Icon } from '../common/Icons';
+import { AvatarURL } from '../utils/avatar';
 
 const styles = createStyleSheet({
   text: {
@@ -42,9 +42,7 @@ const styles = createStyleSheet({
 type Props = $ReadOnly<{|
   senderName: string,
   timestamp: number,
-  avatarUrl: | $PropertyType<Message, 'avatar_url'>
-    | $PropertyType<User, 'avatar_url'>
-    | $PropertyType<CrossRealmBot, 'avatar_url'>,
+  avatarUrl: AvatarURL,
   onPressBack: () => void,
 |}>;
 
@@ -52,7 +50,7 @@ type Props = $ReadOnly<{|
  * Shows sender's name and date of photo being displayed.
  *
  * @prop [senderName] - The sender's full name.
- * @prop [avatarUrl] - `.avatar_url` on a `Message` or a `UserOrBot`
+ * @prop [avatarUrl]
  * @prop [timestamp]
  * @prop [onPressBack]
  */

--- a/src/message/__tests__/fetchActions-test.js
+++ b/src/message/__tests__/fetchActions-test.js
@@ -114,6 +114,18 @@ describe('fetchActions', () => {
   describe('fetchMessages', () => {
     const message1 = eg.streamMessage({ id: 1 });
 
+    type CommonFields = $Diff<Message, { reactions: mixed }>;
+
+    // message1 exactly as we receive it from the server, before our
+    // own transformations.
+    //
+    // TODO: Deduplicate this logic with similar logic in
+    // migrateMessages-test.js.
+    const serverMessage1: ServerMessage = {
+      ...(omit(message1, 'reactions'): CommonFields),
+      reactions: [],
+    };
+
     const baseState = eg.reduxState({
       accounts: [eg.makeAccount()],
       narrows: Immutable.Map({
@@ -123,18 +135,6 @@ describe('fetchActions', () => {
 
     describe('success', () => {
       beforeEach(() => {
-        type CommonFields = $Diff<Message, { reactions: mixed }>;
-
-        // A message exactly as we receive it from the server, before
-        // our own transformations.
-        //
-        // TODO: Deduplicate this logic with similar logic in
-        // migrateMessages-test.js.
-        const serverMessage1: ServerMessage = {
-          ...(omit(message1, 'reactions'): CommonFields),
-          reactions: [],
-        };
-
         const response = {
           messages: [serverMessage1],
           result: 'success',

--- a/src/message/fetchActions.js
+++ b/src/message/fetchActions.js
@@ -320,6 +320,7 @@ export const doInitialFetch = () => async (dispatch: Dispatch, getState: GetStat
           client_capabilities: {
             notification_settings_null: true,
             bulk_message_deletion: true,
+            user_avatar_url_field_optional: true,
           },
         }),
       ),

--- a/src/nullObjects.js
+++ b/src/nullObjects.js
@@ -1,5 +1,6 @@
 /* @flow strict-local */
 import type { User, Subscription } from './types';
+import { GravatarURL } from './utils/avatar';
 
 export const NULL_OBJECT = Object.freeze({});
 
@@ -31,7 +32,7 @@ export const NULL_ARRAY = Object.freeze([]);
 
 /** DEPRECATED; don't add new uses.  See block comment above definition. */
 export const NULL_USER: User = {
-  avatar_url: '',
+  avatar_url: GravatarURL.validateAndConstructInstance({ email: '' }),
   email: '',
   full_name: '',
   is_admin: false,

--- a/src/outbox/outboxActions.js
+++ b/src/outbox/outboxActions.js
@@ -15,6 +15,7 @@ import * as api from '../api';
 import { getAllUsersByEmail, getOwnUser } from '../users/userSelectors';
 import { getUsersAndWildcards } from '../users/userHelpers';
 import { caseNarrowPartial } from '../utils/narrow';
+import { AvatarURL } from '../utils/avatar';
 import { BackoffMachine } from '../utils/async';
 import { recipientsOfPrivateMessage, streamNameOfStreamMessage } from '../utils/recipient';
 
@@ -162,6 +163,7 @@ export const addToOutbox = (narrow: Narrow, content: string) => async (
 ) => {
   const state = getState();
   const ownUser = getOwnUser(state);
+  const auth = getAuth(state);
 
   const localTime = Math.round(new Date().getTime() / 1000);
   dispatch(
@@ -175,7 +177,15 @@ export const addToOutbox = (narrow: Narrow, content: string) => async (
       sender_full_name: ownUser.full_name,
       sender_email: ownUser.email,
       sender_id: ownUser.user_id,
-      avatar_url: ownUser.avatar_url,
+
+      // In the next commit, we'll just use `ownUser.avatar_url`,
+      // since it'll already be an `AvatarURL`.
+      avatar_url: AvatarURL.fromUserOrBotData({
+        rawAvatarUrl: ownUser.avatar_url,
+        email: ownUser.email,
+        realm: auth.realm,
+      }),
+
       isOutbox: true,
       reactions: [],
     }),

--- a/src/outbox/outboxActions.js
+++ b/src/outbox/outboxActions.js
@@ -15,7 +15,6 @@ import * as api from '../api';
 import { getAllUsersByEmail, getOwnUser } from '../users/userSelectors';
 import { getUsersAndWildcards } from '../users/userHelpers';
 import { caseNarrowPartial } from '../utils/narrow';
-import { AvatarURL } from '../utils/avatar';
 import { BackoffMachine } from '../utils/async';
 import { recipientsOfPrivateMessage, streamNameOfStreamMessage } from '../utils/recipient';
 
@@ -163,7 +162,6 @@ export const addToOutbox = (narrow: Narrow, content: string) => async (
 ) => {
   const state = getState();
   const ownUser = getOwnUser(state);
-  const auth = getAuth(state);
 
   const localTime = Math.round(new Date().getTime() / 1000);
   dispatch(
@@ -177,15 +175,7 @@ export const addToOutbox = (narrow: Narrow, content: string) => async (
       sender_full_name: ownUser.full_name,
       sender_email: ownUser.email,
       sender_id: ownUser.user_id,
-
-      // In the next commit, we'll just use `ownUser.avatar_url`,
-      // since it'll already be an `AvatarURL`.
-      avatar_url: AvatarURL.fromUserOrBotData({
-        rawAvatarUrl: ownUser.avatar_url,
-        email: ownUser.email,
-        realm: auth.realm,
-      }),
-
+      avatar_url: ownUser.avatar_url,
       isOutbox: true,
       reactions: [],
     }),

--- a/src/user-picker/AvatarItem.js
+++ b/src/user-picker/AvatarItem.js
@@ -2,6 +2,7 @@
 import React, { PureComponent } from 'react';
 import { Animated, Easing, View } from 'react-native';
 
+import type { Message, User, CrossRealmBot } from '../types';
 import { UserAvatarWithPresence, ComponentWithOverlay, RawLabel, Touchable } from '../common';
 import { createStyleSheet } from '../styles';
 import { IconCancel } from '../common/Icons';
@@ -27,11 +28,21 @@ const styles = createStyleSheet({
 
 type Props = $ReadOnly<{|
   email: string,
-  avatarUrl: ?string,
+  avatarUrl: | $PropertyType<Message, 'avatar_url'>
+    | $PropertyType<User, 'avatar_url'>
+    | $PropertyType<CrossRealmBot, 'avatar_url'>,
   fullName: string,
   onPress: (email: string) => void,
 |}>;
 
+/**
+ * Pressable avatar for items in the user-picker card.
+ *
+ * @prop [email]
+ * @prop [avatarUrl] - `.avatar_url` on a `Message` or a `UserOrBot`
+ * @prop [fullName]
+ * @prop [onPress]
+ */
 export default class AvatarItem extends PureComponent<Props> {
   animatedValue = new Animated.Value(0);
 

--- a/src/user-picker/AvatarItem.js
+++ b/src/user-picker/AvatarItem.js
@@ -2,10 +2,10 @@
 import React, { PureComponent } from 'react';
 import { Animated, Easing, View } from 'react-native';
 
-import type { Message, User, CrossRealmBot } from '../types';
 import { UserAvatarWithPresence, ComponentWithOverlay, RawLabel, Touchable } from '../common';
 import { createStyleSheet } from '../styles';
 import { IconCancel } from '../common/Icons';
+import { AvatarURL } from '../utils/avatar';
 
 const styles = createStyleSheet({
   wrapper: {
@@ -28,9 +28,7 @@ const styles = createStyleSheet({
 
 type Props = $ReadOnly<{|
   email: string,
-  avatarUrl: | $PropertyType<Message, 'avatar_url'>
-    | $PropertyType<User, 'avatar_url'>
-    | $PropertyType<CrossRealmBot, 'avatar_url'>,
+  avatarUrl: AvatarURL,
   fullName: string,
   onPress: (email: string) => void,
 |}>;
@@ -39,7 +37,7 @@ type Props = $ReadOnly<{|
  * Pressable avatar for items in the user-picker card.
  *
  * @prop [email]
- * @prop [avatarUrl] - `.avatar_url` on a `Message` or a `UserOrBot`
+ * @prop [avatarUrl]
  * @prop [fullName]
  * @prop [onPress]
  */

--- a/src/users/__tests__/usersReducer-test.js
+++ b/src/users/__tests__/usersReducer-test.js
@@ -2,7 +2,8 @@
 import deepFreeze from 'deep-freeze';
 
 import * as eg from '../../__tests__/lib/exampleData';
-import { EVENT_USER_ADD, ACCOUNT_SWITCH } from '../../actionConstants';
+import type { User } from '../../types';
+import { EVENT_USER_ADD, EVENT_USER_UPDATE, ACCOUNT_SWITCH } from '../../actionConstants';
 import usersReducer from '../usersReducer';
 
 describe('usersReducer', () => {
@@ -43,6 +44,84 @@ describe('usersReducer', () => {
       const actualState = usersReducer(prevState, action);
 
       expect(actualState).toEqual(expectedState);
+    });
+  });
+
+  describe('EVENT_USER_UPDATE', () => {
+    const theUser = eg.makeUser();
+    const prevState = deepFreeze([theUser]);
+
+    /**
+     * Check that an update event with supplied `person` works.
+     *
+     * May omit `user_id` to avoid repetition.
+     */
+    // Tell ESLint to recognize `check` as a helper function that runs
+    // assertions.
+    /* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["expect", "check"] }] */
+    const check = (personMaybeWithoutId: $Shape<User>) => {
+      const person = {
+        user_id: theUser.user_id,
+        ...personMaybeWithoutId,
+      };
+      const action = deepFreeze({
+        id: 1,
+        type: EVENT_USER_UPDATE,
+        userId: person.user_id,
+        person,
+      });
+
+      expect(usersReducer(prevState, action)).toEqual([{ ...theUser, ...person }]);
+    };
+
+    /*
+     * Should match REALM_USER OP: UPDATE in the doc.
+     *
+     * See https://zulip.com/api/get-events#realm_user-update.
+     *
+     * A few properties that we don't handle are commented out.
+     */
+
+    test('When a user changes their full name.', () => {
+      check({ full_name: eg.randString() });
+    });
+
+    test('When a user changes their avatar.', () => {
+      check({
+        avatar_url: eg.randString(),
+        // avatar_source: user1.avatar_source === 'G' ? 'U' : 'G',
+        // avatar_url_medium: eg.randString(),
+        // avatar_version: user1.avatar_version + 1,
+      });
+    });
+
+    test('When a user changes their timezone setting.', () => {
+      check({ timezone: eg.randString() });
+    });
+
+    // Excluded: "When the owner of a bot changes." The `users` state
+    // doesn't include cross-realm bots.
+
+    test('When the role of a user changes.', () => {
+      check({
+        // role: user1.role + 1,
+      });
+    });
+
+    test('When the delivery email of a user changes.', () => {
+      check({
+        // delivery_email: eg.randString(),
+      });
+    });
+
+    test('When the user updates one of their custom profile fields.', () => {
+      check({
+        // custom_profile_field: {
+        //   id: 4,
+        //   value: eg.randString(),
+        //   rendered_value: eg.randString(),
+        // },
+      });
     });
   });
 

--- a/src/users/__tests__/usersReducer-test.js
+++ b/src/users/__tests__/usersReducer-test.js
@@ -3,6 +3,7 @@ import deepFreeze from 'deep-freeze';
 
 import * as eg from '../../__tests__/lib/exampleData';
 import type { User } from '../../types';
+import { UploadedAvatarURL } from '../../utils/avatar';
 import { EVENT_USER_ADD, EVENT_USER_UPDATE, ACCOUNT_SWITCH } from '../../actionConstants';
 import usersReducer from '../usersReducer';
 
@@ -88,7 +89,10 @@ describe('usersReducer', () => {
 
     test('When a user changes their avatar.', () => {
       check({
-        avatar_url: eg.randString(),
+        avatar_url: UploadedAvatarURL.validateAndConstructInstance({
+          realm: new URL('https://zulip.example.org'),
+          absoluteOrRelativeUrl: `/yo/avatar-${eg.randString()}.png`,
+        }),
         // avatar_source: user1.avatar_source === 'G' ? 'U' : 'G',
         // avatar_url_medium: eg.randString(),
         // avatar_version: user1.avatar_version + 1,

--- a/src/users/usersReducer.js
+++ b/src/users/usersReducer.js
@@ -30,7 +30,9 @@ export default (state: UsersState = initialState, action: Action): UsersState =>
       return state; // TODO
 
     case EVENT_USER_UPDATE:
-      return state; // TODO
+      return state.map(user =>
+        user.user_id === action.userId ? { ...user, ...action.person } : user,
+      );
 
     default:
       return state;

--- a/src/utils/__tests__/avatar-test.js
+++ b/src/utils/__tests__/avatar-test.js
@@ -1,5 +1,160 @@
 /* @flow strict-local */
-import { getMediumAvatar, getGravatarFromEmail } from '../avatar';
+import md5 from 'blueimp-md5';
+
+import {
+  AvatarURL,
+  GravatarURL,
+  UploadedAvatarURL,
+  getMediumAvatar,
+  getGravatarFromEmail,
+} from '../avatar';
+import * as eg from '../../__tests__/lib/exampleData';
+
+describe('AvatarURL', () => {
+  describe('fromUserOrBotData', () => {
+    const user = eg.makeUser();
+    const { email } = user;
+    const realm = eg.realm;
+
+    test('gives a `GravatarURL` if `rawAvatarURL` is null', () => {
+      const rawAvatarUrl = null;
+      expect(AvatarURL.fromUserOrBotData({ rawAvatarUrl, email, realm })).toBeInstanceOf(
+        GravatarURL,
+      );
+    });
+
+    test('gives a `GravatarURL` if `rawAvatarURL` is a URL string on Gravatar origin', () => {
+      const rawAvatarUrl =
+        'https://secure.gravatar.com/avatar/2efaec12efd9bea8a089299208117786?d=identicon&version=3';
+      expect(AvatarURL.fromUserOrBotData({ rawAvatarUrl, email, realm })).toBeInstanceOf(
+        GravatarURL,
+      );
+    });
+
+    test('gives an `UploadedAvatarURL` if `rawAvatarURL` is a non-Gravatar absolute URL string', () => {
+      const rawAvatarUrl =
+        'https://zulip-avatars.s3.amazonaws.com/13/430713047f2cffed661f84e139a64f864f17f286?x=x&version=5';
+      expect(AvatarURL.fromUserOrBotData({ rawAvatarUrl, email, realm })).toBeInstanceOf(
+        UploadedAvatarURL,
+      );
+    });
+
+    test('gives an `UploadedAvatarURL` if `rawAvatarURL` is a relative URL string', () => {
+      const rawAvatarUrl =
+        '/user_avatars/2/08fb6d007eb10a56efee1d64760fbeb6111c4352.png?x=x&version=2';
+      expect(AvatarURL.fromUserOrBotData({ rawAvatarUrl, email, realm })).toBeInstanceOf(
+        UploadedAvatarURL,
+      );
+    });
+  });
+});
+
+const SIZES_TO_TEST = [24, 32, 48, 80, 200];
+
+describe('GravatarURL', () => {
+  test('serializes/deserializes correctly', () => {
+    const instance = GravatarURL.validateAndConstructInstance({ email: eg.selfUser.email });
+
+    const roundTripped = GravatarURL.deserialize(GravatarURL.serialize(instance));
+
+    SIZES_TO_TEST.forEach(size => {
+      expect(instance.get(size).toString()).toEqual(roundTripped.get(size).toString());
+    });
+  });
+
+  test('lowercases email address before hashing', () => {
+    const email = 'uNuSuAlCaPs@example.com';
+    const instance = GravatarURL.validateAndConstructInstance({ email });
+    SIZES_TO_TEST.forEach(size => {
+      expect(instance.get(size).toString()).toContain(md5('unusualcaps@example.com'));
+    });
+  });
+
+  test('uses hash from server, if provided', () => {
+    const email = 'user13313@chat.zulip.org';
+    const hash = md5('cbobbe@zulip.com');
+    const instance = GravatarURL.validateAndConstructInstance({ email, hash });
+    SIZES_TO_TEST.forEach(size => {
+      expect(instance.get(size).toString()).toContain(hash);
+    });
+  });
+
+  test('produces corresponding URLs for all sizes', () => {
+    const instance = GravatarURL.validateAndConstructInstance({ email: eg.selfUser.email });
+
+    SIZES_TO_TEST.forEach(size => {
+      expect(instance.get(size).toString()).toContain(`s=${size.toString()}`);
+    });
+  });
+});
+
+describe('UploadedAvatarURL', () => {
+  test('serializes/deserializes correctly', () => {
+    const instance = UploadedAvatarURL.validateAndConstructInstance({
+      realm: eg.realm,
+      absoluteOrRelativeUrl:
+        'https://zulip-avatars.s3.amazonaws.com/13/430713047f2cffed661f84e139a64f864f17f286?x=x&version=5',
+    });
+
+    const roundTripped = UploadedAvatarURL.deserialize(UploadedAvatarURL.serialize(instance));
+
+    SIZES_TO_TEST.forEach(size => {
+      expect(instance.get(size).toString()).toEqual(roundTripped.get(size).toString());
+    });
+  });
+
+  test('if a relative URL, gives a URL on the given realm', () => {
+    const instance = UploadedAvatarURL.validateAndConstructInstance({
+      realm: new URL('https://chat.zulip.org'),
+      absoluteOrRelativeUrl:
+        '/user_avatars/2/e35cdbc4771c5e4b94e705bf6ff7cca7fa1efcae.png?x=x&version=2',
+    });
+
+    SIZES_TO_TEST.forEach(size => {
+      const result = instance.get(size).toString();
+      expect(
+        result
+          === 'https://chat.zulip.org/user_avatars/2/e35cdbc4771c5e4b94e705bf6ff7cca7fa1efcae.png?x=x&version=2'
+          || result
+            === 'https://chat.zulip.org/user_avatars/2/e35cdbc4771c5e4b94e705bf6ff7cca7fa1efcae-medium.png?x=x&version=2',
+      ).toBeTrue();
+    });
+  });
+
+  test('if an absolute URL, just use it', () => {
+    const instance = UploadedAvatarURL.validateAndConstructInstance({
+      realm: new URL('https://chat.zulip.org'),
+      absoluteOrRelativeUrl:
+        'https://zulip-avatars.s3.amazonaws.com/13/430713047f2cffed661f84e139a64f864f17f286?x=x&version=5',
+    });
+    SIZES_TO_TEST.forEach(size => {
+      expect(instance.get(size).toString()).toMatch(
+        'https://zulip-avatars.s3.amazonaws.com/13/430713047f2cffed661f84e139a64f864f17f286?x=x&version=5',
+      );
+    });
+  });
+
+  test('converts *.png to *-medium.png for sizes over 100', () => {
+    const realm = new URL('https://chat.zulip.org');
+    const instance = UploadedAvatarURL.validateAndConstructInstance({
+      realm,
+      absoluteOrRelativeUrl:
+        '/user_avatars/2/e35cdbc4771c5e4b94e705bf6ff7cca7fa1efcae.png?x=x&version=2',
+    });
+    const sizesOver100 = SIZES_TO_TEST.filter(s => s > 100);
+    const sizesAtMost100 = SIZES_TO_TEST.filter(s => s <= 100);
+    sizesOver100.forEach(size => {
+      expect(instance.get(size).toString()).toEqual(
+        'https://chat.zulip.org/user_avatars/2/e35cdbc4771c5e4b94e705bf6ff7cca7fa1efcae-medium.png?x=x&version=2',
+      );
+    });
+    sizesAtMost100.forEach(size => {
+      expect(instance.get(size).toString()).toEqual(
+        'https://chat.zulip.org/user_avatars/2/e35cdbc4771c5e4b94e705bf6ff7cca7fa1efcae.png?x=x&version=2',
+      );
+    });
+  });
+});
 
 // avatarUrl can be converted to retrieve medium sized avatars(mediumAvatarUrl) if and only if
 // avatarUrl contains avatar image name with a .png extension (e.g. AVATAR_IMAGE_NAME.png).

--- a/src/utils/__tests__/avatar-test.js
+++ b/src/utils/__tests__/avatar-test.js
@@ -1,18 +1,25 @@
 /* @flow strict-local */
 import md5 from 'blueimp-md5';
 
-import { AvatarURL, GravatarURL, UploadedAvatarURL } from '../avatar';
+import { AvatarURL, GravatarURL, FallbackAvatarURL, UploadedAvatarURL } from '../avatar';
 import * as eg from '../../__tests__/lib/exampleData';
 
 describe('AvatarURL', () => {
   describe('fromUserOrBotData', () => {
     const user = eg.makeUser();
-    const { email } = user;
+    const { email, user_id: userId } = user;
     const realm = eg.realm;
+
+    test('gives a `FallbackAvatarURL` if `rawAvatarURL` is undefined', () => {
+      const rawAvatarUrl = undefined;
+      expect(AvatarURL.fromUserOrBotData({ rawAvatarUrl, userId, email, realm })).toBeInstanceOf(
+        FallbackAvatarURL,
+      );
+    });
 
     test('gives a `GravatarURL` if `rawAvatarURL` is null', () => {
       const rawAvatarUrl = null;
-      expect(AvatarURL.fromUserOrBotData({ rawAvatarUrl, email, realm })).toBeInstanceOf(
+      expect(AvatarURL.fromUserOrBotData({ rawAvatarUrl, userId, email, realm })).toBeInstanceOf(
         GravatarURL,
       );
     });
@@ -20,7 +27,7 @@ describe('AvatarURL', () => {
     test('gives a `GravatarURL` if `rawAvatarURL` is a URL string on Gravatar origin', () => {
       const rawAvatarUrl =
         'https://secure.gravatar.com/avatar/2efaec12efd9bea8a089299208117786?d=identicon&version=3';
-      expect(AvatarURL.fromUserOrBotData({ rawAvatarUrl, email, realm })).toBeInstanceOf(
+      expect(AvatarURL.fromUserOrBotData({ rawAvatarUrl, userId, email, realm })).toBeInstanceOf(
         GravatarURL,
       );
     });
@@ -28,7 +35,7 @@ describe('AvatarURL', () => {
     test('gives an `UploadedAvatarURL` if `rawAvatarURL` is a non-Gravatar absolute URL string', () => {
       const rawAvatarUrl =
         'https://zulip-avatars.s3.amazonaws.com/13/430713047f2cffed661f84e139a64f864f17f286?x=x&version=5';
-      expect(AvatarURL.fromUserOrBotData({ rawAvatarUrl, email, realm })).toBeInstanceOf(
+      expect(AvatarURL.fromUserOrBotData({ rawAvatarUrl, userId, email, realm })).toBeInstanceOf(
         UploadedAvatarURL,
       );
     });
@@ -36,7 +43,7 @@ describe('AvatarURL', () => {
     test('gives an `UploadedAvatarURL` if `rawAvatarURL` is a relative URL string', () => {
       const rawAvatarUrl =
         '/user_avatars/2/08fb6d007eb10a56efee1d64760fbeb6111c4352.png?x=x&version=2';
-      expect(AvatarURL.fromUserOrBotData({ rawAvatarUrl, email, realm })).toBeInstanceOf(
+      expect(AvatarURL.fromUserOrBotData({ rawAvatarUrl, userId, email, realm })).toBeInstanceOf(
         UploadedAvatarURL,
       );
     });
@@ -145,6 +152,35 @@ describe('UploadedAvatarURL', () => {
     sizesAtMost100.forEach(size => {
       expect(instance.get(size).toString()).toEqual(
         'https://chat.zulip.org/user_avatars/2/e35cdbc4771c5e4b94e705bf6ff7cca7fa1efcae.png?x=x&version=2',
+      );
+    });
+  });
+});
+
+describe('FallbackAvatarURL', () => {
+  test('serializes/deserializes correctly', () => {
+    const instance = FallbackAvatarURL.validateAndConstructInstance({
+      realm: eg.realm,
+      userId: eg.selfUser.user_id,
+    });
+
+    const roundTripped = FallbackAvatarURL.deserialize(FallbackAvatarURL.serialize(instance));
+
+    SIZES_TO_TEST.forEach(size => {
+      expect(instance.get(size).toString()).toEqual(roundTripped.get(size).toString());
+    });
+  });
+
+  test('gives the `/avatar/{user_id}` URL, on the provided realm', () => {
+    const userId = eg.selfUser.user_id;
+    const instance = FallbackAvatarURL.validateAndConstructInstance({
+      realm: new URL('https://chat.zulip.org'),
+      userId,
+    });
+
+    SIZES_TO_TEST.forEach(size => {
+      expect(instance.get(size).toString()).toEqual(
+        `https://chat.zulip.org/avatar/${userId.toString()}`,
       );
     });
   });

--- a/src/utils/__tests__/avatar-test.js
+++ b/src/utils/__tests__/avatar-test.js
@@ -1,13 +1,7 @@
 /* @flow strict-local */
 import md5 from 'blueimp-md5';
 
-import {
-  AvatarURL,
-  GravatarURL,
-  UploadedAvatarURL,
-  getMediumAvatar,
-  getGravatarFromEmail,
-} from '../avatar';
+import { AvatarURL, GravatarURL, UploadedAvatarURL } from '../avatar';
 import * as eg from '../../__tests__/lib/exampleData';
 
 describe('AvatarURL', () => {
@@ -153,41 +147,5 @@ describe('UploadedAvatarURL', () => {
         'https://chat.zulip.org/user_avatars/2/e35cdbc4771c5e4b94e705bf6ff7cca7fa1efcae.png?x=x&version=2',
       );
     });
-  });
-});
-
-// avatarUrl can be converted to retrieve medium sized avatars(mediumAvatarUrl) if and only if
-// avatarUrl contains avatar image name with a .png extension (e.g. AVATAR_IMAGE_NAME.png).
-
-describe('getMediumAvatar', () => {
-  test('if avatarUrl can be converted into mediumAvatarUrl, return mediumAvatarUrl', () => {
-    const avatarUrl = '/user_avatars/AVATAR_IMAGE_NAME.png/';
-    const mediumAvatarUrl = '/user_avatars/AVATAR_IMAGE_NAME-medium.png/';
-
-    const resultUrl = getMediumAvatar(avatarUrl);
-
-    expect(resultUrl).toEqual(mediumAvatarUrl);
-  });
-
-  test('if avatarUrl cannot be converted into mediumAvatarUrl, return avatarUrl itself', () => {
-    const avatarUrl = '/avatar/AVATAR_IMAGE_NAME/';
-
-    const resultUrl = getMediumAvatar(avatarUrl);
-
-    expect(resultUrl).toEqual(avatarUrl);
-  });
-});
-
-describe('getGravatarFromEmail', () => {
-  test('given an email return gravatar url', () => {
-    expect(getGravatarFromEmail('test@example.com', 80)).toEqual(
-      'https://secure.gravatar.com/avatar/55502f40dc8b7c769880b10874abc9d0?d=identicon&s=80',
-    );
-  });
-
-  test('given a case-sensitive email canonize and return gravatar url', () => {
-    expect(getGravatarFromEmail('Test@example.com', 80)).toEqual(
-      'https://secure.gravatar.com/avatar/55502f40dc8b7c769880b10874abc9d0?d=identicon&s=80',
-    );
   });
 });

--- a/src/utils/__tests__/internalLinks-test.js
+++ b/src/utils/__tests__/internalLinks-test.js
@@ -145,7 +145,7 @@ describe('getNarrowFromLink', () => {
   });
 
   describe('on stream links', () => {
-    // Tell Jest to recognize `expectStream` as a helper function that
+    // Tell ESLint to recognize `expectStream` as a helper function that
     // runs assertions.
     /* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["expect", "expectStream"] }] */
     const expectStream = (operand, streams, expectedName: null | string) => {

--- a/src/utils/avatar.js
+++ b/src/utils/avatar.js
@@ -25,7 +25,7 @@ export const getAvatarUrl = (
   avatarUrl: ?string,
   email: string,
   realm: URL,
-  size: number = 80,
+  size: number,
 ): string => {
   if (typeof avatarUrl !== 'string') {
     return getGravatarFromEmail(email, size);
@@ -36,11 +36,8 @@ export const getAvatarUrl = (
   return size > 100 ? getMediumAvatar(fullUrl) : fullUrl;
 };
 
-export const getAvatarFromUser = (user: UserOrBot, realm: URL, size?: number): string =>
+export const getAvatarFromUser = (user: UserOrBot, realm: URL, size: number): string =>
   getAvatarUrl(user.avatar_url, user.email, realm, size);
 
-export const getAvatarFromMessage = (
-  message: Message | Outbox,
-  realm: URL,
-  size?: number,
-): string => getAvatarUrl(message.avatar_url, message.sender_email, realm, size);
+export const getAvatarFromMessage = (message: Message | Outbox, realm: URL, size: number): string =>
+  getAvatarUrl(message.avatar_url, message.sender_email, realm, size);

--- a/src/utils/avatar.js
+++ b/src/utils/avatar.js
@@ -3,7 +3,7 @@
 /* eslint-disable no-use-before-define */
 import md5 from 'blueimp-md5';
 
-import type { Message, Outbox, UserOrBot } from '../types';
+import type { UserOrBot } from '../types';
 import { tryParseUrl } from './url';
 import * as logging from './logging';
 import { ensureUnreachable } from '../types';
@@ -265,9 +265,3 @@ export const getAvatarUrl = (
 
 export const getAvatarFromUser = (user: UserOrBot, realm: URL, sizePhysicalPx: number): string =>
   getAvatarUrl(user.avatar_url, user.email, realm, sizePhysicalPx);
-
-export const getAvatarFromMessage = (
-  message: Message | Outbox,
-  realm: URL,
-  sizePhysicalPx: number,
-): string => getAvatarUrl(message.avatar_url, message.sender_email, realm, sizePhysicalPx);

--- a/src/utils/avatar.js
+++ b/src/utils/avatar.js
@@ -253,59 +253,15 @@ export class UploadedAvatarURL extends AvatarURL {
   }
 }
 
-/**
- * When selecting the size of a gravatar we can pick any arbitrary
- * size we want. For server-uploaded avatars this is not the case.
- * We have only:
- *  * default - image is 100x100
- *  * medium - image is 500x500
- *
- * This function converts a normal avatar to medium-sized one.
- */
-export const getMediumAvatar = (avatarUrl: string): string => {
-  const matches = new RegExp(/(\w+)\.png/g).exec(avatarUrl);
-
-  return matches ? avatarUrl.replace(matches[0], `${matches[1]}-medium.png`) : avatarUrl;
-};
-
-export const getGravatarFromEmail = (email: string = '', sizePhysicalPx: number): string =>
-  `https://secure.gravatar.com/avatar/${md5(email.toLowerCase())}?d=identicon&s=${sizePhysicalPx}`;
-
 export const getAvatarUrl = (
   avatarUrl: ?string,
   email: string,
   realm: URL,
   sizePhysicalPx: number,
-): string => {
-  if (typeof avatarUrl !== 'string') {
-    // It's our job to compute the Gravatar hash.
-    return getGravatarFromEmail(email, sizePhysicalPx);
-  }
-
-  // If we don't announce `client_gravatar` to the server (we
-  // sometimes don't), or if the server doesn't have
-  // `EMAIL_ADDRESS_VISIBILITY_EVERYONE` set, `avatarUrl` will be a
-  // Gravatar URL, and we should size it correctly with the `size`
-  // parameter.
-  const GRAVATAR_ORIGIN = 'https://secure.gravatar.com';
-  if (tryParseUrl(avatarUrl)?.origin === GRAVATAR_ORIGIN) {
-    const hashMatch = /[0-9a-fA-F]{32}$/.exec(new URL(avatarUrl).pathname);
-    if (hashMatch === null) {
-      const msg = 'Unexpected Gravatar URL shape from server.';
-      logging.error(msg, { value: avatarUrl });
-      throw new Error(msg);
-    }
-
-    const url = new URL(`/avatar/${hashMatch[0]}`, GRAVATAR_ORIGIN);
-    url.searchParams.set('d', 'identicon');
-    url.searchParams.set('s', sizePhysicalPx.toString());
-    return url.toString();
-  }
-
-  const fullUrl = new URL(avatarUrl, realm).toString();
-
-  return sizePhysicalPx > 100 ? getMediumAvatar(fullUrl) : fullUrl;
-};
+): string =>
+  AvatarURL.fromUserOrBotData({ rawAvatarUrl: avatarUrl, email, realm })
+    .get(sizePhysicalPx)
+    .toString();
 
 export const getAvatarFromUser = (user: UserOrBot, realm: URL, sizePhysicalPx: number): string =>
   getAvatarUrl(user.avatar_url, user.email, realm, sizePhysicalPx);

--- a/src/utils/avatar.js
+++ b/src/utils/avatar.js
@@ -251,13 +251,3 @@ export class UploadedAvatarURL extends AvatarURL {
     return result;
   }
 }
-
-export const getAvatarUrl = (
-  avatarUrl: ?string,
-  email: string,
-  realm: URL,
-  sizePhysicalPx: number,
-): string =>
-  AvatarURL.fromUserOrBotData({ rawAvatarUrl: avatarUrl, email, realm })
-    .get(sizePhysicalPx)
-    .toString();

--- a/src/utils/avatar.js
+++ b/src/utils/avatar.js
@@ -1,9 +1,257 @@
 /* @flow strict-local */
+/* eslint-disable no-underscore-dangle */
+/* eslint-disable no-use-before-define */
 import md5 from 'blueimp-md5';
 
 import type { Message, Outbox, UserOrBot } from '../types';
 import { tryParseUrl } from './url';
 import * as logging from './logging';
+import { ensureUnreachable } from '../types';
+
+/**
+ * A way to get a standard avatar URL, or a sized one if available
+ *
+ * This class is abstract. Only instantiate its subclasses.
+ */
+export class AvatarURL {
+  /**
+   * From info on a user or bot, make the right subclass instance.
+   */
+  static fromUserOrBotData(args: {|
+    rawAvatarUrl: string | void | null,
+    email: string,
+    realm: URL,
+  |}): AvatarURL {
+    const { rawAvatarUrl, email, realm } = args;
+    if (rawAvatarUrl === undefined) {
+      // `rawAvatarUrl` will be undefined for cross-realm bots from
+      // servers prior to 58ee3fa8c (1.9.0). Fall back to Gravatar for
+      // this case; it should be pretty rare.
+      return GravatarURL.validateAndConstructInstance({ email });
+    } else if (rawAvatarUrl === null) {
+      // If we announce `client_gravatar`, which we sometimes do,
+      // `rawAvatarUrl` might be null. In that case, we take
+      // responsibility for computing a hash for the user's email and
+      // using it to form a URL for an avatar served by Gravatar.
+      return GravatarURL.validateAndConstructInstance({ email });
+    } else if (typeof rawAvatarUrl === 'string') {
+      // If we don't announce `client_gravatar` (which we sometimes
+      // do), or if the server doesn't have
+      // EMAIL_ADDRESS_VISIBILITY_EVERYONE set, then `rawAvatarUrl`
+      // will be the absolute Gravatar URL string.
+      //
+      // (In the latter case, we won't have real email addresses with
+      // which to generate the correct hash; see
+      // https://github.com/zulip/zulip/issues/15287. Implemented at
+      // `do_events_register` in zerver/lib/events.py on the server.)
+      if (tryParseUrl(rawAvatarUrl)?.origin === GravatarURL.ORIGIN) {
+        const hashMatch = /[0-9a-fA-F]{32}$/.exec(new URL(rawAvatarUrl).pathname);
+        if (hashMatch === null) {
+          const msg = 'Unexpected Gravatar URL shape from server.';
+          logging.error(msg, { value: rawAvatarUrl });
+          throw new Error(msg);
+        }
+        return GravatarURL.validateAndConstructInstance({ email, hash: hashMatch[0] });
+      }
+
+      // Otherwise, it's a realm-uploaded avatar, either absolute or
+      // relative, depending on how uploads are stored.
+      return UploadedAvatarURL.validateAndConstructInstance({
+        realm,
+        absoluteOrRelativeUrl: rawAvatarUrl,
+      });
+    } else {
+      ensureUnreachable(rawAvatarUrl);
+      const msg = 'Unexpected value for `rawAvatarUrl` in `AvatarURL.fromUserOrBotData`';
+      logging.error(msg, { value: rawAvatarUrl });
+      throw new Error(msg);
+    }
+  }
+
+  /* eslint-disable-next-line class-methods-use-this */
+  get(sizePhysicalPx: number): URL {
+    throw new Error('unimplemented');
+  }
+}
+
+/**
+ * A Gravatar URL with a hash we compute from an email address.
+ *
+ * See http://secure.gravatar.com/site/implement/images/, which covers
+ * the size options.
+ */
+export class GravatarURL extends AvatarURL {
+  /**
+   * Serialize to a special string; reversible with `deserialize`.
+   */
+  static serialize(instance: GravatarURL): string {
+    return instance._standardUrl instanceof URL
+      ? instance._standardUrl.toString()
+      : instance._standardUrl;
+  }
+
+  /**
+   * Use a special string from `serialize` to make a new instance.
+   */
+  static deserialize(serialized: string): GravatarURL {
+    return new GravatarURL(serialized);
+  }
+
+  /**
+   * Construct from raw server data, or throw an error.
+   *
+   * Pass the hash if the server provides it, to avoid computing it
+   * unnecessarily.
+   */
+  static validateAndConstructInstance(args: {| email: string, hash?: string |}): GravatarURL {
+    const { email, hash = md5(email.toLowerCase()) } = args;
+
+    const standardSizeUrl = new URL(`/avatar/${hash}`, GravatarURL.ORIGIN);
+    standardSizeUrl.searchParams.set('d', 'identicon');
+
+    return new GravatarURL(standardSizeUrl);
+  }
+
+  static ORIGIN = 'https://secure.gravatar.com';
+
+  /**
+   * Standard URL from which to generate others. PRIVATE.
+   *
+   * May be a string if the instance was constructed at rehydrate
+   * time, when URL validation is unnecessary.
+   */
+  _standardUrl: string | URL;
+
+  /**
+   * PRIVATE: Make an instance from already-validated data.
+   *
+   * Not part of the public interface; use the static methods instead.
+   *
+   * It's private because we need a path to constructing an instance
+   * without constructing URL objects, which takes more time than is
+   * acceptable when we can avoid it, e.g., during rehydration.
+   * Constructing URL objects is a necessary part of validating data
+   * from the server, but we only need to validate the data once, when
+   * it's first received.
+   */
+  constructor(standardUrl: string | URL) {
+    super();
+    this._standardUrl = standardUrl;
+  }
+
+  /**
+   * Get a URL object for the given size.
+   *
+   * `sizePhysicalPx` must be an integer. (Gravatar doesn't advertise
+   * the ability to specify noninteger values for the size.)
+   */
+  get(sizePhysicalPx: number): URL {
+    // `this._standardUrl` may have begun its life as a string, to
+    // avoid computing a URL object during rehydration
+    if (typeof this._standardUrl === 'string') {
+      this._standardUrl = new URL(this._standardUrl);
+    }
+
+    // Make a new URL to mutate
+    // $FlowFixMe - https://github.com/zulip/zulip-mobile/pull/4230#discussion_r512351202
+    const result: URL = new URL(this._standardUrl);
+    result.searchParams.set('s', sizePhysicalPx.toString());
+    return result;
+  }
+}
+
+/**
+ * An avatar that was uploaded to the Zulip server.
+ *
+ * There are two size options; if `sizePhysicalPx` is greater than
+ * 100, medium is chosen:
+ *  * default: 100x100
+ *  * medium: 500x500
+ */
+export class UploadedAvatarURL extends AvatarURL {
+  /**
+   * Serialize to a special string; reversible with `deserialize`.
+   */
+  static serialize(instance: UploadedAvatarURL): string {
+    return instance._standardUrl instanceof URL
+      ? instance._standardUrl.toString()
+      : instance._standardUrl;
+  }
+
+  /**
+   * Use a special string from `serialize` to make a new instance.
+   */
+  static deserialize(serialized: string): UploadedAvatarURL {
+    return new UploadedAvatarURL(serialized);
+  }
+
+  /**
+   * Construct from raw server data, or throw an error.
+   *
+   * Expects a relative URL plus the realm for a local upload;
+   * otherwise, an absolute URL of the avatar on the S3 backend.
+   */
+  static validateAndConstructInstance(args: {|
+    realm: URL,
+    absoluteOrRelativeUrl: string,
+  |}): UploadedAvatarURL {
+    const { realm, absoluteOrRelativeUrl } = args;
+    // If `absoluteOrRelativeUrl` is absolute, the second argument
+    // is ignored.
+    return new UploadedAvatarURL(new URL(absoluteOrRelativeUrl, realm));
+  }
+
+  /**
+   * Standard URL from which to generate others. PRIVATE.
+   *
+   * May be a string if the instance was constructed at rehydrate
+   * time, when URL validation is unnecessary.
+   */
+  _standardUrl: string | URL;
+
+  /**
+   * PRIVATE: Make an instance from already-validated data.
+   *
+   * Not part of the public interface; use the static methods instead.
+   *
+   * It's private because we need a path to constructing an instance
+   * without constructing URL objects, which takes more time than is
+   * acceptable when we can avoid it, e.g., during rehydration.
+   * Constructing URL objects is a necessary part of validating data
+   * from the server, but we only need to validate the data once, when
+   * it's first received.
+   */
+  constructor(standardUrl: string | URL) {
+    super();
+    this._standardUrl = standardUrl;
+  }
+
+  /**
+   * Get a URL object for the given size.
+   *
+   * `sizePhysicalPx` should be an integer.
+   */
+  get(sizePhysicalPx: number): URL {
+    // `this._standardUrl` may have begun its life as a string, to
+    // avoid computing a URL object during rehydration
+    if (typeof this._standardUrl === 'string') {
+      this._standardUrl = new URL(this._standardUrl);
+    }
+
+    let result: URL = this._standardUrl;
+    if (sizePhysicalPx > 100) {
+      // Make a new URL to mutate, instead of mutating this._standardUrl
+      // $FlowFixMe - https://github.com/zulip/zulip-mobile/pull/4230#discussion_r512351202
+      result = new URL(this._standardUrl);
+
+      const match = new RegExp(/(\w+)\.png/g).exec(result.pathname);
+      if (match !== null) {
+        result.pathname = result.pathname.replace(match[0], `${match[1]}-medium.png`);
+      }
+    }
+    return result;
+  }
+}
 
 /**
  * When selecting the size of a gravatar we can pick any arbitrary

--- a/src/utils/avatar.js
+++ b/src/utils/avatar.js
@@ -28,16 +28,16 @@ export class AvatarURL {
       // this case; it should be pretty rare.
       return GravatarURL.validateAndConstructInstance({ email });
     } else if (rawAvatarUrl === null) {
-      // If we announce `client_gravatar`, which we sometimes do,
-      // `rawAvatarUrl` might be null. In that case, we take
-      // responsibility for computing a hash for the user's email and
-      // using it to form a URL for an avatar served by Gravatar.
+      // If we announce `client_gravatar`, which we do, `rawAvatarUrl`
+      // might be null. In that case, we take responsibility for
+      // computing a hash for the user's email and using it to form a
+      // URL for an avatar served by Gravatar.
       return GravatarURL.validateAndConstructInstance({ email });
     } else if (typeof rawAvatarUrl === 'string') {
-      // If we don't announce `client_gravatar` (which we sometimes
-      // do), or if the server doesn't have
-      // EMAIL_ADDRESS_VISIBILITY_EVERYONE set, then `rawAvatarUrl`
-      // will be the absolute Gravatar URL string.
+      // If we don't announce `client_gravatar` (which we do), or if
+      // the server doesn't have EMAIL_ADDRESS_VISIBILITY_EVERYONE
+      // set, then `rawAvatarUrl` will be the absolute Gravatar URL
+      // string.
       //
       // (In the latter case, we won't have real email addresses with
       // which to generate the correct hash; see

--- a/src/utils/avatar.js
+++ b/src/utils/avatar.js
@@ -18,26 +18,29 @@ export const getMediumAvatar = (avatarUrl: string): string => {
   return matches ? avatarUrl.replace(matches[0], `${matches[1]}-medium.png`) : avatarUrl;
 };
 
-export const getGravatarFromEmail = (email: string = '', size: number): string =>
-  `https://secure.gravatar.com/avatar/${md5(email.toLowerCase())}?d=identicon&s=${size}`;
+export const getGravatarFromEmail = (email: string = '', sizePhysicalPx: number): string =>
+  `https://secure.gravatar.com/avatar/${md5(email.toLowerCase())}?d=identicon&s=${sizePhysicalPx}`;
 
 export const getAvatarUrl = (
   avatarUrl: ?string,
   email: string,
   realm: URL,
-  size: number,
+  sizePhysicalPx: number,
 ): string => {
   if (typeof avatarUrl !== 'string') {
-    return getGravatarFromEmail(email, size);
+    return getGravatarFromEmail(email, sizePhysicalPx);
   }
 
   const fullUrl = new URL(avatarUrl, realm).toString();
 
-  return size > 100 ? getMediumAvatar(fullUrl) : fullUrl;
+  return sizePhysicalPx > 100 ? getMediumAvatar(fullUrl) : fullUrl;
 };
 
-export const getAvatarFromUser = (user: UserOrBot, realm: URL, size: number): string =>
-  getAvatarUrl(user.avatar_url, user.email, realm, size);
+export const getAvatarFromUser = (user: UserOrBot, realm: URL, sizePhysicalPx: number): string =>
+  getAvatarUrl(user.avatar_url, user.email, realm, sizePhysicalPx);
 
-export const getAvatarFromMessage = (message: Message | Outbox, realm: URL, size: number): string =>
-  getAvatarUrl(message.avatar_url, message.sender_email, realm, size);
+export const getAvatarFromMessage = (
+  message: Message | Outbox,
+  realm: URL,
+  sizePhysicalPx: number,
+): string => getAvatarUrl(message.avatar_url, message.sender_email, realm, sizePhysicalPx);

--- a/src/utils/avatar.js
+++ b/src/utils/avatar.js
@@ -3,7 +3,6 @@
 /* eslint-disable no-use-before-define */
 import md5 from 'blueimp-md5';
 
-import type { UserOrBot } from '../types';
 import { tryParseUrl } from './url';
 import * as logging from './logging';
 import { ensureUnreachable } from '../types';
@@ -262,6 +261,3 @@ export const getAvatarUrl = (
   AvatarURL.fromUserOrBotData({ rawAvatarUrl: avatarUrl, email, realm })
     .get(sizePhysicalPx)
     .toString();
-
-export const getAvatarFromUser = (user: UserOrBot, realm: URL, sizePhysicalPx: number): string =>
-  getAvatarUrl(user.avatar_url, user.email, realm, sizePhysicalPx);

--- a/src/webview/html/__tests__/render-test.js
+++ b/src/webview/html/__tests__/render-test.js
@@ -7,7 +7,6 @@ describe('typing', () => {
     const name = '&<name';
     const user = {
       ...eg.makeUser({ name }),
-      avatar_url: `https://zulip.example.org/yo/avatar-${name}.png`,
       email: `${name}@example.com`,
     };
 

--- a/src/webview/html/messageAsHtml.js
+++ b/src/webview/html/messageAsHtml.js
@@ -118,7 +118,7 @@ $!${divOpenHtml}
 
   const { sender_full_name } = message;
   const sender_id = message.isOutbox ? backgroundData.ownUser.user_id : message.sender_id;
-  const avatarUrl = getAvatarFromMessage(message, backgroundData.auth.realm);
+  const avatarUrl = getAvatarFromMessage(message, backgroundData.auth.realm, 80);
   const subheaderHtml = template`
 <div class="subheader">
   <div class="username">

--- a/src/webview/html/messageAsHtml.js
+++ b/src/webview/html/messageAsHtml.js
@@ -1,4 +1,5 @@
 /* @flow strict-local */
+import { PixelRatio } from 'react-native';
 import distanceInWordsToNow from 'date-fns/distance_in_words_to_now';
 import template from './template';
 import type {
@@ -118,7 +119,13 @@ $!${divOpenHtml}
 
   const { sender_full_name } = message;
   const sender_id = message.isOutbox ? backgroundData.ownUser.user_id : message.sender_id;
-  const avatarUrl = getAvatarFromMessage(message, backgroundData.auth.realm, 80);
+  const avatarUrl = getAvatarFromMessage(
+    message,
+    backgroundData.auth.realm,
+    // 48 logical pixels; see `.avatar` and `.avatar img` in
+    // src/webview/static/base.css.
+    PixelRatio.getPixelSizeForLayoutSize(48),
+  );
   const subheaderHtml = template`
 <div class="subheader">
   <div class="username">

--- a/src/webview/html/messageAsHtml.js
+++ b/src/webview/html/messageAsHtml.js
@@ -12,7 +12,6 @@ import type {
   ImageEmojiType,
 } from '../../types';
 import type { BackgroundData } from '../MessageList';
-import { getAvatarFromMessage } from '../../utils/avatar';
 import { shortTime } from '../../utils/date';
 import aggregateReactions from '../../reactions/aggregateReactions';
 import { codeToEmojiMap } from '../../emoji/data';
@@ -119,13 +118,13 @@ $!${divOpenHtml}
 
   const { sender_full_name } = message;
   const sender_id = message.isOutbox ? backgroundData.ownUser.user_id : message.sender_id;
-  const avatarUrl = getAvatarFromMessage(
-    message,
-    backgroundData.auth.realm,
-    // 48 logical pixels; see `.avatar` and `.avatar img` in
-    // src/webview/static/base.css.
-    PixelRatio.getPixelSizeForLayoutSize(48),
-  );
+  const avatarUrl = message.avatar_url
+    .get(
+      // 48 logical pixels; see `.avatar` and `.avatar img` in
+      // src/webview/static/base.css.
+      PixelRatio.getPixelSizeForLayoutSize(48),
+    )
+    .toString();
   const subheaderHtml = template`
 <div class="subheader">
   <div class="username">

--- a/src/webview/html/messageTypingAsHtml.js
+++ b/src/webview/html/messageTypingAsHtml.js
@@ -3,20 +3,19 @@ import { PixelRatio } from 'react-native';
 
 import template from './template';
 import type { UserOrBot } from '../../types';
-import { getAvatarFromUser } from '../../utils/avatar';
 
 const typingAvatar = (realm: URL, user: UserOrBot): string => template`
 <div class="avatar">
   <img
     class="avatar-img"
     data-sender-id="${user.user_id}"
-    src="${getAvatarFromUser(
-      user,
-      realm,
-      // 48 logical pixels; see `.avatar` and `.avatar img` in
-      // src/webview/static/base.css.
-      PixelRatio.getPixelSizeForLayoutSize(48),
-    )}">
+    src="${user.avatar_url
+      .get(
+        // 48 logical pixels; see `.avatar` and `.avatar img` in
+        // src/webview/static/base.css.
+        PixelRatio.getPixelSizeForLayoutSize(48),
+      )
+      .toString()}">
 </div>
 `;
 

--- a/src/webview/html/messageTypingAsHtml.js
+++ b/src/webview/html/messageTypingAsHtml.js
@@ -8,7 +8,7 @@ const typingAvatar = (realm: URL, user: UserOrBot): string => template`
   <img
     class="avatar-img"
     data-sender-id="${user.user_id}"
-    src="${getAvatarFromUser(user, realm)}">
+    src="${getAvatarFromUser(user, realm, 80)}">
 </div>
 `;
 

--- a/src/webview/html/messageTypingAsHtml.js
+++ b/src/webview/html/messageTypingAsHtml.js
@@ -1,4 +1,6 @@
 /* @flow strict-local */
+import { PixelRatio } from 'react-native';
+
 import template from './template';
 import type { UserOrBot } from '../../types';
 import { getAvatarFromUser } from '../../utils/avatar';
@@ -8,7 +10,13 @@ const typingAvatar = (realm: URL, user: UserOrBot): string => template`
   <img
     class="avatar-img"
     data-sender-id="${user.user_id}"
-    src="${getAvatarFromUser(user, realm, 80)}">
+    src="${getAvatarFromUser(
+      user,
+      realm,
+      // 48 logical pixels; see `.avatar` and `.avatar img` in
+      // src/webview/static/base.css.
+      PixelRatio.getPixelSizeForLayoutSize(48),
+    )}">
 </div>
 `;
 

--- a/src/webview/static/base.css
+++ b/src/webview/static/base.css
@@ -291,7 +291,12 @@ body {
   transition-timing-function: ease-out;
 }
 
-/* The sender's avatar. */
+/*
+ * The sender's avatar. If changing the size here, be sure to change
+ * the size we request for the avatar image file in the corresponding
+ * HTML-generating code (see messageTypingAsHtml.js and
+ * messageAsHtml.js).
+ */
 .avatar,
 .loading-avatar {
   min-width: 48px;


### PR DESCRIPTION
Following #4171 and #4216, here's a new approach to grabbing the correct URL for a user's avatar in a bunch of places, at the right size, in a [crunchy-shell](https://github.com/zulip/zulip-mobile/blob/master/docs/architecture/crunchy-shell.md) way. It also makes it much easier to fix #4157 and fixes it.

Discussion on CZO around [here](https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/user_avatar_url_field_optional/near/907833).

Some questions for review:

- While writing tests for `AvatarURL.fromMessageData` and `AvatarURL.fromUserOrBotData`, I realized that they're quite similar. I didn't jump in and deduplicate them yet, though, in case that seeming similarity was deceptive. In particular, the `rawAvatarUrl` param is meant to be raw data straight from the server, and that has a slightly different form between users and messages. More importantly, maybe, it's reasonable to expect that those differences will remain and maybe grow. But maybe not dramatically, and maybe one will always be a subtype of the other.
- I think these changes might increase the typical rehydrate time; I'll post some numbers in a followup comment.
- This handles live-updating of the avatar URL (via EVENT_USER_UPDATE) for user objects in `state.users`, but not messages in `state.messages`. So if someone changes their avatar URL, you won't see the new one right away in the message list. There's some work to do before we get there; see [discussion](https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/user_avatar_url_field_optional/near/992469) on implementation.
- For live-updating on a changed `avatar_url`, I'm having `action.person` on EVENT_USER_UPDATE only contain the fields we want to be overwritten in the user object. I've started out small, and I'm only ever having it overwrite the `avatar_url` property. 
  - Does that sound right?
  - One thing I haven't done, which is considered in https://github.com/zulip/zulip-mobile/pull/3403, is to make our code (in `eventToAction`, I think) aware of the different well-defined chunks of properties we might get at a time. The nice new [documentation](https://zulipchat.com/api/get-events#realm_user-update) for the event shows that a handful of properties will be present if the avatar URL is changed, a different handful will be present if the timezone changes, etc. In this branch, I haven't acknowledged that detail, thinking it's simpler to just go property by property: if it's there, we'll consider updating it; if not, we won't.

Fixes: #4157

-----

**EDIT**:

Fixes: #4305 