### PR TITLE
msglist: Fix regression on tapping topic narrows in stream-narrow msg…

### DIFF
--- a/src/utils/encoding.js
+++ b/src/utils/encoding.js
@@ -37,13 +37,10 @@ export const hexToBase64 = (hex: string) => base64.encode(hexToAscii(hex));
  *
  * This lets us pass an arbitrary string through a channel (like the
  * `postMessage` on RN's WebViews on Android) that tries to do something
- * like percent-decode it.
+ * like percent-decode it, or (like an HTML attribute) that forbids certain
+ * characters.
  *
- * It also lets us use the `\x00` character in our `Narrow` keys (see
- * `keyFromNarrow` in narrow.js). That character doesn't round-trip
- * through being stored as the `data-narrow` HTML attribute in our
- * WebView HTML, so we encode the narrow keys on the way in and decode
- * them on the way out.
+ * See also `base64Utf8Decode` for the inverse.
  */
 export const base64Utf8Encode = (text: string): string =>
   // References on reliably encoding strings to Base64:

--- a/src/utils/encoding.js
+++ b/src/utils/encoding.js
@@ -38,6 +38,12 @@ export const hexToBase64 = (hex: string) => base64.encode(hexToAscii(hex));
  * This lets us pass an arbitrary string through a channel (like the
  * `postMessage` on RN's WebViews on Android) that tries to do something
  * like percent-decode it.
+ *
+ * It also lets us use the `\x00` character in our `Narrow` keys (see
+ * `keyFromNarrow` in narrow.js). That character doesn't round-trip
+ * through being stored as the `data-narrow` HTML attribute in our
+ * WebView HTML, so we encode the narrow keys on the way in and decode
+ * them on the way out.
  */
 export const base64Utf8Encode = (text: string): string =>
   // References on reliably encoding strings to Base64:
@@ -53,3 +59,9 @@ export const base64Utf8Encode = (text: string): string =>
   // We use `base64.encode` because `btoa` is unavailable in the JS
   // environment provided by RN on iOS.
   base64.encode(unescape(encodeURIComponent(text)));
+
+/**
+ * The inverse of `base64Utf8Encode`, above.
+ */
+export const base64Utf8Decode = (str: string): string =>
+  decodeURIComponent(escape(base64.decode(str)));

--- a/src/utils/narrow.js
+++ b/src/utils/narrow.js
@@ -275,6 +275,12 @@ export function caseNarrowDefault<T>(
  *
  * See in particular `NarrowsState`, `CaughtUpState`, `FetchingState`,
  * and `DraftsState`.
+ *
+ * Doesn't round-trip through being stored as the value for the
+ * `data-narrow` attribute in our WebView HTML; see note at `topic`.
+ * Our way around this is to encode it with `base64Utf8Encode` on the
+ * way into the WebView (in our HTML-generation functions) and decode
+ * it with `base64Utf8Decode` on the way out.
  */
 export function keyFromNarrow(narrow: Narrow): string {
   // The ":s" bit in several of these is to keep them disjoint, out of an
@@ -286,6 +292,9 @@ export function keyFromNarrow(narrow: Narrow): string {
     stream: name => `stream:s:${name}`,
     // '\x00' is the one character not allowed in Zulip stream names.
     // (See `check_stream_name` in zulip.git:zerver/lib/streams.py.)
+    //
+    // The `\x00` character doesn't round-trip through being stored in
+    // an HTML element attribute (see JSDoc).
     topic: (streamName, topic) => `topic:s:${streamName}\x00${topic}`,
 
     pm: emails => `pm:s:${emails.join(',')}`,

--- a/src/utils/narrow.js
+++ b/src/utils/narrow.js
@@ -276,12 +276,13 @@ export function caseNarrowDefault<T>(
  * See in particular `NarrowsState`, `CaughtUpState`, `FetchingState`,
  * and `DraftsState`.
  *
- * Doesn't round-trip through being stored as the value for the
- * `data-narrow` attribute in our WebView HTML; see note at `topic`.
- * Our way around this is to encode it with `base64Utf8Encode` on the
- * way into the WebView (in our HTML-generation functions) and decode
- * it with `base64Utf8Decode` on the way out.
+ * The key may contain arbitrary Unicode codepoints.  If passing through a
+ * channel (like an HTML attribute) that only allows certain codepoints, use
+ * something like `base64Utf8Encode` to encode into the permitted subset.
  */
+// The arbitrary Unicode codepoints come from (a) stream names and topics,
+// and (b) our use of `\x00` as a delimiter.  Also perhaps email addresses,
+// if it's possible for those to have exciting characters in them.
 export function keyFromNarrow(narrow: Narrow): string {
   // The ":s" bit in several of these is to keep them disjoint, out of an
   // abundance of caution, from future keys that use numeric IDs.
@@ -292,9 +293,6 @@ export function keyFromNarrow(narrow: Narrow): string {
     stream: name => `stream:s:${name}`,
     // '\x00' is the one character not allowed in Zulip stream names.
     // (See `check_stream_name` in zulip.git:zerver/lib/streams.py.)
-    //
-    // The `\x00` character doesn't round-trip through being stored in
-    // an HTML element attribute (see JSDoc).
     topic: (streamName, topic) => `topic:s:${streamName}\x00${topic}`,
 
     pm: emails => `pm:s:${emails.join(',')}`,

--- a/src/webview/html/messageHeaderAsHtml.js
+++ b/src/webview/html/messageHeaderAsHtml.js
@@ -16,6 +16,7 @@ import {
   pmKeyRecipientsFromMessage,
   streamNameOfStreamMessage,
 } from '../../utils/recipient';
+import { base64Utf8Encode } from '../../utils/encoding';
 
 const renderSubject = item =>
   // TODO: pin down if '' happens, and what its proper semantics are.
@@ -54,7 +55,7 @@ export default (
     return template`
 <div
   class="header-wrapper header topic-header"
-  data-narrow="${topicNarrowStr}"
+  data-narrow="${base64Utf8Encode(topicNarrowStr)}"
   data-msg-id="${item.id}"
 >
   <div class="topic-text">$!${topicHtml}</div>
@@ -76,11 +77,11 @@ export default (
     return template`
 <div class="header-wrapper header stream-header topic-header"
     data-msg-id="${item.id}"
-    data-narrow="${topicNarrowStr}">
+    data-narrow="${base64Utf8Encode(topicNarrowStr)}">
   <div class="header stream-text"
        style="color: ${textColor};
               background: ${backgroundColor}"
-       data-narrow="${streamNarrowStr}">
+       data-narrow="${base64Utf8Encode(streamNarrowStr)}">
     # ${streamName}
   </div>
   <div class="topic-text">$!${topicHtml}</div>
@@ -97,7 +98,7 @@ export default (
     const uiRecipients = pmUiRecipientsFromMessage(item, ownUser);
     return template`
 <div class="header-wrapper private-header header"
-     data-narrow="${narrowStr}"
+     data-narrow="${base64Utf8Encode(narrowStr)}"
      data-msg-id="${item.id}">
   ${uiRecipients
     .map(r => r.full_name)

--- a/src/webview/js/js.js
+++ b/src/webview/js/js.js
@@ -620,6 +620,7 @@ const eventUpdateHandlers = {
 // See `handleInitialLoad` for how this gets subscribed to events.
 const handleMessageEvent: MessageEventListener = e => {
   scrollEventsDisabled = true;
+  // This decoding inverts `base64Utf8Encode`.
   const decodedData = decodeURIComponent(escape(window.atob(e.data)));
   const rawUpdateEvents = JSON.parse(decodedData);
   const updateEvents: WebViewUpdateEvent[] = rawUpdateEvents.map(updateEvent => ({

--- a/src/webview/webViewEventHandlers.js
+++ b/src/webview/webViewEventHandlers.js
@@ -24,6 +24,7 @@ import {
 } from '../actions';
 import { showActionSheet } from '../message/messageActionSheet';
 import { ensureUnreachable } from '../types';
+import { base64Utf8Decode } from '../utils/encoding';
 
 type MessageListEventReady = {|
   type: 'ready',
@@ -59,6 +60,8 @@ type MessageListEventAvatar = {|
 
 type MessageListEventNarrow = {|
   type: 'narrow',
+  // The result of `keyFromNarrow`, passed through `base64Utf8Encode`.
+  // Pass it through `base64UtfDecode` before using.
   narrow: string,
 |};
 
@@ -229,7 +232,7 @@ export const handleMessageListEvent = (props: Props, _: GetText, event: MessageL
     }
 
     case 'narrow':
-      props.dispatch(doNarrow(parseNarrow(event.narrow)));
+      props.dispatch(doNarrow(parseNarrow(base64Utf8Decode(event.narrow))));
       break;
 
     case 'image':


### PR DESCRIPTION
…list.

In af1713a76, from #4339, a subtle bug was introduced by our use of
the `\x00` character in making keys for narrows (`keyFromNarrow`).
That character doesn't round-trip through being the value of the
`data-narrow` attribute in our message-list HTML, so we got an error
on pressing a topic-narrow header in the message list for a stream
narrow.

So, make it so that that attribute never contains `\x00` (or indeed
any other non-handled character [1]) by encoding it with our
`base64UtfEncode` function.

See discussion for how we arrived at this solution [2]. In
particular, it has the nice quality of also reducing our exposure to
bugs stemming from stream names (or topics, or users' email
addresses -- anything that ends up in the result of `keyFromNarrow`)
containing characters that aren't allowed in HTML-attribute values.

[1] https://html.spec.whatwg.org/multipage/syntax.html#attributes-2
[2] https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/.23M4339.20regression/near/1085234