### PR TITLE
narrow: Convert more email usage to user IDs

### DIFF
--- a/src/chat/narrowsSelectors.js
+++ b/src/chat/narrowsSelectors.js
@@ -22,7 +22,7 @@ import {
   getOutbox,
 } from '../directSelectors';
 import { getCaughtUpForNarrow } from '../caughtup/caughtUpSelectors';
-import { getAllUsersByEmail, getOwnUser } from '../users/userSelectors';
+import { getAllUsersByEmail, getAllUsersById, getOwnUser } from '../users/userSelectors';
 import {
   isStreamOrTopicNarrow,
   emailsOfGroupPmNarrow,
@@ -149,13 +149,16 @@ export const isNarrowValid: Selector<boolean, Narrow> = createSelector(
   (state, narrow) => narrow,
   state => getStreams(state),
   state => getAllUsersByEmail(state),
-  (narrow, streams, allUsersByEmail) =>
+  state => getAllUsersById(state),
+  (narrow, streams, allUsersByEmail, allUsersById) =>
     caseNarrowDefault(
       narrow,
       {
         stream: streamName => streams.find(s => s.name === streamName) !== undefined,
         topic: streamName => streams.find(s => s.name === streamName) !== undefined,
-        pm: emails => emails.every(email => allUsersByEmail.get(email) !== undefined),
+        pm: (emails, ids) =>
+          emails.every(email => allUsersByEmail.get(email) !== undefined)
+          && ids.every(id => allUsersById.get(id) !== undefined),
       },
       () => true,
     ),

--- a/src/common/GroupAvatar.js
+++ b/src/common/GroupAvatar.js
@@ -20,7 +20,6 @@ const styles = createStyleSheet({
 type Props = $ReadOnly<{|
   names: string[],
   size: number,
-  shape: 'rounded' | 'square',
   children?: React$Node,
   onPress?: () => void,
 |}>;
@@ -43,22 +42,17 @@ export const initialsForGroupIcon = (names: string[]): string => {
  *
  * @prop names - The name of one or more users, used to extract their initials.
  * @prop size - Sets width and height in logical pixels.
- * @prop [shape]
  * @prop children - If provided, will render inside the component body.
  * @prop onPress - Event fired on pressing the component.
  */
 export default class GroupAvatar extends PureComponent<Props> {
-  static defaultProps = {
-    shape: 'rounded',
-  };
-
   render() {
-    const { children, names, size, shape, onPress } = this.props;
+    const { children, names, size, onPress } = this.props;
 
     const frameSize = {
       height: size,
       width: size,
-      borderRadius: shape === 'rounded' ? size / 8 : 0,
+      borderRadius: size / 8,
       backgroundColor: colorHashFromString(names.join(', ')),
     };
     const textSize = {

--- a/src/common/UserAvatar.js
+++ b/src/common/UserAvatar.js
@@ -8,7 +8,6 @@ import { AvatarURL } from '../utils/avatar';
 type Props = $ReadOnly<{|
   avatarUrl: AvatarURL,
   size: number,
-  shape: 'rounded' | 'square',
   children?: React$Node,
   onPress?: () => void,
 |}>;
@@ -18,18 +17,13 @@ type Props = $ReadOnly<{|
  *
  * @prop avatarUrl
  * @prop size - Sets width and height in logical pixels.
- * @prop [shape] - 'rounded' (default) means a square with rounded corners.
  * @prop [children] - If provided, will render inside the component body.
  * @prop [onPress] - Event fired on pressing the component.
  */
 export default class UserAvatar extends PureComponent<Props> {
-  static defaultProps = {
-    shape: 'rounded',
-  };
-
   render() {
-    const { avatarUrl, children, size, shape, onPress } = this.props;
-    const borderRadius = shape === 'rounded' ? size / 8 : 0;
+    const { avatarUrl, children, size, onPress } = this.props;
+    const borderRadius = size / 8;
     const style = {
       height: size,
       width: size,

--- a/src/common/UserAvatarWithPresence.js
+++ b/src/common/UserAvatarWithPresence.js
@@ -19,7 +19,6 @@ type Props = $ReadOnly<{|
   avatarUrl: AvatarURL,
   email: string,
   size: number,
-  shape: 'rounded' | 'square',
   onPress?: () => void,
 |}>;
 
@@ -29,19 +28,14 @@ type Props = $ReadOnly<{|
  * @prop [avatarUrl]
  * @prop [email] - Sender's / user's email address, for the presence dot.
  * @prop [size] - Sets width and height in logical pixels.
- * @prop [shape] - 'rounded' (default) means a square with rounded corners.
  * @prop [onPress] - Event fired on pressing the component.
  */
 export default class UserAvatarWithPresence extends PureComponent<Props> {
-  static defaultProps = {
-    shape: 'rounded',
-  };
-
   render() {
-    const { avatarUrl, email, size, onPress, shape } = this.props;
+    const { avatarUrl, email, size, onPress } = this.props;
 
     return (
-      <UserAvatar avatarUrl={avatarUrl} size={size} onPress={onPress} shape={shape}>
+      <UserAvatar avatarUrl={avatarUrl} size={size} onPress={onPress}>
         <PresenceStatusIndicator style={styles.status} email={email} hideIfOffline />
       </UserAvatar>
     );

--- a/src/common/UserAvatarWithPresence.js
+++ b/src/common/UserAvatarWithPresence.js
@@ -1,11 +1,13 @@
 /* @flow strict-local */
-
-import React, { PureComponent } from 'react';
+import React, { type ComponentType, PureComponent } from 'react';
 
 import { createStyleSheet } from '../styles';
+import type { Dispatch } from '../types';
 import UserAvatar from './UserAvatar';
 import PresenceStatusIndicator from './PresenceStatusIndicator';
 import { AvatarURL } from '../utils/avatar';
+import { getUserForId } from '../users/userSelectors';
+import { connect } from '../react-redux';
 
 const styles = createStyleSheet({
   status: {
@@ -17,20 +19,28 @@ const styles = createStyleSheet({
 
 type Props = $ReadOnly<{|
   avatarUrl: AvatarURL,
-  email: string,
   size: number,
   onPress?: () => void,
+  email: string,
 |}>;
 
 /**
- * Renders a user avatar with a PresenceStatusIndicator in the corner
+ * A user avatar with a PresenceStatusIndicator in the corner.
+ *
+ * Prefer `UserAvatarWithPresenceById` over this component: it does the same
+ * thing but avoids an email in the component's interface.  Once all callers
+ * have migrated to that version, it'll replace this one.
  *
  * @prop [avatarUrl]
  * @prop [email] - Sender's / user's email address, for the presence dot.
  * @prop [size] - Sets width and height in logical pixels.
  * @prop [onPress] - Event fired on pressing the component.
  */
-export default class UserAvatarWithPresence extends PureComponent<Props> {
+// The underlying class gets an inexact Props type to express that it's fine
+// for it to be passed extra props by the implementation of …ById.
+// We don't export it with that type, because we want exact Props types to
+// get the most effective type-checking.
+class UserAvatarWithPresence extends PureComponent<$ReadOnly<{ ...Props, ... }>> {
   render() {
     const { avatarUrl, email, size, onPress } = this.props;
 
@@ -41,3 +51,33 @@ export default class UserAvatarWithPresence extends PureComponent<Props> {
     );
   }
 }
+
+// Export the class with a tighter constraint on acceptable props, namely
+// that the type is an exact object type as usual.
+export default (UserAvatarWithPresence: ComponentType<Props>);
+
+/**
+ * A user avatar with a PresenceStatusIndicator in the corner.
+ *
+ * Use this in preference to the default export `UserAvatarWithPresence`.
+ * We're migrating from that one to this in order to avoid using emails.
+ *
+ * @prop [userId]
+ * @prop [size]
+ * @prop [onPress]
+ */
+export const UserAvatarWithPresenceById = connect<{| avatarUrl: AvatarURL, email: string |}, _, _>(
+  (state, props) => {
+    const user = getUserForId(state, props.userId);
+    return { avatarUrl: user.avatar_url, email: user.email };
+  },
+)(
+  // The type inference embedded in our `connect` type relies on seeing the
+  // exact Props type for the underlying component, complete with all the
+  // expected props.  Normally that's just how our Props types are in the
+  // first place, but here we have to provide it explicitly.
+  /* eslint-disable flowtype/generic-spacing */
+  (UserAvatarWithPresence: ComponentType<
+    $ReadOnly<{| ...Props, dispatch: Dispatch, userId: number |}>,
+  >),
+);

--- a/src/compose/ComposeBox.js
+++ b/src/compose/ComposeBox.js
@@ -44,7 +44,6 @@ import {
   getIsAdmin,
   getSession,
   getLastMessageTopic,
-  getActiveUsersByEmail,
   getCaughtUpForNarrow,
   getStreamInNarrow,
   getVideoChatProvider,
@@ -56,12 +55,12 @@ import {
 import { getDraftForNarrow } from '../drafts/draftsSelectors';
 import TopicAutocomplete from '../autocomplete/TopicAutocomplete';
 import AutocompleteView from '../autocomplete/AutocompleteView';
-import { getOwnEmail } from '../users/userSelectors';
+import { getActiveUsersById, getOwnUserId } from '../users/userSelectors';
 
 type SelectorProps = {|
   auth: Auth,
-  ownEmail: string,
-  usersByEmail: Map<string, UserOrBot>,
+  ownUserId: number,
+  usersById: Map<number, UserOrBot>,
   safeAreaInsets: Dimensions,
   isAdmin: boolean,
   isAnnouncementOnly: boolean,
@@ -420,9 +419,9 @@ class ComposeBox extends PureComponent<Props, State> {
   render() {
     const { isTopicFocused, isMenuExpanded, height, message, topic, selection } = this.state;
     const {
-      ownEmail,
+      ownUserId,
       narrow,
-      usersByEmail,
+      usersById,
       editMessage,
       safeAreaInsets,
       isAdmin,
@@ -441,7 +440,7 @@ class ComposeBox extends PureComponent<Props, State> {
       return <AnnouncementOnly />;
     }
 
-    const placeholder = getComposeInputPlaceholder(narrow, ownEmail, usersByEmail);
+    const placeholder = getComposeInputPlaceholder(narrow, ownUserId, usersById);
     const style = {
       paddingBottom: safeAreaInsets.bottom,
       backgroundColor: 'hsla(0, 0%, 50%, 0.1)',
@@ -519,8 +518,8 @@ class ComposeBox extends PureComponent<Props, State> {
 
 export default connect<SelectorProps, _, _>((state, props) => ({
   auth: getAuth(state),
-  ownEmail: getOwnEmail(state),
-  usersByEmail: getActiveUsersByEmail(state),
+  ownUserId: getOwnUserId(state),
+  usersById: getActiveUsersById(state),
   safeAreaInsets: getSession(state).safeAreaInsets,
   isAdmin: getIsAdmin(state),
   isAnnouncementOnly: getIsActiveStreamAnnouncementOnly(state, props.narrow),

--- a/src/compose/__tests__/getComposeInputPlaceholder-test.js
+++ b/src/compose/__tests__/getComposeInputPlaceholder-test.js
@@ -11,12 +11,12 @@ import {
 import * as eg from '../../__tests__/lib/exampleData';
 
 describe('getComposeInputPlaceholder', () => {
-  const usersByEmail = new Map([eg.selfUser, eg.otherUser, eg.thirdUser].map(u => [u.email, u]));
-  const ownEmail = eg.selfUser.email;
+  const usersById = new Map([eg.selfUser, eg.otherUser, eg.thirdUser].map(u => [u.user_id, u]));
+  const ownUserId = eg.selfUser.user_id;
 
   test('returns "Message @ThisPerson" object for person narrow', () => {
     const narrow = deepFreeze(pm1to1NarrowFromUser(eg.otherUser));
-    const placeholder = getComposeInputPlaceholder(narrow, ownEmail, usersByEmail);
+    const placeholder = getComposeInputPlaceholder(narrow, ownUserId, usersById);
     expect(placeholder).toEqual({
       text: 'Message {recipient}',
       values: { recipient: `@${eg.otherUser.full_name}` },
@@ -25,25 +25,25 @@ describe('getComposeInputPlaceholder', () => {
 
   test('returns "Jot down something" object for self narrow', () => {
     const narrow = deepFreeze(pm1to1NarrowFromUser(eg.selfUser));
-    const placeholder = getComposeInputPlaceholder(narrow, ownEmail, usersByEmail);
+    const placeholder = getComposeInputPlaceholder(narrow, ownUserId, usersById);
     expect(placeholder).toEqual({ text: 'Jot down something' });
   });
 
   test('returns "Message #streamName" for stream narrow', () => {
     const narrow = deepFreeze(streamNarrow('Denmark'));
-    const placeholder = getComposeInputPlaceholder(narrow, ownEmail, usersByEmail);
+    const placeholder = getComposeInputPlaceholder(narrow, ownUserId, usersById);
     expect(placeholder).toEqual({ text: 'Message {recipient}', values: { recipient: '#Denmark' } });
   });
 
   test('returns properly for topic narrow', () => {
     const narrow = deepFreeze(topicNarrow('Denmark', 'Copenhagen'));
-    const placeholder = getComposeInputPlaceholder(narrow, ownEmail, usersByEmail);
+    const placeholder = getComposeInputPlaceholder(narrow, ownUserId, usersById);
     expect(placeholder).toEqual({ text: 'Reply' });
   });
 
   test('returns "Message group" object for group narrow', () => {
     const narrow = deepFreeze(pmNarrowFromUsersUnsafe([eg.otherUser, eg.thirdUser]));
-    const placeholder = getComposeInputPlaceholder(narrow, ownEmail, usersByEmail);
+    const placeholder = getComposeInputPlaceholder(narrow, ownUserId, usersById);
     expect(placeholder).toEqual({ text: 'Message group' });
   });
 });

--- a/src/compose/getComposeInputPlaceholder.js
+++ b/src/compose/getComposeInputPlaceholder.js
@@ -4,23 +4,23 @@ import { caseNarrowDefault } from '../utils/narrow';
 
 export default (
   narrow: Narrow,
-  ownEmail: string,
-  usersByEmail: Map<string, UserOrBot>,
+  ownUserId: number,
+  usersById: Map<number, UserOrBot>,
 ): LocalizableText =>
   caseNarrowDefault(
     narrow,
     {
-      pm: emails => {
-        if (emails.length > 1) {
+      pm: (emails, ids) => {
+        if (ids.length > 1) {
           return { text: 'Message group' };
         }
-        const email = emails[0];
+        const userId = ids[0];
 
-        if (email === ownEmail) {
+        if (userId === ownUserId) {
           return { text: 'Jot down something' };
         }
 
-        const user = usersByEmail.get(email);
+        const user = usersById.get(userId);
         if (!user) {
           return { text: 'Type a message' };
         }

--- a/src/title/Title.js
+++ b/src/title/Title.js
@@ -34,7 +34,7 @@ export default class Title extends PureComponent<Props> {
         ids.length === 1 ? (
           <TitlePrivate userId={ids[0]} color={color} />
         ) : (
-          <TitleGroup narrow={narrow} />
+          <TitleGroup userIds={ids} />
         ),
       search: () => null,
     });

--- a/src/title/Title.js
+++ b/src/title/Title.js
@@ -30,9 +30,9 @@ export default class Title extends PureComponent<Props> {
       allPrivate: () => <TitleSpecial code="private" color={color} />,
       stream: () => <TitleStream narrow={narrow} color={color} />,
       topic: () => <TitleStream narrow={narrow} color={color} />,
-      pm: emails =>
-        emails.length === 1 ? (
-          <TitlePrivate email={emails[0]} color={color} />
+      pm: (emails, ids) =>
+        ids.length === 1 ? (
+          <TitlePrivate userId={ids[0]} color={color} />
         ) : (
           <TitleGroup narrow={narrow} />
         ),

--- a/src/title/TitleGroup.js
+++ b/src/title/TitleGroup.js
@@ -23,8 +23,8 @@ type Props = $ReadOnly<{|
 |}>;
 
 class TitleGroup extends PureComponent<Props> {
-  handlePress = (user: UserOrBot) => {
-    NavigationService.dispatch(navigateToAccountDetails(user.user_id));
+  handlePress = (userId: number) => {
+    NavigationService.dispatch(navigateToAccountDetails(userId));
   };
 
   styles = createStyleSheet({
@@ -38,10 +38,10 @@ class TitleGroup extends PureComponent<Props> {
 
     return (
       <View style={styles.navWrapper}>
-        {recipients.map((user, index) => (
-          <View key={user.email} style={this.styles.titleAvatar}>
+        {recipients.map(user => (
+          <View key={user.user_id} style={this.styles.titleAvatar}>
             <UserAvatarWithPresenceById
-              onPress={() => this.handlePress(user)}
+              onPress={() => this.handlePress(user.user_id)}
               size={32}
               userId={user.user_id}
             />

--- a/src/title/TitleGroup.js
+++ b/src/title/TitleGroup.js
@@ -4,25 +4,15 @@ import React, { PureComponent } from 'react';
 import { View } from 'react-native';
 
 import NavigationService from '../nav/NavigationService';
-import type { Dispatch, UserOrBot, Narrow } from '../types';
 import styles, { createStyleSheet } from '../styles';
-import { connect } from '../react-redux';
 import { UserAvatarWithPresenceById } from '../common/UserAvatarWithPresence';
-import { getRecipientsInGroupPmNarrow } from '../selectors';
 import { navigateToAccountDetails } from '../nav/navActions';
 
-type SelectorProps = $ReadOnly<{|
-  recipients: UserOrBot[],
-|}>;
-
 type Props = $ReadOnly<{|
-  narrow: Narrow,
-
-  dispatch: Dispatch,
-  ...SelectorProps,
+  userIds: $ReadOnlyArray<number>,
 |}>;
 
-class TitleGroup extends PureComponent<Props> {
+export default class TitleGroup extends PureComponent<Props> {
   handlePress = (userId: number) => {
     NavigationService.dispatch(navigateToAccountDetails(userId));
   };
@@ -34,16 +24,15 @@ class TitleGroup extends PureComponent<Props> {
   });
 
   render() {
-    const { recipients } = this.props;
-
+    const { userIds } = this.props;
     return (
       <View style={styles.navWrapper}>
-        {recipients.map(user => (
-          <View key={user.user_id} style={this.styles.titleAvatar}>
+        {userIds.map(userId => (
+          <View key={userId} style={this.styles.titleAvatar}>
             <UserAvatarWithPresenceById
-              onPress={() => this.handlePress(user.user_id)}
+              onPress={() => this.handlePress(userId)}
               size={32}
-              userId={user.user_id}
+              userId={userId}
             />
           </View>
         ))}
@@ -51,7 +40,3 @@ class TitleGroup extends PureComponent<Props> {
     );
   }
 }
-
-export default connect<SelectorProps, _, _>((state, props) => ({
-  recipients: getRecipientsInGroupPmNarrow(state, props.narrow),
-}))(TitleGroup);

--- a/src/title/TitleGroup.js
+++ b/src/title/TitleGroup.js
@@ -7,7 +7,7 @@ import NavigationService from '../nav/NavigationService';
 import type { Dispatch, UserOrBot, Narrow } from '../types';
 import styles, { createStyleSheet } from '../styles';
 import { connect } from '../react-redux';
-import { UserAvatarWithPresence } from '../common';
+import { UserAvatarWithPresenceById } from '../common/UserAvatarWithPresence';
 import { getRecipientsInGroupPmNarrow } from '../selectors';
 import { navigateToAccountDetails } from '../nav/navActions';
 
@@ -40,11 +40,10 @@ class TitleGroup extends PureComponent<Props> {
       <View style={styles.navWrapper}>
         {recipients.map((user, index) => (
           <View key={user.email} style={this.styles.titleAvatar}>
-            <UserAvatarWithPresence
+            <UserAvatarWithPresenceById
               onPress={() => this.handlePress(user)}
               size={32}
-              avatarUrl={user.avatar_url}
-              email={user.email}
+              userId={user.user_id}
             />
           </View>
         ))}

--- a/src/title/TitlePrivate.js
+++ b/src/title/TitlePrivate.js
@@ -9,7 +9,7 @@ import styles, { createStyleSheet } from '../styles';
 import { connect } from '../react-redux';
 import { Touchable, UserAvatarWithPresence, ViewPlaceholder } from '../common';
 import ActivityText from './ActivityText';
-import { getAllUsersByEmail } from '../users/userSelectors';
+import { getAllUsersById } from '../users/userSelectors';
 import { navigateToAccountDetails } from '../nav/navActions';
 import * as logging from '../utils/logging';
 
@@ -18,7 +18,7 @@ type SelectorProps = $ReadOnly<{|
 |}>;
 
 type Props = $ReadOnly<{
-  email: string,
+  userId: number,
   color: string,
 
   dispatch: Dispatch,
@@ -70,6 +70,5 @@ class TitlePrivate extends PureComponent<Props> {
 }
 
 export default connect<SelectorProps, _, _>((state, props) => ({
-  // TODO: use user_id, not email (https://github.com/zulip/zulip-mobile/issues/3764)
-  user: getAllUsersByEmail(state).get(props.email),
+  user: getAllUsersById(state).get(props.userId),
 }))(TitlePrivate);

--- a/src/title/TitlePrivate.js
+++ b/src/title/TitlePrivate.js
@@ -7,7 +7,8 @@ import NavigationService from '../nav/NavigationService';
 import type { Dispatch, UserOrBot } from '../types';
 import styles, { createStyleSheet } from '../styles';
 import { connect } from '../react-redux';
-import { Touchable, UserAvatarWithPresence, ViewPlaceholder } from '../common';
+import { Touchable, ViewPlaceholder } from '../common';
+import { UserAvatarWithPresenceById } from '../common/UserAvatarWithPresence';
 import ActivityText from './ActivityText';
 import { getAllUsersById } from '../users/userSelectors';
 import { navigateToAccountDetails } from '../nav/navActions';
@@ -55,7 +56,7 @@ class TitlePrivate extends PureComponent<Props> {
     return (
       <Touchable onPress={this.handlePress} style={this.styles.outer}>
         <View style={this.styles.inner}>
-          <UserAvatarWithPresence size={32} email={user.email} avatarUrl={user.avatar_url} />
+          <UserAvatarWithPresenceById size={32} userId={user.user_id} />
           <ViewPlaceholder width={8} />
           <View>
             <Text style={[styles.navTitle, { color }]} numberOfLines={1} ellipsizeMode="tail">

--- a/src/users/UserItem.js
+++ b/src/users/UserItem.js
@@ -3,7 +3,8 @@ import React, { PureComponent } from 'react';
 import { View } from 'react-native';
 
 import type { UserOrBot } from '../types';
-import { UserAvatarWithPresence, RawLabel, Touchable, UnreadCount } from '../common';
+import { RawLabel, Touchable, UnreadCount } from '../common';
+import { UserAvatarWithPresenceById } from '../common/UserAvatarWithPresence';
 import styles, { createStyleSheet, BRAND_COLOR } from '../styles';
 
 const componentStyles = createStyleSheet({
@@ -54,12 +55,7 @@ export default class UserItem extends PureComponent<Props> {
     return (
       <Touchable onPress={this.handlePress}>
         <View style={[styles.listItem, isSelected && componentStyles.selectedRow]}>
-          <UserAvatarWithPresence
-            size={48}
-            avatarUrl={user.avatar_url}
-            email={user.email}
-            onPress={this.handlePress}
-          />
+          <UserAvatarWithPresenceById size={48} userId={user.user_id} onPress={this.handlePress} />
           <View style={componentStyles.textWrapper}>
             <RawLabel
               style={[componentStyles.text, isSelected && componentStyles.selectedText]}

--- a/src/users/__tests__/userSelectors-test.js
+++ b/src/users/__tests__/userSelectors-test.js
@@ -1,6 +1,5 @@
 /* @flow strict-local */
 import {
-  getActiveUsersByEmail,
   getAllUsersByEmail,
   getAllUsersById,
   getUsersById,
@@ -10,22 +9,6 @@ import {
   getUserIsActive,
 } from '../userSelectors';
 import * as eg from '../../__tests__/lib/exampleData';
-
-describe('getActiveUsers', () => {
-  test('return users, bots, map by email and do not include inactive users', () => {
-    const state = eg.reduxState({
-      users: [eg.selfUser],
-      realm: {
-        ...eg.baseReduxState.realm,
-        crossRealmBots: [eg.crossRealmBot],
-        nonActiveUsers: [eg.otherUser],
-      },
-    });
-    expect(getActiveUsersByEmail(state)).toEqual(
-      new Map([[eg.selfUser.email, eg.selfUser], [eg.crossRealmBot.email, eg.crossRealmBot]]),
-    );
-  });
-});
 
 describe('getAllUsersByEmail', () => {
   test('return users mapped by their email', () => {

--- a/src/users/userSelectors.js
+++ b/src/users/userSelectors.js
@@ -21,7 +21,7 @@ import { getUsers, getCrossRealmBots, getNonActiveUsers } from '../directSelecto
  * user to send a PM to -- deactivated users should be left out.
  *
  * See:
- *  * `getActiveUsersByEmail` for leaving out deactivated users
+ *  * `getActiveUsersById` for leaving out deactivated users
  *  * `User` for details on properties, and links to docs.
  */
 const getAllUsers: Selector<UserOrBot[]> = createSelector(
@@ -158,18 +158,6 @@ export const getUsersSansMe: Selector<User[]> = createSelector(
   getUsers,
   getOwnEmail,
   (users, ownEmail) => users.filter(user => user.email !== ownEmail),
-);
-
-/**
- * Excludes deactivated users.  See `getAllUsers` for discussion.
- *
- * Prefer `getActiveUsersById`; see #3764.
- */
-export const getActiveUsersByEmail: Selector<Map<string, UserOrBot>> = createSelector(
-  getUsers,
-  getCrossRealmBots,
-  (users = [], crossRealmBots = []) =>
-    new Map([...users, ...crossRealmBots].map(user => [user.email, user])),
 );
 
 /** Excludes deactivated users.  See `getAllUsers` for discussion. */

--- a/src/utils/narrow.js
+++ b/src/utils/narrow.js
@@ -337,10 +337,10 @@ export const isHomeNarrow = (narrow?: Narrow): boolean =>
   !!narrow && caseNarrowDefault(narrow, { home: () => true }, () => false);
 
 export const is1to1PmNarrow = (narrow?: Narrow): boolean =>
-  !!narrow && caseNarrowDefault(narrow, { pm: emails => emails.length === 1 }, () => false);
+  !!narrow && caseNarrowDefault(narrow, { pm: (emails, ids) => ids.length === 1 }, () => false);
 
 export const isGroupPmNarrow = (narrow?: Narrow): boolean =>
-  !!narrow && caseNarrowDefault(narrow, { pm: emails => emails.length > 1 }, () => false);
+  !!narrow && caseNarrowDefault(narrow, { pm: (emails, ids) => ids.length > 1 }, () => false);
 
 /**
  * The recipients' emails if a group PM narrow; else error.


### PR DESCRIPTION
This is the next tranche of changes in the series of PRs up to #4356. It converts several more of the places we use the emails from a PM narrow to use user IDs instead. Along the way we make some other conversions from user IDs to emails, as well as other cleanups in the code we're operating on.
