### PR TITLE
android build: Upgrade Android Gradle Plugin to v3.5.3.

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -28,7 +28,7 @@ buildscript {
     }
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath 'com.android.tools.build:gradle:3.5.2'
+        classpath 'com.android.tools.build:gradle:3.5.3'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
Release notes here:
  https://developer.android.com/studio/releases/gradle-plugin#3-5-0
No major potentially-incompatible changes identified there.

Part of the RN v0.62 -> v0.63 changes to the template app [1],
corresponding to facebook/react-native@e1e081b00.

[1] https://react-native-community.github.io/upgrade-helper/?from=0.62.2&to=0.63.3