### PR TITLE
ChatScreen: Get `isFocused` from React Navigation.

### DIFF
--- a/src/nav/__tests__/navSelectors-test.js
+++ b/src/nav/__tests__/navSelectors-test.js
@@ -1,11 +1,9 @@
 import deepFreeze from 'deep-freeze';
 
-import { streamNarrow } from '../../utils/narrow';
 import {
   getCurrentRouteName,
   getCurrentRouteParams,
   getChatScreenParams,
-  getTopMostNarrow,
   getCanGoBack,
   getSameRoutesCount,
 } from '../navSelectors';
@@ -60,44 +58,6 @@ describe('getChatScreenParams', () => {
     const actualResult = getChatScreenParams(state);
 
     expect(actualResult).toBeDefined();
-  });
-});
-
-describe('getTopMostNarrow', () => {
-  test('return undefined if no chat screen are in stack', () => {
-    const state = deepFreeze({
-      nav: {
-        index: 0,
-        routes: [{ routeName: 'main' }],
-      },
-    });
-    expect(getTopMostNarrow(state)).toBe(undefined);
-  });
-
-  test('return narrow of first chat screen from top', () => {
-    const narrow = streamNarrow('all');
-    const state = deepFreeze({
-      nav: {
-        index: 1,
-        routes: [{ routeName: 'main' }, { routeName: 'chat', params: { narrow } }],
-      },
-    });
-    expect(getTopMostNarrow(state)).toEqual(narrow);
-  });
-
-  test('iterate over stack to get first chat screen', () => {
-    const narrow = streamNarrow('all');
-    const state = deepFreeze({
-      nav: {
-        index: 2,
-        routes: [
-          { routeName: 'main' },
-          { routeName: 'chat', params: { narrow } },
-          { routeName: 'account' },
-        ],
-      },
-    });
-    expect(getTopMostNarrow(state)).toEqual(narrow);
   });
 });
 

--- a/src/nav/navSelectors.js
+++ b/src/nav/navSelectors.js
@@ -24,22 +24,6 @@ export const getChatScreenParams: Selector<{ narrow?: Narrow }> = createSelector
   params => params || { narrow: undefined },
 );
 
-export const getTopMostNarrow: Selector<void | Narrow> = createSelector(
-  getNav,
-  nav => {
-    const { routes } = nav;
-    let { index } = nav;
-    while (index >= 0) {
-      if (routes[index].routeName === 'chat') {
-        const { params } = routes[index];
-        return params ? params.narrow : undefined;
-      }
-      index--;
-    }
-    return undefined;
-  },
-);
-
 export const getCanGoBack = (state: GlobalState) => state.nav.index > 0;
 
 export const getSameRoutesCount: Selector<number> = createSelector(

--- a/src/session/__tests__/sessionReducer-test.js
+++ b/src/session/__tests__/sessionReducer-test.js
@@ -4,7 +4,6 @@ import deepFreeze from 'deep-freeze';
 import {
   DEAD_QUEUE,
   LOGOUT,
-  DO_NARROW,
   APP_ONLINE,
   INITIAL_FETCH_COMPLETE,
   INIT_SAFE_AREA_INSETS,
@@ -16,7 +15,6 @@ import {
 } from '../../actionConstants';
 import sessionReducer from '../sessionReducer';
 import * as eg from '../../__tests__/lib/exampleData';
-import { privateNarrow } from '../../utils/narrow';
 
 describe('sessionReducer', () => {
   const baseState = eg.baseReduxState.session;
@@ -24,14 +22,12 @@ describe('sessionReducer', () => {
   test('ACCOUNT_SWITCH', () => {
     const state = deepFreeze({
       ...baseState,
-      lastNarrow: [],
       needsInitialFetch: false,
       loading: true,
     });
     const newState = sessionReducer(state, eg.action.account_switch);
     expect(newState).toEqual({
       ...baseState,
-      lastNarrow: null,
       needsInitialFetch: true,
       loading: false,
     });
@@ -51,14 +47,12 @@ describe('sessionReducer', () => {
   test('LOGOUT', () => {
     const state = deepFreeze({
       ...baseState,
-      lastNarrow: [],
       needsInitialFetch: true,
       loading: true,
     });
     const newState = sessionReducer(state, deepFreeze({ type: LOGOUT }));
     expect(newState).toEqual({
       ...baseState,
-      lastNarrow: null,
       needsInitialFetch: false,
       loading: false,
     });
@@ -71,13 +65,6 @@ describe('sessionReducer', () => {
     });
     const newState = sessionReducer(baseState, action);
     expect(newState).toEqual({ ...baseState, eventQueueId: 100 });
-  });
-
-  test('DO_NARROW', () => {
-    const state = deepFreeze({ ...baseState, lastNarrow: [] });
-    const action = deepFreeze({ type: DO_NARROW, narrow: privateNarrow('a@a.com') });
-    const newState = sessionReducer(state, action);
-    expect(newState).toEqual({ ...baseState, lastNarrow: privateNarrow('a@a.com') });
   });
 
   test('APP_ONLINE', () => {

--- a/src/session/sessionReducer.js
+++ b/src/session/sessionReducer.js
@@ -1,9 +1,8 @@
 /* @flow strict-local */
-import type { Debug, Dimensions, Narrow, Orientation, Action } from '../types';
+import type { Debug, Dimensions, Orientation, Action } from '../types';
 import {
   REHYDRATE,
   DEAD_QUEUE,
-  DO_NARROW,
   LOGIN_SUCCESS,
   APP_ONLINE,
   ACCOUNT_SWITCH,
@@ -21,17 +20,11 @@ import { hasAuth } from '../account/accountsSelectors';
 
 /**
  * Miscellaneous non-persistent state about this run of the app.
- *
- * @prop lastNarrow - the last narrow we navigated to.  If the user is
- *   currently in a chat screen this will also be the "current" narrow,
- *   but they may also be on an associated info screen or have navigated
- *   away entirely.
  */
 export type SessionState = {|
   eventQueueId: number,
   isOnline: boolean,
   isHydrated: boolean,
-  lastNarrow: ?Narrow,
 
   /**
    * Whether the /register request is in progress.
@@ -73,7 +66,6 @@ const initialState: SessionState = {
   eventQueueId: -1,
   isOnline: true,
   isHydrated: false,
-  lastNarrow: null,
   loading: false,
   needsInitialFetch: false,
   orientation: 'PORTRAIT',
@@ -122,7 +114,6 @@ export default (state: SessionState = initialState, action: Action): SessionStat
     case LOGOUT:
       return {
         ...state,
-        lastNarrow: null,
         needsInitialFetch: false,
         loading: false,
       };
@@ -130,7 +121,6 @@ export default (state: SessionState = initialState, action: Action): SessionStat
     case ACCOUNT_SWITCH:
       return {
         ...state,
-        lastNarrow: null,
         needsInitialFetch: true,
         loading: false,
       };
@@ -142,12 +132,6 @@ export default (state: SessionState = initialState, action: Action): SessionStat
       return {
         ...state,
         eventQueueId: action.data.queue_id,
-      };
-
-    case DO_NARROW:
-      return {
-        ...state,
-        lastNarrow: action.narrow,
       };
 
     case APP_ONLINE:


### PR DESCRIPTION
(Moves us closer toward https://github.com/zulip/zulip-mobile/issues/3804.)

-----

As noted in discussion [1], we haven't been using quite the right
information to decide whether it's time for a ChatScreen to fetch
new messages. As Greg says, there,

"""
[T]he condition we'd like to have governing this isn't "is this
ChatScreen showing the same narrow that's topmost or last", but
rather "is this the topmost or last ChatScreen".
"""

To grab that bit, we first considered [2] something like adding a
unique ID to each ChatScreen, which seems hacky.

But while I was doing the recent React Navigation v3 and v4
upgrades, I came across this `withNavigationFocus` HOC, which
provides an `isFocused` prop [3], which looks more or less exactly
like what we'd want. "Is this ChatScreen focused" isn't *exactly*
the same question as "is this the topmost or last ChatScreen", but
the differences seem trivial, and I think this commit's approach is
simpler and clearer.

There's also an `isFocused` *method* directly on the `navigation`
prop [4]; we get the `navigation` prop for free [5] since we've
stuck `ChatScreen` directly on one of our navigators. The problem
with just using that method is that `ChatScreen` doesn't naturally
update (re-`render`) when it goes in and out of focus, so our code
in `componentDidUpdate` that would ask for the `isFocused` value
would never get run.

So, use this HOC, which does set up `ChatScreen` to listen for a
change of focus.

[1] https://github.com/zulip/zulip-mobile/pull/4205#pullrequestreview-461268523
[2] https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/.23M4156.20Message.20List.20placeholders/near/978256
[3] https://reactnavigation.org/docs/4.x/function-after-focusing-screen#triggering-an-action-with-the-withnavigationfocus-higher-order-component
[4] https://reactnavigation.org/docs/4.x/navigation-prop/#isfocused---query-the-focused-state-of-the-screen
[5] https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/.23M4156.20Message.20List.20placeholders/near/953303