### PR TITLE
replaceRevive [nfc]: Fix a latent bug caused by a sketchy null check.

### DIFF
--- a/src/boot/replaceRevive.js
+++ b/src/boot/replaceRevive.js
@@ -90,7 +90,7 @@ function replacer(key, value) {
         // the reviver will give the same output for both of them
         // (i.e., an empty `Immutable.Map`).
         [SERIALIZED_TYPE_FIELD_NAME]:
-          firstKey && typeof firstKey === 'number' ? 'ImmutableMapNumKeys' : 'ImmutableMap',
+          typeof firstKey === 'number' ? 'ImmutableMapNumKeys' : 'ImmutableMap',
       };
     }
     default: {


### PR DESCRIPTION
This is only latent because, so far, we only use
`ImmutableMapNumKeys` for `state.messages`. Greg confirms that it
would be very surprising if a message could have an ID of zero [1].

[1] https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/replaceRevive.20bug/near/1112480