### PR TITLE
Convert three more components to use Hooks and `useSelector`.

### DIFF
--- a/src/account-info/AwayStatusSwitch.js
+++ b/src/account-info/AwayStatusSwitch.js
@@ -1,5 +1,5 @@
 /* @flow strict-local */
-import React, { PureComponent } from 'react';
+import React from 'react';
 
 import type { Dispatch } from '../types';
 import { connect } from '../react-redux';
@@ -17,23 +17,19 @@ type Props = $ReadOnly<{|
  *  * retrieves the current user's `user status` data and presents it
  *  * allows by switching it to control the `away` status
  */
-class AwayStatusSwitch extends PureComponent<Props> {
-  handleUpdateAwayStatus = (away: boolean) => {
-    const { dispatch } = this.props;
-    dispatch(updateUserAwayStatus(away));
-  };
+function AwayStatusSwitch(props: Props) {
+  const { awayStatus } = props;
 
-  render() {
-    const { awayStatus } = this.props;
-
-    return (
-      <OptionRow
-        label="Set yourself to away"
-        value={awayStatus}
-        onValueChange={this.handleUpdateAwayStatus}
-      />
-    );
-  }
+  return (
+    <OptionRow
+      label="Set yourself to away"
+      value={awayStatus}
+      onValueChange={(away: boolean) => {
+        const { dispatch } = props;
+        dispatch(updateUserAwayStatus(away));
+      }}
+    />
+  );
 }
 
 export default connect(state => ({

--- a/src/account-info/AwayStatusSwitch.js
+++ b/src/account-info/AwayStatusSwitch.js
@@ -1,37 +1,29 @@
 /* @flow strict-local */
 import React from 'react';
 
-import type { Dispatch } from '../types';
-import { connect } from '../react-redux';
+import { useSelector, useDispatch } from '../react-redux';
 import { OptionRow } from '../common';
 import { getSelfUserAwayStatus } from '../selectors';
 import { updateUserAwayStatus } from '../user-status/userStatusActions';
 
-type Props = $ReadOnly<{|
-  awayStatus: boolean,
-  dispatch: Dispatch,
-|}>;
+type Props = $ReadOnly<{||}>;
 
 /**
  * This is a stand-alone component that:
  *  * retrieves the current user's `user status` data and presents it
  *  * allows by switching it to control the `away` status
  */
-function AwayStatusSwitch(props: Props) {
-  const { awayStatus } = props;
+export default function AwayStatusSwitch(props: Props) {
+  const awayStatus = useSelector(getSelfUserAwayStatus);
+  const dispatch = useDispatch();
 
   return (
     <OptionRow
       label="Set yourself to away"
       value={awayStatus}
       onValueChange={(away: boolean) => {
-        const { dispatch } = props;
         dispatch(updateUserAwayStatus(away));
       }}
     />
   );
 }
-
-export default connect(state => ({
-  awayStatus: getSelfUserAwayStatus(state),
-}))(AwayStatusSwitch);

--- a/src/common/OwnAvatar.js
+++ b/src/common/OwnAvatar.js
@@ -1,5 +1,5 @@
 /* @flow strict-local */
-import React, { PureComponent } from 'react';
+import React from 'react';
 
 import type { User, Dispatch } from '../types';
 import { connect } from '../react-redux';
@@ -17,11 +17,9 @@ type Props = $ReadOnly<{|
  *
  * @prop size - Sets width and height in logical pixels.
  */
-class OwnAvatar extends PureComponent<Props> {
-  render() {
-    const { user, size } = this.props;
-    return <UserAvatar avatarUrl={user.avatar_url} size={size} />;
-  }
+function OwnAvatar(props: Props) {
+  const { user, size } = props;
+  return <UserAvatar avatarUrl={user.avatar_url} size={size} />;
 }
 
 export default connect(state => ({

--- a/src/common/OwnAvatar.js
+++ b/src/common/OwnAvatar.js
@@ -1,14 +1,11 @@
 /* @flow strict-local */
 import React from 'react';
 
-import type { User, Dispatch } from '../types';
-import { connect } from '../react-redux';
+import { useSelector } from '../react-redux';
 import UserAvatar from './UserAvatar';
 import { getOwnUser } from '../users/userSelectors';
 
 type Props = $ReadOnly<{|
-  dispatch: Dispatch,
-  user: User,
   size: number,
 |}>;
 
@@ -17,11 +14,8 @@ type Props = $ReadOnly<{|
  *
  * @prop size - Sets width and height in logical pixels.
  */
-function OwnAvatar(props: Props) {
-  const { user, size } = props;
+export default function OwnAvatar(props: Props) {
+  const { size } = props;
+  const user = useSelector(getOwnUser);
   return <UserAvatar avatarUrl={user.avatar_url} size={size} />;
 }
-
-export default connect(state => ({
-  user: getOwnUser(state),
-}))(OwnAvatar);

--- a/src/unread/UnreadCards.js
+++ b/src/unread/UnreadCards.js
@@ -1,6 +1,6 @@
 /* @flow strict-local */
 
-import React, { PureComponent } from 'react';
+import React from 'react';
 import { SectionList } from 'react-native';
 
 import type { Dispatch, PmConversationData, UnreadStreamItem } from '../types';
@@ -19,66 +19,64 @@ type Props = $ReadOnly<{|
   unreadStreamsAndTopics: UnreadStreamItem[],
 |}>;
 
-class UnreadCards extends PureComponent<Props> {
-  render() {
-    const { conversations, dispatch, unreadStreamsAndTopics } = this.props;
-    type Card =
-      | UnreadStreamItem
-      | { key: 'private', data: Array<React$ElementConfig<typeof PmConversationList>> };
-    const unreadCards: Array<Card> = [
-      {
-        key: 'private',
-        data: [{ conversations, dispatch }],
-      },
-      ...unreadStreamsAndTopics,
-    ];
+function UnreadCards(props: Props) {
+  const { conversations, dispatch, unreadStreamsAndTopics } = props;
+  type Card =
+    | UnreadStreamItem
+    | { key: 'private', data: Array<React$ElementConfig<typeof PmConversationList>> };
+  const unreadCards: Array<Card> = [
+    {
+      key: 'private',
+      data: [{ conversations, dispatch }],
+    },
+    ...unreadStreamsAndTopics,
+  ];
 
-    if (unreadStreamsAndTopics.length === 0 && conversations.length === 0) {
-      return <SearchEmptyState text="No unread messages" />;
-    }
-
-    return (
-      /* $FlowFixMe[prop-missing]: SectionList libdef seems confused;
-         should take $ReadOnly objects. */
-      <SectionList
-        stickySectionHeadersEnabled
-        initialNumToRender={20}
-        sections={unreadCards}
-        keyExtractor={item => item.key}
-        renderSectionHeader={({ section }) =>
-          section.key === 'private' ? null : (
-            <StreamItem
-              name={section.streamName}
-              iconSize={16}
-              isMuted={section.isMuted}
-              isPrivate={section.isPrivate}
-              backgroundColor={section.color}
-              unreadCount={section.unread}
-              onPress={(stream: string) => {
-                setTimeout(() => this.props.dispatch(doNarrow(streamNarrow(stream))));
-              }}
-            />
-          )
-        }
-        renderItem={({ item, section }) =>
-          section.key === 'private' ? (
-            <PmConversationList {...item} />
-          ) : (
-            <TopicItem
-              name={item.topic}
-              stream={section.streamName || ''}
-              isMuted={section.isMuted || item.isMuted}
-              isSelected={false}
-              unreadCount={item.unread}
-              onPress={(stream: string, topic: string) => {
-                setTimeout(() => this.props.dispatch(doNarrow(topicNarrow(stream, topic))));
-              }}
-            />
-          )
-        }
-      />
-    );
+  if (unreadStreamsAndTopics.length === 0 && conversations.length === 0) {
+    return <SearchEmptyState text="No unread messages" />;
   }
+
+  return (
+    /* $FlowFixMe[prop-missing]: SectionList libdef seems confused;
+         should take $ReadOnly objects. */
+    <SectionList
+      stickySectionHeadersEnabled
+      initialNumToRender={20}
+      sections={unreadCards}
+      keyExtractor={item => item.key}
+      renderSectionHeader={({ section }) =>
+        section.key === 'private' ? null : (
+          <StreamItem
+            name={section.streamName}
+            iconSize={16}
+            isMuted={section.isMuted}
+            isPrivate={section.isPrivate}
+            backgroundColor={section.color}
+            unreadCount={section.unread}
+            onPress={(stream: string) => {
+              setTimeout(() => props.dispatch(doNarrow(streamNarrow(stream))));
+            }}
+          />
+        )
+      }
+      renderItem={({ item, section }) =>
+        section.key === 'private' ? (
+          <PmConversationList {...item} />
+        ) : (
+          <TopicItem
+            name={item.topic}
+            stream={section.streamName || ''}
+            isMuted={section.isMuted || item.isMuted}
+            isSelected={false}
+            unreadCount={item.unread}
+            onPress={(stream: string, topic: string) => {
+              setTimeout(() => props.dispatch(doNarrow(topicNarrow(stream, topic))));
+            }}
+          />
+        )
+      }
+    />
+  );
 }
 
 export default connect(state => ({

--- a/src/unread/UnreadCards.js
+++ b/src/unread/UnreadCards.js
@@ -3,8 +3,8 @@
 import React from 'react';
 import { SectionList } from 'react-native';
 
-import type { Dispatch, PmConversationData, UnreadStreamItem } from '../types';
-import { connect } from '../react-redux';
+import type { UnreadStreamItem } from '../types';
+import { useDispatch, useSelector } from '../react-redux';
 import { SearchEmptyState } from '../common';
 import PmConversationList from '../pm-conversations/PmConversationList';
 import StreamItem from '../streams/StreamItem';
@@ -13,14 +13,12 @@ import { streamNarrow, topicNarrow } from '../utils/narrow';
 import { getUnreadConversations, getUnreadStreamsAndTopicsSansMuted } from '../selectors';
 import { doNarrow } from '../actions';
 
-type Props = $ReadOnly<{|
-  conversations: PmConversationData[],
-  dispatch: Dispatch,
-  unreadStreamsAndTopics: UnreadStreamItem[],
-|}>;
+type Props = $ReadOnly<{||}>;
 
-function UnreadCards(props: Props) {
-  const { conversations, dispatch, unreadStreamsAndTopics } = props;
+export default function UnreadCards(props: Props) {
+  const dispatch = useDispatch();
+  const conversations = useSelector(getUnreadConversations);
+  const unreadStreamsAndTopics = useSelector(getUnreadStreamsAndTopicsSansMuted);
   type Card =
     | UnreadStreamItem
     | { key: 'private', data: Array<React$ElementConfig<typeof PmConversationList>> };
@@ -54,7 +52,7 @@ function UnreadCards(props: Props) {
             backgroundColor={section.color}
             unreadCount={section.unread}
             onPress={(stream: string) => {
-              setTimeout(() => props.dispatch(doNarrow(streamNarrow(stream))));
+              setTimeout(() => dispatch(doNarrow(streamNarrow(stream))));
             }}
           />
         )
@@ -70,7 +68,7 @@ function UnreadCards(props: Props) {
             isSelected={false}
             unreadCount={item.unread}
             onPress={(stream: string, topic: string) => {
-              setTimeout(() => props.dispatch(doNarrow(topicNarrow(stream, topic))));
+              setTimeout(() => dispatch(doNarrow(topicNarrow(stream, topic))));
             }}
           />
         )
@@ -78,8 +76,3 @@ function UnreadCards(props: Props) {
     />
   );
 }
-
-export default connect(state => ({
-  conversations: getUnreadConversations(state),
-  unreadStreamsAndTopics: getUnreadStreamsAndTopicsSansMuted(state),
-}))(UnreadCards);

--- a/src/unread/UnreadCards.js
+++ b/src/unread/UnreadCards.js
@@ -20,14 +20,6 @@ type Props = $ReadOnly<{|
 |}>;
 
 class UnreadCards extends PureComponent<Props> {
-  handleStreamPress = (stream: string) => {
-    setTimeout(() => this.props.dispatch(doNarrow(streamNarrow(stream))));
-  };
-
-  handleTopicPress = (stream: string, topic: string) => {
-    setTimeout(() => this.props.dispatch(doNarrow(topicNarrow(stream, topic))));
-  };
-
   render() {
     const { conversations, dispatch, unreadStreamsAndTopics } = this.props;
     type Card =
@@ -62,7 +54,9 @@ class UnreadCards extends PureComponent<Props> {
               isPrivate={section.isPrivate}
               backgroundColor={section.color}
               unreadCount={section.unread}
-              onPress={this.handleStreamPress}
+              onPress={(stream: string) => {
+                setTimeout(() => this.props.dispatch(doNarrow(streamNarrow(stream))));
+              }}
             />
           )
         }
@@ -76,7 +70,9 @@ class UnreadCards extends PureComponent<Props> {
               isMuted={section.isMuted || item.isMuted}
               isSelected={false}
               unreadCount={item.unread}
-              onPress={this.handleTopicPress}
+              onPress={(stream: string, topic: string) => {
+                setTimeout(() => this.props.dispatch(doNarrow(topicNarrow(stream, topic))));
+              }}
             />
           )
         }


### PR DESCRIPTION
~~See discussion [here](https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/converting.20to.20Hooks/near/1111919). The use of `connect` in these components instead of `useSelector` has been contributing to a crash.~~

(Never mind; I've got a fix for this open in #4454, where we add a `connect` in `MainTabsScreen`. Still, might as well not lose the work of Hooksifying these components, so I'll leave this PR open.)