### PR TITLE
Handle the "Overlap" part of the user name in the app bar

### DIFF
--- a/src/title/TitlePrivate.js
+++ b/src/title/TitlePrivate.js
@@ -21,6 +21,7 @@ type Props = $ReadOnly<{
 const componentStyles = createStyleSheet({
   outer: { flex: 1 },
   inner: { flexDirection: 'row', alignItems: 'center' },
+  textWrapper: { flex: 1 },
 });
 
 export default function TitlePrivate(props: Props) {
@@ -43,7 +44,7 @@ export default function TitlePrivate(props: Props) {
       <View style={componentStyles.inner}>
         <UserAvatarWithPresenceById size={32} userId={user.user_id} />
         <ViewPlaceholder width={8} />
-        <View>
+        <View style={componentStyles.textWrapper}>
           <Text style={[styles.navTitle, { color }]} numberOfLines={1} ellipsizeMode="tail">
             {user.full_name}
           </Text>


### PR DESCRIPTION
**Changes done**
I specified a width of 250 for the Text component in ```TitlePrivate```. This width will make sure that the truncated part (ellipsis "...")  doesn't overlap with the InfoButton of the app bar.

**Before**
![IMG_20210131_093322](https://user-images.githubusercontent.com/53913514/107020009-59a46c00-67c8-11eb-8466-bcf3ac04b1e0.jpg)


**After**
![Screenshot 2021-02-05 at 12 28 07 PM](https://user-images.githubusercontent.com/53913514/107020028-5f9a4d00-67c8-11eb-8ff7-3a9f5b38d875.png)






Fixes: #4469
