### PR TITLE
logging: Send server version to Sentry.

### DIFF
--- a/flow-typed/@sentry/react-native_v1.x.x.js
+++ b/flow-typed/@sentry/react-native_v1.x.x.js
@@ -103,6 +103,19 @@ declare module '@sentry/react-native' {
   // More methods are available.
   declare export class Scope {
     /**
+     * Set an object that will be merged sent as tags data with the event.
+     * @param tags Tags context object to merge into current context.
+     */
+    setTags(tags: {
+      [key: string]: string,
+    }): this;
+    /**
+     * Set key:value that will be sent as tags data with the event.
+     * @param key String key of tag
+     * @param value String value of tag
+     */
+    setTag(key: string, value: string): this;
+    /**
      * Set key:value that will be sent as extra data with the event.
      * @param key String of extra
      * @param extra Any kind of data. This data will be normalized.

--- a/src/utils/__tests__/zulipVersion-test.js
+++ b/src/utils/__tests__/zulipVersion-test.js
@@ -67,15 +67,29 @@ describe('ZulipVersion.prototype.raw()', () => {
   });
 });
 
-describe('ZulipVersion.prototype.loggingArray()', () => {
+describe('ZulipVersion.prototype.elements()', () => {
   const raw1 = '0.1.0';
-  test(`new ZulipVersion(${raw1}).loggingArray() === [0, 1, 0]`, () => {
-    expect(new ZulipVersion(raw1).loggingArray()).toStrictEqual([0, 1, 0]);
+  test(`new ZulipVersion(${raw1}).elements()`, () => {
+    expect(new ZulipVersion(raw1).elements()).toStrictEqual({
+      major: 0,
+      minor: 1,
+      patch: 0,
+      flag: undefined,
+      numCommits: undefined,
+      commitId: undefined,
+    });
   });
 
   const raw2 = '2.1.0-rc1-112-g35959d43c4';
 
-  test(`new ZulipVersion(${raw2}).loggingArray() === [2, 1, 0]`, () => {
-    expect(new ZulipVersion(raw2).loggingArray()).toStrictEqual([2, 1, 0]);
+  test(`new ZulipVersion(${raw2}).elements()`, () => {
+    expect(new ZulipVersion(raw2).elements()).toStrictEqual({
+      major: 2,
+      minor: 1,
+      patch: 0,
+      flag: ['rc', 1],
+      numCommits: 112,
+      commitId: '35959d43c4',
+    });
   });
 });

--- a/src/utils/zulipVersion.js
+++ b/src/utils/zulipVersion.js
@@ -16,8 +16,9 @@ type VersionElements = {
  * Used on a Zulip version received from the server with /server_settings
  * * to compare it to a threshold version where a feature was added on the
  *   server: use .isAtLeast
- * * to report it to Sentry: use .raw for its raw form, and .loggingArray
- *   for a form handy for event aggregation.
+ * * to report it to Sentry: use .raw for its raw form, and .elements
+ *   for the data needed to make other tags to help with event
+ *   aggregation.
  *
  * The ZulipVersion instance itself cannot be persisted in ZulipAsyncStorage or
  * sent to Sentry because it isn't serializable. Instead, persist the raw
@@ -26,12 +27,12 @@ type VersionElements = {
 export class ZulipVersion {
   _raw: string;
   _comparisonArray: number[];
-  _loggingArray: number[];
+  _elements: VersionElements;
 
   constructor(raw: string) {
     this._raw = raw;
     this._comparisonArray = this._getComparisonArray(raw);
-    this._loggingArray = this._getLoggingArray(raw);
+    this._elements = this._getElements(raw);
   }
 
   /**
@@ -41,12 +42,8 @@ export class ZulipVersion {
 
   /**
    * Data to be sent to Sentry to help with event aggregation.
-   *
-   * A [major, minor, patch] array where missing values
-   * are replaced with zero; everything beyond major, minor, patch
-   * is ignored.
    */
-  loggingArray = () => this._loggingArray;
+  elements = () => this._elements;
 
   /**
    * True if this version is later than or equal to a given threshold.
@@ -71,7 +68,7 @@ export class ZulipVersion {
   };
 
   /**
-   * Parse the raw string into a VersionElements for _getComparisonArray.
+   * Parse the raw string into a VersionElements.
    */
   _getElements = (raw: string): VersionElements => {
     const result: VersionElements = {
@@ -151,10 +148,5 @@ export class ZulipVersion {
     }
 
     return result;
-  };
-
-  _getLoggingArray = (raw: string): number[] => {
-    const { major, minor, patch } = this._getElements(raw);
-    return [major, minor, patch].map(e => (e !== undefined ? e : 0));
   };
 }

--- a/src/utils/zulipVersion.js
+++ b/src/utils/zulipVersion.js
@@ -31,8 +31,9 @@ export class ZulipVersion {
 
   constructor(raw: string) {
     this._raw = raw;
-    this._comparisonArray = this._getComparisonArray(raw);
-    this._elements = this._getElements(raw);
+    const elements = ZulipVersion._getElements(raw);
+    this._comparisonArray = ZulipVersion._getComparisonArray(elements);
+    this._elements = elements;
   }
 
   /**
@@ -70,7 +71,7 @@ export class ZulipVersion {
   /**
    * Parse the raw string into a VersionElements.
    */
-  _getElements = (raw: string): VersionElements => {
+  static _getElements = (raw: string): VersionElements => {
     const result: VersionElements = {
       major: undefined,
       minor: undefined,
@@ -114,8 +115,8 @@ export class ZulipVersion {
   /**
    * Compute a number[] to be used in .isAtLeast comparisons.
    */
-  _getComparisonArray = (raw: string): number[] => {
-    const { major, minor, patch, flag, numCommits } = this._getElements(raw);
+  static _getComparisonArray = (elements: VersionElements): number[] => {
+    const { major, minor, patch, flag, numCommits } = elements;
     const result: number[] = [];
 
     // Push major, minor, and patch first, then trim trailing zeroes.


### PR DESCRIPTION
We include a few tags here:

- `rawServerVersion`: Just what it sounds like.
- `coarseServerVersion`: E.g., 2.1.x or 3.x
- `fineServerVersion`: E.g., 2.1.0 or 3.2

(Note that our numbering conventions changed, effective with 3.0, so
3.x and 4.x are each the same level of granularity as 2.1.x or
2.0.x.)

Also, update our custom libdef to include `scope.setTags`, which we
use here.

Fixes: #3745