### PR TITLE
user: Convert more code to IDs-only, fixing warning-spew in tests

### DIFF
--- a/src/message/messagesActions.js
+++ b/src/message/messagesActions.js
@@ -1,7 +1,7 @@
 /* @flow strict-local */
 import * as NavigationService from '../nav/NavigationService';
 import type { Narrow, Dispatch, GetState } from '../types';
-import { getAuth, getAllUsersById } from '../selectors';
+import { getAuth } from '../selectors';
 import { getMessageIdFromLink, getNarrowFromLink } from '../utils/internalLinks';
 import openLink from '../utils/openLink';
 import { navigateToChat } from '../nav/navActions';
@@ -28,10 +28,9 @@ export const messageLinkPress = (href: string) => async (
 ) => {
   const state = getState();
   const auth = getAuth(state);
-  const allUsersById = getAllUsersById(state);
   const streamsById = getStreamsById(state);
   const ownUserId = getOwnUserId(state);
-  const narrow = getNarrowFromLink(href, auth.realm, allUsersById, streamsById, ownUserId);
+  const narrow = getNarrowFromLink(href, auth.realm, streamsById, ownUserId);
   if (narrow) {
     const anchor = getMessageIdFromLink(href, auth.realm);
     dispatch(doNarrow(narrow, anchor));

--- a/src/notification/index.js
+++ b/src/notification/index.js
@@ -17,7 +17,7 @@ import {
 import { identityOfAuth } from '../account/accountMisc';
 import { fromAPNs } from './extract';
 import { tryParseUrl } from '../utils/url';
-import { pmKeyRecipientsFromIds } from '../utils/recipient';
+import { pmKeyRecipientUsersFromIds } from '../utils/recipient';
 import { makeUserId } from '../api/idTypes';
 
 /**
@@ -109,7 +109,7 @@ export const getNarrowFromNotificationData = (
   }
 
   const ids = data.pm_users.split(',').map(s => makeUserId(parseInt(s, 10)));
-  const users = pmKeyRecipientsFromIds(ids, allUsersById, ownUserId);
+  const users = pmKeyRecipientUsersFromIds(ids, allUsersById, ownUserId);
   return users === null ? null : pmNarrowFromUsers(users);
 };
 

--- a/src/notification/index.js
+++ b/src/notification/index.js
@@ -4,7 +4,7 @@ import NotificationsIOS from 'react-native-notifications';
 
 import type { Notification } from './types';
 import type { Auth, Dispatch, Identity, Narrow, UserId, UserOrBot } from '../types';
-import { topicNarrow, pmNarrowFromUsers, pm1to1NarrowFromUser } from '../utils/narrow';
+import { topicNarrow, pm1to1NarrowFromUser, pmNarrowFromRecipients } from '../utils/narrow';
 import type { JSONable, JSONableDict } from '../utils/jsonable';
 import * as api from '../api';
 import * as logging from '../utils/logging';
@@ -17,7 +17,7 @@ import {
 import { identityOfAuth } from '../account/accountMisc';
 import { fromAPNs } from './extract';
 import { tryParseUrl } from '../utils/url';
-import { pmKeyRecipientUsersFromIds } from '../utils/recipient';
+import { pmKeyRecipientsFromIds } from '../utils/recipient';
 import { makeUserId } from '../api/idTypes';
 
 /**
@@ -86,7 +86,6 @@ export const getAccountFromNotificationData = (
 
 export const getNarrowFromNotificationData = (
   data: Notification,
-  allUsersById: Map<UserId, UserOrBot>,
   allUsersByEmail: Map<string, UserOrBot>,
   ownUserId: UserId,
 ): Narrow | null => {
@@ -109,8 +108,7 @@ export const getNarrowFromNotificationData = (
   }
 
   const ids = data.pm_users.split(',').map(s => makeUserId(parseInt(s, 10)));
-  const users = pmKeyRecipientUsersFromIds(ids, allUsersById, ownUserId);
-  return users === null ? null : pmNarrowFromUsers(users);
+  return pmNarrowFromRecipients(pmKeyRecipientsFromIds(ids, ownUserId));
 };
 
 const getInitialNotification = async (): Promise<Notification | null> => {

--- a/src/notification/notificationActions.js
+++ b/src/notification/notificationActions.js
@@ -14,7 +14,7 @@ import { getAuth, getActiveAccount } from '../selectors';
 import { getSession, getAccounts } from '../directSelectors';
 import { GOT_PUSH_TOKEN, ACK_PUSH_TOKEN, UNACK_PUSH_TOKEN } from '../actionConstants';
 import { identityOfAccount, authOfAccount } from '../account/accountMisc';
-import { getAllUsersByEmail, getAllUsersById, getOwnUserId } from '../users/userSelectors';
+import { getAllUsersByEmail, getOwnUserId } from '../users/userSelectors';
 import { doNarrow } from '../message/messagesActions';
 import { accountSwitch } from '../account/accountActions';
 import { getIdentities } from '../account/accountsSelectors';
@@ -54,7 +54,6 @@ export const narrowToNotification = (data: ?Notification) => (
 
   const narrow = getNarrowFromNotificationData(
     data,
-    getAllUsersById(state),
     getAllUsersByEmail(state),
     getOwnUserId(state),
   );

--- a/src/pm-conversations/pmConversationsSelectors.js
+++ b/src/pm-conversations/pmConversationsSelectors.js
@@ -9,7 +9,7 @@ import { getUnreadByPms, getUnreadByHuddles } from '../unread/unreadSelectors';
 import {
   pmUnreadsKeyFromMessage,
   pmKeyRecipientUsersFromMessage,
-  pmKeyRecipientsFromIds,
+  pmKeyRecipientUsersFromIds,
   pmUnreadsKeyFromPmKeyIds,
 } from '../utils/recipient';
 import { getServerVersion } from '../account/accountsSelectors';
@@ -95,7 +95,7 @@ function getRecentConversationsModernImpl(
   return sorted
     .toSeq()
     .map(recentsKey => {
-      const keyRecipients = pmKeyRecipientsFromIds(
+      const keyRecipients = pmKeyRecipientUsersFromIds(
         model.usersOfKey(recentsKey),
         allUsersById,
         ownUserId,

--- a/src/utils/__tests__/internalLinks-test.js
+++ b/src/utils/__tests__/internalLinks-test.js
@@ -1,6 +1,5 @@
 /* @flow strict-local */
 
-import type { UserId, UserOrBot } from '../../types';
 import { streamNarrow, topicNarrow, pmNarrowFromUsersUnsafe, STARRED_NARROW } from '../narrow';
 import {
   isInternalLink,
@@ -252,9 +251,6 @@ describe('decodeHashComponent', () => {
 
 describe('getNarrowFromLink', () => {
   const [userB, userC] = [eg.makeUser(), eg.makeUser()];
-  const allUsersById: Map<UserId, UserOrBot> = new Map(
-    [eg.selfUser, userB, userC].map(u => [u.user_id, u]),
-  );
 
   const streamGeneral = eg.makeStream({ name: 'general' });
 
@@ -262,7 +258,6 @@ describe('getNarrowFromLink', () => {
     getNarrowFromLink(
       url,
       new URL('https://example.com'),
-      allUsersById,
       new Map(streams.map(s => [s.stream_id, s])),
       eg.selfUser.user_id,
     );
@@ -394,12 +389,6 @@ describe('getNarrowFromLink', () => {
     expect(get(`https://example.com/#narrow/pm-with/${ids}-group`)).toEqual(
       pmNarrowFromUsersUnsafe([userB, userC]),
     );
-  });
-
-  test('if any of the user ids are not found: return null', () => {
-    const otherId = 1 + Math.max(...allUsersById.keys());
-    const ids = `${userB.user_id},${otherId}`;
-    expect(get(`https://example.com/#narrow/pm-with/${ids}-group`)).toEqual(null);
   });
 
   test('on a special link', () => {

--- a/src/utils/__tests__/recipient-test.js
+++ b/src/utils/__tests__/recipient-test.js
@@ -4,7 +4,7 @@ import {
   normalizeRecipientsAsUserIds,
   normalizeRecipientsAsUserIdsSansMe,
   isSameRecipient,
-  pmKeyRecipientsFromIds,
+  pmKeyRecipientUsersFromIds,
 } from '../recipient';
 import * as eg from '../../__tests__/lib/exampleData';
 import { makeUserId } from '../../api/idTypes';
@@ -51,7 +51,7 @@ describe('normalizeRecipientsAsUserIdsSansMe', () => {
   });
 });
 
-describe('pmKeyRecipientsFromIds', () => {
+describe('pmKeyRecipientUsersFromIds', () => {
   const allUsersById = new Map([eg.selfUser, eg.otherUser, eg.thirdUser].map(u => [u.user_id, u]));
   const [self, other, third] = [eg.selfUser, eg.otherUser, eg.thirdUser];
   // prettier-ignore
@@ -67,7 +67,7 @@ describe('pmKeyRecipientsFromIds', () => {
   ]) {
     test(`correct on ${description}`, () => {
       expect(
-        pmKeyRecipientsFromIds(users.map(u => u.user_id), allUsersById, eg.selfUser.user_id),
+        pmKeyRecipientUsersFromIds(users.map(u => u.user_id), allUsersById, eg.selfUser.user_id),
       ).toEqual(expectedSet.sort((a, b) => a.user_id - b.user_id));
     });
   }

--- a/src/utils/internalLinks.js
+++ b/src/utils/internalLinks.js
@@ -1,9 +1,9 @@
 /* @flow strict-local */
 import { addBreadcrumb } from '@sentry/react-native';
 import { makeUserId } from '../api/idTypes';
-import type { Narrow, Stream, UserId, UserOrBot } from '../types';
-import { topicNarrow, streamNarrow, specialNarrow, pmNarrowFromUsers } from './narrow';
-import { pmKeyRecipientUsersFromIds } from './recipient';
+import type { Narrow, Stream, UserId } from '../types';
+import { topicNarrow, streamNarrow, specialNarrow, pmNarrowFromRecipients } from './narrow';
+import { pmKeyRecipientsFromIds } from './recipient';
 
 // TODO: Work out what this does, write a jsdoc for its interface, and
 // reimplement using URL object (not just for the realm)
@@ -153,7 +153,6 @@ const parsePmOperand = operand => {
 export const getNarrowFromLink = (
   url: string,
   realm: URL,
-  allUsersById: Map<UserId, UserOrBot>,
   streamsById: Map<number, Stream>,
   ownUserId: UserId,
 ): Narrow | null => {
@@ -168,8 +167,7 @@ export const getNarrowFromLink = (
       //   else.  In particular this will foil you if, say, you try to give
       //   someone else in the conversation a link to a particular message.
       const ids = parsePmOperand(paths[1]);
-      const users = pmKeyRecipientUsersFromIds(ids, allUsersById, ownUserId);
-      return users === null ? null : pmNarrowFromUsers(users);
+      return pmNarrowFromRecipients(pmKeyRecipientsFromIds(ids, ownUserId));
     }
     case 'topic':
       return topicNarrow(parseStreamOperand(paths[1], streamsById), parseTopicOperand(paths[3]));

--- a/src/utils/internalLinks.js
+++ b/src/utils/internalLinks.js
@@ -3,7 +3,7 @@ import { addBreadcrumb } from '@sentry/react-native';
 import { makeUserId } from '../api/idTypes';
 import type { Narrow, Stream, UserId, UserOrBot } from '../types';
 import { topicNarrow, streamNarrow, specialNarrow, pmNarrowFromUsers } from './narrow';
-import { pmKeyRecipientsFromIds } from './recipient';
+import { pmKeyRecipientUsersFromIds } from './recipient';
 
 // TODO: Work out what this does, write a jsdoc for its interface, and
 // reimplement using URL object (not just for the realm)
@@ -168,7 +168,7 @@ export const getNarrowFromLink = (
       //   else.  In particular this will foil you if, say, you try to give
       //   someone else in the conversation a link to a particular message.
       const ids = parsePmOperand(paths[1]);
-      const users = pmKeyRecipientsFromIds(ids, allUsersById, ownUserId);
+      const users = pmKeyRecipientUsersFromIds(ids, allUsersById, ownUserId);
       return users === null ? null : pmNarrowFromUsers(users);
     }
     case 'topic':

--- a/src/utils/recipient.js
+++ b/src/utils/recipient.js
@@ -147,6 +147,17 @@ export const pmUiRecipientsFromMessage = (
 /**
  * The list of users to identify a PM conversation by in our data structures.
  *
+ * This produces the same list of users as `pmKeyRecipientsFromMessage`,
+ * just from a different form of input.  See there for more discussion.
+ */
+export const pmKeyRecipientsFromIds = (
+  userIds: $ReadOnlyArray<UserId>,
+  ownUserId: UserId,
+): PmKeyRecipients => filterRecipientsAsUserIds(userIds, ownUserId);
+
+/**
+ * The list of users to identify a PM conversation by in our data structures.
+ *
  * This list is sorted by user ID.
  *
  * Typically we go on to take either the emails or user IDs in the result,
@@ -161,10 +172,13 @@ export const pmUiRecipientsFromMessage = (
  *    make keys to identify narrows in general, including stream and topic
  *    narrows.
  *
- *  * `normalizeRecipients`, `normalizeRecipientsSansMe`, and
- *    `pmUnreadsKeyFromMessage`, which do the same job as this function with
- *    slight variations, and which we variously use in different places in
- *    the app.
+ *  * The other `pmKeyRecipients…` functions in this module, which do the
+ *    same computation but with different forms of input and output.
+ *
+ *  * `normalizeRecipientsAsUserIds`, `normalizeRecipientsAsUserIdsSansMe`,
+ *    and `pmUnreadsKeyFromMessage`, which do the same job as this function
+ *    with slight variations, and which we variously use in different places
+ *    in the app.
  *
  *    It would be great to unify on a single version, as the variation is a
  *    possible source of bugs.
@@ -182,7 +196,7 @@ export const pmKeyRecipientsFromMessage = (
   if (message.type !== 'private') {
     throw new Error('pmKeyRecipientsFromMessage: expected PM, got stream message');
   }
-  return filterRecipientsAsUserIds(recipientsOfPrivateMessage(message).map(r => r.id), ownUserId);
+  return pmKeyRecipientsFromIds(recipientsOfPrivateMessage(message).map(r => r.id), ownUserId);
 };
 
 /**

--- a/src/utils/recipient.js
+++ b/src/utils/recipient.js
@@ -196,7 +196,7 @@ export const pmKeyRecipientsFromMessage = (
  *
  * Returns null when a user couldn't be found in the given `allUsersById`.
  */
-export const pmKeyRecipientsFromIds = (
+export const pmKeyRecipientUsersFromIds = (
   userIds: $ReadOnlyArray<UserId>,
   allUsersById: Map<UserId, UserOrBot>,
   ownUserId: UserId,
@@ -208,7 +208,7 @@ export const pmKeyRecipientsFromIds = (
 
   const users = mapOrNull(resultIds, id => allUsersById.get(id));
   if (!users) {
-    logging.warn('pmKeyRecipientsFromIds: missing data on user');
+    logging.warn('pmKeyRecipientUsersFromIds: missing data on user');
     return null;
   }
   return users.sort((a, b) => a.user_id - b.user_id);
@@ -223,7 +223,7 @@ export const pmKeyRecipientUsersFromMessage = (
   ownUserId: UserId,
 ): PmKeyUsers | null => {
   const userIds = recipientsOfPrivateMessage(message).map(r => r.id);
-  return pmKeyRecipientsFromIds(userIds, allUsersById, ownUserId);
+  return pmKeyRecipientUsersFromIds(userIds, allUsersById, ownUserId);
 };
 
 /**


### PR DESCRIPTION
We've had recently a couple of warnings regularly showing up when
running tests.  Generally we should keep our test suite clean of
warning spew, partly to keep our own development experience good
and partly to help us notice new warnings so we can investigate,
in case they're telling us about potential new bugs in the app.

This PR fixes them, by converting a bit more of our code to handle
users purely by ID.  I ended up writing a surprisingly long commit message
for one of these commits, so I'll copy it here just lightly edited:

---

The two warnings are very similar; here's one of them:

```
 PASS  src/notification/__tests__/notification-test.js
  ● Console

    console.warn
      pmKeyRecipientsFromIds: missing data on user

      125 |
      126 |     if (config.enableErrorConsoleLogging) {
    > 127 |       toConsole(event);
          |       ^
      128 |
      129 |       const data = objectEntries(extras)
      130 |         .map(([key, value]) => `    ${key}: ${JSON.stringify(value)}`)

      at Object.<anonymous> (src/utils/logging.js:127:7)
      at pmKeyRecipientsFromIds (src/utils/recipient.js:211:13)
      at getNarrowFromNotificationData (src/notification/index.js:112:53)
      at Object.<anonymous> (src/notification/__tests__/notification-test.js:81:54)
```

This is a warning emitted by our own app code; it says we're trying
to look up data on a user, in order to construct a Narrow object for
a PM conversation involving them, and didn't find them in our
`state.users` data.

And the test that's causing this warning to be emitted turns out to
be... a test specifically for this error case!  In particular, it's
for where this arises as we're trying to construct the Narrow object
for a group-PM conversation a notification came from.  So it's
perfectly appropriate that we have a test exercising that case,
and it will naturally generate a warning log message.

The right way to fix the test would be to have it mock `logging.warn`
and test for the warning instead of letting it spew to the console.
We don't currently have any examples of that, but for past examples
see `git log -p -S logging src/*/__tests__/*.js`.

But we can actually do better than that: this is an edge case that no
longer needs to exist at all.  In this code, we have user IDs as
input, and we're going and looking up these whole UserOrBot objects
in the allUsersById map... but then the only thing we do with them is
pass them straight to pmNarrowFromUsers, which just picks off the
user IDs and ignores the rest of the data.

So we can simplify everything by working purely with the IDs: use a
new helper pmKeyRecipientsFromIds instead of pmKeyRecipientUsersFromIds,
and pass the result to pmNarrowFromRecipients.  That's one less giant
data structure passed around, and one less selector needed by this
code's own caller; and it means this error-case test disappears
entirely, because there is no error case.

Now, what happens if we do get a notification where this error case
would have previously shown up?  The old code would have returned
`null` from getNarrowFromNotificationData, and we would have ignored
the notification from there.  The new code will unsuspectingly return
a Narrow object encoding the list of users the notification gave it,
and we'll attempt to navigate to ChatScreen for that narrow.

(This case can absolutely happen in principle, even with a perfectly
well-behaved server: for example, perhaps a user just signed up and
immediately sent us a PM, and we haven't yet learned about them in
the event queue.  Fundamentally the reason it can happen is that
notifications are independent of the event queue, and don't
participate in its nice atomicity and ordering guarantees.)

Well, that's already a case we've always had to handle for
notifications from stream messages, where we take the stream name
verbatim from the notification without comparing against our data.
And in fact the behavior we have for it is probably a better UX than
the old behavior here: we go ahead and do the navigation, and then
the resulting `ChatScreen` consults the `isNarrowValid` selector,
which does the lookup in our data structures.  When that finds we
don't have the relevant data, `ChatScreen` displays a reasonable
error message.

---

The PR also adds the new recipient-helper in question, and then
fixes the other of the two warnings, which is a very similar story.
