### PR TITLE
Use auth headers in `ImageBackground` to get a FallbackAvatarURL.

### DIFF
--- a/src/common/UserAvatar.js
+++ b/src/common/UserAvatar.js
@@ -1,10 +1,9 @@
 /* @flow strict-local */
 import React, { type Node as React$Node } from 'react';
 import { ImageBackground, View, PixelRatio } from 'react-native';
-import { useSelector } from 'react-redux';
 
+import { useSelector } from '../react-redux';
 import { getAuthHeaders } from '../api/transport';
-import type { GlobalState } from '../types';
 import { getAuth } from '../selectors';
 import Touchable from './Touchable';
 import { AvatarURL } from '../utils/avatar';
@@ -33,7 +32,7 @@ const UserAvatar = function UserAvatar(props: Props) {
     borderRadius,
   };
 
-  const auth = useSelector((state: GlobalState) => getAuth(state));
+  const auth = useSelector(state => getAuth(state));
 
   return (
     <View>

--- a/src/common/UserAvatar.js
+++ b/src/common/UserAvatar.js
@@ -1,7 +1,11 @@
 /* @flow strict-local */
 import React, { type Node as React$Node } from 'react';
 import { ImageBackground, View, PixelRatio } from 'react-native';
+import { useSelector } from 'react-redux';
 
+import { getAuthHeaders } from '../api/transport';
+import type { GlobalState } from '../types';
+import { getAuth } from '../selectors';
 import Touchable from './Touchable';
 import { AvatarURL } from '../utils/avatar';
 
@@ -29,6 +33,8 @@ const UserAvatar = function UserAvatar(props: Props) {
     borderRadius,
   };
 
+  const auth = useSelector((state: GlobalState) => getAuth(state));
+
   return (
     <View>
       <Touchable onPress={onPress} style={style}>
@@ -36,6 +42,8 @@ const UserAvatar = function UserAvatar(props: Props) {
           style={style}
           source={{
             uri: avatarUrl.get(PixelRatio.getPixelSizeForLayoutSize(size)).toString(),
+            // For `FallbackAvatarURL`s.
+            headers: getAuthHeaders(auth),
           }}
           resizeMode="cover"
           /* ImageBackground seems to ignore `style.borderRadius`. */

--- a/src/common/UserAvatar.js
+++ b/src/common/UserAvatar.js
@@ -1,5 +1,5 @@
 /* @flow strict-local */
-import React, { PureComponent, type Node as React$Node } from 'react';
+import React, { type Node as React$Node } from 'react';
 import { ImageBackground, View, PixelRatio } from 'react-native';
 
 import Touchable from './Touchable';
@@ -20,32 +20,32 @@ type Props = $ReadOnly<{|
  * @prop [children] - If provided, will render inside the component body.
  * @prop [onPress] - Event fired on pressing the component.
  */
-export default class UserAvatar extends PureComponent<Props> {
-  render() {
-    const { avatarUrl, children, size, onPress } = this.props;
-    const borderRadius = size / 8;
-    const style = {
-      height: size,
-      width: size,
-      borderRadius,
-    };
+const UserAvatar = function UserAvatar(props: Props) {
+  const { avatarUrl, children, size, onPress } = props;
+  const borderRadius = size / 8;
+  const style = {
+    height: size,
+    width: size,
+    borderRadius,
+  };
 
-    return (
-      <View>
-        <Touchable onPress={onPress} style={style}>
-          <ImageBackground
-            style={style}
-            source={{
-              uri: avatarUrl.get(PixelRatio.getPixelSizeForLayoutSize(size)).toString(),
-            }}
-            resizeMode="cover"
-            /* ImageBackground seems to ignore `style.borderRadius`. */
-            borderRadius={borderRadius}
-          >
-            {children}
-          </ImageBackground>
-        </Touchable>
-      </View>
-    );
-  }
-}
+  return (
+    <View>
+      <Touchable onPress={onPress} style={style}>
+        <ImageBackground
+          style={style}
+          source={{
+            uri: avatarUrl.get(PixelRatio.getPixelSizeForLayoutSize(size)).toString(),
+          }}
+          resizeMode="cover"
+          /* ImageBackground seems to ignore `style.borderRadius`. */
+          borderRadius={borderRadius}
+        >
+          {children}
+        </ImageBackground>
+      </Touchable>
+    </View>
+  );
+};
+
+export default UserAvatar;

--- a/src/react-redux.js
+++ b/src/react-redux.js
@@ -1,6 +1,6 @@
 /* @flow strict-local */
 import type { ComponentType, ElementConfig } from 'react';
-import { connect as connectInner } from 'react-redux';
+import { connect as connectInner, useSelector as useSelectorInner } from 'react-redux';
 
 import type { GlobalState, Dispatch } from './types';
 import type { BoundedDiff } from './generics';
@@ -56,4 +56,20 @@ export function connect<SP, P, C: ComponentType<P>>(
     SP>) => SP,
 ): C => ComponentType<$ReadOnly<OwnProps<C, SP>>> {
   return connectInner(mapStateToProps);
+}
+
+/**
+ * Exactly like the `useSelector` in `react-redux` upstream, but more typed.
+ *
+ * Specifically, this encodes once and for all the type of our Redux state.
+ *
+ * Without this, if Flow isn't specifically told that the type of `state` is
+ * `GlobalState`, it'll infer it as `empty` -- which means the selector
+ * function effectively gets no type-checking of anything it does with it.
+ */
+export function useSelector<SS>(
+  selector: (state: GlobalState) => SS,
+  equalityFn?: (a: SS, b: SS) => boolean,
+): SS {
+  return useSelectorInner<GlobalState, SS>(selector, equalityFn);
 }

--- a/src/utils/avatar.js
+++ b/src/utils/avatar.js
@@ -208,6 +208,9 @@ export class GravatarURL extends AvatarURL {
  * See the point on `user_avatar_url_field_optional` at
  * https://zulipchat.com/api/register-queue.
  *
+ * Note that this endpoint needs authentication; we should send the
+ * auth headers (see src/api/transport) with the request.
+ *
  * This endpoint does not currently support size customization.
  */
 export class FallbackAvatarURL extends AvatarURL {


### PR DESCRIPTION
As discussed yesterday, around [here](https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/302.20redirect.20for.20avatar/near/1089508).