### PR TITLE
UserItem: Clean up onPress logic a bit

### DIFF
--- a/src/sharing/ShareToPm.js
+++ b/src/sharing/ShareToPm.js
@@ -136,7 +136,7 @@ class ShareToPm extends React.Component<Props, State> {
     }
     const preview = [];
     selectedRecipients.forEach(userId => {
-      preview.push(<UserItem userId={userId} onPress={() => {}} key={userId} />);
+      preview.push(<UserItem userId={userId} key={userId} />);
     });
     return preview;
   };

--- a/src/users/UserItem.js
+++ b/src/users/UserItem.js
@@ -56,10 +56,7 @@ export class UserItemRaw<
 
   handlePress = () => {
     const { user, onPress } = this.props;
-    // TODO cut this `user.email` condition -- it should never trigger, and
-    //   looks like a fudge for the possibility of data coming from
-    //   the late NULL_USER
-    if (user.email && onPress) {
+    if (onPress) {
       onPress(user);
     }
   };

--- a/src/users/UserItem.js
+++ b/src/users/UserItem.js
@@ -33,7 +33,7 @@ type Props<UserT> = $ReadOnly<{|
   isSelected: boolean,
   showEmail: boolean,
   unreadCount?: number,
-  onPress: UserT => void,
+  onPress?: UserT => void,
 |}>;
 
 /**

--- a/src/users/UserItem.js
+++ b/src/users/UserItem.js
@@ -62,12 +62,16 @@ export class UserItemRaw<
   };
 
   render() {
-    const { user, isSelected, unreadCount, showEmail } = this.props;
+    const { user, isSelected, onPress, unreadCount, showEmail } = this.props;
 
     return (
-      <Touchable onPress={this.handlePress}>
+      <Touchable onPress={onPress && this.handlePress}>
         <View style={[styles.listItem, isSelected && componentStyles.selectedRow]}>
-          <UserAvatarWithPresenceById size={48} userId={user.user_id} onPress={this.handlePress} />
+          <UserAvatarWithPresenceById
+            size={48}
+            userId={user.user_id}
+            onPress={onPress && this.handlePress}
+          />
           <View style={componentStyles.textWrapper}>
             <RawLabel
               style={[componentStyles.text, isSelected && componentStyles.selectedText]}


### PR DESCRIPTION
This is a quick followup to #4424, to make the cleanups discussed at https://github.com/zulip/zulip-mobile/pull/4424#discussion_r562757466 .

