### PR TITLE
webview build: Spell stdin as `-` for reading rsync filter rules.

### DIFF
--- a/tools/build-webview
+++ b/tools/build-webview
@@ -153,7 +153,7 @@ sync() {
     mkdir -p "${_dest}"
     rsync -aR --no-D --delete --delete-excluded \
           "${src}/./" "${_dest}/." \
-          --filter='. /dev/stdin'
+          --filter='. -'
 }
 
 # Copy over files from KaTeX.


### PR DESCRIPTION
On Windows (in Git Bash) there's no /dev/stdin; but this works
instead, as we learned here:
  https://chat.zulip.org/#narrow/stream/48-mobile/topic/issue/near/1047294

(Things still aren't working there as a whole, but we seem to get
past one error and reach another one.)

Conversely, this exact construct `--filter='. -'` appears in an
example in the rsync man page, even at the ancient rsync 2.6.9
that Apple provides on macOS.

Suggested-by: @andersk 