### PR TITLE
internal_link: allow streamID without stream name

### DIFF
--- a/src/utils/__tests__/internalLinks-test.js
+++ b/src/utils/__tests__/internalLinks-test.js
@@ -288,7 +288,6 @@ describe('getNarrowFromLink', () => {
 
     test('on malformed stream link: treat as old format', () => {
       const expectAsName = name => expectStream(name, [streamGeneral], name);
-      expectAsName(`${streamGeneral.stream_id}`);
       expectAsName(`-${streamGeneral.stream_id}`);
       expectAsName(`${streamGeneral.stream_id}nonsense-general`);
     });
@@ -310,7 +309,7 @@ describe('getNarrowFromLink', () => {
 
       test('on ambiguous new- or old-style: new wins', () => {
         const collider = { ...eg.makeStream({ name: 'collider' }), stream_id: 311 };
-        expectStream('311', [numbers, collider], '311'); // malformed for new-style
+        expectStream('311', [numbers, collider], '311'); // will soon recognize this as the new style
         expectStream('311-', [numbersHyphen, collider], 'collider');
         expectStream('311-help', [numbersPlus, collider], 'collider');
       });

--- a/src/utils/__tests__/internalLinks-test.js
+++ b/src/utils/__tests__/internalLinks-test.js
@@ -289,9 +289,7 @@ describe('getNarrowFromLink', () => {
     test('on malformed stream link: treat as old format', () => {
       const expectAsName = name => expectStream(name, [streamGeneral], name);
       expectAsName(`-${streamGeneral.stream_id}`);
-      // This case will come back when we take the fix in
-      //   zulip/zulip@d67cc2d08, soon.
-      // expectAsName(`${streamGeneral.stream_id}nonsense-general`);
+      expectAsName(`${streamGeneral.stream_id}nonsense-general`);
     });
 
     {

--- a/src/utils/__tests__/internalLinks-test.js
+++ b/src/utils/__tests__/internalLinks-test.js
@@ -289,7 +289,9 @@ describe('getNarrowFromLink', () => {
     test('on malformed stream link: treat as old format', () => {
       const expectAsName = name => expectStream(name, [streamGeneral], name);
       expectAsName(`-${streamGeneral.stream_id}`);
-      expectAsName(`${streamGeneral.stream_id}nonsense-general`);
+      // This case will come back when we take the fix in
+      //   zulip/zulip@d67cc2d08, soon.
+      // expectAsName(`${streamGeneral.stream_id}nonsense-general`);
     });
 
     {
@@ -309,7 +311,7 @@ describe('getNarrowFromLink', () => {
 
       test('on ambiguous new- or old-style: new wins', () => {
         const collider = { ...eg.makeStream({ name: 'collider' }), stream_id: 311 };
-        expectStream('311', [numbers, collider], '311'); // will soon recognize this as the new style
+        expectStream('311', [numbers, collider], 'collider');
         expectStream('311-', [numbersHyphen, collider], 'collider');
         expectStream('311-help', [numbersPlus, collider], 'collider');
       });

--- a/src/utils/internalLinks.js
+++ b/src/utils/internalLinks.js
@@ -121,7 +121,7 @@ export const decodeHashComponent = (string: string): string => {
 /** Parse the operand of a `stream` operator, returning a stream name. */
 const parseStreamOperand = (operand, streamsById): string => {
   // "New" (2018) format: ${stream_id}-${stream_name} .
-  const match = /^([\d]+)(?:-.*)?/.exec(operand);
+  const match = /^([\d]+)(?:-.*)?$/.exec(operand);
   if (match) {
     const stream = streamsById.get(parseInt(match[1], 10));
     if (stream) {

--- a/src/utils/internalLinks.js
+++ b/src/utils/internalLinks.js
@@ -121,7 +121,7 @@ export const decodeHashComponent = (string: string): string => {
 /** Parse the operand of a `stream` operator, returning a stream name. */
 const parseStreamOperand = (operand, streamsById): string => {
   // "New" (2018) format: ${stream_id}-${stream_name} .
-  const match = /^(\d+)-/.exec(operand);
+  const match = /^([\d]+)(-.*)?/.exec(operand);
   if (match) {
     const stream = streamsById.get(parseInt(match[0], 10));
     if (stream) {

--- a/src/utils/internalLinks.js
+++ b/src/utils/internalLinks.js
@@ -123,7 +123,7 @@ const parseStreamOperand = (operand, streamsById): string => {
   // "New" (2018) format: ${stream_id}-${stream_name} .
   const match = /^([\d]+)(-.*)?/.exec(operand);
   if (match) {
-    const stream = streamsById.get(parseInt(match[0], 10));
+    const stream = streamsById.get(parseInt(match[1], 10));
     if (stream) {
       return stream.name;
     }

--- a/src/utils/internalLinks.js
+++ b/src/utils/internalLinks.js
@@ -121,7 +121,7 @@ export const decodeHashComponent = (string: string): string => {
 /** Parse the operand of a `stream` operator, returning a stream name. */
 const parseStreamOperand = (operand, streamsById): string => {
   // "New" (2018) format: ${stream_id}-${stream_name} .
-  const match = /^([\d]+)(-.*)?/.exec(operand);
+  const match = /^([\d]+)(?:-.*)?/.exec(operand);
   if (match) {
     const stream = streamsById.get(parseInt(match[1], 10));
     if (stream) {


### PR DESCRIPTION
This commit allows for the internal links to be of the form:
https://chat.zulip.org/#narrow/stream/3/topic/send_message.20API. Previously, only internal links of the form:
https://chat.zulip.org/#narrow/stream/3-backend/topic/send_message.20API were supported. 

Fixes #4185