### PR TITLE
outbox: Fix some bugs from Narrow confusion; remove Narrow

### DIFF
--- a/src/__tests__/lib/exampleData.js
+++ b/src/__tests__/lib/exampleData.js
@@ -25,7 +25,7 @@ import {
 } from '../../actionConstants';
 import rootReducer from '../../boot/reducers';
 import { authOfAccount } from '../../account/accountMisc';
-import { HOME_NARROW, topicNarrow } from '../../utils/narrow';
+import { HOME_NARROW } from '../../utils/narrow';
 
 /* ========================================================================
  * Utilities
@@ -373,7 +373,6 @@ const outboxMessageBase: $Diff<Outbox, {| id: mixed, timestamp: mixed |}> = deep
   display_recipient: stream.name,
   // id: ...,
   markdownContent: 'Test.',
-  narrow: topicNarrow(stream.name, 'test topic'),
   reactions: [],
   sender_email: selfUser.email,
   sender_full_name: selfUser.full_name,

--- a/src/__tests__/lib/exampleData.js
+++ b/src/__tests__/lib/exampleData.js
@@ -25,7 +25,7 @@ import {
 } from '../../actionConstants';
 import rootReducer from '../../boot/reducers';
 import { authOfAccount } from '../../account/accountMisc';
-import { HOME_NARROW } from '../../utils/narrow';
+import { HOME_NARROW, topicNarrow } from '../../utils/narrow';
 
 /* ========================================================================
  * Utilities
@@ -370,10 +370,10 @@ const outboxMessageBase: $Diff<Outbox, {| id: mixed, timestamp: mixed |}> = deep
 
   avatar_url: selfUser.avatar_url,
   content: '<p>Test.</p>',
-  display_recipient: 'test',
+  display_recipient: stream.name,
   // id: ...,
   markdownContent: 'Test.',
-  narrow: [{ operator: 'stream', operand: 'test' }],
+  narrow: topicNarrow(stream.name, 'test topic'),
   reactions: [],
   sender_email: selfUser.email,
   sender_full_name: selfUser.full_name,

--- a/src/chat/__tests__/narrowsSelectors-test.js
+++ b/src/chat/__tests__/narrowsSelectors-test.js
@@ -81,7 +81,7 @@ describe('getMessagesForNarrow', () => {
         [JSON.stringify(privateNarrow('john@example.com'))]: [123],
       },
       messages,
-      outbox: [{ ...outboxMessage, narrow: streamNarrow('denmark') }],
+      outbox: [outboxMessage],
       realm: eg.realmState({ email: eg.selfUser.email }),
     });
 

--- a/src/chat/__tests__/narrowsSelectors-test.js
+++ b/src/chat/__tests__/narrowsSelectors-test.js
@@ -34,6 +34,7 @@ describe('getMessagesForNarrow', () => {
       },
       messages,
       outbox: [],
+      realm: eg.realmState({ email: eg.selfUser.email }),
     });
 
     const result = getMessagesForNarrow(state, HOME_NARROW);
@@ -51,6 +52,7 @@ describe('getMessagesForNarrow', () => {
       caughtUp: {
         [HOME_NARROW_STR]: { older: false, newer: true },
       },
+      realm: eg.realmState({ email: eg.selfUser.email }),
     });
 
     const result = getMessagesForNarrow(state, HOME_NARROW);
@@ -65,6 +67,7 @@ describe('getMessagesForNarrow', () => {
       },
       messages,
       outbox: [outboxMessage],
+      realm: eg.realmState({ email: eg.selfUser.email }),
     });
 
     const result = getMessagesForNarrow(state, HOME_NARROW);
@@ -79,6 +82,7 @@ describe('getMessagesForNarrow', () => {
       },
       messages,
       outbox: [{ ...outboxMessage, narrow: streamNarrow('denmark') }],
+      realm: eg.realmState({ email: eg.selfUser.email }),
     });
 
     const result = getMessagesForNarrow(state, privateNarrow('john@example.com'));

--- a/src/chat/__tests__/narrowsSelectors-test.js
+++ b/src/chat/__tests__/narrowsSelectors-test.js
@@ -25,9 +25,7 @@ describe('getMessagesForNarrow', () => {
     // them to be numbers.
     [123]: message /* eslint-disable-line no-useless-computed-key */,
   };
-  const outboxMessage = eg.makeOutboxMessage({
-    narrow: HOME_NARROW,
-  });
+  const outboxMessage = eg.makeOutboxMessage({});
 
   test('if no outbox messages returns messages with no change', () => {
     const state = eg.reduxState({

--- a/src/chat/narrowsReducer.js
+++ b/src/chat/narrowsReducer.js
@@ -47,7 +47,11 @@ const eventNewMessage = (state, action) => {
   let stateChange = false;
   const newState: NarrowsState = {};
   Object.keys(state).forEach(key => {
-    const isInNarrow = isMessageInNarrow(action.message, JSON.parse(key), action.ownEmail);
+    const { flags } = action.message;
+    if (!flags) {
+      throw new Error('EVENT_NEW_MESSAGE message missing flags');
+    }
+    const isInNarrow = isMessageInNarrow(action.message, flags, JSON.parse(key), action.ownEmail);
     const isCaughtUp = action.caughtUp[key] && action.caughtUp[key].newer;
     const messageDoesNotExist = state[key].find(id => action.message.id === id) === undefined;
 

--- a/src/events/doEventActionSideEffects.js
+++ b/src/events/doEventActionSideEffects.js
@@ -35,7 +35,7 @@ const messageEvent = (state: GlobalState, message: Message): void => {
     activeAccount
     && narrow !== undefined // chat screen is not at top
     && !isHomeNarrow(narrow)
-    && isMessageInNarrow(message, narrow, activeAccount.email);
+    && isMessageInNarrow(message, flags, narrow, activeAccount.email);
   const isSenderSelf = getOwnEmail(state) === message.sender_email;
   if (!isUserInSameNarrow && !isSenderSelf) {
     playMessageSound();

--- a/src/outbox/outboxActions.js
+++ b/src/outbox/outboxActions.js
@@ -24,7 +24,6 @@ import { getSelfUserDetail, getAllUsersByEmail } from '../users/userSelectors';
 import { getUsersAndWildcards } from '../users/userHelpers';
 import { caseNarrowPartial, isPrivateOrGroupNarrow } from '../utils/narrow';
 import { BackoffMachine } from '../utils/async';
-import { NULL_USER } from '../nullObjects';
 
 export const messageSendStart = (outbox: Outbox): Action => ({
   type: MESSAGE_SEND_START,
@@ -109,7 +108,10 @@ export const sendOutbox = () => async (dispatch: Dispatch, getState: GetState) =
 const mapEmailsToUsers = (emails, allUsersByEmail, selfDetail) =>
   emails
     .map(item => {
-      const user = allUsersByEmail.get(item) || NULL_USER;
+      const user = allUsersByEmail.get(item);
+      if (!user) {
+        throw new Error('outbox: missing user when preparing to send PM');
+      }
       return { email: item, id: user.user_id, full_name: user.full_name };
     })
     .concat({ email: selfDetail.email, id: selfDetail.user_id, full_name: selfDetail.full_name });

--- a/src/outbox/outboxActions.js
+++ b/src/outbox/outboxActions.js
@@ -66,9 +66,12 @@ export const trySendMessages = (dispatch: Dispatch, getState: GetState): boolean
       // prettier-ignore
       const to =
         item.type === 'private'
+            // TODO(server-2.0): switch to numeric user IDs, not emails.
           ? item.display_recipient.map(r => r.email).join(',')
+            // TODO(server-2.0): switch to numeric stream IDs, not names.
+            //   (This will require wiring the stream ID through to here.)
             // HACK: the server attempts to interpret this argument as JSON, then
-            // CSV, then a literal. To avoid misparsing, always use JSON.
+            //   CSV, then a literal. To avoid misparsing, always use JSON.
           : JSON.stringify([item.display_recipient]);
 
       await api.sendMessage(auth, {

--- a/src/outbox/outboxActions.js
+++ b/src/outbox/outboxActions.js
@@ -22,7 +22,7 @@ import { getAuth } from '../selectors';
 import * as api from '../api';
 import { getAllUsersByEmail, getOwnUser } from '../users/userSelectors';
 import { getUsersAndWildcards } from '../users/userHelpers';
-import { caseNarrowPartial, isPrivateOrGroupNarrow } from '../utils/narrow';
+import { caseNarrowPartial } from '../utils/narrow';
 import { BackoffMachine } from '../utils/async';
 
 export const messageSendStart = (outbox: Outbox): Action => ({
@@ -63,17 +63,13 @@ export const trySendMessages = (dispatch: Dispatch, getState: GetState): boolean
         return; // i.e., continue
       }
 
-      const to = ((): string => {
-        const { narrow } = item;
-        // TODO: can this test be `if (item.type === private)`?
-        if (isPrivateOrGroupNarrow(narrow)) {
-          return narrow[0].operand;
-        } else {
-          // HACK: the server attempts to interpret this argument as JSON, then
-          // CSV, then a literal. To avoid misparsing, always use JSON.
-          return JSON.stringify([item.display_recipient]);
-        }
-      })();
+      // prettier-ignore
+      const to =
+        item.type === 'private'
+          ? item.narrow[0].operand
+            // HACK: the server attempts to interpret this argument as JSON, then
+            // CSV, then a literal. To avoid misparsing, always use JSON.
+          : JSON.stringify([item.display_recipient]);
 
       await api.sendMessage(auth, {
         type: item.type,

--- a/src/outbox/outboxActions.js
+++ b/src/outbox/outboxActions.js
@@ -66,7 +66,7 @@ export const trySendMessages = (dispatch: Dispatch, getState: GetState): boolean
       // prettier-ignore
       const to =
         item.type === 'private'
-          ? item.narrow[0].operand
+          ? item.display_recipient.map(r => r.email).join(',')
             // HACK: the server attempts to interpret this argument as JSON, then
             // CSV, then a literal. To avoid misparsing, always use JSON.
           : JSON.stringify([item.display_recipient]);

--- a/src/outbox/outboxActions.js
+++ b/src/outbox/outboxActions.js
@@ -106,9 +106,8 @@ export const sendOutbox = () => async (dispatch: Dispatch, getState: GetState) =
   dispatch(toggleOutboxSending(false));
 };
 
-const mapEmailsToUsers = (usersByEmail, narrow, selfDetail) =>
-  narrow[0].operand
-    .split(',')
+const mapEmailsToUsers = (emails, usersByEmail, selfDetail) =>
+  emails
     .map(item => {
       const user = usersByEmail.get(item) || NULL_USER;
       return { email: item, id: user.user_id, full_name: user.full_name };
@@ -130,7 +129,7 @@ const extractTypeToAndSubjectFromNarrow = (
   if (isPrivateOrGroupNarrow(narrow)) {
     return {
       type: 'private',
-      display_recipient: mapEmailsToUsers(usersByEmail, narrow, selfDetail),
+      display_recipient: mapEmailsToUsers(narrow[0].operand.split(','), usersByEmail, selfDetail),
       subject: '',
     };
   } else if (isStreamNarrow(narrow)) {

--- a/src/outbox/outboxActions.js
+++ b/src/outbox/outboxActions.js
@@ -175,7 +175,6 @@ export const addToOutbox = (narrow: Narrow, content: string) => async (
   const localTime = Math.round(new Date().getTime() / 1000);
   dispatch(
     messageSendStart({
-      narrow,
       isSent: false,
       ...extractTypeToAndSubjectFromNarrow(narrow, getAllUsersByEmail(state), ownUser),
       markdownContent: content,

--- a/src/topics/__tests__/topicsSelectors-test.js
+++ b/src/topics/__tests__/topicsSelectors-test.js
@@ -31,6 +31,7 @@ describe('getLastMessageTopic', () => {
   test('when no messages in narrow return an empty string', () => {
     const state = eg.reduxState({
       narrows: {},
+      realm: eg.realmState({ email: eg.selfUser.email }),
     });
 
     const topic = getLastMessageTopic(state, HOME_NARROW);
@@ -50,6 +51,7 @@ describe('getLastMessageTopic', () => {
         [message1.id]: message1,
         [message2.id]: message2,
       },
+      realm: eg.realmState({ email: eg.selfUser.email }),
     });
 
     const topic = getLastMessageTopic(state, narrow);

--- a/src/types.js
+++ b/src/types.js
@@ -2,7 +2,7 @@
 import type { IntlShape } from 'react-intl';
 import type { DangerouslyImpreciseStyleProp } from 'react-native/Libraries/StyleSheet/StyleSheet';
 
-import type { Auth, Topic, Message, Reaction, ReactionType, Narrow } from './api/apiTypes';
+import type { Auth, Topic, Message, Reaction, ReactionType } from './api/apiTypes';
 import type { ZulipVersion } from './utils/zulipVersion';
 
 export type * from './generics';
@@ -171,10 +171,9 @@ export type Outbox = {|
    */
   isSent: boolean,
 
-  // These fields don't exist in `Message`.
-  // They're used for sending the message to the server.
+  // `markdownContent` doesn't exist in `Message`.
+  // It's used for sending the message to the server.
   markdownContent: string,
-  narrow: Narrow,
 
   // These fields are modeled on `Message`.
   avatar_url: string | null,

--- a/src/utils/__tests__/narrow-test.js
+++ b/src/utils/__tests__/narrow-test.js
@@ -289,19 +289,12 @@ describe('isMessageInNarrow', () => {
       for (const [messageDescription, expected, message] of cases) {
         test(`${expected ? 'contains' : 'excludes'} ${messageDescription}`, () => {
           expect(
-            isMessageInNarrow({ ...message, flags: message.flags ?? [] }, narrow, ownEmail),
+            isMessageInNarrow(message, message.flags ?? [], narrow, ownEmail),
           ).toBe(expected);
         });
       }
     });
   }
-
-  test('message with flags absent throws an error', () => {
-    const message = eg.streamMessage({
-      // no flags
-    });
-    expect(() => isMessageInNarrow(message, MENTIONED_NARROW, ownEmail)).toThrow();
-  });
 });
 
 describe('getNarrowFromMessage', () => {

--- a/src/utils/narrow.js
+++ b/src/utils/narrow.js
@@ -248,8 +248,23 @@ export const isStreamOrTopicNarrow = (narrow?: Narrow): boolean =>
 export const isSearchNarrow = (narrow?: Narrow): boolean =>
   !!narrow && caseNarrowDefault(narrow, { search: () => true }, () => false);
 
-/** (For search narrows, just returns false.) */
-export const isMessageInNarrow = (message: Message, narrow: Narrow, ownEmail: string): boolean => {
+/**
+ * True just if the given message is part of the given narrow.
+ *
+ * This function does not support search narrows, and for them always
+ * returns false.
+ *
+ * The message's flags must be in `flags`; `message.flags` is ignored.  This
+ * makes it the caller's responsibility to deal with the ambiguity in our
+ * Message type of whether the message's flags live in a `flags` property or
+ * somewhere else.
+ */
+export const isMessageInNarrow = (
+  message: Message,
+  flags: $ReadOnlyArray<string>,
+  narrow: Narrow,
+  ownEmail: string,
+): boolean => {
   const matchPmRecipients = (emails: string[]) => {
     if (message.type !== 'private') {
       return false;
@@ -261,11 +276,6 @@ export const isMessageInNarrow = (message: Message, narrow: Narrow, ownEmail: st
       === normalizeRecipientsSansMe(narrowAsRecipients, ownEmail)
     );
   };
-
-  const { flags } = message;
-  if (!flags) {
-    throw new Error('`message.flags` should be defined.');
-  }
 
   return caseNarrow(narrow, {
     home: () => true,

--- a/src/utils/narrow.js
+++ b/src/utils/narrow.js
@@ -260,7 +260,7 @@ export const isSearchNarrow = (narrow?: Narrow): boolean =>
  * somewhere else.
  */
 export const isMessageInNarrow = (
-  message: Message,
+  message: Message | Outbox,
   flags: $ReadOnlyArray<string>,
   narrow: Narrow,
   ownEmail: string,
@@ -303,20 +303,6 @@ export const canSendToNarrow = (narrow: Narrow): boolean =>
     allPrivate: () => false,
     search: () => false,
   });
-
-/** True just if `haystack` contains all possible messages in `needle`. */
-export const narrowContains = (haystack: Narrow, needle: Narrow): boolean => {
-  if (isHomeNarrow(haystack)) {
-    return true;
-  }
-  if (isAllPrivateNarrow(haystack) && isPrivateOrGroupNarrow(needle)) {
-    return true;
-  }
-  if (isStreamNarrow(haystack) && needle[0].operand === haystack[0].operand) {
-    return true;
-  }
-  return JSON.stringify(needle) === JSON.stringify(haystack);
-};
 
 export const getNarrowFromMessage = (message: Message | Outbox, ownEmail: string) => {
   if (Array.isArray(message.display_recipient)) {


### PR DESCRIPTION
This grew out of #3889. It follows #4294 by returning to the outbox code, and includes versions of all the changes made in #3889.

Along the way it fixes additional bugs, and the "Replace narrowContains" commit turns out to fix some bugs of its own. (That is, the old implementation turns out to be outright buggy. Meanwhile the new implementation here is from #4294 and well tested, and avoids the bugs in #3889's new implementation.)

Fixes: #4298
Fixes: #4301 