### PR TITLE
narrow: Stop storing emails!

### DIFF
--- a/src/boot/store.js
+++ b/src/boot/store.js
@@ -18,6 +18,7 @@ import ZulipAsyncStorage from './ZulipAsyncStorage';
 import createMigration from '../redux-persist-migrate/index';
 import { provideLoggingContext } from './loggingContext';
 import { tryGetActiveAccount } from '../account/accountsSelectors';
+import { objectFromEntries } from '../jsBackport';
 
 if (process.env.NODE_ENV === 'development') {
   // Chrome dev tools for Immutable.
@@ -235,6 +236,16 @@ const migrations: { [string]: (GlobalState) => GlobalState } = {
     // and are already discarded whenever switching between accounts;
     // so we just drop them here.
     drafts: {},
+  }),
+
+  // Change format of keys representing PM narrows, dropping emails.
+  '22': state => ({
+    ...dropCache(state),
+    drafts: objectFromEntries(
+      Object.keys(state.drafts)
+        .map(key => key.replace(/^pm:d:(.*?):.*/s, 'pm:$1'))
+        .map(key => [key, state.drafts[key]]),
+    ),
   }),
 
   // TIP: When adding a migration, consider just using `dropCache`.

--- a/src/chat/narrowsSelectors.js
+++ b/src/chat/narrowsSelectors.js
@@ -141,7 +141,7 @@ export const isNarrowValid: Selector<boolean, Narrow> = createSelector(
       {
         stream: streamName => streams.find(s => s.name === streamName) !== undefined,
         topic: streamName => streams.find(s => s.name === streamName) !== undefined,
-        pm: (emails, ids) => ids.every(id => allUsersById.get(id) !== undefined),
+        pm: ids => ids.every(id => allUsersById.get(id) !== undefined),
       },
       () => true,
     ),

--- a/src/chat/narrowsSelectors.js
+++ b/src/chat/narrowsSelectors.js
@@ -20,7 +20,7 @@ import {
   getOutbox,
 } from '../directSelectors';
 import { getCaughtUpForNarrow } from '../caughtup/caughtUpSelectors';
-import { getAllUsersByEmail, getAllUsersById, getOwnUser } from '../users/userSelectors';
+import { getAllUsersById, getOwnUser } from '../users/userSelectors';
 import {
   isStreamOrTopicNarrow,
   isMessageInNarrow,
@@ -134,17 +134,14 @@ export const getStreamInNarrow: Selector<Subscription | {| ...Stream, in_home_vi
 export const isNarrowValid: Selector<boolean, Narrow> = createSelector(
   (state, narrow) => narrow,
   state => getStreams(state),
-  state => getAllUsersByEmail(state),
   state => getAllUsersById(state),
-  (narrow, streams, allUsersByEmail, allUsersById) =>
+  (narrow, streams, allUsersById) =>
     caseNarrowDefault(
       narrow,
       {
         stream: streamName => streams.find(s => s.name === streamName) !== undefined,
         topic: streamName => streams.find(s => s.name === streamName) !== undefined,
-        pm: (emails, ids) =>
-          emails.every(email => allUsersByEmail.get(email) !== undefined)
-          && ids.every(id => allUsersById.get(id) !== undefined),
+        pm: (emails, ids) => ids.every(id => allUsersById.get(id) !== undefined),
       },
       () => true,
     ),

--- a/src/compose/getComposeInputPlaceholder.js
+++ b/src/compose/getComposeInputPlaceholder.js
@@ -10,7 +10,7 @@ export default (
   caseNarrowDefault(
     narrow,
     {
-      pm: (emails, ids) => {
+      pm: ids => {
         if (ids.length > 1) {
           return { text: 'Message group' };
         }

--- a/src/message/fetchActions.js
+++ b/src/message/fetchActions.js
@@ -32,6 +32,7 @@ import { realmInit } from '../realm/realmActions';
 import { startEventPolling } from '../events/eventActions';
 import { logout } from '../account/accountActions';
 import { ZulipVersion } from '../utils/zulipVersion';
+import { getAllUsersById } from '../users/userSelectors';
 
 const messageFetchStart = (narrow: Narrow, numBefore: number, numAfter: number): Action => ({
   type: MESSAGE_FETCH_START,
@@ -88,7 +89,7 @@ export const fetchMessages = (fetchArgs: {|
   try {
     const { messages, found_newest, found_oldest } = await api.getMessages(getAuth(getState()), {
       ...fetchArgs,
-      narrow: apiNarrowOfNarrow(fetchArgs.narrow),
+      narrow: apiNarrowOfNarrow(fetchArgs.narrow, getAllUsersById(getState())),
       useFirstUnread: fetchArgs.anchor === FIRST_UNREAD_ANCHOR, // TODO: don't use this; see #4203
     });
     dispatch(
@@ -236,7 +237,7 @@ export const fetchMessagesInNarrow = (
 const fetchPrivateMessages = () => async (dispatch: Dispatch, getState: GetState) => {
   const auth = getAuth(getState());
   const { messages, found_newest, found_oldest } = await api.getMessages(auth, {
-    narrow: apiNarrowOfNarrow(ALL_PRIVATE_NARROW),
+    narrow: apiNarrowOfNarrow(ALL_PRIVATE_NARROW, getAllUsersById(getState())),
     anchor: LAST_MESSAGE_ANCHOR,
     numBefore: 100,
     numAfter: 0,

--- a/src/outbox/outboxActions.js
+++ b/src/outbox/outboxActions.js
@@ -124,7 +124,7 @@ const extractTypeToAndSubjectFromNarrow = (
   ownUser: UserOrBot,
 ): DataFromNarrow =>
   caseNarrowPartial(narrow, {
-    pm: (emails, ids) => ({
+    pm: ids => ({
       type: 'private',
       display_recipient: recipientsFromIds(ids, allUsersById, ownUser),
       subject: '',

--- a/src/title-buttons/titleButtonFromNarrow.js
+++ b/src/title-buttons/titleButtonFromNarrow.js
@@ -18,7 +18,7 @@ export const InfoButton: ComponentType<Props> = props =>
     {
       stream: streamName => <InfoNavButtonStream {...props} />,
       topic: (streamName, topic) => <InfoNavButtonStream {...props} />,
-      pm: (emails, ids) =>
+      pm: ids =>
         ids.length === 1 ? (
           <InfoNavButtonPrivate userId={ids[0]} color={props.color} />
         ) : (

--- a/src/title/Title.js
+++ b/src/title/Title.js
@@ -30,7 +30,7 @@ export default class Title extends PureComponent<Props> {
       allPrivate: () => <TitleSpecial code="private" color={color} />,
       stream: () => <TitleStream narrow={narrow} color={color} />,
       topic: () => <TitleStream narrow={narrow} color={color} />,
-      pm: (emails, ids) =>
+      pm: ids =>
         ids.length === 1 ? (
           <TitlePrivate userId={ids[0]} color={color} />
         ) : (

--- a/src/unread/unreadSelectors.js
+++ b/src/unread/unreadSelectors.js
@@ -256,7 +256,7 @@ export const getUnreadCountForNarrow: Selector<number, Narrow> = createSelector(
         );
       },
 
-      pm: (emails, ids) => {
+      pm: ids => {
         if (ids.length > 1) {
           const unreadsKey = pmUnreadsKeyFromPmKeyIds(ids, ownUserId);
           const unread = unreadHuddles.find(x => x.user_ids_string === unreadsKey);

--- a/src/utils/__tests__/narrow-test.js
+++ b/src/utils/__tests__/narrow-test.js
@@ -40,7 +40,7 @@ describe('pm1to1NarrowFromUser', () => {
   test('produces a 1:1 narrow', () => {
     const narrow = pm1to1NarrowFromUser(eg.otherUser);
     expect(is1to1PmNarrow(narrow)).toBeTrue();
-    expect(caseNarrowPartial(narrow, { pm: (emails, ids) => ids })).toEqual([eg.otherUser.user_id]);
+    expect(caseNarrowPartial(narrow, { pm: ids => ids })).toEqual([eg.otherUser.user_id]);
   });
 
   test('if operator is "pm-with" and only one email, then it is a private narrow', () => {

--- a/src/utils/narrow.js
+++ b/src/utils/narrow.js
@@ -59,7 +59,7 @@ export const HOME_NARROW_STR: string = keyFromNarrow(HOME_NARROW);
  * accidentally disagreeing on whether to include the self-user, or on how
  * to sort the list (by user ID vs. email), or neglecting to sort it at all.
  */
-const pmNarrowInternal = (userIds: $ReadOnlyArray<number>, emails?: string[]): Narrow =>
+const pmNarrowInternal = (userIds: $ReadOnlyArray<number>): Narrow =>
   Object.freeze({ type: 'pm', userIds });
 
 /**
@@ -73,7 +73,7 @@ const pmNarrowInternal = (userIds: $ReadOnlyArray<number>, emails?: string[]): N
  * different form of input.
  */
 export const pmNarrowFromRecipients = (recipients: PmKeyRecipients): Narrow =>
-  pmNarrowInternal(recipients.map(r => r.id), recipients.map(r => r.email));
+  pmNarrowInternal(recipients.map(r => r.id));
 
 /**
  * A PM narrow, either 1:1 or group.
@@ -85,7 +85,7 @@ export const pmNarrowFromRecipients = (recipients: PmKeyRecipients): Narrow =>
  * single specific user.
  */
 export const pmNarrowFromUsers = (recipients: PmKeyUsers): Narrow =>
-  pmNarrowInternal(recipients.map(r => r.user_id), recipients.map(r => r.email));
+  pmNarrowInternal(recipients.map(r => r.user_id));
 
 /**
  * FOR TESTS ONLY.  Like pmNarrowFromUsers, but without validation.
@@ -105,7 +105,7 @@ export const pmNarrowFromUsers = (recipients: PmKeyUsers): Narrow =>
 // annoying thing is just that that requires an ownUserId value.
 export const pmNarrowFromUsersUnsafe = (recipients: UserOrBot[]): Narrow => {
   recipients.sort((a, b) => a.user_id - b.user_id);
-  return pmNarrowInternal(recipients.map(r => r.user_id), recipients.map(r => r.email));
+  return pmNarrowInternal(recipients.map(r => r.user_id));
 };
 
 /**
@@ -115,8 +115,7 @@ export const pmNarrowFromUsersUnsafe = (recipients: UserOrBot[]): Narrow => {
  * statically has just one other user it's a bit more convenient because it
  * doesn't require going through our `recipient` helpers.
  */
-export const pm1to1NarrowFromUser = (user: UserOrBot): Narrow =>
-  pmNarrowInternal([user.user_id], [user.email]);
+export const pm1to1NarrowFromUser = (user: UserOrBot): Narrow => pmNarrowInternal([user.user_id]);
 
 export const specialNarrow = (operand: string): Narrow => {
   if (operand === 'starred') {

--- a/src/utils/narrow.js
+++ b/src/utils/narrow.js
@@ -73,7 +73,7 @@ const pmNarrowInternal = (userIds: $ReadOnlyArray<number>): Narrow =>
  * different form of input.
  */
 export const pmNarrowFromRecipients = (recipients: PmKeyRecipients): Narrow =>
-  pmNarrowInternal(recipients.map(r => r.id));
+  pmNarrowInternal(recipients);
 
 /**
  * A PM narrow, either 1:1 or group.

--- a/src/utils/recipient.js
+++ b/src/utils/recipient.js
@@ -59,7 +59,7 @@ export const recipientsOfPrivateMessage = (
  *
  * See also `pmNarrowFromRecipients`, which requires a value of this type.
  */
-export opaque type PmKeyRecipients: $ReadOnlyArray<PmRecipientUser> = $ReadOnlyArray<PmRecipientUser>;
+export opaque type PmKeyRecipients: $ReadOnlyArray<number> = $ReadOnlyArray<number>;
 
 /**
  * A list of users identifying a PM conversation, as per pmKeyRecipientsFromMessage.
@@ -180,7 +180,10 @@ export const pmKeyRecipientsFromMessage = (
   if (message.type !== 'private') {
     throw new Error('pmKeyRecipientsFromMessage: expected PM, got stream message');
   }
-  return filterRecipients(recipientsOfPrivateMessage(message), ownUser.user_id);
+  return filterRecipientsAsUserIds(
+    recipientsOfPrivateMessage(message).map(r => r.id),
+    ownUser.user_id,
+  );
 };
 
 /**


### PR DESCRIPTION
This is the next in the long chain of PRs #4330, #4332, #4335, #4339, #4342, #4346, #4356, #4361, #4364, and most recently #4368. This one completes a major objective of all that refactoring: at the end of it, we no longer store emails in Narrow values.

After this change, the portion of #4333 that's about PMs, emails, and user IDs -- aka the portion of #3764 that's about narrows -- is complete.

Still open from #4333 is to convert stream and topic narrows from stream names to stream IDs.  I'm hopeful that that will be simpler: (a) unlike the situation for PMs, there's just one stream mentioned at a time, so there's no question of sorting, and (b) there isn't the "include self or not" complication that's bedeviled much of our code related to PMs.  In other words, stream and topic narrows don't suffer from #4035.

As discussed at #4368, in one of the spots this touches we still need emails, namely to make get-messages requests to the server (so long as we support servers older than 2.1). But we can handle that the same way we've handled such mismatches internally to the app during this refactoring, and the same way we've handled the reverse of them where we receive emails and now want to store user IDs: use the `allUsersById` map (or its inverse) to convert one form to the other. That means we don't need the emails from the Narrow value, and the rest of these changes can proceed.

There's still plenty more places around the app where we can replace emails with user IDs, i.e. #3764. I still have a draft branch on top of this one with some of them. I'm hopeful that much of what remains will be easier now that emails are gone from narrows, because that's such a central data structure that a lot of code ultimately has to feed or is fed by.
