### PR TITLE
Get and maintain a handy optimized data structure of recent PM conversations

### DIFF
--- a/src/__tests__/lib/exampleData.js
+++ b/src/__tests__/lib/exampleData.js
@@ -539,6 +539,7 @@ export const action = deepFreeze({
       realm_users: [],
       user_id: 4,
       realm_user_groups: [],
+      recent_private_conversations: [],
       streams: [],
       never_subscribed: [],
       subscriptions: [],

--- a/src/__tests__/lib/exampleData.js
+++ b/src/__tests__/lib/exampleData.js
@@ -592,6 +592,7 @@ export const action = deepFreeze({
     numAfter: 50,
     foundNewest: undefined,
     foundOldest: undefined,
+    ownUserId: selfUser.user_id,
   },
 });
 

--- a/src/actionTypes.js
+++ b/src/actionTypes.js
@@ -220,6 +220,7 @@ type MessageFetchCompleteAction = {|
   numAfter: number,
   foundNewest: boolean | void,
   foundOldest: boolean | void,
+  ownUserId: number,
 |};
 
 type InitialFetchStartAction = {|

--- a/src/api/initialDataTypes.js
+++ b/src/api/initialDataTypes.js
@@ -4,6 +4,7 @@ import type {
   CrossRealmBot,
   RealmEmojiById,
   RealmFilter,
+  RecentPrivateConversation,
   Stream,
   Subscription,
   User,
@@ -127,6 +128,14 @@ export type InitialDataRealmUserGroups = {|
    * Absent in servers prior to v1.8.0-rc1~2711 (or thereabouts).
    */
   realm_user_groups?: UserGroup[],
+|};
+
+export type InitialDataRecentPmConversations = {|
+  // * Added in server commit 2.1-dev-384-g4c3c669b41.
+  // * `user_id` fields are sorted as of commit 2.2-dev-53-g405a529340, which
+  //    was backported to 2.1.1-50-gd452ad31e0 -- meaning that they are _not_
+  //    sorted in either v2.1.0 or v2.1.1.
+  recent_private_conversations?: RecentPrivateConversation[],
 |};
 
 type NeverSubscribedStream = {|
@@ -307,6 +316,7 @@ export type InitialData = {|
   ...InitialDataRealmFilters,
   ...InitialDataRealmUser,
   ...InitialDataRealmUserGroups,
+  ...InitialDataRecentPmConversations,
   ...InitialDataStream,
   ...InitialDataSubscription,
   ...InitialDataUpdateDisplaySettings,

--- a/src/api/modelTypes.js
+++ b/src/api/modelTypes.js
@@ -579,3 +579,29 @@ export type Message = $ReadOnly<{|
   subject: string,
   subject_links: $ReadOnlyArray<string>,
 |}>;
+
+//
+//
+//
+// ===================================================================
+// Summaries of messages and conversations.
+//
+//
+
+/**
+ * Describes a single recent PM conversation.
+ *
+ * See API documentation under `recent_private_conversations` at:
+ *   https://chat.zulip.org/api/register-queue
+ *
+ * Note that `user_ids` does not contain the `user_id` of the current user.
+ * Consequently, a user's conversation with themselves will be listed here
+ * as [], which is unlike the behaviour found in some other parts of the
+ * codebase.
+ */
+export type RecentPrivateConversation = {|
+  max_message_id: number,
+  // When received from the server, these are guaranteed to be sorted only after
+  // 2.2-dev-53-g405a529340. To be safe, we always sort them on receipt.
+  user_ids: number[],
+|};

--- a/src/boot/__tests__/__snapshots__/replaceRevive-test.js.snap
+++ b/src/boot/__tests__/__snapshots__/replaceRevive-test.js.snap
@@ -4,6 +4,8 @@ exports[`Stringify fallbackAvatarURL 1`] = `"{\\"data\\":\\"https://zulip.exampl
 
 exports[`Stringify gravatarURL 1`] = `"{\\"data\\":\\"https://secure.gravatar.com/avatar/3b01d0f626dc6944ed45dbe6c86d3e30?d=identicon\\",\\"__serializedType__\\":\\"GravatarURL\\"}"`;
 
+exports[`Stringify list 1`] = `"{\\"data\\":[1,2,\\"a\\",null],\\"__serializedType__\\":\\"ImmutableList\\"}"`;
+
 exports[`Stringify map 1`] = `"{\\"data\\":{\\"a\\":1,\\"b\\":2,\\"c\\":3,\\"d\\":4},\\"__serializedType__\\":\\"ImmutableMap\\"}"`;
 
 exports[`Stringify mapWithTypeKey 1`] = `"{\\"data\\":{\\"__serializedType__\\":\\"Object\\",\\"data\\":{\\"a\\":1},\\"__serializedType__value\\":{\\"__serializedType__\\":\\"Object\\",\\"data\\":{\\"b\\":[2]},\\"__serializedType__value\\":{\\"c\\":[3]}}},\\"__serializedType__\\":\\"ImmutableMap\\"}"`;

--- a/src/boot/__tests__/replaceRevive-test.js
+++ b/src/boot/__tests__/replaceRevive-test.js
@@ -10,6 +10,7 @@ import { stringify, parse, SERIALIZED_TYPE_FIELD_NAME } from '../replaceRevive';
 import * as eg from '../../__tests__/lib/exampleData';
 
 const data = {
+  list: Immutable.List([1, 2, 'a', null]),
   map: Immutable.Map({ a: 1, b: 2, c: 3, d: 4 }),
   mapWithTypeKey: Immutable.Map({
     a: 1,

--- a/src/boot/reducers.js
+++ b/src/boot/reducers.js
@@ -18,6 +18,7 @@ import narrows from '../chat/narrowsReducer';
 import messages from '../message/messagesReducer';
 import mute from '../mute/muteReducer';
 import outbox from '../outbox/outboxReducer';
+import { reducer as pmConversations } from '../pm-conversations/pmConversationsModel';
 import presence from '../presence/presenceReducer';
 import realm from '../realm/realmReducer';
 import session from '../session/sessionReducer';
@@ -46,6 +47,7 @@ const reducers = {
   narrows,
   mute,
   outbox,
+  pmConversations,
   presence,
   realm,
   session,

--- a/src/boot/replaceRevive.js
+++ b/src/boot/replaceRevive.js
@@ -73,6 +73,8 @@ function replacer(key, value) {
         data: FallbackAvatarURL.serialize(value),
         [SERIALIZED_TYPE_FIELD_NAME]: 'FallbackAvatarURL',
       };
+    case (Immutable.List.prototype: $FlowFixMe):
+      return { data: value, [SERIALIZED_TYPE_FIELD_NAME]: 'ImmutableList' };
     case (Immutable.Map.prototype: $FlowFixMe):
       return { data: value, [SERIALIZED_TYPE_FIELD_NAME]: 'ImmutableMap' };
     default: {
@@ -132,6 +134,8 @@ function reviver(key, value) {
         return UploadedAvatarURL.deserialize(data);
       case 'FallbackAvatarURL':
         return FallbackAvatarURL.deserialize(data);
+      case 'ImmutableList':
+        return Immutable.List(data);
       case 'ImmutableMap':
         return Immutable.Map(data);
       case 'Object':

--- a/src/boot/store.js
+++ b/src/boot/store.js
@@ -67,7 +67,7 @@ export const storeKeys: Array<$Keys<GlobalState>> = [
  */
 // prettier-ignore
 export const cacheKeys: Array<$Keys<GlobalState>> = [
-  'flags', 'messages', 'mute', 'narrows', 'realm', 'streams',
+  'flags', 'messages', 'mute', 'narrows', 'pmConversations', 'realm', 'streams',
   'subscriptions', 'unread', 'userGroups', 'users',
 ];
 

--- a/src/chat/__tests__/narrowsReducer-test.js
+++ b/src/chat/__tests__/narrowsReducer-test.js
@@ -379,6 +379,7 @@ describe('narrowsReducer', () => {
         numAfter: 100,
         foundNewest: false,
         foundOldest: false,
+        ownUserId: eg.selfUser.user_id,
       });
 
       const expectedState = Immutable.Map({
@@ -407,6 +408,7 @@ describe('narrowsReducer', () => {
         numAfter: 100,
         foundNewest: false,
         foundOldest: false,
+        ownUserId: eg.selfUser.user_id,
       });
 
       const expectedState = Immutable.Map({
@@ -434,6 +436,7 @@ describe('narrowsReducer', () => {
         numAfter: 100,
         foundNewest: false,
         foundOldest: false,
+        ownUserId: eg.selfUser.user_id,
       });
 
       const expectedState = Immutable.Map({
@@ -461,6 +464,7 @@ describe('narrowsReducer', () => {
         numAfter: 100,
         foundNewest: false,
         foundOldest: false,
+        ownUserId: eg.selfUser.user_id,
       });
 
       const expectedState = Immutable.Map({
@@ -487,6 +491,7 @@ describe('narrowsReducer', () => {
         numAfter: 0,
         foundNewest: true,
         foundOldest: false,
+        ownUserId: eg.selfUser.user_id,
       });
 
       const expectedState = Immutable.Map({

--- a/src/config.js
+++ b/src/config.js
@@ -33,6 +33,7 @@ const config: Config = {
     'realm_filters',
     'realm_user',
     'realm_user_groups',
+    'recent_private_conversations',
     'stream',
     'subscription',
     'update_display_settings',

--- a/src/message/__tests__/fetchActions-test.js
+++ b/src/message/__tests__/fetchActions-test.js
@@ -133,6 +133,7 @@ describe('fetchActions', () => {
 
     const baseState = eg.reduxState({
       accounts: [eg.makeAccount()],
+      realm: { ...eg.baseReduxState.realm, user_id: eg.selfUser.user_id },
       narrows: Immutable.Map({
         [streamNarrowStr]: [message1.id],
       }),
@@ -299,6 +300,7 @@ describe('fetchActions', () => {
       const store = mockStore<GlobalState, Action>(
         eg.reduxState({
           accounts: [eg.selfAccount],
+          realm: { ...eg.baseReduxState.realm, user_id: eg.selfUser.user_id },
           narrows: Immutable.Map({
             [streamNarrowStr]: [1],
           }),
@@ -324,6 +326,7 @@ describe('fetchActions', () => {
       const store = mockStore<GlobalState, Action>(
         eg.reduxState({
           accounts: [eg.selfAccount],
+          realm: { ...eg.baseReduxState.realm, user_id: eg.selfUser.user_id },
           narrows: Immutable.Map({
             [streamNarrowStr]: [1],
           }),
@@ -348,6 +351,7 @@ describe('fetchActions', () => {
       const store = mockStore<GlobalState, Action>(
         eg.reduxState({
           accounts: [eg.selfAccount],
+          realm: { ...eg.baseReduxState.realm, user_id: eg.selfUser.user_id },
           narrows: Immutable.Map({
             [streamNarrowStr]: [1],
           }),

--- a/src/message/fetchActions.js
+++ b/src/message/fetchActions.js
@@ -32,7 +32,7 @@ import { realmInit } from '../realm/realmActions';
 import { startEventPolling } from '../events/eventActions';
 import { logout } from '../account/accountActions';
 import { ZulipVersion } from '../utils/zulipVersion';
-import { getAllUsersById } from '../users/userSelectors';
+import { getAllUsersById, getOwnUserId } from '../users/userSelectors';
 
 const messageFetchStart = (narrow: Narrow, numBefore: number, numAfter: number): Action => ({
   type: MESSAGE_FETCH_START,
@@ -58,8 +58,18 @@ const messageFetchComplete = (args: {|
   numAfter: number,
   foundNewest?: boolean,
   foundOldest?: boolean,
+  ownUserId: number,
 |}): Action => {
-  const { messages, narrow, anchor, numBefore, numAfter, foundNewest, foundOldest } = args;
+  const {
+    messages,
+    narrow,
+    anchor,
+    numBefore,
+    numAfter,
+    foundNewest,
+    foundOldest,
+    ownUserId,
+  } = args;
   return {
     type: MESSAGE_FETCH_COMPLETE,
     messages,
@@ -69,6 +79,7 @@ const messageFetchComplete = (args: {|
     numAfter,
     foundNewest,
     foundOldest,
+    ownUserId,
   };
 };
 
@@ -98,6 +109,7 @@ export const fetchMessages = (fetchArgs: {|
         messages,
         foundNewest: found_newest,
         foundOldest: found_oldest,
+        ownUserId: getOwnUserId(getState()),
       }),
     );
     return messages;
@@ -251,6 +263,7 @@ const fetchPrivateMessages = () => async (dispatch: Dispatch, getState: GetState
       numAfter: 0,
       foundNewest: found_newest,
       foundOldest: found_oldest,
+      ownUserId: getOwnUserId(getState()),
     }),
   );
 };

--- a/src/pm-conversations/__tests__/pmConversationsModel-test.js
+++ b/src/pm-conversations/__tests__/pmConversationsModel-test.js
@@ -136,6 +136,15 @@ describe('reducer', () => {
       });
     });
 
+    test('existing newest conversation, newest message', () => {
+      const state = reducer(baseState, action(345, [user1]));
+      expect(state).toEqual({
+        map: Immutable.Map([['1', 345], ['1,2', 123]]),
+        sorted: Immutable.List(['1', '1,2']),
+      });
+      expect(state.sorted).toBe(baseState.sorted);
+    });
+
     test('existing conversation, not newest in conversation', () => {
       const state = reducer(baseState, action(102, [user1, user2]));
       expect(state).toBe(baseState);

--- a/src/pm-conversations/__tests__/pmConversationsModel-test.js
+++ b/src/pm-conversations/__tests__/pmConversationsModel-test.js
@@ -1,0 +1,144 @@
+/* @flow strict-local */
+import Immutable from 'immutable';
+
+import { usersOfKey, keyOfExactUsers, reducer } from '../pmConversationsModel';
+import * as eg from '../../__tests__/lib/exampleData';
+
+describe('usersOfKey', () => {
+  for (const [desc, ids] of [
+    ['self-1:1', []],
+    ['other 1:1 PM', [123]],
+    ['group PM', [123, 345, 567]],
+  ]) {
+    test(desc, () => {
+      expect(usersOfKey(keyOfExactUsers(ids))).toEqual(ids);
+    });
+  }
+});
+
+describe('reducer', () => {
+  const initialState = reducer(undefined, ({ type: eg.randString() }: $FlowFixMe));
+  const someKey = keyOfExactUsers([eg.makeUser().user_id]);
+  const someState = { map: Immutable.Map([[someKey, 123]]), sorted: Immutable.List([someKey]) };
+
+  describe('REALM_INIT', () => {
+    test('no data (old server)', () => {
+      /* eslint-disable-next-line no-unused-vars */
+      const { recent_private_conversations, ...rest } = eg.action.realm_init.data;
+      expect(reducer(someState, { ...eg.action.realm_init, data: rest })).toEqual(initialState);
+    });
+
+    test('works in normal case', () => {
+      // Includes self-1:1, other 1:1, and group PM thread.
+      // Out of order.
+      const recent_private_conversations = [
+        { user_ids: [], max_message_id: 234 },
+        { user_ids: [1], max_message_id: 123 },
+        { user_ids: [2, 1], max_message_id: 345 }, // user_ids out of order
+      ];
+      const expected = {
+        map: Immutable.Map([['', 234], ['1', 123], ['1,2', 345]]),
+        sorted: Immutable.List(['1,2', '', '1']),
+      };
+      expect(
+        reducer(someState, {
+          ...eg.action.realm_init,
+          data: { ...eg.action.realm_init.data, recent_private_conversations },
+        }),
+      ).toEqual(expected);
+    });
+  });
+
+  describe('MESSAGE_FETCH_COMPLETE', () => {
+    const [user1, user2] = [eg.makeUser({ user_id: 1 }), eg.makeUser({ user_id: 2 })];
+    const msg = (id, otherUsers) => eg.pmMessageFromTo(eg.selfUser, otherUsers, { id });
+    const action = messages => ({ ...eg.action.message_fetch_complete, messages });
+
+    test('works', () => {
+      let state = initialState;
+      state = reducer(
+        state,
+        action([msg(45, [user1]), msg(123, [user1, user2]), eg.streamMessage(), msg(234, [user1])]),
+      );
+      expect(state).toEqual({
+        map: Immutable.Map([['1', 234], ['1,2', 123]]),
+        sorted: Immutable.List(['1', '1,2']),
+      });
+
+      const newState = reducer(state, action([eg.streamMessage()]));
+      expect(newState).toBe(state);
+
+      state = reducer(
+        state,
+        action([
+          msg(345, [user2]),
+          msg(159, [user2]),
+          msg(456, [user1, user2]),
+          msg(102, [user1, user2]),
+        ]),
+      );
+      expect(state).toEqual({
+        map: Immutable.Map([['1', 234], ['1,2', 456], ['2', 345]]),
+        sorted: Immutable.List(['1,2', '2', '1']),
+      });
+    });
+  });
+
+  describe('EVENT_NEW_MESSAGE', () => {
+    const actionGeneral = message => ({ ...eg.eventNewMessageActionBase, message });
+    const [user1, user2] = [eg.makeUser({ user_id: 1 }), eg.makeUser({ user_id: 2 })];
+    const action = (id, otherUsers) =>
+      actionGeneral(eg.pmMessageFromTo(eg.selfUser, otherUsers, { id }));
+
+    // We'll start from here to test various updates.
+    const baseState = (() => {
+      let state = initialState;
+      state = reducer(state, action(234, [user1]));
+      state = reducer(state, action(123, [user1, user2]));
+      return state;
+    })();
+
+    test('(check base state)', () => {
+      // This is here mostly for checked documentation of what's in
+      // baseState, to help in reading the other test cases.
+      expect(baseState).toEqual({
+        map: Immutable.Map([['1', 234], ['1,2', 123]]),
+        sorted: Immutable.List(['1', '1,2']),
+      });
+    });
+
+    test('stream message -> do nothing', () => {
+      const state = reducer(baseState, actionGeneral(eg.streamMessage()));
+      expect(state).toBe(baseState);
+    });
+
+    test('new conversation, newest message', () => {
+      const state = reducer(baseState, action(345, [user2]));
+      expect(state).toEqual({
+        map: Immutable.Map([['1', 234], ['1,2', 123], ['2', 345]]),
+        sorted: Immutable.List(['2', '1', '1,2']),
+      });
+    });
+
+    test('new conversation, not newest message', () => {
+      const state = reducer(baseState, action(159, [user2]));
+      expect(state).toEqual({
+        map: Immutable.Map([['1', 234], ['1,2', 123], ['2', 159]]),
+        sorted: Immutable.List(['1', '2', '1,2']),
+      });
+    });
+
+    test('existing conversation, newest message', () => {
+      const state = reducer(baseState, action(345, [user1, user2]));
+      expect(state).toEqual({
+        map: Immutable.Map([['1', 234], ['1,2', 345]]),
+        sorted: Immutable.List(['1,2', '1']),
+      });
+    });
+
+    test('existing conversation, not newest in conversation', () => {
+      const state = reducer(baseState, action(102, [user1, user2]));
+      expect(state).toBe(baseState);
+    });
+  });
+});

--- a/src/pm-conversations/__tests__/pmConversationsSelectors-test.js
+++ b/src/pm-conversations/__tests__/pmConversationsSelectors-test.js
@@ -4,8 +4,10 @@ import Immutable from 'immutable';
 import { getRecentConversations } from '../pmConversationsSelectors';
 import { ALL_PRIVATE_NARROW_STR } from '../../utils/narrow';
 import * as eg from '../../__tests__/lib/exampleData';
+import { ZulipVersion } from '../../utils/zulipVersion';
 
-describe('getRecentConversations', () => {
+describe('getRecentConversationsLegacy', () => {
+  const accounts = [{ ...eg.selfAccount, zulipVersion: new ZulipVersion('2.0') }];
   const userJohn = eg.makeUser();
   const userMark = eg.makeUser();
   const keyForUsers = users =>
@@ -17,6 +19,7 @@ describe('getRecentConversations', () => {
 
   test('when no messages, return no conversations', () => {
     const state = eg.reduxState({
+      accounts,
       realm: eg.realmState({ email: eg.selfUser.email }),
       users: [eg.selfUser],
       narrows: Immutable.Map({
@@ -36,6 +39,7 @@ describe('getRecentConversations', () => {
 
   test('returns unique list of recipients, includes conversations with self', () => {
     const state = eg.reduxState({
+      accounts,
       realm: eg.realmState({ email: eg.selfUser.email }),
       users: [eg.selfUser, userJohn, userMark],
       narrows: Immutable.Map({
@@ -83,6 +87,7 @@ describe('getRecentConversations', () => {
 
   test('returns recipients sorted by last activity', () => {
     const state = eg.reduxState({
+      accounts,
       realm: eg.realmState({ email: eg.selfUser.email }),
       users: [eg.selfUser, userJohn, userMark],
       narrows: Immutable.Map({

--- a/src/pm-conversations/pmConversationsModel.js
+++ b/src/pm-conversations/pmConversationsModel.js
@@ -1,0 +1,190 @@
+/* @flow strict-local */
+import Immutable from 'immutable';
+import invariant from 'invariant';
+import {
+  ACCOUNT_SWITCH,
+  EVENT_NEW_MESSAGE,
+  LOGIN_SUCCESS,
+  LOGOUT,
+  MESSAGE_FETCH_COMPLETE,
+  REALM_INIT,
+} from '../actionConstants';
+
+import type { Action, Message, Outbox } from '../types';
+import { recipientsOfPrivateMessage } from '../utils/recipient';
+
+//
+//
+// Keys.
+//
+
+/** The key identifying a PM conversation in this data structure. */
+// User IDs, excluding self, sorted numerically, joined with commas.
+export opaque type PmConversationKey = string;
+
+/** PRIVATE.  Exported only for tests. */
+// Input must have the exact right (multi-)set of users.  Needn't be sorted.
+export function keyOfExactUsers(ids: number[]): PmConversationKey {
+  return ids.sort((a, b) => a - b).join(',');
+}
+
+// Input may contain self or not, and needn't be sorted.
+function keyOfUsers(ids: number[], ownUserId: number): PmConversationKey {
+  return keyOfExactUsers(ids.filter(id => id !== ownUserId));
+}
+
+// Input must indeed be a PM, else throws.
+function keyOfPrivateMessage(msg: Message | Outbox, ownUserId: number): PmConversationKey {
+  return keyOfUsers(recipientsOfPrivateMessage(msg).map(r => r.id), ownUserId);
+}
+
+/** The users in the conversation, other than self. */
+export function usersOfKey(key: PmConversationKey): number[] {
+  return key ? key.split(',').map(s => Number.parseInt(s, 10)) : [];
+}
+
+//
+//
+// State and reducer.
+//
+
+/**
+ * The list of recent PM conversations, plus data to efficiently maintain it.
+ *
+ * This gets initialized from the `recent_private_conversations` data
+ * structure in the `/register` response (aka our initial fetch), and then
+ * kept up to date as we learn about new or newly-fetched messages.
+ */
+// (Compare the webapp's implementation, in static/js/pm_conversations.js.)
+export type PmConversationsState = {|
+  // The latest message ID in each conversation.
+  map: Immutable.Map<PmConversationKey, number>,
+
+  // The keys of the map, sorted by latest message descending.
+  sorted: Immutable.List<PmConversationKey>,
+|};
+
+const initialState: PmConversationsState = { map: Immutable.Map(), sorted: Immutable.List() };
+
+// Insert the key at the proper place in the sorted list.
+//
+// Optimized, taking O(1) time, for the case where that place is the start,
+// because that's the common case for a new message.  May take O(n) time in
+// general.
+function insertSorted(sorted, map, key, msgId) {
+  const i = sorted.findIndex(k => {
+    const id = map.get(k);
+    invariant(id !== undefined, 'pm-conversations: key in sorted should be in map');
+    return id < msgId;
+  });
+
+  // Immutable.List is a deque, with O(1) shift/unshift as well as push/pop.
+  if (i === 0) {
+    return sorted.unshift(key);
+  }
+  if (i < 0) {
+    // (This case isn't common and isn't here to optimize, though it happens
+    // to be fast; it's just that `sorted.insert(-1, key)` wouldn't work.)
+    return sorted.push(key);
+  }
+  return sorted.insert(i, key);
+}
+
+// Insert the message into the state.
+//
+// Can take linear time in general.  That sounds inefficient...
+// but it's what the webapp does, so must not be catastrophic. 🤷
+// (In fact the webapp calls `Array#sort`, which takes at *least*
+// linear time, and may be 𝛳(N log N).)
+//
+// Optimized for the EVENT_NEW_MESSAGE case; for REALM_INIT and
+// FETCH_MESSAGES_COMPLETE, if we find we want to optimize them, the first
+// thing we'll want to do is probably to batch the work and skip this
+// function.
+//
+// For EVENT_NEW_MESSAGE, the point of the event is that we're learning
+// about the message in real time immediately after it was sent -- so the
+// overwhelmingly common case is that the message is newer than any existing
+// message we know about. (*)  That's therefore the case we optimize for,
+// particularly in the helper `insertSorted`.
+//
+// (*) The alternative is possible, but requires some kind of race to occur;
+// e.g., we get a FETCH_MESSAGES_COMPLETE that includes the just-sent
+// message 1002, and only after that get the event about message 1001, sent
+// moments earlier.  The event queue always delivers events in order, so
+// even the race is possible only because we fetch messages outside of the
+// event queue.
+function insert(
+  state: PmConversationsState,
+  key: PmConversationKey,
+  msgId: number,
+): PmConversationsState {
+  /* eslint-disable padded-blocks */
+  let { map, sorted } = state;
+  const prev = map.get(key);
+  // prettier-ignore
+  if (prev === undefined) {
+    // The conversation is new.  Add to both `map` and `sorted`.
+    map = map.set(key, msgId);
+    return { map, sorted: insertSorted(sorted, map, key, msgId) };
+
+  } else if (prev >= msgId) {
+    // The conversation already has a newer message.  Do nothing.
+    return state;
+
+  } else {
+    // The conversation needs to be (a) updated in `map`...
+    map = map.set(key, msgId);
+
+    // ... and (b) moved around in `sorted` to keep the list sorted.
+    const i = sorted.indexOf(key);
+    invariant(i >= 0, 'pm-conversations: key in map should be in sorted');
+    sorted = sorted.delete(i); // linear time, ouch
+    return { map, sorted: insertSorted(sorted, map, key, msgId) };
+  }
+}
+
+// Insert the message into the state.
+//
+// See `insert` for discussion of the time complexity.
+function insertMessage(state, message, ownUserId) {
+  if (message.type !== 'private') {
+    return state;
+  }
+  return insert(state, keyOfPrivateMessage(message, ownUserId), message.id);
+}
+
+export function reducer(state: PmConversationsState = initialState, action: Action) {
+  switch (action.type) {
+    case LOGOUT:
+    case LOGIN_SUCCESS:
+    case ACCOUNT_SWITCH:
+      return initialState;
+
+    case REALM_INIT: {
+      // TODO optimize; this is quadratic (but so is the webapp's version?!)
+      let st = initialState;
+      for (const r of action.data.recent_private_conversations ?? []) {
+        st = insert(st, keyOfExactUsers(r.user_ids), r.max_message_id);
+      }
+      return st;
+    }
+
+    case MESSAGE_FETCH_COMPLETE: {
+      // TODO optimize; this is quadratic (but so is the webapp's version?!)
+      let st = state;
+      for (const m of action.messages) {
+        st = insertMessage(st, m, action.ownUserId);
+      }
+      return st;
+    }
+
+    case EVENT_NEW_MESSAGE: {
+      const { message, ownUser } = action;
+      return insertMessage(state, message, ownUser.user_id);
+    }
+
+    default:
+      return state;
+  }
+}

--- a/src/pm-conversations/pmConversationsModel.js
+++ b/src/pm-conversations/pmConversationsModel.js
@@ -12,6 +12,14 @@ import {
 
 import type { Action, Message, Outbox } from '../types';
 import { recipientsOfPrivateMessage } from '../utils/recipient';
+import { ZulipVersion } from '../utils/zulipVersion';
+
+/** The minimum server version to expect this data to be available. */
+// Actually 2.1-dev-384-g4c3c669b41 according to our notes in src/api/;
+// but this is cleaner, and 2.1 is out long enough that few people, if any,
+// will be running a 2.1-dev version anymore (and nobody should be.)
+// TODO(server-2.1): Delete this and all code conditioned on older than it.
+export const MIN_RECENTPMS_SERVER_VERSION = new ZulipVersion('2.1');
 
 //
 //

--- a/src/pm-conversations/pmConversationsModel.js
+++ b/src/pm-conversations/pmConversationsModel.js
@@ -144,11 +144,21 @@ function insert(
     // The conversation needs to be (a) updated in `map`...
     map = map.set(key, msgId);
 
-    // ... and (b) moved around in `sorted` to keep the list sorted.
+    // ... and (b) possibly moved around in `sorted` to keep the list sorted.
     const i = sorted.indexOf(key);
     invariant(i >= 0, 'pm-conversations: key in map should be in sorted');
-    sorted = sorted.delete(i); // linear time, ouch
-    return { map, sorted: insertSorted(sorted, map, key, msgId) };
+    if (i === 0) {
+      // The conversation was already the latest, so no reordering needed.
+      // (This is likely a common case in practice -- happens every time
+      // the user gets several PMs in a row in the same thread -- so good to
+      // optimize.)
+    } else {
+      // It wasn't the latest.  Just handle the general case.
+      sorted = sorted.delete(i); // linear time, ouch
+      sorted = insertSorted(sorted, map, key, msgId);
+    }
+
+    return { map, sorted };
   }
 }
 

--- a/src/reduxTypes.js
+++ b/src/reduxTypes.js
@@ -31,6 +31,7 @@ import type {
 } from './api/apiTypes';
 import type { Narrow } from './utils/narrow';
 import type { SessionState } from './session/sessionReducer';
+import type { PmConversationsState } from './pm-conversations/pmConversationsModel';
 
 export type * from './actionTypes';
 
@@ -358,6 +359,7 @@ export type GlobalState = {|
   mute: MuteState,
   narrows: NarrowsState,
   outbox: OutboxState,
+  pmConversations: PmConversationsState,
   presence: PresenceState,
   realm: RealmState,
   session: SessionState,

--- a/src/utils/recipient.js
+++ b/src/utils/recipient.js
@@ -195,6 +195,8 @@ export const pmKeyRecipientsFromMessage = (
  *
  * The input may either include or exclude self, without affecting the
  * result.
+ *
+ * Returns null when a user couldn't be found in the given `allUsersById`.
  */
 export const pmKeyRecipientsFromIds = (
   userIds: number[],

--- a/src/utils/recipient.js
+++ b/src/utils/recipient.js
@@ -1,8 +1,9 @@
 /* @flow strict-local */
 import invariant from 'invariant';
 import isEqual from 'lodash.isequal';
-import { mapOrNull } from '../collections';
 
+import { mapOrNull } from '../collections';
+import * as logging from './logging';
 import type { PmRecipientUser, Message, Outbox, User, UserOrBot } from '../types';
 
 /** The stream name a stream message was sent to.  Throws if a PM. */
@@ -210,6 +211,7 @@ export const pmKeyRecipientsFromIds = (
 
   const users = mapOrNull(resultIds, id => allUsersById.get(id));
   if (!users) {
+    logging.warn('pmKeyRecipientsFromIds: missing data on user');
     return null;
   }
   return users.sort((a, b) => a.user_id - b.user_id);


### PR DESCRIPTION
This fixes #3133 -- making a lot more PM conversations visible on the "PM conversations" screen -- by using the nice `recent_private_conversations` data structure that the server introduced in version 2.1, precisely in order to support fixing #3133.

This PR replaces #3535, and #4104 which was partly based on a rebase of #3535. There's one commit in here which derives from those two PRs; but upon rebasing #4104 and studying it, I decided it'd be better to take a different approach for most of what it needs to do.

Most fundamentally: instead of maintaining the data in the exact same format as it came over the wire as JSON, we arrange it on receipt into a data structure that's optimized for efficiently maintaining and using. The "store it like it came over the wire" approach is the one we use for a lot of the data in the app... but the needs of an in-memory data structure for efficiently updating data, and efficiently finding things in it, are very different from the needs of a simple, highly portable, wire format like JSON. Our #3339 and #3949 already describe how we should be using more appropriate data structures for a lot of our data.

This data structure is another example of that -- and as we're adding it now from scratch, it makes a perfect occasion to go straight for a data structure designed for the purpose, without any of the additional considerations or work required to migrate something we already have and use.

In doing so, we make good use of our new (since #4201) support for Immutable.js data structures in our Redux state: without Immutable (and short of basically reimplementing large parts of Immutable ourselves), it would have been quite difficult to make these data structures as efficient as they should be in a way compatible with Redux's requirement that the state not be mutated.

This also builds on #4385 yesterday, and on the long series of work sorting out the different ways we identify PM conversations (#4035).

Fixes: #3133
