### PR TITLE
narrow/recipient: Fix more bugs, and prep for bigger refactors

### DIFF
--- a/jest/jestSetup.js
+++ b/jest/jestSetup.js
@@ -101,3 +101,19 @@ jest.mock('react-native-image-picker', () => ({
   launchCamera: jest.fn(),
   launchImageLibrary: jest.fn(),
 }));
+
+// Set up our `logging` module with mocks, which tests can use as desired.
+//
+// This global version just passes the calls right through to the real
+// implementations.  To suppress logging in a specific test, make a call
+// like `logging.warn.mockReturnValue()`.  For more, see:
+//   https://jestjs.io/docs/en/mock-function-api
+// or search our code for `logging.warn.` for examples.
+jest.mock('../src/utils/logging', () => {
+  const logging = jest.requireActual('../src/utils/logging');
+  return {
+    __esModule: true, // eslint-disable-line id-match
+    error: jest.fn().mockImplementation(logging.error),
+    warn: jest.fn().mockImplementation(logging.warn),
+  };
+});

--- a/src/boot/loggingContext.js
+++ b/src/boot/loggingContext.js
@@ -1,0 +1,47 @@
+/**
+ * A dead-drop for select data to be included in log events.
+ *
+ * More precisely, for a getter for that data; this way we don't have to be
+ * constantly updating it, as we would if this module contained a copy of
+ * the data itself.
+ *
+ * This arrangement provides a way for the logging code to get this
+ * information without having to import the Redux store.  Otherwise we tend
+ * to get nasty import cycles, because logging is naturally low in the
+ * import graph (imported by lots of other modules) and the app's Redux
+ * store is naturally high in the import graph (importing lots of other
+ * modules).
+ *
+ * @flow strict-local
+ */
+import type { ZulipVersion } from '../utils/zulipVersion';
+
+type LoggingContext = {|
+  serverVersion: ZulipVersion | null,
+|};
+
+let getter: (() => LoggingContext) | null = null;
+
+/**
+ * The logging context, or null if none is available.
+ *
+ * The null case should only happen if we haven't even finished importing
+ * our code yet, in particular the code that provides the Redux store.
+ */
+export const getLoggingContext = (): LoggingContext | null => getter && getter();
+
+/**
+ * Set the getter for the logging context.
+ *
+ * This is called once at startup, after the Redux store is created.
+ */
+// Effectively the getter will contain:
+//  * a reference to the Redux store, to get the state;
+//  * references to some selectors, to pick the relevant data out of the
+//    Redux state.
+// We don't want the logging code to have to know about either of those,
+// lest we create import cycles.  So the getter's implementation lives
+// completely elsewhere and gets injected here.
+export const provideLoggingContext = (newGetter: () => LoggingContext) => {
+  getter = newGetter;
+};

--- a/src/boot/store.js
+++ b/src/boot/store.js
@@ -16,6 +16,8 @@ import { REHYDRATE } from '../actionConstants';
 import rootReducer from './reducers';
 import ZulipAsyncStorage from './ZulipAsyncStorage';
 import createMigration from '../redux-persist-migrate/index';
+import { provideLoggingContext } from './loggingContext';
+import { tryGetActiveAccount } from '../account/accountsSelectors';
 
 // AsyncStorage.clear(); // use to reset storage during development
 
@@ -265,6 +267,10 @@ const store: Store<GlobalState, Action> = createStore(
     autoRehydrate(),
   ),
 );
+
+provideLoggingContext(() => ({
+  serverVersion: tryGetActiveAccount(store.getState())?.zulipVersion ?? null,
+}));
 
 /**
  * A special identifier used by `remotedev-serialize`.

--- a/src/common/PresenceStatusIndicator.js
+++ b/src/common/PresenceStatusIndicator.js
@@ -3,12 +3,12 @@ import React, { PureComponent } from 'react';
 import { View } from 'react-native';
 import type { ViewStyleProp } from 'react-native/Libraries/StyleSheet/StyleSheet';
 
-import type { PresenceState, User, UserStatusMapObject, Dispatch } from '../types';
+import type { PresenceState, UserOrBot, UserStatusMapObject, Dispatch } from '../types';
 import { createStyleSheet } from '../styles';
 import { connect } from '../react-redux';
 import { statusFromPresenceAndUserStatus } from '../utils/presence';
 import { getPresence, getUserStatus } from '../selectors';
-import { getUsersByEmail } from '../users/userSelectors';
+import { getAllUsersByEmail } from '../users/userSelectors';
 import { ensureUnreachable } from '../types';
 
 const styles = createStyleSheet({
@@ -72,7 +72,7 @@ const PresenceStatusIndicatorUnavailable = ({ style }: { style: ViewStyleProp })
 type PropsFromConnect = {|
   dispatch: Dispatch,
   presence: PresenceState,
-  usersByEmail: Map<string, User>,
+  allUsersByEmail: Map<string, UserOrBot>,
   userStatus: UserStatusMapObject,
 |};
 
@@ -95,10 +95,10 @@ type Props = $ReadOnly<{|
  */
 class PresenceStatusIndicator extends PureComponent<Props> {
   render() {
-    const { email, presence, style, hideIfOffline, usersByEmail, userStatus } = this.props;
+    const { email, presence, style, hideIfOffline, allUsersByEmail, userStatus } = this.props;
 
     const userPresence = presence[email];
-    const user = usersByEmail.get(email);
+    const user = allUsersByEmail.get(email);
 
     if (!user || !userPresence || !userPresence.aggregated) {
       return null;
@@ -132,6 +132,6 @@ class PresenceStatusIndicator extends PureComponent<Props> {
 
 export default connect(state => ({
   presence: getPresence(state),
-  usersByEmail: getUsersByEmail(state),
+  allUsersByEmail: getAllUsersByEmail(state),
   userStatus: getUserStatus(state),
 }))(PresenceStatusIndicator);

--- a/src/message/messagesActions.js
+++ b/src/message/messagesActions.js
@@ -1,7 +1,7 @@
 /* @flow strict-local */
 import NavigationService from '../nav/NavigationService';
 import type { Narrow, Dispatch, GetState } from '../types';
-import { getAuth, getUsersById } from '../selectors';
+import { getAuth, getAllUsersById } from '../selectors';
 import { getMessageIdFromLink, getNarrowFromLink } from '../utils/internalLinks';
 import openLink from '../utils/openLink';
 import { navigateToChat } from '../nav/navActions';
@@ -28,10 +28,10 @@ export const messageLinkPress = (href: string) => async (
 ) => {
   const state = getState();
   const auth = getAuth(state);
-  const usersById = getUsersById(state);
+  const allUsersById = getAllUsersById(state);
   const streamsById = getStreamsById(state);
   const ownUserId = getOwnUserId(state);
-  const narrow = getNarrowFromLink(href, auth.realm, usersById, streamsById, ownUserId);
+  const narrow = getNarrowFromLink(href, auth.realm, allUsersById, streamsById, ownUserId);
   if (narrow) {
     const anchor = getMessageIdFromLink(href, auth.realm);
     dispatch(doNarrow(narrow, anchor));

--- a/src/notification/__tests__/notification-test.js
+++ b/src/notification/__tests__/notification-test.js
@@ -1,7 +1,7 @@
 // @flow strict-local
 import deepFreeze from 'deep-freeze';
 
-import type { User } from '../../api/modelTypes';
+import type { UserOrBot } from '../../api/modelTypes';
 import type { JSONableDict } from '../../utils/jsonable';
 import { getNarrowFromNotificationData } from '..';
 import { topicNarrow, pmNarrowFromEmail, pmNarrowFromEmails } from '../../utils/narrow';
@@ -11,7 +11,7 @@ import { fromAPNsImpl as extractIosNotificationData } from '../extract';
 import objectEntries from '../../utils/objectEntries';
 
 describe('getNarrowFromNotificationData', () => {
-  const DEFAULT_MAP = new Map<number, User>();
+  const DEFAULT_MAP = new Map<number, UserOrBot>();
   const ownUserId = eg.selfUser.user_id;
 
   test('unknown notification data returns null', () => {
@@ -42,7 +42,7 @@ describe('getNarrowFromNotificationData', () => {
 
   test('on notification for a group message returns a group narrow', () => {
     const users = [eg.selfUser, eg.makeUser(), eg.makeUser(), eg.makeUser()];
-    const usersById: Map<number, User> = new Map(users.map(u => [u.user_id, u]));
+    const allUsersById: Map<number, UserOrBot> = new Map(users.map(u => [u.user_id, u]));
 
     const notification = {
       recipient_type: 'private',
@@ -51,7 +51,7 @@ describe('getNarrowFromNotificationData', () => {
 
     const expectedNarrow = pmNarrowFromEmails(users.slice(1).map(u => u.email));
 
-    const narrow = getNarrowFromNotificationData(notification, usersById, ownUserId);
+    const narrow = getNarrowFromNotificationData(notification, allUsersById, ownUserId);
 
     expect(narrow).toEqual(expectedNarrow);
   });

--- a/src/notification/extract.js
+++ b/src/notification/extract.js
@@ -186,7 +186,11 @@ export const fromAPNsImpl = (rawData: JSONableDict): Notification | void => {
       if (ids.some(id => Number.isNaN(id))) {
         throw err('invalid');
       }
-      return { recipient_type: 'private', pm_users: ids.sort().join(','), ...realm_uri_obj };
+      return {
+        recipient_type: 'private',
+        pm_users: ids.sort((a, b) => a - b).join(','),
+        ...realm_uri_obj,
+      };
     }
 
     if (typeof sender_email !== 'string') {

--- a/src/notification/index.js
+++ b/src/notification/index.js
@@ -3,7 +3,7 @@ import { DeviceEventEmitter, NativeModules, Platform, PushNotificationIOS } from
 import NotificationsIOS from 'react-native-notifications';
 
 import type { Notification } from './types';
-import type { Auth, Dispatch, Identity, Narrow, User } from '../types';
+import type { Auth, Dispatch, Identity, Narrow, UserOrBot } from '../types';
 import { topicNarrow, pmNarrowFromEmail, pmNarrowFromEmails } from '../utils/narrow';
 import type { JSONable, JSONableDict } from '../utils/jsonable';
 import * as api from '../api';
@@ -85,7 +85,7 @@ export const getAccountFromNotificationData = (
 
 export const getNarrowFromNotificationData = (
   data: Notification,
-  usersById: Map<number, User>,
+  allUsersById: Map<number, UserOrBot>,
   ownUserId: number,
 ): Narrow | null => {
   if (!data.recipient_type) {
@@ -106,7 +106,7 @@ export const getNarrowFromNotificationData = (
   }
 
   const ids = data.pm_users.split(',').map(s => parseInt(s, 10));
-  const users = pmKeyRecipientsFromIds(ids, usersById, ownUserId);
+  const users = pmKeyRecipientsFromIds(ids, allUsersById, ownUserId);
   return users && pmNarrowFromEmails(users.map(u => u.email));
 };
 

--- a/src/notification/notificationActions.js
+++ b/src/notification/notificationActions.js
@@ -14,7 +14,7 @@ import { getAuth, getActiveAccount } from '../selectors';
 import { getSession, getAccounts } from '../directSelectors';
 import { GOT_PUSH_TOKEN, ACK_PUSH_TOKEN, UNACK_PUSH_TOKEN } from '../actionConstants';
 import { identityOfAccount, authOfAccount } from '../account/accountMisc';
-import { getOwnUserId, getUsersById } from '../users/userSelectors';
+import { getAllUsersById, getOwnUserId } from '../users/userSelectors';
 import { doNarrow } from '../message/messagesActions';
 import { accountSwitch } from '../account/accountActions';
 import { getIdentities } from '../account/accountsSelectors';
@@ -52,7 +52,7 @@ export const narrowToNotification = (data: ?Notification) => (
     return;
   }
 
-  const narrow = getNarrowFromNotificationData(data, getUsersById(state), getOwnUserId(state));
+  const narrow = getNarrowFromNotificationData(data, getAllUsersById(state), getOwnUserId(state));
   if (narrow) {
     dispatch(doNarrow(narrow));
   }

--- a/src/typing/__tests__/typingSelectors-test.js
+++ b/src/typing/__tests__/typingSelectors-test.js
@@ -34,10 +34,7 @@ describe('getCurrentTypingUsers', () => {
     const user1 = eg.makeUser();
     const user2 = eg.makeUser();
 
-    const normalizedRecipients = normalizeRecipientsAsUserIds([
-      { user_id: user1.user_id },
-      { user_id: user2.user_id },
-    ]);
+    const normalizedRecipients = normalizeRecipientsAsUserIds([user1.user_id, user2.user_id]);
 
     const state = eg.reduxState({
       typing: {
@@ -57,7 +54,7 @@ describe('getCurrentTypingUsers', () => {
   test('when in private narrow but different user is typing return NULL_ARRAY', () => {
     const user1 = eg.makeUser();
     const user2 = eg.makeUser();
-    const normalizedRecipients = normalizeRecipientsAsUserIds([{ user_id: user1.user_id }]);
+    const normalizedRecipients = normalizeRecipientsAsUserIds([user1.user_id]);
 
     const state = eg.reduxState({
       typing: {
@@ -76,8 +73,8 @@ describe('getCurrentTypingUsers', () => {
     const anotherUser = eg.makeUser();
 
     const normalizedRecipients = normalizeRecipientsAsUserIds([
-      { user_id: expectedUser.user_id },
-      { user_id: anotherUser.user_id },
+      expectedUser.user_id,
+      anotherUser.user_id,
     ]);
     const state = eg.reduxState({
       typing: {

--- a/src/typing/typingReducer.js
+++ b/src/typing/typingReducer.js
@@ -21,7 +21,7 @@ const eventTypingStart = (state, action) => {
   }
 
   const normalizedRecipients: string = normalizeRecipientsAsUserIdsSansMe(
-    action.recipients,
+    action.recipients.map(r => r.user_id),
     action.ownUserId,
   );
   const previousTypingUsers = state[normalizedRecipients] || { userIds: [] };
@@ -48,7 +48,7 @@ const eventTypingStart = (state, action) => {
 
 const eventTypingStop = (state, action) => {
   const normalizedRecipients: string = normalizeRecipientsAsUserIdsSansMe(
-    action.recipients,
+    action.recipients.map(r => r.user_id),
     action.ownUserId,
   );
   const previousTypingUsers = state[normalizedRecipients];

--- a/src/typing/typingSelectors.js
+++ b/src/typing/typingSelectors.js
@@ -23,7 +23,7 @@ export const getCurrentTypingUsers: Selector<$ReadOnlyArray<UserOrBot>, Narrow> 
       if (userId === undefined) {
         throw new Error(`Narrow contains email '${email}' that does not map to any user.`);
       }
-      return { user_id: userId };
+      return userId;
     });
     const normalizedRecipients = normalizeRecipientsAsUserIds(recipients);
     const currentTyping = typing[normalizedRecipients];

--- a/src/utils/__tests__/internalLinks-test.js
+++ b/src/utils/__tests__/internalLinks-test.js
@@ -1,6 +1,6 @@
 /* @flow strict-local */
 
-import type { User } from '../../api/modelTypes';
+import type { UserOrBot } from '../../api/modelTypes';
 import { streamNarrow, topicNarrow, pmNarrowFromEmails, STARRED_NARROW } from '../narrow';
 import {
   isInternalLink,
@@ -125,7 +125,7 @@ describe('decodeHashComponent', () => {
 
 describe('getNarrowFromLink', () => {
   const [userB, userC] = [eg.makeUser(), eg.makeUser()];
-  const usersById: Map<number, User> = new Map(
+  const allUsersById: Map<number, UserOrBot> = new Map(
     [eg.selfUser, userB, userC].map(u => [u.user_id, u]),
   );
 
@@ -135,7 +135,7 @@ describe('getNarrowFromLink', () => {
     getNarrowFromLink(
       url,
       new URL('https://example.com'),
-      usersById,
+      allUsersById,
       new Map(streams.map(s => [s.stream_id, s])),
       eg.selfUser.user_id,
     );
@@ -270,7 +270,7 @@ describe('getNarrowFromLink', () => {
   });
 
   test('if any of the user ids are not found: return null', () => {
-    const otherId = 1 + Math.max(...usersById.keys());
+    const otherId = 1 + Math.max(...allUsersById.keys());
     const ids = `${userB.user_id},${otherId}`;
     expect(get(`https://example.com/#narrow/pm-with/${ids}-group`)).toEqual(null);
   });

--- a/src/utils/__tests__/recipient-test.js
+++ b/src/utils/__tests__/recipient-test.js
@@ -5,6 +5,7 @@ import {
   normalizeRecipientsAsUserIdsSansMe,
   isSameRecipient,
 } from '../recipient';
+import * as logging from '../logging';
 
 describe('normalizeRecipients', () => {
   test('joins emails from recipients, sorted, trimmed, not including missing ones', () => {
@@ -16,9 +17,13 @@ describe('normalizeRecipients', () => {
     ];
     const expectedResult = 'abc@example.com,def@example.com,xyz@example.com';
 
-    const normalized = normalizeRecipients(recipients);
+    logging.error.mockReturnValue();
 
+    const normalized = normalizeRecipients(recipients);
     expect(normalized).toEqual(expectedResult);
+
+    expect(logging.error.mock.calls).toHaveLength(2);
+    logging.error.mockReset();
   });
 });
 
@@ -42,9 +47,13 @@ describe('normalizeRecipientsSansMe', () => {
     const ownEmail = 'me@example.com';
     const expectedResult = 'abc@example.com,def@example.com';
 
-    const normalized = normalizeRecipientsSansMe(recipients, ownEmail);
+    logging.error.mockReturnValue();
 
+    const normalized = normalizeRecipientsSansMe(recipients, ownEmail);
     expect(normalized).toEqual(expectedResult);
+
+    expect(logging.error.mock.calls).toHaveLength(1);
+    logging.error.mockReset();
   });
 });
 

--- a/src/utils/__tests__/recipient-test.js
+++ b/src/utils/__tests__/recipient-test.js
@@ -60,13 +60,13 @@ describe('normalizeRecipientsSansMe', () => {
 describe('normalizeRecipientsAsUserIds', () => {
   test('joins user IDs from recipients, sorted', () => {
     const recipients = [
-      { user_id: 2 },
+      { user_id: 22 },
       { user_id: 1 },
       { user_id: 5 },
       { user_id: 3 },
       { user_id: 4 },
     ];
-    const expectedResult = '1,2,3,4,5';
+    const expectedResult = '1,3,4,5,22';
 
     const normalized = normalizeRecipientsAsUserIds(recipients);
 
@@ -96,13 +96,13 @@ describe('normalizeRecipientsAsUserIdsSansMe', () => {
 
   test('when more than one user IDs normalize but filter out self user ID', () => {
     const recipients = [
-      { user_id: 2 },
+      { user_id: 22 },
       { user_id: 1 },
       { user_id: 5 },
       { user_id: 3 },
       { user_id: 4 },
     ];
-    const expectedResult = '2,3,4,5';
+    const expectedResult = '3,4,5,22';
     const ownUserId = 1;
 
     const normalized = normalizeRecipientsAsUserIdsSansMe(recipients, ownUserId);

--- a/src/utils/__tests__/recipient-test.js
+++ b/src/utils/__tests__/recipient-test.js
@@ -59,13 +59,7 @@ describe('normalizeRecipientsSansMe', () => {
 
 describe('normalizeRecipientsAsUserIds', () => {
   test('joins user IDs from recipients, sorted', () => {
-    const recipients = [
-      { user_id: 22 },
-      { user_id: 1 },
-      { user_id: 5 },
-      { user_id: 3 },
-      { user_id: 4 },
-    ];
+    const recipients = [22, 1, 5, 3, 4];
     const expectedResult = '1,3,4,5,22';
 
     const normalized = normalizeRecipientsAsUserIds(recipients);
@@ -74,7 +68,7 @@ describe('normalizeRecipientsAsUserIds', () => {
   });
 
   test('for a single recipient, returns the user ID as string', () => {
-    const recipients = [{ user_id: 1 }];
+    const recipients = [1];
     const expectedResult = '1';
 
     const normalized = normalizeRecipientsAsUserIds(recipients);
@@ -85,7 +79,7 @@ describe('normalizeRecipientsAsUserIds', () => {
 
 describe('normalizeRecipientsAsUserIdsSansMe', () => {
   test('if only self user ID provided return unmodified', () => {
-    const recipients = [{ user_id: 1 }];
+    const recipients = [1];
     const ownUserId = 1;
     const expectedResult = '1';
 
@@ -95,13 +89,7 @@ describe('normalizeRecipientsAsUserIdsSansMe', () => {
   });
 
   test('when more than one user IDs normalize but filter out self user ID', () => {
-    const recipients = [
-      { user_id: 22 },
-      { user_id: 1 },
-      { user_id: 5 },
-      { user_id: 3 },
-      { user_id: 4 },
-    ];
+    const recipients = [22, 1, 5, 3, 4];
     const expectedResult = '3,4,5,22';
     const ownUserId = 1;
 

--- a/src/utils/internalLinks.js
+++ b/src/utils/internalLinks.js
@@ -111,7 +111,7 @@ const parseStreamOperand = (operand, streamsById): string => {
 const parseTopicOperand = operand => decodeHashComponent(operand);
 
 /** Parse the operand of a `pm-with` operator. */
-const parsePmOperand = (operand, usersById, ownUserId) => {
+const parsePmOperand = operand => {
   const idStrs = operand.split('-')[0].split(',');
   return idStrs.map(s => parseInt(s, 10));
 };
@@ -128,7 +128,7 @@ export const getNarrowFromLink = (
 
   switch (type) {
     case 'pm': {
-      const ids = parsePmOperand(paths[1], usersById, ownUserId);
+      const ids = parsePmOperand(paths[1]);
       const users = pmKeyRecipientsFromIds(ids, usersById, ownUserId);
       return users && pmNarrowFromEmails(users.map(u => u.email));
     }

--- a/src/utils/internalLinks.js
+++ b/src/utils/internalLinks.js
@@ -1,6 +1,6 @@
 /* @flow strict-local */
 import { addBreadcrumb } from '@sentry/react-native';
-import type { Narrow, Stream, User } from '../types';
+import type { Narrow, Stream, UserOrBot } from '../types';
 import { topicNarrow, streamNarrow, pmNarrowFromEmails, specialNarrow } from './narrow';
 import { pmKeyRecipientsFromIds } from './recipient';
 import { isUrlOnRealm } from './url';
@@ -119,7 +119,7 @@ const parsePmOperand = operand => {
 export const getNarrowFromLink = (
   url: string,
   realm: URL,
-  usersById: Map<number, User>,
+  allUsersById: Map<number, UserOrBot>,
   streamsById: Map<number, Stream>,
   ownUserId: number,
 ): Narrow | null => {
@@ -129,7 +129,7 @@ export const getNarrowFromLink = (
   switch (type) {
     case 'pm': {
       const ids = parsePmOperand(paths[1]);
-      const users = pmKeyRecipientsFromIds(ids, usersById, ownUserId);
+      const users = pmKeyRecipientsFromIds(ids, allUsersById, ownUserId);
       return users && pmNarrowFromEmails(users.map(u => u.email));
     }
     case 'topic':

--- a/src/utils/logging.js
+++ b/src/utils/logging.js
@@ -2,11 +2,10 @@
 import type { Scope, SeverityType, EventHint } from '@sentry/react-native';
 import { getCurrentHub, Severity, withScope as withScopeImpl } from '@sentry/react-native';
 
-import store from '../boot/store';
 import type { JSONable } from './jsonable';
 import objectEntries from './objectEntries';
 import config from '../config';
-import { tryGetActiveAccount } from '../account/accountsSelectors';
+import { getLoggingContext } from '../boot/loggingContext';
 
 /** Type of "extras" intended for Sentry. */
 // This type should be exact, but cannot be until Flow v0.126.0. (See note in
@@ -27,7 +26,7 @@ function withScope<R>(callback: Scope => R): R {
  * Get server-version tags at various levels of granularity.
  */
 const getServerVersionTags = () => {
-  const zulipVersion = tryGetActiveAccount(store.getState())?.zulipVersion;
+  const zulipVersion = getLoggingContext()?.serverVersion;
 
   // Why might we not have the server version? If there's no active
   // account.

--- a/src/utils/narrow.js
+++ b/src/utils/narrow.js
@@ -20,7 +20,7 @@ export const HOME_NARROW: Narrow = [];
 export const HOME_NARROW_STR: string = '[]';
 
 /**
- * A PM narrow -- either 1:1 or group.
+ * A PM narrow, either 1:1 or group.
  *
  * Private to this module because the input format is kind of odd.
  * Use `pmNarrowFromEmail` or `pmNarrowFromEmails` instead.
@@ -37,7 +37,7 @@ const pmNarrowByString = (emails: string): Narrow => [
 ];
 
 /**
- * A group PM narrow.
+ * A PM narrow, either 1:1 or group.
  *
  * The users represented in `emails` should agree, as a (multi)set, with
  * `pmKeyRecipientsFromMessage`.  But this isn't checked, and we've had bugs

--- a/src/utils/narrow.js
+++ b/src/utils/narrow.js
@@ -71,7 +71,7 @@ const pmNarrowByString = (emails: string): Narrow => [
 //      the webapp, where the URL that appears in the location bar for a
 //      group PM conversation excludes self -- so it's unusable if you try
 //      to give someone else in it a link to a particular message, say.
-//  * OK, unsorted: getNarrowFromMessage
+//  * OK, unsorted: getNarrowForReply
 //  * Good: getNarrowFromNotificationData: filters, and starts from
 //      notification's pm_users, which is sorted.
 //  * Good: messageHeaderAsHtml: comes from pmKeyRecipientsFromMessage,

--- a/src/utils/recipient.js
+++ b/src/utils/recipient.js
@@ -1,7 +1,7 @@
 /* @flow strict-local */
 import invariant from 'invariant';
 
-import type { PmRecipientUser, Message, Outbox, User } from '../types';
+import type { PmRecipientUser, Message, Outbox, User, UserOrBot } from '../types';
 import * as logging from './logging';
 
 /** The stream name a stream message was sent to.  Throws if a PM. */
@@ -175,15 +175,15 @@ export const pmKeyRecipientsFromMessage = (
  */
 export const pmKeyRecipientsFromIds = (
   userIds: number[],
-  usersById: Map<number, User>,
+  allUsersById: Map<number, UserOrBot>,
   ownUserId: number,
-): User[] | null => {
+): UserOrBot[] | null => {
   const users = [];
   for (const id of userIds) {
     if (id === ownUserId && userIds.length > 1) {
       continue;
     }
-    const user = usersById.get(id);
+    const user = allUsersById.get(id);
     if (!user) {
       return null;
     }

--- a/src/utils/recipient.js
+++ b/src/utils/recipient.js
@@ -40,6 +40,21 @@ const filterRecipients = (
 ): $ReadOnlyArray<PmRecipientUser> =>
   recipients.length === 1 ? recipients : recipients.filter(r => r.id !== ownUserId);
 
+// Like filterRecipients, but the property is called `user_id`.
+const filterRecipientsByUserId = <T: { +user_id: number, ... }>(
+  recipients: $ReadOnlyArray<T>,
+  ownUserId: number,
+): $ReadOnlyArray<T> =>
+  recipients.length === 1 ? recipients : recipients.filter(r => r.user_id !== ownUserId);
+
+// Like filterRecipients, but identifying users by email address.
+// Prefer filterRecipients instead.
+const filterRecipientsByEmail = <T: { +email: string, ... }>(
+  recipients: $ReadOnlyArray<T>,
+  ownEmail: string,
+): $ReadOnlyArray<T> =>
+  recipients.length === 1 ? recipients : recipients.filter(r => r.email !== ownEmail);
+
 /** PRIVATE -- exported only for tests. */
 export const normalizeRecipients = (recipients: $ReadOnlyArray<{ +email: string, ... }>) => {
   const emails = recipients.map(r => r.email);
@@ -78,10 +93,7 @@ export const normalizeRecipients = (recipients: $ReadOnlyArray<{ +email: string,
 export const normalizeRecipientsSansMe = (
   recipients: $ReadOnlyArray<{ +email: string, ... }>,
   ownEmail: string,
-) =>
-  recipients.length === 1
-    ? recipients[0].email
-    : normalizeRecipients(recipients.filter(r => r.email !== ownEmail));
+) => normalizeRecipients(filterRecipientsByEmail(recipients, ownEmail));
 
 export const normalizeRecipientsAsUserIds = (
   recipients: $ReadOnlyArray<{ +user_id: number, ... }>,
@@ -103,10 +115,7 @@ export const normalizeRecipientsAsUserIds = (
 export const normalizeRecipientsAsUserIdsSansMe = (
   recipients: $ReadOnlyArray<{ +user_id: number, ... }>,
   ownUserId: number,
-) =>
-  recipients.length === 1
-    ? recipients[0].user_id.toString()
-    : normalizeRecipientsAsUserIds(recipients.filter(r => r.user_id !== ownUserId));
+) => normalizeRecipientsAsUserIds(filterRecipientsByUserId(recipients, ownUserId));
 
 /**
  * The set of users to show in the UI to identify a PM conversation.

--- a/src/utils/recipient.js
+++ b/src/utils/recipient.js
@@ -40,12 +40,11 @@ const filterRecipients = (
 ): $ReadOnlyArray<PmRecipientUser> =>
   recipients.length === 1 ? recipients : recipients.filter(r => r.id !== ownUserId);
 
-// Like filterRecipients, but the property is called `user_id`.
-const filterRecipientsByUserId = <T: { +user_id: number, ... }>(
-  recipients: $ReadOnlyArray<T>,
+// Like filterRecipients, but on user IDs directly.
+const filterRecipientsAsUserIds = <T: $ReadOnlyArray<number>>(
+  recipients: T,
   ownUserId: number,
-): $ReadOnlyArray<T> =>
-  recipients.length === 1 ? recipients : recipients.filter(r => r.user_id !== ownUserId);
+): T => (recipients.length === 1 ? recipients : recipients.filter(r => r !== ownUserId));
 
 // Like filterRecipients, but identifying users by email address.
 // Prefer filterRecipients instead.
@@ -95,13 +94,8 @@ export const normalizeRecipientsSansMe = (
   ownEmail: string,
 ) => normalizeRecipients(filterRecipientsByEmail(recipients, ownEmail));
 
-export const normalizeRecipientsAsUserIds = (
-  recipients: $ReadOnlyArray<{ +user_id: number, ... }>,
-) =>
-  recipients
-    .map(s => s.user_id)
-    .sort((a, b) => a - b)
-    .join(',');
+export const normalizeRecipientsAsUserIds = (recipients: number[]) =>
+  recipients.sort((a, b) => a - b).join(',');
 
 /**
  * The same set of users as pmKeyRecipientsFromMessage, in quirkier form.
@@ -112,10 +106,8 @@ export const normalizeRecipientsAsUserIds = (
 // (see comment on Message#display_recipient).  Then for 1:1 PMs the
 // server's behavior is quirkier... but we keep only one user for those
 // anyway, so it doesn't matter.
-export const normalizeRecipientsAsUserIdsSansMe = (
-  recipients: $ReadOnlyArray<{ +user_id: number, ... }>,
-  ownUserId: number,
-) => normalizeRecipientsAsUserIds(filterRecipientsByUserId(recipients, ownUserId));
+export const normalizeRecipientsAsUserIdsSansMe = (recipients: number[], ownUserId: number) =>
+  normalizeRecipientsAsUserIds(filterRecipientsAsUserIds(recipients, ownUserId));
 
 /**
  * The set of users to show in the UI to identify a PM conversation.

--- a/src/utils/recipient.js
+++ b/src/utils/recipient.js
@@ -88,7 +88,7 @@ export const normalizeRecipientsAsUserIds = (
 ) =>
   recipients
     .map(s => s.user_id)
-    .sort()
+    .sort((a, b) => a - b)
     .join(',');
 
 /**

--- a/src/webview/html/messageHeaderAsHtml.js
+++ b/src/webview/html/messageHeaderAsHtml.js
@@ -2,13 +2,7 @@
 import template from './template';
 import type { Message, Narrow, Outbox } from '../../types';
 import type { BackgroundData } from '../MessageList';
-import {
-  streamNarrow,
-  topicNarrow,
-  pmNarrowFromEmail,
-  pmNarrowFromEmails,
-  caseNarrow,
-} from '../../utils/narrow';
+import { streamNarrow, topicNarrow, caseNarrow, pmNarrowFromEmails } from '../../utils/narrow';
 import { foregroundColorFromBackground } from '../../utils/color';
 import { humanDate } from '../../utils/date';
 import {
@@ -91,16 +85,13 @@ export default (
 
   if (item.type === 'private' && headerStyle === 'full') {
     const keyRecipients = pmKeyRecipientsFromMessage(item, ownUser);
-    const narrowObj =
-      keyRecipients.length === 1
-        ? pmNarrowFromEmail(keyRecipients[0].email)
-        : pmNarrowFromEmails(keyRecipients.map(r => r.email));
-    const privateNarrowStr = JSON.stringify(narrowObj);
+    const narrowObj = pmNarrowFromEmails(keyRecipients.map(r => r.email));
+    const narrowStr = JSON.stringify(narrowObj);
 
     const uiRecipients = pmUiRecipientsFromMessage(item, ownUser);
     return template`
 <div class="header-wrapper private-header header"
-     data-narrow="${privateNarrowStr}"
+     data-narrow="${narrowStr}"
      data-msg-id="${item.id}">
   ${uiRecipients
     .map(r => r.full_name)


### PR DESCRIPTION
This follows on some work prompted by #4317, begun in #4330.  I have a longer branch on top of this which is still in development, which does much more to encapsulate the fiddly details of how we describe PM conversations, and as a result takes care of most of #4035 which has been the main obstacle to #3133.  This PR contains the changes from that branch which are ready and stand on their own.

Among these changes are some small bugfixes, and other cleanups in areas of the code where the larger branch will do further work.  This branch starts with a couple of infrastructural changes to smooth the way for using error logging in more parts of our code.
