### PR TITLE
narrow: Add `getNarrowsForMessage`.

### DIFF
--- a/flow-typed/jest_v26.x.x.js
+++ b/flow-typed/jest_v26.x.x.js
@@ -333,6 +333,11 @@ type JestExtendedMatchersType = {
    */
   toIncludeAnyMembers(members: any[]): void,
   /**
+   * Use `.toIncludeSameMembers` when checking if two arrays contain equal values, in any order.
+   * @param {Array.<*>} members
+   */
+  toIncludeSameMembers(members: any[]): void,
+  /**
    * Use `.toSatisfyAll` when you want to use a custom matcher by supplying a predicate function that returns a `Boolean` for all values in an array.
    * @param {Function} predicate
    */

--- a/src/message/messageActionSheet.js
+++ b/src/message/messageActionSheet.js
@@ -16,7 +16,7 @@ import type {
 } from '../types';
 import type { BackgroundData } from '../webview/MessageList';
 import {
-  getNarrowFromMessage,
+  getNarrowForReply,
   isPmNarrow,
   isStreamOrTopicNarrow,
   isTopicNarrow,
@@ -61,7 +61,7 @@ type ButtonDescription = {
 //
 
 const reply = ({ message, dispatch, ownUser }) => {
-  dispatch(doNarrow(getNarrowFromMessage(message, ownUser), message.id));
+  dispatch(doNarrow(getNarrowForReply(message, ownUser), message.id));
 };
 reply.title = 'Reply';
 reply.errorMessage = 'Failed to reply';

--- a/src/utils/__tests__/narrow-test.js
+++ b/src/utils/__tests__/narrow-test.js
@@ -20,7 +20,7 @@ import {
   isMessageInNarrow,
   isSameNarrow,
   isStreamOrTopicNarrow,
-  getNarrowFromMessage,
+  getNarrowForReply,
   parseNarrowString,
   STARRED_NARROW,
   MENTIONED_NARROW,
@@ -297,10 +297,10 @@ describe('isMessageInNarrow', () => {
   }
 });
 
-describe('getNarrowFromMessage', () => {
+describe('getNarrowForReply', () => {
   test('for self-PM, returns self-1:1 narrow', () => {
     expect(
-      getNarrowFromMessage(
+      getNarrowForReply(
         eg.pmMessage({ sender: eg.selfUser, recipients: [eg.selfUser] }),
         eg.selfUser,
       ),
@@ -311,7 +311,7 @@ describe('getNarrowFromMessage', () => {
     const message = eg.pmMessage();
     const expectedNarrow = pmNarrowFromEmail(eg.otherUser.email);
 
-    const actualNarrow = getNarrowFromMessage(message, eg.selfUser);
+    const actualNarrow = getNarrowForReply(message, eg.selfUser);
 
     expect(actualNarrow).toEqual(expectedNarrow);
   });
@@ -322,7 +322,7 @@ describe('getNarrowFromMessage', () => {
     });
     const expectedNarrow = pmNarrowFromEmails([eg.otherUser.email, eg.thirdUser.email]);
 
-    const actualNarrow = getNarrowFromMessage(message, eg.selfUser);
+    const actualNarrow = getNarrowForReply(message, eg.selfUser);
 
     expect(actualNarrow).toEqual(expectedNarrow);
   });
@@ -332,7 +332,7 @@ describe('getNarrowFromMessage', () => {
     const message = eg.streamMessage({ subject: '' });
     const expectedNarrow = streamNarrow(eg.stream.name);
 
-    const actualNarrow = getNarrowFromMessage(message, eg.selfUser);
+    const actualNarrow = getNarrowForReply(message, eg.selfUser);
 
     expect(actualNarrow).toEqual(expectedNarrow);
   });
@@ -341,7 +341,7 @@ describe('getNarrowFromMessage', () => {
     const message = eg.streamMessage();
     const expectedNarrow = topicNarrow(eg.stream.name, message.subject);
 
-    const actualNarrow = getNarrowFromMessage(message, eg.selfUser);
+    const actualNarrow = getNarrowForReply(message, eg.selfUser);
 
     expect(actualNarrow).toEqual(expectedNarrow);
   });

--- a/src/utils/__tests__/narrow-test.js
+++ b/src/utils/__tests__/narrow-test.js
@@ -327,16 +327,6 @@ describe('getNarrowForReply', () => {
     expect(actualNarrow).toEqual(expectedNarrow);
   });
 
-  test('for stream message with empty topic, returns a stream narrow', () => {
-    // TODO this behavior seems pretty dubious
-    const message = eg.streamMessage({ subject: '' });
-    const expectedNarrow = streamNarrow(eg.stream.name);
-
-    const actualNarrow = getNarrowForReply(message, eg.selfUser);
-
-    expect(actualNarrow).toEqual(expectedNarrow);
-  });
-
   test('for stream message with nonempty topic, returns a topic narrow', () => {
     const message = eg.streamMessage();
     const expectedNarrow = topicNarrow(eg.stream.name, message.subject);

--- a/src/utils/narrow.js
+++ b/src/utils/narrow.js
@@ -318,22 +318,15 @@ export const canSendToNarrow = (narrow: Narrow): boolean =>
 /**
  * Answers the question, "Where should my reply to a message go?"
  *
- * Careful: quirky behavior on a stream message with empty topic.
- *
- * If you think you want to reuse this function: study carefully; maybe
- * refactor it to something cleaner first; if not, then definitely document
- * its quirky behavior.
+ * For stream messages, chooses a topic narrow over a stream narrow.
  */
-// TODO: do that, or just make this a private local helper of its one caller
+// TODO: probably make this a private local helper of its one caller,
+//   now that it's free of fiddly details from the Narrow data structure
 export const getNarrowForReply = (message: Message | Outbox, ownUser: User) => {
   if (message.type === 'private') {
     return pmNarrowFromEmails(pmKeyRecipientsFromMessage(message, ownUser).map(x => x.email));
   } else {
     const streamName = streamNameOfStreamMessage(message);
-    const topic = message.subject;
-    if (topic && topic.length) {
-      return topicNarrow(streamName, topic);
-    }
-    return streamNarrow(streamName);
+    return topicNarrow(streamName, message.subject);
   }
 };

--- a/src/utils/narrow.js
+++ b/src/utils/narrow.js
@@ -316,6 +316,8 @@ export const canSendToNarrow = (narrow: Narrow): boolean =>
   });
 
 /**
+ * Answers the question, "Where should my reply to a message go?"
+ *
  * Careful: quirky behavior on a stream message with empty topic.
  *
  * If you think you want to reuse this function: study carefully; maybe
@@ -323,7 +325,7 @@ export const canSendToNarrow = (narrow: Narrow): boolean =>
  * its quirky behavior.
  */
 // TODO: do that, or just make this a private local helper of its one caller
-export const getNarrowFromMessage = (message: Message | Outbox, ownUser: User) => {
+export const getNarrowForReply = (message: Message | Outbox, ownUser: User) => {
   if (message.type === 'private') {
     return pmNarrowFromEmails(pmKeyRecipientsFromMessage(message, ownUser).map(x => x.email));
   } else {

--- a/src/utils/narrow.js
+++ b/src/utils/narrow.js
@@ -272,6 +272,9 @@ export const isSearchNarrow = (narrow?: Narrow): boolean =>
  * makes it the caller's responsibility to deal with the ambiguity in our
  * Message type of whether the message's flags live in a `flags` property or
  * somewhere else.
+ *
+ * See also getNarrowsForMessage, which should list exactly the narrows this
+ * would return true for.
  */
 export const isMessageInNarrow = (
   message: Message | Outbox,
@@ -301,6 +304,7 @@ export const isMessageInNarrow = (
     mentioned: () => flags.includes('mentioned') || flags.includes('wildcard_mentioned'),
     allPrivate: () => message.type === 'private',
     search: () => false,
+    // Adding a case here?  Be sure to add to getNarrowsForMessage, too.
   });
 
 export const canSendToNarrow = (narrow: Narrow): boolean =>
@@ -316,7 +320,7 @@ export const canSendToNarrow = (narrow: Narrow): boolean =>
   });
 
 /**
- * Answers the question, "What narrows do this message appear in?"
+ * Answers the question, "What narrows does this message appear in?"
  *
  * This function does not support search narrows, and it always
  * excludes them.
@@ -325,13 +329,16 @@ export const canSendToNarrow = (narrow: Narrow): boolean =>
  * makes it the caller's responsibility to deal with the ambiguity in our
  * Message type of whether the message's flags live in a `flags` property or
  * somewhere else.
+ *
+ * See also isMessageInNarrow, which should return true for exactly the
+ * narrows this lists and no others.
  */
 export const getNarrowsForMessage = (
   message: Message | Outbox,
   ownUser: User,
   flags: $ReadOnlyArray<string>,
 ): Narrow[] => {
-  const result: Narrow[] = [];
+  const result = [];
 
   // All messages are in the home narrow.
   result.push(HOME_NARROW);
@@ -352,6 +359,8 @@ export const getNarrowsForMessage = (
   if (flags.includes('starred')) {
     result.push(STARRED_NARROW);
   }
+
+  // SEARCH_NARROW we always leave out
 
   return result;
 };


### PR DESCRIPTION
narrow: Add `getNarrowsForMessage`.

We've never had a function for getting all the narrows that a
message appears in. Such a function will be important
algorithmically for avoiding a performance regression with the
EVENT_NEW_MESSAGE action if/when we start storing `state.narrows` as
an `Immutable.Map`; see discussion of this strategy at
https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/.60Immutable.2EMap.60.20performance.20for.20.60state.2Enarrows.60/near/1068912.

Might as well put it in `narrow.js` and make it reusable, too.