### PR TITLE
Clean up navigation logic (2/x).

### DIFF
--- a/src/chat/ChatScreen.js
+++ b/src/chat/ChatScreen.js
@@ -21,6 +21,7 @@ import { canSendToNarrow } from '../utils/narrow';
 import { getLoading, getSession } from '../directSelectors';
 import { getFetchingForNarrow } from './fetchingSelectors';
 import { getShownMessagesForNarrow, isNarrowValid as getIsNarrowValid } from './narrowsSelectors';
+import { getTitleBackgroundColor } from '../title/titleSelectors';
 
 type Props = $ReadOnly<{|
   navigation: AppNavigationProp<'chat'>,
@@ -112,11 +113,13 @@ export default function ChatScreen(props: Props) {
   const sayNoMessages = haveNoMessages && !isFetching;
   const showComposeBox = canSendToNarrow(narrow) && !showMessagePlaceholders;
 
+  const titleBackgroundColor = useSelector(state => getTitleBackgroundColor(state, narrow));
+
   return (
     <ActionSheetProvider>
       <View style={[componentStyles.screen, { backgroundColor }]}>
         <KeyboardAvoider style={styles.flexed} behavior="padding">
-          <ZulipStatusBar narrow={narrow} />
+          <ZulipStatusBar backgroundColor={titleBackgroundColor} />
           <ChatNavBar narrow={narrow} editMessage={editMessage} />
           <OfflineNotice />
           <UnreadNotice narrow={narrow} />

--- a/src/common/ZulipStatusBar.js
+++ b/src/common/ZulipStatusBar.js
@@ -35,7 +35,7 @@ type SelectorProps = $ReadOnly<{|
 type Props = $ReadOnly<{
   insets: EdgeInsets,
 
-  backgroundColor?: string,
+  backgroundColor: string,
   hidden: boolean,
 
   dispatch: Dispatch,
@@ -48,11 +48,12 @@ type Props = $ReadOnly<{
 class ZulipStatusBar extends PureComponent<Props> {
   static defaultProps = {
     hidden: false,
+    backgroundColor: DEFAULT_TITLE_BACKGROUND_COLOR,
   };
 
   render() {
     const { theme, hidden, insets, orientation } = this.props;
-    const backgroundColor = this.props.backgroundColor ?? DEFAULT_TITLE_BACKGROUND_COLOR;
+    const backgroundColor = this.props.backgroundColor;
     const style = { height: hidden ? 0 : insets.top, backgroundColor };
     const statusBarColor = getStatusBarColor(backgroundColor, theme);
     return (

--- a/src/common/ZulipStatusBar.js
+++ b/src/common/ZulipStatusBar.js
@@ -7,9 +7,9 @@ import { compose } from 'redux';
 import { EdgeInsets } from 'react-native-safe-area-context';
 
 import { withSafeAreaInsets } from '../react-native-safe-area-context';
-import type { Narrow, Orientation, ThemeName, Dispatch } from '../types';
+import type { Orientation, ThemeName, Dispatch } from '../types';
 import { connect } from '../react-redux';
-import { DEFAULT_TITLE_BACKGROUND_COLOR, getTitleBackgroundColor } from '../title/titleSelectors';
+import { DEFAULT_TITLE_BACKGROUND_COLOR } from '../title/titleSelectors';
 import { foregroundColorFromBackground } from '../utils/color';
 import { getSession, getSettings } from '../selectors';
 
@@ -29,7 +29,6 @@ export const getStatusBarStyle = (statusBarColor: string): BarStyle =>
 
 type SelectorProps = $ReadOnly<{|
   theme: ThemeName,
-  narrowTitleBackgroundColor: string,
   orientation: Orientation,
 |}>;
 
@@ -37,7 +36,6 @@ type Props = $ReadOnly<{
   insets: EdgeInsets,
 
   backgroundColor?: string,
-  narrow?: Narrow,
   hidden: boolean,
 
   dispatch: Dispatch,
@@ -45,12 +43,7 @@ type Props = $ReadOnly<{
 }>;
 
 /**
- * Controls the status bar settings depending on platform
- * and current navigation position.
- * If narrowed to a stream or topic the color of the status bar
- * matches that of the stream.
- *
- * @prop [narrow] - Currently active narrow.
+ * Applies `hidden` and `backgroundColor` in platform-specific ways.
  */
 class ZulipStatusBar extends PureComponent<Props> {
   static defaultProps = {
@@ -59,7 +52,7 @@ class ZulipStatusBar extends PureComponent<Props> {
 
   render() {
     const { theme, hidden, insets, orientation } = this.props;
-    const backgroundColor = this.props.backgroundColor ?? this.props.narrowTitleBackgroundColor;
+    const backgroundColor = this.props.backgroundColor ?? DEFAULT_TITLE_BACKGROUND_COLOR;
     const style = { height: hidden ? 0 : insets.top, backgroundColor };
     const statusBarColor = getStatusBarColor(backgroundColor, theme);
     return (
@@ -81,9 +74,6 @@ class ZulipStatusBar extends PureComponent<Props> {
 export default compose(
   connect<SelectorProps, _, _>((state, props) => ({
     theme: getSettings(state).theme,
-    narrowTitleBackgroundColor: props.narrow
-      ? getTitleBackgroundColor(state, props.narrow)
-      : DEFAULT_TITLE_BACKGROUND_COLOR,
     orientation: getSession(state).orientation,
   })),
   withSafeAreaInsets,

--- a/src/common/ZulipStatusBar.js
+++ b/src/common/ZulipStatusBar.js
@@ -81,7 +81,9 @@ class ZulipStatusBar extends PureComponent<Props> {
 export default compose(
   connect<SelectorProps, _, _>((state, props) => ({
     theme: getSettings(state).theme,
-    narrowTitleBackgroundColor: getTitleBackgroundColor(state, props.narrow),
+    narrowTitleBackgroundColor: props.narrow
+      ? getTitleBackgroundColor(state, props.narrow)
+      : DEFAULT_TITLE_BACKGROUND_COLOR,
     orientation: getSession(state).orientation,
   })),
   withSafeAreaInsets,

--- a/src/lightbox/Lightbox.js
+++ b/src/lightbox/Lightbox.js
@@ -59,7 +59,7 @@ export default function Lightbox(props: Props) {
       ? `Shared in #${streamNameOfStreamMessage(message)}`
       : 'Shared with you';
   const resource = getResource(src, auth);
-  const { width, height } = Dimensions.get('window');
+  const { width: windowWidth, height: windowHeight } = Dimensions.get('window');
 
   const animationProps = {
     easing: Easing.bezier(0.075, 0.82, 0.165, 1),
@@ -71,14 +71,14 @@ export default function Lightbox(props: Props) {
     <View style={styles.container}>
       <PhotoView
         source={resource}
-        style={[styles.img, { width }]}
+        style={[styles.img, { width: windowWidth }]}
         resizeMode="contain"
         onTap={handleImagePress}
         onViewTap={handleImagePress}
       />
       <SlideAnimationView
         property="translateY"
-        style={[styles.overlay, styles.header, { width }]}
+        style={[styles.overlay, styles.header, { width: windowWidth }]}
         from={-NAVBAR_SIZE}
         to={0}
         {...animationProps}
@@ -95,9 +95,9 @@ export default function Lightbox(props: Props) {
       </SlideAnimationView>
       <SlideAnimationView
         property="translateY"
-        style={[styles.overlay, { width, bottom: height - 44 }]}
-        from={height}
-        to={height - 44}
+        style={[styles.overlay, { width: windowWidth, bottom: windowHeight - 44 }]}
+        from={windowHeight}
+        to={windowHeight - 44}
         {...animationProps}
       >
         <LightboxFooter

--- a/src/lightbox/Lightbox.js
+++ b/src/lightbox/Lightbox.js
@@ -60,10 +60,6 @@ class Lightbox extends PureComponent<Props, State> {
     }));
   };
 
-  handlePressBack = () => {
-    NavigationService.dispatch(navigateBack());
-  };
-
   render() {
     const { src, message, auth } = this.props;
     const footerMessage =
@@ -96,7 +92,9 @@ class Lightbox extends PureComponent<Props, State> {
           {...animationProps}
         >
           <LightboxHeader
-            onPressBack={this.handlePressBack}
+            onPressBack={() => {
+              NavigationService.dispatch(navigateBack());
+            }}
             timestamp={message.timestamp}
             avatarUrl={message.avatar_url}
             senderName={message.sender_full_name}

--- a/src/lightbox/Lightbox.js
+++ b/src/lightbox/Lightbox.js
@@ -1,6 +1,6 @@
 /* @flow strict-local */
 
-import React, { PureComponent } from 'react';
+import React, { useState, useCallback } from 'react';
 import { View, Dimensions, Easing } from 'react-native';
 import PhotoView from 'react-native-photo-view';
 import { connectActionSheet } from '@expo/react-native-action-sheet';
@@ -45,94 +45,85 @@ type Props = $ReadOnly<{|
   showActionSheetWithOptions: ShowActionSheetWithOptions,
 |}>;
 
-type State = {|
-  movement: 'in' | 'out',
-|};
+function Lightbox(props: Props) {
+  const [movement, setMovement] = useState<'in' | 'out'>('out');
 
-class Lightbox extends PureComponent<Props, State> {
-  state = {
-    movement: 'out',
+  // Pulled out here just because this function is used twice.
+  const handleImagePress = useCallback(() => {
+    setMovement(m => (m === 'out' ? 'in' : 'out'));
+  }, [setMovement]);
+
+  const { src, message, auth } = props;
+  const footerMessage =
+    message.type === 'stream'
+      ? `Shared in #${streamNameOfStreamMessage(message)}`
+      : 'Shared with you';
+  const resource = getResource(src, auth);
+  const { width, height } = Dimensions.get('window');
+
+  const animationProps = {
+    easing: Easing.bezier(0.075, 0.82, 0.165, 1),
+    duration: 300,
+    movement,
   };
 
-  handleImagePress = () => {
-    this.setState(({ movement }, props) => ({
-      movement: movement === 'out' ? 'in' : 'out',
-    }));
-  };
-
-  render() {
-    const { src, message, auth } = this.props;
-    const footerMessage =
-      message.type === 'stream'
-        ? `Shared in #${streamNameOfStreamMessage(message)}`
-        : 'Shared with you';
-    const resource = getResource(src, auth);
-    const { width, height } = Dimensions.get('window');
-
-    const animationProps = {
-      easing: Easing.bezier(0.075, 0.82, 0.165, 1),
-      duration: 300,
-      movement: this.state.movement,
-    };
-
-    return (
-      <View style={styles.container}>
-        <PhotoView
-          source={resource}
-          style={[styles.img, { width }]}
-          resizeMode="contain"
-          onTap={this.handleImagePress}
-          onViewTap={this.handleImagePress}
+  return (
+    <View style={styles.container}>
+      <PhotoView
+        source={resource}
+        style={[styles.img, { width }]}
+        resizeMode="contain"
+        onTap={handleImagePress}
+        onViewTap={handleImagePress}
+      />
+      <SlideAnimationView
+        property="translateY"
+        style={[styles.overlay, styles.header, { width }]}
+        from={-NAVBAR_SIZE}
+        to={0}
+        {...animationProps}
+      >
+        <LightboxHeader
+          onPressBack={() => {
+            NavigationService.dispatch(navigateBack());
+          }}
+          timestamp={message.timestamp}
+          avatarUrl={message.avatar_url}
+          senderName={message.sender_full_name}
+          senderEmail={message.sender_email}
         />
-        <SlideAnimationView
-          property="translateY"
-          style={[styles.overlay, styles.header, { width }]}
-          from={-NAVBAR_SIZE}
-          to={0}
-          {...animationProps}
-        >
-          <LightboxHeader
-            onPressBack={() => {
-              NavigationService.dispatch(navigateBack());
-            }}
-            timestamp={message.timestamp}
-            avatarUrl={message.avatar_url}
-            senderName={message.sender_full_name}
-            senderEmail={message.sender_email}
-          />
-        </SlideAnimationView>
-        <SlideAnimationView
-          property="translateY"
-          style={[styles.overlay, { width, bottom: height - 44 }]}
-          from={height}
-          to={height - 44}
-          {...animationProps}
-        >
-          <LightboxFooter
-            displayMessage={footerMessage}
-            onOptionsPress={() => {
-              const options = constructActionSheetButtons();
-              const cancelButtonIndex = options.length - 1;
-              const { showActionSheetWithOptions } = this.props;
-              showActionSheetWithOptions(
-                {
-                  options,
-                  cancelButtonIndex,
-                },
-                buttonIndex => {
-                  executeActionSheetAction({
-                    title: options[buttonIndex],
-                    src,
-                    auth,
-                  });
-                },
-              );
-            }}
-          />
-        </SlideAnimationView>
-      </View>
-    );
-  }
+      </SlideAnimationView>
+      <SlideAnimationView
+        property="translateY"
+        style={[styles.overlay, { width, bottom: height - 44 }]}
+        from={height}
+        to={height - 44}
+        {...animationProps}
+      >
+        <LightboxFooter
+          displayMessage={footerMessage}
+          onOptionsPress={() => {
+            const options = constructActionSheetButtons();
+            const cancelButtonIndex = options.length - 1;
+            const { showActionSheetWithOptions } = props;
+            showActionSheetWithOptions(
+              {
+                options,
+                cancelButtonIndex,
+              },
+              buttonIndex => {
+                executeActionSheetAction({
+                  title: options[buttonIndex],
+                  src,
+                  auth,
+                });
+              },
+            );
+          }}
+        />
+      </SlideAnimationView>
+    </View>
+  );
 }
 
 export default connectActionSheet(

--- a/src/lightbox/Lightbox.js
+++ b/src/lightbox/Lightbox.js
@@ -83,12 +83,6 @@ class Lightbox extends PureComponent<Props, State> {
     NavigationService.dispatch(navigateBack());
   };
 
-  getAnimationProps = () => ({
-    easing: Easing.bezier(0.075, 0.82, 0.165, 1),
-    duration: 300,
-    movement: this.state.movement,
-  });
-
   render() {
     const { src, message, auth } = this.props;
     const footerMessage =
@@ -97,6 +91,12 @@ class Lightbox extends PureComponent<Props, State> {
         : 'Shared with you';
     const resource = getResource(src, auth);
     const { width, height } = Dimensions.get('window');
+
+    const animationProps = {
+      easing: Easing.bezier(0.075, 0.82, 0.165, 1),
+      duration: 300,
+      movement: this.state.movement,
+    };
 
     return (
       <View style={styles.container}>
@@ -112,7 +112,7 @@ class Lightbox extends PureComponent<Props, State> {
           style={[styles.overlay, styles.header, { width }]}
           from={-NAVBAR_SIZE}
           to={0}
-          {...this.getAnimationProps()}
+          {...animationProps}
         >
           <LightboxHeader
             onPressBack={this.handlePressBack}
@@ -127,7 +127,7 @@ class Lightbox extends PureComponent<Props, State> {
           style={[styles.overlay, { width, bottom: height - 44 }]}
           from={height}
           to={height - 44}
-          {...this.getAnimationProps()}
+          {...animationProps}
         >
           <LightboxFooter displayMessage={footerMessage} onOptionsPress={this.handleOptionsPress} />
         </SlideAnimationView>

--- a/src/lightbox/Lightbox.js
+++ b/src/lightbox/Lightbox.js
@@ -3,11 +3,11 @@
 import React, { useState, useCallback } from 'react';
 import { View, Dimensions, Easing } from 'react-native';
 import PhotoView from 'react-native-photo-view';
-import { connectActionSheet } from '@expo/react-native-action-sheet';
+import { useActionSheet } from '@expo/react-native-action-sheet';
 
 import * as NavigationService from '../nav/NavigationService';
-import type { Auth, Dispatch, Message } from '../types';
-import { connect } from '../react-redux';
+import type { Message } from '../types';
+import { useSelector } from '../react-redux';
 import type { ShowActionSheetWithOptions } from '../message/messageActionSheet';
 import { getAuth } from '../selectors';
 import { getResource } from '../utils/url';
@@ -38,22 +38,22 @@ const styles = createStyleSheet({
 });
 
 type Props = $ReadOnly<{|
-  auth: Auth,
-  dispatch: Dispatch,
   src: string,
   message: Message,
-  showActionSheetWithOptions: ShowActionSheetWithOptions,
 |}>;
 
-function Lightbox(props: Props) {
+export default function Lightbox(props: Props) {
   const [movement, setMovement] = useState<'in' | 'out'>('out');
+  const showActionSheetWithOptions: ShowActionSheetWithOptions = useActionSheet()
+    .showActionSheetWithOptions;
+  const auth = useSelector(getAuth);
 
   // Pulled out here just because this function is used twice.
   const handleImagePress = useCallback(() => {
     setMovement(m => (m === 'out' ? 'in' : 'out'));
   }, [setMovement]);
 
-  const { src, message, auth } = props;
+  const { src, message } = props;
   const footerMessage =
     message.type === 'stream'
       ? `Shared in #${streamNameOfStreamMessage(message)}`
@@ -105,7 +105,6 @@ function Lightbox(props: Props) {
           onOptionsPress={() => {
             const options = constructActionSheetButtons();
             const cancelButtonIndex = options.length - 1;
-            const { showActionSheetWithOptions } = props;
             showActionSheetWithOptions(
               {
                 options,
@@ -125,9 +124,3 @@ function Lightbox(props: Props) {
     </View>
   );
 }
-
-export default connectActionSheet(
-  connect(state => ({
-    auth: getAuth(state),
-  }))(Lightbox),
-);

--- a/src/lightbox/Lightbox.js
+++ b/src/lightbox/Lightbox.js
@@ -60,25 +60,6 @@ class Lightbox extends PureComponent<Props, State> {
     }));
   };
 
-  handleOptionsPress = () => {
-    const options = constructActionSheetButtons();
-    const cancelButtonIndex = options.length - 1;
-    const { showActionSheetWithOptions, src, auth } = this.props;
-    showActionSheetWithOptions(
-      {
-        options,
-        cancelButtonIndex,
-      },
-      buttonIndex => {
-        executeActionSheetAction({
-          title: options[buttonIndex],
-          src,
-          auth,
-        });
-      },
-    );
-  };
-
   handlePressBack = () => {
     NavigationService.dispatch(navigateBack());
   };
@@ -129,7 +110,27 @@ class Lightbox extends PureComponent<Props, State> {
           to={height - 44}
           {...animationProps}
         >
-          <LightboxFooter displayMessage={footerMessage} onOptionsPress={this.handleOptionsPress} />
+          <LightboxFooter
+            displayMessage={footerMessage}
+            onOptionsPress={() => {
+              const options = constructActionSheetButtons();
+              const cancelButtonIndex = options.length - 1;
+              const { showActionSheetWithOptions } = this.props;
+              showActionSheetWithOptions(
+                {
+                  options,
+                  cancelButtonIndex,
+                },
+                buttonIndex => {
+                  executeActionSheetAction({
+                    title: options[buttonIndex],
+                    src,
+                    auth,
+                  });
+                },
+              );
+            }}
+          />
         </SlideAnimationView>
       </View>
     );

--- a/src/lightbox/LightboxScreen.js
+++ b/src/lightbox/LightboxScreen.js
@@ -1,5 +1,5 @@
 /* @flow strict-local */
-import React, { PureComponent } from 'react';
+import React from 'react';
 import { View } from 'react-native';
 import { ActionSheetProvider } from '@expo/react-native-action-sheet';
 
@@ -22,16 +22,14 @@ type Props = $ReadOnly<{|
   route: AppNavigationRouteProp<'lightbox'>,
 |}>;
 
-export default class LightboxScreen extends PureComponent<Props> {
-  render() {
-    const { src, message } = this.props.route.params;
-    return (
-      <View style={styles.screen}>
-        <ZulipStatusBar hidden backgroundColor="black" />
-        <ActionSheetProvider>
-          <Lightbox src={src} message={message} />
-        </ActionSheetProvider>
-      </View>
-    );
-  }
+export default function LightboxScreen(props: Props) {
+  const { src, message } = props.route.params;
+  return (
+    <View style={styles.screen}>
+      <ZulipStatusBar hidden backgroundColor="black" />
+      <ActionSheetProvider>
+        <Lightbox src={src} message={message} />
+      </ActionSheetProvider>
+    </View>
+  );
 }

--- a/src/nav/ChatNavBar.js
+++ b/src/nav/ChatNavBar.js
@@ -1,12 +1,12 @@
 /* @flow strict-local */
 
-import React, { PureComponent } from 'react';
+import React from 'react';
 import { View } from 'react-native';
 import Color from 'color';
 
-import type { Dispatch, Narrow, EditMessage } from '../types';
+import type { Narrow, EditMessage } from '../types';
 import { LoadingBanner } from '../common';
-import { connect } from '../react-redux';
+import { useSelector } from '../react-redux';
 import { BRAND_COLOR, NAVBAR_SIZE } from '../styles';
 import Title from '../title/Title';
 import NavBarBackButton from './NavBarBackButton';
@@ -14,65 +14,53 @@ import { DEFAULT_TITLE_BACKGROUND_COLOR, getTitleBackgroundColor } from '../titl
 import { foregroundColorFromBackground } from '../utils/color';
 import { ExtraButton, InfoButton } from '../title-buttons/titleButtonFromNarrow';
 
-type SelectorProps = {|
-  backgroundColor: string,
-|};
-
 type Props = $ReadOnly<{|
   narrow: Narrow,
   editMessage: EditMessage | null,
-
-  dispatch: Dispatch,
-  ...SelectorProps,
 |}>;
 
-class ChatNavBar extends PureComponent<Props> {
-  render() {
-    const { backgroundColor, narrow, editMessage } = this.props;
-    const color =
-      backgroundColor === DEFAULT_TITLE_BACKGROUND_COLOR
-        ? BRAND_COLOR
-        : foregroundColorFromBackground(backgroundColor);
-    const spinnerColor =
-      backgroundColor === DEFAULT_TITLE_BACKGROUND_COLOR
-        ? 'default'
-        : foregroundColorFromBackground(backgroundColor);
+export default function ChatNavBar(props: Props) {
+  const { narrow, editMessage } = props;
+  const backgroundColor = useSelector(state => getTitleBackgroundColor(state, narrow));
+  const color =
+    backgroundColor === DEFAULT_TITLE_BACKGROUND_COLOR
+      ? BRAND_COLOR
+      : foregroundColorFromBackground(backgroundColor);
+  const spinnerColor =
+    backgroundColor === DEFAULT_TITLE_BACKGROUND_COLOR
+      ? 'default'
+      : foregroundColorFromBackground(backgroundColor);
 
-    return (
+  return (
+    <View
+      style={{
+        borderColor:
+          backgroundColor === 'transparent'
+            ? 'hsla(0, 0%, 50%, 0.25)'
+            : Color(backgroundColor).darken(0.1),
+        borderBottomWidth: 1,
+      }}
+    >
       <View
-        style={{
-          borderColor:
-            backgroundColor === 'transparent'
-              ? 'hsla(0, 0%, 50%, 0.25)'
-              : Color(backgroundColor).darken(0.1),
-          borderBottomWidth: 1,
-        }}
+        style={[
+          {
+            flexDirection: 'row',
+            height: NAVBAR_SIZE,
+            alignItems: 'center',
+          },
+          { backgroundColor },
+        ]}
       >
-        <View
-          style={[
-            {
-              flexDirection: 'row',
-              height: NAVBAR_SIZE,
-              alignItems: 'center',
-            },
-            { backgroundColor },
-          ]}
-        >
-          <NavBarBackButton color={color} />
-          <Title color={color} narrow={narrow} editMessage={editMessage} />
-          <ExtraButton color={color} narrow={narrow} />
-          <InfoButton color={color} narrow={narrow} />
-        </View>
-        <LoadingBanner
-          spinnerColor={spinnerColor}
-          backgroundColor={backgroundColor}
-          textColor={color}
-        />
+        <NavBarBackButton color={color} />
+        <Title color={color} narrow={narrow} editMessage={editMessage} />
+        <ExtraButton color={color} narrow={narrow} />
+        <InfoButton color={color} narrow={narrow} />
       </View>
-    );
-  }
+      <LoadingBanner
+        spinnerColor={spinnerColor}
+        backgroundColor={backgroundColor}
+        textColor={color}
+      />
+    </View>
+  );
 }
-
-export default connect<SelectorProps, _, _>((state, props) => ({
-  backgroundColor: getTitleBackgroundColor(state, props.narrow),
-}))(ChatNavBar);

--- a/src/nav/ModalNavBar.js
+++ b/src/nav/ModalNavBar.js
@@ -1,10 +1,9 @@
 /* @flow strict-local */
 
-import React, { PureComponent } from 'react';
+import React, { useContext } from 'react';
 import { View } from 'react-native';
 
 import type { LocalizableText } from '../types';
-import type { ThemeData } from '../styles';
 import styles, { ThemeContext, NAVBAR_SIZE } from '../styles';
 import Label from '../common/Label';
 import NavBarBackButton from './NavBarBackButton';
@@ -14,37 +13,31 @@ type Props = $ReadOnly<{|
   title: LocalizableText,
 |}>;
 
-class ModalNavBar extends PureComponent<Props> {
-  static contextType = ThemeContext;
-  context: ThemeData;
+export default function ModalNavBar(props: Props) {
+  const { canGoBack, title } = props;
+  const { backgroundColor } = useContext(ThemeContext);
+  const textStyle = [
+    styles.navTitle,
+    canGoBack ? { marginRight: NAVBAR_SIZE } : { marginLeft: 16 },
+  ];
 
-  render() {
-    const { canGoBack, title } = this.props;
-    const textStyle = [
-      styles.navTitle,
-      canGoBack ? { marginRight: NAVBAR_SIZE } : { marginLeft: 16 },
-    ];
-
-    return (
-      <View
-        style={[
-          {
-            borderColor: 'hsla(0, 0%, 50%, 0.25)',
-            flexDirection: 'row',
-            height: NAVBAR_SIZE,
-            alignItems: 'center',
-            borderBottomWidth: 1,
-            backgroundColor: this.context.backgroundColor,
-          },
-        ]}
-      >
-        {canGoBack && <NavBarBackButton />}
-        <View style={styles.flexedLeftAlign}>
-          <Label style={textStyle} text={title} numberOfLines={1} ellipsizeMode="tail" />
-        </View>
+  return (
+    <View
+      style={[
+        {
+          borderColor: 'hsla(0, 0%, 50%, 0.25)',
+          flexDirection: 'row',
+          height: NAVBAR_SIZE,
+          alignItems: 'center',
+          borderBottomWidth: 1,
+          backgroundColor,
+        },
+      ]}
+    >
+      {canGoBack && <NavBarBackButton />}
+      <View style={styles.flexedLeftAlign}>
+        <Label style={textStyle} text={title} numberOfLines={1} ellipsizeMode="tail" />
       </View>
-    );
-  }
+    </View>
+  );
 }
-
-export default ModalNavBar;

--- a/src/nav/ModalSearchNavBar.js
+++ b/src/nav/ModalSearchNavBar.js
@@ -1,8 +1,7 @@
 /* @flow strict-local */
-import React, { PureComponent } from 'react';
+import React, { useContext } from 'react';
 import { View } from 'react-native';
 
-import type { ThemeData } from '../styles';
 import { ThemeContext, NAVBAR_SIZE } from '../styles';
 import SearchInput from '../common/SearchInput';
 import NavBarBackButton from './NavBarBackButton';
@@ -10,35 +9,25 @@ import NavBarBackButton from './NavBarBackButton';
 type Props = $ReadOnly<{|
   autoFocus: boolean,
   searchBarOnChange: (text: string) => void,
-  canGoBack: boolean,
+  canGoBack?: boolean,
 |}>;
 
-class ModalSearchNavBar extends PureComponent<Props> {
-  static contextType = ThemeContext;
-  context: ThemeData;
-
-  static defaultProps = {
-    canGoBack: true,
-  };
-
-  render() {
-    const { autoFocus, searchBarOnChange, canGoBack } = this.props;
-    return (
-      <View
-        style={{
-          borderColor: 'hsla(0, 0%, 50%, 0.25)',
-          flexDirection: 'row',
-          height: NAVBAR_SIZE,
-          alignItems: 'center',
-          borderBottomWidth: 1,
-          backgroundColor: this.context.backgroundColor,
-        }}
-      >
-        {canGoBack && <NavBarBackButton />}
-        <SearchInput autoFocus={autoFocus} onChangeText={searchBarOnChange} />
-      </View>
-    );
-  }
+export default function ModalSearchNavBar(props: Props) {
+  const { autoFocus, searchBarOnChange, canGoBack = true } = props;
+  const { backgroundColor } = useContext(ThemeContext);
+  return (
+    <View
+      style={{
+        borderColor: 'hsla(0, 0%, 50%, 0.25)',
+        flexDirection: 'row',
+        height: NAVBAR_SIZE,
+        alignItems: 'center',
+        borderBottomWidth: 1,
+        backgroundColor,
+      }}
+    >
+      {canGoBack && <NavBarBackButton />}
+      <SearchInput autoFocus={autoFocus} onChangeText={searchBarOnChange} />
+    </View>
+  );
 }
-
-export default ModalSearchNavBar;

--- a/src/start/LoadingScreen.js
+++ b/src/start/LoadingScreen.js
@@ -1,12 +1,12 @@
 /* @flow strict-local */
-import React, { PureComponent } from 'react';
+import React from 'react';
 import { View } from 'react-native';
 
 import type { AppNavigationProp, AppNavigationRouteProp } from '../nav/AppNavigator';
 import { BRAND_COLOR, createStyleSheet } from '../styles';
 import { LoadingIndicator, ZulipStatusBar } from '../common';
 
-const styles = createStyleSheet({
+const componentStyles = createStyleSheet({
   center: {
     flex: 1,
     justifyContent: 'center',
@@ -25,13 +25,11 @@ type Props = $ReadOnly<{|
   route?: AppNavigationRouteProp<'loading'>,
 |}>;
 
-export default class LoadingScreen extends PureComponent<Props> {
-  render() {
-    return (
-      <View style={styles.center}>
-        <ZulipStatusBar backgroundColor={BRAND_COLOR} />
-        <LoadingIndicator color="black" size={80} showLogo />
-      </View>
-    );
-  }
+export default function LoadingScreen(props: Props) {
+  return (
+    <View style={componentStyles.center}>
+      <ZulipStatusBar backgroundColor={BRAND_COLOR} />
+      <LoadingIndicator color="black" size={80} showLogo />
+    </View>
+  );
 }

--- a/src/title/__tests__/titleSelectors-test.js
+++ b/src/title/__tests__/titleSelectors-test.js
@@ -10,10 +10,6 @@ describe('getTitleBackgroundColor', () => {
     subscriptions: [{ ...eg.makeSubscription({ stream: eg.stream }), color: exampleColor }],
   });
 
-  test('return default for screens other than chat, i.e narrow is undefined', () => {
-    expect(getTitleBackgroundColor(state, undefined)).toEqual(DEFAULT_TITLE_BACKGROUND_COLOR);
-  });
-
   test('return stream color for stream and topic narrow', () => {
     expect(getTitleBackgroundColor(state, streamNarrow(eg.stream.name))).toEqual(exampleColor);
   });

--- a/src/title/titleSelectors.js
+++ b/src/title/titleSelectors.js
@@ -11,9 +11,9 @@ export const DEFAULT_TITLE_BACKGROUND_COLOR = 'transparent';
  * If `narrow` is a stream or topic narrow, this is based on the stream color.
  * Otherwise, it takes a default value.
  */
-export const getTitleBackgroundColor = (state: GlobalState, narrow?: Narrow) => {
+export const getTitleBackgroundColor = (state: GlobalState, narrow: Narrow) => {
   const subscriptionsByName = getSubscriptionsByName(state);
-  if (!narrow || !isStreamOrTopicNarrow(narrow)) {
+  if (!isStreamOrTopicNarrow(narrow)) {
     return DEFAULT_TITLE_BACKGROUND_COLOR;
   }
   const streamName = streamNameOfNarrow(narrow);


### PR DESCRIPTION
This is the second PR in the series that began with #4428.

It converts some more components to Hooks-based components, to prepare for future work, and it also makes some preparatory changes to `ZulipStatusBar`, which I'd like to focus on in the next PR in this series. (`ZulipStatusBar`, I've found, isn't the best place to put logic that handles the safe-area view at the top; that PR will relocate that logic.)

I found that I could reasonably include a fix for #4267 in this PR, to help it land sooner. The status bar still appears in the lightbox after this PR, despite passing `hidden` to the lightbox's `ZulipStatusBar`. I'll get to the bottom of that, later, but it's orthogonal to what's really needed for fixing #4267:

1. having the lightbox header clear the unsafe area at the top (which contains the status bar, if present) when it slides down
2. having the footer clear the unsafe area at the bottom, when it slides up
3. padding the contents of the header and footer horizontally, so they don't appear in the horizontal unsafe areas while the device is in landscape mode.

(I neglected 2 and 3 in my #4268; so, I'm closing that.)

After those fixes, the lightbox looks like this on a newer iPhone (showing the image in [this message](https://chat.zulip.org/#narrow/stream/7-test-here/topic/zt1/near/1100506)). These screenshots show the state when the header and footer are visible; tapping the screen makes them slide cleanly off the screen. I've also tested on the office Android device, and on my own, older, iPhone; all works as expected.

<img width="200" alt="Screen Shot 2021-01-27 at 12 14 19 PM" src="https://user-images.githubusercontent.com/22248748/106029187-d6ce3380-609a-11eb-9b4f-23e1405382c7.png"> <img height="200" alt="Screen Shot 2021-01-27 at 12 14 59 PM" src="https://user-images.githubusercontent.com/22248748/106029195-d897f700-609a-11eb-97f3-a53d60f4d146.png">
