### PR TITLE
webview: Use native scroll deceleration on iOS

### DIFF
--- a/src/webview/MessageList.js
+++ b/src/webview/MessageList.js
@@ -307,6 +307,7 @@ class MessageList extends Component<Props> {
         source={{ baseUrl: (baseUrl.toString(): string), html }}
         originWhitelist={['file://']}
         onShouldStartLoadWithRequest={onShouldStartLoadWithRequest}
+        decelerationRate="normal"
         style={{ backgroundColor: 'transparent' }}
         ref={webview => {
           this.webview = webview;


### PR DESCRIPTION
The default WebView `decelerationRate` is `fast`, which slows down momentum scrolling through messages significantly. This changes it to `normal` which is the native rate on iOS and makes it behave like other apps, allowing for much faster scrolling.

Test Plan: confirmed that this has the expected scroll momentum on an iPhone 12.