### PR TITLE
Update to target Android 10 / API 29.

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -22,7 +22,8 @@
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
-        android:theme="@style/AppTheme">
+        android:theme="@style/AppTheme"
+        android:requestLegacyExternalStorage="true">
         <activity
             android:name=".MainActivity"
             android:configChanges="keyboard|keyboardHidden|orientation|screenSize|uiMode"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -13,7 +13,7 @@ buildscript {
         // but some testing is required and code changes are often required.
         // See upstream for background and more discussion:
         //   https://medium.com/androiddevelopers/picking-your-compilesdkversion-minsdkversion-targetsdkversion-a098a0341ebd
-        targetSdkVersion = 28
+        targetSdkVersion = 29
 
         // Should be the latest SDK version available.  See upstream recommendation:
         //   https://medium.com/androiddevelopers/picking-your-compilesdkversion-minsdkversion-targetsdkversion-a098a0341ebd


### PR DESCRIPTION
This change will be required in order to upload new releases to the
Play Store, effective 2020-11-01, a couple of weeks from now.
    
The change causes Android 10 and later to apply to our app a number
of behavior changes introduced in that version, documented here:
  https://developer.android.com/about/versions/10/behavior-changes-10

Further discussion in #3665.

Fixes: #3665 
