### PR TITLE
isInternalLink: Clarify, fix bugs, add tests, move to use URL object

### DIFF
--- a/jest/jestSetup.js
+++ b/jest/jestSetup.js
@@ -1,6 +1,21 @@
 import * as ReactNative from 'react-native';
+import { polyfillGlobal } from 'react-native/Libraries/Utilities/PolyfillFunctions';
+import { URL, URLSearchParams } from 'react-native-url-polyfill';
 
 import mockAsyncStorage from '@react-native-community/async-storage/jest/async-storage-mock';
+
+// Use the same `URL` polyfill we do in the app.
+//
+// In the app we let `react-native-url-polyfill` handle doing this, by
+// importing `react-native-url-polyfill/auto`.  But in Jest, that produces
+// warnings apparently due to the lazy `require(…)` calls in the getters
+// provided for the polyfill; perhaps from them getting invoked by the Jest
+// framework after the test environment has been torn down.
+//   https://github.com/zulip/zulip-mobile/pull/4350#issuecomment-749247080
+// So we mimic the library's way of doing the polyfill, except we do the
+// imports eagerly so there's no dynamic `require`.
+polyfillGlobal('URL', () => URL);
+polyfillGlobal('URLSearchParams', () => URLSearchParams);
 
 // Mock `react-native` ourselves, following upstream advice [1] [2].
 //

--- a/src/utils/__tests__/internalLinks-test.js
+++ b/src/utils/__tests__/internalLinks-test.js
@@ -30,6 +30,9 @@ describe('isInternalLink', () => {
     [true, 'path-absolute, with numeric IDs', '/#narrow/stream/123-jest'],
     [true, 'path-absolute, with numeric IDs', '/#narrow/pm-with/123-mark'],
 
+    [false, 'same domain, double slash', 'https://example.com//#narrow/stream/jest'],
+    [false, 'same domain, triple slash', 'https://example.com///#narrow/stream/jest'],
+
     // These examples may seem weird, but a previous version accepted most of them.
     [
       false,

--- a/src/utils/__tests__/internalLinks-test.js
+++ b/src/utils/__tests__/internalLinks-test.js
@@ -16,11 +16,16 @@ const realm = new URL('https://example.com');
 
 describe('isInternalLink', () => {
   const cases = [
-    [false, 'another domain', 'https://another.com'],
-    [false, 'same domain, nontrivial path', 'https://example.com/user_uploads'],
-    [true, 'same domain, to a narrow', 'https://example.com/#narrow/stream/jest'],
     [true, 'fragment-only, to a narrow', '#narrow/stream/jest/topic/topic1'],
+    [false, 'fragment-only, wrong fragment', '#nope'],
     [true, 'path-absolute, to a narrow', '/#narrow/stream/jest'],
+    [false, 'path-absolute, wrong fragment', '/#nope'],
+    [false, 'path-absolute, wrong path', '/user_uploads/#narrow/stream/jest'],
+    [true, 'same domain, to a narrow', 'https://example.com/#narrow/stream/jest'],
+    [false, 'same domain, wrong fragment', 'https://example.com/#nope'],
+    [false, 'same domain, wrong path', 'https://example.com/user_uploads/#narrow/stream/jest'],
+    [false, 'wrong domain', 'https://another.com/#narrow/stream/jest'],
+
     [true, 'fragment-only, with numeric IDs', '#narrow/stream/123-jest/topic/topic1'],
     [true, 'path-absolute, with numeric IDs', '/#narrow/stream/123-jest'],
     [true, 'path-absolute, with numeric IDs', '/#narrow/pm-with/123-mark'],

--- a/src/utils/__tests__/internalLinks-test.js
+++ b/src/utils/__tests__/internalLinks-test.js
@@ -15,28 +15,22 @@ import * as eg from '../../__tests__/lib/exampleData';
 const realm = new URL('https://example.com');
 
 describe('isInternalLink', () => {
-  test('when link is external, return false', () => {
-    expect(isInternalLink('https://example.com', new URL('https://another.com'))).toBe(false);
-  });
+  const cases = [
+    [false, 'another domain', 'https://another.com'],
+    [false, 'same domain, nontrivial path', 'https://example.com/user_uploads'],
+    [true, 'same domain, to a narrow', 'https://example.com/#narrow/stream/jest'],
+    [true, 'fragment-only, to a narrow', '#narrow/stream/jest/topic/topic1'],
+    [true, 'path-absolute, to a narrow', '/#narrow/stream/jest'],
+    [true, 'fragment-only, with numeric IDs', '#narrow/stream/123-jest/topic/topic1'],
+    [true, 'path-absolute, with numeric IDs', '/#narrow/stream/123-jest'],
+    [true, 'path-absolute, with numeric IDs', '/#narrow/pm-with/123-mark'],
+  ];
 
-  test('when link is internal, but not in app, return false', () => {
-    expect(isInternalLink('https://example.com/user_uploads', realm)).toBe(false);
-  });
-
-  test('when link is internal and in app, return true', () => {
-    expect(isInternalLink('https://example.com/#narrow/stream/jest', realm)).toBe(true);
-  });
-
-  test('when link is relative and in app, return true', () => {
-    expect(isInternalLink('#narrow/stream/jest/topic/topic1', realm)).toBe(true);
-    expect(isInternalLink('/#narrow/stream/jest', realm)).toBe(true);
-  });
-
-  test('links including IDs are also recognized', () => {
-    expect(isInternalLink('#narrow/stream/123-jest/topic/topic1', realm)).toBe(true);
-    expect(isInternalLink('/#narrow/stream/123-jest', realm)).toBe(true);
-    expect(isInternalLink('/#narrow/pm-with/123-mark', realm)).toBe(true);
-  });
+  for (const [expected, description, url] of cases) {
+    test(`${expected ? 'accept' : 'reject'} ${description}: ${url}`, () => {
+      expect(isInternalLink(url, realm)).toBe(expected);
+    });
+  }
 });
 
 describe('isMessageLink', () => {

--- a/src/utils/__tests__/internalLinks-test.js
+++ b/src/utils/__tests__/internalLinks-test.js
@@ -30,6 +30,10 @@ describe('isInternalLink', () => {
     [true, 'path-absolute, with numeric IDs', '/#narrow/stream/123-jest'],
     [true, 'path-absolute, with numeric IDs', '/#narrow/pm-with/123-mark'],
 
+    [false, 'fragment-only, #narrowly', '#narrowly/stream/jest'],
+    [false, 'path-absolute, #narrowly', '/#narrowly/stream/jest'],
+    [false, 'same domain, #narrowly', 'https://example.com/#narrowly/stream/jest'],
+
     [false, 'same domain, double slash', 'https://example.com//#narrow/stream/jest'],
     [false, 'same domain, triple slash', 'https://example.com///#narrow/stream/jest'],
 

--- a/src/utils/__tests__/internalLinks-test.js
+++ b/src/utils/__tests__/internalLinks-test.js
@@ -29,6 +29,36 @@ describe('isInternalLink', () => {
     [true, 'fragment-only, with numeric IDs', '#narrow/stream/123-jest/topic/topic1'],
     [true, 'path-absolute, with numeric IDs', '/#narrow/stream/123-jest'],
     [true, 'path-absolute, with numeric IDs', '/#narrow/pm-with/123-mark'],
+
+    // These examples may seem weird, but a previous version accepted most of them.
+    [
+      false,
+      'wrong domain, realm-like path, narrow-like fragment',
+      // This one, except possibly the fragment, is a 100% realistic link
+      // for innocent normal use.  The buggy old version narrowly avoided
+      // accepting it... but would accept all the variations below.
+      'https://web.archive.org/web/*/https://example.com/#narrow/stream/jest',
+    ],
+    [
+      false,
+      'odd scheme, wrong domain, realm-like path, narrow-like fragment',
+      'ftp://web.archive.org/web/*/https://example.com/#narrow/stream/jest',
+    ],
+    [
+      false,
+      'same domain, realm-like path, narrow-like fragment',
+      'https://example.com/web/*/https://example.com/#narrow/stream/jest',
+    ],
+    [
+      false,
+      'path-absolute, realm-like path, narrow-like fragment',
+      '/web/*/https://example.com/#narrow/stream/jest',
+    ],
+    [
+      false,
+      'path-relative, realm-like path, narrow-like fragment',
+      'web/*/https://example.com/#narrow/stream/jest',
+    ],
   ];
 
   for (const [expected, description, url] of cases) {

--- a/src/utils/internalLinks.js
+++ b/src/utils/internalLinks.js
@@ -25,6 +25,17 @@ const getPathsFromUrl = (url: string = '', realm: URL) => {
 // reimplement using URL object (not just for the realm)
 /** PRIVATE -- exported only for tests. */
 export const isInternalLink = (url: string, realm: URL): boolean => {
+  // See the URL Standard for the definitions of quoted terms:
+  //   https://url.spec.whatwg.org/#url-writing
+
+  if (/^#narrow/i.test(url)) {
+    // A relative URL consisting of just a fragment (in the standard's
+    // terms: a "relative-URL-with-fragment string", of which the
+    // "relative-URL string" is empty); specifically one that looks like
+    // a link to a Zulip narrow.
+    return true;
+  }
+
   if (url.startsWith('/')) {
     return /^\/#narrow/i.test(url);
   }
@@ -36,7 +47,7 @@ export const isInternalLink = (url: string, realm: URL): boolean => {
     return /^(\/#narrow|#narrow)/i.test(url.substring(realmStr.length));
   }
 
-  return /^#narrow/i.test(url);
+  return false;
 };
 
 // TODO: Work out what this does, write a jsdoc for its interface, and

--- a/src/utils/internalLinks.js
+++ b/src/utils/internalLinks.js
@@ -25,19 +25,18 @@ const getPathsFromUrl = (url: string = '', realm: URL) => {
 // reimplement using URL object (not just for the realm)
 /** PRIVATE -- exported only for tests. */
 export const isInternalLink = (url: string, realm: URL): boolean => {
-  // Because this comes as the serialization of a URL object,
-  // it must be an absolute URL.
-  const realmStr = realm.toString();
-
   if (url.startsWith('/')) {
     return /^\/#narrow/i.test(url);
   }
 
+  // Because this comes as the serialization of a URL object,
+  // it must be an absolute URL.
+  const realmStr = realm.toString();
   if (url.startsWith(realmStr)) {
     return /^(\/#narrow|#narrow)/i.test(url.substring(realmStr.length));
   }
 
-  return /^(\/#narrow|#narrow)/i.test(url);
+  return /^#narrow/i.test(url);
 };
 
 // TODO: Work out what this does, write a jsdoc for its interface, and

--- a/src/utils/internalLinks.js
+++ b/src/utils/internalLinks.js
@@ -3,7 +3,6 @@ import { addBreadcrumb } from '@sentry/react-native';
 import type { Narrow, Stream, UserOrBot } from '../types';
 import { topicNarrow, streamNarrow, specialNarrow, pmNarrowFromUsers } from './narrow';
 import { pmKeyRecipientsFromIds } from './recipient';
-import { isUrlOnRealm } from './url';
 
 // TODO: Work out what this does, write a jsdoc for its interface, and
 // reimplement using URL object (not just for the realm)
@@ -25,10 +24,18 @@ const getPathsFromUrl = (url: string = '', realm: URL) => {
 // TODO: Work out what this does, write a jsdoc for its interface, and
 // reimplement using URL object (not just for the realm)
 /** PRIVATE -- exported only for tests. */
-export const isInternalLink = (url: string, realm: URL): boolean =>
-  isUrlOnRealm(url, realm)
-    ? /^(\/#narrow|#narrow)/i.test(url.split(realm.toString()).pop())
-    : false;
+export const isInternalLink = (url: string, realm: URL): boolean => {
+  if (url.startsWith('/')) {
+    return /^(\/#narrow|#narrow)/i.test(url.split(realm.toString()).pop());
+  }
+  if (url.startsWith(realm.toString())) {
+    return /^(\/#narrow|#narrow)/i.test(url.split(realm.toString()).pop());
+  }
+  if (!/^(http|www.)/i.test(url)) {
+    return /^(\/#narrow|#narrow)/i.test(url.split(realm.toString()).pop());
+  }
+  return false;
+};
 
 // TODO: Work out what this does, write a jsdoc for its interface, and
 // reimplement using URL object (not just for the realm)

--- a/src/utils/internalLinks.js
+++ b/src/utils/internalLinks.js
@@ -46,10 +46,13 @@ export const isInternalLink = (url: string, realm: URL): boolean => {
   // Because this comes as the serialization of a URL object,
   // it must be an absolute URL.  Moreover its path can't be empty.
   const realmStr = realm.toString();
-  if (url.startsWith(realmStr)) {
-    return /^#narrow/i.test(url.substring(realmStr.length));
+  if (url.startsWith(realmStr) && /^#narrow/i.test(url.substring(realmStr.length))) {
+    // An absolute URL consisting of the realm's base URL, plus a fragment
+    // that looks like a link to a Zulip narrow.
+    return true;
   }
 
+  // Any other URL.
   return false;
 };
 

--- a/src/utils/internalLinks.js
+++ b/src/utils/internalLinks.js
@@ -36,8 +36,11 @@ export const isInternalLink = (url: string, realm: URL): boolean => {
     return true;
   }
 
-  if (url.startsWith('/')) {
-    return /^\/#narrow/i.test(url);
+  if (/^\/#narrow/i.test(url)) {
+    // A "path-absolute URL string" with path `/`, followed by a fragment
+    // that looks like a link to a Zulip narrow.  This is another form of
+    // "relative-URL-with-fragment string".
+    return true;
   }
 
   // Because this comes as the serialization of a URL object,

--- a/src/utils/internalLinks.js
+++ b/src/utils/internalLinks.js
@@ -30,18 +30,14 @@ export const isInternalLink = (url: string, realm: URL): boolean => {
   const realmStr = realm.toString();
 
   if (url.startsWith('/')) {
-    return /^(\/#narrow|#narrow)/i.test(url);
+    return /^\/#narrow/i.test(url);
   }
 
   if (url.startsWith(realmStr)) {
     return /^(\/#narrow|#narrow)/i.test(url.substring(realmStr.length));
   }
 
-  if (!/^(http|www.)/i.test(url)) {
-    return /^(\/#narrow|#narrow)/i.test(url);
-  }
-
-  return false;
+  return /^(\/#narrow|#narrow)/i.test(url);
 };
 
 // TODO: Work out what this does, write a jsdoc for its interface, and

--- a/src/utils/internalLinks.js
+++ b/src/utils/internalLinks.js
@@ -21,14 +21,20 @@ const getPathsFromUrl = (url: string = '', realm: URL) => {
   return paths;
 };
 
-// TODO: Work out what this does, write a jsdoc for its interface, and
-// reimplement using URL object (not just for the realm)
-/** PRIVATE -- exported only for tests. */
+/**
+ * PRIVATE -- exported only for tests.
+ *
+ * Test for a link to a Zulip narrow on the given realm.
+ *
+ * True just if the given URL string appears to be a link, either absolute
+ * or relative, to a Zulip narrow on the given realm.
+ */
+// TODO: Reimplement to fully use URL objects.
 export const isInternalLink = (url: string, realm: URL): boolean => {
   // See the URL Standard for the definitions of quoted terms:
   //   https://url.spec.whatwg.org/#url-writing
 
-  if (/^#narrow/i.test(url)) {
+  if (/^#narrow\//i.test(url)) {
     // A relative URL consisting of just a fragment (in the standard's
     // terms: a "relative-URL-with-fragment string", of which the
     // "relative-URL string" is empty); specifically one that looks like
@@ -36,7 +42,7 @@ export const isInternalLink = (url: string, realm: URL): boolean => {
     return true;
   }
 
-  if (/^\/#narrow/i.test(url)) {
+  if (/^\/#narrow\//i.test(url)) {
     // A "path-absolute URL string" with path `/`, followed by a fragment
     // that looks like a link to a Zulip narrow.  This is another form of
     // "relative-URL-with-fragment string".
@@ -46,7 +52,7 @@ export const isInternalLink = (url: string, realm: URL): boolean => {
   // Because this comes as the serialization of a URL object,
   // it must be an absolute URL.  Moreover its path can't be empty.
   const realmStr = realm.toString();
-  if (url.startsWith(realmStr) && /^#narrow/i.test(url.substring(realmStr.length))) {
+  if (url.startsWith(realmStr) && /^#narrow\//i.test(url.substring(realmStr.length))) {
     // An absolute URL consisting of the realm's base URL, plus a fragment
     // that looks like a link to a Zulip narrow.
     return true;

--- a/src/utils/internalLinks.js
+++ b/src/utils/internalLinks.js
@@ -27,7 +27,7 @@ const getPathsFromUrl = (url: string = '', realm: URL) => {
 export const isInternalLink = (url: string, realm: URL): boolean => {
   const realmStr = realm.toString();
 
-  const restUrl = url.split(realmStr).pop();
+  const restUrl = url.startsWith(realmStr) ? url.substring(realmStr.length) : url;
 
   if (url.startsWith('/')) {
     return /^(\/#narrow|#narrow)/i.test(restUrl);

--- a/src/utils/internalLinks.js
+++ b/src/utils/internalLinks.js
@@ -28,48 +28,42 @@ const getPathsFromUrl = (url: string = '', realm: URL) => {
  *
  * True just if the given URL string appears to be a link, either absolute
  * or relative, to a Zulip narrow on the given realm.
+ *
+ * This performs a call to `new URL` and therefore may take a fraction of a
+ * millisecond.  Avoid using in a context where it might be called more than
+ * 10 or 100 times per user action.
  */
-// TODO: Reimplement to fully use URL objects.
 export const isInternalLink = (url: string, realm: URL): boolean => {
-  // See the URL Standard for the definitions of quoted terms:
-  //   https://url.spec.whatwg.org/#url-writing
-
-  if (/^#narrow\//i.test(url)) {
-    // A relative URL consisting of just a fragment (in the standard's
-    // terms: a "relative-URL-with-fragment string", of which the
-    // "relative-URL string" is empty); specifically one that looks like
-    // a link to a Zulip narrow.
-    return true;
-  }
-
-  if (/^\/#narrow\//i.test(url)) {
-    // A "path-absolute URL string" with path `/`, followed by a fragment
-    // that looks like a link to a Zulip narrow.  This is another form of
-    // "relative-URL-with-fragment string".
-    return true;
-  }
-
-  // Because this comes as the serialization of a URL object,
-  // it must be an absolute URL.  Moreover its path can't be empty.
-  const realmStr = realm.toString();
-  if (url.startsWith(realmStr) && /^#narrow\//i.test(url.substring(realmStr.length))) {
-    // An absolute URL consisting of the realm's base URL, plus a fragment
-    // that looks like a link to a Zulip narrow.
-    return true;
-  }
-
-  // Any other URL.
-  return false;
+  const resolved = new URL(url, realm);
+  return (
+    resolved.origin === realm.origin
+    && resolved.pathname === '/'
+    && resolved.search === ''
+    && /^#narrow\//i.test(resolved.hash)
+  );
 };
 
+/**
+ * PRIVATE -- exported only for tests.
+ *
+ * This performs a call to `new URL` and therefore may take a fraction of a
+ * millisecond.  Avoid using in a context where it might be called more than
+ * 10 or 100 times per user action.
+ */
 // TODO: Work out what this does, write a jsdoc for its interface, and
 // reimplement using URL object (not just for the realm)
-/** PRIVATE -- exported only for tests. */
 export const isMessageLink = (url: string, realm: URL): boolean =>
   isInternalLink(url, realm) && url.includes('near');
 
 type LinkType = 'external' | 'home' | 'pm' | 'topic' | 'stream' | 'special';
 
+/**
+ * PRIVATE -- exported only for tests.
+ *
+ * This performs a call to `new URL` and therefore may take a fraction of a
+ * millisecond.  Avoid using in a context where it might be called more than
+ * 10 or 100 times per user action.
+ */
 // TODO: Work out what this does, write a jsdoc for its interface, and
 // reimplement using URL object (not just for the realm)
 export const getLinkType = (url: string, realm: URL): LinkType => {
@@ -148,6 +142,13 @@ const parsePmOperand = operand => {
   return idStrs.map(s => parseInt(s, 10));
 };
 
+/**
+ * TODO write jsdoc
+ *
+ * This performs a call to `new URL` and therefore may take a fraction of a
+ * millisecond.  Avoid using in a context where it might be called more than
+ * 10 or 100 times per user action.
+ */
 export const getNarrowFromLink = (
   url: string,
   realm: URL,
@@ -184,6 +185,13 @@ export const getNarrowFromLink = (
   }
 };
 
+/**
+ * TODO write jsdoc
+ *
+ * This performs a call to `new URL` and therefore may take a fraction of a
+ * millisecond.  Avoid using in a context where it might be called more than
+ * 10 or 100 times per user action.
+ */
 export const getMessageIdFromLink = (url: string, realm: URL): number => {
   const paths = getPathsFromUrl(url, realm);
 

--- a/src/utils/internalLinks.js
+++ b/src/utils/internalLinks.js
@@ -44,10 +44,10 @@ export const isInternalLink = (url: string, realm: URL): boolean => {
   }
 
   // Because this comes as the serialization of a URL object,
-  // it must be an absolute URL.
+  // it must be an absolute URL.  Moreover its path can't be empty.
   const realmStr = realm.toString();
   if (url.startsWith(realmStr)) {
-    return /^(\/#narrow|#narrow)/i.test(url.substring(realmStr.length));
+    return /^#narrow/i.test(url.substring(realmStr.length));
   }
 
   return false;

--- a/src/utils/internalLinks.js
+++ b/src/utils/internalLinks.js
@@ -25,15 +25,22 @@ const getPathsFromUrl = (url: string = '', realm: URL) => {
 // reimplement using URL object (not just for the realm)
 /** PRIVATE -- exported only for tests. */
 export const isInternalLink = (url: string, realm: URL): boolean => {
+  const realmStr = realm.toString();
+
+  const restUrl = url.split(realmStr).pop();
+
   if (url.startsWith('/')) {
-    return /^(\/#narrow|#narrow)/i.test(url.split(realm.toString()).pop());
+    return /^(\/#narrow|#narrow)/i.test(restUrl);
   }
-  if (url.startsWith(realm.toString())) {
-    return /^(\/#narrow|#narrow)/i.test(url.split(realm.toString()).pop());
+
+  if (url.startsWith(realmStr)) {
+    return /^(\/#narrow|#narrow)/i.test(restUrl);
   }
+
   if (!/^(http|www.)/i.test(url)) {
-    return /^(\/#narrow|#narrow)/i.test(url.split(realm.toString()).pop());
+    return /^(\/#narrow|#narrow)/i.test(restUrl);
   }
+
   return false;
 };
 

--- a/src/utils/internalLinks.js
+++ b/src/utils/internalLinks.js
@@ -25,20 +25,20 @@ const getPathsFromUrl = (url: string = '', realm: URL) => {
 // reimplement using URL object (not just for the realm)
 /** PRIVATE -- exported only for tests. */
 export const isInternalLink = (url: string, realm: URL): boolean => {
+  // Because this comes as the serialization of a URL object,
+  // it must be an absolute URL.
   const realmStr = realm.toString();
 
-  const restUrl = url.startsWith(realmStr) ? url.substring(realmStr.length) : url;
-
   if (url.startsWith('/')) {
-    return /^(\/#narrow|#narrow)/i.test(restUrl);
+    return /^(\/#narrow|#narrow)/i.test(url);
   }
 
   if (url.startsWith(realmStr)) {
-    return /^(\/#narrow|#narrow)/i.test(restUrl);
+    return /^(\/#narrow|#narrow)/i.test(url.substring(realmStr.length));
   }
 
   if (!/^(http|www.)/i.test(url)) {
-    return /^(\/#narrow|#narrow)/i.test(restUrl);
+    return /^(\/#narrow|#narrow)/i.test(url);
   }
 
   return false;


### PR DESCRIPTION
After studying closely the URL Standard and its definition of the [syntax](https://url.spec.whatwg.org/#url-writing) and [parsing algorithm](https://url.spec.whatwg.org/#url-parsing) for URLs in order to write some small predicates like `isUrlAbsolute` for #4345, I took a fresh look yesterday at some of our URL-processing code that we've been wanting to fix for a while, i.e. #4146.

Here's a branch fixing one tangly part of that code: the `isInternalLink` function, used for deciding whether a link the user tries to follow in a message is one we should try to interpret within the app to navigate to some other conversation, or is one we should instead handle more generically, with a download or going out to the browser.

We make the changes in a series of very small steps, so that we can spot exactly where the behavior changes. After a long string of those, including a couple of bugfixes, we have a version that's pretty reasonable and is still in explicit string/regexp terms... and then in the final commit, we switch it to using `new URL`. The effect of this is that we start accepting a wide range of URLs we didn't before -- for example it turns out that the URL parser produces exactly the same result for `https://example/#narrow` as for
* `https://example/.#narrow`
* `https://example/foo/bar/../../../baz/.././#narrow`
* `https://%65%78%61%6d%70%6c%65/#narrow`
* `https://example:/#narrow`
* `https://example:0000443/#narrow`
* ... and further kinds of variation are possible for domains with non-ASCII characters and for IP addresses instead of domains
* ... and that's just among "valid URL strings", which aren't all the inputs the URL parser accepts.

So in that final commit we also add a wide variety of test cases to illustrate this variation. These are perhaps overkill for this particular function; but as we revise or write other URL-handling functions, they can serve as a helpful source of material for tests.
