### PR TITLE
UserAvatarWithPresence: Remove dubious default prop for `email`.

### DIFF
--- a/src/common/UserAvatarWithPresence.js
+++ b/src/common/UserAvatarWithPresence.js
@@ -34,9 +34,6 @@ type Props = $ReadOnly<{|
  */
 export default class UserAvatarWithPresence extends PureComponent<Props> {
   static defaultProps = {
-    // TODO: An empty-string `email` is probably up to no good. Remove
-    // this default.
-    email: '',
     shape: 'rounded',
   };
 

--- a/src/lightbox/Lightbox.js
+++ b/src/lightbox/Lightbox.js
@@ -119,6 +119,7 @@ class Lightbox extends PureComponent<Props, State> {
             timestamp={message.timestamp}
             avatarUrl={message.avatar_url}
             senderName={message.sender_full_name}
+            senderEmail={message.sender_email}
           />
         </SlideAnimationView>
         <SlideAnimationView

--- a/src/lightbox/LightboxHeader.js
+++ b/src/lightbox/LightboxHeader.js
@@ -41,6 +41,7 @@ const styles = createStyleSheet({
 
 type Props = $ReadOnly<{|
   senderName: string,
+  senderEmail: string,
   timestamp: number,
   avatarUrl: AvatarURL,
   onPressBack: () => void,
@@ -56,14 +57,14 @@ type Props = $ReadOnly<{|
  */
 export default class LightboxHeader extends PureComponent<Props> {
   render() {
-    const { onPressBack, senderName, timestamp, avatarUrl } = this.props;
+    const { onPressBack, senderName, senderEmail, timestamp, avatarUrl } = this.props;
     const displayDate = humanDate(new Date(timestamp * 1000));
     const time = shortTime(new Date(timestamp * 1000));
     const subheader = `${displayDate} at ${time}`;
 
     return (
       <View style={styles.wrapper}>
-        <UserAvatarWithPresence size={36} avatarUrl={avatarUrl} />
+        <UserAvatarWithPresence size={36} avatarUrl={avatarUrl} email={senderEmail} />
         <View style={styles.text}>
           <Text style={styles.name} numberOfLines={1}>
             {senderName}


### PR DESCRIPTION
As Greg points out, the effect of this default prop has been to
suppress the presence-status indicator for the sender in the
lightbox header. And since that omission is quite unlikely to be
intentional, we should fix it by passing down the sender's email.
So, do.

[1] https://github.com/zulip/zulip-mobile/pull/4230#discussion_r542953311