### PR TITLE
Use `origURL` from react-native-image-picker, when provided.

### DIFF
--- a/src/compose/ComposeMenu.js
+++ b/src/compose/ComposeMenu.js
@@ -78,6 +78,7 @@ class ComposeMenu extends PureComponent<Props> {
       // https://github.com/react-native-community/react-native-image-picker/issues/1271
       fileName: ?string,
     }>,
+    source: 'camera' | 'library',
   ) => {
     if (response.didCancel) {
       return;
@@ -103,7 +104,7 @@ class ComposeMenu extends PureComponent<Props> {
           path: 'images',
         },
       },
-      this.handleImagePickerResponse,
+      response => this.handleImagePickerResponse(response, 'library'),
     );
   };
 
@@ -115,7 +116,9 @@ class ComposeMenu extends PureComponent<Props> {
       },
     };
 
-    ImagePicker.launchCamera(options, this.handleImagePickerResponse);
+    ImagePicker.launchCamera(options, response =>
+      this.handleImagePickerResponse(response, 'camera'),
+    );
   };
 
   handleFilePicker = async () => {

--- a/src/compose/ComposeMenu.js
+++ b/src/compose/ComposeMenu.js
@@ -7,6 +7,7 @@ import ImagePicker from 'react-native-image-picker';
 import * as NavigationService from '../nav/NavigationService';
 import type { Dispatch, Narrow } from '../types';
 import { connect } from '../react-redux';
+import * as logging from '../utils/logging';
 import { showErrorAlert } from '../utils/info';
 import { BRAND_COLOR, createStyleSheet } from '../styles';
 import {
@@ -73,6 +74,7 @@ class ComposeMenu extends PureComponent<Props> {
       // https://github.com/react-native-community/react-native-image-picker/blob/master/docs/Reference.md
       error?: string | void | null | false,
       uri: string,
+      origURL?: string,
       // Upstream docs are wrong (fileName may indeed be null, at least on iOS);
       // surfaced in https://github.com/zulip/zulip-mobile/issues/3813:
       // https://github.com/react-native-community/react-native-image-picker/issues/1271
@@ -91,13 +93,107 @@ class ComposeMenu extends PureComponent<Props> {
       return;
     }
 
-    this.uploadFile(response.uri, response.fileName);
+    const { uri, origURL } = response;
+
+    let url: string;
+    if (Platform.OS === 'android') {
+      // We haven't had reports of inflated file sizes on Android.
+      // Also, `origURL` is only given to us on iOS.
+      url = uri;
+    } else if (source === 'camera') {
+      // We don't get an `origURL` for photos fresh from the camera.
+      // Images straight from the camera on iOS will have inflated
+      // sizes; see the comment in the `else` block.
+      url = uri;
+    } else if (origURL !== undefined) {
+      // Point to the original image in the media library, if we can.
+      //
+      // We don't yet support image editing as part of choosing an
+      // image to send, so there's no need to look at any other URL
+      // besides this one. Unless...
+      //
+      // On iOS, v2 of react-native-image-picker, which we're on now,
+      // uses a deprecated API to get this value. It's unclear when it
+      // will actually be removed [1]; its doc says "Availability: iOS
+      // 4.1-11.0", but that seems to be false, as I'm seeing
+      // `origURL` present on iOS 13.7. So, this conditional.
+      //
+      // At least on iOS, the image won't be affected by the `quality`
+      // prop. iOS's `UIImageJPEGRepresentation` will still be called
+      // with the `quality` value, but the result will be ignored.
+      //
+      // [1] https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/JPEG.20file.20sizes/near/1116304
+      url = origURL;
+    } else {
+      logging.warn('response.origURL missing; falling back on uri', { uri });
+
+      // Fall back on a copy.
+      //
+      // For JPEGs sent from iOS, using this will likely mean the
+      // server will receive a (much) larger file than it really
+      // should.
+      //
+      // The reason is that the chosen image gets
+      // decompressed/recompressed via iOS's
+      // `UIImageJPEGRepresentation`, with a non-optimal
+      // `compressionQuality` argument. Twice, actually -- and in the
+      // second, we can't even prevent 1.0 (the highest, most
+      // size-inflating value) from being used. There doesn't seem to
+      // be an agreed-upon sensible value. [1]
+      //
+      // 1. First, react-native-image-picker v2 uses
+      //    `UIImageJPEGRepresentation` on the image to save it to a
+      //    temporary path, in case it's a just-edited image (we don't
+      //    allow editing just before sending), or an image straight
+      //    from the camera, that isn't in storage yet. At least we
+      //    can (and do) tell the library to use a
+      //    `compressionQuality` of less than 1.0, with the `quality`
+      //    prop.
+      //
+      // 2. Second, React Native (as of v0.63.4) uses it in its
+      //    `fetch` implementation on some image files before sending
+      //    them [2]. We're not sure why (this would be good to find
+      //    out), but RN does *not* seem to use it on a file at
+      //    `origURL`. We don't have control over the
+      //    `compressionQuality` here, and RN has chosen 1.0.
+      //    Empirically, even if we use quite a low value in step 1,
+      //    like 0.4, RN's choice of 1.0 means the size is inflated
+      //    just about as much as it would be otherwise. [3]
+      //
+      // [1] Greg mentions that `compressionQuality` "may cause it to
+      //     do more or less work to compress it *independent of the
+      //     choices the compressor can make that cause loss of
+      //     information*", emphasis mine.
+      //
+      // [2] https://github.com/facebook/react-native/issues/27099#issuecomment-602016225
+      //
+      // [3] https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/JPEG.20file.20sizes/near/1116532
+
+      url = uri;
+    }
+
+    this.uploadFile(url, response.fileName);
   };
 
   handleImagePicker = () => {
     ImagePicker.launchImageLibrary(
       {
-        quality: 1.0,
+        // "Often suggested as a good balance". There doesn't seem to
+        // be any better-established recommendation, and I don't
+        // notice any horrible JPEG artifacts with this value.
+        // https://stackoverflow.com/questions/26330492/what-should-compressionquality-be-when-using-uiimagejpegrepresentation
+        //
+        // Don't expect this to solve all problems with the size
+        // getting inflated on iOS. Empirically, in cases where we
+        // take the output of react-native-image-picker's
+        // `UIImageJPEGRepresentation` call, which is the thing that
+        // uses `quality`, React Native will apply its *own*
+        // `UIImageJPEGRepresentation` call, with the quality set at
+        // 1.0.
+        //
+        // See the comments on `url` in `handleImagePickerResponse`.
+        quality: 0.7,
+
         noData: true,
         storageOptions: {
           skipBackup: true,

--- a/src/compose/ComposeMenu.js
+++ b/src/compose/ComposeMenu.js
@@ -218,6 +218,7 @@ class ComposeMenu extends PureComponent<Props> {
       // See the comment on this option for the image-picker launch.
       quality: 0.7,
 
+      noData: true,
       storageOptions: {
         cameraRoll: true,
         waitUntilSaved: true,

--- a/src/compose/ComposeMenu.js
+++ b/src/compose/ComposeMenu.js
@@ -4,8 +4,9 @@ import { Platform, View } from 'react-native';
 import type { DocumentPickerResponse } from 'react-native-document-picker';
 import ImagePicker from 'react-native-image-picker';
 
+import { TranslationContext } from '../boot/TranslationProvider';
 import * as NavigationService from '../nav/NavigationService';
-import type { Dispatch, Narrow } from '../types';
+import type { Dispatch, Narrow, GetText } from '../types';
 import { connect } from '../react-redux';
 import * as logging from '../utils/logging';
 import { showErrorAlert } from '../utils/info';
@@ -62,9 +63,17 @@ export const chooseUploadImageFilename = (uri: string, fileName: ?string): strin
 };
 
 class ComposeMenu extends PureComponent<Props> {
-  uploadFile = (uri: string, fileName: ?string) => {
+  static contextType = TranslationContext;
+  context: GetText;
+
+  uploadFile = async (uri: string, fileName: ?string) => {
+    const _ = this.context;
     const { dispatch, destinationNarrow } = this.props;
-    dispatch(uploadFile(destinationNarrow, uri, chooseUploadImageFilename(uri, fileName)));
+    try {
+      await dispatch(uploadFile(destinationNarrow, uri, chooseUploadImageFilename(uri, fileName)));
+    } catch (e) {
+      showErrorAlert(_('Failed to send file'));
+    }
   };
 
   handleImagePickerResponse = (

--- a/src/compose/ComposeMenu.js
+++ b/src/compose/ComposeMenu.js
@@ -215,6 +215,9 @@ class ComposeMenu extends PureComponent<Props> {
 
   handleCameraCapture = () => {
     const options = {
+      // See the comment on this option for the image-picker launch.
+      quality: 0.7,
+
       storageOptions: {
         cameraRoll: true,
         waitUntilSaved: true,

--- a/static/translations/messages_en.json
+++ b/static/translations/messages_en.json
@@ -214,6 +214,7 @@
   "Please choose recipients to share with.": "Please choose recipients to share with.",
   "Sending Message...": "Sending Message...",
   "Failed to send message": "Failed to send message",
+  "Failed to send file": "Failed to send file",
   "Message sent": "Message sent",
   "Couldn’t load information about {fullName}": "Couldn’t load information about {fullName}",
   "What’s your status?": "What’s your status?",


### PR DESCRIPTION
Major update (marking this as "blocked" until we investigate more): Looks like React Native has fixed issue facebook/react-native#27099 (linked here), with PR facebook/react-native#31457?! 🎉 I'd predict that this fix would be released in RN v0.65.

-----

Part of #4340.

The added comments are pretty absurdly long, and I'd appreciate any recommendations for how to fix that while still having enough detail. 🙂 

This follows the discussion on CZO up to [here](https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/JPEG.20file.20sizes/near/1117131). My comment there still applies:

> > If I use `origURL`, then I can vary the quality in the React Native snippet above, and I don't see a change in the size the server reports: it's 4267773 whether that quality is 1.0, 0.4, or 0.5.
> 
> I'd love to have a better idea of why using `origURL` seemingly lets us bypass React Native's `UIImageJPEGRepresentation` call.

In particular, this change should eliminate the size inflation that happens when selecting an existing image from the media library on iOS—_for some iOS versions_. Unfortunately, we don't know the iOS version at which Apple will decide to remove a deprecated iOS API that this optimization depends on (discussion [in chat](https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/JPEG.20file.20sizes/near/1116304)).

We'd obviously prefer to use a library that didn't depend on a deprecated API for this optimization. Unfortunately, if we were to upgrade to the latest version of react-native-image-picker, we'd [lose the optimization](https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/JPEG.20file.20sizes/near/1116283) entirely. And on the most obvious alternative to react-native-image-picker—expo-image-picker—the symptom of the deprecated API being removed would be much worse than missing out on an optimization: it looks like [the app would just crash](https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/JPEG.20file.20sizes/near/1116301).

As mentioned in the code comments, images coming straight from the camera will still be inflated to almost the same level as they were before. The major obstacle to fixing this is that React Native rudely [interferes](https://github.com/facebook/react-native/issues/27099#issuecomment-602016225) by uncompressing and recompressing such an image before uploading it, with a `compressionQuality` of 1.0 (the highest possible value; see discussion on CZO for more detail).