### PR TITLE
UserAvatar: Fail gently on bug where auth info is missing.

### DIFF
--- a/src/common/UserAvatar.js
+++ b/src/common/UserAvatar.js
@@ -4,7 +4,7 @@ import { ImageBackground, View, PixelRatio } from 'react-native';
 
 import { useSelector } from '../react-redux';
 import { getAuthHeaders } from '../api/transport';
-import { getAuth } from '../selectors';
+import { tryGetAuth } from '../account/accountsSelectors';
 import Touchable from './Touchable';
 import { AvatarURL } from '../utils/avatar';
 
@@ -32,7 +32,17 @@ function UserAvatar(props: Props) {
     borderRadius,
   };
 
-  const auth = useSelector(state => getAuth(state));
+  const auth = useSelector(state => tryGetAuth(state));
+  if (!auth) {
+    // TODO: This should be impossible (and then the selector should be
+    //   `getAuth` to say so.)  There's a bug where this component (probably
+    //   as part of the whole main nav-tabs UI?) apparently stays mounted,
+    //   and keeps getting updates, after the active account changes on
+    //   choosing "Add new account", or an existing logged-out account, from
+    //   the pick-accounts screen after Profile > Switch account.  See:
+    //     https://github.com/zulip/zulip-mobile/issues/4388
+    return null;
+  }
 
   return (
     <View>


### PR DESCRIPTION
This fixes #4388 with a quick workaround.  The underlying issue is
still present -- we shouldn't have this component mounted at all in
this situation.  But fixing that may involve some tricky changes to
our navigation, and this is a high-severity issue -- a crash in an
essential flow for using the app for many people -- so we want to fix
it promptly even if the underlying fix takes some time.

Fixes: #4388