### PR TITLE
webview: Fix race when setting scroll position

### DIFF
--- a/docs/howto/debugging.md
+++ b/docs/howto/debugging.md
@@ -225,6 +225,10 @@ a physical device via a browser's developer tools.
    familiar with.  You can inspect HTML elements, CSS styles and
    examine console.log output.
 
+To debug code that runs during the initial load of the WebView, add
+`alert("pause"); debugger;` where you want a breakpoint. Then open the
+WebView and connect the debugger before clearing the alert.
+
 
 <div id="webview-chrome" />
 

--- a/src/webview/MessageList.js
+++ b/src/webview/MessageList.js
@@ -206,6 +206,7 @@ class MessageList extends Component<Props> {
     if (eventData.type === 'ready') {
       this.sendUpdateEventsIsReady = true;
       this.sendUpdateEvents(this.unsentUpdateEvents);
+      this.unsentUpdateEvents = [];
     } else {
       const { _ } = this.props;
       handleMessageListEvent(this.props, _, eventData);

--- a/src/webview/js/generatedEs3.js
+++ b/src/webview/js/generatedEs3.js
@@ -668,7 +668,7 @@ var compiledWebviewJs = (function (exports) {
     });
   };
 
-  var handleInitialLoad = function handleInitialLoad(platformOS, scrollMessageId, rawAuth) {
+  var handleInitialLoad = function handleInitialLoad(scrollMessageId, rawAuth) {
     var auth = _objectSpread2(_objectSpread2({}, rawAuth), {}, {
       realm: new URL(rawAuth.realm)
     });

--- a/src/webview/js/generatedEs3.js
+++ b/src/webview/js/generatedEs3.js
@@ -625,6 +625,14 @@ var compiledWebviewJs = (function (exports) {
     window.scrollBy(0, newBoundRect.top - prevBoundTop);
   };
 
+  var runAfterRepaint = function runAfterRepaint(fn) {
+    requestAnimationFrame(function () {
+      requestAnimationFrame(function () {
+        fn();
+      });
+    });
+  };
+
   var handleUpdateEventContent = function handleUpdateEventContent(uevent) {
     var target;
 
@@ -647,16 +655,17 @@ var compiledWebviewJs = (function (exports) {
 
     documentBody.innerHTML = uevent.content;
     rewriteHTML(uevent.auth);
+    runAfterRepaint(function () {
+      if (target.type === 'bottom') {
+        scrollToBottom();
+      } else if (target.type === 'anchor') {
+        scrollToMessage(target.messageId);
+      } else if (target.type === 'preserve') {
+        scrollToPreserve(target.msgId, target.prevBoundTop);
+      }
 
-    if (target.type === 'bottom') {
-      scrollToBottom();
-    } else if (target.type === 'anchor') {
-      scrollToMessage(target.messageId);
-    } else if (target.type === 'preserve') {
-      scrollToPreserve(target.msgId, target.prevBoundTop);
-    }
-
-    sendScrollMessageIfListShort();
+      sendScrollMessageIfListShort();
+    });
   };
 
   var handleInitialLoad = function handleInitialLoad(platformOS, scrollMessageId, rawAuth) {
@@ -687,7 +696,7 @@ var compiledWebviewJs = (function (exports) {
 
     if (elementTyping) {
       elementTyping.innerHTML = uevent.content;
-      setTimeout(function () {
+      runAfterRepaint(function () {
         return scrollToBottomIfNearEnd();
       });
     }

--- a/src/webview/js/generatedEs3.js
+++ b/src/webview/js/generatedEs3.js
@@ -625,7 +625,12 @@ var compiledWebviewJs = (function (exports) {
     window.scrollBy(0, newBoundRect.top - prevBoundTop);
   };
 
-  var runAfterRepaint = function runAfterRepaint(fn) {
+  var runAfterLayout = function runAfterLayout(fn) {
+    if (platformOS === 'android') {
+      fn();
+      return;
+    }
+
     requestAnimationFrame(function () {
       requestAnimationFrame(function () {
         fn();
@@ -655,7 +660,7 @@ var compiledWebviewJs = (function (exports) {
 
     documentBody.innerHTML = uevent.content;
     rewriteHTML(uevent.auth);
-    runAfterRepaint(function () {
+    runAfterLayout(function () {
       if (target.type === 'bottom') {
         scrollToBottom();
       } else if (target.type === 'anchor') {
@@ -696,7 +701,7 @@ var compiledWebviewJs = (function (exports) {
 
     if (elementTyping) {
       elementTyping.innerHTML = uevent.content;
-      runAfterRepaint(function () {
+      runAfterLayout(function () {
         return scrollToBottomIfNearEnd();
       });
     }

--- a/src/webview/js/js.js
+++ b/src/webview/js/js.js
@@ -40,6 +40,13 @@ import rewriteHtml from './rewriteHtml';
  *   about our version-support strategy.
  */
 
+/**
+ * A copy of RN's `Platform.OS`.
+ *
+ * Provided by the template in `script.js`.
+ */
+declare var platformOS: string;
+
 /* eslint-disable no-extend-native */
 
 /* Polyfill Array.from. Native in Chrome 45 and at least Safari 13.
@@ -559,7 +566,6 @@ const handleUpdateEventContent = (uevent: WebViewUpdateEventContent) => {
 
 // We call this when the webview's content first loads.
 export const handleInitialLoad = (
-  platformOS: string,
   scrollMessageId: number | null,
   // The `realm` part of an `Auth` object is a URL object. It's passed
   // in its stringified form.

--- a/src/webview/js/script.js
+++ b/src/webview/js/script.js
@@ -14,9 +14,9 @@ ${smoothScroll}
 ${matchesPolyfill}
 window.enableWebViewErrorDisplay = ${config.enableWebViewErrorDisplay.toString()};
 document.addEventListener('DOMContentLoaded', function() {
+  var platformOS = ${JSON.stringify(Platform.OS)};
   ${compiledWebviewJs}
   compiledWebviewJs.handleInitialLoad(
-    ${JSON.stringify(Platform.OS)},
     ${JSON.stringify(scrollMessageId)},
     ${JSON.stringify(auth)}
   );


### PR DESCRIPTION
Setting innerHTML triggers an asynchronous render of the DOM. On iOS this reliably happens _after_ the code that comes immediately after the `innerHTML` set. This means that if we calculate a scroll position right after a content update, we can get the wrong `scrollHeight` and present the wrong position.

A nested `requestAnimationFrame` callback reliably runs code after the `scrollHeight` is updated, so use that to get the accurate scroll target.

References:
https://twitter.com/rauschma/status/1288868746682081285
https://macarthur.me/posts/when-dom-updates-appear-to-be-asynchronous

Test Plan: Manually loaded streams on iPhone 12 (iOS 14.3)

Fixes: #4357

I don't have an Android device to test on, but I suspect this will resolve or improve at least some variants of #3457 and #3921.