### PR TITLE
deps: Follow @babel/runtime upgrade from RN template app.

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
   "devDependencies": {
     "@babel/core": "^7.11.4",
     "@babel/preset-env": "^7.11.0",
-    "@babel/runtime": "^7.6.2",
+    "@babel/runtime": "^7.8.4",
     "@jest/source-map": "^26.3.0",
     "@rollup/plugin-babel": "^5.2.0",
     "@rollup/plugin-node-resolve": "^9.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -988,7 +988,7 @@
     core-js-pure "^3.0.0"
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.10.2", "@babel/runtime@^7.11.2", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.2", "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.4":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.10.2", "@babel/runtime@^7.11.2", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.4":
   version "7.12.5"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.12.5.tgz#410e7e487441e1b360c29be715d870d9b985882e"
   integrity sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==


### PR DESCRIPTION
Part of the RN v0.62 -> v0.63 changes to the template app [1],
corresponding to facebook/react-native@82e823933.

That RN commit upgrades a few other deps; we don't take those
changes, for the following reasons:

- We're already past ^7.6.2 of @babel/core.

- We don't currently use @react-native-community/eslint-config
  (though we're considering it, in #4119).

- We don't currently use babel-jest.

- We're already past ^25.1.0 of jest.

- We're already past ^0.58.0 of metro-react-native-babel-preset.

Run our usual `yarn yarn-deduplicate && yarn`, as prompted by
`tools/test deps`.

[1] https://react-native-community.github.io/upgrade-helper/?from=0.62.2&to=0.63.4