### PR TITLE
Refresh the still-useful parts of #4116, on path to using recent-PMs data

### DIFF
--- a/src/__tests__/lib/exampleData.js
+++ b/src/__tests__/lib/exampleData.js
@@ -101,8 +101,13 @@ export const diverseCharacters =
  * Users and bots
  */
 
+type UserOrBotPropertiesArgs = {|
+  name?: string,
+  user_id?: number,
+|};
+
 const randUserId: () => number = makeUniqueRandInt('user IDs', 10000);
-const userOrBotProperties = ({ name: _name }) => {
+const userOrBotProperties = ({ name: _name, user_id }: UserOrBotPropertiesArgs) => {
   const name = _name ?? randString();
   const capsName = name.substring(0, 1).toUpperCase() + name.substring(1);
   return deepFreeze({
@@ -119,12 +124,12 @@ const userOrBotProperties = ({ name: _name }) => {
     full_name: `${capsName} User`,
     is_admin: false,
     timezone: 'UTC',
-    user_id: randUserId(),
+    user_id: user_id ?? randUserId(),
   });
 };
 
 /** Beware! These values may not be representative. */
-export const makeUser = (args: { name?: string } = {}): User =>
+export const makeUser = (args: UserOrBotPropertiesArgs = Object.freeze({})): User =>
   deepFreeze({
     ...userOrBotProperties(args),
 
@@ -138,7 +143,9 @@ export const makeUser = (args: { name?: string } = {}): User =>
   });
 
 /** Beware! These values may not be representative. */
-export const makeCrossRealmBot = (args: { name?: string } = {}): CrossRealmBot =>
+export const makeCrossRealmBot = (
+  args: UserOrBotPropertiesArgs = Object.freeze({}),
+): CrossRealmBot =>
   deepFreeze({
     ...userOrBotProperties(args),
     is_bot: true,

--- a/src/__tests__/lib/exampleData.js
+++ b/src/__tests__/lib/exampleData.js
@@ -346,6 +346,9 @@ export const pmMessage = (args?: {|
   return deepFreeze({ ...baseMessage, ...extra });
 };
 
+export const pmMessageFromTo = (from: User, to: User[], extra?: $Rest<Message, {}>): Message =>
+  pmMessage({ sender: from, recipients: [from, ...to], ...extra });
+
 const messagePropertiesFromStream = (stream1: Stream) => {
   const { stream_id, name: display_recipient } = stream1;
   return deepFreeze({

--- a/src/__tests__/lib/exampleData.js
+++ b/src/__tests__/lib/exampleData.js
@@ -332,6 +332,8 @@ export const pmMessage = (args?: {|
 
     content: 'This is an example PM message.',
     content_type: 'text/markdown',
+    // We don't sort the recipients, because they're inconsistently sorted
+    // in real messages.  (See comments on the Message type.)
     display_recipient: recipients.map(displayRecipientFromUser),
     id: randMessageId(),
     recipient_id: 2342,

--- a/src/__tests__/lib/exampleData.js
+++ b/src/__tests__/lib/exampleData.js
@@ -12,7 +12,7 @@ import type {
   User,
   UserGroup,
 } from '../../api/modelTypes';
-import type { Action, GlobalState, RealmState } from '../../reduxTypes';
+import type { Action, GlobalState, MessagesState, RealmState } from '../../reduxTypes';
 import type { Auth, Account, Outbox } from '../../types';
 import { UploadedAvatarURL } from '../../utils/avatar';
 import { ZulipVersion } from '../../utils/zulipVersion';
@@ -27,6 +27,7 @@ import {
 import rootReducer from '../../boot/reducers';
 import { authOfAccount } from '../../account/accountMisc';
 import { HOME_NARROW } from '../../utils/narrow';
+import { objectFromEntries } from '../../jsBackport';
 
 /* ========================================================================
  * Utilities
@@ -387,6 +388,10 @@ export const streamMessage = (args?: {|
 
   return deepFreeze({ ...baseMessage, ...extra });
 };
+
+/** Construct a MessagesState from a list of messages. */
+export const makeMessagesState = (messages: Message[]): MessagesState =>
+  objectFromEntries(messages.map(m => [m.id, m]));
 
 /* ========================================================================
  * Outbox messages

--- a/src/chat/__tests__/narrowsSelectors-test.js
+++ b/src/chat/__tests__/narrowsSelectors-test.js
@@ -117,11 +117,11 @@ describe('getFirstMessageId', () => {
       narrows: Immutable.Map({
         [HOME_NARROW_STR]: [1, 2, 3],
       }),
-      messages: {
-        [1]: eg.streamMessage({ id: 1 }) /* eslint-disable-line no-useless-computed-key */,
-        [2]: eg.streamMessage({ id: 2 }) /* eslint-disable-line no-useless-computed-key */,
-        [3]: eg.streamMessage({ id: 3 }) /* eslint-disable-line no-useless-computed-key */,
-      },
+      messages: eg.makeMessagesState([
+        eg.streamMessage({ id: 1 }),
+        eg.streamMessage({ id: 2 }),
+        eg.streamMessage({ id: 3 }),
+      ]),
       outbox: [],
     });
 
@@ -151,11 +151,11 @@ describe('getLastMessageId', () => {
       narrows: Immutable.Map({
         [HOME_NARROW_STR]: [1, 2, 3],
       }),
-      messages: {
-        [1]: eg.streamMessage({ id: 1 }) /* eslint-disable-line no-useless-computed-key */,
-        [2]: eg.streamMessage({ id: 2 }) /* eslint-disable-line no-useless-computed-key */,
-        [3]: eg.streamMessage({ id: 3 }) /* eslint-disable-line no-useless-computed-key */,
-      },
+      messages: eg.makeMessagesState([
+        eg.streamMessage({ id: 1 }),
+        eg.streamMessage({ id: 2 }),
+        eg.streamMessage({ id: 3 }),
+      ]),
       outbox: [],
     });
 

--- a/src/common/Icons.js
+++ b/src/common/Icons.js
@@ -1,7 +1,7 @@
 /* @flow strict-local */
 import React from 'react';
 import type { ComponentType } from 'react';
-import type { Text } from 'react-native';
+import { Text } from 'react-native';
 import type { Color, IconProps as IconPropsBusted } from 'react-native-vector-icons';
 import Feather from 'react-native-vector-icons/Feather';
 import type { FeatherGlyphs } from 'react-native-vector-icons/Feather';
@@ -24,7 +24,7 @@ import SimpleLineIcons from 'react-native-vector-icons/SimpleLineIcons';
  *    it should be `allowFontScaling?: ?boolean`.
  */
 type IconProps<Glyphs: string> = {|
-  ...$Exact<$PropertyType<Text, 'props'>>,
+  ...$Exact<React$ElementConfig<typeof Text>>,
   size?: number,
   name: Glyphs,
   color?: Color,

--- a/src/common/Input.js
+++ b/src/common/Input.js
@@ -8,10 +8,7 @@ import { ThemeContext, HALF_COLOR, BORDER_COLOR } from '../styles';
 import { withGetText } from '../boot/TranslationProvider';
 
 export type Props = $ReadOnly<{|
-  // Should be fixed in RN v0.63 (#4245); see
-  // https://github.com/zulip/zulip-mobile/issues/4245#issuecomment-695104351.
-  // $FlowFixMe
-  ...$PropertyType<typeof TextInput, 'props'>,
+  ...React$ElementConfig<typeof TextInput>,
   placeholder: LocalizableText,
   onChangeText?: (text: string) => void,
   textInputRef?: React$Ref<typeof TextInput>,

--- a/src/common/Label.js
+++ b/src/common/Label.js
@@ -8,7 +8,7 @@ import { ThemeContext } from '../styles';
 import type { LocalizableText } from '../types';
 
 type Props = $ReadOnly<{|
-  ...$Exact<$PropertyType<Text, 'props'>>,
+  ...$Exact<React$ElementConfig<typeof Text>>,
   text: LocalizableText,
 |}>;
 

--- a/src/common/RawLabel.js
+++ b/src/common/RawLabel.js
@@ -6,7 +6,7 @@ import type { ThemeData } from '../styles';
 import { ThemeContext } from '../styles';
 
 type Props = $ReadOnly<{|
-  ...$Exact<$PropertyType<Text, 'props'>>,
+  ...$Exact<React$ElementConfig<typeof Text>>,
   text: string,
 |}>;
 

--- a/src/common/ZulipStatusBar.js
+++ b/src/common/ZulipStatusBar.js
@@ -10,7 +10,7 @@ import { DEFAULT_TITLE_BACKGROUND_COLOR, getTitleBackgroundColor } from '../titl
 import { foregroundColorFromBackground } from '../utils/color';
 import { getSession, getSettings } from '../selectors';
 
-type BarStyle = $PropertyType<$PropertyType<StatusBar, 'props'>, 'barStyle'>;
+type BarStyle = $PropertyType<React$ElementConfig<typeof StatusBar>, 'barStyle'>;
 
 export const getStatusBarColor = (backgroundColor: string, theme: ThemeName): string =>
   backgroundColor === DEFAULT_TITLE_BACKGROUND_COLOR

--- a/src/message/__tests__/fetchActions-test.js
+++ b/src/message/__tests__/fetchActions-test.js
@@ -68,10 +68,7 @@ describe('fetchActions', () => {
         narrows: Immutable.Map({
           [streamNarrowStr]: [1],
         }),
-        messages: {
-          [message1.id]: message1,
-          [message2.id]: message2,
-        },
+        messages: eg.makeMessagesState([message1, message2]),
         streams: [eg.makeStream({ name: 'some stream' })],
       });
 
@@ -384,11 +381,7 @@ describe('fetchActions', () => {
           [HOME_NARROW_STR]: [message1.id, message2.id],
         }),
       ),
-      messages: {
-        ...eg.baseReduxState.messages,
-        [message1.id]: message1,
-        [message2.id]: message1,
-      },
+      messages: eg.makeMessagesState([message1, message2]),
     });
 
     test('message fetch start action is dispatched with numBefore greater than zero', async () => {
@@ -477,11 +470,7 @@ describe('fetchActions', () => {
           [HOME_NARROW_STR]: [message1.id, message2.id],
         }),
       ),
-      messages: {
-        ...eg.baseReduxState.messages,
-        [message1.id]: message1,
-        [message2.id]: message1,
-      },
+      messages: eg.makeMessagesState([message1, message2]),
     });
 
     test('message fetch start action is dispatched with numAfter greater than zero', async () => {

--- a/src/pm-conversations/PmConversationList.js
+++ b/src/pm-conversations/PmConversationList.js
@@ -20,7 +20,6 @@ const styles = createStyleSheet({
 type Props = $ReadOnly<{|
   dispatch: Dispatch,
   conversations: PmConversationData[],
-  allUsersByEmail: Map<string, UserOrBot>,
 |}>;
 
 /**

--- a/src/pm-conversations/PmConversationsCard.js
+++ b/src/pm-conversations/PmConversationsCard.js
@@ -7,12 +7,12 @@ import type { NavigationTabProp, NavigationStateRoute } from 'react-navigation-t
 import NavigationService from '../nav/NavigationService';
 import type { ThemeData } from '../styles';
 import { ThemeContext, createStyleSheet } from '../styles';
-import type { Dispatch, PmConversationData, UserOrBot } from '../types';
+import type { Dispatch, PmConversationData } from '../types';
 import { connect } from '../react-redux';
 import { Label, ZulipButton, LoadingBanner } from '../common';
 import { IconPeople, IconSearch } from '../common/Icons';
 import PmConversationList from './PmConversationList';
-import { getRecentConversations, getAllUsersByEmail } from '../selectors';
+import { getRecentConversations } from '../selectors';
 import { navigateToCreateGroup, navigateToUsersScreen } from '../actions';
 
 const styles = createStyleSheet({
@@ -43,7 +43,6 @@ type Props = $ReadOnly<{|
 
   dispatch: Dispatch,
   conversations: PmConversationData[],
-  allUsersByEmail: Map<string, UserOrBot>,
 |}>;
 
 /**
@@ -54,7 +53,7 @@ class PmConversationsCard extends PureComponent<Props> {
   context: ThemeData;
 
   render() {
-    const { dispatch, conversations, allUsersByEmail } = this.props;
+    const { dispatch, conversations } = this.props;
 
     return (
       <View style={[styles.container, { backgroundColor: this.context.backgroundColor }]}>
@@ -82,11 +81,7 @@ class PmConversationsCard extends PureComponent<Props> {
         {conversations.length === 0 ? (
           <Label style={styles.emptySlate} text="No recent conversations" />
         ) : (
-          <PmConversationList
-            dispatch={dispatch}
-            conversations={conversations}
-            allUsersByEmail={allUsersByEmail}
-          />
+          <PmConversationList dispatch={dispatch} conversations={conversations} />
         )}
       </View>
     );
@@ -95,5 +90,4 @@ class PmConversationsCard extends PureComponent<Props> {
 
 export default connect(state => ({
   conversations: getRecentConversations(state),
-  allUsersByEmail: getAllUsersByEmail(state),
 }))(PmConversationsCard);

--- a/src/pm-conversations/__tests__/pmConversationsSelectors-test.js
+++ b/src/pm-conversations/__tests__/pmConversationsSelectors-test.js
@@ -8,6 +8,12 @@ import * as eg from '../../__tests__/lib/exampleData';
 describe('getRecentConversations', () => {
   const userJohn = eg.makeUser();
   const userMark = eg.makeUser();
+  const keyForUsers = users =>
+    users
+      .map(u => u.user_id)
+      .sort((a, b) => a - b)
+      .map(String)
+      .join(',');
 
   test('when no messages, return no conversations', () => {
     const state = eg.reduxState({
@@ -60,10 +66,7 @@ describe('getRecentConversations', () => {
         ],
         huddles: [
           {
-            user_ids_string: [eg.selfUser.user_id, userJohn.user_id, userMark.user_id]
-              .sort((a, b) => a - b)
-              .map(String)
-              .join(','),
+            user_ids_string: keyForUsers([eg.selfUser, userJohn, userMark]),
             unread_message_ids: [5], // TODO: where does this come from???
           },
         ],
@@ -90,10 +93,7 @@ describe('getRecentConversations', () => {
         unread: 1,
       },
       {
-        key: [eg.selfUser.user_id, userJohn.user_id, userMark.user_id]
-          .sort((a, b) => a - b)
-          .map(String)
-          .join(','),
+        key: keyForUsers([eg.selfUser, userJohn, userMark]),
         keyRecipients: [userJohn, userMark].sort((a, b) => a.user_id - b.user_id),
         msgId: 0,
         unread: 1,
@@ -138,10 +138,7 @@ describe('getRecentConversations', () => {
         ],
         huddles: [
           {
-            user_ids_string: [eg.selfUser.user_id, userJohn.user_id, userMark.user_id]
-              .sort((a, b) => a - b)
-              .map(String)
-              .join(','),
+            user_ids_string: keyForUsers([eg.selfUser, userJohn, userMark]),
             unread_message_ids: [5],
           },
         ],
@@ -156,10 +153,7 @@ describe('getRecentConversations', () => {
         unread: 1,
       },
       {
-        key: [eg.selfUser.user_id, userJohn.user_id, userMark.user_id]
-          .sort((a, b) => a - b)
-          .map(String)
-          .join(','),
+        key: keyForUsers([eg.selfUser, userJohn, userMark]),
         keyRecipients: [userJohn, userMark].sort((a, b) => a.user_id - b.user_id),
         msgId: 5,
         unread: 1,

--- a/src/pm-conversations/__tests__/pmConversationsSelectors-test.js
+++ b/src/pm-conversations/__tests__/pmConversationsSelectors-test.js
@@ -51,18 +51,9 @@ describe('getRecentConversations', () => {
       unread: {
         ...eg.baseReduxState.unread,
         pms: [
-          {
-            sender_id: eg.selfUser.user_id,
-            unread_message_ids: [4],
-          },
-          {
-            sender_id: userJohn.user_id,
-            unread_message_ids: [1, 3],
-          },
-          {
-            sender_id: userMark.user_id,
-            unread_message_ids: [2],
-          },
+          { sender_id: eg.selfUser.user_id, unread_message_ids: [4] },
+          { sender_id: userJohn.user_id, unread_message_ids: [1, 3] },
+          { sender_id: userMark.user_id, unread_message_ids: [2] },
         ],
         huddles: [
           {
@@ -74,24 +65,9 @@ describe('getRecentConversations', () => {
     });
 
     const expectedResult = [
-      {
-        key: eg.selfUser.user_id.toString(),
-        keyRecipients: [eg.selfUser],
-        msgId: 4,
-        unread: 1,
-      },
-      {
-        key: userJohn.user_id.toString(),
-        keyRecipients: [userJohn],
-        msgId: 3,
-        unread: 2,
-      },
-      {
-        key: userMark.user_id.toString(),
-        keyRecipients: [userMark],
-        msgId: 2,
-        unread: 1,
-      },
+      { key: eg.selfUser.user_id.toString(), keyRecipients: [eg.selfUser], msgId: 4, unread: 1 },
+      { key: userJohn.user_id.toString(), keyRecipients: [userJohn], msgId: 3, unread: 2 },
+      { key: userMark.user_id.toString(), keyRecipients: [userMark], msgId: 2, unread: 1 },
       {
         key: keyForUsers([eg.selfUser, userJohn, userMark]),
         keyRecipients: [userJohn, userMark].sort((a, b) => a.user_id - b.user_id),
@@ -123,18 +99,9 @@ describe('getRecentConversations', () => {
       unread: {
         ...eg.baseReduxState.unread,
         pms: [
-          {
-            sender_id: eg.selfUser.user_id,
-            unread_message_ids: [4],
-          },
-          {
-            sender_id: userJohn.user_id,
-            unread_message_ids: [1, 3],
-          },
-          {
-            sender_id: userMark.user_id,
-            unread_message_ids: [2],
-          },
+          { sender_id: eg.selfUser.user_id, unread_message_ids: [4] },
+          { sender_id: userJohn.user_id, unread_message_ids: [1, 3] },
+          { sender_id: userMark.user_id, unread_message_ids: [2] },
         ],
         huddles: [
           {
@@ -146,30 +113,15 @@ describe('getRecentConversations', () => {
     });
 
     const expectedResult = [
-      {
-        key: eg.selfUser.user_id.toString(),
-        keyRecipients: [eg.selfUser],
-        msgId: 6,
-        unread: 1,
-      },
+      { key: eg.selfUser.user_id.toString(), keyRecipients: [eg.selfUser], msgId: 6, unread: 1 },
       {
         key: keyForUsers([eg.selfUser, userJohn, userMark]),
         keyRecipients: [userJohn, userMark].sort((a, b) => a.user_id - b.user_id),
         msgId: 5,
         unread: 1,
       },
-      {
-        key: userJohn.user_id.toString(),
-        keyRecipients: [userJohn],
-        msgId: 4,
-        unread: 2,
-      },
-      {
-        key: userMark.user_id.toString(),
-        keyRecipients: [userMark],
-        msgId: 3,
-        unread: 1,
-      },
+      { key: userJohn.user_id.toString(), keyRecipients: [userJohn], msgId: 4, unread: 2 },
+      { key: userMark.user_id.toString(), keyRecipients: [userMark], msgId: 3, unread: 1 },
     ];
 
     const actual = getRecentConversations(state);

--- a/src/pm-conversations/__tests__/pmConversationsSelectors-test.js
+++ b/src/pm-conversations/__tests__/pmConversationsSelectors-test.js
@@ -58,7 +58,7 @@ describe('getRecentConversations', () => {
         huddles: [
           {
             user_ids_string: keyForUsers([eg.selfUser, userJohn, userMark]),
-            unread_message_ids: [5], // TODO: where does this come from???
+            unread_message_ids: [0],
           },
         ],
       },
@@ -99,9 +99,9 @@ describe('getRecentConversations', () => {
       unread: {
         ...eg.baseReduxState.unread,
         pms: [
-          { sender_id: eg.selfUser.user_id, unread_message_ids: [4] },
-          { sender_id: userJohn.user_id, unread_message_ids: [1, 3] },
-          { sender_id: userMark.user_id, unread_message_ids: [2] },
+          { sender_id: eg.selfUser.user_id, unread_message_ids: [6] },
+          { sender_id: userJohn.user_id, unread_message_ids: [2, 4] },
+          { sender_id: userMark.user_id, unread_message_ids: [1, 3] },
         ],
         huddles: [
           {
@@ -121,7 +121,7 @@ describe('getRecentConversations', () => {
         unread: 1,
       },
       { key: userJohn.user_id.toString(), keyRecipients: [userJohn], msgId: 4, unread: 2 },
-      { key: userMark.user_id.toString(), keyRecipients: [userMark], msgId: 3, unread: 1 },
+      { key: userMark.user_id.toString(), keyRecipients: [userMark], msgId: 3, unread: 2 },
     ];
 
     const actual = getRecentConversations(state);

--- a/src/pm-conversations/__tests__/pmConversationsSelectors-test.js
+++ b/src/pm-conversations/__tests__/pmConversationsSelectors-test.js
@@ -29,45 +29,33 @@ describe('getRecentConversations', () => {
   });
 
   test('returns unique list of recipients, includes conversations with self', () => {
-    const meAndJohnPm1 = eg.pmMessage({ id: 1, recipients: [eg.selfUser, userJohn] });
-    const meAndMarkPm = eg.pmMessage({ id: 2, recipients: [eg.selfUser, userMark] });
-    const meAndJohnPm2 = eg.pmMessage({ id: 3, recipients: [eg.selfUser, userJohn] });
-    const meOnlyPm = eg.pmMessage({ id: 4, recipients: [eg.selfUser] });
-    const meJohnAndMarkPm = eg.pmMessage({ id: 0, recipients: [eg.selfUser, userJohn, userMark] });
-
     const state = eg.reduxState({
       realm: eg.realmState({ email: eg.selfUser.email }),
       users: [eg.selfUser, userJohn, userMark],
       narrows: Immutable.Map({
-        [ALL_PRIVATE_NARROW_STR]: [
-          meJohnAndMarkPm.id,
-          meAndJohnPm1.id,
-          meAndMarkPm.id,
-          meAndJohnPm2.id,
-          meOnlyPm.id,
-        ],
+        [ALL_PRIVATE_NARROW_STR]: [0, 1, 2, 3, 4],
       }),
-      messages: {
-        [meAndJohnPm1.id]: meAndJohnPm1,
-        [meAndMarkPm.id]: meAndMarkPm,
-        [meAndJohnPm2.id]: meAndJohnPm2,
-        [meOnlyPm.id]: meOnlyPm,
-        [meJohnAndMarkPm.id]: meJohnAndMarkPm,
-      },
+      messages: eg.makeMessagesState([
+        eg.pmMessageFromTo(userJohn, [eg.selfUser], { id: 1 }),
+        eg.pmMessageFromTo(userMark, [eg.selfUser], { id: 2 }),
+        eg.pmMessageFromTo(userJohn, [eg.selfUser], { id: 3 }),
+        eg.pmMessageFromTo(eg.selfUser, [], { id: 4 }),
+        eg.pmMessageFromTo(userJohn, [eg.selfUser, userMark], { id: 0 }),
+      ]),
       unread: {
         ...eg.baseReduxState.unread,
         pms: [
           {
             sender_id: eg.selfUser.user_id,
-            unread_message_ids: [meOnlyPm.id],
+            unread_message_ids: [4],
           },
           {
             sender_id: userJohn.user_id,
-            unread_message_ids: [meAndJohnPm1.id, meAndJohnPm2.id],
+            unread_message_ids: [1, 3],
           },
           {
             sender_id: userMark.user_id,
-            unread_message_ids: [meAndMarkPm.id],
+            unread_message_ids: [2],
           },
         ],
         huddles: [
@@ -86,19 +74,19 @@ describe('getRecentConversations', () => {
       {
         key: eg.selfUser.user_id.toString(),
         keyRecipients: [eg.selfUser],
-        msgId: meOnlyPm.id,
+        msgId: 4,
         unread: 1,
       },
       {
         key: userJohn.user_id.toString(),
         keyRecipients: [userJohn],
-        msgId: meAndJohnPm2.id,
+        msgId: 3,
         unread: 2,
       },
       {
         key: userMark.user_id.toString(),
         keyRecipients: [userMark],
-        msgId: meAndMarkPm.id,
+        msgId: 2,
         unread: 1,
       },
       {
@@ -107,61 +95,45 @@ describe('getRecentConversations', () => {
           .map(String)
           .join(','),
         keyRecipients: [userJohn, userMark].sort((a, b) => a.user_id - b.user_id),
-        msgId: meJohnAndMarkPm.id,
+        msgId: 0,
         unread: 1,
       },
     ];
 
     const actual = getRecentConversations(state);
 
-    expect(actual).toEqual(expectedResult);
+    expect(actual).toMatchObject(expectedResult);
   });
 
   test('returns recipients sorted by last activity', () => {
-    // Maybe we can share these definitions with the above test;
-    // first, we have to sort out why the IDs are different.
-    const meAndMarkPm1 = eg.pmMessage({ id: 1, recipients: [eg.selfUser, userMark] });
-    const meAndJohnPm1 = eg.pmMessage({ id: 2, recipients: [eg.selfUser, userJohn] });
-    const meAndMarkPm2 = eg.pmMessage({ id: 3, recipients: [eg.selfUser, userMark] });
-    const meAndJohnPm2 = eg.pmMessage({ id: 4, recipients: [eg.selfUser, userJohn] });
-    const meJohnAndMarkPm = eg.pmMessage({ id: 5, recipients: [eg.selfUser, userJohn, userMark] });
-    const meOnlyPm = eg.pmMessage({ id: 6, recipients: [eg.selfUser] });
-
     const state = eg.reduxState({
       realm: eg.realmState({ email: eg.selfUser.email }),
       users: [eg.selfUser, userJohn, userMark],
       narrows: Immutable.Map({
-        [ALL_PRIVATE_NARROW_STR]: [
-          meAndMarkPm1.id,
-          meAndJohnPm1.id,
-          meAndMarkPm2.id,
-          meAndJohnPm2.id,
-          meJohnAndMarkPm.id,
-          meOnlyPm.id,
-        ],
+        [ALL_PRIVATE_NARROW_STR]: [1, 2, 3, 4, 5, 6],
       }),
-      messages: {
-        [meAndJohnPm1.id]: meAndJohnPm1,
-        [meAndMarkPm1.id]: meAndMarkPm1,
-        [meAndJohnPm2.id]: meAndJohnPm2,
-        [meAndMarkPm2.id]: meAndMarkPm2,
-        [meJohnAndMarkPm.id]: meJohnAndMarkPm,
-        [meOnlyPm.id]: meOnlyPm,
-      },
+      messages: eg.makeMessagesState([
+        eg.pmMessageFromTo(userJohn, [eg.selfUser], { id: 2 }),
+        eg.pmMessageFromTo(userMark, [eg.selfUser], { id: 1 }),
+        eg.pmMessageFromTo(userJohn, [eg.selfUser], { id: 4 }),
+        eg.pmMessageFromTo(userMark, [eg.selfUser], { id: 3 }),
+        eg.pmMessageFromTo(userMark, [eg.selfUser, userJohn], { id: 5 }),
+        eg.pmMessageFromTo(eg.selfUser, [], { id: 6 }),
+      ]),
       unread: {
         ...eg.baseReduxState.unread,
         pms: [
           {
             sender_id: eg.selfUser.user_id,
-            unread_message_ids: [meAndJohnPm2.id],
+            unread_message_ids: [4],
           },
           {
             sender_id: userJohn.user_id,
-            unread_message_ids: [meAndMarkPm1.id, meAndMarkPm2.id],
+            unread_message_ids: [1, 3],
           },
           {
             sender_id: userMark.user_id,
-            unread_message_ids: [meAndJohnPm1.id],
+            unread_message_ids: [2],
           },
         ],
         huddles: [
@@ -170,7 +142,7 @@ describe('getRecentConversations', () => {
               .sort((a, b) => a - b)
               .map(String)
               .join(','),
-            unread_message_ids: [meJohnAndMarkPm.id],
+            unread_message_ids: [5],
           },
         ],
       },
@@ -180,7 +152,7 @@ describe('getRecentConversations', () => {
       {
         key: eg.selfUser.user_id.toString(),
         keyRecipients: [eg.selfUser],
-        msgId: meOnlyPm.id,
+        msgId: 6,
         unread: 1,
       },
       {
@@ -189,19 +161,19 @@ describe('getRecentConversations', () => {
           .map(String)
           .join(','),
         keyRecipients: [userJohn, userMark].sort((a, b) => a.user_id - b.user_id),
-        msgId: meJohnAndMarkPm.id,
+        msgId: 5,
         unread: 1,
       },
       {
         key: userJohn.user_id.toString(),
         keyRecipients: [userJohn],
-        msgId: meAndJohnPm2.id,
+        msgId: 4,
         unread: 2,
       },
       {
         key: userMark.user_id.toString(),
         keyRecipients: [userMark],
-        msgId: meAndMarkPm2.id,
+        msgId: 3,
         unread: 1,
       },
     ];

--- a/src/pm-conversations/pmConversationsSelectors.js
+++ b/src/pm-conversations/pmConversationsSelectors.js
@@ -20,7 +20,7 @@ export const getRecentConversations: Selector<PmConversationData[]> = createSele
     unreadHuddles: { [string]: number },
     allUsersById,
   ): PmConversationData[] => {
-    const recipients = messages
+    const items = messages
       .map(msg => {
         // Note this can be a different set of users from those in `keyRecipients`.
         const unreadsKey = pmUnreadsKeyFromMessage(msg, ownUser.user_id);
@@ -29,22 +29,22 @@ export const getRecentConversations: Selector<PmConversationData[]> = createSele
       })
       .filter(Boolean);
 
-    const latestByRecipient = new Map();
-    recipients.forEach(recipient => {
-      const prev = latestByRecipient.get(recipient.unreadsKey);
-      if (!prev || recipient.msgId > prev.msgId) {
-        latestByRecipient.set(recipient.unreadsKey, recipient);
+    const latestByRecipients = new Map();
+    items.forEach(item => {
+      const prev = latestByRecipients.get(item.unreadsKey);
+      if (!prev || item.msgId > prev.msgId) {
+        latestByRecipients.set(item.unreadsKey, item);
       }
     });
 
-    const sortedByMostRecent = Array.from(latestByRecipient.values()).sort(
+    const sortedByMostRecent = Array.from(latestByRecipients.values()).sort(
       (a, b) => +b.msgId - +a.msgId,
     );
 
-    return sortedByMostRecent.map(recipient => ({
-      key: recipient.unreadsKey,
-      keyRecipients: recipient.keyRecipients,
-      msgId: recipient.msgId,
+    return sortedByMostRecent.map(conversation => ({
+      key: conversation.unreadsKey,
+      keyRecipients: conversation.keyRecipients,
+      msgId: conversation.msgId,
       unread:
         // This business of looking in one place and then the other is kind
         // of messy.  Fortunately it always works, because the key spaces
@@ -53,7 +53,7 @@ export const getRecentConversations: Selector<PmConversationData[]> = createSele
         /* $FlowFixMe: The keys of unreadPms are logically numbers, but because it's an object they
          end up converted to strings, so this access with string keys works.  We should probably use
          a Map for this and similar maps. */
-        unreadPms[recipient.unreadsKey] || unreadHuddles[recipient.unreadsKey],
+        unreadPms[conversation.unreadsKey] || unreadHuddles[conversation.unreadsKey],
     }));
   },
 );

--- a/src/reduxTypes.js
+++ b/src/reduxTypes.js
@@ -164,7 +164,7 @@ export type FlagName = $Keys<FlagsState>;
  */
 export type MessagesState = {
   // TODO(flow-v0.126): Should be exact. See note in src/utils/jsonable.js.
-  [id: number]: $Exact<Message>,
+  [id: number]: Message,
 };
 
 export type MigrationsState = {|

--- a/src/topics/__tests__/topicsSelectors-test.js
+++ b/src/topics/__tests__/topicsSelectors-test.js
@@ -50,10 +50,7 @@ describe('getLastMessageTopic', () => {
       narrows: Immutable.Map({
         [keyFromNarrow(narrow)]: [1, 2],
       }),
-      messages: {
-        [message1.id]: message1,
-        [message2.id]: message2,
-      },
+      messages: eg.makeMessagesState([message1, message2]),
       users: [eg.selfUser],
       realm: eg.realmState({ user_id: eg.selfUser.user_id, email: eg.selfUser.email }),
     });

--- a/src/types.js
+++ b/src/types.js
@@ -320,9 +320,22 @@ export type TabNavigationOptionsPropsType = {|
  * Summary of a PM conversation (either 1:1 or group PMs).
  */
 export type PmConversationData = {|
+  /**
+   * A comma-separated (numerically-)sorted sequence of the IDs of the users
+   * involved in this conversation.  Omits the self-user just if there are
+   * exactly two recipients.
+   *
+   * (This unusual specification is intended to simultaneously match the
+   * disjoint key-spaces of `unreadPms` and `unreadHuddles`.)
+   */
   key: string,
+
   keyRecipients: PmKeyUsers,
+
+  /** The most recent message in this conversation. */
   msgId: number,
+
+  /** The count of unread messages in this conversation. */
   unread: number,
 |};
 

--- a/src/unread/UnreadCards.js
+++ b/src/unread/UnreadCards.js
@@ -37,7 +37,7 @@ class UnreadCards extends PureComponent<Props> {
     const { conversations, unreadStreamsAndTopics, ...restProps } = this.props;
     type Card =
       | UnreadStreamItem
-      | { key: 'private', data: Array<$PropertyType<PmConversationList, 'props'>> };
+      | { key: 'private', data: Array<React$ElementConfig<typeof PmConversationList>> };
     const unreadCards: Array<Card> = [
       {
         key: 'private',

--- a/src/unread/UnreadCards.js
+++ b/src/unread/UnreadCards.js
@@ -3,24 +3,19 @@
 import React, { PureComponent } from 'react';
 import { SectionList } from 'react-native';
 
-import type { Dispatch, PmConversationData, UnreadStreamItem, UserOrBot } from '../types';
+import type { Dispatch, PmConversationData, UnreadStreamItem } from '../types';
 import { connect } from '../react-redux';
 import { SearchEmptyState } from '../common';
 import PmConversationList from '../pm-conversations/PmConversationList';
 import StreamItem from '../streams/StreamItem';
 import TopicItem from '../streams/TopicItem';
 import { streamNarrow, topicNarrow } from '../utils/narrow';
-import {
-  getUnreadConversations,
-  getAllUsersByEmail,
-  getUnreadStreamsAndTopicsSansMuted,
-} from '../selectors';
+import { getUnreadConversations, getUnreadStreamsAndTopicsSansMuted } from '../selectors';
 import { doNarrow } from '../actions';
 
 type Props = $ReadOnly<{|
   conversations: PmConversationData[],
   dispatch: Dispatch,
-  allUsersByEmail: Map<string, UserOrBot>,
   unreadStreamsAndTopics: UnreadStreamItem[],
 |}>;
 
@@ -34,14 +29,14 @@ class UnreadCards extends PureComponent<Props> {
   };
 
   render() {
-    const { conversations, unreadStreamsAndTopics, ...restProps } = this.props;
+    const { conversations, dispatch, unreadStreamsAndTopics } = this.props;
     type Card =
       | UnreadStreamItem
       | { key: 'private', data: Array<React$ElementConfig<typeof PmConversationList>> };
     const unreadCards: Array<Card> = [
       {
         key: 'private',
-        data: [{ conversations, ...restProps }],
+        data: [{ conversations, dispatch }],
       },
       ...unreadStreamsAndTopics,
     ];
@@ -91,6 +86,5 @@ class UnreadCards extends PureComponent<Props> {
 
 export default connect(state => ({
   conversations: getUnreadConversations(state),
-  allUsersByEmail: getAllUsersByEmail(state),
   unreadStreamsAndTopics: getUnreadStreamsAndTopicsSansMuted(state),
 }))(UnreadCards);

--- a/src/utils/__tests__/narrow-test.js
+++ b/src/utils/__tests__/narrow-test.js
@@ -140,35 +140,35 @@ describe('isMessageInNarrow', () => {
     ]],
 
     ['1:1 PM conversation, non-self', pm1to1NarrowFromUser(eg.otherUser), [
-      ['matching PM, inbound', true, eg.pmMessage()],
-      ['matching PM, outbound', true, eg.pmMessage({ sender: eg.selfUser })],
-      ['self-1:1 message', false, eg.pmMessage({ sender: eg.selfUser, recipients: [eg.selfUser] })],
-      ['group-PM including this user, inbound', false, eg.pmMessage({ recipients: [eg.selfUser, eg.otherUser, eg.thirdUser] })],
-      ['group-PM including this user, outbound', false, eg.pmMessage({ sender: eg.selfUser, recipients: [eg.selfUser, eg.otherUser, eg.thirdUser] })],
+      ['matching PM, inbound', true, eg.pmMessageFromTo(eg.otherUser, [eg.selfUser])],
+      ['matching PM, outbound', true, eg.pmMessageFromTo(eg.selfUser, [eg.otherUser])],
+      ['self-1:1 message', false, eg.pmMessageFromTo(eg.selfUser, [])],
+      ['group-PM including this user, inbound', false, eg.pmMessageFromTo(eg.otherUser, [eg.selfUser, eg.thirdUser])],
+      ['group-PM including this user, outbound', false, eg.pmMessageFromTo(eg.selfUser, [eg.otherUser, eg.thirdUser])],
       ['stream message', false, eg.streamMessage()],
     ]],
     ['self-1:1 conversation', pm1to1NarrowFromUser(eg.selfUser), [
-      ['self-1:1 message', true, eg.pmMessage({ sender: eg.selfUser, recipients: [eg.selfUser] })],
-      ['other 1:1 message, inbound', false, eg.pmMessage()],
-      ['other 1:1 message, outbound', false, eg.pmMessage({ sender: eg.selfUser })],
-      ['group-PM, inbound', false, eg.pmMessage({ recipients: [eg.selfUser, eg.otherUser, eg.thirdUser] })],
-      ['group-PM, outbound', false, eg.pmMessage({ sender: eg.selfUser, recipients: [eg.selfUser, eg.otherUser, eg.thirdUser] })],
+      ['self-1:1 message', true, eg.pmMessageFromTo(eg.selfUser, [])],
+      ['other 1:1 message, inbound', false, eg.pmMessageFromTo(eg.otherUser, [eg.selfUser])],
+      ['other 1:1 message, outbound', false, eg.pmMessageFromTo(eg.selfUser, [eg.otherUser])],
+      ['group-PM, inbound', false, eg.pmMessageFromTo(eg.otherUser, [eg.selfUser, eg.thirdUser])],
+      ['group-PM, outbound', false, eg.pmMessageFromTo(eg.selfUser, [eg.otherUser, eg.thirdUser])],
       ['stream message', false, eg.streamMessage()],
     ]],
     ['group-PM conversation', pmNarrowFromUsersUnsafe([eg.otherUser, eg.thirdUser]), [
-      ['matching group-PM, inbound', true, eg.pmMessage({ recipients: [eg.selfUser, eg.otherUser, eg.thirdUser] })],
-      ['matching group-PM, outbound', true, eg.pmMessage({ sender: eg.selfUser, recipients: [eg.selfUser, eg.otherUser, eg.thirdUser] })],
-      ['1:1 within group, inbound', false, eg.pmMessage()],
-      ['1:1 within group, outbound', false, eg.pmMessage({ sender: eg.selfUser })],
-      ['self-1:1 message', false, eg.pmMessage({ sender: eg.selfUser, recipients: [eg.selfUser] })],
+      ['matching group-PM, inbound', true, eg.pmMessageFromTo(eg.otherUser, [eg.selfUser, eg.thirdUser])],
+      ['matching group-PM, outbound', true, eg.pmMessageFromTo(eg.selfUser, [eg.otherUser, eg.thirdUser])],
+      ['1:1 within group, inbound', false, eg.pmMessageFromTo(eg.otherUser, [eg.selfUser])],
+      ['1:1 within group, outbound', false, eg.pmMessageFromTo(eg.selfUser, [eg.otherUser])],
+      ['self-1:1 message', false, eg.pmMessageFromTo(eg.selfUser, [])],
       ['stream message', false, eg.streamMessage()],
     ]],
     ['group-PM conversation, including self', pmNarrowFromUsersUnsafe([eg.selfUser, eg.otherUser, eg.thirdUser]), [
-      ['matching group-PM, inbound', true, eg.pmMessage({ recipients: [eg.selfUser, eg.otherUser, eg.thirdUser] })],
-      ['matching group-PM, outbound', true, eg.pmMessage({ sender: eg.selfUser, recipients: [eg.selfUser, eg.otherUser, eg.thirdUser] })],
-      ['1:1 within group, inbound', false, eg.pmMessage()],
-      ['1:1 within group, outbound', false, eg.pmMessage({ sender: eg.selfUser })],
-      ['self-1:1 message', false, eg.pmMessage({ sender: eg.selfUser, recipients: [eg.selfUser] })],
+      ['matching group-PM, inbound', true, eg.pmMessageFromTo(eg.otherUser, [eg.selfUser, eg.thirdUser])],
+      ['matching group-PM, outbound', true, eg.pmMessageFromTo(eg.selfUser, [eg.otherUser, eg.thirdUser])],
+      ['1:1 within group, inbound', false, eg.pmMessageFromTo(eg.otherUser, [eg.selfUser])],
+      ['1:1 within group, outbound', false, eg.pmMessageFromTo(eg.selfUser, [eg.otherUser])],
+      ['self-1:1 message', false, eg.pmMessageFromTo(eg.selfUser, [])],
       ['stream message', false, eg.streamMessage()],
     ]],
     ['all-PMs narrow', ALL_PRIVATE_NARROW, [
@@ -276,15 +276,12 @@ describe('getNarrowsForMessage', () => {
     },
     {
       label: 'PM message with one person',
-      message: eg.pmMessage({ sender: eg.otherUser }),
+      message: eg.pmMessage(),
       expectedNarrows: [HOME_NARROW, ALL_PRIVATE_NARROW, pm1to1NarrowFromUser(eg.otherUser)],
     },
     {
       label: 'Group PM message',
-      message: eg.pmMessage({
-        sender: eg.otherUser,
-        recipients: [eg.selfUser, eg.otherUser, eg.thirdUser],
-      }),
+      message: eg.pmMessageFromTo(eg.otherUser, [eg.selfUser, eg.thirdUser]),
       expectedNarrows: [
         HOME_NARROW,
         ALL_PRIVATE_NARROW,
@@ -300,12 +297,9 @@ describe('getNarrowsForMessage', () => {
 
 describe('getNarrowForReply', () => {
   test('for self-PM, returns self-1:1 narrow', () => {
-    expect(
-      getNarrowForReply(
-        eg.pmMessage({ sender: eg.selfUser, recipients: [eg.selfUser] }),
-        eg.selfUser,
-      ),
-    ).toEqual(pm1to1NarrowFromUser(eg.selfUser));
+    expect(getNarrowForReply(eg.pmMessageFromTo(eg.selfUser, []), eg.selfUser)).toEqual(
+      pm1to1NarrowFromUser(eg.selfUser),
+    );
   });
 
   test('for 1:1 PM, returns a 1:1 PM narrow', () => {
@@ -318,9 +312,7 @@ describe('getNarrowForReply', () => {
   });
 
   test('for group PM, returns a group PM narrow', () => {
-    const message = eg.pmMessage({
-      recipients: [eg.selfUser, eg.otherUser, eg.thirdUser],
-    });
+    const message = eg.pmMessageFromTo(eg.otherUser, [eg.selfUser, eg.thirdUser]);
     const expectedNarrow = pmNarrowFromUsersUnsafe([eg.otherUser, eg.thirdUser]);
 
     const actualNarrow = getNarrowForReply(message, eg.selfUser);


### PR DESCRIPTION
After taking care of #4035 (cleanly handling PM recipients, in place of our complex old handling of them) with my series of PRs up to #4356, I'm taking a look back at #3133/#3535, to start using the recent_private_conversations data structure, which had been blocked by that work.

Ray had a PR #4116 that sought to do some of that. Some of it goes in some of the same directions as I've since done with my recent PRs for #4035, and there are some parts that I don't think are helpful or needed. But there are other changes there that were and still are useful. Here I've rebased those changes, and added some related commits of my own.

After this, I'll return to Ray's further PR #4104 (which builds on the changes in #4116) to see what parts of that are also helpful to use now.
