### PR TITLE
Address a performance regression from #4230 by deferring `new URL` computations.

### DIFF
--- a/src/utils/__tests__/avatar-test.js
+++ b/src/utils/__tests__/avatar-test.js
@@ -71,12 +71,22 @@ describe('GravatarURL', () => {
     });
   });
 
-  test('uses hash from server, if provided', () => {
+  test('uses URL from server, if provided', () => {
     const email = 'user13313@chat.zulip.org';
-    const hash = md5('cbobbe@zulip.com');
-    const instance = GravatarURL.validateAndConstructInstance({ email, hash });
+    const urlFromServer =
+      'https://secure.gravatar.com/avatar/de6685f1d3eb74439c1dcda84f92543e?d=identicon&version=1';
+    const instance = GravatarURL.validateAndConstructInstance({
+      email,
+      urlFromServer,
+    });
     SIZES_TO_TEST.forEach(size => {
-      expect(instance.get(size).toString()).toContain(hash);
+      const clonedUrlOfSize = new URL(instance.get(size).toString());
+      const clonedUrlFromServer = new URL(urlFromServer);
+      clonedUrlFromServer.searchParams.delete('s');
+      clonedUrlOfSize.searchParams.delete('s');
+      // `urlFromServer` should equal the result for this size, modulo
+      // the actual size param.
+      expect(clonedUrlOfSize.toString()).toEqual(clonedUrlFromServer.toString());
     });
   });
 

--- a/src/utils/avatar.js
+++ b/src/utils/avatar.js
@@ -3,7 +3,6 @@
 /* eslint-disable no-use-before-define */
 import md5 from 'blueimp-md5';
 
-import { tryParseUrl } from './url';
 import * as logging from './logging';
 import { ensureUnreachable } from '../types';
 
@@ -53,7 +52,16 @@ export class AvatarURL {
       // which to generate the correct hash; see
       // https://github.com/zulip/zulip/issues/15287. Implemented at
       // `do_events_register` in zerver/lib/events.py on the server.)
-      if (tryParseUrl(rawAvatarUrl)?.origin === GravatarURL.ORIGIN) {
+      if (
+        rawAvatarUrl.startsWith(
+          // Best not to use an expensive `new URL` call, when the
+          // following is equivalent (assuming `rawAvatarUrl` is also
+          // valid through its /pathname, ?query=params, and
+          // #fragment). The trailing slash ensures that we've
+          // examined the full origin in `rawAvatarUrl`.
+          `${GravatarURL.ORIGIN}/`,
+        )
+      ) {
         const hashMatch = /[0-9a-fA-F]{32}$/.exec(new URL(rawAvatarUrl).pathname);
         if (hashMatch === null) {
           const msg = 'Unexpected Gravatar URL shape from server.';

--- a/src/utils/avatar.js
+++ b/src/utils/avatar.js
@@ -144,9 +144,12 @@ export class GravatarURL extends AvatarURL {
       // bonus.
       return new GravatarURL(urlFromServer);
     } else {
-      const standardSizeUrl = new URL(`/avatar/${md5(email.toLowerCase())}`, GravatarURL.ORIGIN);
-      standardSizeUrl.searchParams.set('d', 'identicon');
-      return new GravatarURL(standardSizeUrl);
+      return new GravatarURL(
+        // Thankfully, this string concatenation is quite safe: we
+        // know enough about our inputs here to compose a properly
+        // formatted URL with them, without using `new URL`.
+        `${GravatarURL.ORIGIN}/avatar/${md5(email.toLowerCase())}?d=identicon`,
+      );
     }
   }
 


### PR DESCRIPTION
<img width="1679" alt="Screen Shot 2020-12-16 at 3 11 09 PM" src="https://user-images.githubusercontent.com/22248748/102401370-3243d680-3fb1-11eb-8b03-030abba4ef5c.png">

Following some profiling with Chrome DevTools, and [discussion](https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/user_avatar_url_field_optional/near/1081038) on CZO, keep going in the direction of deferring `new URL` computations, since the computations done in `api.registerForEvents` have made the initial fetch take quite a lot longer after #4230 than before, and URL computations were observed to be a big part of that in profiling.

The above measurements are taken with release builds on my 4+ year-old iPhone 6s running iOS 13.7, on CZO, at notable commits (see the chart's key):

- 998947d807 (narrow [nfc]: Unexport pmNarrowFromEmails!) — Before #4230
- c642677685 (registerForEvents: Start sending `user_avatar_url_field_optional`.) — Tip of #4230
- Then each commit in this series. Note that they're based on #4230; I haven't rebased them atop `master`, which contains more recent commits.

The logging code is the following (also pasted in [discussion](https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/user_avatar_url_field_optional/near/1080938)):

```diff
diff --git src/message/fetchActions.js src/message/fetchActions.js
index a610c11ea..46cb1e189 100644
--- src/message/fetchActions.js
+++ src/message/fetchActions.js
@@ -4,6 +4,7 @@ import type { Narrow, Dispatch, GetState, GlobalState, Message, Action } from '.
 import type { ApiResponseServerSettings } from '../api/settings/getServerSettings';
index a610c11ea..46cb1e189 100644
--- src/message/fetchActions.js
+++ src/message/fetchActions.js
@@ -4,6 +4,7 @@ import type { Narrow, Dispatch, GetState, GlobalState, Message, Action } from '.
 import type { ApiResponseServerSettings } from '../api/settings/getServerSettings';
 import type { InitialData } from '../api/initialDataTypes';
 import * as api from '../api';
+import * as logging from '../utils/logging';
 import { resetToMainTabs } from '../actions';
 import { isClientError } from '../api/apiErrors';
 import {
@@ -309,6 +310,7 @@ export const doInitialFetch = () => async (dispatch: Dispatch, getState: GetStat
   let initData: InitialData;
   let serverSettings: ApiResponseServerSettings;
 
+  const before = Date.now();
   try {
     [initData, serverSettings] = await Promise.all([
       tryFetch(() =>
@@ -331,6 +333,8 @@ export const doInitialFetch = () => async (dispatch: Dispatch, getState: GetStat
     dispatch(logout());
     return;
   }
+  const after = Date.now();
+  logging.logToProfiling({ durationMs: after - before, ip: '192.168.1.7' });
```

It seems to confirm our [expectation](https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/user_avatar_url_field_optional/near/1081247) that the biggest difference is made by removing the `new URL` in `FallbackAvatarURL`'s `validateAndConstructInstance`. That's 9ec9e20684 in this revision.

Also, removing a `new URL` from `fromUserOrBotData` (which was used to discern which subclass to use) is helpful, as [expected](https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/user_avatar_url_field_optional/near/1081272). That's 1d3c38a725 in this revision.

Removing two `new URL`s in `GravatarURL`'s `validateAndConstructInstance` seems definitely helpful; that's 1de50ccd49 in this revision.

The remaining changes in this revision, 720547ff2b and 190eb154f4...aren't large improvements, it seems. The former might have shortened the time by just a hair; the latter (the tool chose purple, like the before-#4230 measurements, oops) actually ended up with a larger mean than the mean for 1de50ccd49.

Unfortunately, nothing was able to clearly beat the before-#4230 measurements (the lowest purple line shows its mean), but it's close.