### PR TITLE
eslint: Specify Jest version in config.

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -51,6 +51,19 @@ settings:
     node:
       extensions: [.js, .ios.js, .android.js, .json]
 
+  jest:
+    # Some Jest rules depend on the Jest version. In particular,
+    #   "jest/no-deprecated-functions". If we don't provide it here,
+    #   that rule will use `process.cwd()` to grab the Jest version
+    #   from node_modules. But our VSCode plugin for ESLint seems to
+    #   be changing the working directory in a way that interferes
+    #   with that, and I haven't found the right value for that
+    #   plugin's `eslint.workingDirectories` setting to fix the
+    #   problem. Even if I did, though, that'd be one more thing to
+    #   document as part of the dev setup, so we might as well fix the
+    #   problem here.
+    version: "26"
+
 
 rules:
 


### PR DESCRIPTION
This fixes a problem where format-on-save had stopped working for
me, probably after updating vscode-eslint. I'd been getting this
error:

```
Error: Error while loading rule 'jest/no-deprecated-functions':
  Unable to detect Jest version - please ensure jest package is
  installed, or otherwise set version explicitly

Occurred while linting
  /Users/chrisbobbe/dev/zulip-mobile/src/compose/ComposeMenu.js

	at detectJestVersion
	  (/Users/chrisbobbe/dev/zulip-mobile/node_modules/eslint-plugin-jest/lib/rules/no-deprecated-functions.js:38:9)

	at create
	  (/Users/chrisbobbe/dev/zulip-mobile/node_modules/eslint-plugin-jest/lib/rules/no-deprecated-functions.js:61:256)

	[...]
```

Now I don't get that error, and format-on-save works again.

See these issues:

- jest-community/eslint-plugin-jest#686
- microsoft/vscode-eslint#1145
