### PR TITLE
status symbol aligned before name and lowering its height

### DIFF
--- a/src/account-info/AccountDetails.js
+++ b/src/account-info/AccountDetails.js
@@ -20,6 +20,11 @@ const componentStyles = createStyleSheet({
     justifyContent: 'center',
     flexDirection: 'row',
   },
+  statusSymbol: {
+    position: 'relative',
+    top: 2,
+    marginRight: 5,
+  },
   statusText: {
     textAlign: 'center',
   },
@@ -60,8 +65,12 @@ class AccountDetails extends PureComponent<Props> {
           <UserAvatar avatarUrl={getAvatarFromUser(user, realm, AVATAR_SIZE)} size={AVATAR_SIZE} />
         </View>
         <View style={componentStyles.statusWrapper}>
+          <PresenceStatusIndicator
+            style={componentStyles.statusSymbol}
+            email={user.email}
+            hideIfOffline={false}
+          />
           <RawLabel style={[styles.largerText, styles.halfMarginRight]} text={user.full_name} />
-          <PresenceStatusIndicator email={user.email} hideIfOffline={false} />
         </View>
         {userStatusText !== undefined && (
           <RawLabel style={[styles.largerText, componentStyles.statusText]} text={userStatusText} />

--- a/src/account-info/AccountDetails.js
+++ b/src/account-info/AccountDetails.js
@@ -20,7 +20,7 @@ const componentStyles = createStyleSheet({
     justifyContent: 'center',
     flexDirection: 'row',
   },
-  statusSymbol: {
+  presenceStatusIndicator: {
     position: 'relative',
     top: 2,
     marginRight: 5,
@@ -66,7 +66,7 @@ class AccountDetails extends PureComponent<Props> {
         </View>
         <View style={componentStyles.statusWrapper}>
           <PresenceStatusIndicator
-            style={componentStyles.statusSymbol}
+            style={componentStyles.presenceStatusIndicator}
             email={user.email}
             hideIfOffline={false}
           />


### PR DESCRIPTION
fixes: #4307

Greg pointed out in the issue  #4307 that status symbol is slightly misaligned and should be place before name as in zulip's Web UI
so I placed the status symbol to the left of the name and also adjusted the alignment (slightly lowers the status symbol)

Also more explanation is given in the above issue