### PR TITLE
template: Add pull request template for reporting PR's

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,45 @@
+Fixes: #<!--issue number-->
+## Proposed changes
+
+Brief description of what is fixed or changed
+
+<!-- ## Types of changes
+
+_Put an `x` in the boxes that apply_
+
+- [ ] Bugfix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Documentation update (Documentation content changed)
+- [ ] Other (please describe): 
+
+<!--
+
+Zulip has a high quality standard for merged code. This takes a bit of effort to get used to, but it makes Zulip better. Part of this is that it makes the project more accessible to contributors in the long run: careless bugs and unclear/missing explanations present some of the largest barriers to contributors, especially new contributors. We strive to avoid them. 🙂 Here is a list of mental notes you can use to help your PR be successful:
+
+- I've read the style guide: https://github.com/zulip/zulip-mobile/blob/master/docs/style.md.
+- My commits are clear and coherent: https://zulip.readthedocs.io/en/latest/contributing/version-control.html.
+- Each commit message has a properly formatted summary line and body, with attention to line lengths, etc. The reviewers read a lot of commits.
+- I've tried to answer a reviewer's questions before they're asked. (See a list of examples in the style guide.)
+- I've read these tips for changing my PR branch locally, so I know how to fix problems in my commits and update my PR: https://zulip.readthedocs.io/en/latest/git/fixing-commits.html.
+- I've read the Git guide, so I know how to inform myself about the history of the code I'd like to change: https://github.com/zulip/zulip-mobile/blob/master/docs/howto/git.md.
+- All of my commits pass our tests, which I can run with `tools/test`. A shortcut for running it on all new commits in your branch is `git rebase --exec 'tools/test'`.
+- If I'm changing the visual appearance of the app, I've made screenshots or GIFs to show the changes: https://github.com/zulip/zulip/blob/master/docs/tutorials/screenshot-and-gif-software.md.
+- If I just want feedback, and I'm not ready for a thorough code review, I've marked the PR as a work in progress: https://github.com/zulip/zulip/blob/master/docs/git/pull-requests.md#work-in-progress-pull-requests.
+
+That being said, please let us know, either here in the PR thread or on chat.zulip.org in the #mobile stream, what questions you have about the process. 🙂
+
+Please also let us know your questions that arose while working on the specific changes in this PR. For example:
+
+- "This PR removes some lines of code from `FooMachine` that were asking for help from some other code outside `FooMachine`. At first I thought `FooMachine` could do its job without help from that other code, but now I'm not so sure. Is that right?"
+- "I think it would be good to make some followup changes to `FooMachine`. Should I add more commits to this PR branch, or make a new PR?"
+
+-->
+
+## Screenshots
+
+Please attach the screenshots of the changes made in case of change in user interface
+
+## Other information
+
+Any other information that is important to this pull request


### PR DESCRIPTION
**Changes Proposed**
Added a new file inside the .github folder which will render a Pull Request template whenever someone opens a new PR.

**Chat thread** in [ZM](https://chat.zulip.org/#narrow/stream/48-mobile/topic/New.20Issue.20Template)



Fixes #4411 
