### PR TITLE
Fix a `recipients` bug, preparing to use recent-PMs data

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -68,6 +68,18 @@ rules:
   no-plusplus: off
   no-nested-ternary: off
 
+  # We prefer `let foo = undefined;` over `let foo;`, not vice versa.
+  #
+  # Sadly there doesn't seem to be a rule to say what we want, but at least
+  # turn off the one that says the opposite.
+  #
+  # This rule is dubious to begin with, because explicit is better than
+  # implicit.  Then for us, the overriding reason we definitely don't
+  # want it is that plain `let foo;` can trigger a Flow bug:
+  #   https://github.com/facebook/flow/issues/8526
+  # while `let foo = undefined;` makes Flow handle the logic smoothly.
+  no-undef-init: off
+
   # Allow multiple classes per file.
   #
   # It's best to have just one class per file, but there are cases

--- a/src/__tests__/collections-test.js
+++ b/src/__tests__/collections-test.js
@@ -1,0 +1,23 @@
+/* @flow strict-local */
+
+const { mapOrNull } = require('../collections');
+
+describe('mapOrNull', () => {
+  test('behaves right in happy case', () => {
+    expect(mapOrNull([10, 20], (x, i, a) => x + i + a.length)).toEqual([12, 23]);
+  });
+
+  test('returns null on nullish item', () => {
+    expect(mapOrNull([1, 2, 3], x => (x === 2 ? null : x))).toEqual(null);
+    expect(mapOrNull([1, 2, 3], x => (x === 2 ? undefined : x))).toEqual(null);
+  });
+
+  test('aborts on nullish item', () => {
+    const log = [];
+    mapOrNull([1, 2, 3], x => {
+      log.push(x);
+      return x === 2 ? null : x;
+    });
+    expect(log).toEqual([1, 2]);
+  });
+});

--- a/src/caughtup/caughtUpReducer.js
+++ b/src/caughtup/caughtUpReducer.js
@@ -90,7 +90,7 @@ export default (state: CaughtUpState = initialState, action: Action): CaughtUpSt
         return state;
       }
       const key = keyFromNarrow(action.narrow);
-      let caughtUp;
+      let caughtUp = undefined;
       if (action.foundNewest !== undefined && action.foundOldest !== undefined) {
         /* This should always be the case for Zulip Server v1.8 or newer. */
         caughtUp = { older: action.foundOldest, newer: action.foundNewest };

--- a/src/collections.js
+++ b/src/collections.js
@@ -1,0 +1,41 @@
+/**
+ * Handy generic functions for operating on JS collections.
+ *
+ * Any function here is the sort of thing that perhaps should be in the
+ * language's standard library.
+ *
+ * See also
+ *  * `jsBackport.js`, for things that actually are in newer versions of JS,
+ *    or late-stage proposals for future versions
+ *  * `generics.js`, for things that operate on types
+ *
+ * @flow strict-local
+ */
+
+/**
+ * Like `Array#map`, but returns null if `f` ever returns a nullish value.
+ *
+ * If `f` returns nullish at any element, the iteration stops and `f` is not
+ * called on any later elements.
+ *
+ * This replaces either (a) writing an explicit loop, in order to be able to
+ * abort on a nullish value, or (b) using `Array#map` and then running
+ * through the list again to look for nullish values.
+ */
+export function mapOrNull<T, U>(
+  array: $ReadOnlyArray<T>,
+  f: (T, number, $ReadOnlyArray<T>) => U,
+  // `Array#map` has one more parameter, "thisArg".  Skipping that because
+  //   it seems like there isn't a way to type it properly in Flow (flowlib
+  //   has `any`), and we haven't had a need for it.
+): Array<$NonMaybeType<U>> | null {
+  const result = [];
+  for (let i = 0; i < array.length; i++) {
+    const r = f(array[i], i, array);
+    if (r == null) {
+      return null;
+    }
+    result.push(r);
+  }
+  return result;
+}

--- a/src/compose/ComposeMenu.js
+++ b/src/compose/ComposeMenu.js
@@ -123,7 +123,7 @@ class ComposeMenu extends PureComponent<Props> {
     // from this library when in the test environment.
     const DocumentPicker = (await import('react-native-document-picker')).default;
 
-    let response;
+    let response = undefined;
     try {
       response = (await DocumentPicker.pick({
         type: [DocumentPicker.types.allFiles],

--- a/src/message/renderMessages.js
+++ b/src/message/renderMessages.js
@@ -10,11 +10,13 @@ export default (
 ): RenderedSectionDescriptor[] => {
   const showHeader = !isPmNarrow(narrow) && !isTopicNarrow(narrow);
 
-  let prevItem;
+  // eslint-disable-next-line no-undef-init
+  let prevItem = undefined;
   const sections = [{ key: 0, data: [], message: {} }];
   messages.forEach(item => {
     const diffDays =
-      prevItem && !isSameDay(new Date(prevItem.timestamp * 1000), new Date(item.timestamp * 1000));
+      !!prevItem
+      && !isSameDay(new Date(prevItem.timestamp * 1000), new Date(item.timestamp * 1000));
     if (!prevItem || diffDays) {
       sections[sections.length - 1].data.push({
         key: `time${item.timestamp}`,
@@ -23,6 +25,7 @@ export default (
         firstMessage: item,
       });
     }
+
     const diffRecipient = !isSameRecipient(prevItem, item);
     if (showHeader && diffRecipient) {
       sections.push({
@@ -37,7 +40,7 @@ export default (
     //   values that lack it; which is fine once the release that adds it
     //   has been out for a few weeks.
     const shouldGroupWithPrev =
-      !diffRecipient && !diffDays && prevItem && prevItem.sender_email === item.sender_email;
+      !diffRecipient && !diffDays && !!prevItem && prevItem.sender_email === item.sender_email;
 
     sections[sections.length - 1].data.push({
       key: item.id,

--- a/src/message/renderMessages.js
+++ b/src/message/renderMessages.js
@@ -10,7 +10,6 @@ export default (
 ): RenderedSectionDescriptor[] => {
   const showHeader = !isPmNarrow(narrow) && !isTopicNarrow(narrow);
 
-  // eslint-disable-next-line no-undef-init
   let prevItem = undefined;
   const sections = [{ key: 0, data: [], message: {} }];
   messages.forEach(item => {

--- a/src/utils/__tests__/recipient-test.js
+++ b/src/utils/__tests__/recipient-test.js
@@ -1,8 +1,11 @@
+/* @flow strict-local */
+
 import {
   normalizeRecipientsAsUserIds,
   normalizeRecipientsAsUserIdsSansMe,
   isSameRecipient,
 } from '../recipient';
+import * as eg from '../../__tests__/lib/exampleData';
 
 describe('normalizeRecipientsAsUserIds', () => {
   test('joins user IDs from recipients, sorted', () => {
@@ -48,42 +51,26 @@ describe('normalizeRecipientsAsUserIdsSansMe', () => {
 
 describe('isSameRecipient', () => {
   test('passing undefined as any of parameters means recipients are not the same', () => {
-    expect(isSameRecipient(undefined, {})).toBe(false);
-    expect(isSameRecipient({}, undefined)).toBe(false);
+    expect(isSameRecipient(undefined, eg.pmMessage())).toBe(false);
+    expect(isSameRecipient(eg.streamMessage(), undefined)).toBe(false);
     expect(isSameRecipient(undefined, undefined)).toBe(false);
   });
 
   test('recipient types are compared first, if they differ then recipients differ', () => {
-    expect(isSameRecipient({ type: 'private' }, { type: 'stream' })).toBe(false);
+    expect(isSameRecipient(eg.pmMessage(), eg.streamMessage())).toBe(false);
   });
 
-  test('recipient of unknown types are never the same', () => {
-    expect(isSameRecipient({ type: 'someUnknown' }, { type: 'someUnknown' })).toBe(false);
-  });
-
-  test('recipients are same for private type if display_recipient match in any order', () => {
-    const msg1 = {
-      type: 'private',
-      display_recipient: [{ email: 'abc@example.com' }, { email: 'xyz@example.com' }],
-    };
-    const msg2 = {
-      type: 'private',
-      display_recipient: [{ email: 'xyz@example.com' }, { email: 'abc@example.com' }],
-    };
+  // Skipped because we don't currently support this.  See comment on implementation.
+  test.skip('recipients are same for private type if display_recipient match in any order', () => {
+    const msg1 = eg.pmMessageFromTo(eg.selfUser, [eg.otherUser, eg.thirdUser]);
+    const msg2 = eg.pmMessageFromTo(eg.selfUser, [eg.thirdUser, eg.otherUser]);
     expect(isSameRecipient(msg1, msg2)).toBe(true);
   });
 
   test('recipients are same for stream type if display_recipient and subject match', () => {
-    const msg1 = {
-      type: 'stream',
-      display_recipient: 'abc',
-      subject: 'def',
-    };
-    const msg2 = {
-      type: 'stream',
-      display_recipient: 'abc',
-      subject: 'def',
-    };
+    const topic = eg.randString();
+    const msg1 = eg.streamMessage({ stream: eg.stream, subject: topic, content: eg.randString() });
+    const msg2 = eg.streamMessage({ stream: eg.stream, subject: topic, content: eg.randString() });
     expect(isSameRecipient(msg1, msg2)).toBe(true);
   });
 });

--- a/src/utils/__tests__/recipient-test.js
+++ b/src/utils/__tests__/recipient-test.js
@@ -4,6 +4,7 @@ import {
   normalizeRecipientsAsUserIds,
   normalizeRecipientsAsUserIdsSansMe,
   isSameRecipient,
+  pmKeyRecipientsFromIds,
 } from '../recipient';
 import * as eg from '../../__tests__/lib/exampleData';
 
@@ -47,6 +48,28 @@ describe('normalizeRecipientsAsUserIdsSansMe', () => {
 
     expect(normalized).toEqual(expectedResult);
   });
+});
+
+describe('pmKeyRecipientsFromIds', () => {
+  const allUsersById = new Map([eg.selfUser, eg.otherUser, eg.thirdUser].map(u => [u.user_id, u]));
+  const [self, other, third] = [eg.selfUser, eg.otherUser, eg.thirdUser];
+  // prettier-ignore
+  /* eslint-disable no-multi-spaces */
+  /* eslint-disable array-bracket-spacing */
+  for (const [description, users, expectedSet] of [
+    ['self-1:1, self included',  [self],               [self]],
+    ['self-1:1, self omitted',   [    ],               [self]],
+    ['other 1:1, self included', [self, other],        [other]],
+    ['other 1:1, self included', [      other],        [other]],
+    ['group PM, self included',  [self, other, third], [other, third]],
+    ['group PM, self included',  [      other, third], [other, third]],
+  ]) {
+    test(`correct on ${description}`, () => {
+      expect(
+        pmKeyRecipientsFromIds(users.map(u => u.user_id), allUsersById, eg.selfUser.user_id),
+      ).toEqual(expectedSet.sort((a, b) => a.user_id - b.user_id));
+    });
+  }
 });
 
 describe('isSameRecipient', () => {

--- a/src/utils/avatar.js
+++ b/src/utils/avatar.js
@@ -328,7 +328,7 @@ export class UploadedAvatarURL extends AvatarURL {
     // The URL constructor is too expensive; but we can do an exact
     // equivalent, given our assumptions on the kinds of URL strings
     // the server will send.
-    let absoluteUrl;
+    let absoluteUrl = undefined;
     if (isUrlAbsolute(absoluteOrRelativeUrl)) {
       // An absolute URL string.  Ignore the base URL.
       absoluteUrl = absoluteOrRelativeUrl;

--- a/src/utils/logging.js
+++ b/src/utils/logging.js
@@ -44,8 +44,8 @@ const getServerVersionTags = () => {
   const minor = elements.minor ?? UNKNOWN;
   const patch = elements.patch ?? UNKNOWN;
 
-  let coarseServerVersion;
-  let fineServerVersion;
+  let coarseServerVersion = undefined;
+  let fineServerVersion = undefined;
   // Effective with 3.0, we changed our numbering conventions; 3.x and
   // 4.x are each the same level of granularity as 2.1.x or 2.0.x.
   if (zulipVersion.isAtLeast('3.0')) {

--- a/src/utils/recipient.js
+++ b/src/utils/recipient.js
@@ -339,8 +339,8 @@ export const pmTypingKeyFromRecipients = (
 ): string => pmTypingKeyFromPmKeyIds(filterRecipientsAsUserIds(recipients, ownUserId));
 
 export const isSameRecipient = (
-  message1: Message | Outbox,
-  message2: Message | Outbox,
+  message1: Message | Outbox | void,
+  message2: Message | Outbox | void,
 ): boolean => {
   if (message1 === undefined || message2 === undefined) {
     return false;

--- a/src/utils/recipient.js
+++ b/src/utils/recipient.js
@@ -1,6 +1,7 @@
 /* @flow strict-local */
 import invariant from 'invariant';
 import isEqual from 'lodash.isequal';
+import { mapOrNull } from '../collections';
 
 import type { PmRecipientUser, Message, Outbox, User, UserOrBot } from '../types';
 
@@ -200,16 +201,14 @@ export const pmKeyRecipientsFromIds = (
   allUsersById: Map<number, UserOrBot>,
   ownUserId: number,
 ): PmKeyUsers | null => {
-  const users = [];
-  for (const id of userIds) {
-    if (id === ownUserId && userIds.length > 1) {
-      continue;
-    }
-    const user = allUsersById.get(id);
-    if (!user) {
-      return null;
-    }
-    users.push(user);
+  const resultIds = userIds.filter(id => id !== ownUserId);
+  if (resultIds.length === 0) {
+    resultIds.push(ownUserId);
+  }
+
+  const users = mapOrNull(resultIds, id => allUsersById.get(id));
+  if (!users) {
+    return null;
   }
   return users.sort((a, b) => a.user_id - b.user_id);
 };

--- a/src/webview/js/generatedEs3.js
+++ b/src/webview/js/generatedEs3.js
@@ -613,7 +613,7 @@ var compiledWebviewJs = (function (exports) {
 
   var scrollEventsDisabled = true;
   var hasLongPressed = false;
-  var longPressTimeout;
+  var longPressTimeout = undefined;
   var lastTouchPositionX = -1;
   var lastTouchPositionY = -1;
 

--- a/src/webview/js/js.js
+++ b/src/webview/js/js.js
@@ -441,7 +441,7 @@ const sendScrollMessageIfListShort = () => {
 let scrollEventsDisabled = true;
 
 let hasLongPressed = false;
-let longPressTimeout;
+let longPressTimeout = undefined;
 let lastTouchPositionX = -1;
 let lastTouchPositionY = -1;
 


### PR DESCRIPTION
I wrote up today a draft branch that will take care of #3133, replacing the previous #3535 and #4104, to use the server's handy `recent_private_conversations` feature in order to populate the "PM conversations" screen both more completely and more efficiently.

Along the way -- actually while rebasing and studying #4104, before I decided it'd be better to take a different approach than it or #3535 did -- I discovered a bug in `pmKeyRecipientsFromIds`: it's supposed to work whether the input contains or excludes self, but it doesn't live up to that spec in the case of a self-1:1. This has been a latent bug because all of the representations for PM conversations that we deal with so far represent the self-1:1 thread with a singleton list, not empty. But the `recent_private_conversations` data structure does use an empty list for the self-1:1 thread, so it would trip on this bug and make it a live one.

This PR fixes that bug, and also takes care of several other issues that that change turns up. (Including discovering a Flow bug which I then reported. Though that part was actually a couple of months ago -- I was looking at some of this code as part of #4299 and #4304, and that work led to the first two commits here and that Flow bug report.)
