### PR TITLE
UserAvatar: Don't send auth headers to s3 backend.

### DIFF
--- a/src/common/UserAvatar.js
+++ b/src/common/UserAvatar.js
@@ -6,7 +6,7 @@ import { useSelector } from '../react-redux';
 import { getAuthHeaders } from '../api/transport';
 import { tryGetAuth } from '../account/accountsSelectors';
 import Touchable from './Touchable';
-import { AvatarURL } from '../utils/avatar';
+import { AvatarURL, FallbackAvatarURL } from '../utils/avatar';
 
 type Props = $ReadOnly<{|
   avatarUrl: AvatarURL,
@@ -51,8 +51,9 @@ function UserAvatar(props: Props) {
           style={style}
           source={{
             uri: avatarUrl.get(PixelRatio.getPixelSizeForLayoutSize(size)).toString(),
-            // For `FallbackAvatarURL`s.
-            headers: getAuthHeaders(auth),
+            ...(avatarUrl instanceof FallbackAvatarURL
+              ? { headers: getAuthHeaders(auth) }
+              : undefined),
           }}
           resizeMode="cover"
           /* ImageBackground seems to ignore `style.borderRadius`. */

--- a/src/utils/avatar.js
+++ b/src/utils/avatar.js
@@ -294,6 +294,10 @@ export class FallbackAvatarURL extends AvatarURL {
  * 100, medium is chosen:
  *  * default: 100x100
  *  * medium: 500x500
+ *
+ * Don't send auth headers with requests to this type of avatar URL.
+ * The s3 backend doesn't want them; it gives a 400 with an
+ * "Unsupported Authorization Type" message.
  */
 export class UploadedAvatarURL extends AvatarURL {
   /**


### PR DESCRIPTION
See discussion at
  https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/302.20redirect.20for.20avatar/near/1097413.

In #4367, I'd assumed that it would be fine to include the auth
headers even when they're unnecessary. That turns out not to be
true: the s3 backend doesn't want them.

Fixes: #4401