### PR TITLE
redux-persist: Stop saving `REHYDRATE` payload to disk.

### DIFF
--- a/src/third/redux-persist/createPersistor.js
+++ b/src/third/redux-persist/createPersistor.js
@@ -114,7 +114,12 @@ export default function createPersistor (store, config) {
     rehydrate: adhocRehydrate,
     pause: () => { paused = true },
     resume: () => { paused = false },
-    purge: (keys) => purgeStoredState({storage, keyPrefix}, keys)
+    purge: (keys) => purgeStoredState({storage, keyPrefix}, keys),
+
+    // Only used in `persistStore`, to force `lastState` to update
+    // with the results of `REHYDRATE` even when the persistor is
+    // paused.
+    _resetLastState: () => { lastState = store.getState() }
   }
 }
 


### PR DESCRIPTION
The expensive part of persisting the state to disk is running
`stringify` (see replaceRevive.js). While #4348 brought this time
from almost 2000ms down to, perhaps, 300ms on one account on my
device [1], that's still a long time, especially for work that
doesn't need to be done.

See discussion [2] for this solution.

[1] https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/.60remotedev-serialize.60.20and.20.60jsan.60/near/1083700
[2] https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/.60remotedev-serialize.60.20and.20.60jsan.60/near/1089466