### PR TITLE
narrow: Switch to a reasonable representation, and store user IDs

### DIFF
--- a/src/boot/store.js
+++ b/src/boot/store.js
@@ -239,6 +239,21 @@ const migrations: { [string]: (GlobalState) => GlobalState } = {
     ),
   }),
 
+  // Change format of keys representing PM narrows, adding user IDs.
+  '20': state => ({
+    ...dropCache(state),
+    drafts: objectFromEntries(
+      Object.keys(state.drafts)
+        // Just drop any old-style, email-only PM keys.  Converting them
+        // would require using additional information to look up the IDs,
+        // which would make this more complex than any of our other
+        // migrations.  Drafts are inherently short-term, and are already
+        // discarded whenever switching between accounts.
+        .filter(key => !key.startsWith('pm:s:'))
+        .map(key => [key, state.drafts[key]]),
+    ),
+  }),
+
   // TIP: When adding a migration, consider just using `dropCache`.
 };
 

--- a/src/chat/__tests__/narrowsSelectors-test.js
+++ b/src/chat/__tests__/narrowsSelectors-test.js
@@ -11,7 +11,7 @@ import {
 import {
   HOME_NARROW,
   HOME_NARROW_STR,
-  pmNarrowFromEmail,
+  pm1to1NarrowFromUser,
   streamNarrow,
   topicNarrow,
   STARRED_NARROW,
@@ -81,14 +81,14 @@ describe('getMessagesForNarrow', () => {
   test('do not combine messages and outbox in different narrow', () => {
     const state = eg.reduxState({
       narrows: Immutable.Map({
-        [keyFromNarrow(pmNarrowFromEmail(eg.otherUser.email))]: [123],
+        [keyFromNarrow(pm1to1NarrowFromUser(eg.otherUser))]: [123],
       }),
       messages,
       outbox: [outboxMessage],
       realm: eg.realmState({ email: eg.selfUser.email }),
     });
 
-    const result = getMessagesForNarrow(state, pmNarrowFromEmail(eg.otherUser.email));
+    const result = getMessagesForNarrow(state, pm1to1NarrowFromUser(eg.otherUser));
 
     expect(result).toEqual([message]);
   });
@@ -193,9 +193,7 @@ describe('getStreamInNarrow', () => {
   });
 
   test('return NULL_SUBSCRIPTION is narrow is not topic or stream', () => {
-    expect(getStreamInNarrow(state, pmNarrowFromEmail(eg.otherUser.email))).toEqual(
-      NULL_SUBSCRIPTION,
-    );
+    expect(getStreamInNarrow(state, pm1to1NarrowFromUser(eg.otherUser))).toEqual(NULL_SUBSCRIPTION);
     expect(getStreamInNarrow(state, topicNarrow(stream4.name, 'topic'))).toEqual(NULL_SUBSCRIPTION);
   });
 });
@@ -258,7 +256,7 @@ describe('isNarrowValid', () => {
       streams: [],
       users: [user],
     });
-    const narrow = pmNarrowFromEmail(user.email);
+    const narrow = pm1to1NarrowFromUser(user);
 
     const result = isNarrowValid(state, narrow);
 
@@ -276,7 +274,7 @@ describe('isNarrowValid', () => {
       streams: [],
       users: [],
     });
-    const narrow = pmNarrowFromEmail(user.email);
+    const narrow = pm1to1NarrowFromUser(user);
 
     const result = isNarrowValid(state, narrow);
 
@@ -333,7 +331,7 @@ describe('isNarrowValid', () => {
       streams: [],
       users: [],
     });
-    const narrow = pmNarrowFromEmail(bot.email);
+    const narrow = pm1to1NarrowFromUser(bot);
 
     const result = isNarrowValid(state, narrow);
 
@@ -351,7 +349,7 @@ describe('isNarrowValid', () => {
       streams: [],
       users: [],
     });
-    const narrow = pmNarrowFromEmail(notActiveUser.email);
+    const narrow = pm1to1NarrowFromUser(notActiveUser);
 
     const result = isNarrowValid(state, narrow);
 

--- a/src/chat/__tests__/narrowsSelectors-test.js
+++ b/src/chat/__tests__/narrowsSelectors-test.js
@@ -81,14 +81,14 @@ describe('getMessagesForNarrow', () => {
   test('do not combine messages and outbox in different narrow', () => {
     const state = eg.reduxState({
       narrows: Immutable.Map({
-        [keyFromNarrow(pmNarrowFromEmail('john@example.com'))]: [123],
+        [keyFromNarrow(pmNarrowFromEmail(eg.otherUser.email))]: [123],
       }),
       messages,
       outbox: [outboxMessage],
       realm: eg.realmState({ email: eg.selfUser.email }),
     });
 
-    const result = getMessagesForNarrow(state, pmNarrowFromEmail('john@example.com'));
+    const result = getMessagesForNarrow(state, pmNarrowFromEmail(eg.otherUser.email));
 
     expect(result).toEqual([message]);
   });
@@ -193,7 +193,9 @@ describe('getStreamInNarrow', () => {
   });
 
   test('return NULL_SUBSCRIPTION is narrow is not topic or stream', () => {
-    expect(getStreamInNarrow(state, pmNarrowFromEmail('abc@zulip.com'))).toEqual(NULL_SUBSCRIPTION);
+    expect(getStreamInNarrow(state, pmNarrowFromEmail(eg.otherUser.email))).toEqual(
+      NULL_SUBSCRIPTION,
+    );
     expect(getStreamInNarrow(state, topicNarrow(stream4.name, 'topic'))).toEqual(NULL_SUBSCRIPTION);
   });
 });

--- a/src/compose/__tests__/getComposeInputPlaceholder-test.js
+++ b/src/compose/__tests__/getComposeInputPlaceholder-test.js
@@ -3,7 +3,7 @@ import deepFreeze from 'deep-freeze';
 
 import getComposeInputPlaceholder from '../getComposeInputPlaceholder';
 import {
-  pmNarrowFromEmail,
+  pm1to1NarrowFromUser,
   streamNarrow,
   topicNarrow,
   pmNarrowFromUsersUnsafe,
@@ -15,7 +15,7 @@ describe('getComposeInputPlaceholder', () => {
   const ownEmail = eg.selfUser.email;
 
   test('returns "Message @ThisPerson" object for person narrow', () => {
-    const narrow = deepFreeze(pmNarrowFromEmail(eg.otherUser.email));
+    const narrow = deepFreeze(pm1to1NarrowFromUser(eg.otherUser));
     const placeholder = getComposeInputPlaceholder(narrow, ownEmail, usersByEmail);
     expect(placeholder).toEqual({
       text: 'Message {recipient}',
@@ -24,7 +24,7 @@ describe('getComposeInputPlaceholder', () => {
   });
 
   test('returns "Jot down something" object for self narrow', () => {
-    const narrow = deepFreeze(pmNarrowFromEmail(eg.selfUser.email));
+    const narrow = deepFreeze(pm1to1NarrowFromUser(eg.selfUser));
     const placeholder = getComposeInputPlaceholder(narrow, ownEmail, usersByEmail);
     expect(placeholder).toEqual({ text: 'Jot down something' });
   });

--- a/src/notification/__tests__/notification-test.js
+++ b/src/notification/__tests__/notification-test.js
@@ -34,10 +34,10 @@ describe('getNarrowFromNotificationData', () => {
   test('on notification for a private message returns a PM narrow', () => {
     const notification = {
       recipient_type: 'private',
-      sender_email: 'mark@example.com',
+      sender_email: eg.otherUser.email,
     };
     const narrow = getNarrowFromNotificationData(notification, DEFAULT_MAP, ownUserId);
-    expect(narrow).toEqual(pmNarrowFromEmail('mark@example.com'));
+    expect(narrow).toEqual(pmNarrowFromEmail(eg.otherUser.email));
   });
 
   test('on notification for a group message returns a group narrow', () => {

--- a/src/notification/__tests__/notification-test.js
+++ b/src/notification/__tests__/notification-test.js
@@ -4,7 +4,7 @@ import deepFreeze from 'deep-freeze';
 import type { UserOrBot } from '../../api/modelTypes';
 import type { JSONableDict } from '../../utils/jsonable';
 import { getNarrowFromNotificationData } from '..';
-import { topicNarrow, pmNarrowFromEmail, pmNarrowFromUsersUnsafe } from '../../utils/narrow';
+import { topicNarrow, pm1to1NarrowFromUser, pmNarrowFromUsersUnsafe } from '../../utils/narrow';
 
 import * as eg from '../../__tests__/lib/exampleData';
 import { fromAPNsImpl as extractIosNotificationData } from '../extract';
@@ -37,7 +37,7 @@ describe('getNarrowFromNotificationData', () => {
       sender_email: eg.otherUser.email,
     };
     const narrow = getNarrowFromNotificationData(notification, DEFAULT_MAP, ownUserId);
-    expect(narrow).toEqual(pmNarrowFromEmail(eg.otherUser.email));
+    expect(narrow).toEqual(pm1to1NarrowFromUser(eg.otherUser));
   });
 
   test('on notification for a group message returns a group narrow', () => {

--- a/src/notification/index.js
+++ b/src/notification/index.js
@@ -4,7 +4,7 @@ import NotificationsIOS from 'react-native-notifications';
 
 import type { Notification } from './types';
 import type { Auth, Dispatch, Identity, Narrow, UserOrBot } from '../types';
-import { topicNarrow, pmNarrowFromEmail, pmNarrowFromUsers } from '../utils/narrow';
+import { topicNarrow, pmNarrowFromUsers, pm1to1NarrowFromUser } from '../utils/narrow';
 import type { JSONable, JSONableDict } from '../utils/jsonable';
 import * as api from '../api';
 import * as logging from '../utils/logging';
@@ -86,6 +86,7 @@ export const getAccountFromNotificationData = (
 export const getNarrowFromNotificationData = (
   data: Notification,
   allUsersById: Map<number, UserOrBot>,
+  allUsersByEmail: Map<string, UserOrBot>,
   ownUserId: number,
 ): Narrow | null => {
   if (!data.recipient_type) {
@@ -102,7 +103,8 @@ export const getNarrowFromNotificationData = (
   }
 
   if (data.pm_users === undefined) {
-    return pmNarrowFromEmail(data.sender_email);
+    const user = allUsersByEmail.get(data.sender_email);
+    return (user && pm1to1NarrowFromUser(user)) ?? null;
   }
 
   const ids = data.pm_users.split(',').map(s => parseInt(s, 10));

--- a/src/notification/notificationActions.js
+++ b/src/notification/notificationActions.js
@@ -14,7 +14,7 @@ import { getAuth, getActiveAccount } from '../selectors';
 import { getSession, getAccounts } from '../directSelectors';
 import { GOT_PUSH_TOKEN, ACK_PUSH_TOKEN, UNACK_PUSH_TOKEN } from '../actionConstants';
 import { identityOfAccount, authOfAccount } from '../account/accountMisc';
-import { getAllUsersById, getOwnUserId } from '../users/userSelectors';
+import { getAllUsersByEmail, getAllUsersById, getOwnUserId } from '../users/userSelectors';
 import { doNarrow } from '../message/messagesActions';
 import { accountSwitch } from '../account/accountActions';
 import { getIdentities } from '../account/accountsSelectors';
@@ -52,7 +52,12 @@ export const narrowToNotification = (data: ?Notification) => (
     return;
   }
 
-  const narrow = getNarrowFromNotificationData(data, getAllUsersById(state), getOwnUserId(state));
+  const narrow = getNarrowFromNotificationData(
+    data,
+    getAllUsersById(state),
+    getAllUsersByEmail(state),
+    getOwnUserId(state),
+  );
   if (narrow) {
     dispatch(doNarrow(narrow));
   }

--- a/src/title/__tests__/titleSelectors-test.js
+++ b/src/title/__tests__/titleSelectors-test.js
@@ -1,7 +1,7 @@
 /* @flow strict-local */
 
 import { DEFAULT_TITLE_BACKGROUND_COLOR, getTitleBackgroundColor } from '../titleSelectors';
-import { pmNarrowFromUsersUnsafe, streamNarrow, pmNarrowFromEmail } from '../../utils/narrow';
+import { pmNarrowFromUsersUnsafe, streamNarrow, pm1to1NarrowFromUser } from '../../utils/narrow';
 import * as eg from '../../__tests__/lib/exampleData';
 
 describe('getTitleBackgroundColor', () => {
@@ -24,7 +24,7 @@ describe('getTitleBackgroundColor', () => {
   });
 
   test('return default for non topic/stream narrow', () => {
-    expect(getTitleBackgroundColor(state, pmNarrowFromEmail(eg.otherUser.email))).toEqual(
+    expect(getTitleBackgroundColor(state, pm1to1NarrowFromUser(eg.otherUser))).toEqual(
       DEFAULT_TITLE_BACKGROUND_COLOR,
     );
     expect(

--- a/src/utils/__tests__/narrow-test.js
+++ b/src/utils/__tests__/narrow-test.js
@@ -3,7 +3,7 @@
 import {
   HOME_NARROW,
   isHomeNarrow,
-  pmNarrowFromEmail,
+  pm1to1NarrowFromUser,
   is1to1PmNarrow,
   pmNarrowFromUsersUnsafe,
   isSpecialNarrow,
@@ -22,7 +22,6 @@ import {
   parseNarrow,
   STARRED_NARROW,
   MENTIONED_NARROW,
-  pm1to1NarrowFromUser,
   keyFromNarrow,
   streamNameOfNarrow,
   topicOfNarrow,
@@ -37,16 +36,16 @@ describe('HOME_NARROW', () => {
   });
 });
 
-describe('pmNarrowFromEmail', () => {
+describe('pm1to1NarrowFromUser', () => {
   test('produces a 1:1 narrow', () => {
-    const narrow = pmNarrowFromEmail(eg.otherUser.email);
+    const narrow = pm1to1NarrowFromUser(eg.otherUser);
     expect(is1to1PmNarrow(narrow)).toBeTrue();
     expect(emailOfPm1to1Narrow(narrow)).toEqual(eg.otherUser.email);
   });
 
   test('if operator is "pm-with" and only one email, then it is a private narrow', () => {
     expect(is1to1PmNarrow(HOME_NARROW)).toBe(false);
-    expect(is1to1PmNarrow(pmNarrowFromEmail(eg.otherUser.email))).toBe(true);
+    expect(is1to1PmNarrow(pm1to1NarrowFromUser(eg.otherUser))).toBe(true);
   });
 });
 
@@ -54,7 +53,7 @@ describe('isPmNarrow', () => {
   test('a private or group narrow is any "pm-with" narrow', () => {
     expect(isPmNarrow(undefined)).toBe(false);
     expect(isPmNarrow(HOME_NARROW)).toBe(false);
-    expect(isPmNarrow(pmNarrowFromEmail(eg.otherUser.email))).toBe(true);
+    expect(isPmNarrow(pm1to1NarrowFromUser(eg.otherUser))).toBe(true);
     expect(isPmNarrow(pmNarrowFromUsersUnsafe([eg.otherUser, eg.thirdUser]))).toBe(true);
   });
 });
@@ -65,7 +64,7 @@ describe('isStreamOrTopicNarrow', () => {
     expect(isStreamOrTopicNarrow(streamNarrow('some stream'))).toBe(true);
     expect(isStreamOrTopicNarrow(topicNarrow('some stream', 'some topic'))).toBe(true);
     expect(isStreamOrTopicNarrow(HOME_NARROW)).toBe(false);
-    expect(isStreamOrTopicNarrow(pmNarrowFromEmail(eg.otherUser.email))).toBe(false);
+    expect(isStreamOrTopicNarrow(pm1to1NarrowFromUser(eg.otherUser))).toBe(false);
     expect(isStreamOrTopicNarrow(pmNarrowFromUsersUnsafe([eg.otherUser, eg.thirdUser]))).toBe(
       false,
     );
@@ -141,7 +140,7 @@ describe('isMessageInNarrow', () => {
       ['PM', false, eg.pmMessage()],
     ]],
 
-    ['1:1 PM conversation, non-self', pmNarrowFromEmail(eg.otherUser.email), [
+    ['1:1 PM conversation, non-self', pm1to1NarrowFromUser(eg.otherUser), [
       ['matching PM, inbound', true, eg.pmMessage()],
       ['matching PM, outbound', true, eg.pmMessage({ sender: eg.selfUser })],
       ['self-1:1 message', false, eg.pmMessage({ sender: eg.selfUser, recipients: [eg.selfUser] })],
@@ -149,7 +148,7 @@ describe('isMessageInNarrow', () => {
       ['group-PM including this user, outbound', false, eg.pmMessage({ sender: eg.selfUser, recipients: [eg.selfUser, eg.otherUser, eg.thirdUser] })],
       ['stream message', false, eg.streamMessage()],
     ]],
-    ['self-1:1 conversation', pmNarrowFromEmail(eg.selfUser.email), [
+    ['self-1:1 conversation', pm1to1NarrowFromUser(eg.selfUser), [
       ['self-1:1 message', true, eg.pmMessage({ sender: eg.selfUser, recipients: [eg.selfUser] })],
       ['other 1:1 message, inbound', false, eg.pmMessage()],
       ['other 1:1 message, outbound', false, eg.pmMessage({ sender: eg.selfUser })],
@@ -279,7 +278,7 @@ describe('getNarrowsForMessage', () => {
     {
       label: 'PM message with one person',
       message: eg.pmMessage({ sender: eg.otherUser }),
-      expectedNarrows: [HOME_NARROW, ALL_PRIVATE_NARROW, pmNarrowFromEmail(eg.otherUser.email)],
+      expectedNarrows: [HOME_NARROW, ALL_PRIVATE_NARROW, pm1to1NarrowFromUser(eg.otherUser)],
     },
     {
       label: 'Group PM message',
@@ -307,12 +306,12 @@ describe('getNarrowForReply', () => {
         eg.pmMessage({ sender: eg.selfUser, recipients: [eg.selfUser] }),
         eg.selfUser,
       ),
-    ).toEqual(pmNarrowFromEmail(eg.selfUser.email));
+    ).toEqual(pm1to1NarrowFromUser(eg.selfUser));
   });
 
   test('for 1:1 PM, returns a 1:1 PM narrow', () => {
     const message = eg.pmMessage();
-    const expectedNarrow = pmNarrowFromEmail(eg.otherUser.email);
+    const expectedNarrow = pm1to1NarrowFromUser(eg.otherUser);
 
     const actualNarrow = getNarrowForReply(message, eg.selfUser);
 

--- a/src/utils/__tests__/narrow-test.js
+++ b/src/utils/__tests__/narrow-test.js
@@ -6,7 +6,6 @@ import {
   pmNarrowFromEmail,
   is1to1PmNarrow,
   pmNarrowFromUsersUnsafe,
-  specialNarrow,
   isSpecialNarrow,
   ALL_PRIVATE_NARROW,
   streamNarrow,
@@ -17,7 +16,6 @@ import {
   isSearchNarrow,
   isPmNarrow,
   isMessageInNarrow,
-  isSameNarrow,
   isStreamOrTopicNarrow,
   getNarrowsForMessage,
   getNarrowForReply,
@@ -339,20 +337,6 @@ describe('getNarrowForReply', () => {
     const actualNarrow = getNarrowForReply(message, eg.selfUser);
 
     expect(actualNarrow).toEqual(expectedNarrow);
-  });
-});
-
-describe('isSameNarrow', () => {
-  test('Return true if two narrows are same', () => {
-    expect(isSameNarrow(streamNarrow('stream'), streamNarrow('stream'))).toBe(true);
-    expect(isSameNarrow(streamNarrow('stream'), streamNarrow('stream1'))).toBe(false);
-    expect(isSameNarrow(streamNarrow('stream'), topicNarrow('stream', 'topic'))).toBe(false);
-    expect(isSameNarrow(topicNarrow('stream', 'topic'), topicNarrow('stream', 'topic'))).toBe(true);
-    expect(isSameNarrow(topicNarrow('stream', 'topic'), topicNarrow('stream', 'topic1'))).toBe(
-      false,
-    );
-    expect(isSameNarrow(HOME_NARROW, specialNarrow('private'))).toBe(false);
-    expect(isSameNarrow(HOME_NARROW, HOME_NARROW)).toBe(true);
   });
 });
 

--- a/src/utils/internalLinks.js
+++ b/src/utils/internalLinks.js
@@ -142,7 +142,11 @@ export const getNarrowFromLink = (
     case 'stream':
       return streamNarrow(parseStreamOperand(paths[1], streamsById));
     case 'special':
-      return specialNarrow(paths[1]);
+      try {
+        return specialNarrow(paths[1]);
+      } catch (e) {
+        return null;
+      }
     default:
       return null;
   }

--- a/src/utils/narrow.js
+++ b/src/utils/narrow.js
@@ -1,6 +1,5 @@
 /* @flow strict-local */
 import invariant from 'invariant';
-import isEqual from 'lodash.isequal';
 
 import type { ApiNarrow, Message, Outbox, User, UserOrBot } from '../types';
 import {
@@ -32,9 +31,6 @@ import {
  *    server, and `apiNarrowOfNarrow` for converting to it.
  */
 export opaque type Narrow = ApiNarrow;
-
-export const isSameNarrow = (narrow1: Narrow, narrow2: Narrow): boolean =>
-  Array.isArray(narrow1) && Array.isArray(narrow2) && isEqual(narrow1, narrow2);
 
 export const HOME_NARROW: Narrow = [];
 

--- a/src/utils/narrow.js
+++ b/src/utils/narrow.js
@@ -63,15 +63,6 @@ export const HOME_NARROW_STR: string = keyFromNarrow(HOME_NARROW);
 const pmNarrowFromEmails = (emails: string[]): Narrow => Object.freeze({ type: 'pm', emails });
 
 /**
- * DEPRECATED.  Use `pm1to1NarrowFromUser` instead.
- *
- * This function is being replaced by `pm1to1NarrowFromUser`, as part of
- * migrating from emails to user IDs to identify users.  Don't add new uses
- * of this function; use that one instead.
- */
-export const pmNarrowFromEmail = (email: string): Narrow => pmNarrowFromEmails([email]);
-
-/**
  * A PM narrow, either 1:1 or group.
  *
  * The argument's type guarantees that it comes from


### PR DESCRIPTION
This follows on #4342 and its predecessors, and accomplishes part of #4333: at the end of this PR, we now have user IDs in our internal representation of PM narrows.

After this, in the next PR or two we'll go on to switch all the various places we consume narrows to use the IDs instead of the emails -- which as mentioned at https://github.com/zulip/zulip-mobile/issues/4035#issuecomment-746896403 will include completing #4035 -- and stop storing emails in our narrows at all.

Thanks to all the prep work in the preceding several PRs, not much actually has to change in this one -- we've already quite thoroughly encapsulated the details of the Narrow type, and also eliminated nearly all the places where we were constructing PM narrows without passing a user ID to the constructor along with an email. Most of what's in this PR is just taking care of the last few of those.
