### PR TITLE
msglist: Rename `timestamp` class to `msg-timestamp`.

### DIFF
--- a/docs/style.md
+++ b/docs/style.md
@@ -313,30 +313,27 @@ apart from related functions at different layers.
 
 ## WebView: HTML, CSS, JS
 
-### HTML classes
+### HTML
 
-The set of HTML classes that can appear in the message-content HTML
-should be considered part of the Zulip API. To prevent unexpected
-interference, we should avoid using any of them in our own HTML that
-wraps and enhances the message-content HTML. This should be observed
-even for names that are no longer used in current Zulip Server
-versions -- not only because some servers will still be on old
+**Avoid classes that the server might use in messages:** In our own
+HTML in the webview, we avoid using any class names which appear in
+message content as rendered by the server.
+
+There isn't a single comprehensive list of these.  Most of them can be
+found in `static/styles/rendered_markdown.css` in zulip/zulip, which
+is where the webapp styles the message content.  In addition to names
+used in current Zulip Server versions, we need to avoid those used in
+the past -- not only because some servers will still be on old
 versions, but also because old messages generally aren't re-rendered
 into HTML even after the rendering logic changes.
 
-We could consider guarding against names that show up in future server
-versions, with a mildly annoying name-prefixing scheme. But in the
-status quo, problems have been infrequent, so we can consider that
-later.
+(In principle we should take steps to avoid future names, too.  We
+don't worry about that for now, because this hasn't often been a problem.)
 
-One observed problem was with our use of `timestamp` (now called
-`msg-timestamp`) as a class, for our timestamp pills. For just a few
-weeks, between zulip/zulip@648307ef3 and zulip/zulip@6ea3816fa, some
-messages were sent in which the `timestamp` class was present in the
-message-content HTML, and it caused the timestamp pills to display
-very weirdly. So we stopped using `timestamp` and renamed the existing
-occurrences to `msg-timestamp`, and those messages showed up
-correctly.
+See [chat discussion][class-conflict-chat] for further rationale.
+
+[class-conflict-chat]: https://chat.zulip.org/#narrow/stream/48-mobile/topic/Weird.20timestamps/near/1075485
+
 
 ### Styling/CSS
 

--- a/docs/style.md
+++ b/docs/style.md
@@ -313,6 +313,31 @@ apart from related functions at different layers.
 
 ## WebView: HTML, CSS, JS
 
+### HTML classes
+
+The set of HTML classes that can appear in the message-content HTML
+should be considered part of the Zulip API. To prevent unexpected
+interference, we should avoid using any of them in our own HTML that
+wraps and enhances the message-content HTML. This should be observed
+even for names that are no longer used in current Zulip Server
+versions -- not only because some servers will still be on old
+versions, but also because old messages generally aren't re-rendered
+into HTML even after the rendering logic changes.
+
+We could consider guarding against names that show up in future server
+versions, with a mildly annoying name-prefixing scheme. But in the
+status quo, problems have been infrequent, so we can consider that
+later.
+
+One observed problem was with our use of `timestamp` (now called
+`msg-timestamp`) as a class, for our timestamp pills. For just a few
+weeks, between zulip/zulip@648307ef3 and zulip/zulip@6ea3816fa, some
+messages were sent in which the `timestamp` class was present in the
+message-content HTML, and it caused the timestamp pills to display
+very weirdly. So we stopped using `timestamp` and renamed the existing
+occurrences to `msg-timestamp`, and those messages showed up
+correctly.
+
 ### Styling/CSS
 
 **Use `px`, sometimes `rem`, no `em`:** For CSS lengths in the

--- a/src/webview/css/cssNight.js
+++ b/src/webview/css/cssNight.js
@@ -8,7 +8,7 @@ body {
 .topic-header {
   background: hsl(212, 13%, 38%);
 }
-.timestamp {
+.msg-timestamp {
   background: hsl(212, 28%, 25%);
 }
 .highlight {

--- a/src/webview/html/htmlBody.js
+++ b/src/webview/html/htmlBody.js
@@ -7,7 +7,7 @@ const messageLoadingHtml = template`
   <div class="loading-content">
     <div class="loading-subheader">
       <div class="block name"></div>
-      <div class="block timestamp show"></div>
+      <div class="block msg-timestamp show"></div>
     </div>
     <div class="block"></div>
     <div class="block"></div>

--- a/src/webview/html/messageAsHtml.js
+++ b/src/webview/html/messageAsHtml.js
@@ -95,7 +95,7 @@ export default (backgroundData: BackgroundData, message: Message | Outbox, isBri
 
   const timestampHtml = (showOnRender: boolean) => template`
 <div class="time-container">
-  <div class="timestamp ${showOnRender ? 'show' : ''}">
+  <div class="msg-timestamp ${showOnRender ? 'show' : ''}">
     ${messageTime}
   </div>
 </div>

--- a/src/webview/js/generatedEs3.js
+++ b/src/webview/js/generatedEs3.js
@@ -856,7 +856,7 @@ var compiledWebviewJs = (function (exports) {
     var messageElement = target.closest('.message-brief');
 
     if (messageElement) {
-      messageElement.getElementsByClassName('timestamp')[0].classList.toggle('show');
+      messageElement.getElementsByClassName('msg-timestamp')[0].classList.toggle('show');
       return;
     }
   });

--- a/src/webview/js/js.js
+++ b/src/webview/js/js.js
@@ -770,7 +770,7 @@ documentBody.addEventListener('click', (e: MouseEvent) => {
 
   const messageElement = target.closest('.message-brief');
   if (messageElement) {
-    messageElement.getElementsByClassName('timestamp')[0].classList.toggle('show');
+    messageElement.getElementsByClassName('msg-timestamp')[0].classList.toggle('show');
     return;
   }
 });

--- a/src/webview/static/base.css
+++ b/src/webview/static/base.css
@@ -265,7 +265,7 @@ body {
   width: 10rem;
   background-color: hsla(0, 0%, 50%, 0.9);
 }
-.loading-subheader .timestamp {
+.loading-subheader .msg-timestamp {
   width: 5rem;
 }
 @keyframes spin {
@@ -332,7 +332,7 @@ body {
   overflow: hidden;
   pointer-events: none;
 }
-.timestamp {
+.msg-timestamp {
   position: absolute;
   right: 4px;
   transform: translateX(100%);
@@ -349,7 +349,7 @@ body {
       0px 2px 2px  0px hsla(0, 0%, 0%, 0.14),
       0px 1px 5px  0px hsla(0, 0%, 0%, 0.12);
 }
-.timestamp.show {
+.msg-timestamp.show {
   right: 8px;
   transform: none;
 }


### PR DESCRIPTION
Prompted by an issue discussed on CZO at
https://chat.zulip.org/#narrow/stream/48-mobile/topic/Weird.20timestamps/near/1075475.