### PR TITLE
autocomplete: Fix crash in showing avatar for pseudo-users

### DIFF
--- a/src/common/UserAvatarWithPresence.js
+++ b/src/common/UserAvatarWithPresence.js
@@ -6,7 +6,7 @@ import { createStyleSheet } from '../styles';
 import UserAvatar from './UserAvatar';
 import PresenceStatusIndicator from './PresenceStatusIndicator';
 import { AvatarURL } from '../utils/avatar';
-import { getUserForId } from '../users/userSelectors';
+import { tryGetUserForId } from '../users/userSelectors';
 import { useSelector } from '../react-redux';
 
 const styles = createStyleSheet({
@@ -70,6 +70,14 @@ export function UserAvatarWithPresenceById(
   |}>,
 ) {
   const { userId, ...restProps } = props;
-  const user = useSelector(state => getUserForId(state, userId));
+
+  const user = useSelector(state => tryGetUserForId(state, userId));
+  if (!user) {
+    // This condition really does happen, because UserItem can be passed a fake
+    // pseudo-user by PeopleAutocomplete, to represent `@all` or `@everyone`.
+    // TODO eliminate that, and use plain `getUserForId` here.
+    return null;
+  }
+
   return <UserAvatarWithPresence {...restProps} avatarUrl={user.avatar_url} email={user.email} />;
 }

--- a/src/events/eventToAction.js
+++ b/src/events/eventToAction.js
@@ -32,7 +32,7 @@ import {
   EVENT_SUBSCRIPTION,
   EVENT,
 } from '../actionConstants';
-import { getOwnUser, getOwnUserId, getAllUsersById } from '../users/userSelectors';
+import { getOwnUser, getOwnUserId, tryGetUserForId } from '../users/userSelectors';
 import { AvatarURL } from '../utils/avatar';
 import { getCurrentRealm } from '../account/accountsSelectors';
 
@@ -152,7 +152,7 @@ export default (state: GlobalState, event: $FlowFixMe): EventAction => {
 
         case 'update': {
           const { user_id: userId } = event.person;
-          const existingUser = getAllUsersById(state).get(userId);
+          const existingUser = tryGetUserForId(state, userId);
           if (!existingUser) {
             // If we get one of these events and don't have
             // information on the user, there's nothing to do about

--- a/src/title/TitlePrivate.js
+++ b/src/title/TitlePrivate.js
@@ -10,7 +10,7 @@ import { useSelector } from '../react-redux';
 import { Touchable, ViewPlaceholder } from '../common';
 import { UserAvatarWithPresenceById } from '../common/UserAvatarWithPresence';
 import ActivityText from './ActivityText';
-import { getAllUsersById } from '../users/userSelectors';
+import { tryGetUserForId } from '../users/userSelectors';
 import { navigateToAccountDetails } from '../nav/navActions';
 
 type Props = $ReadOnly<{
@@ -25,11 +25,11 @@ const componentStyles = createStyleSheet({
 
 export default function TitlePrivate(props: Props) {
   const { userId, color } = props;
-  const user = useSelector(state => getAllUsersById(state).get(userId));
-
+  const user = useSelector(state => tryGetUserForId(state, userId));
   if (!user) {
     return null;
   }
+
   return (
     <Touchable
       onPress={() => {

--- a/src/users/UserItem.js
+++ b/src/users/UserItem.js
@@ -1,5 +1,5 @@
 /* @flow strict-local */
-import React, { type ComponentType, type ElementConfig, PureComponent } from 'react';
+import React, { type ElementConfig, PureComponent } from 'react';
 import { View } from 'react-native';
 
 import type { UserId, UserOrBot } from '../types';
@@ -36,8 +36,17 @@ type Props = $ReadOnly<{|
   onPress: UserOrBot => void,
 |}>;
 
-// See UserAvatarWithPresence for discussion of this inexact object type.
-class UserItem extends PureComponent<$ReadOnly<{ ...Props, ... }>> {
+/**
+ * A user represented with avatar and name, for use in a list.
+ *
+ * Prefer the default export `UserItem` over this component: it does the
+ * same thing but provides a more encapsulated interface.
+ *
+ * This component is potentially appropriate if displaying a synthetic fake
+ * user, one that doesn't exist in the database.  (But anywhere we're doing
+ * that, there's probably a better UI anyway than showing a fake user.)
+ */
+export class UserItemRaw extends PureComponent<Props> {
   static defaultProps = {
     isSelected: false,
     showEmail: false,
@@ -86,22 +95,8 @@ class UserItem extends PureComponent<$ReadOnly<{ ...Props, ... }>> {
   }
 }
 
-/**
- * A user represented with avatar and name, for use in a list.
- *
- * Prefer the default export `UserItem` over this component: it does the
- * same thing but provides a more encapsulated interface.
- *
- * This component is potentially appropriate if displaying a synthetic fake
- * user, one that doesn't exist in the database.  (But anywhere we're doing
- * that, there's probably a better UI anyway than showing a fake user.)
- */
-// Export the class with a tighter constraint on acceptable props, namely
-// that the type is an exact object type as usual.
-export const UserItemRaw = (UserItem: ComponentType<$Exact<ElementConfig<typeof UserItem>>>);
-
 type OuterProps = $ReadOnly<{|
-  ...$Exact<$Diff<ElementConfig<typeof UserItem>, { user: mixed }>>,
+  ...$Exact<$Diff<ElementConfig<typeof UserItemRaw>, { user: mixed }>>,
   userId: UserId,
 |}>;
 
@@ -113,6 +108,7 @@ type OuterProps = $ReadOnly<{|
  */
 // eslint-disable-next-line func-names
 export default function (props: OuterProps) {
-  const user = useSelector(state => getUserForId(state, props.userId));
-  return <UserItem {...props} user={user} />;
+  const { userId, ...restProps } = props;
+  const user = useSelector(state => getUserForId(state, userId));
+  return <UserItemRaw {...restProps} user={user} />;
 }

--- a/src/users/userSelectors.js
+++ b/src/users/userSelectors.js
@@ -169,15 +169,30 @@ export const getActiveUsersById: Selector<Map<UserId, UserOrBot>> = createSelect
 );
 
 /**
+ * The user with the given user ID, or null if no such user is known.
+ *
+ * This works for any user in this Zulip org/realm, including deactivated
+ * users and cross-realm bots.  See `getAllUsers` for details.
+ *
+ * See `getUserForId` for a version which only ever returns a real user,
+ * throwing if none.  That makes it a bit simpler to use in contexts where
+ * we assume the relevant user must exist, which is true of most of the app.
+ */
+export const tryGetUserForId = (state: GlobalState, userId: UserId): UserOrBot | null =>
+  getAllUsersById(state).get(userId) ?? null;
+
+/**
  * The user with the given user ID.
  *
  * This works for any user in this Zulip org/realm, including deactivated
  * users and cross-realm bots.  See `getAllUsers` for details.
  *
  * Throws if no such user exists.
+ *
+ * See `tryGetUserForId` for a non-throwing version.
  */
 export const getUserForId = (state: GlobalState, userId: UserId): UserOrBot => {
-  const user = getAllUsersById(state).get(userId);
+  const user = tryGetUserForId(state, userId);
   if (!user) {
     throw new Error(`getUserForId: missing user: id ${userId}`);
   }


### PR DESCRIPTION
Along the way, add `tryGetUserForId` as a non-throwing variant of `getUserForId`, and use it in a couple of existing spots where we already do something equivalent.

Fixes: #4422
