### PR TITLE
Switch shebang to use /usr/bin/env

### DIFF
--- a/tools/android
+++ b/tools/android
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 

--- a/tools/build-webview
+++ b/tools/build-webview
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eu
 unset CDPATH
 

--- a/tools/bump-version
+++ b/tools/bump-version
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 usage () {

--- a/tools/changelog
+++ b/tools/changelog
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 this_file=$(readlink -f "${BASH_SOURCE[0]}")
 root=${this_file%/*/*}

--- a/tools/checkout-keystore
+++ b/tools/checkout-keystore
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 ## CLI PARSING

--- a/tools/fmt
+++ b/tools/fmt
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 ## CLI PARSING

--- a/tools/info
+++ b/tools/info
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Compute what remote name is being used for the upstream repo.
 upstream_remote_name() {

--- a/tools/ios
+++ b/tools/ios
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 ## CLI PARSING

--- a/tools/postinstall
+++ b/tools/postinstall
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eu
 
 ROOT_DIR=$(git rev-parse --show-toplevel)

--- a/tools/run-android
+++ b/tools/run-android
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eu
 
 run_visibly () {

--- a/tools/test
+++ b/tools/test
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 ## CLI PARSING

--- a/tools/tsort-modules
+++ b/tools/tsort-modules
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 shopt -s globstar
 

--- a/tools/tx-pull
+++ b/tools/tx-pull
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -ex
 exec tx --quiet pull -a -f --parallel

--- a/tools/tx-sync
+++ b/tools/tx-sync
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eu
 
 usage () {

--- a/tools/upgrade
+++ b/tools/upgrade
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 set -o pipefail

--- a/tools/verify-webview-js
+++ b/tools/verify-webview-js
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 oldjs=$(<./src/webview/js/generatedEs3.js)
 
 tools/generate-webview-js


### PR DESCRIPTION
This is more portable, allowing me to run the install script on NixOS, which
does not have a `/bin/bash` binary, but does have `/usr/bin/env`. Any system
that has `/bin/bash` should have `/usr/bin/env` as well.