### PR TITLE
Anticipate and fix a few Flow errors we'd get with RN v0.63 and Flow 0.122.

### DIFF
--- a/src/actionTypes.js
+++ b/src/actionTypes.js
@@ -324,8 +324,22 @@ type EventUpdateMessageAction = {|
   message_id: number,
   // TODO is it really right that just one of the orig_* is optional?
   orig_content: string,
-  // $FlowFixMe clarify orig_subject vs. other orig_*, and missing vs. empty
+
+  // TODO: The doc for this field isn't yet correct; it turns out that
+  // the question of whether `orig_subject` is present or not is
+  // complicated; see discussion at
+  // https://chat.zulip.org/#narrow/stream/206-zulip-terminal/topic/subject.20always.20present.20in.20event/near/1098954.
+  //
+  // We can be pretty sure of a few things, though:
+  // - it will not be present if the message doesn't have a topic
+  //   (i.e., if it's a private message)
+  // - it's guaranteed to be present if the topic did indeed change
+  // - it will never be an empty string, because the server doesn't
+  //   accept the empty string for a message's topic; it requires
+  //   clients to specify something like `(no topic)` if no topic is
+  //   desired.
   orig_subject?: string,
+
   orig_rendered_content: string,
   prev_rendered_content_version: number,
   rendered_content: string,

--- a/src/animation/AnimatedRotateComponent.js
+++ b/src/animation/AnimatedRotateComponent.js
@@ -27,7 +27,7 @@ export default class AnimatedRotateComponent extends PureComponent<Props> {
     const { children, style } = this.props;
     const rotation = this.rotation.interpolate({
       inputRange: [0, 360],
-      outputRange: ['0deg', '360deg'],
+      outputRange: (['0deg', '360deg']: string[]),
     });
     const animatedStyle = { transform: [{ rotate: rotation }] };
 

--- a/src/boot/TranslationProvider.js
+++ b/src/boot/TranslationProvider.js
@@ -1,5 +1,5 @@
 /* @flow strict-local */
-import React, { PureComponent } from 'react';
+import React, { PureComponent, type Context } from 'react';
 import type { ComponentType, ElementConfig, Node as React$Node } from 'react';
 import { Text } from 'react-native';
 import { IntlProvider, IntlContext } from 'react-intl';
@@ -11,7 +11,7 @@ import { getSettings } from '../selectors';
 import messages from '../i18n/messages';
 
 // $FlowFixMe could put a well-typed mock value here, to help write tests
-export const TranslationContext = React.createContext(undefined);
+export const TranslationContext: Context<GetText> = React.createContext(undefined);
 
 /**
  * Provide `_` to the wrapped component, passing other props through.

--- a/src/common/SlideAnimationView.js
+++ b/src/common/SlideAnimationView.js
@@ -46,7 +46,7 @@ export default class SlideAnimationView extends PureComponent<Props, State> {
     const { property, from, to, movement, style } = this.props;
     const animationValue = this.state.animationIndex.interpolate({
       inputRange: [0, 1],
-      outputRange: movement === 'out' ? [from, to] : [to, from],
+      outputRange: ((movement === 'out' ? [from, to] : [to, from]): number[]),
     });
 
     const slideStyle = { transform: [{ [property]: animationValue }] };

--- a/src/message/messagesReducer.js
+++ b/src/message/messagesReducer.js
@@ -110,7 +110,7 @@ export default (state: MessagesState = initialState, action: Action): MessagesSt
             subject_links: action.subject_links || oldMessage.subject_links,
             edit_history: [
               action.orig_rendered_content
-                ? action.orig_subject
+                ? action.orig_subject !== undefined
                   ? {
                       prev_rendered_content: action.orig_rendered_content,
                       prev_subject: oldMessage.subject,

--- a/src/notification/__tests__/notification-test.js
+++ b/src/notification/__tests__/notification-test.js
@@ -1,6 +1,7 @@
 // @flow strict-local
 import deepFreeze from 'deep-freeze';
 
+import type { Notification } from '../types';
 import type { UserOrBot } from '../../api/modelTypes';
 import type { JSONableDict } from '../../utils/jsonable';
 import { getNarrowFromNotificationData } from '..';

--- a/src/start/RealmScreen.js
+++ b/src/start/RealmScreen.js
@@ -1,6 +1,6 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
-import { ScrollView, Keyboard } from 'react-native';
+import { Keyboard } from 'react-native';
 
 import type { AppNavigationProp, AppNavigationRouteProp } from '../nav/AppNavigator';
 import * as NavigationService from '../nav/NavigationService';
@@ -37,8 +37,6 @@ class RealmScreen extends PureComponent<Props, State> {
     realmInputValue: this.props.initialRealmInputValue,
     error: null,
   };
-
-  scrollView: ScrollView;
 
   tryRealm = async () => {
     const { realmInputValue } = this.state;


### PR DESCRIPTION
On #4245, the issue for upgrading to React Native v0.63, I [said](https://github.com/zulip/zulip-mobile/issues/4245#issuecomment-753239808):

> Much of the work has already been done, but the new Flow version that we'll take along with it has lots of issues with our use of react-navigation, so I've been hoping to finish #4296 (for which #4300 is open) before taking up the RN upgrade again.

Well, #4296 has been resolved! As we'd hoped, the new Flow version (0.122.0) doesn't complain about anything that has to do with react-navigation anymore, which brings us closer to being able to take the Flow version along with RN v0.63.

This branch whittles down the new Flow version's output to the single warning below, with the helpful comment that we can remove a $FlowFixMe along with the upgrade.

```
Warning ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ src/presence/presenceReducer.js:30:9

Unused suppression comment.

     27│     case PRESENCE_RESPONSE:
     28│       return {
     29│         ...state,
     30│         // $FlowFixMe - Flow bug; should resolve in #4245
     31│         ...action.presence,
     32│       };
     33│
```