### PR TITLE
ComposeBox: Fix a crash on sending a message.

### DIFF
--- a/src/compose/ComposeBox.js
+++ b/src/compose/ComposeBox.js
@@ -138,7 +138,7 @@ class ComposeBox extends PureComponent<Props, State> {
   //   mentionWarnings = React.createRef<typeof MentionWarnings>()
   //
   // but we need our `react-redux` wrapper to be aware of
-  // `getWrappedInstance`, since we need to access that.
+  // `{ forwardRef: true }`, since we use that.
   mentionWarnings = React.createRef();
 
   inputBlurTimeoutId: ?TimeoutID = null;
@@ -325,7 +325,7 @@ class ComposeBox extends PureComponent<Props, State> {
     this.setMessageInputValue('');
 
     if (this.mentionWarnings.current) {
-      this.mentionWarnings.current.getWrappedInstance().clearMentionWarnings();
+      this.mentionWarnings.current.clearMentionWarnings();
     }
 
     dispatch(sendTypingStop(narrow));


### PR DESCRIPTION
This is a regression caused by something that was missed in
fd4debbae; we partly but incompletely removed our use of
`getWrappedInstance` with a react-redux API change. From that commit
message:

"""
So, make that change, including the implied removal of
`getWrappedInstance`; that bit of UI works fine on Android and iOS
after that removal.
"""

It looks like "that bit of UI" was something other than sending a
message, and I didn't do a full-project search for the term
`getWrappedInstance` in that revision. This should be the last of
them now.

Fixes: #4270