### PR TITLE
narrow: Convert more emails to user IDs

### DIFF
--- a/src/chat/GroupDetailsScreen.js
+++ b/src/chat/GroupDetailsScreen.js
@@ -7,7 +7,7 @@ import NavigationService from '../nav/NavigationService';
 import type { Dispatch, UserOrBot } from '../types';
 import { connect } from '../react-redux';
 import { Screen } from '../common';
-import UserItem from '../users/UserItem';
+import { UserItemById } from '../users/UserItem';
 import { navigateToAccountDetails } from '../actions';
 
 type Props = $ReadOnly<{|
@@ -35,9 +35,14 @@ class GroupDetailsScreen extends PureComponent<Props> {
         <FlatList
           initialNumToRender={10}
           data={recipients}
-          keyExtractor={item => item.email}
+          keyExtractor={item => String(item.user_id)}
           renderItem={({ item }) => (
-            <UserItem key={item.user_id} user={item} showEmail onPress={this.handlePress} />
+            <UserItemById
+              key={item.user_id}
+              userId={item.user_id}
+              showEmail
+              onPress={this.handlePress}
+            />
           )}
         />
       </Screen>

--- a/src/chat/GroupDetailsScreen.js
+++ b/src/chat/GroupDetailsScreen.js
@@ -17,7 +17,7 @@ type Props = $ReadOnly<{|
   // `navigation` prop for free, with the stack-nav shape.
   navigation: NavigationStackProp<{|
     ...NavigationStateRoute,
-    params: {| recipients: UserOrBot[] |},
+    params: {| recipients: $ReadOnlyArray<number> |},
   |}>,
 
   dispatch: Dispatch,
@@ -35,14 +35,9 @@ class GroupDetailsScreen extends PureComponent<Props> {
         <FlatList
           initialNumToRender={10}
           data={recipients}
-          keyExtractor={item => String(item.user_id)}
+          keyExtractor={item => String(item)}
           renderItem={({ item }) => (
-            <UserItemById
-              key={item.user_id}
-              userId={item.user_id}
-              showEmail
-              onPress={this.handlePress}
-            />
+            <UserItemById key={item} userId={item} showEmail onPress={this.handlePress} />
           )}
         />
       </Screen>

--- a/src/chat/narrowsSelectors.js
+++ b/src/chat/narrowsSelectors.js
@@ -1,5 +1,4 @@
 /* @flow strict-local */
-import invariant from 'invariant';
 import isEqual from 'lodash.isequal';
 import { createSelector } from 'reselect';
 
@@ -11,7 +10,6 @@ import type {
   Selector,
   Stream,
   Subscription,
-  UserOrBot,
 } from '../types';
 import {
   getAllNarrows,
@@ -25,7 +23,6 @@ import { getCaughtUpForNarrow } from '../caughtup/caughtUpSelectors';
 import { getAllUsersByEmail, getAllUsersById, getOwnUser } from '../users/userSelectors';
 import {
   isStreamOrTopicNarrow,
-  emailsOfGroupPmNarrow,
   isMessageInNarrow,
   caseNarrowDefault,
   keyFromNarrow,
@@ -103,17 +100,6 @@ export const getLastMessageId = (state: GlobalState, narrow: Narrow): number | v
   const ids = getFetchedMessageIdsForNarrow(state, narrow);
   return ids.length > 0 ? ids[ids.length - 1] : undefined;
 };
-
-export const getRecipientsInGroupPmNarrow: Selector<UserOrBot[], Narrow> = createSelector(
-  (state, narrow) => narrow,
-  state => getAllUsersByEmail(state),
-  (narrow, allUsersByEmail) =>
-    emailsOfGroupPmNarrow(narrow).map(r => {
-      const user = allUsersByEmail.get(r);
-      invariant(user, 'missing user: %s', r);
-      return user;
-    }),
-);
 
 // Prettier mishandles this Flow syntax.
 // prettier-ignore

--- a/src/nav/navActions.js
+++ b/src/nav/navActions.js
@@ -1,7 +1,7 @@
 /* @flow strict-local */
 import { StackActions, NavigationActions } from 'react-navigation';
 
-import type { NavigationAction, Message, Narrow, UserOrBot, SharedData } from '../types';
+import type { NavigationAction, Message, Narrow, SharedData } from '../types';
 import type { ApiResponseServerSettings } from '../api/settings/getServerSettings';
 import { getSameRoutesCount } from '../selectors';
 
@@ -63,7 +63,7 @@ export const navigateToAccountPicker = (): NavigationAction =>
 export const navigateToAccountDetails = (userId: number): NavigationAction =>
   StackActions.push({ routeName: 'account-details', params: { userId } });
 
-export const navigateToGroupDetails = (recipients: UserOrBot[]): NavigationAction =>
+export const navigateToGroupDetails = (recipients: $ReadOnlyArray<number>): NavigationAction =>
   StackActions.push({ routeName: 'group-details', params: { recipients } });
 
 export const navigateToRealmScreen = (

--- a/src/title-buttons/InfoNavButtonGroup.js
+++ b/src/title-buttons/InfoNavButtonGroup.js
@@ -3,28 +3,18 @@
 import React, { PureComponent } from 'react';
 
 import NavigationService from '../nav/NavigationService';
-import type { Dispatch, Narrow, UserOrBot } from '../types';
-import { connect } from '../react-redux';
-import { getRecipientsInGroupPmNarrow } from '../selectors';
 import NavButton from '../nav/NavButton';
 import { navigateToGroupDetails } from '../actions';
 
-type SelectorProps = {|
-  recipients: UserOrBot[],
-|};
-
 type Props = $ReadOnly<{|
   color: string,
-  narrow: Narrow,
-
-  dispatch: Dispatch,
-  ...SelectorProps,
+  userIds: $ReadOnlyArray<number>,
 |}>;
 
-class InfoNavButtonGroup extends PureComponent<Props> {
+export default class InfoNavButtonGroup extends PureComponent<Props> {
   handlePress = () => {
-    const { recipients } = this.props;
-    NavigationService.dispatch(navigateToGroupDetails(recipients.map(u => u.user_id)));
+    const { userIds } = this.props;
+    NavigationService.dispatch(navigateToGroupDetails(userIds));
   };
 
   render() {
@@ -33,7 +23,3 @@ class InfoNavButtonGroup extends PureComponent<Props> {
     return <NavButton name="info" color={color} onPress={this.handlePress} />;
   }
 }
-
-export default connect<SelectorProps, _, _>((state, props) => ({
-  recipients: getRecipientsInGroupPmNarrow(state, props.narrow),
-}))(InfoNavButtonGroup);

--- a/src/title-buttons/InfoNavButtonGroup.js
+++ b/src/title-buttons/InfoNavButtonGroup.js
@@ -24,7 +24,7 @@ type Props = $ReadOnly<{|
 class InfoNavButtonGroup extends PureComponent<Props> {
   handlePress = () => {
     const { recipients } = this.props;
-    NavigationService.dispatch(navigateToGroupDetails(recipients));
+    NavigationService.dispatch(navigateToGroupDetails(recipients.map(u => u.user_id)));
   };
 
   render() {

--- a/src/title-buttons/InfoNavButtonPrivate.js
+++ b/src/title-buttons/InfoNavButtonPrivate.js
@@ -1,27 +1,16 @@
 /* @flow strict-local */
-
 import React, { PureComponent } from 'react';
 
 import NavigationService from '../nav/NavigationService';
-import type { Dispatch, Narrow } from '../types';
-import { connect } from '../react-redux';
 import NavButton from '../nav/NavButton';
 import { navigateToAccountDetails } from '../actions';
-import { getUserForEmail } from '../users/userSelectors';
-import { emailOfPm1to1Narrow } from '../utils/narrow';
 
-type SelectorProps = $ReadOnly<{|
+type Props = $ReadOnly<{|
+  color: string,
   userId: number,
 |}>;
 
-type Props = $ReadOnly<{|
-  dispatch: Dispatch,
-  narrow: Narrow,
-  color: string,
-  ...SelectorProps,
-|}>;
-
-class InfoNavButtonPrivate extends PureComponent<Props> {
+export default class InfoNavButtonPrivate extends PureComponent<Props> {
   handlePress = () => {
     const { userId } = this.props;
     NavigationService.dispatch(navigateToAccountDetails(userId));
@@ -29,11 +18,6 @@ class InfoNavButtonPrivate extends PureComponent<Props> {
 
   render() {
     const { color } = this.props;
-
     return <NavButton name="info" color={color} onPress={this.handlePress} />;
   }
 }
-
-export default connect<SelectorProps, _, _>((state, props) => ({
-  userId: getUserForEmail(state, emailOfPm1to1Narrow(props.narrow)).user_id,
-}))(InfoNavButtonPrivate);

--- a/src/title-buttons/titleButtonFromNarrow.js
+++ b/src/title-buttons/titleButtonFromNarrow.js
@@ -19,7 +19,11 @@ export const InfoButton: ComponentType<Props> = props =>
       stream: streamName => <InfoNavButtonStream {...props} />,
       topic: (streamName, topic) => <InfoNavButtonStream {...props} />,
       pm: (emails, ids) =>
-        ids.length === 1 ? <InfoNavButtonPrivate {...props} /> : <InfoNavButtonGroup {...props} />,
+        ids.length === 1 ? (
+          <InfoNavButtonPrivate userId={ids[0]} color={props.color} />
+        ) : (
+          <InfoNavButtonGroup {...props} />
+        ),
     },
     () => false,
   );

--- a/src/title-buttons/titleButtonFromNarrow.js
+++ b/src/title-buttons/titleButtonFromNarrow.js
@@ -3,14 +3,7 @@ import React from 'react';
 import type { ComponentType } from 'react';
 
 import type { Narrow } from '../types';
-import {
-  isHomeNarrow,
-  is1to1PmNarrow,
-  isGroupPmNarrow,
-  isSpecialNarrow,
-  isStreamNarrow,
-  isTopicNarrow,
-} from '../utils/narrow';
+import { caseNarrowDefault } from '../utils/narrow';
 import InfoNavButtonStream from './InfoNavButtonStream';
 import InfoNavButtonPrivate from './InfoNavButtonPrivate';
 import InfoNavButtonGroup from './InfoNavButtonGroup';
@@ -18,36 +11,25 @@ import ExtraNavButtonStream from './ExtraNavButtonStream';
 import ExtraNavButtonTopic from './ExtraNavButtonTopic';
 
 type Props = $ReadOnly<{| color: string, narrow: Narrow |}>;
-type NarrowNavButton = ComponentType<Props>;
-type NarrowNavButtonCandidate = {|
-  isFunc: Narrow => boolean,
-  ButtonComponent: NarrowNavButton | null,
-|};
 
-const infoButtonHandlers: NarrowNavButtonCandidate[] = [
-  { isFunc: isHomeNarrow, ButtonComponent: null },
-  { isFunc: isSpecialNarrow, ButtonComponent: null },
-  { isFunc: isStreamNarrow, ButtonComponent: InfoNavButtonStream },
-  { isFunc: isTopicNarrow, ButtonComponent: InfoNavButtonStream },
-  { isFunc: is1to1PmNarrow, ButtonComponent: InfoNavButtonPrivate },
-  { isFunc: isGroupPmNarrow, ButtonComponent: InfoNavButtonGroup },
-];
+export const InfoButton: ComponentType<Props> = props =>
+  caseNarrowDefault(
+    props.narrow,
+    {
+      stream: streamName => <InfoNavButtonStream {...props} />,
+      topic: (streamName, topic) => <InfoNavButtonStream {...props} />,
+      pm: (emails, ids) =>
+        ids.length === 1 ? <InfoNavButtonPrivate {...props} /> : <InfoNavButtonGroup {...props} />,
+    },
+    () => false,
+  );
 
-const extraButtonHandlers: NarrowNavButtonCandidate[] = [
-  { isFunc: isHomeNarrow, ButtonComponent: null },
-  { isFunc: isSpecialNarrow, ButtonComponent: null },
-  { isFunc: isStreamNarrow, ButtonComponent: ExtraNavButtonStream },
-  { isFunc: isTopicNarrow, ButtonComponent: ExtraNavButtonTopic },
-  { isFunc: is1to1PmNarrow, ButtonComponent: null },
-  { isFunc: isGroupPmNarrow, ButtonComponent: null },
-];
-
-const makeButton = (handlers): NarrowNavButton => props => {
-  const handler = handlers.find(x => x.isFunc(props.narrow)) || null;
-  const SpecificButton = handler && handler.ButtonComponent;
-  return !!SpecificButton && <SpecificButton {...props} />;
-};
-
-export const InfoButton = makeButton(infoButtonHandlers);
-
-export const ExtraButton = makeButton(extraButtonHandlers);
+export const ExtraButton: ComponentType<Props> = props =>
+  caseNarrowDefault(
+    props.narrow,
+    {
+      stream: streamName => <ExtraNavButtonStream {...props} />,
+      topic: (streamName, topic) => <ExtraNavButtonTopic {...props} />,
+    },
+    () => false,
+  );

--- a/src/title-buttons/titleButtonFromNarrow.js
+++ b/src/title-buttons/titleButtonFromNarrow.js
@@ -22,7 +22,7 @@ export const InfoButton: ComponentType<Props> = props =>
         ids.length === 1 ? (
           <InfoNavButtonPrivate userId={ids[0]} color={props.color} />
         ) : (
-          <InfoNavButtonGroup {...props} />
+          <InfoNavButtonGroup userIds={ids} color={props.color} />
         ),
     },
     () => false,

--- a/src/users/__tests__/userSelectors-test.js
+++ b/src/users/__tests__/userSelectors-test.js
@@ -5,7 +5,6 @@ import {
   getUsersById,
   getUsersSansMe,
   getUserForId,
-  getUserForEmail,
   getUserIsActive,
 } from '../userSelectors';
 import * as eg from '../../__tests__/lib/exampleData';
@@ -110,33 +109,6 @@ describe('getUserForId', () => {
 
   test('returns the user if it is a cross realm bot', () => {
     expect(getUserForId(state, state.realm.crossRealmBots[0].user_id)).toEqual(
-      state.realm.crossRealmBots[0],
-    );
-  });
-});
-
-describe('getUserForEmail', () => {
-  const state = eg.reduxState({
-    users: [eg.selfUser],
-    realm: {
-      ...eg.baseReduxState.realm,
-      crossRealmBots: [eg.crossRealmBot],
-      nonActiveUsers: [eg.makeUser(), eg.makeUser()],
-    },
-  });
-
-  test('returns the user if it has not been deactivated', () => {
-    expect(getUserForEmail(state, state.users[0].email)).toEqual(state.users[0]);
-  });
-
-  test('returns the user if it has been deactivated', () => {
-    expect(getUserForEmail(state, state.realm.nonActiveUsers[0].email)).toEqual(
-      state.realm.nonActiveUsers[0],
-    );
-  });
-
-  test('returns the user if it is a cross realm bot', () => {
-    expect(getUserForEmail(state, state.realm.crossRealmBots[0].email)).toEqual(
       state.realm.crossRealmBots[0],
     );
   });

--- a/src/users/userSelectors.js
+++ b/src/users/userSelectors.js
@@ -185,24 +185,6 @@ export const getUserForId = (state: GlobalState, userId: number): UserOrBot => {
 };
 
 /**
- * The user with the given email.
- *
- * Prefer `getUserForId` where a user ID is available; see #3764.
- *
- * This works for any user in this Zulip org/realm, including deactivated
- * users and cross-realm bots.  See `getAllUsers` for details.
- *
- * Throws if no such user exists.
- */
-export const getUserForEmail = (state: GlobalState, email: string): UserOrBot => {
-  const user = getAllUsersByEmail(state).get(email);
-  if (!user) {
-    throw new Error(`getUserForEmail: missing user: email ${email}`);
-  }
-  return user;
-};
-
-/**
  * The value of `is_active` for the given user.
  *
  * For a normal user, this is true unless the user or an admin has

--- a/src/utils/__tests__/narrow-test.js
+++ b/src/utils/__tests__/narrow-test.js
@@ -25,7 +25,7 @@ import {
   keyFromNarrow,
   streamNameOfNarrow,
   topicOfNarrow,
-  emailOfPm1to1Narrow,
+  caseNarrowPartial,
 } from '../narrow';
 import type { Narrow, Message } from '../../types';
 import * as eg from '../../__tests__/lib/exampleData';
@@ -40,7 +40,7 @@ describe('pm1to1NarrowFromUser', () => {
   test('produces a 1:1 narrow', () => {
     const narrow = pm1to1NarrowFromUser(eg.otherUser);
     expect(is1to1PmNarrow(narrow)).toBeTrue();
-    expect(emailOfPm1to1Narrow(narrow)).toEqual(eg.otherUser.email);
+    expect(caseNarrowPartial(narrow, { pm: (emails, ids) => ids })).toEqual([eg.otherUser.user_id]);
   });
 
   test('if operator is "pm-with" and only one email, then it is a private narrow', () => {

--- a/src/utils/narrow.js
+++ b/src/utils/narrow.js
@@ -1,5 +1,4 @@
 /* @flow strict-local */
-import invariant from 'invariant';
 
 import type { ApiNarrow, Message, Outbox, User, UserOrBot } from '../types';
 import {
@@ -355,25 +354,6 @@ export const emailsOfGroupPmNarrow = (narrow: Narrow): $ReadOnlyArray<string> =>
         throw new Error('emailsOfGroupPmNarrow: got 1:1 narrow');
       }
       return emails;
-    },
-  });
-
-/**
- * The "other" user's email for a 1:1 PM narrow; else error.
- *
- * With "other" in scare-quotes because for the self-PM narrow, this is the
- * self user.
- *
- * Any caller of this probably should be getting a whole user object instead
- * of a Narrow in the first place.  And then that wrinkle about the self-PM
- * narrow vs. other 1:1 narrows is a UI decision that can get made
- * explicitly at the appropriate spot.
- */
-export const emailOfPm1to1Narrow = (narrow: Narrow): string =>
-  caseNarrowPartial(narrow, {
-    pm: emails => {
-      invariant(emails.length === 1, 'emailOfPm1to1Narrow: got group-PM narrow');
-      return emails[0];
     },
   });
 

--- a/src/utils/narrow.js
+++ b/src/utils/narrow.js
@@ -342,22 +342,6 @@ export const isGroupPmNarrow = (narrow?: Narrow): boolean =>
   !!narrow && caseNarrowDefault(narrow, { pm: (emails, ids) => ids.length > 1 }, () => false);
 
 /**
- * The recipients' emails if a group PM narrow; else error.
- *
- * Any use of this probably means something higher up should be refactored
- * to use caseNarrow.
- */
-export const emailsOfGroupPmNarrow = (narrow: Narrow): $ReadOnlyArray<string> =>
-  caseNarrowPartial(narrow, {
-    pm: emails => {
-      if (emails.length === 1) {
-        throw new Error('emailsOfGroupPmNarrow: got 1:1 narrow');
-      }
-      return emails;
-    },
-  });
-
-/**
  * The "PM key recipients" emails for a PM narrow; else error.
  *
  * This is the same list of users that can appear in a `PmKeyRecipients` or


### PR DESCRIPTION
This is the next tranche after #4361.

There's some additional places the new `UserItemById` can be used, much like `UserAvatarWithPresenceById`. In a draft branch I've converted those, but haven't finished following the chain of further simplifications that those enable. Those will come in a future PR.

After this PR, there's just a handful of places remaining where we consume the emails from a PM narrow. We'll shortly eliminate those, and then stop storing emails in `Narrow` values altogether.
