### PR TITLE
using Keyborad.remove()

### DIFF
--- a/src/start/RealmScreen.js
+++ b/src/start/RealmScreen.js
@@ -50,6 +50,7 @@ class RealmScreen extends PureComponent<Props, State> {
   scrollView: ScrollView;
 
   tryRealm = async () => {
+    Keyboard.dismiss();
     const { realmInputValue } = this.state;
 
     const parsedRealm = tryParseUrl(realmInputValue);
@@ -77,7 +78,6 @@ class RealmScreen extends PureComponent<Props, State> {
         ),
       );
       NavigationService.dispatch(navigateToAuth(serverSettings));
-      Keyboard.dismiss();
     } catch (err) {
       this.setState({ error: 'Cannot connect to server' });
       /* eslint-disable no-console */


### PR DESCRIPTION
Actually when the go button(in land scape Orientation) is pressed then there is
 a try and catch statement in `RealmScreen.js` which is asynchronous so we have
to wait but ideal behavior must be this that whatever be the case first of all
keypad must be closed in a synchronized  manner so `Keyborad.remove()` must be
called before the try catch statement.

https://user-images.githubusercontent.com/56453541/104292591-0568dd80-54e3-11eb-8eee-25e0ce212228.mp4

Fixes: #4386