### PR TITLE
crash: Fix crash in getUserFromMention as unformattedMessage gives undefined.

### DIFF
--- a/src/compose/MentionWarnings.js
+++ b/src/compose/MentionWarnings.js
@@ -57,7 +57,6 @@ class MentionWarnings extends PureComponent<Props, State> {
     const { allUsersById } = this.props;
 
     const unformattedMessage = completion.split('**')[1];
-    const [userFullName, userIdRaw] = unformattedMessage.split('|');
 
     // We skip user groups, for which autocompletes are of the form
     // `*<user_group_name>*`, and therefore, message.split('**')[1]
@@ -65,6 +64,8 @@ class MentionWarnings extends PureComponent<Props, State> {
     if (unformattedMessage === undefined) {
       return undefined;
     }
+
+    const [userFullName, userIdRaw] = unformattedMessage.split('|');
 
     if (userIdRaw !== undefined) {
       const userId = makeUserId(Number.parseInt(userIdRaw, 10));


### PR DESCRIPTION
**What was the error?**
The **unformattedMessage** in **getUserFromMention** was giving undefined which was the cause of the crash.

**How I solved this issue?**
Since on mentioning the **group** in the ComposeBox was providing the same error. I used a constant called **splittedMessage** which splits the string through "*". This computation can provide me an array of length either 3 or 5. Thus, according to the size, I specified which index's value is further needed in the code. Hence, the bug was solved. 

**Before**
![Screenshot-2021-02-05-at-10 52 28-AM](https://user-images.githubusercontent.com/53913514/107819204-ca3a2280-6d9e-11eb-8b29-c5691f05a048.png)

**After changes**
 No error
![Screenshot 2021-02-13 at 1 58 09 AM](https://user-images.githubusercontent.com/53913514/107819299-f05fc280-6d9e-11eb-8c9a-980babb23f10.png)

Fixes: #4460 

