### PR TITLE
Introduce `invariant`; use it to handle display_recipient more cleanly.

### DIFF
--- a/docs/style.md
+++ b/docs/style.md
@@ -294,7 +294,7 @@ definitely mean a bug within our own zulip-mobile codebase.
 [flow-invariant-pseudodocs]: https://github.com/facebook/flow/issues/6052
 
 
-## Internal to our codebase
+## Internal to Zulip and our codebase
 
 ### Zulip API bindings
 
@@ -328,6 +328,22 @@ creators.  Moreover, the API bindings tend to be imported into scope
 in exactly the same places as we're defining those other values.  The
 `api.*` naming gives a convenient, regular way to tell the API binding
 apart from related functions at different layers.
+
+
+### Zulip data model
+
+**Avoid using `display_recipient` directly**: When inspecting a
+`Message` object, or a relative like `Outbox`, never consume its
+`display_recipient` property directly.  Instead, always use one of the
+helper functions found in `src/utils/recipient.js`.
+
+One reason we do this is because the type and the semantics of that
+property, which we take directly from message objects provided by the
+Zulip server API, are complicated and have some legacy quirks; using
+the helper functions helps keep other code simpler and well-typed.
+Using the helper functions also helps us find all the places in the
+code where we're using a given aspect of the `display_recipient`
+semantics, which makes refactoring easier.
 
 
 ## WebView: HTML, CSS, JS

--- a/docs/style.md
+++ b/docs/style.md
@@ -275,6 +275,25 @@ pick just one, and that's the one we use.
 [gh-close-issue-keywords]: https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
 
 
+## JavaScript and Flow
+
+**Use `invariant` for runtime assertions the type-checker can use**:
+If there's a fact you're sure is true at a certain point in the code,
+and you want the type-checker to know it so it will accept the code
+that comes after, then go ahead and assert that fact with the
+`invariant` function.
+
+Flow [has a feature][flow-invariant-pseudodocs] (albeit not well
+documented) where a call `invariant(foo, …)` is treated much like
+saying `if (!foo) { throw new Error(…); }`.  Meanwhile at runtime,
+that's essentially what the implementation of `invariant` does.
+
+Use `invariant` only for conditions which, if they ever failed, would
+definitely mean a bug within our own zulip-mobile codebase.
+
+[flow-invariant-pseudodocs]: https://github.com/facebook/flow/issues/6052
+
+
 ## Internal to our codebase
 
 ### Zulip API bindings

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "expo-screen-orientation": "^1.0.0",
     "expo-splash-screen": "^0.5.0",
     "immutable": "^4.0.0-rc.12",
+    "invariant": "^2.2.4",
     "json-stringify-safe": "^5.0.1",
     "katex": "^0.11.1",
     "lodash.escape": "^4.0.1",

--- a/src/api/modelTypes.js
+++ b/src/api/modelTypes.js
@@ -380,15 +380,17 @@ export type MessageEdit = $ReadOnly<{|
 |}>;
 
 /** A user, as seen in the `display_recipient` of a PM `Message`. */
-export type PmRecipientUser = {|
+export type PmRecipientUser = $ReadOnly<{|
   // These five fields (id, email, full_name, short_name, is_mirror_dummy)
   // have all been present since server commit 6b13f4a3c, in 2014.
   id: number,
   email: string,
   full_name: string,
-  short_name: string,
-  is_mirror_dummy: boolean,
-|};
+  // We mark short_name and is_mirror_dummy optional so we can leave them
+  // out of Outbox values; we never rely on them anyway.
+  short_name?: string,
+  is_mirror_dummy?: boolean,
+|}>;
 
 /**
  * Submessages are items containing extra data that can be added to a
@@ -535,7 +537,7 @@ export type Message = $ReadOnly<{|
    *
    * For stream messages, prefer `stream_id`; see #3918.
    */
-  display_recipient: $FlowFixMe, // `string` for type stream, else PmRecipientUser[].
+  display_recipient: string | $ReadOnlyArray<PmRecipientUser>, // `string` for type stream, else PmRecipientUser[]
 
   /** Deprecated; a server implementation detail not useful in a client. */
   recipient_id: number,

--- a/src/chat/narrowsSelectors.js
+++ b/src/chat/narrowsSelectors.js
@@ -1,4 +1,5 @@
 /* @flow strict-local */
+import invariant from 'invariant';
 import isEqual from 'lodash.isequal';
 import { createSelector } from 'reselect';
 
@@ -107,9 +108,7 @@ export const getRecipientsInGroupNarrow: Selector<UserOrBot[], Narrow> = createS
   (narrow, allUsersByEmail) =>
     emailsOfGroupNarrow(narrow).map(r => {
       const user = allUsersByEmail.get(r);
-      if (user === undefined) {
-        throw new Error(`missing user: ${r}`);
-      }
+      invariant(user, 'missing user: %s', r);
       return user;
     }),
 );

--- a/src/events/doEventActionSideEffects.js
+++ b/src/events/doEventActionSideEffects.js
@@ -21,9 +21,8 @@ const messageEvent = (state: GlobalState, message: Message): void => {
     return;
   }
 
-  const isPrivateMessage = Array.isArray(message.display_recipient);
   const isMentioned = flags.includes('mentioned') || flags.includes('wildcard_mentioned');
-  if (!(isPrivateMessage || isMentioned)) {
+  if (!(message.type === 'private' || isMentioned)) {
     return;
   }
 

--- a/src/lightbox/Lightbox.js
+++ b/src/lightbox/Lightbox.js
@@ -18,6 +18,7 @@ import { constructActionSheetButtons, executeActionSheetAction } from './Lightbo
 import { NAVBAR_SIZE, createStyleSheet } from '../styles';
 import { getAvatarFromMessage } from '../utils/avatar';
 import { navigateBack } from '../actions';
+import { streamNameOfStreamMessage } from '../utils/recipient';
 
 const styles = createStyleSheet({
   img: {
@@ -92,7 +93,9 @@ class Lightbox extends PureComponent<Props, State> {
   render() {
     const { src, message, auth } = this.props;
     const footerMessage =
-      message.type === 'stream' ? `Shared in #${message.display_recipient}` : 'Shared with you';
+      message.type === 'stream'
+        ? `Shared in #${streamNameOfStreamMessage(message)}`
+        : 'Shared with you';
     const resource = getResource(src, auth);
     const { width, height } = Dimensions.get('window');
 

--- a/src/message/__tests__/fetchActions-test.js
+++ b/src/message/__tests__/fetchActions-test.js
@@ -1,4 +1,5 @@
 /* @flow strict-local */
+import invariant from 'invariant';
 import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import omit from 'lodash.omit';
@@ -308,10 +309,9 @@ describe('fetchActions', () => {
       expect(actions.length).toBeGreaterThanOrEqual(1);
       const [action] = actions;
       expect(action.type).toBe('MESSAGE_FETCH_START');
-      if (action.type === 'MESSAGE_FETCH_START') {
-        expect(action.numBefore).toBeGreaterThan(0);
-        expect(action.numAfter).toBeGreaterThan(0);
-      }
+      invariant(action.type === 'MESSAGE_FETCH_START', 'expect failed');
+      expect(action.numBefore).toBeGreaterThan(0);
+      expect(action.numAfter).toBeGreaterThan(0);
     });
 
     test('when no messages to be fetched before the anchor, numBefore is not greater than zero', async () => {
@@ -334,9 +334,8 @@ describe('fetchActions', () => {
       expect(actions.length).toBeGreaterThanOrEqual(1);
       const [action] = actions;
       expect(action.type).toBe('MESSAGE_FETCH_START');
-      if (action.type === 'MESSAGE_FETCH_START') {
-        expect(action.numBefore).not.toBeGreaterThan(0);
-      }
+      invariant(action.type === 'MESSAGE_FETCH_START', 'expect failed');
+      expect(action.numBefore).not.toBeGreaterThan(0);
     });
 
     test('when no messages to be fetched after the anchor, numAfter is not greater than zero', async () => {
@@ -359,9 +358,8 @@ describe('fetchActions', () => {
       expect(actions.length).toBeGreaterThanOrEqual(1);
       const [action] = actions;
       expect(action.type).toBe('MESSAGE_FETCH_START');
-      if (action.type === 'MESSAGE_FETCH_START') {
-        expect(action.numAfter).not.toBeGreaterThan(0);
-      }
+      invariant(action.type === 'MESSAGE_FETCH_START', 'expect failed');
+      expect(action.numAfter).not.toBeGreaterThan(0);
     });
   });
 
@@ -401,9 +399,8 @@ describe('fetchActions', () => {
       expect(actions).toHaveLength(1);
       const [action] = actions;
       expect(action.type).toBe('MESSAGE_FETCH_START');
-      if (action.type === 'MESSAGE_FETCH_START') {
-        expect(action.numBefore).toBeGreaterThan(0);
-      }
+      invariant(action.type === 'MESSAGE_FETCH_START', 'expect failed');
+      expect(action.numBefore).toBeGreaterThan(0);
     });
 
     test('when caughtUp older is true, no action is dispatched', async () => {
@@ -494,9 +491,8 @@ describe('fetchActions', () => {
       expect(actions).toHaveLength(1);
       const [action] = actions;
       expect(action.type).toBe('MESSAGE_FETCH_START');
-      if (action.type === 'MESSAGE_FETCH_START') {
-        expect(action.numAfter).toBeGreaterThan(0);
-      }
+      invariant(action.type === 'MESSAGE_FETCH_START', 'expect failed');
+      expect(action.numAfter).toBeGreaterThan(0);
     });
 
     test('when caughtUp newer is true, no action is dispatched', async () => {

--- a/src/message/messageActionSheet.js
+++ b/src/message/messageActionSheet.js
@@ -41,7 +41,7 @@ type ButtonDescription = {
   /** The callback. */
   ({
     auth: Auth,
-    ownEmail: string,
+    ownUser: User,
     message: Message | Outbox,
     subscriptions: Subscription[],
     dispatch: Dispatch,
@@ -60,8 +60,8 @@ type ButtonDescription = {
 // Options for the action sheet go below: ...
 //
 
-const reply = ({ message, dispatch, ownEmail }) => {
-  dispatch(doNarrow(getNarrowFromMessage(message, ownEmail), message.id));
+const reply = ({ message, dispatch, ownUser }) => {
+  dispatch(doNarrow(getNarrowFromMessage(message, ownUser), message.id));
 };
 reply.title = 'Reply';
 reply.errorMessage = 'Failed to reply';
@@ -116,7 +116,7 @@ const muteTopic = async ({ auth, message }) => {
 muteTopic.title = 'Mute topic';
 muteTopic.errorMessage = 'Failed to mute topic';
 
-const deleteTopic = async ({ auth, message, dispatch, ownEmail, _ }) => {
+const deleteTopic = async ({ auth, message, dispatch, _ }) => {
   invariant(message.type === 'stream', 'deleteTopic: got PM');
   const alertTitle = _('Are you sure you want to delete the topic “{topic}”?', {
     topic: message.subject,
@@ -369,7 +369,7 @@ export const showActionSheet = (
         await pressedButton({
           subscriptions: params.backgroundData.subscriptions,
           auth: params.backgroundData.auth,
-          ownEmail: params.backgroundData.ownUser.email,
+          ownUser: params.backgroundData.ownUser,
           ...params,
           ...callbacks,
         });

--- a/src/message/messageActionSheet.js
+++ b/src/message/messageActionSheet.js
@@ -153,7 +153,8 @@ deleteTopic.title = 'Delete topic';
 deleteTopic.errorMessage = 'Failed to delete topic';
 
 const unmuteStream = async ({ auth, message, subscriptions }) => {
-  const sub = subscriptions.find(x => x.name === message.display_recipient);
+  invariant(message.type === 'stream', 'unmuteStream: got PM');
+  const sub = subscriptions.find(x => x.name === streamNameOfStreamMessage(message));
   if (sub) {
     await api.toggleMuteStream(auth, sub.stream_id, false);
   }
@@ -162,7 +163,8 @@ unmuteStream.title = 'Unmute stream';
 unmuteStream.errorMessage = 'Failed to unmute stream';
 
 const muteStream = async ({ auth, message, subscriptions }) => {
-  const sub = subscriptions.find(x => x.name === message.display_recipient);
+  invariant(message.type === 'stream', 'muteStream: got PM');
+  const sub = subscriptions.find(x => x.name === streamNameOfStreamMessage(message));
   if (sub) {
     await api.toggleMuteStream(auth, sub.stream_id, true);
   }

--- a/src/outbox/outboxActions.js
+++ b/src/outbox/outboxActions.js
@@ -2,16 +2,8 @@
 import parseMarkdown from 'zulip-markdown-parser';
 
 import * as logging from '../utils/logging';
-import type {
-  Dispatch,
-  GetState,
-  GlobalState,
-  NamedUser,
-  Narrow,
-  Outbox,
-  UserOrBot,
-  Action,
-} from '../types';
+import type { Dispatch, GetState, GlobalState, Narrow, Outbox, UserOrBot, Action } from '../types';
+import type { SubsetProperties } from '../generics';
 import {
   MESSAGE_SEND_START,
   TOGGLE_OUTBOX_SENDING,
@@ -121,12 +113,10 @@ const mapEmailsToUsers = (emails, allUsersByEmail, ownUser) => {
   return result;
 };
 
-// TODO type: `string | NamedUser[]` is a bit confusing.
-type DataFromNarrow = {|
-  type: 'private' | 'stream',
-  display_recipient: string | NamedUser[],
-  subject: string,
-|};
+type DataFromNarrow = SubsetProperties<
+  Outbox,
+  {| type: mixed, display_recipient: mixed, subject: mixed |},
+>;
 
 const extractTypeToAndSubjectFromNarrow = (
   narrow: Narrow,

--- a/src/outbox/outboxActions.js
+++ b/src/outbox/outboxActions.js
@@ -24,6 +24,7 @@ import { getAllUsersByEmail, getOwnUser } from '../users/userSelectors';
 import { getUsersAndWildcards } from '../users/userHelpers';
 import { caseNarrowPartial } from '../utils/narrow';
 import { BackoffMachine } from '../utils/async';
+import { recipientsOfPrivateMessage, streamNameOfStreamMessage } from '../utils/recipient';
 
 export const messageSendStart = (outbox: Outbox): Action => ({
   type: MESSAGE_SEND_START,
@@ -67,12 +68,12 @@ export const trySendMessages = (dispatch: Dispatch, getState: GetState): boolean
       const to =
         item.type === 'private'
             // TODO(server-2.0): switch to numeric user IDs, not emails.
-          ? item.display_recipient.map(r => r.email).join(',')
+          ? recipientsOfPrivateMessage(item).map(r => r.email).join(',')
             // TODO(server-2.0): switch to numeric stream IDs, not names.
             //   (This will require wiring the stream ID through to here.)
             // HACK: the server attempts to interpret this argument as JSON, then
             //   CSV, then a literal. To avoid misparsing, always use JSON.
-          : JSON.stringify([item.display_recipient]);
+          : JSON.stringify([streamNameOfStreamMessage(item)]);
 
       await api.sendMessage(auth, {
         type: item.type,

--- a/src/pm-conversations/pmConversationsSelectors.js
+++ b/src/pm-conversations/pmConversationsSelectors.js
@@ -5,7 +5,11 @@ import type { Message, PmConversationData, Selector, User } from '../types';
 import { getPrivateMessages } from '../message/messageSelectors';
 import { getOwnUser } from '../users/userSelectors';
 import { getUnreadByPms, getUnreadByHuddles } from '../unread/unreadSelectors';
-import { normalizeRecipientsSansMe, pmUnreadsKeyFromMessage } from '../utils/recipient';
+import {
+  normalizeRecipientsSansMe,
+  pmUnreadsKeyFromMessage,
+  recipientsOfPrivateMessage,
+} from '../utils/recipient';
 
 export const getRecentConversations: Selector<PmConversationData[]> = createSelector(
   getOwnUser,
@@ -23,7 +27,7 @@ export const getRecentConversations: Selector<PmConversationData[]> = createSele
       ids: pmUnreadsKeyFromMessage(msg, ownUser.user_id),
 
       // The users represented in this `emails` string are sorted by email address.
-      emails: normalizeRecipientsSansMe(msg.display_recipient, ownUser.email),
+      emails: normalizeRecipientsSansMe(recipientsOfPrivateMessage(msg), ownUser.email),
 
       msgId: msg.id,
     }));

--- a/src/topics/topicActions.js
+++ b/src/topics/topicActions.js
@@ -6,6 +6,7 @@ import { isStreamNarrow } from '../utils/narrow';
 import { getAuth, getStreams } from '../selectors';
 import { deleteOutboxMessage } from '../actions';
 import { getOutbox } from '../directSelectors';
+import { streamNameOfStreamMessage } from '../utils/recipient';
 
 export const initTopics = (topics: Topic[], streamId: number): Action => ({
   type: INIT_TOPICS,
@@ -46,7 +47,7 @@ export const deleteMessagesForTopic = (streamName: string, topic: string) => asy
   outbox.forEach((outboxMessage: Outbox) => {
     if (
       outboxMessage.type === 'stream'
-      && outboxMessage.display_recipient === streamName
+      && streamNameOfStreamMessage(outboxMessage) === streamName
       && outboxMessage.subject === topic
     ) {
       dispatch(deleteOutboxMessage(outboxMessage.id));

--- a/src/types.js
+++ b/src/types.js
@@ -2,7 +2,8 @@
 import type { IntlShape } from 'react-intl';
 import type { DangerouslyImpreciseStyleProp } from 'react-native/Libraries/StyleSheet/StyleSheet';
 
-import type { Auth, Topic, Message, PmRecipientUser, Reaction, ReactionType } from './api/apiTypes';
+import type { SubsetProperties } from './generics';
+import type { Auth, Topic, Message, ReactionType } from './api/apiTypes';
 import type { ZulipVersion } from './utils/zulipVersion';
 
 export type * from './generics';
@@ -158,7 +159,7 @@ export type TopicExtended = {|
  * This type most often appears in the union `Message | Outbox`, and so its
  * properties are deliberately similar to those of `Message`.
  */
-export type Outbox = {|
+export type Outbox = $ReadOnly<{|
   /** Used for distinguishing from a `Message` object. */
   isOutbox: true,
 
@@ -177,24 +178,29 @@ export type Outbox = {|
 
   // The remaining fields are modeled on `Message`.
 
-  avatar_url: string | null,
-  content: string,
-  display_recipient: string | $ReadOnlyArray<PmRecipientUser>, // `string` for type stream, else PmRecipientUser[]
-  id: number,
-  reactions: Reaction[],
-  sender_email: string,
-  sender_full_name: string,
-
   // TODO(#3764): Make sender_id required.  Needs a migration to drop Outbox
   //   values that lack it; which is fine once the release that adds it has
   //   been out for a few weeks.
   //   (Also drop the hack line about it in MessageLike.)
   sender_id?: number,
 
-  subject: string,
-  timestamp: number,
-  type: 'stream' | 'private',
-|};
+  /* eslint-disable flowtype/generic-spacing */
+  ...SubsetProperties<
+    Message,
+    {|
+      avatar_url: mixed,
+      content: mixed,
+      display_recipient: mixed,
+      id: mixed,
+      reactions: mixed,
+      sender_email: mixed,
+      sender_full_name: mixed,
+      subject: mixed,
+      timestamp: mixed,
+      type: mixed,
+    |},
+  >,
+|}>;
 
 /**
  * MessageLike: Imprecise alternative to `Message | Outbox`.

--- a/src/types.js
+++ b/src/types.js
@@ -2,7 +2,7 @@
 import type { IntlShape } from 'react-intl';
 import type { DangerouslyImpreciseStyleProp } from 'react-native/Libraries/StyleSheet/StyleSheet';
 
-import type { Auth, Topic, Message, Reaction, ReactionType } from './api/apiTypes';
+import type { Auth, Topic, Message, PmRecipientUser, Reaction, ReactionType } from './api/apiTypes';
 import type { ZulipVersion } from './utils/zulipVersion';
 
 export type * from './generics';
@@ -179,7 +179,7 @@ export type Outbox = {|
 
   avatar_url: string | null,
   content: string,
-  display_recipient: $FlowFixMe, // `string` for type stream, else PmRecipientUser[].
+  display_recipient: string | $ReadOnlyArray<PmRecipientUser>, // `string` for type stream, else PmRecipientUser[]
   id: number,
   reactions: Reaction[],
   sender_email: string,

--- a/src/types.js
+++ b/src/types.js
@@ -309,12 +309,6 @@ export type TimingItemType = {|
   endMs: number,
 |};
 
-export type NamedUser = {|
-  id: number,
-  email: string,
-  full_name: string,
-|};
-
 export type TabNavigationOptionsPropsType = {|
   isFocussed: boolean,
   tintColor: string,

--- a/src/unread/unreadHuddlesReducer.js
+++ b/src/unread/unreadHuddlesReducer.js
@@ -8,7 +8,7 @@ import {
   EVENT_MESSAGE_DELETE,
   EVENT_UPDATE_MESSAGE_FLAGS,
 } from '../actionConstants';
-import { pmUnreadsKeyFromMessage } from '../utils/recipient';
+import { pmUnreadsKeyFromMessage, recipientsOfPrivateMessage } from '../utils/recipient';
 import { addItemsToHuddleArray, removeItemsDeeply } from './unreadHelpers';
 import { NULL_ARRAY } from '../nullObjects';
 
@@ -19,7 +19,7 @@ const eventNewMessage = (state, action) => {
     return state;
   }
 
-  if (action.message.display_recipient.length < 3) {
+  if (recipientsOfPrivateMessage(action.message).length < 3) {
     return state;
   }
 

--- a/src/unread/unreadPmsReducer.js
+++ b/src/unread/unreadPmsReducer.js
@@ -10,6 +10,7 @@ import {
 } from '../actionConstants';
 import { addItemsToPmArray, removeItemsDeeply } from './unreadHelpers';
 import { NULL_ARRAY } from '../nullObjects';
+import { recipientsOfPrivateMessage } from '../utils/recipient';
 
 const initialState: UnreadPmsState = NULL_ARRAY;
 
@@ -18,7 +19,7 @@ const eventNewMessage = (state, action) => {
     return state;
   }
 
-  if (action.message.display_recipient.length !== 2) {
+  if (recipientsOfPrivateMessage(action.message).length !== 2) {
     return state;
   }
 

--- a/src/utils/__tests__/message-test.js
+++ b/src/utils/__tests__/message-test.js
@@ -28,6 +28,7 @@ describe('shouldBeMuted', () => {
 
   test('message in a stream is muted if stream is not in mute list', () => {
     const message = {
+      type: 'stream',
       display_recipient: 'stream',
     };
 
@@ -38,6 +39,7 @@ describe('shouldBeMuted', () => {
 
   test('message in a stream is muted if the stream is muted', () => {
     const message = {
+      type: 'stream',
       display_recipient: 'stream',
     };
     const subscriptions = [
@@ -53,6 +55,7 @@ describe('shouldBeMuted', () => {
 
   test('message in a stream is muted if the topic is muted and topic matches', () => {
     const message = {
+      type: 'stream',
       display_recipient: 'stream',
       subject: 'topic',
     };

--- a/src/utils/__tests__/narrow-test.js
+++ b/src/utils/__tests__/narrow-test.js
@@ -298,13 +298,11 @@ describe('isMessageInNarrow', () => {
 });
 
 describe('getNarrowFromMessage', () => {
-  const ownEmail = eg.selfUser.email;
-
   test('for self-PM, returns self-1:1 narrow', () => {
     expect(
       getNarrowFromMessage(
         eg.pmMessage({ sender: eg.selfUser, recipients: [eg.selfUser] }),
-        ownEmail,
+        eg.selfUser,
       ),
     ).toEqual(privateNarrow(eg.selfUser.email));
   });
@@ -313,7 +311,7 @@ describe('getNarrowFromMessage', () => {
     const message = eg.pmMessage();
     const expectedNarrow = privateNarrow(eg.otherUser.email);
 
-    const actualNarrow = getNarrowFromMessage(message, ownEmail);
+    const actualNarrow = getNarrowFromMessage(message, eg.selfUser);
 
     expect(actualNarrow).toEqual(expectedNarrow);
   });
@@ -324,7 +322,7 @@ describe('getNarrowFromMessage', () => {
     });
     const expectedNarrow = groupNarrow([eg.otherUser.email, eg.thirdUser.email]);
 
-    const actualNarrow = getNarrowFromMessage(message, ownEmail);
+    const actualNarrow = getNarrowFromMessage(message, eg.selfUser);
 
     expect(actualNarrow).toEqual(expectedNarrow);
   });
@@ -334,7 +332,7 @@ describe('getNarrowFromMessage', () => {
     const message = eg.streamMessage({ subject: '' });
     const expectedNarrow = streamNarrow(eg.stream.name);
 
-    const actualNarrow = getNarrowFromMessage(message, ownEmail);
+    const actualNarrow = getNarrowFromMessage(message, eg.selfUser);
 
     expect(actualNarrow).toEqual(expectedNarrow);
   });
@@ -343,7 +341,7 @@ describe('getNarrowFromMessage', () => {
     const message = eg.streamMessage();
     const expectedNarrow = topicNarrow(eg.stream.name, message.subject);
 
-    const actualNarrow = getNarrowFromMessage(message, ownEmail);
+    const actualNarrow = getNarrowFromMessage(message, eg.selfUser);
 
     expect(actualNarrow).toEqual(expectedNarrow);
   });

--- a/src/utils/__tests__/narrow-test.js
+++ b/src/utils/__tests__/narrow-test.js
@@ -300,10 +300,17 @@ describe('isMessageInNarrow', () => {
 describe('getNarrowFromMessage', () => {
   const ownEmail = eg.selfUser.email;
 
-  test('message with single recipient, returns a private narrow', () => {
-    const message = eg.pmMessage({
-      display_recipient: [eg.displayRecipientFromUser(eg.otherUser)],
-    });
+  test('for self-PM, returns self-1:1 narrow', () => {
+    expect(
+      getNarrowFromMessage(
+        eg.pmMessage({ sender: eg.selfUser, recipients: [eg.selfUser] }),
+        ownEmail,
+      ),
+    ).toEqual(privateNarrow(eg.selfUser.email));
+  });
+
+  test('for 1:1 PM, returns a 1:1 PM narrow', () => {
+    const message = eg.pmMessage();
     const expectedNarrow = privateNarrow(eg.otherUser.email);
 
     const actualNarrow = getNarrowFromMessage(message, ownEmail);
@@ -311,9 +318,9 @@ describe('getNarrowFromMessage', () => {
     expect(actualNarrow).toEqual(expectedNarrow);
   });
 
-  test('for message with multiple recipients, return a group narrow', () => {
+  test('for group PM, returns a group PM narrow', () => {
     const message = eg.pmMessage({
-      display_recipient: [eg.otherUser, eg.thirdUser].map(eg.displayRecipientFromUser),
+      recipients: [eg.selfUser, eg.otherUser, eg.thirdUser],
     });
     const expectedNarrow = groupNarrow([eg.otherUser.email, eg.thirdUser.email]);
 
@@ -322,7 +329,8 @@ describe('getNarrowFromMessage', () => {
     expect(actualNarrow).toEqual(expectedNarrow);
   });
 
-  test('if recipient of a message is string, returns a stream narrow', () => {
+  test('for stream message with empty topic, returns a stream narrow', () => {
+    // TODO this behavior seems pretty dubious
     const message = eg.streamMessage({ subject: '' });
     const expectedNarrow = streamNarrow(eg.stream.name);
 
@@ -331,7 +339,7 @@ describe('getNarrowFromMessage', () => {
     expect(actualNarrow).toEqual(expectedNarrow);
   });
 
-  test('if recipient is a string and there is a subject returns a topic narrow', () => {
+  test('for stream message with nonempty topic, returns a topic narrow', () => {
     const message = eg.streamMessage();
     const expectedNarrow = topicNarrow(eg.stream.name, message.subject);
 

--- a/src/utils/__tests__/recipient-test.js
+++ b/src/utils/__tests__/recipient-test.js
@@ -20,15 +20,6 @@ describe('normalizeRecipients', () => {
 
     expect(normalized).toEqual(expectedResult);
   });
-
-  test('on a string input, returns same string', () => {
-    const recipients = 'abc@example.com';
-    const expectedResult = 'abc@example.com';
-
-    const normalized = normalizeRecipients(recipients);
-
-    expect(normalized).toEqual(expectedResult);
-  });
 });
 
 describe('normalizeRecipientsSansMe', () => {

--- a/src/utils/message.js
+++ b/src/utils/message.js
@@ -1,6 +1,7 @@
 /* @flow strict-local */
 import type { Narrow, Message, MuteState, Outbox, Subscription } from '../types';
 import { isTopicNarrow } from './narrow';
+import { streamNameOfStreamMessage } from './recipient';
 
 export const isTopicMuted = (stream: string, topic: string, mute: MuteState = []): boolean =>
   mute.some(x => x[0] === stream && x[1] === topic);
@@ -19,12 +20,14 @@ export const shouldBeMuted = (
     return false; // never hide a message when narrowed to topic
   }
 
+  const streamName = streamNameOfStreamMessage(message);
+
   if (narrow.length === 0) {
-    const sub = subscriptions.find(x => x.name === message.display_recipient);
+    const sub = subscriptions.find(x => x.name === streamName);
     if (!sub || !sub.in_home_view) {
       return true;
     }
   }
 
-  return mutes.some(x => x[0] === message.display_recipient && x[1] === message.subject);
+  return mutes.some(x => x[0] === streamName && x[1] === message.subject);
 };

--- a/src/utils/narrow.js
+++ b/src/utils/narrow.js
@@ -2,8 +2,8 @@
 import isEqual from 'lodash.isequal';
 import unescape from 'lodash.unescape';
 
-import type { Narrow, Message, Outbox, PmRecipientUser } from '../types';
-import { normalizeRecipientsSansMe } from './recipient';
+import type { Narrow, Message, Outbox } from '../types';
+import { normalizeRecipientsSansMe, recipientsOfPrivateMessage } from './recipient';
 
 export const isSameNarrow = (narrow1: Narrow, narrow2: Narrow): boolean =>
   Array.isArray(narrow1) && Array.isArray(narrow2) && isEqual(narrow1, narrow2);
@@ -269,7 +269,7 @@ export const isMessageInNarrow = (
     if (message.type !== 'private') {
       return false;
     }
-    const recipients: PmRecipientUser[] = message.display_recipient;
+    const recipients = recipientsOfPrivateMessage(message);
     const narrowAsRecipients = emails.map(email => ({ email }));
     return (
       normalizeRecipientsSansMe(recipients, ownEmail)

--- a/src/utils/narrow.js
+++ b/src/utils/narrow.js
@@ -2,7 +2,7 @@
 import isEqual from 'lodash.isequal';
 import unescape from 'lodash.unescape';
 
-import type { Narrow, Message, Outbox } from '../types';
+import type { Narrow, Message, Outbox, User } from '../types';
 import { normalizeRecipientsSansMe, recipientsOfPrivateMessage } from './recipient';
 
 export const isSameNarrow = (narrow1: Narrow, narrow2: Narrow): boolean =>
@@ -304,11 +304,19 @@ export const canSendToNarrow = (narrow: Narrow): boolean =>
     search: () => false,
   });
 
-export const getNarrowFromMessage = (message: Message | Outbox, ownEmail: string) => {
+/**
+ * Careful: quirky behavior on a stream message with empty topic.
+ *
+ * If you think you want to reuse this function: study carefully; maybe
+ * refactor it to something cleaner first; if not, then definitely document
+ * its quirky behavior.
+ */
+// TODO: do that, or just make this a private local helper of its one caller
+export const getNarrowFromMessage = (message: Message | Outbox, ownUser: User) => {
   if (Array.isArray(message.display_recipient)) {
     const recipient =
       message.display_recipient.length > 1
-        ? message.display_recipient.filter(x => x.email !== ownEmail)
+        ? message.display_recipient.filter(x => x.id !== ownUser.user_id)
         : message.display_recipient;
     return groupNarrow(recipient.map(x => x.email));
   }

--- a/src/utils/recipient.js
+++ b/src/utils/recipient.js
@@ -9,11 +9,14 @@ import type { PmRecipientUser, Message, Outbox, User } from '../types';
 // This is a module-private helper.  See callers for what this set of
 // conditions *means* -- two different things, in fact, that have the same
 // behavior by coincidence.
-const filterRecipients = (recipients: PmRecipientUser[], ownUserId: number): PmRecipientUser[] =>
+const filterRecipients = (
+  recipients: $ReadOnlyArray<PmRecipientUser>,
+  ownUserId: number,
+): $ReadOnlyArray<PmRecipientUser> =>
   recipients.length === 1 ? recipients : recipients.filter(r => r.id !== ownUserId);
 
 // TODO types: this union is confusing
-export const normalizeRecipients = (recipients: $ReadOnlyArray<{ email: string, ... }> | string) =>
+export const normalizeRecipients = (recipients: $ReadOnlyArray<{ +email: string, ... }> | string) =>
   !Array.isArray(recipients)
     ? recipients
     : recipients
@@ -31,7 +34,7 @@ export const normalizeRecipients = (recipients: $ReadOnlyArray<{ email: string, 
  * Users are sorted by email address.
  */
 export const normalizeRecipientsSansMe = (
-  recipients: $ReadOnlyArray<{ email: string, ... }>,
+  recipients: $ReadOnlyArray<{ +email: string, ... }>,
   ownEmail: string,
 ) =>
   recipients.length === 1
@@ -39,7 +42,7 @@ export const normalizeRecipientsSansMe = (
     : normalizeRecipients(recipients.filter(r => r.email !== ownEmail));
 
 export const normalizeRecipientsAsUserIds = (
-  recipients: $ReadOnlyArray<{ user_id: number, ... }>,
+  recipients: $ReadOnlyArray<{ +user_id: number, ... }>,
 ) =>
   recipients
     .map(s => s.user_id)
@@ -56,7 +59,7 @@ export const normalizeRecipientsAsUserIds = (
 // server's behavior is quirkier... but we keep only one user for those
 // anyway, so it doesn't matter.
 export const normalizeRecipientsAsUserIdsSansMe = (
-  recipients: $ReadOnlyArray<{ user_id: number, ... }>,
+  recipients: $ReadOnlyArray<{ +user_id: number, ... }>,
   ownUserId: number,
 ) =>
   recipients.length === 1
@@ -74,7 +77,7 @@ export const normalizeRecipientsAsUserIdsSansMe = (
 export const pmUiRecipientsFromMessage = (
   message: Message | Outbox,
   ownUser: User,
-): PmRecipientUser[] => {
+): $ReadOnlyArray<PmRecipientUser> => {
   if (message.type !== 'private') {
     throw new Error('pmUiRecipientsFromMessage: expected PM, got stream message');
   }
@@ -111,7 +114,7 @@ export const pmUiRecipientsFromMessage = (
 export const pmKeyRecipientsFromMessage = (
   message: Message | Outbox,
   ownUser: User,
-): PmRecipientUser[] => {
+): $ReadOnlyArray<PmRecipientUser> => {
   if (message.type !== 'private') {
     throw new Error('pmKeyRecipientsFromMessage: expected PM, got stream message');
   }

--- a/src/utils/recipient.js
+++ b/src/utils/recipient.js
@@ -39,15 +39,13 @@ const filterRecipients = (
 ): $ReadOnlyArray<PmRecipientUser> =>
   recipients.length === 1 ? recipients : recipients.filter(r => r.id !== ownUserId);
 
-// TODO types: this union is confusing
-export const normalizeRecipients = (recipients: $ReadOnlyArray<{ +email: string, ... }> | string) =>
-  !Array.isArray(recipients)
-    ? recipients
-    : recipients
-        .map(s => s.email.trim())
-        .filter(x => x.length > 0)
-        .sort()
-        .join(',');
+/** PRIVATE -- exported only for tests. */
+export const normalizeRecipients = (recipients: $ReadOnlyArray<{ +email: string, ... }>) =>
+  recipients
+    .map(s => s.email.trim())
+    .filter(x => x.length > 0)
+    .sort()
+    .join(',');
 
 /**
  * The same set of users as pmKeyRecipientsFromMessage, in quirkier form.
@@ -230,8 +228,8 @@ export const isSameRecipient = (
   switch (message1.type) {
     case 'private':
       return (
-        normalizeRecipients(message1.display_recipient).toLowerCase()
-        === normalizeRecipients(message2.display_recipient).toLowerCase()
+        normalizeRecipients(recipientsOfPrivateMessage(message1)).toLowerCase()
+        === normalizeRecipients(recipientsOfPrivateMessage(message2)).toLowerCase()
       );
     case 'stream':
       return (

--- a/src/webview/html/messageHeaderAsHtml.js
+++ b/src/webview/html/messageHeaderAsHtml.js
@@ -11,7 +11,11 @@ import {
 } from '../../utils/narrow';
 import { foregroundColorFromBackground } from '../../utils/color';
 import { humanDate } from '../../utils/date';
-import { pmUiRecipientsFromMessage, pmKeyRecipientsFromMessage } from '../../utils/recipient';
+import {
+  pmUiRecipientsFromMessage,
+  pmKeyRecipientsFromMessage,
+  streamNameOfStreamMessage,
+} from '../../utils/recipient';
 
 const renderSubject = item =>
   // TODO: pin down if '' happens, and what its proper semantics are.
@@ -44,7 +48,8 @@ export default (
   }
 
   if (item.type === 'stream' && headerStyle === 'topic+date') {
-    const topicNarrowStr = JSON.stringify(topicNarrow(item.display_recipient, item.subject));
+    const streamName = streamNameOfStreamMessage(item);
+    const topicNarrowStr = JSON.stringify(topicNarrow(streamName, item.subject));
     const topicHtml = renderSubject(item);
 
     return template`
@@ -60,15 +65,13 @@ export default (
   }
 
   if (item.type === 'stream' && headerStyle === 'full') {
-    // Somehow, if `item.display_recipient` appears in the `find` callback,
-    // Flow worries that `item` will turn out to be a {||} after all.
-    const { display_recipient } = item;
-    const stream = subscriptions.find(x => x.name === display_recipient);
+    const streamName = streamNameOfStreamMessage(item);
+    const stream = subscriptions.find(x => x.name === streamName);
 
     const backgroundColor = stream ? stream.color : 'hsl(0, 0%, 80%)';
     const textColor = foregroundColorFromBackground(backgroundColor);
-    const streamNarrowStr = JSON.stringify(streamNarrow(item.display_recipient));
-    const topicNarrowStr = JSON.stringify(topicNarrow(item.display_recipient, item.subject));
+    const streamNarrowStr = JSON.stringify(streamNarrow(streamName));
+    const topicNarrowStr = JSON.stringify(topicNarrow(streamName, item.subject));
     const topicHtml = renderSubject(item);
 
     return template`
@@ -79,7 +82,7 @@ export default (
        style="color: ${textColor};
               background: ${backgroundColor}"
        data-narrow="${streamNarrowStr}">
-    # ${item.display_recipient}
+    # ${streamName}
   </div>
   <div class="topic-text">$!${topicHtml}</div>
   <div class="topic-date">${humanDate(new Date(item.timestamp * 1000))}</div>


### PR DESCRIPTION
This starts us using Flow's support for an assertion function named `invariant`, which I learned about recently: https://github.com/facebook/flow/issues/6052

The immediate inspiration is the last commit in this series, a small test cleanup which clears things up for #4327. I thought a bit about more substantial ways to make use of it, and landed on a refactoring of how we handle the notorious `display_recipient` property on messages: at the end of this branch, when we consume `display_recipient` we always do so through a pair of helpers in `recipient.js`, which explicitly check our assumptions and return well-typed results.

There's also a few other cleanups in here which either came up as prerequisites for the main changes, or were suggested by them and quick to add in.
