### PR TITLE
Start type checking `MessageList`'s props.

### DIFF
--- a/src/message/messageSelectors.js
+++ b/src/message/messageSelectors.js
@@ -1,7 +1,7 @@
 /* @flow strict-local */
 import { createSelector, defaultMemoize } from 'reselect';
 
-import type { Message, Outbox, Narrow, HtmlPieceDescriptor, Selector } from '../types';
+import type { Message, Outbox, Narrow, Selector } from '../types';
 import {
   getAllNarrows,
   getFlags,
@@ -59,15 +59,6 @@ export const getPrivateMessages: Selector<Message[]> = createSelector(
     }
     return privateMessages;
   },
-);
-
-export const getHtmlPieceDescriptorsForShownMessages: Selector<
-  HtmlPieceDescriptor[],
-  Narrow,
-> = createSelector(
-  (state, narrow) => narrow,
-  getShownMessagesForNarrow,
-  (narrow, messages) => getHtmlPieceDescriptors(messages, narrow),
 );
 
 export const getHtmlPieceDescriptorsForMessages = defaultMemoize(

--- a/src/message/messageSelectors.js
+++ b/src/message/messageSelectors.js
@@ -1,7 +1,7 @@
 /* @flow strict-local */
-import { createSelector } from 'reselect';
+import { createSelector, defaultMemoize } from 'reselect';
 
-import type { Message, Narrow, HtmlPieceDescriptor, Selector } from '../types';
+import type { Message, Outbox, Narrow, HtmlPieceDescriptor, Selector } from '../types';
 import {
   getAllNarrows,
   getFlags,
@@ -68,6 +68,11 @@ export const getHtmlPieceDescriptorsForShownMessages: Selector<
   (state, narrow) => narrow,
   getShownMessagesForNarrow,
   (narrow, messages) => getHtmlPieceDescriptors(messages, narrow),
+);
+
+export const getHtmlPieceDescriptorsForMessages = defaultMemoize(
+  (messages: $ReadOnlyArray<Message | Outbox>, narrow: Narrow) =>
+    getHtmlPieceDescriptors(messages, narrow),
 );
 
 export const getFirstUnreadIdInNarrow: Selector<number | null, Narrow> = createSelector(

--- a/src/react-native-action-sheet.js
+++ b/src/react-native-action-sheet.js
@@ -1,0 +1,29 @@
+/* @flow strict-local */
+import type { ComponentType, ElementConfig } from 'react';
+import { connectActionSheet as connectActionSheetInner } from '@expo/react-native-action-sheet';
+
+import type { BoundedDiff } from './generics';
+
+/* eslint-disable flowtype/generic-spacing */
+
+export type ShowActionSheetWithOptions = (
+  { options: string[], cancelButtonIndex: number },
+  (number) => void,
+) => void;
+
+/**
+ * Exactly like the `connectActionSheet` in
+ *   `react-native-action-sheet` upstream, but more typed.
+ */
+export function connectActionSheet<P, C: ComponentType<P>>(
+  WrappedComponent: C,
+): ComponentType<
+  $ReadOnly<
+    BoundedDiff<
+      $Exact<ElementConfig<C>>,
+      {| showActionSheetWithOptions: ShowActionSheetWithOptions |},
+    >,
+  >,
+> {
+  return connectActionSheetInner(WrappedComponent);
+}

--- a/src/search/SearchMessagesCard.js
+++ b/src/search/SearchMessagesCard.js
@@ -22,8 +22,6 @@ type Props = $ReadOnly<{|
 |}>;
 
 export default class SearchMessagesCard extends PureComponent<Props> {
-  static NOT_FETCHING = { older: false, newer: false };
-
   render() {
     const { isFetching, messages } = this.props;
 
@@ -52,7 +50,6 @@ export default class SearchMessagesCard extends PureComponent<Props> {
           messages={messages}
           narrow={HOME_NARROW}
           htmlPieceDescriptorsForShownMessages={htmlPieceDescriptors}
-          fetching={SearchMessagesCard.NOT_FETCHING}
           showMessagePlaceholders={false}
         />
       </View>

--- a/src/search/SearchMessagesCard.js
+++ b/src/search/SearchMessagesCard.js
@@ -41,15 +41,19 @@ export default class SearchMessagesCard extends PureComponent<Props> {
       return <SearchEmptyState text="No results" />;
     }
 
-    const htmlPieceDescriptors = getHtmlPieceDescriptorsForMessages(messages, HOME_NARROW);
+    // TODO: This is kind of a hack.
+    const narrow = HOME_NARROW;
 
     return (
       <View style={styles.results}>
         <MessageList
           initialScrollMessageId={messages[0].id}
           messages={messages}
-          narrow={HOME_NARROW}
-          htmlPieceDescriptorsForShownMessages={htmlPieceDescriptors}
+          narrow={narrow}
+          htmlPieceDescriptorsForShownMessages={getHtmlPieceDescriptorsForMessages(
+            messages,
+            narrow,
+          )}
           showMessagePlaceholders={false}
         />
       </View>

--- a/src/search/SearchMessagesCard.js
+++ b/src/search/SearchMessagesCard.js
@@ -50,6 +50,9 @@ export default class SearchMessagesCard extends PureComponent<Props> {
           messages={messages}
           narrow={narrow}
           showMessagePlaceholders={false}
+          // TODO: handle editing a message from the search results,
+          // or make this prop optional
+          startEditMessage={() => undefined}
         />
       </View>
     );

--- a/src/search/SearchMessagesCard.js
+++ b/src/search/SearchMessagesCard.js
@@ -8,7 +8,7 @@ import { createStyleSheet } from '../styles';
 import { LoadingIndicator, SearchEmptyState } from '../common';
 import { HOME_NARROW } from '../utils/narrow';
 import MessageList from '../webview/MessageList';
-import getHtmlPieceDescriptors from '../message/getHtmlPieceDescriptors';
+import { getHtmlPieceDescriptorsForMessages } from '../message/messageSelectors';
 
 const styles = createStyleSheet({
   results: {
@@ -41,7 +41,7 @@ export default class SearchMessagesCard extends PureComponent<Props> {
       return <SearchEmptyState text="No results" />;
     }
 
-    const htmlPieceDescriptors = getHtmlPieceDescriptors(messages, HOME_NARROW);
+    const htmlPieceDescriptors = getHtmlPieceDescriptorsForMessages(messages, HOME_NARROW);
 
     return (
       <View style={styles.results}>

--- a/src/search/SearchMessagesCard.js
+++ b/src/search/SearchMessagesCard.js
@@ -8,7 +8,6 @@ import { createStyleSheet } from '../styles';
 import { LoadingIndicator, SearchEmptyState } from '../common';
 import { HOME_NARROW } from '../utils/narrow';
 import MessageList from '../webview/MessageList';
-import { getHtmlPieceDescriptorsForMessages } from '../message/messageSelectors';
 
 const styles = createStyleSheet({
   results: {
@@ -50,10 +49,6 @@ export default class SearchMessagesCard extends PureComponent<Props> {
           initialScrollMessageId={messages[0].id}
           messages={messages}
           narrow={narrow}
-          htmlPieceDescriptorsForShownMessages={getHtmlPieceDescriptorsForMessages(
-            messages,
-            narrow,
-          )}
           showMessagePlaceholders={false}
         />
       </View>

--- a/src/search/SearchMessagesCard.js
+++ b/src/search/SearchMessagesCard.js
@@ -9,7 +9,6 @@ import { LoadingIndicator, SearchEmptyState } from '../common';
 import { HOME_NARROW } from '../utils/narrow';
 import MessageList from '../webview/MessageList';
 import getHtmlPieceDescriptors from '../message/getHtmlPieceDescriptors';
-import { NULL_ARRAY } from '../nullObjects';
 
 const styles = createStyleSheet({
   results: {
@@ -55,7 +54,6 @@ export default class SearchMessagesCard extends PureComponent<Props> {
           htmlPieceDescriptorsForShownMessages={htmlPieceDescriptors}
           fetching={SearchMessagesCard.NOT_FETCHING}
           showMessagePlaceholders={false}
-          typingUsers={NULL_ARRAY}
         />
       </View>
     );

--- a/src/webview/MessageList.js
+++ b/src/webview/MessageList.js
@@ -308,10 +308,6 @@ type OuterProps = {|
   messages?: Message[],
   htmlPieceDescriptorsForShownMessages?: HtmlPieceDescriptor[],
   initialScrollMessageId?: number | null,
-
-  /* Passing this from the parent is kind of a hack; search uses it to
-     hard-code some behavior. */
-  fetching?: Fetching,
 |};
 
 export default connect<SelectorProps, _, _>((state, props: OuterProps) => {
@@ -339,7 +335,7 @@ export default connect<SelectorProps, _, _>((state, props: OuterProps) => {
       props.initialScrollMessageId !== undefined
         ? props.initialScrollMessageId
         : getFirstUnreadIdInNarrow(state, props.narrow),
-    fetching: props.fetching || getFetchingForNarrow(state, props.narrow),
+    fetching: getFetchingForNarrow(state, props.narrow),
     messages: props.messages || getShownMessagesForNarrow(state, props.narrow),
     htmlPieceDescriptorsForShownMessages:
       props.htmlPieceDescriptorsForShownMessages

--- a/src/webview/MessageList.js
+++ b/src/webview/MessageList.js
@@ -1,5 +1,5 @@
 /* @flow strict-local */
-import React, { Component } from 'react';
+import React, { Component, type ComponentType } from 'react';
 import { Platform, NativeModules } from 'react-native';
 import { WebView } from 'react-native-webview';
 import type { WebViewNavigation } from 'react-native-webview';
@@ -142,7 +142,7 @@ const assetsUrl =
  */
 const webviewAssetsUrl = new URL('webview/', assetsUrl);
 
-class MessageList extends Component<Props> {
+class MessageListInner extends Component<Props> {
   static contextType = ThemeContext;
   context: ThemeData;
 
@@ -304,32 +304,36 @@ type OuterProps = {|
   startEditMessage: (editMessage: EditMessage) => void,
 |};
 
-export default connect<SelectorProps, _, _>((state, props: OuterProps) => {
-  // TODO Ideally this ought to be a caching selector that doesn't change
-  // when the inputs don't.  Doesn't matter in a practical way here, because
-  // we have a `shouldComponentUpdate` that doesn't look at this prop... but
-  // it'd be better to set an example of the right general pattern.
-  const backgroundData: BackgroundData = {
-    alertWords: state.alertWords,
-    allImageEmojiById: getAllImageEmojiById(state),
-    auth: getAuth(state),
-    debug: getDebug(state),
-    flags: getFlags(state),
-    mute: getMute(state),
-    mutedUsers: getMutedUsers(state),
-    ownUser: getOwnUser(state),
-    subscriptions: getSubscriptions(state),
-    theme: getSettings(state).theme,
-    twentyFourHourTime: getRealm(state).twentyFourHourTime,
-  };
+const MessageList: ComponentType<OuterProps> = connect<SelectorProps, _, _>(
+  (state, props: OuterProps) => {
+    // TODO Ideally this ought to be a caching selector that doesn't change
+    // when the inputs don't.  Doesn't matter in a practical way here, because
+    // we have a `shouldComponentUpdate` that doesn't look at this prop... but
+    // it'd be better to set an example of the right general pattern.
+    const backgroundData: BackgroundData = {
+      alertWords: state.alertWords,
+      allImageEmojiById: getAllImageEmojiById(state),
+      auth: getAuth(state),
+      debug: getDebug(state),
+      flags: getFlags(state),
+      mute: getMute(state),
+      mutedUsers: getMutedUsers(state),
+      ownUser: getOwnUser(state),
+      subscriptions: getSubscriptions(state),
+      theme: getSettings(state).theme,
+      twentyFourHourTime: getRealm(state).twentyFourHourTime,
+    };
 
-  return {
-    backgroundData,
-    fetching: getFetchingForNarrow(state, props.narrow),
-    htmlPieceDescriptorsForShownMessages: getHtmlPieceDescriptorsForMessages(
-      props.messages,
-      props.narrow,
-    ),
-    typingUsers: getCurrentTypingUsers(state, props.narrow),
-  };
-})(connectActionSheet(withGetText(MessageList)));
+    return {
+      backgroundData,
+      fetching: getFetchingForNarrow(state, props.narrow),
+      htmlPieceDescriptorsForShownMessages: getHtmlPieceDescriptorsForMessages(
+        props.messages,
+        props.narrow,
+      ),
+      typingUsers: getCurrentTypingUsers(state, props.narrow),
+    };
+  },
+)(connectActionSheet(withGetText(MessageListInner)));
+
+export default MessageList;

--- a/src/webview/MessageList.js
+++ b/src/webview/MessageList.js
@@ -37,13 +37,11 @@ import {
   getHtmlPieceDescriptorsForShownMessages,
   getFlags,
   getFetchingForNarrow,
-  getFirstUnreadIdInNarrow,
   getMute,
   getMutedUsers,
   getOwnUser,
   getSettings,
   getSubscriptions,
-  getShownMessagesForNarrow,
   getRealm,
 } from '../selectors';
 import { withGetText } from '../boot/TranslationProvider';
@@ -93,9 +91,7 @@ type SelectorProps = {|
   // The remaining props contain data specific to the particular narrow or
   // particular messages we're displaying.  Data that's independent of those
   // should go in `BackgroundData`, above.
-  initialScrollMessageId: number | null,
   fetching: Fetching,
-  messages: $ReadOnlyArray<Message | Outbox>,
   htmlPieceDescriptorsForShownMessages: HtmlPieceDescriptor[],
   typingUsers: $ReadOnlyArray<UserOrBot>,
 |};
@@ -103,6 +99,8 @@ type SelectorProps = {|
 // TODO get a type for `connectActionSheet` so this gets fully type-checked.
 export type Props = $ReadOnly<{|
   narrow: Narrow,
+  messages: $ReadOnlyArray<Message | Outbox>,
+  initialScrollMessageId: number | null,
   showMessagePlaceholders: boolean,
   startEditMessage: (editMessage: EditMessage) => void,
 
@@ -301,13 +299,10 @@ class MessageList extends Component<Props> {
 
 type OuterProps = {|
   narrow: Narrow,
+  messages: $ReadOnlyArray<Message | Outbox>,
+  initialScrollMessageId: number | null,
   showMessagePlaceholders: boolean,
-
-  /* Remaining props are derived from `narrow` by default. */
-
-  messages?: Message[],
   htmlPieceDescriptorsForShownMessages?: HtmlPieceDescriptor[],
-  initialScrollMessageId?: number | null,
 |};
 
 export default connect<SelectorProps, _, _>((state, props: OuterProps) => {
@@ -331,12 +326,7 @@ export default connect<SelectorProps, _, _>((state, props: OuterProps) => {
 
   return {
     backgroundData,
-    initialScrollMessageId:
-      props.initialScrollMessageId !== undefined
-        ? props.initialScrollMessageId
-        : getFirstUnreadIdInNarrow(state, props.narrow),
     fetching: getFetchingForNarrow(state, props.narrow),
-    messages: props.messages || getShownMessagesForNarrow(state, props.narrow),
     htmlPieceDescriptorsForShownMessages:
       props.htmlPieceDescriptorsForShownMessages
       || getHtmlPieceDescriptorsForShownMessages(state, props.narrow),

--- a/src/webview/MessageList.js
+++ b/src/webview/MessageList.js
@@ -302,7 +302,6 @@ type OuterProps = {|
   messages: $ReadOnlyArray<Message | Outbox>,
   initialScrollMessageId: number | null,
   showMessagePlaceholders: boolean,
-  htmlPieceDescriptorsForShownMessages?: HtmlPieceDescriptor[],
 |};
 
 export default connect<SelectorProps, _, _>((state, props: OuterProps) => {
@@ -327,9 +326,10 @@ export default connect<SelectorProps, _, _>((state, props: OuterProps) => {
   return {
     backgroundData,
     fetching: getFetchingForNarrow(state, props.narrow),
-    htmlPieceDescriptorsForShownMessages: props.htmlPieceDescriptorsForShownMessages
-      ? props.htmlPieceDescriptorsForShownMessages
-      : getHtmlPieceDescriptorsForMessages(props.messages, props.narrow),
+    htmlPieceDescriptorsForShownMessages: getHtmlPieceDescriptorsForMessages(
+      props.messages,
+      props.narrow,
+    ),
     typingUsers: getCurrentTypingUsers(state, props.narrow),
   };
 })(connectActionSheet(withGetText(MessageList)));

--- a/src/webview/MessageList.js
+++ b/src/webview/MessageList.js
@@ -302,6 +302,7 @@ type OuterProps = {|
   messages: $ReadOnlyArray<Message | Outbox>,
   initialScrollMessageId: number | null,
   showMessagePlaceholders: boolean,
+  startEditMessage: (editMessage: EditMessage) => void,
 |};
 
 export default connect<SelectorProps, _, _>((state, props: OuterProps) => {

--- a/src/webview/MessageList.js
+++ b/src/webview/MessageList.js
@@ -3,8 +3,8 @@ import React, { Component } from 'react';
 import { Platform, NativeModules } from 'react-native';
 import { WebView } from 'react-native-webview';
 import type { WebViewNavigation } from 'react-native-webview';
-import { connectActionSheet } from '@expo/react-native-action-sheet';
 
+import { connectActionSheet } from '../react-native-action-sheet';
 import type {
   AlertWordsState,
   Auth,
@@ -96,7 +96,6 @@ type SelectorProps = {|
   typingUsers: $ReadOnlyArray<UserOrBot>,
 |};
 
-// TODO get a type for `connectActionSheet` so this gets fully type-checked.
 export type Props = $ReadOnly<{|
   narrow: Narrow,
   messages: $ReadOnlyArray<Message | Outbox>,

--- a/src/webview/MessageList.js
+++ b/src/webview/MessageList.js
@@ -34,7 +34,6 @@ import {
   getAllImageEmojiById,
   getCurrentTypingUsers,
   getDebug,
-  getHtmlPieceDescriptorsForShownMessages,
   getFlags,
   getFetchingForNarrow,
   getMute,
@@ -46,6 +45,7 @@ import {
 } from '../selectors';
 import { withGetText } from '../boot/TranslationProvider';
 import type { ShowActionSheetWithOptions } from '../message/messageActionSheet';
+import { getHtmlPieceDescriptorsForMessages } from '../message/messageSelectors';
 import type { WebViewInboundEvent } from './generateInboundEvents';
 import type { WebViewOutboundEvent } from './handleOutboundEvents';
 import getHtml from './html/html';
@@ -329,7 +329,7 @@ export default connect<SelectorProps, _, _>((state, props: OuterProps) => {
     fetching: getFetchingForNarrow(state, props.narrow),
     htmlPieceDescriptorsForShownMessages:
       props.htmlPieceDescriptorsForShownMessages
-      || getHtmlPieceDescriptorsForShownMessages(state, props.narrow),
+      || getHtmlPieceDescriptorsForMessages(props.messages, props.narrow),
     typingUsers: getCurrentTypingUsers(state, props.narrow),
   };
 })(connectActionSheet(withGetText(MessageList)));

--- a/src/webview/MessageList.js
+++ b/src/webview/MessageList.js
@@ -309,10 +309,9 @@ type OuterProps = {|
   htmlPieceDescriptorsForShownMessages?: HtmlPieceDescriptor[],
   initialScrollMessageId?: number | null,
 
-  /* Passing these two from the parent is kind of a hack; search uses it
-     to hard-code some behavior. */
+  /* Passing this from the parent is kind of a hack; search uses it to
+     hard-code some behavior. */
   fetching?: Fetching,
-  typingUsers?: UserOrBot[],
 |};
 
 export default connect<SelectorProps, _, _>((state, props: OuterProps) => {
@@ -345,6 +344,6 @@ export default connect<SelectorProps, _, _>((state, props: OuterProps) => {
     htmlPieceDescriptorsForShownMessages:
       props.htmlPieceDescriptorsForShownMessages
       || getHtmlPieceDescriptorsForShownMessages(state, props.narrow),
-    typingUsers: props.typingUsers || getCurrentTypingUsers(state, props.narrow),
+    typingUsers: getCurrentTypingUsers(state, props.narrow),
   };
 })(connectActionSheet(withGetText(MessageList)));

--- a/src/webview/MessageList.js
+++ b/src/webview/MessageList.js
@@ -84,6 +84,14 @@ export type BackgroundData = $ReadOnly<{|
   twentyFourHourTime: boolean,
 |}>;
 
+type OuterProps = {|
+  narrow: Narrow,
+  messages: $ReadOnlyArray<Message | Outbox>,
+  initialScrollMessageId: number | null,
+  showMessagePlaceholders: boolean,
+  startEditMessage: (editMessage: EditMessage) => void,
+|};
+
 type SelectorProps = {|
   // Data independent of the particular narrow or messages we're displaying.
   backgroundData: BackgroundData,
@@ -97,11 +105,7 @@ type SelectorProps = {|
 |};
 
 export type Props = $ReadOnly<{|
-  narrow: Narrow,
-  messages: $ReadOnlyArray<Message | Outbox>,
-  initialScrollMessageId: number | null,
-  showMessagePlaceholders: boolean,
-  startEditMessage: (editMessage: EditMessage) => void,
+  ...OuterProps,
 
   dispatch: Dispatch,
   ...SelectorProps,
@@ -295,14 +299,6 @@ class MessageListInner extends Component<Props> {
     );
   }
 }
-
-type OuterProps = {|
-  narrow: Narrow,
-  messages: $ReadOnlyArray<Message | Outbox>,
-  initialScrollMessageId: number | null,
-  showMessagePlaceholders: boolean,
-  startEditMessage: (editMessage: EditMessage) => void,
-|};
 
 const MessageList: ComponentType<OuterProps> = connect<SelectorProps, _, _>(
   (state, props: OuterProps) => {

--- a/src/webview/MessageList.js
+++ b/src/webview/MessageList.js
@@ -327,9 +327,9 @@ export default connect<SelectorProps, _, _>((state, props: OuterProps) => {
   return {
     backgroundData,
     fetching: getFetchingForNarrow(state, props.narrow),
-    htmlPieceDescriptorsForShownMessages:
-      props.htmlPieceDescriptorsForShownMessages
-      || getHtmlPieceDescriptorsForMessages(props.messages, props.narrow),
+    htmlPieceDescriptorsForShownMessages: props.htmlPieceDescriptorsForShownMessages
+      ? props.htmlPieceDescriptorsForShownMessages
+      : getHtmlPieceDescriptorsForMessages(props.messages, props.narrow),
     typingUsers: getCurrentTypingUsers(state, props.narrow),
   };
 })(connectActionSheet(withGetText(MessageList)));


### PR DESCRIPTION
By adding a type-wrapper for `connectActionSheet`, and annotating the export of MessageList.js with `ComponentType<OuterProps>`, as @gnprice mentioned in [a recent discussion of Flow and `connect`](https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/Flow.20and.20.60connect.60/near/1098230).

I've removed the kind of hacky cases where we use the same name for an "outer" prop as we use for a prop that `connect` provides. Let me know if you see a better way to do this, and in particular, if you don't like the changes to `MessageList`'s interface. 🙂 

Also, in this one—

MessageList [nfc]: Remove htmlPieceDescriptorsForShownMessages prop (3/x).

—there's a potential performance regression, where we stop using a caching selector. After I'd removed that, it occurred to me that some of the work it caches (calling `getHtmlPieceDescriptors` on each shown message) is enough that we'll want to keep the caching and find something else to do about the `htmlPieceDescriptorsForShownMessages` prop. What do you think?