### PR TITLE
user: Convert a lot more emails to user IDs, and other cleanups

### DIFF
--- a/src/__tests__/lib/exampleData.js
+++ b/src/__tests__/lib/exampleData.js
@@ -627,5 +627,5 @@ export const eventNewMessageActionBase /* \: $Diff<EventNewMessageAction, {| mes
   type: EVENT_NEW_MESSAGE,
   id: 1001,
   caughtUp: {},
-  ownUser: selfUser,
+  ownUserId: selfUser.user_id,
 };

--- a/src/account-info/ProfileCard.js
+++ b/src/account-info/ProfileCard.js
@@ -6,7 +6,6 @@ import type { MainTabsNavigationProp, MainTabsRouteProp } from '../main/MainTabs
 import * as NavigationService from '../nav/NavigationService';
 import { createStyleSheet } from '../styles';
 import { useDispatch, useSelector } from '../react-redux';
-import { getSelfUserDetail } from '../selectors';
 import { ZulipButton } from '../common';
 import {
   logout,
@@ -16,6 +15,7 @@ import {
 } from '../actions';
 import AccountDetails from './AccountDetails';
 import AwayStatusSwitch from './AwayStatusSwitch';
+import { getOwnUser } from '../users/userSelectors';
 
 const styles = createStyleSheet({
   buttonRow: {
@@ -81,11 +81,11 @@ type Props = $ReadOnly<{|
  * The user can still open `AccountDetails` on themselves via the (i) icon in a chat screen.
  */
 export default function ProfileCard(props: Props) {
-  const selfUserDetail = useSelector(getSelfUserDetail);
+  const ownUser = useSelector(getOwnUser);
 
   return (
     <ScrollView>
-      <AccountDetails user={selfUserDetail} />
+      <AccountDetails user={ownUser} />
       <AwayStatusSwitch />
       <View style={styles.buttonRow}>
         <SetStatusButton />

--- a/src/actionTypes.js
+++ b/src/actionTypes.js
@@ -306,7 +306,7 @@ type EventNewMessageAction = {|
   ...$Diff<MessageEvent, { flags: mixed }>,
   type: typeof EVENT_NEW_MESSAGE,
   caughtUp: CaughtUpState,
-  ownUser: User,
+  ownUserId: UserId,
 |};
 
 type EventSubmessageAction = {|

--- a/src/autocomplete/PeopleAutocomplete.js
+++ b/src/autocomplete/PeopleAutocomplete.js
@@ -3,9 +3,9 @@
 import React, { PureComponent } from 'react';
 import { SectionList } from 'react-native';
 
-import type { User, UserGroup, UserOrBot, Dispatch } from '../types';
+import type { User, UserId, UserGroup, UserOrBot, Dispatch } from '../types';
 import { connect } from '../react-redux';
-import { getOwnEmail, getSortedUsers, getUserGroups } from '../selectors';
+import { getSortedUsers, getUserGroups } from '../selectors';
 import {
   getAutocompleteSuggestion,
   getAutocompleteUserGroupSuggestions,
@@ -13,12 +13,13 @@ import {
 import { Popup } from '../common';
 import { UserItemRaw } from '../users/UserItem';
 import UserGroupItem from '../user-groups/UserGroupItem';
+import { getOwnUserId } from '../users/userSelectors';
 
 type Props = $ReadOnly<{|
   dispatch: Dispatch,
   filter: string,
   onAutocomplete: (name: string) => void,
-  ownEmail: string,
+  ownUserId: UserId,
   users: User[],
   userGroups: UserGroup[],
 |}>;
@@ -42,9 +43,9 @@ class PeopleAutocomplete extends PureComponent<Props> {
   };
 
   render() {
-    const { filter, ownEmail, users, userGroups } = this.props;
+    const { filter, ownUserId, users, userGroups } = this.props;
     const filteredUserGroups = getAutocompleteUserGroupSuggestions(userGroups, filter);
-    const filteredUsers: User[] = getAutocompleteSuggestion(users, filter, ownEmail);
+    const filteredUsers: User[] = getAutocompleteSuggestion(users, filter, ownUserId);
 
     if (filteredUserGroups.length + filteredUsers.length === 0) {
       return null;
@@ -92,7 +93,7 @@ class PeopleAutocomplete extends PureComponent<Props> {
 }
 
 export default connect(state => ({
-  ownEmail: getOwnEmail(state),
+  ownUserId: getOwnUserId(state),
   users: getSortedUsers(state),
   userGroups: getUserGroups(state),
 }))(PeopleAutocomplete);

--- a/src/chat/narrowsReducer.js
+++ b/src/chat/narrowsReducer.js
@@ -53,7 +53,7 @@ const eventNewMessage = (state, action) => {
   }
 
   return state.withMutations(stateMutable => {
-    const narrowsForMessage = getNarrowsForMessage(message, action.ownUser, flags);
+    const narrowsForMessage = getNarrowsForMessage(message, action.ownUser.user_id, flags);
 
     narrowsForMessage.forEach(narrow => {
       const key = keyFromNarrow(narrow);

--- a/src/chat/narrowsReducer.js
+++ b/src/chat/narrowsReducer.js
@@ -53,7 +53,7 @@ const eventNewMessage = (state, action) => {
   }
 
   return state.withMutations(stateMutable => {
-    const narrowsForMessage = getNarrowsForMessage(message, action.ownUser.user_id, flags);
+    const narrowsForMessage = getNarrowsForMessage(message, action.ownUserId, flags);
 
     narrowsForMessage.forEach(narrow => {
       const key = keyFromNarrow(narrow);

--- a/src/chat/narrowsSelectors.js
+++ b/src/chat/narrowsSelectors.js
@@ -20,7 +20,7 @@ import {
   getOutbox,
 } from '../directSelectors';
 import { getCaughtUpForNarrow } from '../caughtup/caughtUpSelectors';
-import { getAllUsersById, getOwnUser } from '../users/userSelectors';
+import { getAllUsersById, getOwnUserId } from '../users/userSelectors';
 import {
   isStreamOrTopicNarrow,
   isMessageInNarrow,
@@ -36,8 +36,8 @@ export const outboxMessagesForNarrow: Selector<Outbox[], Narrow> = createSelecto
   (state, narrow) => narrow,
   getCaughtUpForNarrow,
   state => getOutbox(state),
-  getOwnUser,
-  (narrow, caughtUp, outboxMessages, ownUser) => {
+  getOwnUserId,
+  (narrow, caughtUp, outboxMessages, ownUserId) => {
     if (!caughtUp.newer) {
       return NULL_ARRAY;
     }
@@ -50,7 +50,7 @@ export const outboxMessagesForNarrow: Selector<Outbox[], Narrow> = createSelecto
     // messages can't be starred, so "no flags" gives that the right answer.
     const fakeFlags = [];
     const filtered = outboxMessages.filter(message =>
-      isMessageInNarrow(message, fakeFlags, narrow, ownUser),
+      isMessageInNarrow(message, fakeFlags, narrow, ownUserId),
     );
     return isEqual(filtered, outboxMessages) ? outboxMessages : filtered;
   },

--- a/src/common/OwnAvatar.js
+++ b/src/common/OwnAvatar.js
@@ -3,8 +3,8 @@ import React, { PureComponent } from 'react';
 
 import type { User, Dispatch } from '../types';
 import { connect } from '../react-redux';
-import { getSelfUserDetail } from '../selectors';
 import UserAvatar from './UserAvatar';
+import { getOwnUser } from '../users/userSelectors';
 
 type Props = $ReadOnly<{|
   dispatch: Dispatch,
@@ -25,5 +25,5 @@ class OwnAvatar extends PureComponent<Props> {
 }
 
 export default connect(state => ({
-  user: getSelfUserDetail(state),
+  user: getOwnUser(state),
 }))(OwnAvatar);

--- a/src/compose/ComposeBox.js
+++ b/src/compose/ComposeBox.js
@@ -57,12 +57,12 @@ import {
 import { getDraftForNarrow } from '../drafts/draftsSelectors';
 import TopicAutocomplete from '../autocomplete/TopicAutocomplete';
 import AutocompleteView from '../autocomplete/AutocompleteView';
-import { getActiveUsersById, getOwnUserId } from '../users/userSelectors';
+import { getAllUsersById, getOwnUserId } from '../users/userSelectors';
 
 type SelectorProps = {|
   auth: Auth,
   ownUserId: UserId,
-  usersById: Map<UserId, UserOrBot>,
+  allUsersById: Map<UserId, UserOrBot>,
   isAdmin: boolean,
   isAnnouncementOnly: boolean,
   isSubscribed: boolean,
@@ -422,7 +422,7 @@ class ComposeBox extends PureComponent<Props, State> {
     const {
       ownUserId,
       narrow,
-      usersById,
+      allUsersById,
       editMessage,
       insets,
       isAdmin,
@@ -441,7 +441,7 @@ class ComposeBox extends PureComponent<Props, State> {
       return <AnnouncementOnly />;
     }
 
-    const placeholder = getComposeInputPlaceholder(narrow, ownUserId, usersById);
+    const placeholder = getComposeInputPlaceholder(narrow, ownUserId, allUsersById);
     const style = {
       paddingBottom: insets.bottom,
       backgroundColor: 'hsla(0, 0%, 50%, 0.1)',
@@ -522,7 +522,7 @@ export default compose(
   connect<SelectorProps, _, _>((state, props) => ({
     auth: getAuth(state),
     ownUserId: getOwnUserId(state),
-    usersById: getActiveUsersById(state),
+    allUsersById: getAllUsersById(state),
     isAdmin: getIsAdmin(state),
     isAnnouncementOnly: getIsActiveStreamAnnouncementOnly(state, props.narrow),
     isSubscribed: getIsActiveStreamSubscribed(state, props.narrow),

--- a/src/compose/MentionWarnings.js
+++ b/src/compose/MentionWarnings.js
@@ -14,7 +14,7 @@ import type {
   UserId,
 } from '../types';
 import { TranslationContext } from '../boot/TranslationProvider';
-import { getActiveUsersById, getAuth } from '../selectors';
+import { getAllUsersById, getAuth } from '../selectors';
 import { is1to1PmNarrow } from '../utils/narrow';
 import * as api from '../api';
 import { showToast } from '../utils/info';
@@ -28,7 +28,7 @@ type State = {|
 
 type SelectorProps = {|
   auth: Auth,
-  usersById: Map<UserId, UserOrBot>,
+  allUsersById: Map<UserId, UserOrBot>,
 |};
 
 type Props = $ReadOnly<{|
@@ -54,7 +54,7 @@ class MentionWarnings extends PureComponent<Props, State> {
       See JSDoc for AutoCompleteView for details.
    */
   getUserFromMention = (completion: string): UserOrBot | void => {
-    const { usersById } = this.props;
+    const { allUsersById } = this.props;
 
     const unformattedMessage = completion.split('**')[1];
     const [userFullName, userIdRaw] = unformattedMessage.split('|');
@@ -68,10 +68,10 @@ class MentionWarnings extends PureComponent<Props, State> {
 
     if (userIdRaw !== undefined) {
       const userId = makeUserId(Number.parseInt(userIdRaw, 10));
-      return usersById.get(userId);
+      return allUsersById.get(userId);
     }
 
-    for (const user of usersById.values()) {
+    for (const user of allUsersById.values()) {
       if (user.full_name === userFullName) {
         return user;
       }
@@ -145,7 +145,7 @@ class MentionWarnings extends PureComponent<Props, State> {
 
   render() {
     const { unsubscribedMentions } = this.state;
-    const { stream, narrow, usersById } = this.props;
+    const { stream, narrow, allUsersById } = this.props;
 
     if (is1to1PmNarrow(narrow)) {
       return null;
@@ -153,7 +153,7 @@ class MentionWarnings extends PureComponent<Props, State> {
 
     const mentionWarnings = [];
     for (const userId of unsubscribedMentions) {
-      const user = usersById.get(userId);
+      const user = allUsersById.get(userId);
 
       if (user === undefined) {
         continue;
@@ -177,7 +177,7 @@ class MentionWarnings extends PureComponent<Props, State> {
 export default connect(
   state => ({
     auth: getAuth(state),
-    usersById: getActiveUsersById(state),
+    allUsersById: getAllUsersById(state),
   }),
   null,
   null,

--- a/src/compose/getComposeInputPlaceholder.js
+++ b/src/compose/getComposeInputPlaceholder.js
@@ -5,7 +5,7 @@ import { caseNarrowDefault } from '../utils/narrow';
 export default (
   narrow: Narrow,
   ownUserId: UserId,
-  usersById: Map<UserId, UserOrBot>,
+  allUsersById: Map<UserId, UserOrBot>,
 ): LocalizableText =>
   caseNarrowDefault(
     narrow,
@@ -20,7 +20,7 @@ export default (
           return { text: 'Jot down something' };
         }
 
-        const user = usersById.get(userId);
+        const user = allUsersById.get(userId);
         if (!user) {
           return { text: 'Type a message' };
         }

--- a/src/events/doEventActionSideEffects.js
+++ b/src/events/doEventActionSideEffects.js
@@ -10,7 +10,7 @@ import { getActiveAccount, getChatScreenParams } from '../selectors';
 import { playMessageSound } from '../utils/sound';
 import { NULL_ARRAY } from '../nullObjects';
 import { ensureTypingStatusExpiryLoop } from '../typing/typingActions';
-import { getOwnUser, getOwnUserId } from '../users/userSelectors';
+import { getOwnUserId } from '../users/userSelectors';
 
 /**
  * React to incoming `MessageEvent`s.
@@ -35,7 +35,7 @@ const messageEvent = (state: GlobalState, message: Message): void => {
     activeAccount
     && narrow !== undefined // chat screen is not at top
     && !isHomeNarrow(narrow)
-    && isMessageInNarrow(message, flags, narrow, getOwnUser(state));
+    && isMessageInNarrow(message, flags, narrow, getOwnUserId(state));
   const isSenderSelf = getOwnUserId(state) === message.sender_id;
   if (!isUserInSameNarrow && !isSenderSelf) {
     playMessageSound();

--- a/src/events/doEventActionSideEffects.js
+++ b/src/events/doEventActionSideEffects.js
@@ -6,11 +6,11 @@ import type { GlobalState, GetState, Dispatch, Message } from '../types';
 import type { EventAction } from '../actionTypes';
 import { EVENT_NEW_MESSAGE, EVENT_TYPING_START } from '../actionConstants';
 import { isHomeNarrow, isMessageInNarrow } from '../utils/narrow';
-import { getActiveAccount, getChatScreenParams, getOwnEmail } from '../selectors';
+import { getActiveAccount, getChatScreenParams } from '../selectors';
 import { playMessageSound } from '../utils/sound';
 import { NULL_ARRAY } from '../nullObjects';
 import { ensureTypingStatusExpiryLoop } from '../typing/typingActions';
-import { getOwnUser } from '../users/userSelectors';
+import { getOwnUser, getOwnUserId } from '../users/userSelectors';
 
 /**
  * React to incoming `MessageEvent`s.
@@ -36,7 +36,7 @@ const messageEvent = (state: GlobalState, message: Message): void => {
     && narrow !== undefined // chat screen is not at top
     && !isHomeNarrow(narrow)
     && isMessageInNarrow(message, flags, narrow, getOwnUser(state));
-  const isSenderSelf = getOwnEmail(state) === message.sender_email;
+  const isSenderSelf = getOwnUserId(state) === message.sender_id;
   if (!isUserInSameNarrow && !isSenderSelf) {
     playMessageSound();
     // Vibration.vibrate();

--- a/src/events/eventToAction.js
+++ b/src/events/eventToAction.js
@@ -32,7 +32,7 @@ import {
   EVENT_SUBSCRIPTION,
   EVENT,
 } from '../actionConstants';
-import { getOwnUser, getOwnUserId, tryGetUserForId } from '../users/userSelectors';
+import { getOwnUserId, tryGetUserForId } from '../users/userSelectors';
 import { AvatarURL } from '../utils/avatar';
 import { getCurrentRealm } from '../account/accountsSelectors';
 
@@ -95,7 +95,7 @@ export default (state: GlobalState, event: $FlowFixMe): EventAction => {
         },
         local_message_id: event.local_message_id,
         caughtUp: state.caughtUp,
-        ownUser: getOwnUser(state),
+        ownUserId: getOwnUserId(state),
       };
 
     // Before server feature level 13, or if we don't specify the

--- a/src/message/messageActionSheet.js
+++ b/src/message/messageActionSheet.js
@@ -340,7 +340,7 @@ export const constructNonHeaderActionButtons = ({
 /** Returns the title for the action sheet. */
 const getActionSheetTitle = (message: Message | Outbox, ownUser: User): string => {
   if (message.type === 'private') {
-    const recipients = pmUiRecipientsFromMessage(message, ownUser);
+    const recipients = pmUiRecipientsFromMessage(message, ownUser.user_id);
     return recipients
       .map(r => r.full_name)
       .sort()

--- a/src/message/messageActionSheet.js
+++ b/src/message/messageActionSheet.js
@@ -61,7 +61,7 @@ type ButtonDescription = {
 //
 
 const reply = ({ message, dispatch, ownUser }) => {
-  dispatch(doNarrow(getNarrowForReply(message, ownUser), message.id));
+  dispatch(doNarrow(getNarrowForReply(message, ownUser.user_id), message.id));
 };
 reply.title = 'Reply';
 reply.errorMessage = 'Failed to reply';

--- a/src/message/messageActionSheet.js
+++ b/src/message/messageActionSheet.js
@@ -307,13 +307,13 @@ export const constructMessageActionButtons = ({
     buttons.push('shareMessage');
   }
   if (
-    message.sender_email === ownUser.email
+    message.sender_id === ownUser.user_id
     // Our "edit message" UI only works in certain kinds of narrows.
     && (isStreamOrTopicNarrow(narrow) || isPmNarrow(narrow))
   ) {
     buttons.push('editMessage');
   }
-  if (message.sender_email === ownUser.email && messageNotDeleted(message)) {
+  if (message.sender_id === ownUser.user_id && messageNotDeleted(message)) {
     buttons.push('deleteMessage');
   }
   if (message.id in flags.starred) {

--- a/src/nullObjects.js
+++ b/src/nullObjects.js
@@ -1,7 +1,5 @@
 /* @flow strict-local */
-import { makeUserId } from './api/idTypes';
-import type { User, Subscription } from './types';
-import { GravatarURL } from './utils/avatar';
+import type { Subscription } from './types';
 
 export const NULL_OBJECT = Object.freeze({});
 
@@ -30,17 +28,6 @@ export const NULL_ARRAY = Object.freeze([]);
  *  * Commit e22596c24 -- throwing an error, in a case that required some
  *    more work to decide that was the right thing.
  */
-
-/** DEPRECATED; don't add new uses.  See block comment above definition. */
-export const NULL_USER: User = {
-  avatar_url: GravatarURL.validateAndConstructInstance({ email: '' }),
-  email: '',
-  full_name: '',
-  is_admin: false,
-  is_bot: false,
-  timezone: '',
-  user_id: makeUserId(-1),
-};
 
 /** DEPRECATED; don't add new uses.  See block comment above definition. */
 export const NULL_SUBSCRIPTION: Subscription = {

--- a/src/pm-conversations/__tests__/pmConversationsSelectors-test.js
+++ b/src/pm-conversations/__tests__/pmConversationsSelectors-test.js
@@ -70,7 +70,7 @@ describe('getRecentConversationsLegacy', () => {
   test('when no messages, return no conversations', () => {
     const state = eg.reduxState({
       accounts,
-      realm: eg.realmState({ email: eg.selfUser.email }),
+      realm: eg.realmState({ user_id: eg.selfUser.user_id }),
       users: [eg.selfUser],
       narrows: Immutable.Map({
         [ALL_PRIVATE_NARROW_STR]: [],
@@ -90,7 +90,7 @@ describe('getRecentConversationsLegacy', () => {
   test('returns unique list of recipients, includes conversations with self', () => {
     const state = eg.reduxState({
       accounts,
-      realm: eg.realmState({ email: eg.selfUser.email }),
+      realm: eg.realmState({ user_id: eg.selfUser.user_id }),
       users: [eg.selfUser, userJohn, userMark],
       narrows: Immutable.Map({
         [ALL_PRIVATE_NARROW_STR]: [0, 1, 2, 3, 4],
@@ -138,7 +138,7 @@ describe('getRecentConversationsLegacy', () => {
   test('returns recipients sorted by last activity', () => {
     const state = eg.reduxState({
       accounts,
-      realm: eg.realmState({ email: eg.selfUser.email }),
+      realm: eg.realmState({ user_id: eg.selfUser.user_id }),
       users: [eg.selfUser, userJohn, userMark],
       narrows: Immutable.Map({
         [ALL_PRIVATE_NARROW_STR]: [1, 2, 3, 4, 5, 6],

--- a/src/pm-conversations/pmConversationsModel.js
+++ b/src/pm-conversations/pmConversationsModel.js
@@ -199,8 +199,8 @@ export function reducer(state: PmConversationsState = initialState, action: Acti
     }
 
     case EVENT_NEW_MESSAGE: {
-      const { message, ownUser } = action;
-      return insertMessage(state, message, ownUser.user_id);
+      const { message, ownUserId } = action;
+      return insertMessage(state, message, ownUserId);
     }
 
     default:

--- a/src/pm-conversations/pmConversationsSelectors.js
+++ b/src/pm-conversations/pmConversationsSelectors.js
@@ -2,9 +2,9 @@
 import invariant from 'invariant';
 import { createSelector } from 'reselect';
 
-import type { GlobalState, Message, PmConversationData, Selector, User } from '../types';
+import type { GlobalState, Message, PmConversationData, Selector } from '../types';
 import { getPrivateMessages } from '../message/messageSelectors';
-import { getAllUsersById, getOwnUser, getOwnUserId } from '../users/userSelectors';
+import { getAllUsersById, getOwnUserId } from '../users/userSelectors';
 import { getUnreadByPms, getUnreadByHuddles } from '../unread/unreadSelectors';
 import {
   pmUnreadsKeyFromMessage,
@@ -30,13 +30,13 @@ function unreadCount(unreadsKey, unreadPms, unreadHuddles): number {
 
 // TODO(server-2.1): Delete this, and simplify logic around it.
 export const getRecentConversationsLegacy: Selector<PmConversationData[]> = createSelector(
-  getOwnUser,
+  getOwnUserId,
   getPrivateMessages,
   getUnreadByPms,
   getUnreadByHuddles,
   getAllUsersById,
   (
-    ownUser: User,
+    ownUserId,
     messages: Message[],
     unreadPms: { [number]: number },
     unreadHuddles: { [string]: number },
@@ -45,8 +45,8 @@ export const getRecentConversationsLegacy: Selector<PmConversationData[]> = crea
     const items = messages
       .map(msg => {
         // Note this can be a different set of users from those in `keyRecipients`.
-        const unreadsKey = pmUnreadsKeyFromMessage(msg, ownUser.user_id);
-        const keyRecipients = pmKeyRecipientUsersFromMessage(msg, allUsersById, ownUser.user_id);
+        const unreadsKey = pmUnreadsKeyFromMessage(msg, ownUserId);
+        const keyRecipients = pmKeyRecipientUsersFromMessage(msg, allUsersById, ownUserId);
         return keyRecipients === null ? null : { unreadsKey, keyRecipients, msgId: msg.id };
       })
       .filter(Boolean);

--- a/src/reactions/MessageReactionList.js
+++ b/src/reactions/MessageReactionList.js
@@ -10,7 +10,7 @@ import ReactionUserList from './ReactionUserList';
 import { connect } from '../react-redux';
 import type { Dispatch, EmojiType, Message, ReactionType, UserId } from '../types';
 import { Screen, Label, RawLabel } from '../common';
-import { getOwnUser } from '../selectors';
+import { getOwnUserId } from '../selectors';
 import aggregateReactions from './aggregateReactions';
 import styles from '../styles';
 import { materialTopTabNavigatorConfig } from '../styles/tabs';
@@ -139,5 +139,5 @@ class MessageReactionList extends PureComponent<Props> {
 export default connect<SelectorProps, _, _>((state, props) => ({
   // message *can* be undefined; see componentDidUpdate for explanation and handling.
   message: state.messages.get(props.route.params.messageId),
-  ownUserId: getOwnUser(state).user_id,
+  ownUserId: getOwnUserId(state),
 }))(MessageReactionList);

--- a/src/sharing/ChooseRecipientsScreen.js
+++ b/src/sharing/ChooseRecipientsScreen.js
@@ -1,6 +1,6 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
-import type { User, Dispatch, UserId } from '../types';
+import type { Dispatch, UserId, UserOrBot } from '../types';
 import { connect } from '../react-redux';
 import { Screen } from '../common';
 import UserPickerCard from '../user-picker/UserPickerCard';
@@ -21,7 +21,7 @@ class ChooseRecipientsScreen extends PureComponent<Props, State> {
 
   handleFilterChange = (filter: string) => this.setState({ filter });
 
-  handleComplete = (selected: Array<User>) => {
+  handleComplete = (selected: Array<UserOrBot>) => {
     const { onComplete } = this.props;
     onComplete(selected.map(u => u.user_id));
   };

--- a/src/streams/InviteUsersScreen.js
+++ b/src/streams/InviteUsersScreen.js
@@ -3,7 +3,7 @@ import React, { PureComponent } from 'react';
 
 import type { AppNavigationProp, AppNavigationRouteProp } from '../nav/AppNavigator';
 import * as NavigationService from '../nav/NavigationService';
-import type { Auth, Dispatch, Stream, User } from '../types';
+import type { Auth, Dispatch, Stream, UserOrBot } from '../types';
 import { connect } from '../react-redux';
 import { Screen } from '../common';
 import { navigateBack } from '../actions';
@@ -35,7 +35,7 @@ class InviteUsersScreen extends PureComponent<Props, State> {
 
   handleFilterChange = (filter: string) => this.setState({ filter });
 
-  handleInviteUsers = (selected: User[]) => {
+  handleInviteUsers = (selected: UserOrBot[]) => {
     const { auth, stream } = this.props;
 
     const recipients = selected.map(user => user.email);

--- a/src/typing/typingSelectors.js
+++ b/src/typing/typingSelectors.js
@@ -5,7 +5,7 @@ import type { Narrow, Selector, UserOrBot } from '../types';
 import { getTyping } from '../directSelectors';
 import { userIdsOfPmNarrow, isPmNarrow } from '../utils/narrow';
 import { pmTypingKeyFromPmKeyIds } from '../utils/recipient';
-import { NULL_ARRAY, NULL_USER } from '../nullObjects';
+import { NULL_ARRAY } from '../nullObjects';
 import { getAllUsersById } from '../users/userSelectors';
 
 export const getCurrentTypingUsers: Selector<$ReadOnlyArray<UserOrBot>, Narrow> = createSelector(
@@ -24,6 +24,6 @@ export const getCurrentTypingUsers: Selector<$ReadOnlyArray<UserOrBot>, Narrow> 
       return NULL_ARRAY;
     }
 
-    return currentTyping.userIds.map(userId => allUsersById.get(userId) || NULL_USER);
+    return currentTyping.userIds.map(userId => allUsersById.get(userId)).filter(Boolean);
   },
 );

--- a/src/unread/__tests__/unreadHuddlesReducer-test.js
+++ b/src/unread/__tests__/unreadHuddlesReducer-test.js
@@ -134,7 +134,7 @@ describe('unreadHuddlesReducer', () => {
         type: EVENT_NEW_MESSAGE,
         ...eg.eventNewMessageActionBase,
         message: message2,
-        ownUser: selfUser,
+        ownUserId: selfUser.user_id,
       });
 
       const actualState = unreadHuddlesReducer(initialState, action);

--- a/src/unread/__tests__/unreadPmsReducer-test.js
+++ b/src/unread/__tests__/unreadPmsReducer-test.js
@@ -121,7 +121,7 @@ describe('unreadPmsReducer', () => {
       const action = deepFreeze({
         ...eg.eventNewMessageActionBase,
         message: message1,
-        ownUser: eg.selfUser,
+        ownUserId: eg.selfUser.user_id,
       });
 
       const actualState = unreadPmsReducer(initialState, action);

--- a/src/unread/unreadHuddlesReducer.js
+++ b/src/unread/unreadHuddlesReducer.js
@@ -24,7 +24,7 @@ const eventNewMessage = (state, action) => {
     return state;
   }
 
-  if (action.ownUser.user_id === action.message.sender_id) {
+  if (action.ownUserId === action.message.sender_id) {
     return state;
   }
 

--- a/src/unread/unreadHuddlesReducer.js
+++ b/src/unread/unreadHuddlesReducer.js
@@ -24,7 +24,7 @@ const eventNewMessage = (state, action) => {
     return state;
   }
 
-  if (action.ownUser.email && action.ownUser.email === action.message.sender_email) {
+  if (action.ownUser.user_id === action.message.sender_id) {
     return state;
   }
 

--- a/src/unread/unreadPmsReducer.js
+++ b/src/unread/unreadPmsReducer.js
@@ -24,7 +24,7 @@ const eventNewMessage = (state, action) => {
     return state;
   }
 
-  if (action.ownUser.user_id === action.message.sender_id) {
+  if (action.ownUserId === action.message.sender_id) {
     return state;
   }
 

--- a/src/unread/unreadPmsReducer.js
+++ b/src/unread/unreadPmsReducer.js
@@ -24,7 +24,7 @@ const eventNewMessage = (state, action) => {
     return state;
   }
 
-  if (action.ownUser.email && action.ownUser.email === action.message.sender_email) {
+  if (action.ownUser.user_id === action.message.sender_id) {
     return state;
   }
 

--- a/src/unread/unreadStreamsReducer.js
+++ b/src/unread/unreadStreamsReducer.js
@@ -19,7 +19,7 @@ const eventNewMessage = (state, action) => {
     return state;
   }
 
-  if (action.ownUser.email && action.ownUser.email === action.message.sender_email) {
+  if (action.ownUser.user_id === action.message.sender_id) {
     return state;
   }
 

--- a/src/unread/unreadStreamsReducer.js
+++ b/src/unread/unreadStreamsReducer.js
@@ -19,7 +19,7 @@ const eventNewMessage = (state, action) => {
     return state;
   }
 
-  if (action.ownUser.user_id === action.message.sender_id) {
+  if (action.ownUserId === action.message.sender_id) {
     return state;
   }
 

--- a/src/user-groups/CreateGroupScreen.js
+++ b/src/user-groups/CreateGroupScreen.js
@@ -3,7 +3,7 @@ import React, { PureComponent } from 'react';
 
 import type { AppNavigationProp, AppNavigationRouteProp } from '../nav/AppNavigator';
 import * as NavigationService from '../nav/NavigationService';
-import type { Dispatch, User, UserId } from '../types';
+import type { Dispatch, UserId, UserOrBot } from '../types';
 import { connect } from '../react-redux';
 import { Screen } from '../common';
 import { doNarrow, navigateBack } from '../actions';
@@ -35,7 +35,7 @@ class CreateGroupScreen extends PureComponent<Props, State> {
 
   handleFilterChange = (filter: string) => this.setState({ filter });
 
-  handleCreateGroup = (selected: User[]) => {
+  handleCreateGroup = (selected: UserOrBot[]) => {
     const { dispatch, ownUserId } = this.props;
     NavigationService.dispatch(navigateBack());
     dispatch(doNarrow(pmNarrowFromUsers(pmKeyRecipientsFromUsers(selected, ownUserId))));

--- a/src/user-picker/AvatarItem.js
+++ b/src/user-picker/AvatarItem.js
@@ -2,6 +2,7 @@
 import React, { PureComponent } from 'react';
 import { Animated, Easing, View } from 'react-native';
 
+import type { UserId } from '../types';
 import { UserAvatarWithPresence, ComponentWithOverlay, RawLabel, Touchable } from '../common';
 import { createStyleSheet } from '../styles';
 import { IconCancel } from '../common/Icons';
@@ -27,10 +28,11 @@ const styles = createStyleSheet({
 });
 
 type Props = $ReadOnly<{|
+  userId: UserId,
   email: string,
   avatarUrl: AvatarURL,
   fullName: string,
-  onPress: (email: string) => void,
+  onPress: UserId => void,
 |}>;
 
 /**
@@ -54,13 +56,13 @@ export default class AvatarItem extends PureComponent<Props> {
   }
 
   handlePress = () => {
-    const { email, onPress } = this.props;
+    const { userId, onPress } = this.props;
     Animated.timing(this.animatedValue, {
       toValue: 0,
       duration: 300,
       useNativeDriver: true,
       easing: Easing.elastic(),
-    }).start(() => onPress(email));
+    }).start(() => onPress(userId));
   };
 
   render() {

--- a/src/user-picker/AvatarItem.js
+++ b/src/user-picker/AvatarItem.js
@@ -2,11 +2,10 @@
 import React, { PureComponent } from 'react';
 import { Animated, Easing, View } from 'react-native';
 
-import type { UserId } from '../types';
+import type { UserId, UserOrBot } from '../types';
 import { UserAvatarWithPresence, ComponentWithOverlay, RawLabel, Touchable } from '../common';
 import { createStyleSheet } from '../styles';
 import { IconCancel } from '../common/Icons';
-import { AvatarURL } from '../utils/avatar';
 
 const styles = createStyleSheet({
   wrapper: {
@@ -28,20 +27,12 @@ const styles = createStyleSheet({
 });
 
 type Props = $ReadOnly<{|
-  userId: UserId,
-  email: string,
-  avatarUrl: AvatarURL,
-  fullName: string,
+  user: UserOrBot,
   onPress: UserId => void,
 |}>;
 
 /**
  * Pressable avatar for items in the user-picker card.
- *
- * @prop [email]
- * @prop [avatarUrl]
- * @prop [fullName]
- * @prop [onPress]
  */
 export default class AvatarItem extends PureComponent<Props> {
   animatedValue = new Animated.Value(0);
@@ -56,21 +47,21 @@ export default class AvatarItem extends PureComponent<Props> {
   }
 
   handlePress = () => {
-    const { userId, onPress } = this.props;
+    const { user, onPress } = this.props;
     Animated.timing(this.animatedValue, {
       toValue: 0,
       duration: 300,
       useNativeDriver: true,
       easing: Easing.elastic(),
-    }).start(() => onPress(userId));
+    }).start(() => onPress(user.user_id));
   };
 
   render() {
-    const { email, avatarUrl, fullName } = this.props;
+    const { user } = this.props;
     const animatedStyle = {
       transform: [{ scale: this.animatedValue }],
     };
-    const firstName = fullName.trim().split(' ')[0];
+    const firstName = user.full_name.trim().split(' ')[0];
 
     return (
       <Animated.View style={[styles.wrapper, animatedStyle]}>
@@ -81,7 +72,12 @@ export default class AvatarItem extends PureComponent<Props> {
             overlayPosition="bottom-right"
             overlay={<IconCancel color="gray" size={20} />}
           >
-            <UserAvatarWithPresence key={email} size={50} avatarUrl={avatarUrl} email={email} />
+            <UserAvatarWithPresence
+              key={user.user_id}
+              size={50}
+              avatarUrl={user.avatar_url}
+              email={user.email}
+            />
           </ComponentWithOverlay>
         </Touchable>
         <View style={styles.textFrame}>

--- a/src/user-picker/AvatarList.js
+++ b/src/user-picker/AvatarList.js
@@ -2,12 +2,12 @@
 import React, { PureComponent } from 'react';
 import { FlatList } from 'react-native';
 
-import type { User } from '../types';
+import type { UserOrBot } from '../types';
 import AvatarItem from './AvatarItem';
 
 type Props = $ReadOnly<{|
-  users: User[],
-  listRef: (component: FlatList<User> | null) => void,
+  users: UserOrBot[],
+  listRef: (component: FlatList<UserOrBot> | null) => void,
   onPress: (email: string) => void,
 |}>;
 
@@ -21,7 +21,7 @@ export default class AvatarList extends PureComponent<Props> {
         showsHorizontalScrollIndicator={false}
         initialNumToRender={20}
         data={users}
-        ref={(component: FlatList<User> | null) => {
+        ref={(component: FlatList<UserOrBot> | null) => {
           if (listRef) {
             listRef(component);
           }

--- a/src/user-picker/AvatarList.js
+++ b/src/user-picker/AvatarList.js
@@ -2,13 +2,13 @@
 import React, { PureComponent } from 'react';
 import { FlatList } from 'react-native';
 
-import type { UserOrBot } from '../types';
+import type { UserId, UserOrBot } from '../types';
 import AvatarItem from './AvatarItem';
 
 type Props = $ReadOnly<{|
   users: UserOrBot[],
   listRef: (component: FlatList<UserOrBot> | null) => void,
-  onPress: (email: string) => void,
+  onPress: UserId => void,
 |}>;
 
 export default class AvatarList extends PureComponent<Props> {
@@ -29,6 +29,7 @@ export default class AvatarList extends PureComponent<Props> {
         keyExtractor={item => item.email}
         renderItem={({ item }) => (
           <AvatarItem
+            userId={item.user_id}
             email={item.email}
             avatarUrl={item.avatar_url}
             fullName={item.full_name}

--- a/src/user-picker/AvatarList.js
+++ b/src/user-picker/AvatarList.js
@@ -26,16 +26,8 @@ export default class AvatarList extends PureComponent<Props> {
             listRef(component);
           }
         }}
-        keyExtractor={item => item.email}
-        renderItem={({ item }) => (
-          <AvatarItem
-            userId={item.user_id}
-            email={item.email}
-            avatarUrl={item.avatar_url}
-            fullName={item.full_name}
-            onPress={onPress}
-          />
-        )}
+        keyExtractor={user => String(user.user_id)}
+        renderItem={({ item: user }) => <AvatarItem user={user} onPress={onPress} />}
       />
     );
   }

--- a/src/user-picker/UserPickerCard.js
+++ b/src/user-picker/UserPickerCard.js
@@ -2,9 +2,9 @@
 import React, { PureComponent } from 'react';
 import { View } from 'react-native';
 import type { FlatList } from 'react-native';
-
 import { createSelector } from 'reselect';
-import type { User, UserOrBot, PresenceState, Selector, Dispatch } from '../types';
+
+import type { User, UserId, UserOrBot, PresenceState, Selector, Dispatch } from '../types';
 import { createStyleSheet } from '../styles';
 import { connect } from '../react-redux';
 import { FloatingActionButton, LineSeparator } from '../common';
@@ -56,9 +56,9 @@ class UserPickerCard extends PureComponent<Props, State> {
     });
   };
 
-  handleUserDeselect = (email: string) => {
+  handleUserDeselect = (userId: UserId) => {
     this.setState(state => ({
-      selected: state.selected.filter(x => x.email !== email),
+      selected: state.selected.filter(x => x.user_id !== userId),
     }));
   };
 

--- a/src/user-picker/UserPickerCard.js
+++ b/src/user-picker/UserPickerCard.js
@@ -43,28 +43,21 @@ class UserPickerCard extends PureComponent<Props, State> {
 
   listRef: ?FlatList<UserOrBot>;
 
-  handleUserSelect = (user: UserOrBot) => {
-    const { selected } = this.state;
-    this.setState({
-      selected: [...selected, user],
-    });
-  };
-
   handleUserPress = (user: UserOrBot) => {
-    const { selected } = this.state;
-    if (selected.find(x => x.email === user.email)) {
-      this.handleUserDeselect(user.email);
-    } else {
-      this.handleUserSelect(user);
-    }
+    this.setState(state => {
+      const { selected } = state;
+      if (selected.find(x => x.email === user.email)) {
+        return { selected: selected.filter(x => x.email !== user.email) };
+      } else {
+        return { selected: [...selected, user] };
+      }
+    });
   };
 
   handleUserDeselect = (email: string) => {
-    const { selected } = this.state;
-
-    this.setState({
-      selected: selected.filter(x => x.email !== email),
-    });
+    this.setState(state => ({
+      selected: state.selected.filter(x => x.email !== email),
+    }));
   };
 
   handleComplete = () => {

--- a/src/user-picker/UserPickerCard.js
+++ b/src/user-picker/UserPickerCard.js
@@ -11,7 +11,7 @@ import { IconDone } from '../common/Icons';
 import UserList from '../users/UserList';
 import AvatarList from './AvatarList';
 import AnimatedScaleComponent from '../animation/AnimatedScaleComponent';
-import { getPresence, getUsersSansMe, getAllUsersByEmail } from '../selectors';
+import { getPresence, getUsersSansMe } from '../selectors';
 
 const styles = createStyleSheet({
   wrapper: {
@@ -27,7 +27,6 @@ const styles = createStyleSheet({
 type Props = $ReadOnly<{|
   dispatch: Dispatch,
   users: User[],
-  allUsersByEmail: Map<string, UserOrBot>,
   presences: PresenceState,
   filter: string,
   onComplete: (selected: UserOrBot[]) => void,
@@ -44,16 +43,11 @@ class UserPickerCard extends PureComponent<Props, State> {
 
   listRef: ?FlatList<UserOrBot>;
 
-  handleUserSelect = (email: string) => {
-    const { allUsersByEmail } = this.props;
+  handleUserSelect = (user: UserOrBot) => {
     const { selected } = this.state;
-
-    const user = allUsersByEmail.get(email);
-    if (user) {
-      this.setState({
-        selected: [...selected, user],
-      });
-    }
+    this.setState({
+      selected: [...selected, user],
+    });
   };
 
   handleUserPress = (user: UserOrBot) => {
@@ -61,7 +55,7 @@ class UserPickerCard extends PureComponent<Props, State> {
     if (selected.find(x => x.email === user.email)) {
       this.handleUserDeselect(user.email);
     } else {
-      this.handleUserSelect(user.email);
+      this.handleUserSelect(user);
     }
   };
 
@@ -123,6 +117,5 @@ class UserPickerCard extends PureComponent<Props, State> {
 
 export default connect(state => ({
   users: getUsersSansMe(state),
-  allUsersByEmail: getAllUsersByEmail(state),
   presences: getPresence(state),
 }))(UserPickerCard);

--- a/src/user-picker/UserPickerCard.js
+++ b/src/user-picker/UserPickerCard.js
@@ -11,7 +11,7 @@ import { IconDone } from '../common/Icons';
 import UserList from '../users/UserList';
 import AvatarList from './AvatarList';
 import AnimatedScaleComponent from '../animation/AnimatedScaleComponent';
-import { getPresence, getUsersSansMe, getUsersByEmail } from '../selectors';
+import { getPresence, getUsersSansMe, getAllUsersByEmail } from '../selectors';
 
 const styles = createStyleSheet({
   wrapper: {
@@ -27,14 +27,14 @@ const styles = createStyleSheet({
 type Props = $ReadOnly<{|
   dispatch: Dispatch,
   users: User[],
-  usersByEmail: Map<string, User>,
+  allUsersByEmail: Map<string, UserOrBot>,
   presences: PresenceState,
   filter: string,
-  onComplete: (selected: User[]) => void,
+  onComplete: (selected: UserOrBot[]) => void,
 |}>;
 
 type State = {|
-  selected: User[],
+  selected: UserOrBot[],
 |};
 
 class UserPickerCard extends PureComponent<Props, State> {
@@ -42,13 +42,13 @@ class UserPickerCard extends PureComponent<Props, State> {
     selected: [],
   };
 
-  listRef: ?FlatList<User>;
+  listRef: ?FlatList<UserOrBot>;
 
   handleUserSelect = (email: string) => {
-    const { usersByEmail } = this.props;
+    const { allUsersByEmail } = this.props;
     const { selected } = this.state;
 
-    const user = usersByEmail.get(email);
+    const user = allUsersByEmail.get(email);
     if (user) {
       this.setState({
         selected: [...selected, user],
@@ -123,6 +123,6 @@ class UserPickerCard extends PureComponent<Props, State> {
 
 export default connect(state => ({
   users: getUsersSansMe(state),
-  usersByEmail: getUsersByEmail(state),
+  allUsersByEmail: getAllUsersByEmail(state),
   presences: getPresence(state),
 }))(UserPickerCard);

--- a/src/user-picker/UserPickerCard.js
+++ b/src/user-picker/UserPickerCard.js
@@ -46,8 +46,8 @@ class UserPickerCard extends PureComponent<Props, State> {
   handleUserPress = (user: UserOrBot) => {
     this.setState(state => {
       const { selected } = state;
-      if (selected.find(x => x.email === user.email)) {
-        return { selected: selected.filter(x => x.email !== user.email) };
+      if (selected.find(x => x.user_id === user.user_id)) {
+        return { selected: selected.filter(x => x.user_id !== user.user_id) };
       } else {
         return { selected: [...selected, user] };
       }

--- a/src/user-picker/UserPickerCard.js
+++ b/src/user-picker/UserPickerCard.js
@@ -3,7 +3,8 @@ import React, { PureComponent } from 'react';
 import { View } from 'react-native';
 import type { FlatList } from 'react-native';
 
-import type { User, UserOrBot, PresenceState, Dispatch } from '../types';
+import { createSelector } from 'reselect';
+import type { User, UserOrBot, PresenceState, Selector, Dispatch } from '../types';
 import { createStyleSheet } from '../styles';
 import { connect } from '../react-redux';
 import { FloatingActionButton, LineSeparator } from '../common';
@@ -11,7 +12,8 @@ import { IconDone } from '../common/Icons';
 import UserList from '../users/UserList';
 import AvatarList from './AvatarList';
 import AnimatedScaleComponent from '../animation/AnimatedScaleComponent';
-import { getPresence, getUsersSansMe } from '../selectors';
+import { getUsers, getPresence } from '../selectors';
+import { getOwnEmail } from '../users/userSelectors';
 
 const styles = createStyleSheet({
   wrapper: {
@@ -108,7 +110,15 @@ class UserPickerCard extends PureComponent<Props, State> {
   }
 }
 
+// The users we want to show in this particular UI.
+// We exclude (a) users with `is_active` false; (b) cross-realm bots; (c) self.
+const getUsersToShow: Selector<User[]> = createSelector(
+  getUsers,
+  getOwnEmail,
+  (users, ownEmail) => users.filter(user => user.email !== ownEmail),
+);
+
 export default connect(state => ({
-  users: getUsersSansMe(state),
+  users: getUsersToShow(state),
   presences: getPresence(state),
 }))(UserPickerCard);

--- a/src/user-picker/UserPickerCard.js
+++ b/src/user-picker/UserPickerCard.js
@@ -13,7 +13,7 @@ import UserList from '../users/UserList';
 import AvatarList from './AvatarList';
 import AnimatedScaleComponent from '../animation/AnimatedScaleComponent';
 import { getUsers, getPresence } from '../selectors';
-import { getOwnEmail } from '../users/userSelectors';
+import { getOwnUserId } from '../users/userSelectors';
 
 const styles = createStyleSheet({
   wrapper: {
@@ -114,8 +114,8 @@ class UserPickerCard extends PureComponent<Props, State> {
 // We exclude (a) users with `is_active` false; (b) cross-realm bots; (c) self.
 const getUsersToShow: Selector<User[]> = createSelector(
   getUsers,
-  getOwnEmail,
-  (users, ownEmail) => users.filter(user => user.email !== ownEmail),
+  getOwnUserId,
+  (users, ownUserId) => users.filter(user => user.user_id !== ownUserId),
 );
 
 export default connect(state => ({

--- a/src/user-status/userStatusSelectors.js
+++ b/src/user-status/userStatusSelectors.js
@@ -1,8 +1,7 @@
 /* @flow strict-local */
 import type { GlobalState, Selector, UserId, UserStatus } from '../types';
 import { getUserStatus } from '../directSelectors';
-
-import { getSelfUserDetail } from '../users/userSelectors';
+import { getOwnUserId } from '../users/userSelectors';
 
 /**
  * Extract the user status object for the logged in user.
@@ -10,8 +9,7 @@ import { getSelfUserDetail } from '../users/userSelectors';
  */
 export const getSelfUserStatus: Selector<?UserStatus> = (state: GlobalState) => {
   const userStatus = getUserStatus(state);
-  const selfUserDetail = getSelfUserDetail(state);
-  return userStatus[selfUserDetail.user_id];
+  return userStatus[getOwnUserId(state)];
 };
 
 /**

--- a/src/users/UserItem.js
+++ b/src/users/UserItem.js
@@ -2,7 +2,7 @@
 import React, { type ElementConfig, PureComponent } from 'react';
 import { View } from 'react-native';
 
-import type { UserId, UserOrBot } from '../types';
+import type { UserId } from '../types';
 import { RawLabel, Touchable, UnreadCount } from '../common';
 import { UserAvatarWithPresenceById } from '../common/UserAvatarWithPresence';
 import styles, { createStyleSheet, BRAND_COLOR } from '../styles';
@@ -28,12 +28,12 @@ const componentStyles = createStyleSheet({
   },
 });
 
-type Props = $ReadOnly<{|
-  user: UserOrBot,
+type Props<UserT> = $ReadOnly<{|
+  user: UserT,
   isSelected: boolean,
   showEmail: boolean,
   unreadCount?: number,
-  onPress: UserOrBot => void,
+  onPress: UserT => void,
 |}>;
 
 /**
@@ -46,7 +46,9 @@ type Props = $ReadOnly<{|
  * user, one that doesn't exist in the database.  (But anywhere we're doing
  * that, there's probably a better UI anyway than showing a fake user.)
  */
-export class UserItemRaw extends PureComponent<Props> {
+export class UserItemRaw<
+  UserT: { user_id: UserId, email: string, full_name: string, ... },
+> extends PureComponent<Props<UserT>> {
   static defaultProps = {
     isSelected: false,
     showEmail: false,

--- a/src/users/UserItem.js
+++ b/src/users/UserItem.js
@@ -57,7 +57,8 @@ export class UserItemRaw<
   handlePress = () => {
     const { user, onPress } = this.props;
     // TODO cut this `user.email` condition -- it should never trigger, and
-    //   looks like a fudge for the possibility of data coming from NULL_USER
+    //   looks like a fudge for the possibility of data coming from
+    //   the late NULL_USER
     if (user.email && onPress) {
       onPress(user);
     }

--- a/src/users/UserList.js
+++ b/src/users/UserList.js
@@ -2,7 +2,7 @@
 import React, { PureComponent } from 'react';
 import { SectionList } from 'react-native';
 
-import type { PresenceState, User, UserOrBot } from '../types';
+import type { PresenceState, UserOrBot } from '../types';
 import { createStyleSheet } from '../styles';
 import { SectionHeader, SearchEmptyState } from '../common';
 import UserItem from './UserItem';
@@ -16,8 +16,8 @@ const styles = createStyleSheet({
 
 type Props = $ReadOnly<{|
   filter: string,
-  users: User[],
-  selected: User[],
+  users: $ReadOnlyArray<UserOrBot>,
+  selected: $ReadOnlyArray<UserOrBot>,
   presences: PresenceState,
   onPress: (user: UserOrBot) => void,
 |}>;

--- a/src/users/__tests__/userHelpers-test.js
+++ b/src/users/__tests__/userHelpers-test.js
@@ -40,7 +40,7 @@ describe('filterUserList', () => {
     const users = deepFreeze([user1, user2]);
 
     const shouldMatch = [user1];
-    const filteredUsers = filterUserList(users, '', user2.email);
+    const filteredUsers = filterUserList(users, '', user2.user_id);
     expect(filteredUsers).toEqual(shouldMatch);
   });
 
@@ -62,7 +62,7 @@ describe('getAutocompleteSuggestion', () => {
   test('empty input results in empty list', () => {
     const users = deepFreeze([]);
 
-    const filteredUsers = getAutocompleteSuggestion(users, 'some filter', eg.selfUser.email);
+    const filteredUsers = getAutocompleteSuggestion(users, 'some filter', eg.selfUser.user_id);
     expect(filteredUsers).toBe(users);
   });
 
@@ -83,7 +83,7 @@ describe('getAutocompleteSuggestion', () => {
       },
       someGuyUser,
     ];
-    const filteredUsers = getAutocompleteSuggestion(users, '', meUser.email);
+    const filteredUsers = getAutocompleteSuggestion(users, '', meUser.user_id);
     expect(filteredUsers).toEqual(shouldMatch);
   });
 
@@ -96,7 +96,7 @@ describe('getAutocompleteSuggestion', () => {
     const allUsers = deepFreeze([user1, user2, user3, user4, user5]);
 
     const shouldMatch = [user1, user2, user3, user5];
-    const filteredUsers = getAutocompleteSuggestion(allUsers, 'match', eg.selfUser.email);
+    const filteredUsers = getAutocompleteSuggestion(allUsers, 'match', eg.selfUser.user_id);
     expect(filteredUsers).toEqual(shouldMatch);
   });
 
@@ -136,7 +136,7 @@ describe('getAutocompleteSuggestion', () => {
       user11, // have priority because of 'ma' contains in name
       user4, // email contains 'ma'
     ];
-    const filteredUsers = getAutocompleteSuggestion(allUsers, 'ma', eg.selfUser.email);
+    const filteredUsers = getAutocompleteSuggestion(allUsers, 'ma', eg.selfUser.user_id);
     expect(filteredUsers).toEqual(shouldMatch);
   });
 });
@@ -233,11 +233,11 @@ describe('filterUserStartWith', () => {
     const user3 = { ...eg.makeUser({ name: 'app' }), email: 'p@p.com' };
     const user4 = { ...eg.makeUser({ name: 'Mobile app' }), email: 'p3@p.com' };
     const user5 = { ...eg.makeUser({ name: 'Mac App' }), email: 'p@p2.com' };
-    const user6 = { ...eg.makeUser({ name: 'app' }), email: 'own@example.com' };
-    const users = deepFreeze([user1, user2, user3, user4, user5, user6]);
+    const selfUser = { ...eg.makeUser({ name: 'app' }), email: 'own@example.com' };
+    const users = deepFreeze([user1, user2, user3, user4, user5, selfUser]);
 
     const expectedUsers = [user1, user3];
-    expect(filterUserStartWith(users, 'app', 'own@example.com')).toEqual(expectedUsers);
+    expect(filterUserStartWith(users, 'app', selfUser.user_id)).toEqual(expectedUsers);
   });
 });
 
@@ -249,12 +249,12 @@ describe('filterUserByInitials', () => {
     const user4 = { ...eg.makeUser({ name: 'Mobile Application' }), email: 'p3@p.com' };
     const user5 = { ...eg.makeUser({ name: 'Mac App' }), email: 'p@p2.com' };
     const user6 = { ...eg.makeUser({ name: 'app' }), email: 'p@p.com' };
-    const user7 = { ...eg.makeUser({ name: 'app' }), email: 'own@example.com' };
+    const selfUser = { ...eg.makeUser({ name: 'app' }), email: 'own@example.com' };
 
-    const users = deepFreeze([user1, user2, user3, user4, user5, user6, user7]);
+    const users = deepFreeze([user1, user2, user3, user4, user5, user6, selfUser]);
 
     const expectedUsers = [user4, user5];
-    expect(filterUserByInitials(users, 'ma', 'own@example.com')).toEqual(expectedUsers);
+    expect(filterUserByInitials(users, 'ma', selfUser.user_id)).toEqual(expectedUsers);
   });
 });
 
@@ -304,12 +304,12 @@ describe('filterUserThatContains', () => {
     const user4 = { ...eg.makeUser({ name: 'Mobile app' }), email: 'p3@p.com' };
     const user5 = { ...eg.makeUser({ name: 'Mac App' }), email: 'p@p2.com' };
     const user6 = { ...eg.makeUser({ name: 'app' }), email: 'p@p.com' };
-    const user7 = { ...eg.makeUser({ name: 'app' }), email: 'own@example.com' };
+    const selfUser = { ...eg.makeUser({ name: 'app' }), email: 'own@example.com' };
 
-    const users = deepFreeze([user1, user2, user3, user4, user5, user6, user7]);
+    const users = deepFreeze([user1, user2, user3, user4, user5, user6, selfUser]);
 
     const expectedUsers = [user2, user5];
-    expect(filterUserThatContains(users, 'ma', 'own@example.com')).toEqual(expectedUsers);
+    expect(filterUserThatContains(users, 'ma', selfUser.user_id)).toEqual(expectedUsers);
   });
 });
 
@@ -321,11 +321,11 @@ describe('filterUserMatchesEmail', () => {
     const user4 = { ...eg.makeUser({ name: 'Mobile app' }), email: 'p3@p.com' };
     const user5 = { ...eg.makeUser({ name: 'Mac App' }), email: 'p@p2.com' };
     const user6 = { ...eg.makeUser({ name: 'app' }), email: 'p@p.com' };
-    const user7 = { ...eg.makeUser({ name: 'app' }), email: 'own@example.com' };
+    const selfUser = { ...eg.makeUser({ name: 'app' }), email: 'own@example.com' };
 
-    const users = deepFreeze([user1, user2, user3, user4, user5, user6, user7]);
+    const users = deepFreeze([user1, user2, user3, user4, user5, user6, selfUser]);
     const expectedUsers = [user1];
-    expect(filterUserMatchesEmail(users, 'example', 'own@example.com')).toEqual(expectedUsers);
+    expect(filterUserMatchesEmail(users, 'example', selfUser.user_id)).toEqual(expectedUsers);
   });
 });
 

--- a/src/users/__tests__/userHelpers-test.js
+++ b/src/users/__tests__/userHelpers-test.js
@@ -15,7 +15,6 @@ import {
   groupUsersByStatus,
 } from '../userHelpers';
 import * as eg from '../../__tests__/lib/exampleData';
-import { NULL_USER } from '../../nullObjects';
 
 describe('filterUserList', () => {
   test('empty input results in empty list', () => {
@@ -72,15 +71,7 @@ describe('getAutocompleteSuggestion', () => {
     const users = deepFreeze([someGuyUser, meUser]);
 
     const shouldMatch = [
-      {
-        full_name: 'all',
-        email: '(Notify everyone)',
-        user_id: -1,
-        avatar_url: NULL_USER.avatar_url,
-        timezone: '',
-        is_admin: false,
-        is_bot: false,
-      },
+      { user_id: -1, full_name: 'all', email: '(Notify everyone)' },
       someGuyUser,
     ];
     const filteredUsers = getAutocompleteSuggestion(users, '', meUser.user_id);

--- a/src/users/__tests__/userHelpers-test.js
+++ b/src/users/__tests__/userHelpers-test.js
@@ -22,7 +22,7 @@ describe('filterUserList', () => {
     const users = deepFreeze([]);
 
     const filteredUsers = filterUserList(users, 'some filter');
-    expect(filteredUsers).toBe(users);
+    expect(filteredUsers).toEqual(users);
   });
 
   test('returns same list if no filter', () => {

--- a/src/users/__tests__/userSelectors-test.js
+++ b/src/users/__tests__/userSelectors-test.js
@@ -3,7 +3,6 @@ import {
   getAllUsersByEmail,
   getAllUsersById,
   getUsersById,
-  getUsersSansMe,
   getUserForId,
   getUserIsActive,
 } from '../userSelectors';
@@ -74,16 +73,6 @@ describe('getUsersById', () => {
     const users = [eg.makeUser(), eg.makeUser(), eg.makeUser()];
     const state = eg.reduxState({ users });
     expect(getUsersById(state)).toEqual(new Map(users.map(u => [u.user_id, u])));
-  });
-});
-
-describe('getUsersSansMe', () => {
-  test('returns all users except current user', () => {
-    const state = eg.reduxState({
-      users: [eg.selfUser, eg.otherUser],
-      realm: eg.realmState({ email: eg.selfUser.email }),
-    });
-    expect(getUsersSansMe(state)).toEqual([eg.otherUser]);
   });
 });
 

--- a/src/users/userHelpers.js
+++ b/src/users/userHelpers.js
@@ -1,7 +1,7 @@
 /* @flow strict-local */
 import uniqby from 'lodash.uniqby';
 
-import type { UserPresence, User, UserGroup, PresenceState } from '../types';
+import type { UserPresence, User, UserId, UserGroup, PresenceState } from '../types';
 import { ensureUnreachable } from '../types';
 import { NULL_USER } from '../nullObjects';
 import { statusFromPresence } from '../utils/presence';
@@ -44,11 +44,11 @@ export const sortUserList = (users: User[], presences: PresenceState): User[] =>
       || x1.full_name.toLowerCase().localeCompare(x2.full_name.toLowerCase()),
   );
 
-export const filterUserList = (users: User[], filter: string = '', ownEmail: ?string): User[] =>
+export const filterUserList = (users: User[], filter: string = '', ownUserId: ?UserId): User[] =>
   users.length > 0
     ? users.filter(
         user =>
-          user.email !== ownEmail
+          user.user_id !== ownUserId
           && (filter === ''
             || user.full_name.toLowerCase().includes(filter.toLowerCase())
             || user.email.toLowerCase().includes(filter.toLowerCase())),
@@ -58,20 +58,24 @@ export const filterUserList = (users: User[], filter: string = '', ownEmail: ?st
 export const sortAlphabetically = (users: User[]): User[] =>
   [...users].sort((x1, x2) => x1.full_name.toLowerCase().localeCompare(x2.full_name.toLowerCase()));
 
-export const filterUserStartWith = (users: User[], filter: string = '', ownEmail: string): User[] =>
+export const filterUserStartWith = (
+  users: User[],
+  filter: string = '',
+  ownUserId: UserId,
+): User[] =>
   users.filter(
     user =>
-      user.email !== ownEmail && user.full_name.toLowerCase().startsWith(filter.toLowerCase()),
+      user.user_id !== ownUserId && user.full_name.toLowerCase().startsWith(filter.toLowerCase()),
   );
 
 export const filterUserByInitials = (
   users: User[],
   filter: string = '',
-  ownEmail: string,
+  ownUserId: UserId,
 ): User[] =>
   users.filter(
     user =>
-      user.email !== ownEmail
+      user.user_id !== ownUserId
       && user.full_name
         .replace(/(\s|[a-z])/g, '')
         .toLowerCase()
@@ -81,19 +85,20 @@ export const filterUserByInitials = (
 export const filterUserThatContains = (
   users: User[],
   filter: string = '',
-  ownEmail: string,
+  ownUserId: UserId,
 ): User[] =>
   users.filter(
-    user => user.email !== ownEmail && user.full_name.toLowerCase().includes(filter.toLowerCase()),
+    user =>
+      user.user_id !== ownUserId && user.full_name.toLowerCase().includes(filter.toLowerCase()),
   );
 
 export const filterUserMatchesEmail = (
   users: User[],
   filter: string = '',
-  ownEmail: string,
+  ownUserId: UserId,
 ): User[] =>
   users.filter(
-    user => user.email !== ownEmail && user.email.toLowerCase().includes(filter.toLowerCase()),
+    user => user.user_id !== ownUserId && user.email.toLowerCase().includes(filter.toLowerCase()),
   );
 
 export const getUniqueUsers = (users: User[]): User[] => uniqby(users, 'email');
@@ -107,16 +112,16 @@ export const getUsersAndWildcards = (users: User[]) => [
 export const getAutocompleteSuggestion = (
   users: User[],
   filter: string = '',
-  ownEmail: string,
+  ownUserId: UserId,
 ): User[] => {
   if (users.length === 0) {
     return users;
   }
   const allAutocompleteOptions = getUsersAndWildcards(users);
-  const startWith = filterUserStartWith(allAutocompleteOptions, filter, ownEmail);
-  const initials = filterUserByInitials(allAutocompleteOptions, filter, ownEmail);
-  const contains = filterUserThatContains(allAutocompleteOptions, filter, ownEmail);
-  const matchesEmail = filterUserMatchesEmail(users, filter, ownEmail);
+  const startWith = filterUserStartWith(allAutocompleteOptions, filter, ownUserId);
+  const initials = filterUserByInitials(allAutocompleteOptions, filter, ownUserId);
+  const contains = filterUserThatContains(allAutocompleteOptions, filter, ownUserId);
+  const matchesEmail = filterUserMatchesEmail(users, filter, ownUserId);
   return getUniqueUsers([...startWith, ...initials, ...contains, ...matchesEmail]);
 };
 

--- a/src/users/userHelpers.js
+++ b/src/users/userHelpers.js
@@ -44,16 +44,18 @@ export const sortUserList = (users: User[], presences: PresenceState): User[] =>
       || x1.full_name.toLowerCase().localeCompare(x2.full_name.toLowerCase()),
   );
 
-export const filterUserList = (users: User[], filter: string = '', ownUserId: ?UserId): User[] =>
-  users.length > 0
-    ? users.filter(
-        user =>
-          user.user_id !== ownUserId
-          && (filter === ''
-            || user.full_name.toLowerCase().includes(filter.toLowerCase())
-            || user.email.toLowerCase().includes(filter.toLowerCase())),
-      )
-    : users;
+export const filterUserList = (
+  users: $ReadOnlyArray<User>,
+  filter: string = '',
+  ownUserId: ?UserId,
+): User[] =>
+  users.filter(
+    user =>
+      user.user_id !== ownUserId
+      && (filter === ''
+        || user.full_name.toLowerCase().includes(filter.toLowerCase())
+        || user.email.toLowerCase().includes(filter.toLowerCase())),
+  );
 
 export const sortAlphabetically = (users: User[]): User[] =>
   [...users].sort((x1, x2) => x1.full_name.toLowerCase().localeCompare(x2.full_name.toLowerCase()));

--- a/src/users/userHelpers.js
+++ b/src/users/userHelpers.js
@@ -1,19 +1,19 @@
 /* @flow strict-local */
 import uniqby from 'lodash.uniqby';
 
-import type { UserPresence, User, UserId, UserGroup, PresenceState } from '../types';
+import type { UserPresence, User, UserId, UserGroup, PresenceState, UserOrBot } from '../types';
 import { ensureUnreachable } from '../types';
 import { NULL_USER } from '../nullObjects';
 import { statusFromPresence } from '../utils/presence';
 
 type UsersByStatus = {|
-  active: User[],
-  idle: User[],
-  offline: User[],
-  unavailable: User[],
+  active: UserOrBot[],
+  idle: UserOrBot[],
+  offline: UserOrBot[],
+  unavailable: UserOrBot[],
 |};
 
-export const groupUsersByStatus = (users: User[], presences: PresenceState): UsersByStatus => {
+export const groupUsersByStatus = (users: UserOrBot[], presences: PresenceState): UsersByStatus => {
   const groupedUsers = { active: [], idle: [], offline: [], unavailable: [] };
   users.forEach(user => {
     const status = statusFromPresence(presences[user.email]);
@@ -37,7 +37,7 @@ const statusOrder = (presence: UserPresence): number => {
   }
 };
 
-export const sortUserList = (users: User[], presences: PresenceState): User[] =>
+export const sortUserList = (users: UserOrBot[], presences: PresenceState): UserOrBot[] =>
   [...users].sort(
     (x1, x2) =>
       statusOrder(presences[x1.email]) - statusOrder(presences[x2.email])
@@ -45,10 +45,10 @@ export const sortUserList = (users: User[], presences: PresenceState): User[] =>
   );
 
 export const filterUserList = (
-  users: $ReadOnlyArray<User>,
+  users: $ReadOnlyArray<UserOrBot>,
   filter: string = '',
   ownUserId: ?UserId,
-): User[] =>
+): UserOrBot[] =>
   users.filter(
     user =>
       user.user_id !== ownUserId

--- a/src/users/userSelectors.js
+++ b/src/users/userSelectors.js
@@ -138,14 +138,6 @@ export const getOwnUser = (state: GlobalState): User => {
 export const getSelfUserDetail = (state: GlobalState): User =>
   getUsersById(state).get(getOwnUserId(state)) || NULL_USER;
 
-/** Excludes deactivated users.  See `getAllUsers` for discussion. */
-export const getActiveUsersById: Selector<Map<UserId, UserOrBot>> = createSelector(
-  getUsers,
-  getCrossRealmBots,
-  (users = [], crossRealmBots = []) =>
-    new Map([...users, ...crossRealmBots].map(user => [user.user_id, user])),
-);
-
 /**
  * The user with the given user ID, or null if no such user is known.
  *
@@ -176,6 +168,23 @@ export const getUserForId = (state: GlobalState, userId: UserId): UserOrBot => {
   }
   return user;
 };
+
+/**
+ * DEPRECATED except as a cache private to this module.
+ *
+ * Excludes deactivated users.  See `getAllUsers` for discussion.
+ *
+ * Instead of this selector, use:
+ *  * `getAllUsersById` for data on an arbitrary user
+ *  * `getUserIsActive` for the specific information of whether a user is
+ *    deactivated.
+ */
+const getActiveUsersById: Selector<Map<UserId, UserOrBot>> = createSelector(
+  getUsers,
+  getCrossRealmBots,
+  (users = [], crossRealmBots = []) =>
+    new Map([...users, ...crossRealmBots].map(user => [user.user_id, user])),
+);
 
 /**
  * The value of `is_active` for the given user.

--- a/src/users/userSelectors.js
+++ b/src/users/userSelectors.js
@@ -138,17 +138,6 @@ export const getOwnUser = (state: GlobalState): User => {
 export const getSelfUserDetail = (state: GlobalState): User =>
   getUsersById(state).get(getOwnUserId(state)) || NULL_USER;
 
-/**
- * WARNING: despite the name, only (a) `is_active` users (b) excluding cross-realm bots.
- *
- * See `getAllUsers`.
- */
-export const getUsersSansMe: Selector<User[]> = createSelector(
-  getUsers,
-  getOwnEmail,
-  (users, ownEmail) => users.filter(user => user.email !== ownEmail),
-);
-
 /** Excludes deactivated users.  See `getAllUsers` for discussion. */
 export const getActiveUsersById: Selector<Map<UserId, UserOrBot>> = createSelector(
   getUsers,

--- a/src/users/userSelectors.js
+++ b/src/users/userSelectors.js
@@ -53,6 +53,8 @@ export const getAllUsersByEmail: Selector<Map<string, UserOrBot>> = createSelect
 );
 
 /**
+ * PRIVATE; exported only for tests.
+ *
  * WARNING: despite the name, only (a) `is_active` users (b) excluding cross-realm bots.
  *
  * See `getAllUsersById`, and `getAllUsers` for discussion.
@@ -60,18 +62,6 @@ export const getAllUsersByEmail: Selector<Map<string, UserOrBot>> = createSelect
 export const getUsersById: Selector<Map<UserId, User>> = createSelector(
   getUsers,
   (users = []) => new Map(users.map(user => [user.user_id, user])),
-);
-
-/**
- * WARNING: despite the name, only (a) `is_active` users (b) excluding cross-realm bots.
- *
- * Prefer `getUsersById`; see #3764.
- *
- * See `getAllUsersByEmail`, and `getAllUsers` for discussion.
- */
-export const getUsersByEmail: Selector<Map<string, User>> = createSelector(
-  getUsers,
-  (users = []) => new Map(users.map(user => [user.email, user])),
 );
 
 /**
@@ -131,10 +121,9 @@ export const getOwnEmail = (state: GlobalState): string => {
  * See also `getOwnUserId` and `getOwnEmail`.
  */
 export const getOwnUser = (state: GlobalState): User => {
-  const ownEmail = getOwnEmail(state);
-  const ownUser = getUsersByEmail(state).get(ownEmail);
+  const ownUser = getUsersById(state).get(getOwnUserId(state));
   if (ownUser === undefined) {
-    throw new Error('Have ownEmail, but not found in user data');
+    throw new Error('Have ownUserId, but not found in user data');
   }
   return ownUser;
 };
@@ -147,7 +136,7 @@ export const getOwnUser = (state: GlobalState): User => {
  * For discussion, see `nullObjects.js`.
  */
 export const getSelfUserDetail = (state: GlobalState): User =>
-  getUsersByEmail(state).get(getOwnEmail(state)) || NULL_USER;
+  getUsersById(state).get(getOwnUserId(state)) || NULL_USER;
 
 /**
  * WARNING: despite the name, only (a) `is_active` users (b) excluding cross-realm bots.

--- a/src/users/userSelectors.js
+++ b/src/users/userSelectors.js
@@ -2,7 +2,6 @@
 import { createSelector } from 'reselect';
 
 import type { GlobalState, UserOrBot, Selector, User, UserId } from '../types';
-import { NULL_USER } from '../nullObjects';
 import { getUsers, getCrossRealmBots, getNonActiveUsers } from '../directSelectors';
 
 /**
@@ -127,16 +126,6 @@ export const getOwnUser = (state: GlobalState): User => {
   }
   return ownUser;
 };
-
-/**
- * DEPRECATED; don't add new uses.  Generally, use `getOwnUser` instead.
- *
- * PRs to eliminate the remaining uses of this are welcome.
- *
- * For discussion, see `nullObjects.js`.
- */
-export const getSelfUserDetail = (state: GlobalState): User =>
-  getUsersById(state).get(getOwnUserId(state)) || NULL_USER;
 
 /**
  * The user with the given user ID, or null if no such user is known.

--- a/src/utils/__tests__/narrow-test.js
+++ b/src/utils/__tests__/narrow-test.js
@@ -210,35 +210,32 @@ describe('getNarrowsForMessage', () => {
   /* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["expect", "checkCase"] }] */
   const checkCase = (c: {| label: string, message: Message, expectedNarrows: Narrow[] |}) => {
     test(`${c.label}; no flags`, () => {
-      expect(getNarrowsForMessage(c.message, eg.selfUser, [])).toIncludeSameMembers(
+      expect(getNarrowsForMessage(c.message, eg.selfUser.user_id, [])).toIncludeSameMembers(
         c.expectedNarrows,
       );
     });
 
     test(`${c.label}; starred`, () => {
-      expect(getNarrowsForMessage(c.message, eg.selfUser, ['starred'])).toIncludeSameMembers([
-        ...c.expectedNarrows,
-        STARRED_NARROW,
-      ]);
+      expect(
+        getNarrowsForMessage(c.message, eg.selfUser.user_id, ['starred']),
+      ).toIncludeSameMembers([...c.expectedNarrows, STARRED_NARROW]);
     });
 
     test(`${c.label}; mentioned`, () => {
-      expect(getNarrowsForMessage(c.message, eg.selfUser, ['mentioned'])).toIncludeSameMembers([
-        ...c.expectedNarrows,
-        MENTIONED_NARROW,
-      ]);
+      expect(
+        getNarrowsForMessage(c.message, eg.selfUser.user_id, ['mentioned']),
+      ).toIncludeSameMembers([...c.expectedNarrows, MENTIONED_NARROW]);
     });
 
     test(`${c.label}; wildcard_mentioned`, () => {
-      expect(getNarrowsForMessage(c.message, eg.selfUser, ['mentioned'])).toIncludeSameMembers([
-        ...c.expectedNarrows,
-        MENTIONED_NARROW,
-      ]);
+      expect(
+        getNarrowsForMessage(c.message, eg.selfUser.user_id, ['mentioned']),
+      ).toIncludeSameMembers([...c.expectedNarrows, MENTIONED_NARROW]);
     });
 
     test(`${c.label}; starred, mentioned, and wildcard_mentioned`, () => {
       expect(
-        getNarrowsForMessage(c.message, eg.selfUser, [
+        getNarrowsForMessage(c.message, eg.selfUser.user_id, [
           'starred',
           'mentioned',
           'wildcard_mentioned',
@@ -297,7 +294,7 @@ describe('getNarrowsForMessage', () => {
 
 describe('getNarrowForReply', () => {
   test('for self-PM, returns self-1:1 narrow', () => {
-    expect(getNarrowForReply(eg.pmMessageFromTo(eg.selfUser, []), eg.selfUser)).toEqual(
+    expect(getNarrowForReply(eg.pmMessageFromTo(eg.selfUser, []), eg.selfUser.user_id)).toEqual(
       pm1to1NarrowFromUser(eg.selfUser),
     );
   });
@@ -306,7 +303,7 @@ describe('getNarrowForReply', () => {
     const message = eg.pmMessage();
     const expectedNarrow = pm1to1NarrowFromUser(eg.otherUser);
 
-    const actualNarrow = getNarrowForReply(message, eg.selfUser);
+    const actualNarrow = getNarrowForReply(message, eg.selfUser.user_id);
 
     expect(actualNarrow).toEqual(expectedNarrow);
   });
@@ -315,7 +312,7 @@ describe('getNarrowForReply', () => {
     const message = eg.pmMessageFromTo(eg.otherUser, [eg.selfUser, eg.thirdUser]);
     const expectedNarrow = pmNarrowFromUsersUnsafe([eg.otherUser, eg.thirdUser]);
 
-    const actualNarrow = getNarrowForReply(message, eg.selfUser);
+    const actualNarrow = getNarrowForReply(message, eg.selfUser.user_id);
 
     expect(actualNarrow).toEqual(expectedNarrow);
   });
@@ -324,7 +321,7 @@ describe('getNarrowForReply', () => {
     const message = eg.streamMessage();
     const expectedNarrow = topicNarrow(eg.stream.name, message.subject);
 
-    const actualNarrow = getNarrowForReply(message, eg.selfUser);
+    const actualNarrow = getNarrowForReply(message, eg.selfUser.user_id);
 
     expect(actualNarrow).toEqual(expectedNarrow);
   });

--- a/src/utils/__tests__/narrow-test.js
+++ b/src/utils/__tests__/narrow-test.js
@@ -190,7 +190,7 @@ describe('isMessageInNarrow', () => {
       for (const [messageDescription, expected, message] of cases) {
         test(`${expected ? 'contains' : 'excludes'} ${messageDescription}`, () => {
           expect(
-            isMessageInNarrow(message, message.flags ?? [], narrow, eg.selfUser),
+            isMessageInNarrow(message, message.flags ?? [], narrow, eg.selfUser.user_id),
           ).toBe(expected);
         });
       }

--- a/src/utils/narrow.js
+++ b/src/utils/narrow.js
@@ -502,7 +502,7 @@ export const getNarrowsForMessage = (
 
   if (message.type === 'private') {
     result.push(ALL_PRIVATE_NARROW);
-    result.push(pmNarrowFromRecipients(pmKeyRecipientsFromMessage(message, ownUser)));
+    result.push(pmNarrowFromRecipients(pmKeyRecipientsFromMessage(message, ownUser.user_id)));
   } else {
     const streamName = streamNameOfStreamMessage(message);
     result.push(topicNarrow(streamName, message.subject));
@@ -531,7 +531,7 @@ export const getNarrowsForMessage = (
 //   now that it's free of fiddly details from the Narrow data structure
 export const getNarrowForReply = (message: Message | Outbox, ownUser: User) => {
   if (message.type === 'private') {
-    return pmNarrowFromRecipients(pmKeyRecipientsFromMessage(message, ownUser));
+    return pmNarrowFromRecipients(pmKeyRecipientsFromMessage(message, ownUser.user_id));
   } else {
     const streamName = streamNameOfStreamMessage(message);
     return topicNarrow(streamName, message.subject);

--- a/src/utils/narrow.js
+++ b/src/utils/narrow.js
@@ -1,7 +1,7 @@
 /* @flow strict-local */
 
 import { makeUserId } from '../api/idTypes';
-import type { ApiNarrow, Message, Outbox, User, UserId, UserOrBot } from '../types';
+import type { ApiNarrow, Message, Outbox, UserId, UserOrBot } from '../types';
 import {
   normalizeRecipientsAsUserIdsSansMe,
   pmKeyRecipientsFromMessage,
@@ -437,7 +437,7 @@ export const isMessageInNarrow = (
   message: Message | Outbox,
   flags: $ReadOnlyArray<string>,
   narrow: Narrow,
-  ownUser: User,
+  ownUserId: UserId,
 ): boolean =>
   caseNarrow(narrow, {
     home: () => true,
@@ -453,8 +453,8 @@ export const isMessageInNarrow = (
       const recipients = recipientsOfPrivateMessage(message).map(r => r.id);
       const narrowAsRecipients = ids;
       return (
-        normalizeRecipientsAsUserIdsSansMe(recipients, ownUser.user_id)
-        === normalizeRecipientsAsUserIdsSansMe(narrowAsRecipients, ownUser.user_id)
+        normalizeRecipientsAsUserIdsSansMe(recipients, ownUserId)
+        === normalizeRecipientsAsUserIdsSansMe(narrowAsRecipients, ownUserId)
       );
     },
     starred: () => flags.includes('starred'),

--- a/src/utils/narrow.js
+++ b/src/utils/narrow.js
@@ -492,7 +492,7 @@ export const canSendToNarrow = (narrow: Narrow): boolean =>
  */
 export const getNarrowsForMessage = (
   message: Message | Outbox,
-  ownUser: User,
+  ownUserId: UserId,
   flags: $ReadOnlyArray<string>,
 ): Narrow[] => {
   const result = [];
@@ -502,7 +502,7 @@ export const getNarrowsForMessage = (
 
   if (message.type === 'private') {
     result.push(ALL_PRIVATE_NARROW);
-    result.push(pmNarrowFromRecipients(pmKeyRecipientsFromMessage(message, ownUser.user_id)));
+    result.push(pmNarrowFromRecipients(pmKeyRecipientsFromMessage(message, ownUserId)));
   } else {
     const streamName = streamNameOfStreamMessage(message);
     result.push(topicNarrow(streamName, message.subject));
@@ -529,9 +529,9 @@ export const getNarrowsForMessage = (
  */
 // TODO: probably make this a private local helper of its one caller,
 //   now that it's free of fiddly details from the Narrow data structure
-export const getNarrowForReply = (message: Message | Outbox, ownUser: User) => {
+export const getNarrowForReply = (message: Message | Outbox, ownUserId: UserId) => {
   if (message.type === 'private') {
-    return pmNarrowFromRecipients(pmKeyRecipientsFromMessage(message, ownUser.user_id));
+    return pmNarrowFromRecipients(pmKeyRecipientsFromMessage(message, ownUserId));
   } else {
     const streamName = streamNameOfStreamMessage(message);
     return topicNarrow(streamName, message.subject);

--- a/src/utils/recipient.js
+++ b/src/utils/recipient.js
@@ -4,7 +4,7 @@ import isEqual from 'lodash.isequal';
 
 import { mapOrNull } from '../collections';
 import * as logging from './logging';
-import type { PmRecipientUser, Message, Outbox, User, UserId, UserOrBot } from '../types';
+import type { PmRecipientUser, Message, Outbox, UserId, UserOrBot } from '../types';
 
 /** The stream name a stream message was sent to.  Throws if a PM. */
 export const streamNameOfStreamMessage = (message: Message | Outbox): string => {
@@ -136,12 +136,12 @@ export const normalizeRecipientsAsUserIdsSansMe = (
  */
 export const pmUiRecipientsFromMessage = (
   message: Message | Outbox,
-  ownUser: User,
+  ownUserId: UserId,
 ): $ReadOnlyArray<PmRecipientUser> => {
   if (message.type !== 'private') {
     throw new Error('pmUiRecipientsFromMessage: expected PM, got stream message');
   }
-  return filterRecipients(recipientsOfPrivateMessage(message), ownUser.user_id);
+  return filterRecipients(recipientsOfPrivateMessage(message), ownUserId);
 };
 
 /**
@@ -177,15 +177,12 @@ export const pmUiRecipientsFromMessage = (
 // the server; it's easy enough to do.
 export const pmKeyRecipientsFromMessage = (
   message: Message | Outbox,
-  ownUser: User,
+  ownUserId: UserId,
 ): PmKeyRecipients => {
   if (message.type !== 'private') {
     throw new Error('pmKeyRecipientsFromMessage: expected PM, got stream message');
   }
-  return filterRecipientsAsUserIds(
-    recipientsOfPrivateMessage(message).map(r => r.id),
-    ownUser.user_id,
-  );
+  return filterRecipientsAsUserIds(recipientsOfPrivateMessage(message).map(r => r.id), ownUserId);
 };
 
 /**

--- a/src/webview/html/messageHeaderAsHtml.js
+++ b/src/webview/html/messageHeaderAsHtml.js
@@ -87,11 +87,11 @@ export default (
   }
 
   if (item.type === 'private' && headerStyle === 'full') {
-    const keyRecipients = pmKeyRecipientsFromMessage(item, ownUser);
+    const keyRecipients = pmKeyRecipientsFromMessage(item, ownUser.user_id);
     const narrowObj = pmNarrowFromRecipients(keyRecipients);
     const narrowStr = keyFromNarrow(narrowObj);
 
-    const uiRecipients = pmUiRecipientsFromMessage(item, ownUser);
+    const uiRecipients = pmUiRecipientsFromMessage(item, ownUser.user_id);
     return template`
 <div class="header-wrapper private-header header"
      data-narrow="${base64Utf8Encode(narrowStr)}"


### PR DESCRIPTION
This branch pushes forward several interrelated cleanups to our data on users:
* Convert a lot of the places we use emails to identify users, to use user IDs instead. (This is #3764.)
* Convert most of the places where we use the `getActiveUsersBy*` or `getUsersBy*` maps to instead use the full, `getAllUsersBy*` map. Some of these areas of code have good reasons why they don't ever try to look up a user that won't be in the smaller maps. But it's better to just always use the full map anyway, for two reasons:
  * It's easier to think through and understand the code if we don't have to worry about it crashing, or getting bogus data, if it does for some reason look up one of those other users (like a cross-realm bot, or a deactivated user.) Conversely, we've had bugs in the past where some code was using a smaller map but could in fact perfectly well end up trying to look up a user that wasn't there. (And there might even be some remaining such bugs that this branch fixes; it's hard to tell for sure, which is why it's better not to have to.)
  * Both the smaller maps and the full one are large, and it's wasteful to have several of them around; we need the full map for plenty of things, so it's more efficient to have only the one.
* Eliminate the remaining places where we were using generic bogus data from `NULL_USER`, and then delete that value. Instead, when we can't find data on a user we wanted to operate on, either skip that user or fail at a higher level, as appropriate; and in general, have each spot of code that was using `NULL_USER` instead make explicit choices appropriate for its own context.

At the end of this branch, #3764 is mostly complete; the majority of the remaining references to emails in the codebase are legitimate, mostly for logging in and for displaying in the UI. Of the remaining email-uses that should be eliminated, the most prominent are:
* the presence data;
* various server API calls which either require emails at some server versions we still support, or where we simply haven't yet investigated the options for switching to user IDs and what server version those become available at.
