### PR TITLE
BottomTab: Hardware back button handling

### DIFF
--- a/src/main/MainTabs.js
+++ b/src/main/MainTabs.js
@@ -56,7 +56,8 @@ export default createBottomTabNavigator(
     },
   },
   {
-    backBehavior: 'none',
+    initialRouteName: 'home',
+    backBehavior: 'initialRoute',
     ...bottomTabNavigatorConfig({
       showLabel: !!Platform.isPad,
       showIcon: true,


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue below. -->
Back button handling in in MainTabs
## Issue(s)	
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
Current Behaviour: On pressing the android back button in any of the main tabs closes the application.
Ideal Behaviour: Pressing the back button should take the user back to the Home Tab.
fixes #4353 
Modification for #4354 

## Working

```Before```

https://user-images.githubusercontent.com/50165440/104406366-26820a80-5585-11eb-8491-c5f0d11d221c.mp4


```After```

https://user-images.githubusercontent.com/50165440/104406411-3b5e9e00-5585-11eb-93de-1d6ca86216b4.mp4
