### PR TITLE
replaceRevive: Throw an error on trying to revive unknown serialized …

### DIFF
--- a/src/boot/replaceRevive.js
+++ b/src/boot/replaceRevive.js
@@ -163,7 +163,12 @@ function reviver(key, value) {
           [SERIALIZED_TYPE_FIELD_NAME]: value[SERIALIZED_TYPE_FIELD_NAME_ESCAPED],
         };
       default:
-        return data;
+        // This should be impossible for data that came from our
+        // corresponding replacer, above.  If we do have a bug that leads to
+        // this case, there's nothing we can return that isn't likely to be
+        // a corrupt data structure that causes a crash somewhere else
+        // downstream; so just fail immediately.
+        throw new Error(`Unhandled serialized type: ${value[SERIALIZED_TYPE_FIELD_NAME]}`);
     }
   }
   return value;


### PR DESCRIPTION
…type.

If we know `SERIALIZED_TYPE_FIELD_NAME in value`, then we should be
able to enumerate all the possible values of
`value[SERIALIZED_TYPE_FIELD_NAME]`. In fact, that's the job of the
reviver's big switch/case: to enumerate all those possible values
and handle each one appropriately.

The `default:` case should be impossible, if we've included a case
for each possible value of `value[SERIALIZED_TYPE_FIELD_NAME]`.
Currently, it looks like we have included all the necessary cases.

But we'll want to know right away if we've made a mistake, rather
than waiting for it to cause a problem somewhere later, where it'll
be harder to debug.

See discussion [1], where Greg identified this problem and solution.

[1] https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/.23M4458.3A.20.22t.2Eget.20is.20not.20a.20function.22.20on.20state.2Enarrows.20at.20sta.2E.2E.2E/near/1115886