### PR TITLE
Using ScrollView instead of View

### DIFF
--- a/src/common/Screen.js
+++ b/src/common/Screen.js
@@ -2,7 +2,7 @@
 
 import React, { PureComponent } from 'react';
 import type { Node as React$Node } from 'react';
-import { View, ScrollView } from 'react-native';
+import { ScrollView } from 'react-native';
 import type { ViewStyleProp } from 'react-native/Libraries/StyleSheet/StyleSheet';
 import { type EdgeInsets } from 'react-native-safe-area-context';
 
@@ -112,7 +112,7 @@ class Screen extends PureComponent<Props> {
     } = this.props;
 
     return (
-      <View
+      <ScrollView
         style={[
           componentStyles.screen,
           { backgroundColor: this.context.backgroundColor },
@@ -145,7 +145,7 @@ class Screen extends PureComponent<Props> {
             {children}
           </ScrollView>
         </KeyboardAvoider>
-      </View>
+      </ScrollView>
     );
   }
 }


### PR DESCRIPTION
 In `AuthScreen.js` when we change our orientation from
    portrait to landscape then the screen UI not looks good
    as the logo of zulip and the lower sign in button not fits
    in the screen so we should use a `ScrollView`


https://user-images.githubusercontent.com/56453541/104576765-a213b280-567e-11eb-8a7a-b21fb8f46cf0.mp4



 
 Fixes: #4405 