### PR TITLE
Convert `StreamItem` and `TopicItem` to use Hooks.

### DIFF
--- a/src/streams/StreamItem.js
+++ b/src/streams/StreamItem.js
@@ -70,15 +70,6 @@ export default class StreamItem extends PureComponent<Props> {
     isSwitchedOn: false,
   };
 
-  handlePress = () => this.props.onPress(this.props.name);
-
-  handleSwitch = (newValue: boolean) => {
-    const { name, onSwitch } = this.props;
-    if (onSwitch) {
-      onSwitch(name, newValue);
-    }
-  };
-
   render() {
     const {
       name,
@@ -91,6 +82,8 @@ export default class StreamItem extends PureComponent<Props> {
       showSwitch,
       isSwitchedOn,
       unreadCount,
+      onPress,
+      onSwitch,
     } = this.props;
 
     const wrapperStyle = [styles.listItem, { backgroundColor }, isMuted && componentStyles.muted];
@@ -106,7 +99,7 @@ export default class StreamItem extends PureComponent<Props> {
         : this.context.color;
 
     return (
-      <Touchable onPress={this.handlePress}>
+      <Touchable onPress={() => onPress(this.props.name)}>
         <View style={wrapperStyle}>
           <StreamIcon size={iconSize} color={iconColor} isMuted={isMuted} isPrivate={isPrivate} />
           <View style={componentStyles.text}>
@@ -129,7 +122,11 @@ export default class StreamItem extends PureComponent<Props> {
           {showSwitch && (
             <ZulipSwitch
               value={!!isSwitchedOn}
-              onValueChange={this.handleSwitch}
+              onValueChange={(newValue: boolean) => {
+                if (onSwitch) {
+                  onSwitch(name, newValue);
+                }
+              }}
               disabled={!isSwitchedOn && isPrivate}
             />
           )}

--- a/src/streams/StreamItem.js
+++ b/src/streams/StreamItem.js
@@ -1,8 +1,7 @@
 /* @flow strict-local */
-import React, { PureComponent } from 'react';
+import React, { useContext } from 'react';
 import { View } from 'react-native';
 
-import type { ThemeData } from '../styles';
 import styles, { createStyleSheet, ThemeContext } from '../styles';
 import { RawLabel, Touchable, UnreadCount, ZulipSwitch } from '../common';
 import { foregroundColorFromBackground } from '../utils/color';
@@ -26,15 +25,15 @@ const componentStyles = createStyleSheet({
 type Props = $ReadOnly<{|
   name: string,
   description?: string,
-  isMuted: boolean,
-  isPrivate: boolean,
+  isMuted?: boolean,
+  isPrivate?: boolean,
   color?: string,
   backgroundColor?: string,
 
   unreadCount?: number,
   iconSize: number,
-  showSwitch: boolean,
-  isSwitchedOn: boolean,
+  showSwitch?: boolean,
+  isSwitchedOn?: boolean,
   onPress: (name: string) => void,
   onSwitch?: (name: string, newValue: boolean) => void,
 |}>;
@@ -59,79 +58,69 @@ type Props = $ReadOnly<{|
  * @prop onPress - press handler for the item; receives the stream name
  * @prop onSwitch - if switch exists; receives stream name and new value
  */
-export default class StreamItem extends PureComponent<Props> {
-  static contextType = ThemeContext;
-  context: ThemeData;
+export default function StreamItem(props: Props) {
+  const {
+    name,
+    description,
+    color,
+    backgroundColor,
+    isPrivate = false,
+    isMuted = false,
+    iconSize,
+    showSwitch = false,
+    isSwitchedOn = false,
+    unreadCount,
+    onPress,
+    onSwitch,
+  } = props;
 
-  static defaultProps = {
-    isMuted: false,
-    isPrivate: false,
-    showSwitch: false,
-    isSwitchedOn: false,
-  };
+  const { backgroundColor: themeBackgroundColor, color: themeColor } = useContext(ThemeContext);
 
-  render() {
-    const {
-      name,
-      description,
-      color,
-      backgroundColor,
-      isPrivate,
-      isMuted,
-      iconSize,
-      showSwitch,
-      isSwitchedOn,
-      unreadCount,
-      onPress,
-      onSwitch,
-    } = this.props;
+  const wrapperStyle = [styles.listItem, { backgroundColor }, isMuted && componentStyles.muted];
+  const iconColor =
+    color !== undefined
+      ? color
+      : foregroundColorFromBackground(
+          backgroundColor !== undefined ? backgroundColor : themeBackgroundColor,
+        );
+  const textColor =
+    backgroundColor !== undefined
+      ? (foregroundColorFromBackground(backgroundColor): string)
+      : themeColor;
 
-    const wrapperStyle = [styles.listItem, { backgroundColor }, isMuted && componentStyles.muted];
-    const iconColor =
-      color !== undefined
-        ? color
-        : foregroundColorFromBackground(
-            backgroundColor !== undefined ? backgroundColor : this.context.backgroundColor,
-          );
-    const textColor =
-      backgroundColor !== undefined
-        ? (foregroundColorFromBackground(backgroundColor): string)
-        : this.context.color;
-
-    return (
-      <Touchable onPress={() => onPress(this.props.name)}>
-        <View style={wrapperStyle}>
-          <StreamIcon size={iconSize} color={iconColor} isMuted={isMuted} isPrivate={isPrivate} />
-          <View style={componentStyles.text}>
+  return (
+    <Touchable onPress={() => onPress(name)}>
+      <View style={wrapperStyle}>
+        <StreamIcon size={iconSize} color={iconColor} isMuted={isMuted} isPrivate={isPrivate} />
+        <View style={componentStyles.text}>
+          <RawLabel
+            numberOfLines={1}
+            style={{ color: textColor }}
+            text={name}
+            ellipsizeMode="tail"
+          />
+          {description !== undefined && description !== '' && (
             <RawLabel
               numberOfLines={1}
-              style={{ color: textColor }}
-              text={name}
+              style={componentStyles.description}
+              text={description}
               ellipsizeMode="tail"
-            />
-            {description !== undefined && description !== '' && (
-              <RawLabel
-                numberOfLines={1}
-                style={componentStyles.description}
-                text={description}
-                ellipsizeMode="tail"
-              />
-            )}
-          </View>
-          <UnreadCount color={iconColor} count={unreadCount} />
-          {showSwitch && (
-            <ZulipSwitch
-              value={!!isSwitchedOn}
-              onValueChange={(newValue: boolean) => {
-                if (onSwitch) {
-                  onSwitch(name, newValue);
-                }
-              }}
-              disabled={!isSwitchedOn && isPrivate}
             />
           )}
         </View>
-      </Touchable>
-    );
-  }
+        <UnreadCount color={iconColor} count={unreadCount} />
+        {showSwitch && (
+          <ZulipSwitch
+            value={!!isSwitchedOn}
+            onValueChange={(newValue: boolean) => {
+              if (onSwitch) {
+                onSwitch(name, newValue);
+              }
+            }}
+            disabled={!isSwitchedOn && isPrivate}
+          />
+        )}
+      </View>
+    </Touchable>
+  );
 }

--- a/src/streams/TopicItem.js
+++ b/src/streams/TopicItem.js
@@ -41,14 +41,7 @@ export default function TopicItem(props: Props) {
   } = props;
 
   return (
-    <Touchable
-      onPress={() => {
-        onPress(stream, name);
-      }}
-      onLongPress={() => {
-        showToast(name);
-      }}
-    >
+    <Touchable onPress={() => onPress(stream, name)} onLongPress={() => showToast(name)}>
       <View
         style={[
           styles.listItem,

--- a/src/streams/TopicItem.js
+++ b/src/streams/TopicItem.js
@@ -1,5 +1,5 @@
 /* @flow strict-local */
-import React, { PureComponent } from 'react';
+import React from 'react';
 import { View } from 'react-native';
 
 import styles, { BRAND_COLOR, createStyleSheet } from '../styles';
@@ -22,50 +22,48 @@ const componentStyles = createStyleSheet({
 });
 
 type Props = $ReadOnly<{|
-  stream: string,
+  stream?: string,
   name: string,
-  isMuted: boolean,
-  isSelected: boolean,
-  unreadCount: number,
+  isMuted?: boolean,
+  isSelected?: boolean,
+  unreadCount?: number,
   onPress: (topic: string, stream: string) => void,
 |}>;
 
-export default class TopicItem extends PureComponent<Props> {
-  static defaultProps = {
-    stream: '',
-    isMuted: false,
-    isSelected: false,
-    unreadCount: 0,
-  };
+export default function TopicItem(props: Props) {
+  const {
+    name,
+    stream = '',
+    isMuted = false,
+    isSelected = false,
+    unreadCount = 0,
+    onPress,
+  } = props;
 
-  render() {
-    const { name, stream, isMuted, isSelected, unreadCount, onPress } = this.props;
-
-    return (
-      <Touchable
-        onPress={() => {
-          onPress(stream, name);
-        }}
-        onLongPress={() => {
-          showToast(name);
-        }}
+  return (
+    <Touchable
+      onPress={() => {
+        onPress(stream, name);
+      }}
+      onLongPress={() => {
+        showToast(name);
+      }}
+    >
+      <View
+        style={[
+          styles.listItem,
+          isSelected && componentStyles.selectedRow,
+          isMuted && componentStyles.muted,
+        ]}
       >
-        <View
-          style={[
-            styles.listItem,
-            isSelected && componentStyles.selectedRow,
-            isMuted && componentStyles.muted,
-          ]}
-        >
-          <RawLabel
-            style={[componentStyles.label, isSelected && componentStyles.selectedText]}
-            text={name}
-            numberOfLines={1}
-            ellipsizeMode="tail"
-          />
-          <UnreadCount count={unreadCount} inverse={isSelected} />
-        </View>
-      </Touchable>
-    );
-  }
+        <RawLabel
+          style={[componentStyles.label, isSelected && componentStyles.selectedText]}
+          text={name}
+          numberOfLines={1}
+          ellipsizeMode="tail"
+        />
+        <UnreadCount count={unreadCount} inverse={isSelected} />
+      </View>
+    </Touchable>
+  );
 }

--- a/src/streams/TopicItem.js
+++ b/src/streams/TopicItem.js
@@ -38,21 +38,18 @@ export default class TopicItem extends PureComponent<Props> {
     unreadCount: 0,
   };
 
-  handlePress = () => {
-    const { name, stream, onPress } = this.props;
-    onPress(stream, name);
-  };
-
-  handleLongPress = () => {
-    const { name } = this.props;
-    showToast(name);
-  };
-
   render() {
-    const { name, isMuted, isSelected, unreadCount } = this.props;
+    const { name, stream, isMuted, isSelected, unreadCount, onPress } = this.props;
 
     return (
-      <Touchable onPress={this.handlePress} onLongPress={this.handleLongPress}>
+      <Touchable
+        onPress={() => {
+          onPress(stream, name);
+        }}
+        onLongPress={() => {
+          showToast(name);
+        }}
+      >
         <View
           style={[
             styles.listItem,


### PR DESCRIPTION
To simplify translating some user-facing strings. `StreamItem`, at least, will need two contexts: the theme context and the translation context. With the new Context API, a class component can't declare multiple `contextType`s. But Hooks components work just fine with two different `useContext` calls (see [example](https://reactjs.org/docs/hooks-overview.html#other-hooks)).

From [discussion](https://chat.zulip.org/#narrow/stream/48-mobile/topic/Adding.20Accessibilty/near/1113306).