### PR TITLE
Fix a few more regressions from #4235.

### DIFF
--- a/src/start/AuthScreen.js
+++ b/src/start/AuthScreen.js
@@ -260,8 +260,7 @@ class AuthScreen extends PureComponent<Props> {
       id_token: credential.identityToken,
     });
 
-    // TODO: Use a `URL` computation, for #4146.
-    openLink(`${this.props.realm.toString()}/complete/apple/?${params}`);
+    openLink(new URL(`/complete/apple/?${params}`, this.props.realm).toString());
 
     // Currently, the rest is handled with the `zulip://` redirect,
     // same as in the web flow.

--- a/src/webview/js/generatedEs3.js
+++ b/src/webview/js/generatedEs3.js
@@ -724,7 +724,14 @@ var compiledWebviewJs = (function (exports) {
   var handleMessageEvent = function handleMessageEvent(e) {
     scrollEventsDisabled = true;
     var decodedData = decodeURIComponent(escape(window.atob(e.data)));
-    var updateEvents = JSON.parse(decodedData);
+    var rawUpdateEvents = JSON.parse(decodedData);
+    var updateEvents = rawUpdateEvents.map(function (updateEvent) {
+      return _objectSpread2(_objectSpread2({}, updateEvent), updateEvent.auth ? {
+        auth: _objectSpread2(_objectSpread2({}, updateEvent.auth), {}, {
+          realm: new URL(updateEvent.auth.realm)
+        })
+      } : {});
+    });
     updateEvents.forEach(function (uevent) {
       eventLogger.maybeCaptureInboundEvent(uevent);
       eventUpdateHandlers[uevent.type](uevent);


### PR DESCRIPTION
Explanations in the commit messages.

For the second (doubled slashes in Apple auth endpoint), following Greg's comment at https://github.com/zulip/zulip-mobile/pull/4265#issuecomment-697040991—chat.zulip.org seems perfectly happy to accept the double-slash version, like it did before cfebe3f53752968235e33ee428e2239025b5c11c 😆. At first I was confused about why it seemed to work both before and after my commit here. Anyway, that's probably why.