### PR TITLE
messagesReducer: Address a performance TODO for EVENT_NEW_MESSAGE.

### DIFF
--- a/src/chat/narrowsReducer.js
+++ b/src/chat/narrowsReducer.js
@@ -72,8 +72,11 @@ const eventNewMessage = (state, action) => {
       if (!action.caughtUp[key]?.newer) {
         // Don't add a message to the end of the list unless we know
         // it's the most recent message, i.e., unless we know we're
-        // currently looking at (caught up with) the newest messages in
-        // the narrow.
+        // currently looking at (caught up with) the newest messages
+        // in the narrow. We don't want to accidentally show a message
+        // at the end of a message list if there might be messages
+        // between the currently latest-shown message and this
+        // message.
         return; // i.e., continue
       }
 

--- a/src/chat/narrowsReducer.js
+++ b/src/chat/narrowsReducer.js
@@ -77,6 +77,11 @@ const eventNewMessage = (state, action) => {
         // at the end of a message list if there might be messages
         // between the currently latest-shown message and this
         // message.
+        //
+        // See a corresponding condition in messagesReducer, where we
+        // don't bother to add to `state.messages` if this condition
+        // (after running on all of `narrowsForMessage`) means the new
+        // message wasn't added anywhere in `state.narrows`.
         return; // i.e., continue
       }
 
@@ -87,6 +92,12 @@ const eventNewMessage = (state, action) => {
         // investigate?)
         return; // i.e., continue
       }
+
+      // If changing or removing a case where we ignore a message
+      // here: Careful! Every message in `state.narrows` must exist in
+      // `state.messages`. If we choose to include a message in
+      // `state.narrows`, then messagesReducer MUST ALSO choose to
+      // include it in `state.messages`.
 
       stateMutable.set(key, [...value, message.id]);
     });

--- a/src/message/messagesReducer.js
+++ b/src/message/messagesReducer.js
@@ -28,11 +28,15 @@ const eventNewMessage = (state, action) => {
     throw new Error('EVENT_NEW_MESSAGE message missing flags');
   }
 
-  // TODO: Optimize -- Only update if the new message belongs to at least
-  // one narrow that is caught up.
+  // Don't add a message that's already been added. It's probably
+  // very rare for a message to have already been added when we
+  // get an EVENT_NEW_MESSAGE, and perhaps impossible. (TODO:
+  // investigate?)
   if (state.get(action.message.id)) {
     return state;
   }
+  // TODO: Optimize -- Only update if the new message belongs to at least
+  // one narrow that is caught up.
   return state.set(action.message.id, omit(action.message, 'flags'));
 };
 

--- a/src/message/messagesReducer.js
+++ b/src/message/messagesReducer.js
@@ -21,6 +21,13 @@ import { NULL_ARRAY } from '../nullObjects';
 const initialState: MessagesState = Immutable.Map([]);
 
 const eventNewMessage = (state, action) => {
+  const { message } = action;
+  const { flags } = message;
+
+  if (!flags) {
+    throw new Error('EVENT_NEW_MESSAGE message missing flags');
+  }
+
   // TODO: Optimize -- Only update if the new message belongs to at least
   // one narrow that is caught up.
   if (state.get(action.message.id)) {


### PR DESCRIPTION
Discovered while working on #4390, which was recently merged.

-----

messagesReducer: Address a performance TODO for EVENT_NEW_MESSAGE.

Using the recently added `getNarrowsForMessage`.

And leave bidirectional comments with narrowsReducer so that we
never end up with messages in `state.narrows` that don't exist in
`state.messages`.