### PR TITLE
tools/build-webview: Work in terms of relative paths.

### DIFF
--- a/tools/build-webview
+++ b/tools/build-webview
@@ -36,6 +36,15 @@ err() {
     exit 1;
 }
 
+# If verbose, format and log message.  First arg is format string.
+verbose_printf() {
+    if ! (( verbose )); then
+        return
+    fi
+    # shellcheck disable=SC2059 # format string from parameter
+    printf >&2 "%s: $1\n" "$0" "${@:2}"
+}
+
 ################################################################################
 # Environment
 ################################################################################
@@ -63,6 +72,7 @@ readonly root
 unset target
 unset dest
 check_path_name=0
+verbose=0
 while (( $# )); do
     case "$1" in
         --help|-h|help)
@@ -75,6 +85,8 @@ while (( $# )); do
             shift; dest="$1"; shift;;
         --check-path-name)
             shift; check_path_name=1;;
+        --verbose|-v)
+            shift; verbose=1;;
         *) usage; exit 2;;
     esac
 done
@@ -92,7 +104,7 @@ dest=$(realpath -m --relative-to="$root" "$dest")
 cd "$root"
 
 # Argument parsing has concluded; argument variables are no longer mutable.
-readonly target dest check_path_name
+readonly target dest check_path_name verbose
 
 if (( check_path_name )); then
     case "$target" in
@@ -153,6 +165,7 @@ sync() {
     # "_dest" because bash's `readonly` means can't shadow with `local`
     local src="$1" _dest="$2"
     mkdir -p "${_dest}"
+    verbose_printf "RSYNC %q -> %q" "${src}" "${_dest}"
     rsync -aR --no-D --delete --delete-excluded \
           "${src}/./" "${_dest}/." \
           --filter='. -'

--- a/tools/build-webview
+++ b/tools/build-webview
@@ -86,8 +86,10 @@ elif [ -z "${dest-}" ]; then
     usage; exit 2
 fi
 
-# Make $dest absolute, if it isn't already.
-dest=$(readlink -m "$dest")
+# Interpret destination path based on current directory...
+dest=$(realpath -m --relative-to="$root" "$dest")
+# ... then cd to the root.
+cd "$root"
 
 # Argument parsing has concluded; argument variables are no longer mutable.
 readonly target dest check_path_name
@@ -105,8 +107,8 @@ if (( check_path_name )); then
             # of this script, and once in the "Copy Bundle Resources" step. If you
             # change it, you'll need to change it in both places. (And here, of
             # course.)
-            if [[ "$dest" != "$root/ios/"* ]]; then
-                err "unexpected destination directory '$dest' (expected target in $root/ios/)"
+            if [[ "$dest" != "ios/"* ]]; then
+                err "unexpected destination directory '$dest' (expected target in ios/)"
             fi
         ;;
         android)
@@ -115,8 +117,8 @@ if (( check_path_name )); then
             # Gradle -- more precisely, the Android Gradle plugin -- is already
             # configured to copy some directory from `build/` into the APK. We
             # determine which directory that is in Gradle, and pass it here.
-            if [[ "$dest" != "$root/android/app/build/"* ]]; then
-                err "unexpected destination directory '$dest' (expected target in $root/android/app/build/)"
+            if [[ "$dest" != "android/app/build/"* ]]; then
+                err "unexpected destination directory '$dest' (expected target in android/app/build/)"
             fi
         ;;
         *) err "impossible target $target";;
@@ -157,7 +159,7 @@ sync() {
 }
 
 # Copy over files from KaTeX.
-sync "${root}/node_modules/katex/dist" "${dest}/katex" <<EOF
+sync "node_modules/katex/dist" "${dest}/katex" <<EOF
 + /katex.min.css
 
 # The KaTeX JS renders LaTeX code into HTML and MathML.
@@ -173,7 +175,7 @@ sync "${root}/node_modules/katex/dist" "${dest}/katex" <<EOF
 EOF
 
 # Copy over our own files.
-sync "${root}/src/webview/static" "${dest}" <<EOF
+sync "src/webview/static" "${dest}" <<EOF
 # Leave alone the katex directory we just made.
 -,r /katex
 


### PR DESCRIPTION
On Windows (at least in Git Bash, which is our recommended way to set up the dev environment on Windows), the absolute paths end up looking like `/d/zulip-mobile/…`.  When one of those gets passed to rsync, it somehow decides to interpret it as a remote location, where the leading `/d/` means to go to a remote host called `d`.  Naturally, that doesn't work out.

To solve the problem, use relative paths.

This is made slightly tricky by the fact that the two different arguments we pass to rsync come to us in the form of paths relative to two different locations: the sources we want to copy are at particular places relative to the source tree, while the destination directory comes from the command line and is therefore relative to the current directory the script was started with.  So we can't pass them both directly to rsync without doing some kind of normalization on them first: if we're not at the source tree's root, then a source path like `src/webview/static` won't be right, but if we cd to the root then the destination path from the command line won't be right.  That's the problem we'd previously cut right through by normalizing everything into absolute paths.

Happily, GNU's coreutils offers not only `readlink` but `realpath`, which includes a `--relative-to` option.  So we can use that to turn `dest` relative to the starting directory into a `dest` that's still relative, but now relative to the source root, just like the source paths are.

(We already require GNU coreutils; that's the `ensure-coreutils.sh` script invoked near the top of this one.)

Also add a cleaned-up, optional version of the verbose logging that was helpful in debugging this.

Fixes: #4297
