### PR TITLE
flipper: Upgrade Flipper to 0.39.0.

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -28,4 +28,4 @@ android.useAndroidX=true
 android.enableJetifier=true
 
 # Version of flipper SDK to use with React Native
-FLIPPER_VERSION=0.33.1
+FLIPPER_VERSION=0.39.0

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -7,7 +7,7 @@ require_relative '../node_modules/react-native-unimodules/cocoapods.rb'
 
 # Add Flipper Pods
 def add_flipper_pods!(versions = {})
-  versions['Flipper'] ||= '~> 0.33.1'
+  versions['Flipper'] ||= '~> 0.39.0'
   versions['DoubleConversion'] ||= '1.1.7'
   versions['Flipper-Folly'] ||= '~> 2.1'
   versions['Flipper-Glog'] ||= '0.3.6'

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -34,9 +34,9 @@ PODS:
     - React-Core (= 0.62.2)
     - React-jsi (= 0.62.2)
     - ReactCommon/turbomodule/core (= 0.62.2)
-  - Flipper (0.33.1):
-    - Flipper-Folly (~> 2.1)
-    - Flipper-RSocket (~> 1.0)
+  - Flipper (0.39.0):
+    - Flipper-Folly (~> 2.2)
+    - Flipper-RSocket (~> 1.1)
   - Flipper-DoubleConversion (1.1.7)
   - Flipper-Folly (2.2.0):
     - boost-for-react-native
@@ -48,36 +48,36 @@ PODS:
   - Flipper-PeerTalk (0.0.4)
   - Flipper-RSocket (1.1.0):
     - Flipper-Folly (~> 2.2)
-  - FlipperKit (0.33.1):
-    - FlipperKit/Core (= 0.33.1)
-  - FlipperKit/Core (0.33.1):
-    - Flipper (~> 0.33.1)
+  - FlipperKit (0.39.0):
+    - FlipperKit/Core (= 0.39.0)
+  - FlipperKit/Core (0.39.0):
+    - Flipper (~> 0.39.0)
     - FlipperKit/CppBridge
     - FlipperKit/FBCxxFollyDynamicConvert
     - FlipperKit/FBDefines
     - FlipperKit/FKPortForwarding
-  - FlipperKit/CppBridge (0.33.1):
-    - Flipper (~> 0.33.1)
-  - FlipperKit/FBCxxFollyDynamicConvert (0.33.1):
-    - Flipper-Folly (~> 2.1)
-  - FlipperKit/FBDefines (0.33.1)
-  - FlipperKit/FKPortForwarding (0.33.1):
+  - FlipperKit/CppBridge (0.39.0):
+    - Flipper (~> 0.39.0)
+  - FlipperKit/FBCxxFollyDynamicConvert (0.39.0):
+    - Flipper-Folly (~> 2.2)
+  - FlipperKit/FBDefines (0.39.0)
+  - FlipperKit/FKPortForwarding (0.39.0):
     - CocoaAsyncSocket (~> 7.6)
     - Flipper-PeerTalk (~> 0.0.4)
-  - FlipperKit/FlipperKitHighlightOverlay (0.33.1)
-  - FlipperKit/FlipperKitLayoutPlugin (0.33.1):
+  - FlipperKit/FlipperKitHighlightOverlay (0.39.0)
+  - FlipperKit/FlipperKitLayoutPlugin (0.39.0):
     - FlipperKit/Core
     - FlipperKit/FlipperKitHighlightOverlay
     - FlipperKit/FlipperKitLayoutTextSearchable
     - YogaKit (~> 1.18)
-  - FlipperKit/FlipperKitLayoutTextSearchable (0.33.1)
-  - FlipperKit/FlipperKitNetworkPlugin (0.33.1):
+  - FlipperKit/FlipperKitLayoutTextSearchable (0.39.0)
+  - FlipperKit/FlipperKitNetworkPlugin (0.39.0):
     - FlipperKit/Core
-  - FlipperKit/FlipperKitReactPlugin (0.33.1):
+  - FlipperKit/FlipperKitReactPlugin (0.39.0):
     - FlipperKit/Core
-  - FlipperKit/FlipperKitUserDefaultsPlugin (0.33.1):
+  - FlipperKit/FlipperKitUserDefaultsPlugin (0.39.0):
     - FlipperKit/Core
-  - FlipperKit/SKIOSNetworkPlugin (0.33.1):
+  - FlipperKit/SKIOSNetworkPlugin (0.39.0):
     - FlipperKit/Core
     - FlipperKit/FlipperKitNetworkPlugin
   - Folly (2018.10.22.00):
@@ -408,25 +408,25 @@ DEPENDENCIES:
   - EXSplashScreen (from `../node_modules/expo-splash-screen/ios`)
   - FBLazyVector (from `../node_modules/react-native/Libraries/FBLazyVector`)
   - FBReactNativeSpec (from `../node_modules/react-native/Libraries/FBReactNativeSpec`)
-  - Flipper (~> 0.33.1)
+  - Flipper (~> 0.39.0)
   - Flipper-DoubleConversion (= 1.1.7)
   - Flipper-Folly (~> 2.1)
   - Flipper-Glog (= 0.3.6)
   - Flipper-PeerTalk (~> 0.0.4)
   - Flipper-RSocket (~> 1.0)
-  - FlipperKit (~> 0.33.1)
-  - FlipperKit/Core (~> 0.33.1)
-  - FlipperKit/CppBridge (~> 0.33.1)
-  - FlipperKit/FBCxxFollyDynamicConvert (~> 0.33.1)
-  - FlipperKit/FBDefines (~> 0.33.1)
-  - FlipperKit/FKPortForwarding (~> 0.33.1)
-  - FlipperKit/FlipperKitHighlightOverlay (~> 0.33.1)
-  - FlipperKit/FlipperKitLayoutPlugin (~> 0.33.1)
-  - FlipperKit/FlipperKitLayoutTextSearchable (~> 0.33.1)
-  - FlipperKit/FlipperKitNetworkPlugin (~> 0.33.1)
-  - FlipperKit/FlipperKitReactPlugin (~> 0.33.1)
-  - FlipperKit/FlipperKitUserDefaultsPlugin (~> 0.33.1)
-  - FlipperKit/SKIOSNetworkPlugin (~> 0.33.1)
+  - FlipperKit (~> 0.39.0)
+  - FlipperKit/Core (~> 0.39.0)
+  - FlipperKit/CppBridge (~> 0.39.0)
+  - FlipperKit/FBCxxFollyDynamicConvert (~> 0.39.0)
+  - FlipperKit/FBDefines (~> 0.39.0)
+  - FlipperKit/FKPortForwarding (~> 0.39.0)
+  - FlipperKit/FlipperKitHighlightOverlay (~> 0.39.0)
+  - FlipperKit/FlipperKitLayoutPlugin (~> 0.39.0)
+  - FlipperKit/FlipperKitLayoutTextSearchable (~> 0.39.0)
+  - FlipperKit/FlipperKitNetworkPlugin (~> 0.39.0)
+  - FlipperKit/FlipperKitReactPlugin (~> 0.39.0)
+  - FlipperKit/FlipperKitUserDefaultsPlugin (~> 0.39.0)
+  - FlipperKit/SKIOSNetworkPlugin (~> 0.39.0)
   - Folly (from `../node_modules/react-native/third-party-podspecs/Folly.podspec`)
   - glog (from `../node_modules/react-native/third-party-podspecs/glog.podspec`)
   - RCTRequired (from `../node_modules/react-native/Libraries/RCTRequired`)
@@ -652,13 +652,13 @@ SPEC CHECKSUMS:
   EXSplashScreen: 9423d258b71afa5bf128a83dcb57b636d9900a74
   FBLazyVector: 4aab18c93cd9546e4bfed752b4084585eca8b245
   FBReactNativeSpec: 5465d51ccfeecb7faa12f9ae0024f2044ce4044e
-  Flipper: 6c1f484f9a88d30ab3e272800d53688439e50f69
+  Flipper: bee8d5809012d1b6affa747fb756567ecd8c7c0b
   Flipper-DoubleConversion: 38631e41ef4f9b12861c67d17cb5518d06badc41
   Flipper-Folly: c12092ea368353b58e992843a990a3225d4533c3
   Flipper-Glog: 1dfd6abf1e922806c52ceb8701a3599a79a200a6
   Flipper-PeerTalk: 116d8f857dc6ef55c7a5a75ea3ceaafe878aadc9
   Flipper-RSocket: 64e7431a55835eb953b0bf984ef3b90ae9fdddd7
-  FlipperKit: 6dc9b8f4ef60d9e5ded7f0264db299c91f18832e
+  FlipperKit: 45e659ff1bfa264bb55ea0b20926c9c11599c628
   Folly: 30e7936e1c45c08d884aa59369ed951a8e68cf51
   glog: 1f3da668190260b06b429bb211bfbee5cd790c28
   OpenSSL-Universal: 8b48cc0d10c1b2923617dfe5c178aa9ed2689355
@@ -719,6 +719,6 @@ SPEC CHECKSUMS:
   Yoga: 3ebccbdd559724312790e7742142d062476b698e
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
-PODFILE CHECKSUM: f97ccaf74c7d6739c10ca3488c4e765b5337b5fb
+PODFILE CHECKSUM: d6def8f1d60984ef9a9b01f3e009735301aada6b
 
 COCOAPODS: 1.9.3


### PR DESCRIPTION
See discussion [1], where Greg reported that 7c7271598 introduced an
issue where uploading images from the camera was broken on Android.

The issue is facebook/react-native#28551; it seems to be a problem
specifically with Flipper's "network" plugin [2].

The discussion on that issue links to facebook/flipper#993, which
suggests [3] upgrading Flipper to 0.39.0. So, do. On Android, it may
be necessary to do a `cd android && ./gradlew clean` after this
commit.

It's nice that we can upgrade Flipper independently of React Native;
it seems this will stay possible [4].

[1] https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/Flipper/near/1042657
[2] https://github.com/facebook/react-native/issues/28551#issuecomment-611085378
[3] https://github.com/facebook/flipper/issues/993#issuecomment-619823916
[4] https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/Flipper/near/1042764

Fixes: #4281 