### PR TITLE
Finish putting route-param types next to props.

### DIFF
--- a/src/account-info/AccountDetailsScreen.js
+++ b/src/account-info/AccountDetailsScreen.js
@@ -1,8 +1,9 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
 
-import type { AppNavigationProp, AppNavigationRouteProp } from '../nav/AppNavigator';
-import type { Dispatch, UserOrBot } from '../types';
+import type { RouteProp } from '../react-navigation';
+import type { AppNavigationProp } from '../nav/AppNavigator';
+import type { Dispatch, UserOrBot, UserId } from '../types';
 import { createStyleSheet } from '../styles';
 import { connect } from '../react-redux';
 import { Screen, ZulipButton, Label } from '../common';
@@ -31,7 +32,7 @@ type SelectorProps = $ReadOnly<{|
 
 type Props = $ReadOnly<{|
   navigation: AppNavigationProp<'account-details'>,
-  route: AppNavigationRouteProp<'account-details'>,
+  route: RouteProp<'account-details', {| userId: UserId |}>,
 
   dispatch: Dispatch,
   ...SelectorProps,

--- a/src/account-info/ProfileScreen.js
+++ b/src/account-info/ProfileScreen.js
@@ -2,7 +2,8 @@
 import React from 'react';
 import { ScrollView, View } from 'react-native';
 
-import type { MainTabsNavigationProp, MainTabsRouteProp } from '../main/MainTabsScreen';
+import type { RouteProp } from '../react-navigation';
+import type { MainTabsNavigationProp } from '../main/MainTabsScreen';
 import * as NavigationService from '../nav/NavigationService';
 import { createStyleSheet } from '../styles';
 import { useDispatch, useSelector } from '../react-redux';
@@ -71,7 +72,7 @@ function LogoutButton(props: {||}) {
 
 type Props = $ReadOnly<{|
   navigation: MainTabsNavigationProp<'profile'>,
-  route: MainTabsRouteProp<'profile'>,
+  route: RouteProp<'profile', void>,
 |}>;
 
 /**

--- a/src/account/AccountPickScreen.js
+++ b/src/account/AccountPickScreen.js
@@ -2,7 +2,8 @@
 
 import React, { PureComponent } from 'react';
 
-import type { AppNavigationProp, AppNavigationRouteProp } from '../nav/AppNavigator';
+import type { RouteProp } from '../react-navigation';
+import type { AppNavigationProp } from '../nav/AppNavigator';
 import * as NavigationService from '../nav/NavigationService';
 import type { Dispatch } from '../types';
 import { connect } from '../react-redux';
@@ -14,7 +15,7 @@ import { navigateToRealmInputScreen, accountSwitch, removeAccount } from '../act
 
 type Props = $ReadOnly<{|
   navigation: AppNavigationProp<'account-pick'>,
-  route: AppNavigationRouteProp<'account-pick'>,
+  route: RouteProp<'account-pick', void>,
 
   accounts: $ReadOnlyArray<AccountStatus>,
   dispatch: Dispatch,

--- a/src/chat/ChatScreen.js
+++ b/src/chat/ChatScreen.js
@@ -5,9 +5,10 @@ import { useIsFocused } from '@react-navigation/native';
 import { ActionSheetProvider } from '@expo/react-native-action-sheet';
 
 import { useSelector, useDispatch } from '../react-redux';
-import type { AppNavigationProp, AppNavigationRouteProp } from '../nav/AppNavigator';
+import type { RouteProp } from '../react-navigation';
+import type { AppNavigationProp } from '../nav/AppNavigator';
 import styles, { ThemeContext, createStyleSheet } from '../styles';
-import type { EditMessage } from '../types';
+import type { Narrow, EditMessage } from '../types';
 import { KeyboardAvoider, OfflineNotice, ZulipStatusBar } from '../common';
 import ChatNavBar from '../nav/ChatNavBar';
 import MessageList from '../webview/MessageList';
@@ -25,7 +26,7 @@ import { getTitleBackgroundColor } from '../title/titleSelectors';
 
 type Props = $ReadOnly<{|
   navigation: AppNavigationProp<'chat'>,
-  route: AppNavigationRouteProp<'chat'>,
+  route: RouteProp<'chat', {| narrow: Narrow |}>,
 |}>;
 
 const componentStyles = createStyleSheet({

--- a/src/chat/GroupDetailsScreen.js
+++ b/src/chat/GroupDetailsScreen.js
@@ -2,9 +2,10 @@
 import React, { PureComponent } from 'react';
 import { FlatList } from 'react-native';
 
-import type { AppNavigationProp, AppNavigationRouteProp } from '../nav/AppNavigator';
+import type { RouteProp } from '../react-navigation';
+import type { AppNavigationProp } from '../nav/AppNavigator';
 import * as NavigationService from '../nav/NavigationService';
-import type { Dispatch, UserOrBot } from '../types';
+import type { Dispatch, UserOrBot, UserId } from '../types';
 import { connect } from '../react-redux';
 import { Screen } from '../common';
 import UserItem from '../users/UserItem';
@@ -12,7 +13,7 @@ import { navigateToAccountDetails } from '../actions';
 
 type Props = $ReadOnly<{|
   navigation: AppNavigationProp<'group-details'>,
-  route: AppNavigationRouteProp<'group-details'>,
+  route: RouteProp<'group-details', {| recipients: $ReadOnlyArray<UserId> |}>,
 
   dispatch: Dispatch,
 |}>;

--- a/src/diagnostics/DiagnosticsScreen.js
+++ b/src/diagnostics/DiagnosticsScreen.js
@@ -3,7 +3,8 @@
 import React, { PureComponent } from 'react';
 import { nativeApplicationVersion } from 'expo-application';
 
-import type { AppNavigationProp, AppNavigationRouteProp } from '../nav/AppNavigator';
+import type { RouteProp } from '../react-navigation';
+import type { AppNavigationProp } from '../nav/AppNavigator';
 import * as NavigationService from '../nav/NavigationService';
 import { createStyleSheet } from '../styles';
 import { OptionButton, OptionDivider, Screen, RawLabel } from '../common';
@@ -23,7 +24,7 @@ const styles = createStyleSheet({
 
 type Props = $ReadOnly<{|
   navigation: AppNavigationProp<'diagnostics'>,
-  route: AppNavigationRouteProp<'diagnostics'>,
+  route: RouteProp<'diagnostics', void>,
 |}>;
 
 export default class DiagnosticsScreen extends PureComponent<Props> {

--- a/src/diagnostics/StorageScreen.js
+++ b/src/diagnostics/StorageScreen.js
@@ -3,7 +3,8 @@
 import React, { PureComponent } from 'react';
 import { FlatList } from 'react-native';
 
-import type { AppNavigationProp, AppNavigationRouteProp } from '../nav/AppNavigator';
+import type { RouteProp } from '../react-navigation';
+import type { AppNavigationProp } from '../nav/AppNavigator';
 import type { GlobalState, Dispatch } from '../types';
 import { connect } from '../react-redux';
 import { Screen } from '../common';
@@ -19,7 +20,7 @@ const calculateKeyStorageSizes = obj =>
 
 type Props = $ReadOnly<{|
   navigation: AppNavigationProp<'storage'>,
-  route: AppNavigationRouteProp<'storage'>,
+  route: RouteProp<'storage', void>,
 
   dispatch: Dispatch,
   state: GlobalState,

--- a/src/diagnostics/TimingScreen.js
+++ b/src/diagnostics/TimingScreen.js
@@ -2,14 +2,15 @@
 import React, { PureComponent } from 'react';
 import { FlatList } from 'react-native';
 
-import type { AppNavigationProp, AppNavigationRouteProp } from '../nav/AppNavigator';
+import type { RouteProp } from '../react-navigation';
+import type { AppNavigationProp } from '../nav/AppNavigator';
 import { Screen } from '../common';
 import TimeItem from './TimeItem';
 import timing from '../utils/timing';
 
 type Props = $ReadOnly<{|
   navigation: AppNavigationProp<'timing'>,
-  route: AppNavigationRouteProp<'timing'>,
+  route: RouteProp<'timing', void>,
 |}>;
 
 export default class TimingScreen extends PureComponent<Props> {

--- a/src/diagnostics/VariablesScreen.js
+++ b/src/diagnostics/VariablesScreen.js
@@ -2,14 +2,15 @@
 import React, { PureComponent } from 'react';
 import { FlatList } from 'react-native';
 
-import type { AppNavigationProp, AppNavigationRouteProp } from '../nav/AppNavigator';
+import type { RouteProp } from '../react-navigation';
+import type { AppNavigationProp } from '../nav/AppNavigator';
 import config from '../config';
 import { Screen } from '../common';
 import InfoItem from './InfoItem';
 
 type Props = $ReadOnly<{|
   navigation: AppNavigationProp<'variables'>,
-  route: AppNavigationRouteProp<'variables'>,
+  route: RouteProp<'variables', void>,
 |}>;
 
 export default class VariablesScreen extends PureComponent<Props> {

--- a/src/emoji/EmojiPickerScreen.js
+++ b/src/emoji/EmojiPickerScreen.js
@@ -3,7 +3,8 @@
 import React, { PureComponent } from 'react';
 import { FlatList } from 'react-native';
 
-import type { AppNavigationProp, AppNavigationRouteProp } from '../nav/AppNavigator';
+import type { RouteProp } from '../react-navigation';
+import type { AppNavigationProp } from '../nav/AppNavigator';
 import * as NavigationService from '../nav/NavigationService';
 import * as api from '../api';
 import { unicodeCodeByName } from './codePointMap';
@@ -18,7 +19,7 @@ import zulipExtraEmojiMap from './zulipExtraEmojiMap';
 
 type Props = $ReadOnly<{|
   navigation: AppNavigationProp<'emoji-picker'>,
-  route: AppNavigationRouteProp<'emoji-picker'>,
+  route: RouteProp<'emoji-picker', {| messageId: number |}>,
 
   activeImageEmojiByName: RealmEmojiById,
   auth: Auth,

--- a/src/lightbox/LightboxScreen.js
+++ b/src/lightbox/LightboxScreen.js
@@ -3,7 +3,9 @@ import React from 'react';
 import { View } from 'react-native';
 import { ActionSheetProvider } from '@expo/react-native-action-sheet';
 
-import type { AppNavigationProp, AppNavigationRouteProp } from '../nav/AppNavigator';
+import type { Message } from '../types';
+import type { RouteProp } from '../react-navigation';
+import type { AppNavigationProp } from '../nav/AppNavigator';
 import { ZulipStatusBar } from '../common';
 import { createStyleSheet } from '../styles';
 import Lightbox from './Lightbox';
@@ -19,7 +21,7 @@ const styles = createStyleSheet({
 
 type Props = $ReadOnly<{|
   navigation: AppNavigationProp<'lightbox'>,
-  route: AppNavigationRouteProp<'lightbox'>,
+  route: RouteProp<'lightbox', {| src: string, message: Message |}>,
 |}>;
 
 export default function LightboxScreen(props: Props) {

--- a/src/main/HomeScreen.js
+++ b/src/main/HomeScreen.js
@@ -3,7 +3,8 @@
 import React, { PureComponent } from 'react';
 import { View } from 'react-native';
 
-import type { MainTabsNavigationProp, MainTabsRouteProp } from './MainTabsScreen';
+import type { RouteProp } from '../react-navigation';
+import type { MainTabsNavigationProp } from './MainTabsScreen';
 import * as NavigationService from '../nav/NavigationService';
 import type { Dispatch } from '../types';
 import { connect } from '../react-redux';
@@ -29,7 +30,7 @@ const styles = createStyleSheet({
 
 type Props = $ReadOnly<{|
   navigation: MainTabsNavigationProp<'home'>,
-  route: MainTabsRouteProp<'home'>,
+  route: RouteProp<'home', void>,
 
   dispatch: Dispatch,
 |}>;

--- a/src/main/MainTabsScreen.js
+++ b/src/main/MainTabsScreen.js
@@ -5,10 +5,10 @@ import {
   createBottomTabNavigator,
   type BottomTabNavigationProp,
 } from '@react-navigation/bottom-tabs';
-import type { RouteProp } from '@react-navigation/native';
 
 import type { AppNavigationProp, AppNavigationRouteProp } from '../nav/AppNavigator';
 import type { GlobalParamList } from '../nav/globalTypes';
+import type { RouteParamsOf } from '../react-navigation';
 import { bottomTabNavigatorConfig } from '../styles/tabs';
 import HomeScreen from './HomeScreen';
 import StreamTabsScreen from './StreamTabsScreen';
@@ -23,20 +23,16 @@ import { getHaveServerData } from '../selectors';
 import styles, { ThemeContext } from '../styles';
 
 export type MainTabsNavigatorParamList = {|
-  home: void,
-  'stream-tabs': void,
-  'pm-conversations': void,
-  settings: void,
-  profile: void,
+  home: RouteParamsOf<typeof HomeScreen>,
+  'stream-tabs': RouteParamsOf<typeof StreamTabsScreen>,
+  'pm-conversations': RouteParamsOf<typeof PmConversationsScreen>,
+  settings: RouteParamsOf<typeof SettingsScreen>,
+  profile: RouteParamsOf<typeof ProfileScreen>,
 |};
 
 export type MainTabsNavigationProp<
   +RouteName: $Keys<MainTabsNavigatorParamList> = $Keys<MainTabsNavigatorParamList>,
 > = BottomTabNavigationProp<GlobalParamList, RouteName>;
-
-export type MainTabsRouteProp<
-  RouteName: $Keys<MainTabsNavigatorParamList> = $Keys<MainTabsNavigatorParamList>,
-> = RouteProp<GlobalParamList, RouteName>;
 
 const Tab = createBottomTabNavigator<
   GlobalParamList,

--- a/src/main/MainTabsScreen.js
+++ b/src/main/MainTabsScreen.js
@@ -6,9 +6,10 @@ import {
   type BottomTabNavigationProp,
 } from '@react-navigation/bottom-tabs';
 
-import type { AppNavigationProp, AppNavigationRouteProp } from '../nav/AppNavigator';
+import type { RouteProp, RouteParamsOf } from '../react-navigation';
+import type { AppNavigationProp } from '../nav/AppNavigator';
 import type { GlobalParamList } from '../nav/globalTypes';
-import type { RouteParamsOf } from '../react-navigation';
+
 import { bottomTabNavigatorConfig } from '../styles/tabs';
 import HomeScreen from './HomeScreen';
 import StreamTabsScreen from './StreamTabsScreen';
@@ -42,7 +43,7 @@ const Tab = createBottomTabNavigator<
 
 type Props = $ReadOnly<{|
   navigation: AppNavigationProp<'main-tabs'>,
-  route: AppNavigationRouteProp<'main-tabs'>,
+  route: RouteProp<'main-tabs', void>,
 |}>;
 
 export default function MainTabsScreen(props: Props) {

--- a/src/main/StreamTabsScreen.js
+++ b/src/main/StreamTabsScreen.js
@@ -8,8 +8,8 @@ import {
 } from '@react-navigation/material-top-tabs';
 
 import { createStyleSheet } from '../styles';
-import type { MainTabsNavigationProp, MainTabsRouteProp } from './MainTabsScreen';
-import type { RouteParamsOf } from '../react-navigation';
+import type { RouteProp, RouteParamsOf } from '../react-navigation';
+import type { MainTabsNavigationProp } from './MainTabsScreen';
 import type { GlobalParamList } from '../nav/globalTypes';
 import { materialTopTabNavigatorConfig } from '../styles/tabs';
 import SubscriptionsCard from '../streams/SubscriptionsCard';
@@ -39,7 +39,7 @@ const styles = createStyleSheet({
 
 type Props = $ReadOnly<{|
   navigation: MainTabsNavigationProp<'stream-tabs'>,
-  route: MainTabsRouteProp<'stream-tabs'>,
+  route: RouteProp<'stream-tabs', void>,
 |}>;
 
 export default function StreamTabsScreen(props: Props) {

--- a/src/main/StreamTabsScreen.js
+++ b/src/main/StreamTabsScreen.js
@@ -6,27 +6,23 @@ import {
   createMaterialTopTabNavigator,
   type MaterialTopTabNavigationProp,
 } from '@react-navigation/material-top-tabs';
-import type { RouteProp } from '@react-navigation/native';
 
 import { createStyleSheet } from '../styles';
 import type { MainTabsNavigationProp, MainTabsRouteProp } from './MainTabsScreen';
+import type { RouteParamsOf } from '../react-navigation';
 import type { GlobalParamList } from '../nav/globalTypes';
 import { materialTopTabNavigatorConfig } from '../styles/tabs';
 import SubscriptionsCard from '../streams/SubscriptionsCard';
 import StreamListCard from '../subscriptions/StreamListCard';
 
 export type StreamTabsNavigatorParamList = {|
-  subscribed: void,
-  allStreams: void,
+  subscribed: RouteParamsOf<typeof SubscriptionsCard>,
+  allStreams: RouteParamsOf<typeof StreamListCard>,
 |};
 
 export type StreamTabsNavigationProp<
   +RouteName: $Keys<StreamTabsNavigatorParamList> = $Keys<StreamTabsNavigatorParamList>,
 > = MaterialTopTabNavigationProp<GlobalParamList, RouteName>;
-
-export type StreamTabsRouteProp<
-  RouteName: $Keys<StreamTabsNavigatorParamList> = $Keys<StreamTabsNavigatorParamList>,
-> = RouteProp<GlobalParamList, RouteName>;
 
 const Tab = createMaterialTopTabNavigator<
   GlobalParamList,

--- a/src/nav/AppNavigator.js
+++ b/src/nav/AppNavigator.js
@@ -1,19 +1,17 @@
 /* @flow strict-local */
 import React from 'react';
 import { Platform } from 'react-native';
-import type { RouteProp } from '@react-navigation/native';
 import {
   createStackNavigator,
   type StackNavigationProp,
   TransitionPresets,
 } from '@react-navigation/stack';
 
+import type { RouteParamsOf } from '../react-navigation';
 import { useSelector } from '../react-redux';
 import { hasAuth as getHasAuth, getAccounts, getHaveServerData } from '../selectors';
 import getInitialRouteInfo from './getInitialRouteInfo';
 import type { GlobalParamList } from './globalTypes';
-import type { Narrow, Message, SharedData, UserId } from '../types';
-import type { ApiResponseServerSettings } from '../api/settings/getServerSettings';
 import AccountPickScreen from '../account/AccountPickScreen';
 import RealmInputScreen from '../start/RealmInputScreen';
 import AuthScreen from '../start/AuthScreen';
@@ -47,46 +45,46 @@ import UserStatusScreen from '../user-status/UserStatusScreen';
 import SharingScreen from '../sharing/SharingScreen';
 
 export type AppNavigatorParamList = {|
-  'account-pick': void,
-  'account-details': {| userId: UserId |},
-  'group-details': {| recipients: $ReadOnlyArray<UserId> |},
-  auth: {| serverSettings: ApiResponseServerSettings |},
-  chat: {| narrow: Narrow |},
-  'dev-auth': void,
-  'emoji-picker': {| messageId: number |},
+  'account-pick': RouteParamsOf<typeof AccountPickScreen>,
+  'account-details': RouteParamsOf<typeof AccountDetailsScreen>,
+  'group-details': RouteParamsOf<typeof GroupDetailsScreen>,
+  auth: RouteParamsOf<typeof AuthScreen>,
+  chat: RouteParamsOf<typeof ChatScreen>,
+  'dev-auth': RouteParamsOf<typeof DevAuthScreen>,
+  'emoji-picker': RouteParamsOf<typeof EmojiPickerScreen>,
+
+  // Can't instantiate `RouteParamsOf` for `typeof LoadingScreen`
+  // because its `route` prop is optional.
   loading: void,
-  'main-tabs': void,
-  'message-reactions': {| reactionName?: string, messageId: number |},
-  'password-auth': {| requireEmailFormat: boolean |},
-  'realm-input': {| realm: URL | void, initial: boolean | void |},
-  'search-messages': void,
-  users: void,
-  language: void,
-  lightbox: {| src: string, message: Message |},
-  'create-group': void,
-  'invite-users': {| streamId: number |},
-  diagnostics: void,
-  variables: void,
-  timing: void,
-  storage: void,
-  debug: void,
-  'stream-settings': {| streamId: number |},
-  'edit-stream': {| streamId: number |},
-  'create-stream': void,
-  'topic-list': {| streamId: number |},
-  notifications: void,
-  legal: void,
-  'user-status': void,
-  sharing: {| sharedData: SharedData |},
+
+  'main-tabs': RouteParamsOf<typeof MainTabsScreen>,
+  'message-reactions': RouteParamsOf<typeof MessageReactionsScreen>,
+  'password-auth': RouteParamsOf<typeof PasswordAuthScreen>,
+  'realm-input': RouteParamsOf<typeof RealmInputScreen>,
+  'search-messages': RouteParamsOf<typeof SearchMessagesScreen>,
+  users: RouteParamsOf<typeof UsersScreen>,
+  language: RouteParamsOf<typeof LanguageScreen>,
+  lightbox: RouteParamsOf<typeof LightboxScreen>,
+  'create-group': RouteParamsOf<typeof CreateGroupScreen>,
+  'invite-users': RouteParamsOf<typeof InviteUsersScreen>,
+  diagnostics: RouteParamsOf<typeof DiagnosticsScreen>,
+  variables: RouteParamsOf<typeof VariablesScreen>,
+  timing: RouteParamsOf<typeof TimingScreen>,
+  storage: RouteParamsOf<typeof StorageScreen>,
+  debug: RouteParamsOf<typeof DebugScreen>,
+  'stream-settings': RouteParamsOf<typeof StreamSettingsScreen>,
+  'edit-stream': RouteParamsOf<typeof EditStreamScreen>,
+  'create-stream': RouteParamsOf<typeof CreateStreamScreen>,
+  'topic-list': RouteParamsOf<typeof TopicListScreen>,
+  notifications: RouteParamsOf<typeof NotificationsScreen>,
+  legal: RouteParamsOf<typeof LegalScreen>,
+  'user-status': RouteParamsOf<typeof UserStatusScreen>,
+  sharing: RouteParamsOf<typeof SharingScreen>,
 |};
 
 export type AppNavigationProp<
   +RouteName: $Keys<AppNavigatorParamList> = $Keys<AppNavigatorParamList>,
 > = StackNavigationProp<GlobalParamList, RouteName>;
-
-export type AppNavigationRouteProp<
-  RouteName: $Keys<AppNavigatorParamList> = $Keys<AppNavigatorParamList>,
-> = RouteProp<GlobalParamList, RouteName>;
 
 const Stack = createStackNavigator<GlobalParamList, AppNavigatorParamList, AppNavigationProp<>>();
 

--- a/src/pm-conversations/PmConversationsScreen.js
+++ b/src/pm-conversations/PmConversationsScreen.js
@@ -3,7 +3,8 @@
 import React, { useContext } from 'react';
 import { View } from 'react-native';
 
-import type { MainTabsNavigationProp, MainTabsRouteProp } from '../main/MainTabsScreen';
+import type { RouteProp } from '../react-navigation';
+import type { MainTabsNavigationProp } from '../main/MainTabsScreen';
 import * as NavigationService from '../nav/NavigationService';
 import { ThemeContext, createStyleSheet } from '../styles';
 import { useSelector, useDispatch } from '../react-redux';
@@ -34,7 +35,7 @@ const styles = createStyleSheet({
 
 type Props = $ReadOnly<{|
   navigation: MainTabsNavigationProp<'pm-conversations'>,
-  route: MainTabsRouteProp<'pm-conversations'>,
+  route: RouteProp<'pm-conversations', void>,
 |}>;
 
 /**

--- a/src/react-navigation.js
+++ b/src/react-navigation.js
@@ -31,7 +31,7 @@ import type { GlobalParamList } from './nav/globalTypes';
  *   by at the navigator.  (This is type-checked at the navigator.)
  * @param {RouteParams} - The type to use for `props.route.params`.
  */
-export type RouteProp<+RouteName: string, +RouteParams: ScreenParams> = {|
+export type RouteProp<+RouteName: string, +RouteParams: ScreenParams | void> = {|
   ...LeafRoute<RouteName>,
   +params: RouteParams,
 |};

--- a/src/reactions/MessageReactionsScreen.js
+++ b/src/reactions/MessageReactionsScreen.js
@@ -3,7 +3,8 @@ import React, { PureComponent } from 'react';
 import { View } from 'react-native';
 import { createMaterialTopTabNavigator } from '@react-navigation/material-top-tabs';
 
-import type { AppNavigationProp, AppNavigationRouteProp } from '../nav/AppNavigator';
+import type { RouteProp } from '../react-navigation';
+import type { AppNavigationProp } from '../nav/AppNavigator';
 import * as NavigationService from '../nav/NavigationService';
 import * as logging from '../utils/logging';
 import ReactionUserList from './ReactionUserList';
@@ -33,7 +34,7 @@ type SelectorProps = $ReadOnly<{|
 
 type Props = $ReadOnly<{|
   navigation: AppNavigationProp<'message-reactions'>,
-  route: AppNavigationRouteProp<'message-reactions'>,
+  route: RouteProp<'message-reactions', {| reactionName?: string, messageId: number |}>,
 
   dispatch: Dispatch,
   ...SelectorProps,

--- a/src/search/SearchMessagesScreen.js
+++ b/src/search/SearchMessagesScreen.js
@@ -1,7 +1,8 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
 
-import type { AppNavigationProp, AppNavigationRouteProp } from '../nav/AppNavigator';
+import type { RouteProp } from '../react-navigation';
+import type { AppNavigationProp } from '../nav/AppNavigator';
 import type { Auth, Dispatch, Message } from '../types';
 import { Screen } from '../common';
 import SearchMessagesCard from './SearchMessagesCard';
@@ -14,7 +15,7 @@ import { fetchMessages } from '../message/fetchActions';
 
 type Props = $ReadOnly<{|
   navigation: AppNavigationProp<'search-messages'>,
-  route: AppNavigationRouteProp<'search-messages'>,
+  route: RouteProp<'search-messages', void>,
 
   auth: Auth,
   dispatch: Dispatch,

--- a/src/settings/DebugScreen.js
+++ b/src/settings/DebugScreen.js
@@ -2,7 +2,8 @@
 
 import React, { PureComponent } from 'react';
 
-import type { AppNavigationProp, AppNavigationRouteProp } from '../nav/AppNavigator';
+import type { RouteProp } from '../react-navigation';
+import type { AppNavigationProp } from '../nav/AppNavigator';
 import type { Debug, Dispatch } from '../types';
 import { connect } from '../react-redux';
 import { getSession } from '../selectors';
@@ -11,7 +12,7 @@ import { debugFlagToggle } from '../actions';
 
 type Props = $ReadOnly<{|
   navigation: AppNavigationProp<'debug'>,
-  route: AppNavigationRouteProp<'debug'>,
+  route: RouteProp<'debug', void>,
 
   debug: Debug,
   dispatch: Dispatch,

--- a/src/settings/LanguageScreen.js
+++ b/src/settings/LanguageScreen.js
@@ -2,7 +2,8 @@
 
 import React, { PureComponent } from 'react';
 
-import type { AppNavigationProp, AppNavigationRouteProp } from '../nav/AppNavigator';
+import type { RouteProp } from '../react-navigation';
+import type { AppNavigationProp } from '../nav/AppNavigator';
 import type { Dispatch } from '../types';
 import { connect } from '../react-redux';
 import { Screen } from '../common';
@@ -12,7 +13,7 @@ import { settingsChange } from '../actions';
 
 type Props = $ReadOnly<{|
   navigation: AppNavigationProp<'language'>,
-  route: AppNavigationRouteProp<'language'>,
+  route: RouteProp<'language', void>,
 
   dispatch: Dispatch,
   locale: string,

--- a/src/settings/LegalScreen.js
+++ b/src/settings/LegalScreen.js
@@ -2,7 +2,8 @@
 
 import React, { PureComponent } from 'react';
 
-import type { AppNavigationProp, AppNavigationRouteProp } from '../nav/AppNavigator';
+import type { RouteProp } from '../react-navigation';
+import type { AppNavigationProp } from '../nav/AppNavigator';
 import type { Dispatch } from '../types';
 import { connect } from '../react-redux';
 import { Screen, OptionButton } from '../common';
@@ -11,7 +12,7 @@ import { getCurrentRealm } from '../selectors';
 
 type Props = $ReadOnly<{|
   navigation: AppNavigationProp<'legal'>,
-  route: AppNavigationRouteProp<'legal'>,
+  route: RouteProp<'legal', void>,
 
   dispatch: Dispatch,
   realm: URL,

--- a/src/settings/NotificationsScreen.js
+++ b/src/settings/NotificationsScreen.js
@@ -2,7 +2,8 @@
 
 import React, { PureComponent } from 'react';
 
-import type { AppNavigationProp, AppNavigationRouteProp } from '../nav/AppNavigator';
+import type { RouteProp } from '../react-navigation';
+import type { AppNavigationProp } from '../nav/AppNavigator';
 import type { Auth, Dispatch } from '../types';
 import { connect } from '../react-redux';
 import { getAuth, getSettings } from '../selectors';
@@ -12,7 +13,7 @@ import { settingsChange } from '../actions';
 
 type Props = $ReadOnly<{|
   navigation: AppNavigationProp<'notifications'>,
-  route: AppNavigationRouteProp<'notifications'>,
+  route: RouteProp<'notifications', void>,
 
   auth: Auth,
   dispatch: Dispatch,

--- a/src/settings/SettingsScreen.js
+++ b/src/settings/SettingsScreen.js
@@ -3,7 +3,8 @@
 import React, { PureComponent } from 'react';
 import { ScrollView } from 'react-native';
 
-import type { MainTabsNavigationProp, MainTabsRouteProp } from '../main/MainTabsScreen';
+import type { RouteProp } from '../react-navigation';
+import type { MainTabsNavigationProp } from '../main/MainTabsScreen';
 import * as NavigationService from '../nav/NavigationService';
 import type { Dispatch } from '../types';
 import { createStyleSheet } from '../styles';
@@ -34,7 +35,7 @@ const styles = createStyleSheet({
 
 type Props = $ReadOnly<{|
   navigation: MainTabsNavigationProp<'settings'>,
-  route: MainTabsRouteProp<'settings'>,
+  route: RouteProp<'settings', void>,
 
   theme: string,
   dispatch: Dispatch,

--- a/src/sharing/SharingScreen.js
+++ b/src/sharing/SharingScreen.js
@@ -8,10 +8,11 @@ import {
 import { FormattedMessage } from 'react-intl';
 
 import type { GlobalParamList } from '../nav/globalTypes';
-import type { RouteParamsOf } from '../react-navigation';
-import type { AppNavigationProp, AppNavigationRouteProp } from '../nav/AppNavigator';
+import type { RouteParamsOf, RouteProp } from '../react-navigation';
+
+import type { AppNavigationProp } from '../nav/AppNavigator';
 import * as NavigationService from '../nav/NavigationService';
-import type { Dispatch, Auth } from '../types';
+import type { Dispatch, Auth, SharedData } from '../types';
 import { createStyleSheet } from '../styles';
 import { materialTopTabNavigatorConfig } from '../styles/tabs';
 import { connect } from '../react-redux';
@@ -38,7 +39,7 @@ const Tab = createMaterialTopTabNavigator<
 
 type Props = $ReadOnly<{|
   navigation: AppNavigationProp<'sharing'>,
-  route: AppNavigationRouteProp<'sharing'>,
+  route: RouteProp<'sharing', {| sharedData: SharedData |}>,
 
   auth: Auth | void,
   dispatch: Dispatch,

--- a/src/start/AuthScreen.js
+++ b/src/start/AuthScreen.js
@@ -5,14 +5,16 @@ import { Linking, Platform } from 'react-native';
 import type { AppleAuthenticationCredential } from 'expo-apple-authentication';
 import * as AppleAuthentication from 'expo-apple-authentication';
 
-import type { AppNavigationProp, AppNavigationRouteProp } from '../nav/AppNavigator';
-import * as NavigationService from '../nav/NavigationService';
-import config from '../config';
-import type { Dispatch } from '../types';
 import type {
+  ApiResponseServerSettings,
   AuthenticationMethods,
   ExternalAuthenticationMethod,
 } from '../api/settings/getServerSettings';
+import type { RouteProp } from '../react-navigation';
+import type { AppNavigationProp } from '../nav/AppNavigator';
+import * as NavigationService from '../nav/NavigationService';
+import config from '../config';
+import type { Dispatch } from '../types';
 import {
   IconApple,
   IconPrivate,
@@ -168,7 +170,7 @@ export const activeAuthentications = (
 
 type Props = $ReadOnly<{|
   navigation: AppNavigationProp<'auth'>,
-  route: AppNavigationRouteProp<'auth'>,
+  route: RouteProp<'auth', {| serverSettings: ApiResponseServerSettings |}>,
 
   dispatch: Dispatch,
   realm: URL,

--- a/src/start/DevAuthScreen.js
+++ b/src/start/DevAuthScreen.js
@@ -3,7 +3,8 @@
 import React, { PureComponent } from 'react';
 import { ActivityIndicator, View, FlatList } from 'react-native';
 
-import type { AppNavigationProp, AppNavigationRouteProp } from '../nav/AppNavigator';
+import type { RouteProp } from '../react-navigation';
+import type { AppNavigationProp } from '../nav/AppNavigator';
 import type { Auth, DevUser, Dispatch } from '../types';
 import styles, { createStyleSheet } from '../styles';
 import { connect } from '../react-redux';
@@ -29,7 +30,7 @@ const componentStyles = createStyleSheet({
 
 type Props = $ReadOnly<{|
   navigation: AppNavigationProp<'dev-auth'>,
-  route: AppNavigationRouteProp<'dev-auth'>,
+  route: RouteProp<'dev-auth', void>,
 
   partialAuth: Auth,
   dispatch: Dispatch,

--- a/src/start/LoadingScreen.js
+++ b/src/start/LoadingScreen.js
@@ -2,7 +2,8 @@
 import React from 'react';
 import { View } from 'react-native';
 
-import type { AppNavigationProp, AppNavigationRouteProp } from '../nav/AppNavigator';
+import type { RouteProp } from '../react-navigation';
+import type { AppNavigationProp } from '../nav/AppNavigator';
 import { BRAND_COLOR, createStyleSheet } from '../styles';
 import { LoadingIndicator, ZulipStatusBar } from '../common';
 
@@ -22,7 +23,7 @@ type Props = $ReadOnly<{|
   // prop (with the particular shape for this route) and the `route`
   // prop for free.
   navigation?: AppNavigationProp<'loading'>,
-  route?: AppNavigationRouteProp<'loading'>,
+  route?: RouteProp<'loading', void>,
 |}>;
 
 export default function LoadingScreen(props: Props) {

--- a/src/start/PasswordAuthScreen.js
+++ b/src/start/PasswordAuthScreen.js
@@ -2,7 +2,8 @@
 import React, { PureComponent } from 'react';
 import { View } from 'react-native';
 
-import type { AppNavigationProp, AppNavigationRouteProp } from '../nav/AppNavigator';
+import type { RouteProp } from '../react-navigation';
+import type { AppNavigationProp } from '../nav/AppNavigator';
 import type { Auth, Dispatch } from '../types';
 import { createStyleSheet } from '../styles';
 import { connect } from '../react-redux';
@@ -28,7 +29,7 @@ const styles = createStyleSheet({
 
 type Props = $ReadOnly<{|
   navigation: AppNavigationProp<'password-auth'>,
-  route: AppNavigationRouteProp<'password-auth'>,
+  route: RouteProp<'password-auth', {| requireEmailFormat: boolean |}>,
 
   partialAuth: Auth,
   dispatch: Dispatch,

--- a/src/start/RealmInputScreen.js
+++ b/src/start/RealmInputScreen.js
@@ -2,7 +2,8 @@
 import React, { PureComponent } from 'react';
 import { Keyboard } from 'react-native';
 
-import type { AppNavigationProp, AppNavigationRouteProp } from '../nav/AppNavigator';
+import type { RouteProp } from '../react-navigation';
+import type { AppNavigationProp } from '../nav/AppNavigator';
 import * as NavigationService from '../nav/NavigationService';
 import { ZulipVersion } from '../utils/zulipVersion';
 import type { Dispatch } from '../types';
@@ -19,7 +20,7 @@ type SelectorProps = {|
 
 type Props = $ReadOnly<{|
   navigation: AppNavigationProp<'realm-input'>,
-  route: AppNavigationRouteProp<'realm-input'>,
+  route: RouteProp<'realm-input', {| realm: URL | void, initial: boolean | void |}>,
 
   dispatch: Dispatch,
   ...SelectorProps,

--- a/src/streams/CreateStreamScreen.js
+++ b/src/streams/CreateStreamScreen.js
@@ -1,7 +1,8 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
 
-import type { AppNavigationProp, AppNavigationRouteProp } from '../nav/AppNavigator';
+import type { RouteProp } from '../react-navigation';
+import type { AppNavigationProp } from '../nav/AppNavigator';
 import * as NavigationService from '../nav/NavigationService';
 import type { Dispatch } from '../types';
 import { connect } from '../react-redux';
@@ -12,7 +13,7 @@ import EditStreamCard from './EditStreamCard';
 
 type Props = $ReadOnly<{|
   navigation: AppNavigationProp<'create-stream'>,
-  route: AppNavigationRouteProp<'create-stream'>,
+  route: RouteProp<'create-stream', void>,
 
   dispatch: Dispatch,
   ownEmail: string,

--- a/src/streams/EditStreamScreen.js
+++ b/src/streams/EditStreamScreen.js
@@ -1,7 +1,8 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
 
-import type { AppNavigationProp, AppNavigationRouteProp } from '../nav/AppNavigator';
+import type { RouteProp } from '../react-navigation';
+import type { AppNavigationProp } from '../nav/AppNavigator';
 import * as NavigationService from '../nav/NavigationService';
 import type { Dispatch, Stream } from '../types';
 import { connect } from '../react-redux';
@@ -16,7 +17,7 @@ type SelectorProps = $ReadOnly<{|
 
 type Props = $ReadOnly<{|
   navigation: AppNavigationProp<'edit-stream'>,
-  route: AppNavigationRouteProp<'edit-stream'>,
+  route: RouteProp<'edit-stream', {| streamId: number |}>,
 
   dispatch: Dispatch,
   ...SelectorProps,

--- a/src/streams/InviteUsersScreen.js
+++ b/src/streams/InviteUsersScreen.js
@@ -1,7 +1,8 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
 
-import type { AppNavigationProp, AppNavigationRouteProp } from '../nav/AppNavigator';
+import type { RouteProp } from '../react-navigation';
+import type { AppNavigationProp } from '../nav/AppNavigator';
 import * as NavigationService from '../nav/NavigationService';
 import type { Auth, Dispatch, Stream, UserOrBot } from '../types';
 import { connect } from '../react-redux';
@@ -18,7 +19,7 @@ type SelectorProps = $ReadOnly<{|
 
 type Props = $ReadOnly<{|
   navigation: AppNavigationProp<'invite-users'>,
-  route: AppNavigationRouteProp<'invite-users'>,
+  route: RouteProp<'invite-users', {| streamId: number |}>,
 
   dispatch: Dispatch,
   ...SelectorProps,

--- a/src/streams/StreamSettingsScreen.js
+++ b/src/streams/StreamSettingsScreen.js
@@ -2,7 +2,8 @@
 import React, { PureComponent } from 'react';
 import { View } from 'react-native';
 
-import type { AppNavigationProp, AppNavigationRouteProp } from '../nav/AppNavigator';
+import type { RouteProp } from '../react-navigation';
+import type { AppNavigationProp } from '../nav/AppNavigator';
 import * as NavigationService from '../nav/NavigationService';
 import type { Dispatch, Stream, Subscription } from '../types';
 import { connect } from '../react-redux';
@@ -32,7 +33,7 @@ type SelectorProps = $ReadOnly<{|
 
 type Props = $ReadOnly<{|
   navigation: AppNavigationProp<'stream-settings'>,
-  route: AppNavigationRouteProp<'stream-settings'>,
+  route: RouteProp<'stream-settings', {| streamId: number |}>,
 
   dispatch: Dispatch,
   ...SelectorProps,

--- a/src/streams/SubscriptionsCard.js
+++ b/src/streams/SubscriptionsCard.js
@@ -3,7 +3,8 @@
 import React, { PureComponent } from 'react';
 import { View } from 'react-native';
 
-import type { StreamTabsNavigationProp, StreamTabsRouteProp } from '../main/StreamTabsScreen';
+import type { RouteProp } from '../react-navigation';
+import type { StreamTabsNavigationProp } from '../main/StreamTabsScreen';
 import type { Dispatch, Subscription } from '../types';
 import { createStyleSheet } from '../styles';
 import { connect } from '../react-redux';
@@ -28,7 +29,7 @@ type SelectorProps = $ReadOnly<{|
 
 type Props = $ReadOnly<{|
   navigation: StreamTabsNavigationProp<'subscribed'>,
-  route: StreamTabsRouteProp<'subscribed'>,
+  route: RouteProp<'subscribed', void>,
 
   dispatch: Dispatch,
   ...SelectorProps,

--- a/src/subscriptions/StreamListCard.js
+++ b/src/subscriptions/StreamListCard.js
@@ -3,7 +3,8 @@
 import React, { PureComponent } from 'react';
 import { View } from 'react-native';
 
-import type { StreamTabsNavigationProp, StreamTabsRouteProp } from '../main/StreamTabsScreen';
+import type { RouteProp } from '../react-navigation';
+import type { StreamTabsNavigationProp } from '../main/StreamTabsScreen';
 import * as NavigationService from '../nav/NavigationService';
 import type { Auth, Dispatch, Stream, Subscription } from '../types';
 import { createStyleSheet } from '../styles';
@@ -27,7 +28,7 @@ const styles = createStyleSheet({
 
 type Props = $ReadOnly<{|
   navigation: StreamTabsNavigationProp<'allStreams'>,
-  route: StreamTabsRouteProp<'allStreams'>,
+  route: RouteProp<'allStreams', void>,
 
   dispatch: Dispatch,
   auth: Auth,

--- a/src/topics/TopicListScreen.js
+++ b/src/topics/TopicListScreen.js
@@ -2,7 +2,8 @@
 
 import React, { PureComponent } from 'react';
 
-import type { AppNavigationProp, AppNavigationRouteProp } from '../nav/AppNavigator';
+import type { RouteProp } from '../react-navigation';
+import type { AppNavigationProp } from '../nav/AppNavigator';
 import type { Dispatch, Stream, TopicExtended } from '../types';
 import { connect } from '../react-redux';
 import { Screen } from '../common';
@@ -19,7 +20,7 @@ type SelectorProps = $ReadOnly<{|
 
 type Props = $ReadOnly<{|
   navigation: AppNavigationProp<'topic-list'>,
-  route: AppNavigationRouteProp<'topic-list'>,
+  route: RouteProp<'topic-list', {| streamId: number |}>,
 
   dispatch: Dispatch,
   ...SelectorProps,

--- a/src/user-groups/CreateGroupScreen.js
+++ b/src/user-groups/CreateGroupScreen.js
@@ -1,7 +1,8 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
 
-import type { AppNavigationProp, AppNavigationRouteProp } from '../nav/AppNavigator';
+import type { RouteProp } from '../react-navigation';
+import type { AppNavigationProp } from '../nav/AppNavigator';
 import * as NavigationService from '../nav/NavigationService';
 import type { Dispatch, UserId, UserOrBot } from '../types';
 import { connect } from '../react-redux';
@@ -18,7 +19,7 @@ type SelectorProps = {|
 
 type Props = $ReadOnly<{|
   navigation: AppNavigationProp<'create-group'>,
-  route: AppNavigationRouteProp<'create-group'>,
+  route: RouteProp<'create-group', void>,
 
   dispatch: Dispatch,
   ...SelectorProps,

--- a/src/user-status/UserStatusScreen.js
+++ b/src/user-status/UserStatusScreen.js
@@ -4,7 +4,8 @@ import { FlatList, View } from 'react-native';
 import { TranslationContext } from '../boot/TranslationProvider';
 import { createStyleSheet } from '../styles';
 
-import type { AppNavigationProp, AppNavigationRouteProp } from '../nav/AppNavigator';
+import type { RouteProp } from '../react-navigation';
+import type { AppNavigationProp } from '../nav/AppNavigator';
 import * as NavigationService from '../nav/NavigationService';
 import type { GetText, Dispatch } from '../types';
 import { connect } from '../react-redux';
@@ -30,7 +31,7 @@ const styles = createStyleSheet({
 
 type Props = $ReadOnly<{|
   navigation: AppNavigationProp<'user-status'>,
-  route: AppNavigationRouteProp<'user-status'>,
+  route: RouteProp<'user-status', void>,
 
   dispatch: Dispatch,
   userStatusText: string,

--- a/src/users/UsersScreen.js
+++ b/src/users/UsersScreen.js
@@ -1,13 +1,14 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
 
-import type { AppNavigationProp, AppNavigationRouteProp } from '../nav/AppNavigator';
+import type { RouteProp } from '../react-navigation';
+import type { AppNavigationProp } from '../nav/AppNavigator';
 import { Screen } from '../common';
 import UsersCard from './UsersCard';
 
 type Props = $ReadOnly<{|
   navigation: AppNavigationProp<'users'>,
-  route: AppNavigationRouteProp<'users'>,
+  route: RouteProp<'users', void>,
 |}>;
 
 type State = {|


### PR DESCRIPTION
Following #4430, finish moving the screens' route-param type definitions to the files that define the screens themselves.

In the last of these commits, I've put a comment on `loading`/`LoadingScreen` in AppNavigator.js. I'm not quite sure how best to handle this one (see the comment on the `navigation` and `route` props in `LoadingScreen`). Possibly the right thing is to make `RouteParamsOf` not care if the screen's `route` prop is optional, but I wasn't sure about the potential downsides to relaxing it this way.