### PR TITLE
UserItem [nfc]: Use more whole user objects, fewer bags of properties

### DIFF
--- a/src/autocomplete/PeopleAutocomplete.js
+++ b/src/autocomplete/PeopleAutocomplete.js
@@ -3,7 +3,7 @@
 import React, { PureComponent } from 'react';
 import { SectionList } from 'react-native';
 
-import type { User, UserGroup, Dispatch } from '../types';
+import type { User, UserGroup, UserOrBot, Dispatch } from '../types';
 import { connect } from '../react-redux';
 import { getOwnEmail, getSortedUsers, getUserGroups } from '../selectors';
 import {
@@ -28,20 +28,17 @@ class PeopleAutocomplete extends PureComponent<Props> {
     this.props.onAutocomplete(`*${name}*`);
   };
 
-  handleUserItemAutocomplete = (email: string): void => {
+  handleUserItemAutocomplete = (user: UserOrBot): void => {
     const { users, onAutocomplete } = this.props;
-    const user = users.find(x => x.email === email);
-    if (user) {
-      // If another user with the same full name is found, we send the
-      // user ID as well, to ensure the mentioned user is uniquely identified.
-      if (users.find(x => x.full_name === user.full_name && x.user_id !== user.user_id)) {
-        // See the `get_mention_syntax` function in
-        // `static/js/people.js` in the webapp.
-        onAutocomplete(`**${user.full_name}|${user.user_id}**`);
-        return;
-      }
-      onAutocomplete(`**${user.full_name}**`);
+    // If another user with the same full name is found, we send the
+    // user ID as well, to ensure the mentioned user is uniquely identified.
+    if (users.find(x => x.full_name === user.full_name && x.user_id !== user.user_id)) {
+      // See the `get_mention_syntax` function in
+      // `static/js/people.js` in the webapp.
+      onAutocomplete(`**${user.full_name}|${user.user_id}**`);
+      return;
     }
+    onAutocomplete(`**${user.full_name}**`);
   };
 
   render() {

--- a/src/autocomplete/PeopleAutocomplete.js
+++ b/src/autocomplete/PeopleAutocomplete.js
@@ -70,9 +70,7 @@ class PeopleAutocomplete extends PureComponent<Props> {
         renderItem: ({ item }) => (
           <UserItem
             key={item.user_id}
-            fullName={item.full_name}
-            avatarUrl={item.avatar_url}
-            email={item.email}
+            user={item}
             showEmail
             onPress={this.handleUserItemAutocomplete}
           />

--- a/src/chat/GroupDetailsScreen.js
+++ b/src/chat/GroupDetailsScreen.js
@@ -37,10 +37,8 @@ class GroupDetailsScreen extends PureComponent<Props> {
           keyExtractor={item => item.email}
           renderItem={({ item }) => (
             <UserItem
-              key={item.email}
-              fullName={item.full_name}
-              avatarUrl={item.avatar_url}
-              email={item.email}
+              key={item.user_id}
+              user={item}
               showEmail
               onPress={() => {
                 this.handlePress(item.user_id);

--- a/src/chat/GroupDetailsScreen.js
+++ b/src/chat/GroupDetailsScreen.js
@@ -23,8 +23,8 @@ type Props = $ReadOnly<{|
 |}>;
 
 class GroupDetailsScreen extends PureComponent<Props> {
-  handlePress = (userId: number) => {
-    this.props.dispatch(navigateToAccountDetails(userId));
+  handlePress = (user: UserOrBot) => {
+    this.props.dispatch(navigateToAccountDetails(user.user_id));
   };
 
   render() {
@@ -36,14 +36,7 @@ class GroupDetailsScreen extends PureComponent<Props> {
           data={recipients}
           keyExtractor={item => item.email}
           renderItem={({ item }) => (
-            <UserItem
-              key={item.user_id}
-              user={item}
-              showEmail
-              onPress={() => {
-                this.handlePress(item.user_id);
-              }}
-            />
+            <UserItem key={item.user_id} user={item} showEmail onPress={this.handlePress} />
           )}
         />
       </Screen>

--- a/src/pm-conversations/PmConversationList.js
+++ b/src/pm-conversations/PmConversationList.js
@@ -52,13 +52,7 @@ export default class PmConversationList extends PureComponent<Props> {
             }
 
             return (
-              <UserItem
-                email={user.email}
-                fullName={user.full_name}
-                avatarUrl={user.avatar_url}
-                unreadCount={item.unread}
-                onPress={this.handleUserNarrow}
-              />
+              <UserItem user={user} unreadCount={item.unread} onPress={this.handleUserNarrow} />
             );
           }
 

--- a/src/pm-conversations/PmConversationList.js
+++ b/src/pm-conversations/PmConversationList.js
@@ -26,8 +26,8 @@ type Props = $ReadOnly<{|
  * A list describing all PM conversations.
  * */
 export default class PmConversationList extends PureComponent<Props> {
-  handleUserNarrow = (email: string) => {
-    this.props.dispatch(doNarrow(privateNarrow(email)));
+  handleUserNarrow = (user: UserOrBot) => {
+    this.props.dispatch(doNarrow(privateNarrow(user.email)));
   };
 
   handleGroupNarrow = (email: string) => {

--- a/src/reactions/ReactionUserList.js
+++ b/src/reactions/ReactionUserList.js
@@ -39,9 +39,7 @@ class ReactionUserList extends PureComponent<Props> {
           return (
             <UserItem
               key={user.user_id}
-              fullName={user.full_name}
-              avatarUrl={user.avatar_url}
-              email={user.email}
+              user={user}
               onPress={() => {
                 this.handlePress(user.user_id);
               }}

--- a/src/reactions/ReactionUserList.js
+++ b/src/reactions/ReactionUserList.js
@@ -19,9 +19,9 @@ type Props = $ReadOnly<{|
  * Used within `MessageReactionList`.
  */
 class ReactionUserList extends PureComponent<Props> {
-  handlePress = (userId: number) => {
+  handlePress = (user: UserOrBot) => {
     const { dispatch } = this.props;
-    dispatch(navigateToAccountDetails(userId));
+    dispatch(navigateToAccountDetails(user.user_id));
   };
 
   render() {
@@ -36,15 +36,7 @@ class ReactionUserList extends PureComponent<Props> {
           if (!user) {
             return null;
           }
-          return (
-            <UserItem
-              key={user.user_id}
-              user={user}
-              onPress={() => {
-                this.handlePress(user.user_id);
-              }}
-            />
-          );
+          return <UserItem key={user.user_id} user={user} onPress={this.handlePress} />;
         }}
       />
     );

--- a/src/sharing/ShareToPm.js
+++ b/src/sharing/ShareToPm.js
@@ -143,15 +143,7 @@ class ShareToPm extends React.Component<Props, State> {
     }
     const preview = [];
     selectedRecipients.forEach((user: User) => {
-      preview.push(
-        <UserItem
-          avatarUrl={user.avatar_url}
-          email={user.email}
-          fullName={user.full_name}
-          onPress={() => {}}
-          key={user.user_id}
-        />,
-      );
+      preview.push(<UserItem user={user} onPress={() => {}} key={user.user_id} />);
     });
     return preview;
   };

--- a/src/user-picker/UserPickerCard.js
+++ b/src/user-picker/UserPickerCard.js
@@ -3,7 +3,7 @@ import React, { PureComponent } from 'react';
 import { View } from 'react-native';
 import type { FlatList } from 'react-native';
 
-import type { User, PresenceState, Dispatch } from '../types';
+import type { User, UserOrBot, PresenceState, Dispatch } from '../types';
 import { createStyleSheet } from '../styles';
 import { connect } from '../react-redux';
 import { FloatingActionButton, LineSeparator } from '../common';
@@ -56,13 +56,12 @@ class UserPickerCard extends PureComponent<Props, State> {
     }
   };
 
-  handleUserPress = (email: string) => {
+  handleUserPress = (user: UserOrBot) => {
     const { selected } = this.state;
-
-    if (selected.find(x => x.email === email)) {
-      this.handleUserDeselect(email);
+    if (selected.find(x => x.email === user.email)) {
+      this.handleUserDeselect(user.email);
     } else {
-      this.handleUserSelect(email);
+      this.handleUserSelect(user.email);
     }
   };
 

--- a/src/users/UserItem.js
+++ b/src/users/UserItem.js
@@ -2,6 +2,7 @@
 import React, { PureComponent } from 'react';
 import { View } from 'react-native';
 
+import type { UserOrBot } from '../types';
 import { UserAvatarWithPresence, RawLabel, Touchable, UnreadCount } from '../common';
 import styles, { createStyleSheet, BRAND_COLOR } from '../styles';
 
@@ -25,9 +26,7 @@ const componentStyles = createStyleSheet({
 });
 
 type Props = $ReadOnly<{|
-  email: string,
-  fullName: string,
-  avatarUrl: ?string,
+  user: UserOrBot,
   isSelected: boolean,
   showEmail: boolean,
   unreadCount?: number,
@@ -41,28 +40,30 @@ export default class UserItem extends PureComponent<Props> {
   };
 
   handlePress = () => {
-    const { email, onPress } = this.props;
-    if (email && onPress) {
-      onPress(email);
+    const { user, onPress } = this.props;
+    // TODO cut this `user.email` condition -- it should never trigger, and
+    //   looks like a fudge for the possibility of data coming from NULL_USER
+    if (user.email && onPress) {
+      onPress(user.email);
     }
   };
 
   render() {
-    const { fullName, avatarUrl, isSelected, unreadCount, showEmail, email } = this.props;
+    const { user, isSelected, unreadCount, showEmail } = this.props;
 
     return (
       <Touchable onPress={this.handlePress}>
         <View style={[styles.listItem, isSelected && componentStyles.selectedRow]}>
           <UserAvatarWithPresence
             size={48}
-            avatarUrl={avatarUrl}
-            email={email}
+            avatarUrl={user.avatar_url}
+            email={user.email}
             onPress={this.handlePress}
           />
           <View style={componentStyles.textWrapper}>
             <RawLabel
               style={[componentStyles.text, isSelected && componentStyles.selectedText]}
-              text={fullName}
+              text={user.full_name}
               numberOfLines={1}
               ellipsizeMode="tail"
             />
@@ -73,7 +74,7 @@ export default class UserItem extends PureComponent<Props> {
                   componentStyles.textEmail,
                   isSelected && componentStyles.selectedText,
                 ]}
-                text={email}
+                text={user.email}
                 numberOfLines={1}
                 ellipsizeMode="tail"
               />

--- a/src/users/UserItem.js
+++ b/src/users/UserItem.js
@@ -30,7 +30,7 @@ type Props = $ReadOnly<{|
   isSelected: boolean,
   showEmail: boolean,
   unreadCount?: number,
-  onPress: (email: string) => void,
+  onPress: UserOrBot => void,
 |}>;
 
 export default class UserItem extends PureComponent<Props> {
@@ -44,7 +44,7 @@ export default class UserItem extends PureComponent<Props> {
     // TODO cut this `user.email` condition -- it should never trigger, and
     //   looks like a fudge for the possibility of data coming from NULL_USER
     if (user.email && onPress) {
-      onPress(user.email);
+      onPress(user);
     }
   };
 

--- a/src/users/UserList.js
+++ b/src/users/UserList.js
@@ -2,7 +2,7 @@
 import React, { PureComponent } from 'react';
 import { SectionList } from 'react-native';
 
-import type { PresenceState, User } from '../types';
+import type { PresenceState, User, UserOrBot } from '../types';
 import { createStyleSheet } from '../styles';
 import { SectionHeader, SearchEmptyState } from '../common';
 import UserItem from './UserItem';
@@ -19,7 +19,7 @@ type Props = $ReadOnly<{|
   users: User[],
   selected: User[],
   presences: PresenceState,
-  onPress: (email: string) => void,
+  onPress: (user: UserOrBot) => void,
 |}>;
 
 export default class UserList extends PureComponent<Props> {

--- a/src/users/UserList.js
+++ b/src/users/UserList.js
@@ -51,10 +51,8 @@ export default class UserList extends PureComponent<Props> {
         keyExtractor={item => item.email}
         renderItem={({ item }) => (
           <UserItem
-            key={item.email}
-            fullName={item.full_name}
-            avatarUrl={item.avatar_url}
-            email={item.email}
+            key={item.user_id}
+            user={item}
             onPress={onPress}
             isSelected={!!selected.find(user => user.user_id === item.user_id)}
           />

--- a/src/users/UsersCard.js
+++ b/src/users/UsersCard.js
@@ -2,7 +2,7 @@
 
 import React, { PureComponent } from 'react';
 
-import type { Dispatch, PresenceState, User } from '../types';
+import type { Dispatch, PresenceState, User, UserOrBot } from '../types';
 import { connect } from '../react-redux';
 import { privateNarrow } from '../utils/narrow';
 import UserList from './UserList';
@@ -17,10 +17,10 @@ type Props = $ReadOnly<{|
 |}>;
 
 class UsersCard extends PureComponent<Props> {
-  handleUserNarrow = (email: string) => {
+  handleUserNarrow = (user: UserOrBot) => {
     const { dispatch } = this.props;
     dispatch(navigateBack());
-    dispatch(doNarrow(privateNarrow(email)));
+    dispatch(doNarrow(privateNarrow(user.email)));
   };
 
   render() {


### PR DESCRIPTION
These changes were sitting in an old branch of mine from February where I experimented with prototyping a major overhaul of the `Narrow` data structures. These are quite independent of that and easily pulled out, and help us advance #3764 (converting from using emails to using user IDs); so might as well get them in.
