### PR TITLE
narrow/recipient: Always centrally filter and sort PM users, and verify that.

### DIFF
--- a/src/account-info/AccountDetailsScreen.js
+++ b/src/account-info/AccountDetailsScreen.js
@@ -7,7 +7,7 @@ import { createStyleSheet } from '../styles';
 import { connect } from '../react-redux';
 import { Screen, ZulipButton, Label } from '../common';
 import { IconPrivateChat } from '../common/Icons';
-import { pmNarrowFromEmail } from '../utils/narrow';
+import { pm1to1NarrowFromUser } from '../utils/narrow';
 import AccountDetails from './AccountDetails';
 import { doNarrow } from '../actions';
 import { getUserIsActive, getUserForId } from '../users/userSelectors';
@@ -43,7 +43,7 @@ type Props = $ReadOnly<{|
 class AccountDetailsScreen extends PureComponent<Props> {
   handleChatPress = () => {
     const { user, dispatch } = this.props;
-    dispatch(doNarrow(pmNarrowFromEmail(user.email)));
+    dispatch(doNarrow(pm1to1NarrowFromUser(user)));
   };
 
   render() {

--- a/src/chat/__tests__/narrowsReducer-test.js
+++ b/src/chat/__tests__/narrowsReducer-test.js
@@ -6,7 +6,7 @@ import narrowsReducer from '../narrowsReducer';
 import {
   HOME_NARROW,
   HOME_NARROW_STR,
-  pmNarrowFromEmail,
+  pm1to1NarrowFromUser,
   ALL_PRIVATE_NARROW_STR,
   pmNarrowFromEmails,
   streamNarrow,
@@ -23,7 +23,7 @@ import { LAST_MESSAGE_ANCHOR, FIRST_UNREAD_ANCHOR } from '../../anchor';
 import * as eg from '../../__tests__/lib/exampleData';
 
 describe('narrowsReducer', () => {
-  const privateNarrowStr = JSON.stringify(pmNarrowFromEmail(eg.otherUser.email));
+  const privateNarrowStr = JSON.stringify(pm1to1NarrowFromUser(eg.otherUser));
   const groupNarrowStr = JSON.stringify(
     pmNarrowFromEmails([eg.otherUser.email, eg.thirdUser.email]),
   );
@@ -147,7 +147,7 @@ describe('narrowsReducer', () => {
   });
 
   test('message sent to self is stored correctly', () => {
-    const narrowWithSelfStr = JSON.stringify(pmNarrowFromEmail(eg.selfUser.email));
+    const narrowWithSelfStr = JSON.stringify(pm1to1NarrowFromUser(eg.selfUser));
     const initialState = Immutable.Map({
       [HOME_NARROW_STR]: [],
       [narrowWithSelfStr]: [],
@@ -373,7 +373,7 @@ describe('narrowsReducer', () => {
       const action = deepFreeze({
         type: MESSAGE_FETCH_COMPLETE,
         anchor: 2,
-        narrow: pmNarrowFromEmail(eg.otherUser.email),
+        narrow: pm1to1NarrowFromUser(eg.otherUser),
         messages: [],
         numBefore: 100,
         numAfter: 100,
@@ -383,7 +383,7 @@ describe('narrowsReducer', () => {
 
       const expectedState = Immutable.Map({
         [HOME_NARROW_STR]: [1, 2, 3],
-        [JSON.stringify(pmNarrowFromEmail(eg.otherUser.email))]: [],
+        [JSON.stringify(pm1to1NarrowFromUser(eg.otherUser))]: [],
       });
 
       const newState = narrowsReducer(initialState, action);

--- a/src/chat/__tests__/narrowsReducer-test.js
+++ b/src/chat/__tests__/narrowsReducer-test.js
@@ -8,7 +8,7 @@ import {
   HOME_NARROW_STR,
   pm1to1NarrowFromUser,
   ALL_PRIVATE_NARROW_STR,
-  pmNarrowFromEmails,
+  pmNarrowFromUsersUnsafe,
   streamNarrow,
   topicNarrow,
   STARRED_NARROW_STR,
@@ -24,9 +24,7 @@ import * as eg from '../../__tests__/lib/exampleData';
 
 describe('narrowsReducer', () => {
   const privateNarrowStr = JSON.stringify(pm1to1NarrowFromUser(eg.otherUser));
-  const groupNarrowStr = JSON.stringify(
-    pmNarrowFromEmails([eg.otherUser.email, eg.thirdUser.email]),
-  );
+  const groupNarrowStr = JSON.stringify(pmNarrowFromUsersUnsafe([eg.otherUser, eg.thirdUser]));
   const streamNarrowStr = JSON.stringify(streamNarrow(eg.stream.name));
   const egTopic = eg.streamMessage().subject;
   const topicNarrowStr = JSON.stringify(topicNarrow(eg.stream.name, egTopic));

--- a/src/chat/__tests__/narrowsSelectors-test.js
+++ b/src/chat/__tests__/narrowsSelectors-test.js
@@ -15,7 +15,7 @@ import {
   streamNarrow,
   topicNarrow,
   STARRED_NARROW,
-  pmNarrowFromEmails,
+  pmNarrowFromUsersUnsafe,
 } from '../../utils/narrow';
 import { NULL_SUBSCRIPTION } from '../../nullObjects';
 import * as eg from '../../__tests__/lib/exampleData';
@@ -293,7 +293,7 @@ describe('isNarrowValid', () => {
       streams: [],
       users: [john, mark],
     });
-    const narrow = pmNarrowFromEmails([john.email, mark.email]);
+    const narrow = pmNarrowFromUsersUnsafe([john, mark]);
 
     const result = isNarrowValid(state, narrow);
 
@@ -312,7 +312,7 @@ describe('isNarrowValid', () => {
       streams: [],
       users: [john],
     });
-    const narrow = pmNarrowFromEmails([john.email, mark.email]);
+    const narrow = pmNarrowFromUsersUnsafe([john, mark]);
 
     const result = isNarrowValid(state, narrow);
 

--- a/src/compose/__tests__/getComposeInputPlaceholder-test.js
+++ b/src/compose/__tests__/getComposeInputPlaceholder-test.js
@@ -6,7 +6,7 @@ import {
   pmNarrowFromEmail,
   streamNarrow,
   topicNarrow,
-  pmNarrowFromEmails,
+  pmNarrowFromUsersUnsafe,
 } from '../../utils/narrow';
 import * as eg from '../../__tests__/lib/exampleData';
 
@@ -42,7 +42,7 @@ describe('getComposeInputPlaceholder', () => {
   });
 
   test('returns "Message group" object for group narrow', () => {
-    const narrow = deepFreeze(pmNarrowFromEmails([eg.otherUser.email, eg.thirdUser.email]));
+    const narrow = deepFreeze(pmNarrowFromUsersUnsafe([eg.otherUser, eg.thirdUser]));
     const placeholder = getComposeInputPlaceholder(narrow, ownEmail, usersByEmail);
     expect(placeholder).toEqual({ text: 'Message group' });
   });

--- a/src/compose/__tests__/getComposeInputPlaceholder-test.js
+++ b/src/compose/__tests__/getComposeInputPlaceholder-test.js
@@ -1,3 +1,4 @@
+/* @flow strict-local */
 import deepFreeze from 'deep-freeze';
 
 import getComposeInputPlaceholder from '../getComposeInputPlaceholder';
@@ -7,65 +8,42 @@ import {
   topicNarrow,
   pmNarrowFromEmails,
 } from '../../utils/narrow';
+import * as eg from '../../__tests__/lib/exampleData';
 
 describe('getComposeInputPlaceholder', () => {
+  const usersByEmail = new Map([eg.selfUser, eg.otherUser, eg.thirdUser].map(u => [u.email, u]));
+  const ownEmail = eg.selfUser.email;
+
   test('returns "Message @ThisPerson" object for person narrow', () => {
-    const narrow = deepFreeze(pmNarrowFromEmail('abc@zulip.com'));
-
-    const ownEmail = 'hamlet@zulip.com';
-
-    const usersByEmail = new Map([
-      [
-        'abc@zulip.com',
-        {
-          id: 23,
-          email: 'abc@zulip.com',
-          full_name: 'ABC',
-        },
-      ],
-      [
-        'xyz@zulip.com',
-        {
-          id: 22,
-          email: 'xyz@zulip.com',
-          full_name: 'XYZ',
-        },
-      ],
-    ]);
-
+    const narrow = deepFreeze(pmNarrowFromEmail(eg.otherUser.email));
     const placeholder = getComposeInputPlaceholder(narrow, ownEmail, usersByEmail);
-    expect(placeholder).toEqual({ text: 'Message {recipient}', values: { recipient: '@ABC' } });
+    expect(placeholder).toEqual({
+      text: 'Message {recipient}',
+      values: { recipient: `@${eg.otherUser.full_name}` },
+    });
   });
 
   test('returns "Jot down something" object for self narrow', () => {
-    const narrow = deepFreeze(pmNarrowFromEmail('abc@zulip.com'));
-
-    const ownEmail = 'abc@zulip.com';
-
-    const placeholder = getComposeInputPlaceholder(narrow, ownEmail);
+    const narrow = deepFreeze(pmNarrowFromEmail(eg.selfUser.email));
+    const placeholder = getComposeInputPlaceholder(narrow, ownEmail, usersByEmail);
     expect(placeholder).toEqual({ text: 'Jot down something' });
   });
 
   test('returns "Message #streamName" for stream narrow', () => {
     const narrow = deepFreeze(streamNarrow('Denmark'));
-
-    const placeholder = getComposeInputPlaceholder(narrow);
+    const placeholder = getComposeInputPlaceholder(narrow, ownEmail, usersByEmail);
     expect(placeholder).toEqual({ text: 'Message {recipient}', values: { recipient: '#Denmark' } });
   });
 
   test('returns properly for topic narrow', () => {
     const narrow = deepFreeze(topicNarrow('Denmark', 'Copenhagen'));
-
-    const placeholder = getComposeInputPlaceholder(narrow);
-    expect(placeholder).toEqual({
-      text: 'Reply',
-    });
+    const placeholder = getComposeInputPlaceholder(narrow, ownEmail, usersByEmail);
+    expect(placeholder).toEqual({ text: 'Reply' });
   });
 
   test('returns "Message group" object for group narrow', () => {
-    const narrow = deepFreeze(pmNarrowFromEmails(['abc@zulip.com, xyz@zulip.com']));
-
-    const placeholder = getComposeInputPlaceholder(narrow);
+    const narrow = deepFreeze(pmNarrowFromEmails([eg.otherUser.email, eg.thirdUser.email]));
+    const placeholder = getComposeInputPlaceholder(narrow, ownEmail, usersByEmail);
     expect(placeholder).toEqual({ text: 'Message group' });
   });
 });

--- a/src/notification/__tests__/notification-test.js
+++ b/src/notification/__tests__/notification-test.js
@@ -61,9 +61,9 @@ describe('getNarrowFromNotificationData', () => {
       recipient_type: 'private',
       pm_users: '1,2,4',
     };
-    const usersById = new Map();
+    const allUsersById = new Map();
 
-    const narrow = getNarrowFromNotificationData(notification, usersById, ownUserId);
+    const narrow = getNarrowFromNotificationData(notification, allUsersById, ownUserId);
 
     expect(narrow).toBe(null);
   });

--- a/src/notification/__tests__/notification-test.js
+++ b/src/notification/__tests__/notification-test.js
@@ -4,7 +4,7 @@ import deepFreeze from 'deep-freeze';
 import type { UserOrBot } from '../../api/modelTypes';
 import type { JSONableDict } from '../../utils/jsonable';
 import { getNarrowFromNotificationData } from '..';
-import { topicNarrow, pmNarrowFromEmail, pmNarrowFromEmails } from '../../utils/narrow';
+import { topicNarrow, pmNarrowFromEmail, pmNarrowFromUsersUnsafe } from '../../utils/narrow';
 
 import * as eg from '../../__tests__/lib/exampleData';
 import { fromAPNsImpl as extractIosNotificationData } from '../extract';
@@ -49,7 +49,7 @@ describe('getNarrowFromNotificationData', () => {
       pm_users: users.map(u => u.user_id).join(','),
     };
 
-    const expectedNarrow = pmNarrowFromEmails(users.slice(1).map(u => u.email));
+    const expectedNarrow = pmNarrowFromUsersUnsafe(users.slice(1));
 
     const narrow = getNarrowFromNotificationData(notification, allUsersById, ownUserId);
 

--- a/src/notification/index.js
+++ b/src/notification/index.js
@@ -4,7 +4,7 @@ import NotificationsIOS from 'react-native-notifications';
 
 import type { Notification } from './types';
 import type { Auth, Dispatch, Identity, Narrow, UserOrBot } from '../types';
-import { topicNarrow, pmNarrowFromEmail, pmNarrowFromEmails } from '../utils/narrow';
+import { topicNarrow, pmNarrowFromEmail, pmNarrowFromUsers } from '../utils/narrow';
 import type { JSONable, JSONableDict } from '../utils/jsonable';
 import * as api from '../api';
 import * as logging from '../utils/logging';
@@ -107,7 +107,7 @@ export const getNarrowFromNotificationData = (
 
   const ids = data.pm_users.split(',').map(s => parseInt(s, 10));
   const users = pmKeyRecipientsFromIds(ids, allUsersById, ownUserId);
-  return users && pmNarrowFromEmails(users.map(u => u.email));
+  return users === null ? null : pmNarrowFromUsers(users);
 };
 
 const getInitialNotification = async (): Promise<Notification | null> => {

--- a/src/pm-conversations/GroupPmConversationItem.js
+++ b/src/pm-conversations/GroupPmConversationItem.js
@@ -16,7 +16,7 @@ const componentStyles = createStyleSheet({
 
 type Props = $ReadOnly<{|
   email: string,
-  usersByEmail: Map<string, UserOrBot>,
+  allUsersByEmail: Map<string, UserOrBot>,
   unreadCount: number,
   onPress: (emails: string) => void,
 |}>;
@@ -31,8 +31,8 @@ export default class GroupPmConversationItem extends PureComponent<Props> {
   };
 
   render() {
-    const { email, usersByEmail, unreadCount } = this.props;
-    const allUsers = email.split(',').map(e => usersByEmail.get(e));
+    const { email, allUsersByEmail, unreadCount } = this.props;
+    const allUsers = email.split(',').map(e => allUsersByEmail.get(e));
 
     const allUsersFound = allUsers.every(user => user);
 

--- a/src/pm-conversations/GroupPmConversationItem.js
+++ b/src/pm-conversations/GroupPmConversationItem.js
@@ -14,16 +14,18 @@ const componentStyles = createStyleSheet({
   },
 });
 
-type Props = $ReadOnly<{|
-  users: $ReadOnlyArray<UserOrBot>,
+type Props<U> = $ReadOnly<{|
+  users: U,
   unreadCount: number,
-  onPress: (users: $ReadOnlyArray<UserOrBot>) => void,
+  onPress: (users: U) => void,
 |}>;
 
 /**
  * A list item describing one group PM conversation.
  * */
-export default class GroupPmConversationItem extends PureComponent<Props> {
+export default class GroupPmConversationItem<U: $ReadOnlyArray<UserOrBot>> extends PureComponent<
+  Props<U>,
+> {
   handlePress = () => {
     const { users, onPress } = this.props;
     onPress(users);

--- a/src/pm-conversations/GroupPmConversationItem.js
+++ b/src/pm-conversations/GroupPmConversationItem.js
@@ -15,10 +15,9 @@ const componentStyles = createStyleSheet({
 });
 
 type Props = $ReadOnly<{|
-  email: string,
-  allUsersByEmail: Map<string, UserOrBot>,
+  users: $ReadOnlyArray<UserOrBot>,
   unreadCount: number,
-  onPress: (emails: string) => void,
+  onPress: (users: $ReadOnlyArray<UserOrBot>) => void,
 |}>;
 
 /**
@@ -26,32 +25,23 @@ type Props = $ReadOnly<{|
  * */
 export default class GroupPmConversationItem extends PureComponent<Props> {
   handlePress = () => {
-    const { email, onPress } = this.props;
-    onPress(email);
+    const { users, onPress } = this.props;
+    onPress(users);
   };
 
   render() {
-    const { email, allUsersByEmail, unreadCount } = this.props;
-    const allUsers = email.split(',').map(e => allUsersByEmail.get(e));
-
-    const allUsersFound = allUsers.every(user => user);
-
-    if (!allUsersFound) {
-      return null;
-    }
-
-    // $FlowFixMe Flow doesn't see the `every` check above.
-    const allNames = allUsers.map(user => user.full_name);
+    const { users, unreadCount } = this.props;
+    const names = users.map(user => user.full_name);
 
     return (
       <Touchable onPress={this.handlePress}>
         <View style={styles.listItem}>
-          <GroupAvatar size={48} names={allNames} />
+          <GroupAvatar size={48} names={names} />
           <RawLabel
             style={componentStyles.text}
             numberOfLines={2}
             ellipsizeMode="tail"
-            text={allNames.join(', ')}
+            text={names.join(', ')}
           />
           <UnreadCount count={unreadCount} />
         </View>

--- a/src/pm-conversations/PmConversationList.js
+++ b/src/pm-conversations/PmConversationList.js
@@ -30,8 +30,8 @@ export default class PmConversationList extends PureComponent<Props> {
     this.props.dispatch(doNarrow(pm1to1NarrowFromUser(user)));
   };
 
-  handleGroupNarrow = (email: string) => {
-    this.props.dispatch(doNarrow(pmNarrowFromEmails(email.split(','))));
+  handleGroupNarrow = (users: $ReadOnlyArray<UserOrBot>) => {
+    this.props.dispatch(doNarrow(pmNarrowFromEmails(users.map(u => u.email))));
   };
 
   render() {
@@ -44,26 +44,28 @@ export default class PmConversationList extends PureComponent<Props> {
         data={conversations}
         keyExtractor={item => item.recipients}
         renderItem={({ item }) => {
-          if (item.recipients.indexOf(',') === -1) {
-            const user = allUsersByEmail.get(item.recipients);
-
+          const users = [];
+          for (const email of item.recipients.split(',')) {
+            const user = allUsersByEmail.get(email);
             if (!user) {
               return null;
             }
-
-            return (
-              <UserItem user={user} unreadCount={item.unread} onPress={this.handleUserNarrow} />
-            );
+            users.push(user);
           }
 
-          return (
-            <GroupPmConversationItem
-              email={item.recipients}
-              unreadCount={item.unread}
-              allUsersByEmail={allUsersByEmail}
-              onPress={this.handleGroupNarrow}
-            />
-          );
+          if (users.length === 1) {
+            return (
+              <UserItem user={users[0]} unreadCount={item.unread} onPress={this.handleUserNarrow} />
+            );
+          } else {
+            return (
+              <GroupPmConversationItem
+                users={users}
+                unreadCount={item.unread}
+                onPress={this.handleGroupNarrow}
+              />
+            );
+          }
         }}
       />
     );

--- a/src/pm-conversations/PmConversationList.js
+++ b/src/pm-conversations/PmConversationList.js
@@ -4,7 +4,8 @@ import { FlatList } from 'react-native';
 
 import type { Dispatch, PmConversationData, UserOrBot } from '../types';
 import { createStyleSheet } from '../styles';
-import { pm1to1NarrowFromUser, pmNarrowFromEmails } from '../utils/narrow';
+import { type PmKeyUsers } from '../utils/recipient';
+import { pm1to1NarrowFromUser, pmNarrowFromUsers } from '../utils/narrow';
 import UserItem from '../users/UserItem';
 import GroupPmConversationItem from './GroupPmConversationItem';
 import { doNarrow } from '../actions';
@@ -30,29 +31,21 @@ export default class PmConversationList extends PureComponent<Props> {
     this.props.dispatch(doNarrow(pm1to1NarrowFromUser(user)));
   };
 
-  handleGroupNarrow = (users: $ReadOnlyArray<UserOrBot>) => {
-    this.props.dispatch(doNarrow(pmNarrowFromEmails(users.map(u => u.email))));
+  handleGroupNarrow = (users: PmKeyUsers) => {
+    this.props.dispatch(doNarrow(pmNarrowFromUsers(users)));
   };
 
   render() {
-    const { conversations, allUsersByEmail } = this.props;
+    const { conversations } = this.props;
 
     return (
       <FlatList
         style={styles.list}
         initialNumToRender={20}
         data={conversations}
-        keyExtractor={item => item.recipients}
+        keyExtractor={item => item.key}
         renderItem={({ item }) => {
-          const users = [];
-          for (const email of item.recipients.split(',')) {
-            const user = allUsersByEmail.get(email);
-            if (!user) {
-              return null;
-            }
-            users.push(user);
-          }
-
+          const users = item.keyRecipients;
           if (users.length === 1) {
             return (
               <UserItem user={users[0]} unreadCount={item.unread} onPress={this.handleUserNarrow} />

--- a/src/pm-conversations/PmConversationList.js
+++ b/src/pm-conversations/PmConversationList.js
@@ -19,7 +19,7 @@ const styles = createStyleSheet({
 type Props = $ReadOnly<{|
   dispatch: Dispatch,
   conversations: PmConversationData[],
-  usersByEmail: Map<string, UserOrBot>,
+  allUsersByEmail: Map<string, UserOrBot>,
 |}>;
 
 /**
@@ -35,7 +35,7 @@ export default class PmConversationList extends PureComponent<Props> {
   };
 
   render() {
-    const { conversations, usersByEmail } = this.props;
+    const { conversations, allUsersByEmail } = this.props;
 
     return (
       <FlatList
@@ -45,7 +45,7 @@ export default class PmConversationList extends PureComponent<Props> {
         keyExtractor={item => item.recipients}
         renderItem={({ item }) => {
           if (item.recipients.indexOf(',') === -1) {
-            const user = usersByEmail.get(item.recipients);
+            const user = allUsersByEmail.get(item.recipients);
 
             if (!user) {
               return null;
@@ -60,7 +60,7 @@ export default class PmConversationList extends PureComponent<Props> {
             <GroupPmConversationItem
               email={item.recipients}
               unreadCount={item.unread}
-              usersByEmail={usersByEmail}
+              allUsersByEmail={allUsersByEmail}
               onPress={this.handleGroupNarrow}
             />
           );

--- a/src/pm-conversations/PmConversationList.js
+++ b/src/pm-conversations/PmConversationList.js
@@ -4,7 +4,7 @@ import { FlatList } from 'react-native';
 
 import type { Dispatch, PmConversationData, UserOrBot } from '../types';
 import { createStyleSheet } from '../styles';
-import { pmNarrowFromEmail, pmNarrowFromEmails } from '../utils/narrow';
+import { pm1to1NarrowFromUser, pmNarrowFromEmails } from '../utils/narrow';
 import UserItem from '../users/UserItem';
 import GroupPmConversationItem from './GroupPmConversationItem';
 import { doNarrow } from '../actions';
@@ -27,7 +27,7 @@ type Props = $ReadOnly<{|
  * */
 export default class PmConversationList extends PureComponent<Props> {
   handleUserNarrow = (user: UserOrBot) => {
-    this.props.dispatch(doNarrow(pmNarrowFromEmail(user.email)));
+    this.props.dispatch(doNarrow(pm1to1NarrowFromUser(user)));
   };
 
   handleGroupNarrow = (email: string) => {

--- a/src/pm-conversations/PmConversationsCard.js
+++ b/src/pm-conversations/PmConversationsCard.js
@@ -43,7 +43,7 @@ type Props = $ReadOnly<{|
 
   dispatch: Dispatch,
   conversations: PmConversationData[],
-  usersByEmail: Map<string, UserOrBot>,
+  allUsersByEmail: Map<string, UserOrBot>,
 |}>;
 
 /**
@@ -54,7 +54,7 @@ class PmConversationsCard extends PureComponent<Props> {
   context: ThemeData;
 
   render() {
-    const { dispatch, conversations, usersByEmail } = this.props;
+    const { dispatch, conversations, allUsersByEmail } = this.props;
 
     return (
       <View style={[styles.container, { backgroundColor: this.context.backgroundColor }]}>
@@ -85,7 +85,7 @@ class PmConversationsCard extends PureComponent<Props> {
           <PmConversationList
             dispatch={dispatch}
             conversations={conversations}
-            usersByEmail={usersByEmail}
+            allUsersByEmail={allUsersByEmail}
           />
         )}
       </View>
@@ -95,5 +95,5 @@ class PmConversationsCard extends PureComponent<Props> {
 
 export default connect(state => ({
   conversations: getRecentConversations(state),
-  usersByEmail: getAllUsersByEmail(state),
+  allUsersByEmail: getAllUsersByEmail(state),
 }))(PmConversationsCard);

--- a/src/pm-conversations/__tests__/pmConversationsSelectors-test.js
+++ b/src/pm-conversations/__tests__/pmConversationsSelectors-test.js
@@ -33,7 +33,7 @@ describe('getRecentConversations', () => {
     const meAndMarkPm = eg.pmMessage({ id: 2, recipients: [eg.selfUser, userMark] });
     const meAndJohnPm2 = eg.pmMessage({ id: 3, recipients: [eg.selfUser, userJohn] });
     const meOnlyPm = eg.pmMessage({ id: 4, recipients: [eg.selfUser] });
-    const meJohnAndMarkPm = eg.pmMessage({ id: 0, recipients: [eg.selfUser, userMark, userJohn] });
+    const meJohnAndMarkPm = eg.pmMessage({ id: 0, recipients: [eg.selfUser, userJohn, userMark] });
 
     const state = eg.reduxState({
       realm: eg.realmState({ email: eg.selfUser.email }),
@@ -84,29 +84,29 @@ describe('getRecentConversations', () => {
 
     const expectedResult = [
       {
-        ids: eg.selfUser.user_id.toString(),
-        recipients: eg.selfUser.email,
+        key: eg.selfUser.user_id.toString(),
+        keyRecipients: [eg.selfUser],
         msgId: meOnlyPm.id,
         unread: 1,
       },
       {
-        ids: userJohn.user_id.toString(),
-        recipients: userJohn.email,
+        key: userJohn.user_id.toString(),
+        keyRecipients: [userJohn],
         msgId: meAndJohnPm2.id,
         unread: 2,
       },
       {
-        ids: userMark.user_id.toString(),
-        recipients: userMark.email,
+        key: userMark.user_id.toString(),
+        keyRecipients: [userMark],
         msgId: meAndMarkPm.id,
         unread: 1,
       },
       {
-        ids: [eg.selfUser.user_id, userJohn.user_id, userMark.user_id]
+        key: [eg.selfUser.user_id, userJohn.user_id, userMark.user_id]
           .sort((a, b) => a - b)
           .map(String)
           .join(','),
-        recipients: [userJohn.email, userMark.email].sort().join(','),
+        keyRecipients: [userJohn, userMark].sort((a, b) => a.user_id - b.user_id),
         msgId: meJohnAndMarkPm.id,
         unread: 1,
       },
@@ -178,29 +178,29 @@ describe('getRecentConversations', () => {
 
     const expectedResult = [
       {
-        ids: eg.selfUser.user_id.toString(),
-        recipients: eg.selfUser.email,
+        key: eg.selfUser.user_id.toString(),
+        keyRecipients: [eg.selfUser],
         msgId: meOnlyPm.id,
         unread: 1,
       },
       {
-        ids: [eg.selfUser.user_id, userJohn.user_id, userMark.user_id]
+        key: [eg.selfUser.user_id, userJohn.user_id, userMark.user_id]
           .sort((a, b) => a - b)
           .map(String)
           .join(','),
-        recipients: [userJohn.email, userMark.email].sort().join(','),
+        keyRecipients: [userJohn, userMark].sort((a, b) => a.user_id - b.user_id),
         msgId: meJohnAndMarkPm.id,
         unread: 1,
       },
       {
-        ids: userJohn.user_id.toString(),
-        recipients: userJohn.email,
+        key: userJohn.user_id.toString(),
+        keyRecipients: [userJohn],
         msgId: meAndJohnPm2.id,
         unread: 2,
       },
       {
-        ids: userMark.user_id.toString(),
-        recipients: userMark.email,
+        key: userMark.user_id.toString(),
+        keyRecipients: [userMark],
         msgId: meAndMarkPm2.id,
         unread: 1,
       },

--- a/src/pm-conversations/__tests__/pmConversationsSelectors-test.js
+++ b/src/pm-conversations/__tests__/pmConversationsSelectors-test.js
@@ -6,8 +6,8 @@ import { ALL_PRIVATE_NARROW_STR } from '../../utils/narrow';
 import * as eg from '../../__tests__/lib/exampleData';
 
 describe('getRecentConversations', () => {
-  const userJohn = { ...eg.makeUser({ name: 'John' }), user_id: 1 };
-  const userMark = { ...eg.makeUser({ name: 'Mark' }), user_id: 2 };
+  const userJohn = eg.makeUser();
+  const userMark = eg.makeUser();
 
   test('when no messages, return no conversations', () => {
     const state = eg.reduxState({

--- a/src/pm-conversations/pmConversationsSelectors.js
+++ b/src/pm-conversations/pmConversationsSelectors.js
@@ -3,44 +3,37 @@ import { createSelector } from 'reselect';
 
 import type { Message, PmConversationData, Selector, User } from '../types';
 import { getPrivateMessages } from '../message/messageSelectors';
-import { getOwnUser } from '../users/userSelectors';
+import { getAllUsersById, getOwnUser } from '../users/userSelectors';
 import { getUnreadByPms, getUnreadByHuddles } from '../unread/unreadSelectors';
-import {
-  normalizeRecipientsSansMe,
-  pmUnreadsKeyFromMessage,
-  recipientsOfPrivateMessage,
-} from '../utils/recipient';
+import { pmUnreadsKeyFromMessage, pmKeyRecipientUsersFromMessage } from '../utils/recipient';
 
 export const getRecentConversations: Selector<PmConversationData[]> = createSelector(
   getOwnUser,
   getPrivateMessages,
   getUnreadByPms,
   getUnreadByHuddles,
+  getAllUsersById,
   (
     ownUser: User,
     messages: Message[],
     unreadPms: { [number]: number },
     unreadHuddles: { [string]: number },
+    allUsersById,
   ): PmConversationData[] => {
-    const recipients = messages.map(msg => ({
-      // Note this can be a different set of users from those in `emails` below.
-      ids: pmUnreadsKeyFromMessage(msg, ownUser.user_id),
-
-      // The users represented in this `emails` string are sorted by email address.
-      emails: normalizeRecipientsSansMe(recipientsOfPrivateMessage(msg), ownUser.email),
-
-      msgId: msg.id,
-    }));
+    const recipients = messages
+      .map(msg => {
+        // Note this can be a different set of users from those in `keyRecipients`.
+        const unreadsKey = pmUnreadsKeyFromMessage(msg, ownUser.user_id);
+        const keyRecipients = pmKeyRecipientUsersFromMessage(msg, allUsersById, ownUser.user_id);
+        return keyRecipients === null ? null : { unreadsKey, keyRecipients, msgId: msg.id };
+      })
+      .filter(Boolean);
 
     const latestByRecipient = new Map();
     recipients.forEach(recipient => {
-      const prev = latestByRecipient.get(recipient.emails);
+      const prev = latestByRecipient.get(recipient.unreadsKey);
       if (!prev || recipient.msgId > prev.msgId) {
-        latestByRecipient.set(recipient.emails, {
-          ids: recipient.ids,
-          recipients: recipient.emails,
-          msgId: recipient.msgId,
-        });
+        latestByRecipient.set(recipient.unreadsKey, recipient);
       }
     });
 
@@ -49,7 +42,9 @@ export const getRecentConversations: Selector<PmConversationData[]> = createSele
     );
 
     return sortedByMostRecent.map(recipient => ({
-      ...recipient,
+      key: recipient.unreadsKey,
+      keyRecipients: recipient.keyRecipients,
+      msgId: recipient.msgId,
       unread:
         // This business of looking in one place and then the other is kind
         // of messy.  Fortunately it always works, because the key spaces
@@ -58,7 +53,7 @@ export const getRecentConversations: Selector<PmConversationData[]> = createSele
         /* $FlowFixMe: The keys of unreadPms are logically numbers, but because it's an object they
          end up converted to strings, so this access with string keys works.  We should probably use
          a Map for this and similar maps. */
-        unreadPms[recipient.ids] || unreadHuddles[recipient.ids],
+        unreadPms[recipient.unreadsKey] || unreadHuddles[recipient.unreadsKey],
     }));
   },
 );

--- a/src/title/__tests__/titleSelectors-test.js
+++ b/src/title/__tests__/titleSelectors-test.js
@@ -1,45 +1,34 @@
-import deepFreeze from 'deep-freeze';
+/* @flow strict-local */
 
 import { DEFAULT_TITLE_BACKGROUND_COLOR, getTitleBackgroundColor } from '../titleSelectors';
 import { pmNarrowFromEmails, streamNarrow, pmNarrowFromEmail } from '../../utils/narrow';
-
-const subscriptions = [{ name: 'all', color: '#fff' }, { name: 'announce', color: '#000' }];
+import * as eg from '../../__tests__/lib/exampleData';
 
 describe('getTitleBackgroundColor', () => {
-  test('return default for screens other than chat, i.e narrow is undefined', () => {
-    const state = deepFreeze({
-      subscriptions,
-    });
+  const exampleColor = '#fff';
+  const state = eg.reduxState({
+    subscriptions: [{ ...eg.makeSubscription({ stream: eg.stream }), color: exampleColor }],
+  });
 
+  test('return default for screens other than chat, i.e narrow is undefined', () => {
     expect(getTitleBackgroundColor(state, undefined)).toEqual(DEFAULT_TITLE_BACKGROUND_COLOR);
   });
 
   test('return stream color for stream and topic narrow', () => {
-    const state = deepFreeze({
-      subscriptions,
-    });
-
-    expect(getTitleBackgroundColor(state, streamNarrow('all'))).toEqual('#fff');
+    expect(getTitleBackgroundColor(state, streamNarrow(eg.stream.name))).toEqual(exampleColor);
   });
 
   test('return null stream color for invalid stream or unknown subscriptions', () => {
-    const state = deepFreeze({
-      subscriptions,
-    });
-
-    expect(getTitleBackgroundColor(state, streamNarrow('feedback'))).toEqual('gray');
+    const unknownStream = eg.makeStream();
+    expect(getTitleBackgroundColor(state, streamNarrow(unknownStream.name))).toEqual('gray');
   });
 
   test('return default for non topic/stream narrow', () => {
-    const state = deepFreeze({
-      subscriptions,
-    });
-
-    expect(getTitleBackgroundColor(state, pmNarrowFromEmail('abc@zulip.com'))).toEqual(
+    expect(getTitleBackgroundColor(state, pmNarrowFromEmail(eg.otherUser.email))).toEqual(
       DEFAULT_TITLE_BACKGROUND_COLOR,
     );
     expect(
-      getTitleBackgroundColor(state, pmNarrowFromEmails(['abc@zulip.com', 'def@zulip.com'])),
+      getTitleBackgroundColor(state, pmNarrowFromEmails([eg.otherUser.email, eg.thirdUser.email])),
     ).toEqual(DEFAULT_TITLE_BACKGROUND_COLOR);
   });
 });

--- a/src/title/__tests__/titleSelectors-test.js
+++ b/src/title/__tests__/titleSelectors-test.js
@@ -1,7 +1,7 @@
 /* @flow strict-local */
 
 import { DEFAULT_TITLE_BACKGROUND_COLOR, getTitleBackgroundColor } from '../titleSelectors';
-import { pmNarrowFromEmails, streamNarrow, pmNarrowFromEmail } from '../../utils/narrow';
+import { pmNarrowFromUsersUnsafe, streamNarrow, pmNarrowFromEmail } from '../../utils/narrow';
 import * as eg from '../../__tests__/lib/exampleData';
 
 describe('getTitleBackgroundColor', () => {
@@ -28,7 +28,7 @@ describe('getTitleBackgroundColor', () => {
       DEFAULT_TITLE_BACKGROUND_COLOR,
     );
     expect(
-      getTitleBackgroundColor(state, pmNarrowFromEmails([eg.otherUser.email, eg.thirdUser.email])),
+      getTitleBackgroundColor(state, pmNarrowFromUsersUnsafe([eg.otherUser, eg.thirdUser])),
     ).toEqual(DEFAULT_TITLE_BACKGROUND_COLOR);
   });
 });

--- a/src/types.js
+++ b/src/types.js
@@ -5,6 +5,7 @@ import type { DangerouslyImpreciseStyleProp } from 'react-native/Libraries/Style
 import type { SubsetProperties } from './generics';
 import type { Auth, Topic, Message, ReactionType } from './api/apiTypes';
 import type { ZulipVersion } from './utils/zulipVersion';
+import type { PmKeyUsers } from './utils/recipient';
 
 export type * from './generics';
 export type * from './reduxTypes';
@@ -318,9 +319,9 @@ export type TabNavigationOptionsPropsType = {|
  * Summary of a PM conversation (either 1:1 or group PMs).
  */
 export type PmConversationData = {|
-  ids: string,
+  key: string,
+  keyRecipients: PmKeyUsers,
   msgId: number,
-  recipients: string,
   unread: number,
 |};
 

--- a/src/typing/__tests__/typingSelectors-test.js
+++ b/src/typing/__tests__/typingSelectors-test.js
@@ -2,7 +2,7 @@
 
 import type { GlobalState } from '../../types';
 import { getCurrentTypingUsers } from '../typingSelectors';
-import { HOME_NARROW, pm1to1NarrowFromUser, pmNarrowFromEmails } from '../../utils/narrow';
+import { HOME_NARROW, pm1to1NarrowFromUser, pmNarrowFromUsersUnsafe } from '../../utils/narrow';
 import { NULL_ARRAY } from '../../nullObjects';
 import * as eg from '../../__tests__/lib/exampleData';
 import { normalizeRecipientsAsUserIds } from '../../utils/recipient';
@@ -43,10 +43,7 @@ describe('getCurrentTypingUsers', () => {
       users: [user1, user2],
     });
 
-    const typingUsers = getCurrentTypingUsers(
-      state,
-      pmNarrowFromEmails([user1.email, user2.email]),
-    );
+    const typingUsers = getCurrentTypingUsers(state, pmNarrowFromUsersUnsafe([user1, user2]));
 
     expect(typingUsers).toEqual([user1, user2]);
   });
@@ -85,7 +82,7 @@ describe('getCurrentTypingUsers', () => {
 
     const typingUsers = getCurrentTypingUsers(
       state,
-      pmNarrowFromEmails([expectedUser.email, anotherUser.email]),
+      pmNarrowFromUsersUnsafe([expectedUser, anotherUser]),
     );
 
     expect(typingUsers).toEqual([expectedUser]);

--- a/src/typing/__tests__/typingSelectors-test.js
+++ b/src/typing/__tests__/typingSelectors-test.js
@@ -2,7 +2,7 @@
 
 import type { GlobalState } from '../../types';
 import { getCurrentTypingUsers } from '../typingSelectors';
-import { HOME_NARROW, pmNarrowFromEmail, pmNarrowFromEmails } from '../../utils/narrow';
+import { HOME_NARROW, pm1to1NarrowFromUser, pmNarrowFromEmails } from '../../utils/narrow';
 import { NULL_ARRAY } from '../../nullObjects';
 import * as eg from '../../__tests__/lib/exampleData';
 import { normalizeRecipientsAsUserIds } from '../../utils/recipient';
@@ -25,7 +25,7 @@ describe('getCurrentTypingUsers', () => {
       users: [expectedUser],
     });
 
-    const typingUsers = getCurrentTypingUsers(state, pmNarrowFromEmail(expectedUser.email));
+    const typingUsers = getCurrentTypingUsers(state, pm1to1NarrowFromUser(expectedUser));
 
     expect(typingUsers).toEqual([expectedUser]);
   });
@@ -63,7 +63,7 @@ describe('getCurrentTypingUsers', () => {
       users: [user1, user2],
     });
 
-    const typingUsers = getCurrentTypingUsers(state, pmNarrowFromEmail(user2.email));
+    const typingUsers = getCurrentTypingUsers(state, pm1to1NarrowFromUser(user2));
 
     expect(typingUsers).toEqual(NULL_ARRAY);
   });
@@ -99,7 +99,7 @@ describe('getCurrentTypingUsers', () => {
     });
 
     const getTypingUsers = () =>
-      getCurrentTypingUsers(state, pmNarrowFromEmail(deactivatedUser.email));
+      getCurrentTypingUsers(state, pm1to1NarrowFromUser(deactivatedUser));
 
     expect(getTypingUsers).not.toThrow();
     expect(getTypingUsers()).toEqual([]);
@@ -112,8 +112,7 @@ describe('getCurrentTypingUsers', () => {
       realm: eg.realmState({ crossRealmBots: [crossRealmBot] }),
     });
 
-    const getTypingUsers = () =>
-      getCurrentTypingUsers(state, pmNarrowFromEmail(crossRealmBot.email));
+    const getTypingUsers = () => getCurrentTypingUsers(state, pm1to1NarrowFromUser(crossRealmBot));
 
     expect(getTypingUsers).not.toThrow();
     expect(getTypingUsers()).toEqual([]);

--- a/src/unread/UnreadCards.js
+++ b/src/unread/UnreadCards.js
@@ -20,7 +20,7 @@ import { doNarrow } from '../actions';
 type Props = $ReadOnly<{|
   conversations: PmConversationData[],
   dispatch: Dispatch,
-  usersByEmail: Map<string, UserOrBot>,
+  allUsersByEmail: Map<string, UserOrBot>,
   unreadStreamsAndTopics: UnreadStreamItem[],
 |}>;
 
@@ -91,6 +91,6 @@ class UnreadCards extends PureComponent<Props> {
 
 export default connect(state => ({
   conversations: getUnreadConversations(state),
-  usersByEmail: getAllUsersByEmail(state),
+  allUsersByEmail: getAllUsersByEmail(state),
   unreadStreamsAndTopics: getUnreadStreamsAndTopicsSansMuted(state),
 }))(UnreadCards);

--- a/src/unread/unreadSelectors.js
+++ b/src/unread/unreadSelectors.js
@@ -236,7 +236,7 @@ export const getUnreadCountForNarrow: Selector<number, Narrow> = createSelector(
   (
     narrow,
     streams,
-    usersByEmail,
+    allUsersByEmail,
     ownEmail,
     unreadTotal,
     unreadStreams,
@@ -278,7 +278,7 @@ export const getUnreadCountForNarrow: Selector<number, Narrow> = createSelector(
 
     if (isGroupPmNarrow(narrow)) {
       const userIds = [...narrow[0].operand.split(','), ownEmail]
-        .map(email => (usersByEmail.get(email) || NULL_USER).user_id)
+        .map(email => (allUsersByEmail.get(email) || NULL_USER).user_id)
         .sort((a, b) => a - b)
         .join(',');
       const unread = unreadHuddles.find(x => x.user_ids_string === userIds);
@@ -286,7 +286,7 @@ export const getUnreadCountForNarrow: Selector<number, Narrow> = createSelector(
     }
 
     if (is1to1PmNarrow(narrow)) {
-      const sender = usersByEmail.get(narrow[0].operand);
+      const sender = allUsersByEmail.get(narrow[0].operand);
       if (!sender) {
         return 0;
       }

--- a/src/user-groups/CreateGroupScreen.js
+++ b/src/user-groups/CreateGroupScreen.js
@@ -34,7 +34,7 @@ class CreateGroupScreen extends PureComponent<Props, State> {
   handleCreateGroup = (selected: User[]) => {
     const { dispatch } = this.props;
 
-    const recipients = selected.map(user => user.email);
+    const recipients = selected.sort((a, b) => a.user_id - b.user_id).map(user => user.email);
     NavigationService.dispatch(navigateBack());
     dispatch(doNarrow(pmNarrowFromEmails(recipients)));
   };

--- a/src/users/UsersCard.js
+++ b/src/users/UsersCard.js
@@ -5,7 +5,7 @@ import React, { PureComponent } from 'react';
 import NavigationService from '../nav/NavigationService';
 import type { Dispatch, PresenceState, User, UserOrBot } from '../types';
 import { connect } from '../react-redux';
-import { pmNarrowFromEmail } from '../utils/narrow';
+import { pm1to1NarrowFromUser } from '../utils/narrow';
 import UserList from './UserList';
 import { getUsers, getPresence } from '../selectors';
 import { navigateBack, doNarrow } from '../actions';
@@ -21,7 +21,7 @@ class UsersCard extends PureComponent<Props> {
   handleUserNarrow = (user: UserOrBot) => {
     const { dispatch } = this.props;
     NavigationService.dispatch(navigateBack());
-    dispatch(doNarrow(pmNarrowFromEmail(user.email)));
+    dispatch(doNarrow(pm1to1NarrowFromUser(user)));
   };
 
   render() {

--- a/src/users/usersActions.js
+++ b/src/users/usersActions.js
@@ -64,11 +64,11 @@ export const sendTypingStart = (narrow: Narrow) => async (
     return;
   }
 
-  const usersByEmail = getAllUsersByEmail(getState());
+  const allUsersByEmail = getAllUsersByEmail(getState());
   const recipientIds = caseNarrowPartial(narrow, {
     pm: emails => emails,
   }).map(email => {
-    const user = usersByEmail.get(email);
+    const user = allUsersByEmail.get(email);
     if (!user) {
       throw new Error('unknown user');
     }

--- a/src/utils/__tests__/internalLinks-test.js
+++ b/src/utils/__tests__/internalLinks-test.js
@@ -1,7 +1,7 @@
 /* @flow strict-local */
 
 import type { UserOrBot } from '../../api/modelTypes';
-import { streamNarrow, topicNarrow, pmNarrowFromEmails, STARRED_NARROW } from '../narrow';
+import { streamNarrow, topicNarrow, pmNarrowFromUsersUnsafe, STARRED_NARROW } from '../narrow';
 import {
   isInternalLink,
   isMessageLink,
@@ -257,7 +257,7 @@ describe('getNarrowFromLink', () => {
   test('on group PM link', () => {
     const ids = `${userB.user_id},${userC.user_id}`;
     expect(get(`https://example.com/#narrow/pm-with/${ids}-group`)).toEqual(
-      pmNarrowFromEmails([userB.email, userC.email]),
+      pmNarrowFromUsersUnsafe([userB, userC]),
     );
   });
 
@@ -265,7 +265,7 @@ describe('getNarrowFromLink', () => {
     // The webapp doesn't generate these, but best to handle them anyway.
     const ids = `${eg.selfUser.user_id},${userB.user_id},${userC.user_id}`;
     expect(get(`https://example.com/#narrow/pm-with/${ids}-group`)).toEqual(
-      pmNarrowFromEmails([userB.email, userC.email]),
+      pmNarrowFromUsersUnsafe([userB, userC]),
     );
   });
 
@@ -282,7 +282,7 @@ describe('getNarrowFromLink', () => {
   test('on a message link', () => {
     const ids = `${userB.user_id},${userC.user_id}`;
     expect(get(`https://example.com/#narrow/pm-with/${ids}-group/near/2`)).toEqual(
-      pmNarrowFromEmails([userB.email, userC.email]),
+      pmNarrowFromUsersUnsafe([userB, userC]),
     );
 
     expect(get('https://example.com/#narrow/stream/jest/topic/test/near/1')).toEqual(

--- a/src/utils/__tests__/narrow-test.js
+++ b/src/utils/__tests__/narrow-test.js
@@ -104,7 +104,7 @@ describe('isPmNarrow', () => {
     expect(isPmNarrow(undefined)).toBe(false);
     expect(isPmNarrow(HOME_NARROW)).toBe(false);
     expect(isPmNarrow(pmNarrowFromEmail(eg.otherUser.email))).toBe(true);
-    expect(isPmNarrow(pmNarrowFromEmails([eg.otherUser.email, eg.thirdUser.email]))).toBe(true);
+    expect(isPmNarrow(pmNarrowFromUsersUnsafe([eg.otherUser, eg.thirdUser]))).toBe(true);
     expect(
       isPmNarrow([
         {
@@ -131,9 +131,9 @@ describe('isStreamOrTopicNarrow', () => {
     expect(isStreamOrTopicNarrow(topicNarrow('some stream', 'some topic'))).toBe(true);
     expect(isStreamOrTopicNarrow(HOME_NARROW)).toBe(false);
     expect(isStreamOrTopicNarrow(pmNarrowFromEmail(eg.otherUser.email))).toBe(false);
-    expect(
-      isStreamOrTopicNarrow(pmNarrowFromEmails([eg.otherUser.email, eg.thirdUser.email])),
-    ).toBe(false);
+    expect(isStreamOrTopicNarrow(pmNarrowFromUsersUnsafe([eg.otherUser, eg.thirdUser]))).toBe(
+      false,
+    );
     expect(isStreamOrTopicNarrow(STARRED_NARROW)).toBe(false);
   });
 });
@@ -258,7 +258,7 @@ describe('isMessageInNarrow', () => {
       ['group-PM, outbound', false, eg.pmMessage({ sender: eg.selfUser, recipients: [eg.selfUser, eg.otherUser, eg.thirdUser] })],
       ['stream message', false, eg.streamMessage()],
     ]],
-    ['group-PM conversation', pmNarrowFromEmails([eg.otherUser.email, eg.thirdUser.email]), [
+    ['group-PM conversation', pmNarrowFromUsersUnsafe([eg.otherUser, eg.thirdUser]), [
       ['matching group-PM, inbound', true, eg.pmMessage({ recipients: [eg.selfUser, eg.otherUser, eg.thirdUser] })],
       ['matching group-PM, outbound', true, eg.pmMessage({ sender: eg.selfUser, recipients: [eg.selfUser, eg.otherUser, eg.thirdUser] })],
       ['1:1 within group, inbound', false, eg.pmMessage()],
@@ -266,7 +266,7 @@ describe('isMessageInNarrow', () => {
       ['self-1:1 message', false, eg.pmMessage({ sender: eg.selfUser, recipients: [eg.selfUser] })],
       ['stream message', false, eg.streamMessage()],
     ]],
-    ['group-PM conversation, including self', pmNarrowFromEmails([eg.selfUser.email, eg.otherUser.email, eg.thirdUser.email]), [
+    ['group-PM conversation, including self', pmNarrowFromUsersUnsafe([eg.selfUser, eg.otherUser, eg.thirdUser]), [
       ['matching group-PM, inbound', true, eg.pmMessage({ recipients: [eg.selfUser, eg.otherUser, eg.thirdUser] })],
       ['matching group-PM, outbound', true, eg.pmMessage({ sender: eg.selfUser, recipients: [eg.selfUser, eg.otherUser, eg.thirdUser] })],
       ['1:1 within group, inbound', false, eg.pmMessage()],

--- a/src/utils/__tests__/narrow-test.js
+++ b/src/utils/__tests__/narrow-test.js
@@ -5,9 +5,7 @@ import {
   isHomeNarrow,
   pmNarrowFromEmail,
   is1to1PmNarrow,
-  pmNarrowFromEmails,
   pmNarrowFromUsersUnsafe,
-  isGroupPmNarrow,
   specialNarrow,
   isSpecialNarrow,
   ALL_PRIVATE_NARROW,
@@ -58,41 +56,6 @@ describe('pmNarrowFromEmail', () => {
         {
           operator: 'pm-with',
           operand: eg.otherUser.email,
-        },
-      ]),
-    ).toBe(true);
-  });
-});
-
-describe('pmNarrowFromEmails', () => {
-  test('returns a narrow with specified recipients', () => {
-    expect(pmNarrowFromEmails([eg.otherUser.email, eg.thirdUser.email])).toEqual([
-      {
-        operator: 'pm-with',
-        operand: [eg.otherUser.email, eg.thirdUser.email].join(','),
-      },
-    ]);
-  });
-
-  test('a group narrow is only private chat with more than one recipients', () => {
-    expect(isGroupPmNarrow(HOME_NARROW)).toBe(false);
-    expect(isGroupPmNarrow(pmNarrowFromEmail(eg.otherUser.email))).toBe(false);
-    expect(isGroupPmNarrow(pmNarrowFromEmails([eg.otherUser.email, eg.thirdUser.email]))).toBe(
-      true,
-    );
-    expect(
-      isGroupPmNarrow([
-        {
-          operator: 'pm-with',
-          operand: eg.otherUser.email,
-        },
-      ]),
-    ).toBe(false);
-    expect(
-      isGroupPmNarrow([
-        {
-          operator: 'pm-with',
-          operand: [eg.otherUser.email, eg.thirdUser.email].join(','),
         },
       ]),
     ).toBe(true);

--- a/src/utils/__tests__/narrow-test.js
+++ b/src/utils/__tests__/narrow-test.js
@@ -6,6 +6,7 @@ import {
   pmNarrowFromEmail,
   is1to1PmNarrow,
   pmNarrowFromEmails,
+  pmNarrowFromUsersUnsafe,
   isGroupPmNarrow,
   specialNarrow,
   isSpecialNarrow,
@@ -388,7 +389,7 @@ describe('getNarrowsForMessage', () => {
       expectedNarrows: [
         HOME_NARROW,
         ALL_PRIVATE_NARROW,
-        pmNarrowFromEmails([eg.otherUser.email, eg.thirdUser.email]),
+        pmNarrowFromUsersUnsafe([eg.otherUser, eg.thirdUser]),
       ],
     },
   ];
@@ -421,7 +422,7 @@ describe('getNarrowForReply', () => {
     const message = eg.pmMessage({
       recipients: [eg.selfUser, eg.otherUser, eg.thirdUser],
     });
-    const expectedNarrow = pmNarrowFromEmails([eg.otherUser.email, eg.thirdUser.email]);
+    const expectedNarrow = pmNarrowFromUsersUnsafe([eg.otherUser, eg.thirdUser]);
 
     const actualNarrow = getNarrowForReply(message, eg.selfUser);
 

--- a/src/utils/__tests__/narrow-test.js
+++ b/src/utils/__tests__/narrow-test.js
@@ -42,22 +42,22 @@ describe('HOME_NARROW', () => {
 
 describe('pmNarrowFromEmail', () => {
   test('produces an one item list, pm-with operator and single email', () => {
-    expect(pmNarrowFromEmail('bob@example.com')).toEqual([
+    expect(pmNarrowFromEmail(eg.otherUser.email)).toEqual([
       {
         operator: 'pm-with',
-        operand: 'bob@example.com',
+        operand: eg.otherUser.email,
       },
     ]);
   });
 
   test('if operator is "pm-with" and only one email, then it is a private narrow', () => {
     expect(is1to1PmNarrow(HOME_NARROW)).toBe(false);
-    expect(is1to1PmNarrow(pmNarrowFromEmail('bob@example.com'))).toBe(true);
+    expect(is1to1PmNarrow(pmNarrowFromEmail(eg.otherUser.email))).toBe(true);
     expect(
       is1to1PmNarrow([
         {
           operator: 'pm-with',
-          operand: 'bob@example.com',
+          operand: eg.otherUser.email,
         },
       ]),
     ).toBe(true);
@@ -66,23 +66,25 @@ describe('pmNarrowFromEmail', () => {
 
 describe('pmNarrowFromEmails', () => {
   test('returns a narrow with specified recipients', () => {
-    expect(pmNarrowFromEmails(['bob@example.com', 'john@example.com'])).toEqual([
+    expect(pmNarrowFromEmails([eg.otherUser.email, eg.thirdUser.email])).toEqual([
       {
         operator: 'pm-with',
-        operand: 'bob@example.com,john@example.com',
+        operand: [eg.otherUser.email, eg.thirdUser.email].join(','),
       },
     ]);
   });
 
   test('a group narrow is only private chat with more than one recipients', () => {
     expect(isGroupPmNarrow(HOME_NARROW)).toBe(false);
-    expect(isGroupPmNarrow(pmNarrowFromEmail('bob@example.com'))).toBe(false);
-    expect(isGroupPmNarrow(pmNarrowFromEmails(['bob@example.com', 'john@example.com']))).toBe(true);
+    expect(isGroupPmNarrow(pmNarrowFromEmail(eg.otherUser.email))).toBe(false);
+    expect(isGroupPmNarrow(pmNarrowFromEmails([eg.otherUser.email, eg.thirdUser.email]))).toBe(
+      true,
+    );
     expect(
       isGroupPmNarrow([
         {
           operator: 'pm-with',
-          operand: 'bob@example.com',
+          operand: eg.otherUser.email,
         },
       ]),
     ).toBe(false);
@@ -90,7 +92,7 @@ describe('pmNarrowFromEmails', () => {
       isGroupPmNarrow([
         {
           operator: 'pm-with',
-          operand: 'bob@example.com,john@example.com',
+          operand: [eg.otherUser.email, eg.thirdUser.email].join(','),
         },
       ]),
     ).toBe(true);
@@ -101,13 +103,13 @@ describe('isPmNarrow', () => {
   test('a private or group narrow is any "pm-with" narrow', () => {
     expect(isPmNarrow(undefined)).toBe(false);
     expect(isPmNarrow(HOME_NARROW)).toBe(false);
-    expect(isPmNarrow(pmNarrowFromEmail('bob@example.com'))).toBe(true);
-    expect(isPmNarrow(pmNarrowFromEmails(['bob@example.com', 'john@example.com']))).toBe(true);
+    expect(isPmNarrow(pmNarrowFromEmail(eg.otherUser.email))).toBe(true);
+    expect(isPmNarrow(pmNarrowFromEmails([eg.otherUser.email, eg.thirdUser.email]))).toBe(true);
     expect(
       isPmNarrow([
         {
           operator: 'pm-with',
-          operand: 'bob@example.com',
+          operand: eg.otherUser.email,
         },
       ]),
     ).toBe(true);
@@ -115,7 +117,7 @@ describe('isPmNarrow', () => {
       isPmNarrow([
         {
           operator: 'pm-with',
-          operand: 'bob@example.com,john@example.com',
+          operand: [eg.otherUser.email, eg.thirdUser.email].join(','),
         },
       ]),
     ).toBe(true);
@@ -128,9 +130,9 @@ describe('isStreamOrTopicNarrow', () => {
     expect(isStreamOrTopicNarrow(streamNarrow('some stream'))).toBe(true);
     expect(isStreamOrTopicNarrow(topicNarrow('some stream', 'some topic'))).toBe(true);
     expect(isStreamOrTopicNarrow(HOME_NARROW)).toBe(false);
-    expect(isStreamOrTopicNarrow(pmNarrowFromEmail('a@a.com'))).toBe(false);
+    expect(isStreamOrTopicNarrow(pmNarrowFromEmail(eg.otherUser.email))).toBe(false);
     expect(
-      isStreamOrTopicNarrow(pmNarrowFromEmails(['john@example.com', 'mark@example.com'])),
+      isStreamOrTopicNarrow(pmNarrowFromEmails([eg.otherUser.email, eg.thirdUser.email])),
     ).toBe(false);
     expect(isStreamOrTopicNarrow(STARRED_NARROW)).toBe(false);
   });

--- a/src/utils/internalLinks.js
+++ b/src/utils/internalLinks.js
@@ -128,6 +128,11 @@ export const getNarrowFromLink = (
 
   switch (type) {
     case 'pm': {
+      // TODO: This case is pretty useless in practice, due to basically a
+      //   bug in the webapp: the URL that appears in the location bar for a
+      //   group PM conversation excludes self, so it's unusable for anyone
+      //   else.  In particular this will foil you if, say, you try to give
+      //   someone else in the conversation a link to a particular message.
       const ids = parsePmOperand(paths[1]);
       const users = pmKeyRecipientsFromIds(ids, allUsersById, ownUserId);
       return users === null ? null : pmNarrowFromUsers(users);

--- a/src/utils/internalLinks.js
+++ b/src/utils/internalLinks.js
@@ -1,7 +1,7 @@
 /* @flow strict-local */
 import { addBreadcrumb } from '@sentry/react-native';
 import type { Narrow, Stream, UserOrBot } from '../types';
-import { topicNarrow, streamNarrow, pmNarrowFromEmails, specialNarrow } from './narrow';
+import { topicNarrow, streamNarrow, specialNarrow, pmNarrowFromUsers } from './narrow';
 import { pmKeyRecipientsFromIds } from './recipient';
 import { isUrlOnRealm } from './url';
 
@@ -130,7 +130,7 @@ export const getNarrowFromLink = (
     case 'pm': {
       const ids = parsePmOperand(paths[1]);
       const users = pmKeyRecipientsFromIds(ids, allUsersById, ownUserId);
-      return users && pmNarrowFromEmails(users.map(u => u.email));
+      return users === null ? null : pmNarrowFromUsers(users);
     }
     case 'topic':
       return topicNarrow(parseStreamOperand(paths[1], streamsById), parseTopicOperand(paths[3]));

--- a/src/utils/narrow.js
+++ b/src/utils/narrow.js
@@ -71,11 +71,12 @@ const pmNarrowByString = (emails: string): Narrow => [
 //      the webapp, where the URL that appears in the location bar for a
 //      group PM conversation excludes self -- so it's unusable if you try
 //      to give someone else in it a link to a particular message, say.
-//  * OK, unsorted: getNarrowForReply
 //  * Good: getNarrowFromNotificationData: filters, and starts from
 //      notification's pm_users, which is sorted.
 //  * Good: messageHeaderAsHtml: comes from pmKeyRecipientsFromMessage,
 //      which filters and sorts by ID
+//  * Good: getNarrowForReply: also pmKeyRecipientsFromMessage
+//  * Good: getNarrowsForMessage: also pmKeyRecipientsFromMessage
 export const pmNarrowFromEmails = (emails: string[]): Narrow => pmNarrowByString(emails.join());
 
 /** Convenience wrapper for `pmNarrowFromEmails`. */

--- a/src/utils/narrow.js
+++ b/src/utils/narrow.js
@@ -9,6 +9,7 @@ import {
   recipientsOfPrivateMessage,
   streamNameOfStreamMessage,
   type PmKeyRecipients,
+  type PmKeyUsers,
 } from './recipient';
 
 export const isSameNarrow = (narrow1: Narrow, narrow2: Narrow): boolean =>
@@ -68,15 +69,15 @@ const pmNarrowByString = (emails: string): Narrow => [
 //  * OK, email: PmConversationList < PmConversationCard: the data comes
 //      from `getRecentConversations`, which filters and sorts by email
 //  * OK, email: PmConversationList < UnreadCards: ditto
+//
+// Known call stacks using the validating helpers -- still listed here
+// because sorting can still vary, for now:
 //  * OK, unsorted: getNarrowFromLink.  Though there's basically a bug in
 //      the webapp, where the URL that appears in the location bar for a
 //      group PM conversation excludes self -- so it's unusable if you try
 //      to give someone else in it a link to a particular message, say.
 //  * Good: getNarrowFromNotificationData: filters, and starts from
 //      notification's pm_users, which is sorted.
-//
-// Known call stacks using the validating helpers -- still listed here
-// because sorting can still vary, for now:
 //  * Good: messageHeaderAsHtml: comes from pmKeyRecipientsFromMessage,
 //      which filters and sorts by ID
 //  * Good: getNarrowForReply: also pmKeyRecipientsFromMessage
@@ -92,8 +93,20 @@ export const pmNarrowFromEmail = (email: string): Narrow => pmNarrowFromEmails([
  * The argument's type guarantees that it comes from
  * `pmKeyRecipientsFromMessage` or one of its related functions.  This
  * ensures that we've properly either removed the self user, or not.
+ *
+ * See also `pmNarrowFromUsers`, which does the same thing with a slightly
+ * different form of input.
  */
 export const pmNarrowFromRecipients = (recipients: PmKeyRecipients): Narrow =>
+  pmNarrowFromEmails(recipients.map(r => r.email));
+
+/**
+ * A PM narrow, either 1:1 or group.
+ *
+ * This is just like `pmNarrowFromRecipients`, but taking a slightly
+ * different form of input.  Use whichever one is more convenient.
+ */
+export const pmNarrowFromUsers = (recipients: PmKeyUsers): Narrow =>
   pmNarrowFromEmails(recipients.map(r => r.email));
 
 export const specialNarrow = (operand: string): Narrow => [

--- a/src/utils/narrow.js
+++ b/src/utils/narrow.js
@@ -63,9 +63,8 @@ const pmNarrowByString = (emails: string): Narrow => [
 // user-visible effect.
 //
 // Known call stacks not using the validating helpers:
-//  * OK, perilously, unsorted: CreateGroupScreen: the self user isn't
-//      offered in the UI, so effectively the list is filtered; can call
-//      with just one email, but happily this works out the same as pmNarrow
+//  * OK, perilously: CreateGroupScreen: the self user isn't offered in the
+//      UI, so effectively the list is filtered; does sort by ID
 //  * OK, email: PmConversationList < PmConversationCard: the data comes
 //      from `getRecentConversations`, which filters and sorts by email
 //  * OK, email: PmConversationList < UnreadCards: ditto

--- a/src/utils/narrow.js
+++ b/src/utils/narrow.js
@@ -48,29 +48,19 @@ const pmNarrowByString = (emails: string): Narrow => [
  * They might not have a consistent sorting.  (This would be good to fix.)
  * Consumers of this data should sort for themselves when making comparisons.
  */
-// Ideally, all callers should agree on how they're sorted, too.  Because
-// they don't, we have latent bugs (possibly a live one somewhere) where we
+// Ideally, all callers should agree on how they're sorted, too.  If not, we
 // can wind up with several distinct narrows that are actually the same
-// group PM conversation.
-//
-// For example this happens if you have a group PM conversation where email
-// and ID sorting don't happen to coincide; visit a group PM conversation
-// from the main nav (either the unreads or PMs screen) -- which sorts by
-// email; and then visit the same conversation from a recipient bar on the
-// "all messages" narrow -- which sorts by ID.  The Redux logs in the
-// debugger will show two different entries in `state.narrows`.  This bug is
-// merely latent only because it doesn't (as far as we know) have any
-// user-visible effect.
+// group PM conversation.  But it appears that we now do sort consistently,
+// by user ID.
 //
 // Known call stacks not using the validating helpers:
 //  * OK, perilously: CreateGroupScreen: the self user isn't offered in the
 //      UI, so effectively the list is filtered; does sort by ID
-//  * OK, email: PmConversationList < PmConversationCard: the data comes
-//      from `getRecentConversations`, which filters and sorts by email
-//  * OK, email: PmConversationList < UnreadCards: ditto
 //
 // Known call stacks using the validating helpers -- which guarantee not
 // only filtering but sorting by ID, hooray:
+//  * PmConversationList < PmConversationCard
+//  * PmConversationList < UnreadCards
 //  * getNarrowFromLink.  Though there's basically a bug in the webapp,
 //      where the URL that appears in the location bar for a group PM
 //      conversation excludes self -- so it's unusable if you try to give

--- a/src/utils/narrow.js
+++ b/src/utils/narrow.js
@@ -54,11 +54,11 @@ const pmNarrowByString = (emails: string): Narrow => [
 // by user ID.
 //
 // Known call stacks not using the validating helpers:
-//  * OK, perilously: CreateGroupScreen: the self user isn't offered in the
-//      UI, so effectively the list is filtered; does sort by ID
+//  none!
 //
 // Known call stacks using the validating helpers -- which guarantee not
 // only filtering but sorting by ID, hooray:
+//  * CreateGroupScreen
 //  * PmConversationList < PmConversationCard
 //  * PmConversationList < UnreadCards
 //  * getNarrowFromLink.  Though there's basically a bug in the webapp,

--- a/src/utils/narrow.js
+++ b/src/utils/narrow.js
@@ -70,18 +70,16 @@ const pmNarrowByString = (emails: string): Narrow => [
 //      from `getRecentConversations`, which filters and sorts by email
 //  * OK, email: PmConversationList < UnreadCards: ditto
 //
-// Known call stacks using the validating helpers -- still listed here
-// because sorting can still vary, for now:
-//  * OK, unsorted: getNarrowFromLink.  Though there's basically a bug in
-//      the webapp, where the URL that appears in the location bar for a
-//      group PM conversation excludes self -- so it's unusable if you try
-//      to give someone else in it a link to a particular message, say.
-//  * Good: getNarrowFromNotificationData: filters, and starts from
-//      notification's pm_users, which is sorted.
-//  * Good: messageHeaderAsHtml: comes from pmKeyRecipientsFromMessage,
-//      which filters and sorts by ID
-//  * Good: getNarrowForReply: also pmKeyRecipientsFromMessage
-//  * Good: getNarrowsForMessage: also pmKeyRecipientsFromMessage
+// Known call stacks using the validating helpers -- which guarantee not
+// only filtering but sorting by ID, hooray:
+//  * getNarrowFromLink.  Though there's basically a bug in the webapp,
+//      where the URL that appears in the location bar for a group PM
+//      conversation excludes self -- so it's unusable if you try to give
+//      someone else in it a link to a particular message, say.
+//  * getNarrowFromNotificationData
+//  * messageHeaderAsHtml
+//  * getNarrowForReply
+//  * getNarrowsForMessage
 export const pmNarrowFromEmails = (emails: string[]): Narrow => pmNarrowByString(emails.join());
 
 /**

--- a/src/utils/narrow.js
+++ b/src/utils/narrow.js
@@ -2,7 +2,7 @@
 import isEqual from 'lodash.isequal';
 import unescape from 'lodash.unescape';
 
-import type { Narrow, Message, Outbox, User } from '../types';
+import type { Narrow, Message, Outbox, User, UserOrBot } from '../types';
 import {
   normalizeRecipientsSansMe,
   pmKeyRecipientsFromMessage,
@@ -84,7 +84,13 @@ const pmNarrowByString = (emails: string): Narrow => [
 //  * Good: getNarrowsForMessage: also pmKeyRecipientsFromMessage
 export const pmNarrowFromEmails = (emails: string[]): Narrow => pmNarrowByString(emails.join());
 
-/** Convenience wrapper for `pmNarrowFromEmails`. */
+/**
+ * DEPRECATED.  Convenience wrapper for `pmNarrowFromEmails`.
+ *
+ * This function is being replaced by `pm1to1NarrowFromUser`, as part of
+ * migrating from emails to user IDs to identify users.  Don't add new uses
+ * of this function; use that one instead.
+ */
 export const pmNarrowFromEmail = (email: string): Narrow => pmNarrowFromEmails([email]);
 
 /**
@@ -105,9 +111,21 @@ export const pmNarrowFromRecipients = (recipients: PmKeyRecipients): Narrow =>
  *
  * This is just like `pmNarrowFromRecipients`, but taking a slightly
  * different form of input.  Use whichever one is more convenient.
+ *
+ * See also `pm1to1NarrowFromUser`, which is more convenient when you have a
+ * single specific user.
  */
 export const pmNarrowFromUsers = (recipients: PmKeyUsers): Narrow =>
   pmNarrowFromEmails(recipients.map(r => r.email));
+
+/**
+ * A 1:1 PM narrow, possibly with self.
+ *
+ * This has the same effect as calling pmNarrowFromUsers, but for code that
+ * statically has just one other user it's a bit more convenient because it
+ * doesn't require going through our `recipient` helpers.
+ */
+export const pm1to1NarrowFromUser = (user: UserOrBot): Narrow => pmNarrowFromEmails([user.email]);
 
 export const specialNarrow = (operand: string): Narrow => [
   {

--- a/src/utils/narrow.js
+++ b/src/utils/narrow.js
@@ -119,6 +119,25 @@ export const pmNarrowFromUsers = (recipients: PmKeyUsers): Narrow =>
   pmNarrowFromEmails(recipients.map(r => r.email));
 
 /**
+ * FOR TESTS ONLY.  Like pmNarrowFromUsers, but without validation.
+ *
+ * This exists purely for convenience in tests. Unlike the other Narrow
+ * constructors, its type does not require the argument to have come from a
+ * function that applies our "maybe filter out self" convention.  The caller
+ * is still required to do so, but nothing checks this.
+ *
+ * Outside of tests, always use pmNarrowFromUsers instead.  Use
+ * pmKeyRecipientsFromUsers, along with an ownUserId value, to produce the
+ * needed input.
+ *
+ * This does take care of sorting the input as needed.
+ */
+// It'd be fine for test data to go through the usual filtering logic; the
+// annoying thing is just that that requires an ownUserId value.
+export const pmNarrowFromUsersUnsafe = (recipients: UserOrBot[]): Narrow =>
+  pmNarrowFromEmails(recipients.sort((a, b) => a.user_id - b.user_id).map(r => r.email));
+
+/**
  * A 1:1 PM narrow, possibly with self.
  *
  * This has the same effect as calling pmNarrowFromUsers, but for code that

--- a/src/utils/recipient.js
+++ b/src/utils/recipient.js
@@ -246,6 +246,18 @@ export const pmKeyRecipientsFromIds = (
 };
 
 /**
+ * Just like pmKeyRecipientsFromMessage, but in a slightly different format.
+ */
+export const pmKeyRecipientUsersFromMessage = (
+  message: Message | Outbox,
+  allUsersById: Map<number, UserOrBot>,
+  ownUserId: number,
+): PmKeyUsers | null => {
+  const userIds = recipientsOfPrivateMessage(message).map(r => r.id);
+  return pmKeyRecipientsFromIds(userIds, allUsersById, ownUserId);
+};
+
+/**
  * The key this PM is filed under in the "unread messages" data structure.
  *
  * Note this diverges slightly from pmKeyRecipientsFromMessage in its

--- a/src/utils/recipient.js
+++ b/src/utils/recipient.js
@@ -61,6 +61,16 @@ export const recipientsOfPrivateMessage = (
  */
 export opaque type PmKeyRecipients: $ReadOnlyArray<PmRecipientUser> = $ReadOnlyArray<PmRecipientUser>;
 
+/**
+ * A set of users identifying a PM conversation, as per pmKeyRecipientsFromMessage.
+ *
+ * This is just like `PmKeyRecipients` but with a different selection of
+ * details about the users.  See there for discussion.
+ *
+ * See also `pmNarrowFromUsers`, which requires a value of this type.
+ */
+export opaque type PmKeyUsers: $ReadOnlyArray<UserOrBot> = $ReadOnlyArray<UserOrBot>;
+
 // Filter a list of PM recipients in the quirky way that we do.
 //
 // Specifically: all users, except the self-user, except if it's the
@@ -212,7 +222,7 @@ export const pmKeyRecipientsFromIds = (
   userIds: number[],
   allUsersById: Map<number, UserOrBot>,
   ownUserId: number,
-): UserOrBot[] | null => {
+): PmKeyUsers | null => {
   const users = [];
   for (const id of userIds) {
     if (id === ownUserId && userIds.length > 1) {

--- a/src/utils/recipient.js
+++ b/src/utils/recipient.js
@@ -87,6 +87,15 @@ const filterRecipients = (
     ? recipients
     : recipients.filter(r => r.id !== ownUserId).sort((a, b) => a.id - b.id);
 
+// Like filterRecipients, but on User objects.
+const filterRecipientUsers = (
+  recipients: $ReadOnlyArray<UserOrBot>,
+  ownUserId: number,
+): $ReadOnlyArray<UserOrBot> =>
+  recipients.length === 1
+    ? recipients
+    : recipients.filter(r => r.user_id !== ownUserId).sort((a, b) => a.user_id - b.user_id);
+
 // Like filterRecipients, but on user IDs directly.
 const filterRecipientsAsUserIds = <T: $ReadOnlyArray<number>>(
   recipients: T,
@@ -256,6 +265,14 @@ export const pmKeyRecipientUsersFromMessage = (
   const userIds = recipientsOfPrivateMessage(message).map(r => r.id);
   return pmKeyRecipientsFromIds(userIds, allUsersById, ownUserId);
 };
+
+/**
+ * Just like pmKeyRecipientsFromMessage, but with slightly different formats of data.
+ */
+export const pmKeyRecipientsFromUsers = (
+  users: $ReadOnlyArray<UserOrBot>,
+  ownUserId: number,
+): PmKeyUsers => filterRecipientUsers(users, ownUserId);
 
 /**
  * The key this PM is filed under in the "unread messages" data structure.

--- a/src/utils/recipient.js
+++ b/src/utils/recipient.js
@@ -83,16 +83,22 @@ const filterRecipients = (
   recipients: $ReadOnlyArray<PmRecipientUser>,
   ownUserId: number,
 ): $ReadOnlyArray<PmRecipientUser> =>
-  recipients.length === 1 ? recipients : recipients.filter(r => r.id !== ownUserId);
+  recipients.length === 1
+    ? recipients
+    : recipients.filter(r => r.id !== ownUserId).sort((a, b) => a.id - b.id);
 
 // Like filterRecipients, but on user IDs directly.
 const filterRecipientsAsUserIds = <T: $ReadOnlyArray<number>>(
   recipients: T,
   ownUserId: number,
-): T => (recipients.length === 1 ? recipients : recipients.filter(r => r !== ownUserId));
+): T =>
+  recipients.length === 1
+    ? recipients
+    : recipients.filter(r => r !== ownUserId).sort((a, b) => a - b);
 
 // Like filterRecipients, but identifying users by email address.
 // Prefer filterRecipients instead.
+// No sort; caller must sort if needed.
 const filterRecipientsByEmail = <T: { +email: string, ... }>(
   recipients: $ReadOnlyArray<T>,
   ownEmail: string,

--- a/src/utils/recipient.js
+++ b/src/utils/recipient.js
@@ -26,6 +26,41 @@ export const recipientsOfPrivateMessage = (
   return recipients;
 };
 
+/**
+ * A set of users identifying a PM conversation, as per pmKeyRecipientsFromMessage.
+ *
+ * This is an "opaque type alias" for an array of plain old data.
+ * See Flow docs: https://flow.org/en/docs/types/opaque-types/
+ *
+ * That means:
+ *  * For code outside this module, it's some unknown subtype of the given
+ *    array type.
+ *  * Secretly, it actually is just that array type, and code inside this
+ *    module can see that.
+ *  * (In general, the public type bound and the secret underlying type can
+ *    be different, but in this case we've made them the same.)
+ *
+ * As a result:
+ *  * The only way to produce a value of this type is with code inside this
+ *    module.  (For code outside the module, the secret underlying type
+ *    could have any number of requirements it can't see; it could even be
+ *    `empty`, which has no values.)
+ *  * But code outside this module can still freely *consume* the data in a
+ *    value of this type, just like any other value of the given array type.
+ *
+ * Or to say the same things from a different angle:
+ *  * For code inside this module, this is just like a normal type alias,
+ *    to the secret/private underlying type.
+ *  * For code outside this module trying to produce a value of this type,
+ *    it's a brick wall -- it's effectively like the `empty` type.
+ *  * For code outside this module trying to consume a value of this type,
+ *    it's just like a normal type alias to the public type bound; which in
+ *    this case we've chosen to make the same as the private underlying type.
+ *
+ * See also `pmNarrowFromRecipients`, which requires a value of this type.
+ */
+export opaque type PmKeyRecipients: $ReadOnlyArray<PmRecipientUser> = $ReadOnlyArray<PmRecipientUser>;
+
 // Filter a list of PM recipients in the quirky way that we do.
 //
 // Specifically: all users, except the self-user, except if it's the
@@ -157,7 +192,7 @@ export const pmUiRecipientsFromMessage = (
 export const pmKeyRecipientsFromMessage = (
   message: Message | Outbox,
   ownUser: User,
-): $ReadOnlyArray<PmRecipientUser> => {
+): PmKeyRecipients => {
   if (message.type !== 'private') {
     throw new Error('pmKeyRecipientsFromMessage: expected PM, got stream message');
   }

--- a/src/webview/html/messageHeaderAsHtml.js
+++ b/src/webview/html/messageHeaderAsHtml.js
@@ -2,7 +2,7 @@
 import template from './template';
 import type { Message, Narrow, Outbox } from '../../types';
 import type { BackgroundData } from '../MessageList';
-import { streamNarrow, topicNarrow, caseNarrow, pmNarrowFromEmails } from '../../utils/narrow';
+import { streamNarrow, topicNarrow, caseNarrow, pmNarrowFromRecipients } from '../../utils/narrow';
 import { foregroundColorFromBackground } from '../../utils/color';
 import { humanDate } from '../../utils/date';
 import {
@@ -85,7 +85,7 @@ export default (
 
   if (item.type === 'private' && headerStyle === 'full') {
     const keyRecipients = pmKeyRecipientsFromMessage(item, ownUser);
-    const narrowObj = pmNarrowFromEmails(keyRecipients.map(r => r.email));
+    const narrowObj = pmNarrowFromRecipients(keyRecipients);
     const narrowStr = JSON.stringify(narrowObj);
 
     const uiRecipients = pmUiRecipientsFromMessage(item, ownUser);


### PR DESCRIPTION

This is the larger refactoring branch foreshadowed by #4332, following up further on #4330.  This takes care of most of #4035 which has been the main obstacle to #3133, and brings us much closer to being able to handle #4333.

The main thrust of this series is to further centralize responsibility for the fiddly details of how we describe PM conversations.  In particular, at the end of this series:

 * All PM narrows we construct, outside of test code, use data that is verified -- with the help of the type-checker -- to have the right set of users, including or excluding self in a consistent way.

   We've previously had a number of bugs where these didn't match.  The last few of those were fixed in #4294; this part doesn't change any behavior, but effectively consolidates those fixes.

 * All PM narrows we construct are similarly verified to have consistent sorting of the users.

   Here we still had some mismatches even after #4294, which represented at least latent bugs.  We fix those here along the way.

 * Almost all PM narrows we construct are through constructors that receive user IDs as well as emails, setting us up to start recording user IDs in the Narrow objects in the future, i.e. #4333.

   The remaining exceptions are some 1:1 narrows constructed through pmNarrowFromEmail.  These consist of some test data and one remaining non-test callsite.

For enlisting the type-checker to verify that we apply the right processing to the data, we use Flow's "opaque type" feature: the helper functions that do that work return types which code outside the `recipient` module cannot produce, and then the Narrow factories require those types.

Conveniently, we can still let other code *consume* the data: we export that the types are subtypes of certain array types (and secretly they really are just those array types), so app code can use the results as usual to get user IDs, etc., in addition to creating narrows.
