### PR TITLE
narrow: Treat group PMs and 1:1 PMs more symmetrically.

### DIFF
--- a/src/account-info/AccountDetailsScreen.js
+++ b/src/account-info/AccountDetailsScreen.js
@@ -7,7 +7,7 @@ import { createStyleSheet } from '../styles';
 import { connect } from '../react-redux';
 import { Screen, ZulipButton, Label } from '../common';
 import { IconPrivateChat } from '../common/Icons';
-import { privateNarrow } from '../utils/narrow';
+import { pmNarrowFromEmail } from '../utils/narrow';
 import AccountDetails from './AccountDetails';
 import { doNarrow } from '../actions';
 import { getUserIsActive, getUserForId } from '../users/userSelectors';
@@ -43,7 +43,7 @@ type Props = $ReadOnly<{|
 class AccountDetailsScreen extends PureComponent<Props> {
   handleChatPress = () => {
     const { user, dispatch } = this.props;
-    dispatch(doNarrow(privateNarrow(user.email)));
+    dispatch(doNarrow(pmNarrowFromEmail(user.email)));
   };
 
   render() {

--- a/src/chat/__tests__/narrowsReducer-test.js
+++ b/src/chat/__tests__/narrowsReducer-test.js
@@ -5,7 +5,7 @@ import narrowsReducer from '../narrowsReducer';
 import {
   HOME_NARROW,
   HOME_NARROW_STR,
-  privateNarrow,
+  pmNarrowFromEmail,
   ALL_PRIVATE_NARROW_STR,
   groupNarrow,
   streamNarrow,
@@ -22,7 +22,7 @@ import { LAST_MESSAGE_ANCHOR, FIRST_UNREAD_ANCHOR } from '../../anchor';
 import * as eg from '../../__tests__/lib/exampleData';
 
 describe('narrowsReducer', () => {
-  const privateNarrowStr = JSON.stringify(privateNarrow(eg.otherUser.email));
+  const privateNarrowStr = JSON.stringify(pmNarrowFromEmail(eg.otherUser.email));
   const groupNarrowStr = JSON.stringify(groupNarrow([eg.otherUser.email, eg.thirdUser.email]));
   const streamNarrowStr = JSON.stringify(streamNarrow(eg.stream.name));
   const egTopic = eg.streamMessage().subject;
@@ -157,7 +157,7 @@ describe('narrowsReducer', () => {
   });
 
   test('message sent to self is stored correctly', () => {
-    const narrowWithSelfStr = JSON.stringify(privateNarrow(eg.selfUser.email));
+    const narrowWithSelfStr = JSON.stringify(pmNarrowFromEmail(eg.selfUser.email));
     const initialState = deepFreeze({
       [HOME_NARROW_STR]: [],
       [narrowWithSelfStr]: [],
@@ -406,7 +406,7 @@ describe('narrowsReducer', () => {
       const action = deepFreeze({
         type: MESSAGE_FETCH_COMPLETE,
         anchor: 2,
-        narrow: privateNarrow(eg.otherUser.email),
+        narrow: pmNarrowFromEmail(eg.otherUser.email),
         messages: [],
         numBefore: 100,
         numAfter: 100,
@@ -416,7 +416,7 @@ describe('narrowsReducer', () => {
 
       const expectedState = {
         [HOME_NARROW_STR]: [1, 2, 3],
-        [JSON.stringify(privateNarrow(eg.otherUser.email))]: [],
+        [JSON.stringify(pmNarrowFromEmail(eg.otherUser.email))]: [],
       };
 
       const newState = narrowsReducer(initialState, action);

--- a/src/chat/__tests__/narrowsReducer-test.js
+++ b/src/chat/__tests__/narrowsReducer-test.js
@@ -7,7 +7,7 @@ import {
   HOME_NARROW_STR,
   pmNarrowFromEmail,
   ALL_PRIVATE_NARROW_STR,
-  groupNarrow,
+  pmNarrowFromEmails,
   streamNarrow,
   topicNarrow,
   STARRED_NARROW_STR,
@@ -23,7 +23,9 @@ import * as eg from '../../__tests__/lib/exampleData';
 
 describe('narrowsReducer', () => {
   const privateNarrowStr = JSON.stringify(pmNarrowFromEmail(eg.otherUser.email));
-  const groupNarrowStr = JSON.stringify(groupNarrow([eg.otherUser.email, eg.thirdUser.email]));
+  const groupNarrowStr = JSON.stringify(
+    pmNarrowFromEmails([eg.otherUser.email, eg.thirdUser.email]),
+  );
   const streamNarrowStr = JSON.stringify(streamNarrow(eg.stream.name));
   const egTopic = eg.streamMessage().subject;
   const topicNarrowStr = JSON.stringify(topicNarrow(eg.stream.name, egTopic));

--- a/src/chat/__tests__/narrowsSelectors-test.js
+++ b/src/chat/__tests__/narrowsSelectors-test.js
@@ -9,7 +9,7 @@ import {
 import {
   HOME_NARROW,
   HOME_NARROW_STR,
-  privateNarrow,
+  pmNarrowFromEmail,
   streamNarrow,
   topicNarrow,
   STARRED_NARROW,
@@ -78,14 +78,14 @@ describe('getMessagesForNarrow', () => {
   test('do not combine messages and outbox in different narrow', () => {
     const state = eg.reduxState({
       narrows: {
-        [JSON.stringify(privateNarrow('john@example.com'))]: [123],
+        [JSON.stringify(pmNarrowFromEmail('john@example.com'))]: [123],
       },
       messages,
       outbox: [outboxMessage],
       realm: eg.realmState({ email: eg.selfUser.email }),
     });
 
-    const result = getMessagesForNarrow(state, privateNarrow('john@example.com'));
+    const result = getMessagesForNarrow(state, pmNarrowFromEmail('john@example.com'));
 
     expect(result).toEqual([message]);
   });
@@ -190,7 +190,7 @@ describe('getStreamInNarrow', () => {
   });
 
   test('return NULL_SUBSCRIPTION is narrow is not topic or stream', () => {
-    expect(getStreamInNarrow(state, privateNarrow('abc@zulip.com'))).toEqual(NULL_SUBSCRIPTION);
+    expect(getStreamInNarrow(state, pmNarrowFromEmail('abc@zulip.com'))).toEqual(NULL_SUBSCRIPTION);
     expect(getStreamInNarrow(state, topicNarrow(stream4.name, 'topic'))).toEqual(NULL_SUBSCRIPTION);
   });
 });
@@ -253,7 +253,7 @@ describe('isNarrowValid', () => {
       streams: [],
       users: [user],
     });
-    const narrow = privateNarrow(user.email);
+    const narrow = pmNarrowFromEmail(user.email);
 
     const result = isNarrowValid(state, narrow);
 
@@ -271,7 +271,7 @@ describe('isNarrowValid', () => {
       streams: [],
       users: [],
     });
-    const narrow = privateNarrow(user.email);
+    const narrow = pmNarrowFromEmail(user.email);
 
     const result = isNarrowValid(state, narrow);
 
@@ -326,7 +326,7 @@ describe('isNarrowValid', () => {
       streams: [],
       users: [],
     });
-    const narrow = privateNarrow(bot.email);
+    const narrow = pmNarrowFromEmail(bot.email);
 
     const result = isNarrowValid(state, narrow);
 
@@ -344,7 +344,7 @@ describe('isNarrowValid', () => {
       streams: [],
       users: [],
     });
-    const narrow = privateNarrow(notActiveUser.email);
+    const narrow = pmNarrowFromEmail(notActiveUser.email);
 
     const result = isNarrowValid(state, narrow);
 

--- a/src/chat/__tests__/narrowsSelectors-test.js
+++ b/src/chat/__tests__/narrowsSelectors-test.js
@@ -278,7 +278,7 @@ describe('isNarrowValid', () => {
     expect(result).toBe(false);
   });
 
-  test('narrowing to a group chat with non-existing user is not valid', () => {
+  test('narrowing to a group chat with existing users is valid', () => {
     const john = eg.makeUser({ name: 'john' });
     const mark = eg.makeUser({ name: 'mark' });
 
@@ -298,7 +298,9 @@ describe('isNarrowValid', () => {
     expect(result).toBe(true);
   });
 
-  test('narrowing to a group chat with non-existing users is also valid', () => {
+  test('narrowing to a group chat with non-existing users is not valid', () => {
+    const john = eg.makeUser({ name: 'john' });
+    const mark = eg.makeUser({ name: 'mark' });
     const state = eg.reduxState({
       realm: {
         ...eg.realmState(),
@@ -306,13 +308,13 @@ describe('isNarrowValid', () => {
         nonActiveUsers: [],
       },
       streams: [],
-      users: [],
+      users: [john],
     });
-    const narrow = pmNarrowFromEmails(['john@example.com', 'mark@example.com']);
+    const narrow = pmNarrowFromEmails([john.email, mark.email]);
 
     const result = isNarrowValid(state, narrow);
 
-    expect(result).toBe(true);
+    expect(result).toBe(false);
   });
 
   test('narrowing to a PM with bots is valid', () => {

--- a/src/chat/__tests__/narrowsSelectors-test.js
+++ b/src/chat/__tests__/narrowsSelectors-test.js
@@ -13,7 +13,7 @@ import {
   streamNarrow,
   topicNarrow,
   STARRED_NARROW,
-  groupNarrow,
+  pmNarrowFromEmails,
 } from '../../utils/narrow';
 import { NULL_SUBSCRIPTION } from '../../nullObjects';
 import * as eg from '../../__tests__/lib/exampleData';
@@ -291,7 +291,7 @@ describe('isNarrowValid', () => {
       streams: [],
       users: [john, mark],
     });
-    const narrow = groupNarrow([john.email, mark.email]);
+    const narrow = pmNarrowFromEmails([john.email, mark.email]);
 
     const result = isNarrowValid(state, narrow);
 
@@ -308,7 +308,7 @@ describe('isNarrowValid', () => {
       streams: [],
       users: [],
     });
-    const narrow = groupNarrow(['john@example.com', 'mark@example.com']);
+    const narrow = pmNarrowFromEmails(['john@example.com', 'mark@example.com']);
 
     const result = isNarrowValid(state, narrow);
 

--- a/src/chat/narrowsSelectors.js
+++ b/src/chat/narrowsSelectors.js
@@ -152,8 +152,7 @@ export const isNarrowValid: Selector<boolean, Narrow> = createSelector(
       {
         stream: streamName => streams.find(s => s.name === streamName) !== undefined,
         topic: streamName => streams.find(s => s.name === streamName) !== undefined,
-        pm: email => allUsersByEmail.get(email) !== undefined,
-        groupPm: emails => emails.every(email => allUsersByEmail.get(email) !== undefined),
+        pm: emails => emails.every(email => allUsersByEmail.get(email) !== undefined),
       },
       () => true,
     ),

--- a/src/chat/narrowsSelectors.js
+++ b/src/chat/narrowsSelectors.js
@@ -24,10 +24,10 @@ import {
 import { getCaughtUpForNarrow } from '../caughtup/caughtUpSelectors';
 import { getAllUsersByEmail, getOwnEmail } from '../users/userSelectors';
 import {
-  isPrivateNarrow,
   isStreamOrTopicNarrow,
   emailsOfGroupNarrow,
   isMessageInNarrow,
+  caseNarrowDefault,
 } from '../utils/narrow';
 import { shouldBeMuted } from '../utils/message';
 import { NULL_ARRAY, NULL_SUBSCRIPTION } from '../nullObjects';
@@ -146,15 +146,14 @@ export const isNarrowValid: Selector<boolean, Narrow> = createSelector(
   (state, narrow) => narrow,
   state => getStreams(state),
   state => getAllUsersByEmail(state),
-  (narrow, streams, allUsersByEmail) => {
-    if (isStreamOrTopicNarrow(narrow)) {
-      return streams.find(s => s.name === narrow[0].operand) !== undefined;
-    }
-
-    if (isPrivateNarrow(narrow)) {
-      return allUsersByEmail.get(narrow[0].operand) !== undefined;
-    }
-
-    return true;
-  },
+  (narrow, streams, allUsersByEmail) =>
+    caseNarrowDefault(
+      narrow,
+      {
+        stream: streamName => streams.find(s => s.name === streamName) !== undefined,
+        topic: streamName => streams.find(s => s.name === streamName) !== undefined,
+        pm: email => allUsersByEmail.get(email) !== undefined,
+      },
+      () => true,
+    ),
 );

--- a/src/chat/narrowsSelectors.js
+++ b/src/chat/narrowsSelectors.js
@@ -25,7 +25,7 @@ import { getCaughtUpForNarrow } from '../caughtup/caughtUpSelectors';
 import { getAllUsersByEmail, getOwnEmail } from '../users/userSelectors';
 import {
   isStreamOrTopicNarrow,
-  emailsOfGroupNarrow,
+  emailsOfGroupPmNarrow,
   isMessageInNarrow,
   caseNarrowDefault,
 } from '../utils/narrow';
@@ -102,11 +102,11 @@ export const getLastMessageId = (state: GlobalState, narrow: Narrow): number | v
   return ids.length > 0 ? ids[ids.length - 1] : undefined;
 };
 
-export const getRecipientsInGroupNarrow: Selector<UserOrBot[], Narrow> = createSelector(
+export const getRecipientsInGroupPmNarrow: Selector<UserOrBot[], Narrow> = createSelector(
   (state, narrow) => narrow,
   state => getAllUsersByEmail(state),
   (narrow, allUsersByEmail) =>
-    emailsOfGroupNarrow(narrow).map(r => {
+    emailsOfGroupPmNarrow(narrow).map(r => {
       const user = allUsersByEmail.get(r);
       invariant(user, 'missing user: %s', r);
       return user;

--- a/src/chat/narrowsSelectors.js
+++ b/src/chat/narrowsSelectors.js
@@ -153,6 +153,7 @@ export const isNarrowValid: Selector<boolean, Narrow> = createSelector(
         stream: streamName => streams.find(s => s.name === streamName) !== undefined,
         topic: streamName => streams.find(s => s.name === streamName) !== undefined,
         pm: email => allUsersByEmail.get(email) !== undefined,
+        groupPm: emails => emails.every(email => allUsersByEmail.get(email) !== undefined),
       },
       () => true,
     ),

--- a/src/compose/MentionWarnings.js
+++ b/src/compose/MentionWarnings.js
@@ -6,7 +6,7 @@ import { connect } from 'react-redux';
 import type { Auth, Stream, Dispatch, Narrow, UserOrBot, Subscription, GetText } from '../types';
 import { TranslationContext } from '../boot/TranslationProvider';
 import { getActiveUsersById, getAuth } from '../selectors';
-import { isPrivateNarrow } from '../utils/narrow';
+import { is1to1PmNarrow } from '../utils/narrow';
 import * as api from '../api';
 import { showToast } from '../utils/info';
 
@@ -94,7 +94,7 @@ class MentionWarnings extends PureComponent<Props, State> {
     const { narrow, auth, stream } = this.props;
     const { unsubscribedMentions } = this.state;
 
-    if (isPrivateNarrow(narrow)) {
+    if (is1to1PmNarrow(narrow)) {
       return;
     }
     const mentionedUser = this.getUserFromMention(completion);
@@ -139,7 +139,7 @@ class MentionWarnings extends PureComponent<Props, State> {
     const { unsubscribedMentions } = this.state;
     const { stream, narrow, usersById } = this.props;
 
-    if (isPrivateNarrow(narrow)) {
+    if (is1to1PmNarrow(narrow)) {
       return null;
     }
 

--- a/src/compose/__tests__/getComposeInputPlaceholder-test.js
+++ b/src/compose/__tests__/getComposeInputPlaceholder-test.js
@@ -1,11 +1,11 @@
 import deepFreeze from 'deep-freeze';
 
 import getComposeInputPlaceholder from '../getComposeInputPlaceholder';
-import { privateNarrow, streamNarrow, topicNarrow, groupNarrow } from '../../utils/narrow';
+import { pmNarrowFromEmail, streamNarrow, topicNarrow, groupNarrow } from '../../utils/narrow';
 
 describe('getComposeInputPlaceholder', () => {
   test('returns "Message @ThisPerson" object for person narrow', () => {
-    const narrow = deepFreeze(privateNarrow('abc@zulip.com'));
+    const narrow = deepFreeze(pmNarrowFromEmail('abc@zulip.com'));
 
     const ownEmail = 'hamlet@zulip.com';
 
@@ -33,7 +33,7 @@ describe('getComposeInputPlaceholder', () => {
   });
 
   test('returns "Jot down something" object for self narrow', () => {
-    const narrow = deepFreeze(privateNarrow('abc@zulip.com'));
+    const narrow = deepFreeze(pmNarrowFromEmail('abc@zulip.com'));
 
     const ownEmail = 'abc@zulip.com';
 

--- a/src/compose/__tests__/getComposeInputPlaceholder-test.js
+++ b/src/compose/__tests__/getComposeInputPlaceholder-test.js
@@ -1,7 +1,12 @@
 import deepFreeze from 'deep-freeze';
 
 import getComposeInputPlaceholder from '../getComposeInputPlaceholder';
-import { pmNarrowFromEmail, streamNarrow, topicNarrow, groupNarrow } from '../../utils/narrow';
+import {
+  pmNarrowFromEmail,
+  streamNarrow,
+  topicNarrow,
+  pmNarrowFromEmails,
+} from '../../utils/narrow';
 
 describe('getComposeInputPlaceholder', () => {
   test('returns "Message @ThisPerson" object for person narrow', () => {
@@ -58,7 +63,7 @@ describe('getComposeInputPlaceholder', () => {
   });
 
   test('returns "Message group" object for group narrow', () => {
-    const narrow = deepFreeze(groupNarrow(['abc@zulip.com, xyz@zulip.com']));
+    const narrow = deepFreeze(pmNarrowFromEmails(['abc@zulip.com, xyz@zulip.com']));
 
     const placeholder = getComposeInputPlaceholder(narrow);
     expect(placeholder).toEqual({ text: 'Message group' });

--- a/src/compose/getComposeInputPlaceholder.js
+++ b/src/compose/getComposeInputPlaceholder.js
@@ -1,17 +1,17 @@
 /* @flow strict-local */
 import type { Narrow, UserOrBot, LocalizableText } from '../types';
-import { isStreamNarrow, isTopicNarrow, isPrivateNarrow, isGroupNarrow } from '../utils/narrow';
+import { isStreamNarrow, isTopicNarrow, isGroupPmNarrow, is1to1PmNarrow } from '../utils/narrow';
 
 export default (
   narrow: Narrow,
   ownEmail: string,
   usersByEmail: Map<string, UserOrBot>,
 ): LocalizableText => {
-  if (isGroupNarrow(narrow)) {
+  if (isGroupPmNarrow(narrow)) {
     return { text: 'Message group' };
   }
 
-  if (isPrivateNarrow(narrow)) {
+  if (is1to1PmNarrow(narrow)) {
     if (ownEmail && narrow[0].operand === ownEmail) {
       return { text: 'Jot down something' };
     }

--- a/src/message/NoMessages.js
+++ b/src/message/NoMessages.js
@@ -9,8 +9,8 @@ import { Label } from '../common';
 
 import {
   isHomeNarrow,
-  isPrivateNarrow,
-  isGroupNarrow,
+  is1to1PmNarrow,
+  isGroupPmNarrow,
   isSpecialNarrow,
   isStreamNarrow,
   isTopicNarrow,
@@ -41,8 +41,8 @@ const messages: EmptyMessage[] = [
   { isFunc: isSpecialNarrow, text: 'No messages' },
   { isFunc: isStreamNarrow, text: 'No messages in stream' },
   { isFunc: isTopicNarrow, text: 'No messages with this topic' },
-  { isFunc: isPrivateNarrow, text: 'No messages with this person' },
-  { isFunc: isGroupNarrow, text: 'No messages in this group' },
+  { isFunc: is1to1PmNarrow, text: 'No messages with this person' },
+  { isFunc: isGroupPmNarrow, text: 'No messages in this group' },
   { isFunc: isSearchNarrow, text: 'No messages' },
 ];
 

--- a/src/message/messageActionSheet.js
+++ b/src/message/messageActionSheet.js
@@ -17,7 +17,7 @@ import type {
 import type { BackgroundData } from '../webview/MessageList';
 import {
   getNarrowFromMessage,
-  isPrivateOrGroupNarrow,
+  isPmNarrow,
   isStreamOrTopicNarrow,
   isTopicNarrow,
 } from '../utils/narrow';
@@ -299,7 +299,7 @@ export const constructMessageActionButtons = ({
   if (message.reactions.length > 0) {
     buttons.push('showReactions');
   }
-  if (!isTopicNarrow(narrow) && !isPrivateOrGroupNarrow(narrow)) {
+  if (!isTopicNarrow(narrow) && !isPmNarrow(narrow)) {
     buttons.push('reply');
   }
   if (messageNotDeleted(message)) {
@@ -309,7 +309,7 @@ export const constructMessageActionButtons = ({
   if (
     message.sender_email === ownUser.email
     // Our "edit message" UI only works in certain kinds of narrows.
-    && (isStreamOrTopicNarrow(narrow) || isPrivateOrGroupNarrow(narrow))
+    && (isStreamOrTopicNarrow(narrow) || isPmNarrow(narrow))
   ) {
     buttons.push('editMessage');
   }

--- a/src/message/renderMessages.js
+++ b/src/message/renderMessages.js
@@ -1,6 +1,6 @@
 /* @flow strict-local */
 import type { Message, Narrow, Outbox, RenderedSectionDescriptor } from '../types';
-import { isTopicNarrow, isPrivateOrGroupNarrow } from '../utils/narrow';
+import { isTopicNarrow, isPmNarrow } from '../utils/narrow';
 import { isSameRecipient } from '../utils/recipient';
 import { isSameDay } from '../utils/date';
 
@@ -8,7 +8,7 @@ export default (
   messages: $ReadOnlyArray<Message | Outbox>,
   narrow: Narrow,
 ): RenderedSectionDescriptor[] => {
-  const showHeader = !isPrivateOrGroupNarrow(narrow) && !isTopicNarrow(narrow);
+  const showHeader = !isPmNarrow(narrow) && !isTopicNarrow(narrow);
 
   let prevItem;
   const sections = [{ key: 0, data: [], message: {} }];

--- a/src/notification/__tests__/notification-test.js
+++ b/src/notification/__tests__/notification-test.js
@@ -4,7 +4,7 @@ import deepFreeze from 'deep-freeze';
 import type { User } from '../../api/modelTypes';
 import type { JSONableDict } from '../../utils/jsonable';
 import { getNarrowFromNotificationData } from '..';
-import { topicNarrow, pmNarrowFromEmail, groupNarrow } from '../../utils/narrow';
+import { topicNarrow, pmNarrowFromEmail, pmNarrowFromEmails } from '../../utils/narrow';
 
 import * as eg from '../../__tests__/lib/exampleData';
 import { fromAPNsImpl as extractIosNotificationData } from '../extract';
@@ -49,7 +49,7 @@ describe('getNarrowFromNotificationData', () => {
       pm_users: users.map(u => u.user_id).join(','),
     };
 
-    const expectedNarrow = groupNarrow(users.slice(1).map(u => u.email));
+    const expectedNarrow = pmNarrowFromEmails(users.slice(1).map(u => u.email));
 
     const narrow = getNarrowFromNotificationData(notification, usersById, ownUserId);
 

--- a/src/notification/__tests__/notification-test.js
+++ b/src/notification/__tests__/notification-test.js
@@ -4,7 +4,7 @@ import deepFreeze from 'deep-freeze';
 import type { User } from '../../api/modelTypes';
 import type { JSONableDict } from '../../utils/jsonable';
 import { getNarrowFromNotificationData } from '..';
-import { topicNarrow, privateNarrow, groupNarrow } from '../../utils/narrow';
+import { topicNarrow, pmNarrowFromEmail, groupNarrow } from '../../utils/narrow';
 
 import * as eg from '../../__tests__/lib/exampleData';
 import { fromAPNsImpl as extractIosNotificationData } from '../extract';
@@ -37,7 +37,7 @@ describe('getNarrowFromNotificationData', () => {
       sender_email: 'mark@example.com',
     };
     const narrow = getNarrowFromNotificationData(notification, DEFAULT_MAP, ownUserId);
-    expect(narrow).toEqual(privateNarrow('mark@example.com'));
+    expect(narrow).toEqual(pmNarrowFromEmail('mark@example.com'));
   });
 
   test('on notification for a group message returns a group narrow', () => {

--- a/src/notification/index.js
+++ b/src/notification/index.js
@@ -4,7 +4,7 @@ import NotificationsIOS from 'react-native-notifications';
 
 import type { Notification } from './types';
 import type { Auth, Dispatch, Identity, Narrow, User } from '../types';
-import { topicNarrow, privateNarrow, groupNarrow } from '../utils/narrow';
+import { topicNarrow, pmNarrowFromEmail, groupNarrow } from '../utils/narrow';
 import type { JSONable, JSONableDict } from '../utils/jsonable';
 import * as api from '../api';
 import * as logging from '../utils/logging';
@@ -102,7 +102,7 @@ export const getNarrowFromNotificationData = (
   }
 
   if (data.pm_users === undefined) {
-    return privateNarrow(data.sender_email);
+    return pmNarrowFromEmail(data.sender_email);
   }
 
   const ids = data.pm_users.split(',').map(s => parseInt(s, 10));

--- a/src/notification/index.js
+++ b/src/notification/index.js
@@ -4,7 +4,7 @@ import NotificationsIOS from 'react-native-notifications';
 
 import type { Notification } from './types';
 import type { Auth, Dispatch, Identity, Narrow, User } from '../types';
-import { topicNarrow, pmNarrowFromEmail, groupNarrow } from '../utils/narrow';
+import { topicNarrow, pmNarrowFromEmail, pmNarrowFromEmails } from '../utils/narrow';
 import type { JSONable, JSONableDict } from '../utils/jsonable';
 import * as api from '../api';
 import * as logging from '../utils/logging';
@@ -107,7 +107,7 @@ export const getNarrowFromNotificationData = (
 
   const ids = data.pm_users.split(',').map(s => parseInt(s, 10));
   const users = pmKeyRecipientsFromIds(ids, usersById, ownUserId);
-  return users && groupNarrow(users.map(u => u.email));
+  return users && pmNarrowFromEmails(users.map(u => u.email));
 };
 
 const getInitialNotification = async (): Promise<Notification | null> => {

--- a/src/outbox/outboxActions.js
+++ b/src/outbox/outboxActions.js
@@ -122,15 +122,13 @@ const extractTypeToAndSubjectFromNarrow = (
   narrow: Narrow,
   allUsersByEmail: Map<string, UserOrBot>,
   ownUser: UserOrBot,
-): DataFromNarrow => {
-  const forPm = emails => ({
-    type: 'private',
-    display_recipient: mapEmailsToUsers(emails, allUsersByEmail, ownUser),
-    subject: '',
-  });
-  return caseNarrowPartial(narrow, {
-    pm: email => forPm([email]),
-    groupPm: forPm,
+): DataFromNarrow =>
+  caseNarrowPartial(narrow, {
+    pm: emails => ({
+      type: 'private',
+      display_recipient: mapEmailsToUsers(emails, allUsersByEmail, ownUser),
+      subject: '',
+    }),
 
     // TODO: we shouldn't ever be passing a whole-stream narrow here;
     //   ensure we don't, then remove this case
@@ -142,7 +140,6 @@ const extractTypeToAndSubjectFromNarrow = (
       subject: topic,
     }),
   });
-};
 
 const getContentPreview = (content: string, state: GlobalState): string => {
   try {

--- a/src/pm-conversations/PmConversationList.js
+++ b/src/pm-conversations/PmConversationList.js
@@ -4,7 +4,7 @@ import { FlatList } from 'react-native';
 
 import type { Dispatch, PmConversationData, UserOrBot } from '../types';
 import { createStyleSheet } from '../styles';
-import { pmNarrowFromEmail, groupNarrow } from '../utils/narrow';
+import { pmNarrowFromEmail, pmNarrowFromEmails } from '../utils/narrow';
 import UserItem from '../users/UserItem';
 import GroupPmConversationItem from './GroupPmConversationItem';
 import { doNarrow } from '../actions';
@@ -31,7 +31,7 @@ export default class PmConversationList extends PureComponent<Props> {
   };
 
   handleGroupNarrow = (email: string) => {
-    this.props.dispatch(doNarrow(groupNarrow(email.split(','))));
+    this.props.dispatch(doNarrow(pmNarrowFromEmails(email.split(','))));
   };
 
   render() {

--- a/src/pm-conversations/PmConversationList.js
+++ b/src/pm-conversations/PmConversationList.js
@@ -4,7 +4,7 @@ import { FlatList } from 'react-native';
 
 import type { Dispatch, PmConversationData, UserOrBot } from '../types';
 import { createStyleSheet } from '../styles';
-import { privateNarrow, groupNarrow } from '../utils/narrow';
+import { pmNarrowFromEmail, groupNarrow } from '../utils/narrow';
 import UserItem from '../users/UserItem';
 import GroupPmConversationItem from './GroupPmConversationItem';
 import { doNarrow } from '../actions';
@@ -27,7 +27,7 @@ type Props = $ReadOnly<{|
  * */
 export default class PmConversationList extends PureComponent<Props> {
   handleUserNarrow = (user: UserOrBot) => {
-    this.props.dispatch(doNarrow(privateNarrow(user.email)));
+    this.props.dispatch(doNarrow(pmNarrowFromEmail(user.email)));
   };
 
   handleGroupNarrow = (email: string) => {

--- a/src/title-buttons/InfoNavButtonGroup.js
+++ b/src/title-buttons/InfoNavButtonGroup.js
@@ -5,7 +5,7 @@ import React, { PureComponent } from 'react';
 import NavigationService from '../nav/NavigationService';
 import type { Dispatch, Narrow, UserOrBot } from '../types';
 import { connect } from '../react-redux';
-import { getRecipientsInGroupNarrow } from '../selectors';
+import { getRecipientsInGroupPmNarrow } from '../selectors';
 import NavButton from '../nav/NavButton';
 import { navigateToGroupDetails } from '../actions';
 
@@ -35,5 +35,5 @@ class InfoNavButtonGroup extends PureComponent<Props> {
 }
 
 export default connect<SelectorProps, _, _>((state, props) => ({
-  recipients: getRecipientsInGroupNarrow(state, props.narrow),
+  recipients: getRecipientsInGroupPmNarrow(state, props.narrow),
 }))(InfoNavButtonGroup);

--- a/src/title-buttons/titleButtonFromNarrow.js
+++ b/src/title-buttons/titleButtonFromNarrow.js
@@ -5,8 +5,8 @@ import type { ComponentType } from 'react';
 import type { Narrow } from '../types';
 import {
   isHomeNarrow,
-  isPrivateNarrow,
-  isGroupNarrow,
+  is1to1PmNarrow,
+  isGroupPmNarrow,
   isSpecialNarrow,
   isStreamNarrow,
   isTopicNarrow,
@@ -29,8 +29,8 @@ const infoButtonHandlers: NarrowNavButtonCandidate[] = [
   { isFunc: isSpecialNarrow, ButtonComponent: null },
   { isFunc: isStreamNarrow, ButtonComponent: InfoNavButtonStream },
   { isFunc: isTopicNarrow, ButtonComponent: InfoNavButtonStream },
-  { isFunc: isPrivateNarrow, ButtonComponent: InfoNavButtonPrivate },
-  { isFunc: isGroupNarrow, ButtonComponent: InfoNavButtonGroup },
+  { isFunc: is1to1PmNarrow, ButtonComponent: InfoNavButtonPrivate },
+  { isFunc: isGroupPmNarrow, ButtonComponent: InfoNavButtonGroup },
 ];
 
 const extraButtonHandlers: NarrowNavButtonCandidate[] = [
@@ -38,8 +38,8 @@ const extraButtonHandlers: NarrowNavButtonCandidate[] = [
   { isFunc: isSpecialNarrow, ButtonComponent: null },
   { isFunc: isStreamNarrow, ButtonComponent: ExtraNavButtonStream },
   { isFunc: isTopicNarrow, ButtonComponent: ExtraNavButtonTopic },
-  { isFunc: isPrivateNarrow, ButtonComponent: null },
-  { isFunc: isGroupNarrow, ButtonComponent: null },
+  { isFunc: is1to1PmNarrow, ButtonComponent: null },
+  { isFunc: isGroupPmNarrow, ButtonComponent: null },
 ];
 
 const makeButton = (handlers): NarrowNavButton => props => {

--- a/src/title/Title.js
+++ b/src/title/Title.js
@@ -30,8 +30,12 @@ export default class Title extends PureComponent<Props> {
       allPrivate: () => <TitleSpecial code="private" color={color} />,
       stream: () => <TitleStream narrow={narrow} color={color} />,
       topic: () => <TitleStream narrow={narrow} color={color} />,
-      pm: email => <TitlePrivate email={email} color={color} />,
-      groupPm: () => <TitleGroup narrow={narrow} />,
+      pm: emails =>
+        emails.length === 1 ? (
+          <TitlePrivate email={emails[0]} color={color} />
+        ) : (
+          <TitleGroup narrow={narrow} />
+        ),
       search: () => null,
     });
   }

--- a/src/title/TitleGroup.js
+++ b/src/title/TitleGroup.js
@@ -8,7 +8,7 @@ import type { Dispatch, UserOrBot, Narrow } from '../types';
 import styles, { createStyleSheet } from '../styles';
 import { connect } from '../react-redux';
 import { UserAvatarWithPresence } from '../common';
-import { getRecipientsInGroupNarrow } from '../selectors';
+import { getRecipientsInGroupPmNarrow } from '../selectors';
 import { navigateToAccountDetails } from '../nav/navActions';
 
 type SelectorProps = $ReadOnly<{|
@@ -54,5 +54,5 @@ class TitleGroup extends PureComponent<Props> {
 }
 
 export default connect<SelectorProps, _, _>((state, props) => ({
-  recipients: getRecipientsInGroupNarrow(state, props.narrow),
+  recipients: getRecipientsInGroupPmNarrow(state, props.narrow),
 }))(TitleGroup);

--- a/src/title/__tests__/titleSelectors-test.js
+++ b/src/title/__tests__/titleSelectors-test.js
@@ -1,7 +1,7 @@
 import deepFreeze from 'deep-freeze';
 
 import { DEFAULT_TITLE_BACKGROUND_COLOR, getTitleBackgroundColor } from '../titleSelectors';
-import { groupNarrow, streamNarrow, pmNarrowFromEmail } from '../../utils/narrow';
+import { pmNarrowFromEmails, streamNarrow, pmNarrowFromEmail } from '../../utils/narrow';
 
 const subscriptions = [{ name: 'all', color: '#fff' }, { name: 'announce', color: '#000' }];
 
@@ -38,8 +38,8 @@ describe('getTitleBackgroundColor', () => {
     expect(getTitleBackgroundColor(state, pmNarrowFromEmail('abc@zulip.com'))).toEqual(
       DEFAULT_TITLE_BACKGROUND_COLOR,
     );
-    expect(getTitleBackgroundColor(state, groupNarrow(['abc@zulip.com', 'def@zulip.com']))).toEqual(
-      DEFAULT_TITLE_BACKGROUND_COLOR,
-    );
+    expect(
+      getTitleBackgroundColor(state, pmNarrowFromEmails(['abc@zulip.com', 'def@zulip.com'])),
+    ).toEqual(DEFAULT_TITLE_BACKGROUND_COLOR);
   });
 });

--- a/src/title/__tests__/titleSelectors-test.js
+++ b/src/title/__tests__/titleSelectors-test.js
@@ -1,7 +1,7 @@
 import deepFreeze from 'deep-freeze';
 
 import { DEFAULT_TITLE_BACKGROUND_COLOR, getTitleBackgroundColor } from '../titleSelectors';
-import { groupNarrow, streamNarrow, privateNarrow } from '../../utils/narrow';
+import { groupNarrow, streamNarrow, pmNarrowFromEmail } from '../../utils/narrow';
 
 const subscriptions = [{ name: 'all', color: '#fff' }, { name: 'announce', color: '#000' }];
 
@@ -35,7 +35,7 @@ describe('getTitleBackgroundColor', () => {
       subscriptions,
     });
 
-    expect(getTitleBackgroundColor(state, privateNarrow('abc@zulip.com'))).toEqual(
+    expect(getTitleBackgroundColor(state, pmNarrowFromEmail('abc@zulip.com'))).toEqual(
       DEFAULT_TITLE_BACKGROUND_COLOR,
     );
     expect(getTitleBackgroundColor(state, groupNarrow(['abc@zulip.com', 'def@zulip.com']))).toEqual(

--- a/src/typing/__tests__/typingSelectors-test.js
+++ b/src/typing/__tests__/typingSelectors-test.js
@@ -2,7 +2,7 @@
 
 import type { GlobalState } from '../../types';
 import { getCurrentTypingUsers } from '../typingSelectors';
-import { HOME_NARROW, privateNarrow, groupNarrow } from '../../utils/narrow';
+import { HOME_NARROW, pmNarrowFromEmail, groupNarrow } from '../../utils/narrow';
 import { NULL_ARRAY } from '../../nullObjects';
 import * as eg from '../../__tests__/lib/exampleData';
 import { normalizeRecipientsAsUserIds } from '../../utils/recipient';
@@ -25,7 +25,7 @@ describe('getCurrentTypingUsers', () => {
       users: [expectedUser],
     });
 
-    const typingUsers = getCurrentTypingUsers(state, privateNarrow(expectedUser.email));
+    const typingUsers = getCurrentTypingUsers(state, pmNarrowFromEmail(expectedUser.email));
 
     expect(typingUsers).toEqual([expectedUser]);
   });
@@ -63,7 +63,7 @@ describe('getCurrentTypingUsers', () => {
       users: [user1, user2],
     });
 
-    const typingUsers = getCurrentTypingUsers(state, privateNarrow(user2.email));
+    const typingUsers = getCurrentTypingUsers(state, pmNarrowFromEmail(user2.email));
 
     expect(typingUsers).toEqual(NULL_ARRAY);
   });
@@ -98,7 +98,8 @@ describe('getCurrentTypingUsers', () => {
       realm: eg.realmState({ nonActiveUsers: [deactivatedUser] }),
     });
 
-    const getTypingUsers = () => getCurrentTypingUsers(state, privateNarrow(deactivatedUser.email));
+    const getTypingUsers = () =>
+      getCurrentTypingUsers(state, pmNarrowFromEmail(deactivatedUser.email));
 
     expect(getTypingUsers).not.toThrow();
     expect(getTypingUsers()).toEqual([]);
@@ -111,7 +112,8 @@ describe('getCurrentTypingUsers', () => {
       realm: eg.realmState({ crossRealmBots: [crossRealmBot] }),
     });
 
-    const getTypingUsers = () => getCurrentTypingUsers(state, privateNarrow(crossRealmBot.email));
+    const getTypingUsers = () =>
+      getCurrentTypingUsers(state, pmNarrowFromEmail(crossRealmBot.email));
 
     expect(getTypingUsers).not.toThrow();
     expect(getTypingUsers()).toEqual([]);

--- a/src/typing/__tests__/typingSelectors-test.js
+++ b/src/typing/__tests__/typingSelectors-test.js
@@ -2,7 +2,7 @@
 
 import type { GlobalState } from '../../types';
 import { getCurrentTypingUsers } from '../typingSelectors';
-import { HOME_NARROW, pmNarrowFromEmail, groupNarrow } from '../../utils/narrow';
+import { HOME_NARROW, pmNarrowFromEmail, pmNarrowFromEmails } from '../../utils/narrow';
 import { NULL_ARRAY } from '../../nullObjects';
 import * as eg from '../../__tests__/lib/exampleData';
 import { normalizeRecipientsAsUserIds } from '../../utils/recipient';
@@ -46,7 +46,10 @@ describe('getCurrentTypingUsers', () => {
       users: [user1, user2],
     });
 
-    const typingUsers = getCurrentTypingUsers(state, groupNarrow([user1.email, user2.email]));
+    const typingUsers = getCurrentTypingUsers(
+      state,
+      pmNarrowFromEmails([user1.email, user2.email]),
+    );
 
     expect(typingUsers).toEqual([user1, user2]);
   });
@@ -85,7 +88,7 @@ describe('getCurrentTypingUsers', () => {
 
     const typingUsers = getCurrentTypingUsers(
       state,
-      groupNarrow([expectedUser.email, anotherUser.email]),
+      pmNarrowFromEmails([expectedUser.email, anotherUser.email]),
     );
 
     expect(typingUsers).toEqual([expectedUser]);

--- a/src/typing/typingSelectors.js
+++ b/src/typing/typingSelectors.js
@@ -3,7 +3,7 @@ import { createSelector } from 'reselect';
 
 import type { Narrow, Selector, UserOrBot } from '../types';
 import { getTyping } from '../directSelectors';
-import { isPrivateOrGroupNarrow } from '../utils/narrow';
+import { isPmNarrow } from '../utils/narrow';
 import { normalizeRecipientsAsUserIds } from '../utils/recipient';
 import { NULL_ARRAY, NULL_USER } from '../nullObjects';
 import { getAllUsersById, getAllUsersByEmail } from '../users/userSelectors';
@@ -14,7 +14,7 @@ export const getCurrentTypingUsers: Selector<$ReadOnlyArray<UserOrBot>, Narrow> 
   state => getAllUsersById(state),
   state => getAllUsersByEmail(state),
   (narrow, typing, allUsersById, allUsersByEmail): UserOrBot[] => {
-    if (!isPrivateOrGroupNarrow(narrow)) {
+    if (!isPmNarrow(narrow)) {
       return NULL_ARRAY;
     }
 

--- a/src/unread/unreadSelectors.js
+++ b/src/unread/unreadSelectors.js
@@ -18,8 +18,8 @@ import {
   isHomeNarrow,
   isStreamNarrow,
   isTopicNarrow,
-  isGroupNarrow,
-  isPrivateNarrow,
+  isGroupPmNarrow,
+  is1to1PmNarrow,
 } from '../utils/narrow';
 import { NULL_SUBSCRIPTION, NULL_USER } from '../nullObjects';
 
@@ -276,7 +276,7 @@ export const getUnreadCountForNarrow: Selector<number, Narrow> = createSelector(
         .reduce((sum, x) => sum + x.unread_message_ids.length, 0);
     }
 
-    if (isGroupNarrow(narrow)) {
+    if (isGroupPmNarrow(narrow)) {
       const userIds = [...narrow[0].operand.split(','), ownEmail]
         .map(email => (usersByEmail.get(email) || NULL_USER).user_id)
         .sort((a, b) => a - b)
@@ -285,7 +285,7 @@ export const getUnreadCountForNarrow: Selector<number, Narrow> = createSelector(
       return unread ? unread.unread_message_ids.length : 0;
     }
 
-    if (isPrivateNarrow(narrow)) {
+    if (is1to1PmNarrow(narrow)) {
       const sender = usersByEmail.get(narrow[0].operand);
       if (!sender) {
         return 0;

--- a/src/user-groups/CreateGroupScreen.js
+++ b/src/user-groups/CreateGroupScreen.js
@@ -7,7 +7,7 @@ import type { Dispatch, User } from '../types';
 import { connect } from '../react-redux';
 import { Screen } from '../common';
 import { doNarrow, navigateBack } from '../actions';
-import { groupNarrow } from '../utils/narrow';
+import { pmNarrowFromEmails } from '../utils/narrow';
 import UserPickerCard from '../user-picker/UserPickerCard';
 
 type Props = $ReadOnly<{|
@@ -36,7 +36,7 @@ class CreateGroupScreen extends PureComponent<Props, State> {
 
     const recipients = selected.map(user => user.email);
     NavigationService.dispatch(navigateBack());
-    dispatch(doNarrow(groupNarrow(recipients)));
+    dispatch(doNarrow(pmNarrowFromEmails(recipients)));
   };
 
   render() {

--- a/src/users/UsersCard.js
+++ b/src/users/UsersCard.js
@@ -5,7 +5,7 @@ import React, { PureComponent } from 'react';
 import NavigationService from '../nav/NavigationService';
 import type { Dispatch, PresenceState, User, UserOrBot } from '../types';
 import { connect } from '../react-redux';
-import { privateNarrow } from '../utils/narrow';
+import { pmNarrowFromEmail } from '../utils/narrow';
 import UserList from './UserList';
 import { getUsers, getPresence } from '../selectors';
 import { navigateBack, doNarrow } from '../actions';
@@ -21,7 +21,7 @@ class UsersCard extends PureComponent<Props> {
   handleUserNarrow = (user: UserOrBot) => {
     const { dispatch } = this.props;
     NavigationService.dispatch(navigateBack());
-    dispatch(doNarrow(privateNarrow(user.email)));
+    dispatch(doNarrow(pmNarrowFromEmail(user.email)));
   };
 
   render() {

--- a/src/users/usersActions.js
+++ b/src/users/usersActions.js
@@ -66,8 +66,7 @@ export const sendTypingStart = (narrow: Narrow) => async (
 
   const usersByEmail = getAllUsersByEmail(getState());
   const recipientIds = caseNarrowPartial(narrow, {
-    pm: email => [email],
-    groupPm: emails => emails,
+    pm: emails => emails,
   }).map(email => {
     const user = usersByEmail.get(email);
     if (!user) {

--- a/src/users/usersActions.js
+++ b/src/users/usersActions.js
@@ -5,7 +5,7 @@ import type { Auth, Dispatch, GetState, GlobalState, Narrow } from '../types';
 import * as api from '../api';
 import { PRESENCE_RESPONSE } from '../actionConstants';
 import { getAuth, tryGetAuth, getServerVersion } from '../selectors';
-import { isPrivateOrGroupNarrow, caseNarrowPartial } from '../utils/narrow';
+import { isPmNarrow, caseNarrowPartial } from '../utils/narrow';
 import { getAllUsersByEmail, getUserForId } from './userSelectors';
 import { ZulipVersion } from '../utils/zulipVersion';
 
@@ -60,7 +60,7 @@ export const sendTypingStart = (narrow: Narrow) => async (
   dispatch: Dispatch,
   getState: GetState,
 ) => {
-  if (!isPrivateOrGroupNarrow(narrow)) {
+  if (!isPmNarrow(narrow)) {
     return;
   }
 
@@ -84,7 +84,7 @@ export const sendTypingStop = (narrow: Narrow) => async (
   dispatch: Dispatch,
   getState: GetState,
 ) => {
-  if (!isPrivateOrGroupNarrow(narrow)) {
+  if (!isPmNarrow(narrow)) {
     return;
   }
 

--- a/src/utils/__tests__/internalLinks-test.js
+++ b/src/utils/__tests__/internalLinks-test.js
@@ -1,7 +1,7 @@
 /* @flow strict-local */
 
 import type { User } from '../../api/modelTypes';
-import { streamNarrow, topicNarrow, groupNarrow, STARRED_NARROW } from '../narrow';
+import { streamNarrow, topicNarrow, pmNarrowFromEmails, STARRED_NARROW } from '../narrow';
 import {
   isInternalLink,
   isMessageLink,
@@ -257,7 +257,7 @@ describe('getNarrowFromLink', () => {
   test('on group PM link', () => {
     const ids = `${userB.user_id},${userC.user_id}`;
     expect(get(`https://example.com/#narrow/pm-with/${ids}-group`)).toEqual(
-      groupNarrow([userB.email, userC.email]),
+      pmNarrowFromEmails([userB.email, userC.email]),
     );
   });
 
@@ -265,7 +265,7 @@ describe('getNarrowFromLink', () => {
     // The webapp doesn't generate these, but best to handle them anyway.
     const ids = `${eg.selfUser.user_id},${userB.user_id},${userC.user_id}`;
     expect(get(`https://example.com/#narrow/pm-with/${ids}-group`)).toEqual(
-      groupNarrow([userB.email, userC.email]),
+      pmNarrowFromEmails([userB.email, userC.email]),
     );
   });
 
@@ -282,7 +282,7 @@ describe('getNarrowFromLink', () => {
   test('on a message link', () => {
     const ids = `${userB.user_id},${userC.user_id}`;
     expect(get(`https://example.com/#narrow/pm-with/${ids}-group/near/2`)).toEqual(
-      groupNarrow([userB.email, userC.email]),
+      pmNarrowFromEmails([userB.email, userC.email]),
     );
 
     expect(get('https://example.com/#narrow/stream/jest/topic/test/near/1')).toEqual(

--- a/src/utils/__tests__/narrow-test.js
+++ b/src/utils/__tests__/narrow-test.js
@@ -5,7 +5,7 @@ import {
   isHomeNarrow,
   pmNarrowFromEmail,
   isPrivateNarrow,
-  groupNarrow,
+  pmNarrowFromEmails,
   isGroupNarrow,
   specialNarrow,
   isSpecialNarrow,
@@ -62,9 +62,9 @@ describe('pmNarrowFromEmail', () => {
   });
 });
 
-describe('groupNarrow', () => {
+describe('pmNarrowFromEmails', () => {
   test('returns a narrow with specified recipients', () => {
-    expect(groupNarrow(['bob@example.com', 'john@example.com'])).toEqual([
+    expect(pmNarrowFromEmails(['bob@example.com', 'john@example.com'])).toEqual([
       {
         operator: 'pm-with',
         operand: 'bob@example.com,john@example.com',
@@ -75,7 +75,7 @@ describe('groupNarrow', () => {
   test('a group narrow is only private chat with more than one recipients', () => {
     expect(isGroupNarrow(HOME_NARROW)).toBe(false);
     expect(isGroupNarrow(pmNarrowFromEmail('bob@example.com'))).toBe(false);
-    expect(isGroupNarrow(groupNarrow(['bob@example.com', 'john@example.com']))).toBe(true);
+    expect(isGroupNarrow(pmNarrowFromEmails(['bob@example.com', 'john@example.com']))).toBe(true);
     expect(
       isGroupNarrow([
         {
@@ -100,7 +100,9 @@ describe('isPrivateOrGroupNarrow', () => {
     expect(isPrivateOrGroupNarrow(undefined)).toBe(false);
     expect(isPrivateOrGroupNarrow(HOME_NARROW)).toBe(false);
     expect(isPrivateOrGroupNarrow(pmNarrowFromEmail('bob@example.com'))).toBe(true);
-    expect(isPrivateOrGroupNarrow(groupNarrow(['bob@example.com', 'john@example.com']))).toBe(true);
+    expect(
+      isPrivateOrGroupNarrow(pmNarrowFromEmails(['bob@example.com', 'john@example.com'])),
+    ).toBe(true);
     expect(
       isPrivateOrGroupNarrow([
         {
@@ -127,9 +129,9 @@ describe('isStreamOrTopicNarrow', () => {
     expect(isStreamOrTopicNarrow(topicNarrow('some stream', 'some topic'))).toBe(true);
     expect(isStreamOrTopicNarrow(HOME_NARROW)).toBe(false);
     expect(isStreamOrTopicNarrow(pmNarrowFromEmail('a@a.com'))).toBe(false);
-    expect(isStreamOrTopicNarrow(groupNarrow(['john@example.com', 'mark@example.com']))).toBe(
-      false,
-    );
+    expect(
+      isStreamOrTopicNarrow(pmNarrowFromEmails(['john@example.com', 'mark@example.com'])),
+    ).toBe(false);
     expect(isStreamOrTopicNarrow(STARRED_NARROW)).toBe(false);
   });
 });
@@ -254,7 +256,7 @@ describe('isMessageInNarrow', () => {
       ['group-PM, outbound', false, eg.pmMessage({ sender: eg.selfUser, recipients: [eg.selfUser, eg.otherUser, eg.thirdUser] })],
       ['stream message', false, eg.streamMessage()],
     ]],
-    ['group-PM conversation', groupNarrow([eg.otherUser.email, eg.thirdUser.email]), [
+    ['group-PM conversation', pmNarrowFromEmails([eg.otherUser.email, eg.thirdUser.email]), [
       ['matching group-PM, inbound', true, eg.pmMessage({ recipients: [eg.selfUser, eg.otherUser, eg.thirdUser] })],
       ['matching group-PM, outbound', true, eg.pmMessage({ sender: eg.selfUser, recipients: [eg.selfUser, eg.otherUser, eg.thirdUser] })],
       ['1:1 within group, inbound', false, eg.pmMessage()],
@@ -262,7 +264,7 @@ describe('isMessageInNarrow', () => {
       ['self-1:1 message', false, eg.pmMessage({ sender: eg.selfUser, recipients: [eg.selfUser] })],
       ['stream message', false, eg.streamMessage()],
     ]],
-    ['group-PM conversation, including self', groupNarrow([eg.selfUser.email, eg.otherUser.email, eg.thirdUser.email]), [
+    ['group-PM conversation, including self', pmNarrowFromEmails([eg.selfUser.email, eg.otherUser.email, eg.thirdUser.email]), [
       ['matching group-PM, inbound', true, eg.pmMessage({ recipients: [eg.selfUser, eg.otherUser, eg.thirdUser] })],
       ['matching group-PM, outbound', true, eg.pmMessage({ sender: eg.selfUser, recipients: [eg.selfUser, eg.otherUser, eg.thirdUser] })],
       ['1:1 within group, inbound', false, eg.pmMessage()],
@@ -320,7 +322,7 @@ describe('getNarrowFromMessage', () => {
     const message = eg.pmMessage({
       recipients: [eg.selfUser, eg.otherUser, eg.thirdUser],
     });
-    const expectedNarrow = groupNarrow([eg.otherUser.email, eg.thirdUser.email]);
+    const expectedNarrow = pmNarrowFromEmails([eg.otherUser.email, eg.thirdUser.email]);
 
     const actualNarrow = getNarrowFromMessage(message, eg.selfUser);
 

--- a/src/utils/__tests__/narrow-test.js
+++ b/src/utils/__tests__/narrow-test.js
@@ -3,7 +3,7 @@
 import {
   HOME_NARROW,
   isHomeNarrow,
-  privateNarrow,
+  pmNarrowFromEmail,
   isPrivateNarrow,
   groupNarrow,
   isGroupNarrow,
@@ -38,9 +38,9 @@ describe('HOME_NARROW', () => {
   });
 });
 
-describe('privateNarrow', () => {
+describe('pmNarrowFromEmail', () => {
   test('produces an one item list, pm-with operator and single email', () => {
-    expect(privateNarrow('bob@example.com')).toEqual([
+    expect(pmNarrowFromEmail('bob@example.com')).toEqual([
       {
         operator: 'pm-with',
         operand: 'bob@example.com',
@@ -50,7 +50,7 @@ describe('privateNarrow', () => {
 
   test('if operator is "pm-with" and only one email, then it is a private narrow', () => {
     expect(isPrivateNarrow(HOME_NARROW)).toBe(false);
-    expect(isPrivateNarrow(privateNarrow('bob@example.com'))).toBe(true);
+    expect(isPrivateNarrow(pmNarrowFromEmail('bob@example.com'))).toBe(true);
     expect(
       isPrivateNarrow([
         {
@@ -74,7 +74,7 @@ describe('groupNarrow', () => {
 
   test('a group narrow is only private chat with more than one recipients', () => {
     expect(isGroupNarrow(HOME_NARROW)).toBe(false);
-    expect(isGroupNarrow(privateNarrow('bob@example.com'))).toBe(false);
+    expect(isGroupNarrow(pmNarrowFromEmail('bob@example.com'))).toBe(false);
     expect(isGroupNarrow(groupNarrow(['bob@example.com', 'john@example.com']))).toBe(true);
     expect(
       isGroupNarrow([
@@ -99,7 +99,7 @@ describe('isPrivateOrGroupNarrow', () => {
   test('a private or group narrow is any "pm-with" narrow', () => {
     expect(isPrivateOrGroupNarrow(undefined)).toBe(false);
     expect(isPrivateOrGroupNarrow(HOME_NARROW)).toBe(false);
-    expect(isPrivateOrGroupNarrow(privateNarrow('bob@example.com'))).toBe(true);
+    expect(isPrivateOrGroupNarrow(pmNarrowFromEmail('bob@example.com'))).toBe(true);
     expect(isPrivateOrGroupNarrow(groupNarrow(['bob@example.com', 'john@example.com']))).toBe(true);
     expect(
       isPrivateOrGroupNarrow([
@@ -126,7 +126,7 @@ describe('isStreamOrTopicNarrow', () => {
     expect(isStreamOrTopicNarrow(streamNarrow('some stream'))).toBe(true);
     expect(isStreamOrTopicNarrow(topicNarrow('some stream', 'some topic'))).toBe(true);
     expect(isStreamOrTopicNarrow(HOME_NARROW)).toBe(false);
-    expect(isStreamOrTopicNarrow(privateNarrow('a@a.com'))).toBe(false);
+    expect(isStreamOrTopicNarrow(pmNarrowFromEmail('a@a.com'))).toBe(false);
     expect(isStreamOrTopicNarrow(groupNarrow(['john@example.com', 'mark@example.com']))).toBe(
       false,
     );
@@ -238,7 +238,7 @@ describe('isMessageInNarrow', () => {
       ['PM', false, eg.pmMessage()],
     ]],
 
-    ['1:1 PM conversation, non-self', privateNarrow(eg.otherUser.email), [
+    ['1:1 PM conversation, non-self', pmNarrowFromEmail(eg.otherUser.email), [
       ['matching PM, inbound', true, eg.pmMessage()],
       ['matching PM, outbound', true, eg.pmMessage({ sender: eg.selfUser })],
       ['self-1:1 message', false, eg.pmMessage({ sender: eg.selfUser, recipients: [eg.selfUser] })],
@@ -246,7 +246,7 @@ describe('isMessageInNarrow', () => {
       ['group-PM including this user, outbound', false, eg.pmMessage({ sender: eg.selfUser, recipients: [eg.selfUser, eg.otherUser, eg.thirdUser] })],
       ['stream message', false, eg.streamMessage()],
     ]],
-    ['self-1:1 conversation', privateNarrow(eg.selfUser.email), [
+    ['self-1:1 conversation', pmNarrowFromEmail(eg.selfUser.email), [
       ['self-1:1 message', true, eg.pmMessage({ sender: eg.selfUser, recipients: [eg.selfUser] })],
       ['other 1:1 message, inbound', false, eg.pmMessage()],
       ['other 1:1 message, outbound', false, eg.pmMessage({ sender: eg.selfUser })],
@@ -304,12 +304,12 @@ describe('getNarrowFromMessage', () => {
         eg.pmMessage({ sender: eg.selfUser, recipients: [eg.selfUser] }),
         eg.selfUser,
       ),
-    ).toEqual(privateNarrow(eg.selfUser.email));
+    ).toEqual(pmNarrowFromEmail(eg.selfUser.email));
   });
 
   test('for 1:1 PM, returns a 1:1 PM narrow', () => {
     const message = eg.pmMessage();
-    const expectedNarrow = privateNarrow(eg.otherUser.email);
+    const expectedNarrow = pmNarrowFromEmail(eg.otherUser.email);
 
     const actualNarrow = getNarrowFromMessage(message, eg.selfUser);
 

--- a/src/utils/__tests__/narrow-test.js
+++ b/src/utils/__tests__/narrow-test.js
@@ -16,7 +16,7 @@ import {
   isTopicNarrow,
   SEARCH_NARROW,
   isSearchNarrow,
-  isPrivateOrGroupNarrow,
+  isPmNarrow,
   isMessageInNarrow,
   isSameNarrow,
   isStreamOrTopicNarrow,
@@ -95,16 +95,14 @@ describe('pmNarrowFromEmails', () => {
   });
 });
 
-describe('isPrivateOrGroupNarrow', () => {
+describe('isPmNarrow', () => {
   test('a private or group narrow is any "pm-with" narrow', () => {
-    expect(isPrivateOrGroupNarrow(undefined)).toBe(false);
-    expect(isPrivateOrGroupNarrow(HOME_NARROW)).toBe(false);
-    expect(isPrivateOrGroupNarrow(pmNarrowFromEmail('bob@example.com'))).toBe(true);
+    expect(isPmNarrow(undefined)).toBe(false);
+    expect(isPmNarrow(HOME_NARROW)).toBe(false);
+    expect(isPmNarrow(pmNarrowFromEmail('bob@example.com'))).toBe(true);
+    expect(isPmNarrow(pmNarrowFromEmails(['bob@example.com', 'john@example.com']))).toBe(true);
     expect(
-      isPrivateOrGroupNarrow(pmNarrowFromEmails(['bob@example.com', 'john@example.com'])),
-    ).toBe(true);
-    expect(
-      isPrivateOrGroupNarrow([
+      isPmNarrow([
         {
           operator: 'pm-with',
           operand: 'bob@example.com',
@@ -112,7 +110,7 @@ describe('isPrivateOrGroupNarrow', () => {
       ]),
     ).toBe(true);
     expect(
-      isPrivateOrGroupNarrow([
+      isPmNarrow([
         {
           operator: 'pm-with',
           operand: 'bob@example.com,john@example.com',

--- a/src/utils/__tests__/narrow-test.js
+++ b/src/utils/__tests__/narrow-test.js
@@ -4,9 +4,9 @@ import {
   HOME_NARROW,
   isHomeNarrow,
   pmNarrowFromEmail,
-  isPrivateNarrow,
+  is1to1PmNarrow,
   pmNarrowFromEmails,
-  isGroupNarrow,
+  isGroupPmNarrow,
   specialNarrow,
   isSpecialNarrow,
   ALL_PRIVATE_NARROW,
@@ -49,10 +49,10 @@ describe('pmNarrowFromEmail', () => {
   });
 
   test('if operator is "pm-with" and only one email, then it is a private narrow', () => {
-    expect(isPrivateNarrow(HOME_NARROW)).toBe(false);
-    expect(isPrivateNarrow(pmNarrowFromEmail('bob@example.com'))).toBe(true);
+    expect(is1to1PmNarrow(HOME_NARROW)).toBe(false);
+    expect(is1to1PmNarrow(pmNarrowFromEmail('bob@example.com'))).toBe(true);
     expect(
-      isPrivateNarrow([
+      is1to1PmNarrow([
         {
           operator: 'pm-with',
           operand: 'bob@example.com',
@@ -73,11 +73,11 @@ describe('pmNarrowFromEmails', () => {
   });
 
   test('a group narrow is only private chat with more than one recipients', () => {
-    expect(isGroupNarrow(HOME_NARROW)).toBe(false);
-    expect(isGroupNarrow(pmNarrowFromEmail('bob@example.com'))).toBe(false);
-    expect(isGroupNarrow(pmNarrowFromEmails(['bob@example.com', 'john@example.com']))).toBe(true);
+    expect(isGroupPmNarrow(HOME_NARROW)).toBe(false);
+    expect(isGroupPmNarrow(pmNarrowFromEmail('bob@example.com'))).toBe(false);
+    expect(isGroupPmNarrow(pmNarrowFromEmails(['bob@example.com', 'john@example.com']))).toBe(true);
     expect(
-      isGroupNarrow([
+      isGroupPmNarrow([
         {
           operator: 'pm-with',
           operand: 'bob@example.com',
@@ -85,7 +85,7 @@ describe('pmNarrowFromEmails', () => {
       ]),
     ).toBe(false);
     expect(
-      isGroupNarrow([
+      isGroupPmNarrow([
         {
           operator: 'pm-with',
           operand: 'bob@example.com,john@example.com',

--- a/src/utils/internalLinks.js
+++ b/src/utils/internalLinks.js
@@ -1,7 +1,7 @@
 /* @flow strict-local */
 import { addBreadcrumb } from '@sentry/react-native';
 import type { Narrow, Stream, User } from '../types';
-import { topicNarrow, streamNarrow, groupNarrow, specialNarrow } from './narrow';
+import { topicNarrow, streamNarrow, pmNarrowFromEmails, specialNarrow } from './narrow';
 import { pmKeyRecipientsFromIds } from './recipient';
 import { isUrlOnRealm } from './url';
 
@@ -130,7 +130,7 @@ export const getNarrowFromLink = (
     case 'pm': {
       const ids = parsePmOperand(paths[1], usersById, ownUserId);
       const users = pmKeyRecipientsFromIds(ids, usersById, ownUserId);
-      return users && groupNarrow(users.map(u => u.email));
+      return users && pmNarrowFromEmails(users.map(u => u.email));
     }
     case 'topic':
       return topicNarrow(parseStreamOperand(paths[1], streamsById), parseTopicOperand(paths[3]));

--- a/src/utils/narrow.js
+++ b/src/utils/narrow.js
@@ -23,7 +23,7 @@ export const HOME_NARROW_STR: string = '[]';
  * A PM narrow -- either 1:1 or group.
  *
  * Private to this module because the input format is kind of odd.
- * Use `privateNarrow` or `groupNarrow` instead.
+ * Use `pmNarrowFromEmail` or `groupNarrow` instead.
  *
  * For the quirks of the underlying format in the Zulip API, see:
  *   https://zulipchat.com/api/construct-narrow
@@ -36,7 +36,7 @@ const pmNarrowByString = (emails: string): Narrow => [
   },
 ];
 
-export const privateNarrow = (email: string): Narrow => pmNarrowByString(email);
+export const pmNarrowFromEmail = (email: string): Narrow => pmNarrowByString(email);
 
 /**
  * A group PM narrow.

--- a/src/utils/narrow.js
+++ b/src/utils/narrow.js
@@ -19,12 +19,24 @@ export const HOME_NARROW: Narrow = [];
 
 export const HOME_NARROW_STR: string = '[]';
 
-export const privateNarrow = (email: string): Narrow => [
+/**
+ * A PM narrow -- either 1:1 or group.
+ *
+ * Private to this module because the input format is kind of odd.
+ * Use `privateNarrow` or `groupNarrow` instead.
+ *
+ * For the quirks of the underlying format in the Zulip API, see:
+ *   https://zulipchat.com/api/construct-narrow
+ *   https://github.com/zulip/zulip/issues/13167
+ */
+const pmNarrowByString = (emails: string): Narrow => [
   {
     operator: 'pm-with',
-    operand: email,
+    operand: emails,
   },
 ];
+
+export const privateNarrow = (email: string): Narrow => pmNarrowByString(email);
 
 /**
  * A group PM narrow.
@@ -66,12 +78,7 @@ export const privateNarrow = (email: string): Narrow => [
 //      notification's pm_users, which is sorted.
 //  * Good: messageHeaderAsHtml: comes from pmKeyRecipientsFromMessage,
 //      which filters and sorts by ID
-export const groupNarrow = (emails: string[]): Narrow => [
-  {
-    operator: 'pm-with',
-    operand: emails.join(),
-  },
-];
+export const groupNarrow = (emails: string[]): Narrow => pmNarrowByString(emails.join());
 
 export const specialNarrow = (operand: string): Narrow => [
   {

--- a/src/utils/narrow.js
+++ b/src/utils/narrow.js
@@ -36,8 +36,6 @@ const pmNarrowByString = (emails: string): Narrow => [
   },
 ];
 
-export const pmNarrowFromEmail = (email: string): Narrow => pmNarrowByString(email);
-
 /**
  * A group PM narrow.
  *
@@ -79,6 +77,9 @@ export const pmNarrowFromEmail = (email: string): Narrow => pmNarrowByString(ema
 //  * Good: messageHeaderAsHtml: comes from pmKeyRecipientsFromMessage,
 //      which filters and sorts by ID
 export const pmNarrowFromEmails = (emails: string[]): Narrow => pmNarrowByString(emails.join());
+
+/** Convenience wrapper for `pmNarrowFromEmails`. */
+export const pmNarrowFromEmail = (email: string): Narrow => pmNarrowFromEmails([email]);
 
 export const specialNarrow = (operand: string): Narrow => [
   {

--- a/src/utils/narrow.js
+++ b/src/utils/narrow.js
@@ -235,7 +235,7 @@ export const isGroupPmNarrow = (narrow?: Narrow): boolean =>
 export const emailsOfGroupNarrow = (narrow: Narrow): string[] =>
   caseNarrowPartial(narrow, { groupPm: emails => emails });
 
-export const isPrivateOrGroupNarrow = (narrow?: Narrow): boolean =>
+export const isPmNarrow = (narrow?: Narrow): boolean =>
   !!narrow && caseNarrowDefault(narrow, { pm: () => true, groupPm: () => true }, () => false);
 
 export const isSpecialNarrow = (narrow?: Narrow): boolean =>

--- a/src/utils/narrow.js
+++ b/src/utils/narrow.js
@@ -220,10 +220,10 @@ export function caseNarrowDefault<T>(
 export const isHomeNarrow = (narrow?: Narrow): boolean =>
   !!narrow && caseNarrowDefault(narrow, { home: () => true }, () => false);
 
-export const isPrivateNarrow = (narrow?: Narrow): boolean =>
+export const is1to1PmNarrow = (narrow?: Narrow): boolean =>
   !!narrow && caseNarrowDefault(narrow, { pm: () => true }, () => false);
 
-export const isGroupNarrow = (narrow?: Narrow): boolean =>
+export const isGroupPmNarrow = (narrow?: Narrow): boolean =>
   !!narrow && caseNarrowDefault(narrow, { groupPm: () => true }, () => false);
 
 /**

--- a/src/utils/narrow.js
+++ b/src/utils/narrow.js
@@ -23,7 +23,7 @@ export const HOME_NARROW_STR: string = '[]';
  * A PM narrow -- either 1:1 or group.
  *
  * Private to this module because the input format is kind of odd.
- * Use `pmNarrowFromEmail` or `groupNarrow` instead.
+ * Use `pmNarrowFromEmail` or `pmNarrowFromEmails` instead.
  *
  * For the quirks of the underlying format in the Zulip API, see:
  *   https://zulipchat.com/api/construct-narrow
@@ -78,7 +78,7 @@ export const pmNarrowFromEmail = (email: string): Narrow => pmNarrowByString(ema
 //      notification's pm_users, which is sorted.
 //  * Good: messageHeaderAsHtml: comes from pmKeyRecipientsFromMessage,
 //      which filters and sorts by ID
-export const groupNarrow = (emails: string[]): Narrow => pmNarrowByString(emails.join());
+export const pmNarrowFromEmails = (emails: string[]): Narrow => pmNarrowByString(emails.join());
 
 export const specialNarrow = (operand: string): Narrow => [
   {
@@ -328,7 +328,7 @@ export const canSendToNarrow = (narrow: Narrow): boolean =>
 // TODO: do that, or just make this a private local helper of its one caller
 export const getNarrowFromMessage = (message: Message | Outbox, ownUser: User) => {
   if (message.type === 'private') {
-    return groupNarrow(pmKeyRecipientsFromMessage(message, ownUser).map(x => x.email));
+    return pmNarrowFromEmails(pmKeyRecipientsFromMessage(message, ownUser).map(x => x.email));
   } else {
     const streamName = streamNameOfStreamMessage(message);
     const topic = message.subject;

--- a/src/utils/narrow.js
+++ b/src/utils/narrow.js
@@ -232,7 +232,7 @@ export const isGroupPmNarrow = (narrow?: Narrow): boolean =>
  * Any use of this probably means something higher up should be refactored
  * to use caseNarrow.
  */
-export const emailsOfGroupNarrow = (narrow: Narrow): string[] =>
+export const emailsOfGroupPmNarrow = (narrow: Narrow): string[] =>
   caseNarrowPartial(narrow, { groupPm: emails => emails });
 
 export const isPmNarrow = (narrow?: Narrow): boolean =>

--- a/src/webview/html/messageHeaderAsHtml.js
+++ b/src/webview/html/messageHeaderAsHtml.js
@@ -34,7 +34,6 @@ export default (
     topic: () => 'none',
 
     pm: () => 'none',
-    groupPm: () => 'none',
 
     home: () => 'full',
     starred: () => 'full',

--- a/src/webview/html/messageHeaderAsHtml.js
+++ b/src/webview/html/messageHeaderAsHtml.js
@@ -6,7 +6,7 @@ import {
   streamNarrow,
   topicNarrow,
   pmNarrowFromEmail,
-  groupNarrow,
+  pmNarrowFromEmails,
   caseNarrow,
 } from '../../utils/narrow';
 import { foregroundColorFromBackground } from '../../utils/color';
@@ -95,7 +95,7 @@ export default (
     const narrowObj =
       keyRecipients.length === 1
         ? pmNarrowFromEmail(keyRecipients[0].email)
-        : groupNarrow(keyRecipients.map(r => r.email));
+        : pmNarrowFromEmails(keyRecipients.map(r => r.email));
     const privateNarrowStr = JSON.stringify(narrowObj);
 
     const uiRecipients = pmUiRecipientsFromMessage(item, ownUser);

--- a/src/webview/html/messageHeaderAsHtml.js
+++ b/src/webview/html/messageHeaderAsHtml.js
@@ -5,7 +5,7 @@ import type { BackgroundData } from '../MessageList';
 import {
   streamNarrow,
   topicNarrow,
-  privateNarrow,
+  pmNarrowFromEmail,
   groupNarrow,
   caseNarrow,
 } from '../../utils/narrow';
@@ -94,7 +94,7 @@ export default (
     const keyRecipients = pmKeyRecipientsFromMessage(item, ownUser);
     const narrowObj =
       keyRecipients.length === 1
-        ? privateNarrow(keyRecipients[0].email)
+        ? pmNarrowFromEmail(keyRecipients[0].email)
         : groupNarrow(keyRecipients.map(r => r.email));
     const privateNarrowStr = JSON.stringify(narrowObj);
 


### PR DESCRIPTION
We have two "constructors" `privateNarrow` and `groupNarrow` for 1:1 PMs and group PMs respectively, but they end up building basically the same data structure.  Then in a lot of places in our code we have control flow to handle the group-PM case on the one hand and the 1:1 case on the other, and it ends up just saying the same thing twice to treat them both the same way.  (In a few places, like `getNarrowFromMessage`, we have no such logic and already implicitly rely on the fact that they're the same underneath.)

In general the Zulip model is that group PMs and 1:1 PMs are very much alike, and the Zulip API generally treats them alike.  So let's move toward more consistently handling them alike, and only having conditionals to distinguish between them when we actually want to do something different.

I wrote the bulk of these changes back in February, as part of a larger draft branch for refactoring our handling of narrows. Prompted today by https://github.com/zulip/zulip-mobile/pull/4317#discussion_r537995930 , I went and took another look at that branch. Here's a portion of it -- rebased forward, and with proper commit messages added where it didn't have them. (For some other portions of the original branch, I'm either not convinced they're the right direction or they just need a bit more work.)
