### PR TITLE
webview errors: Report browser version

### DIFF
--- a/src/webview/handleOutboundEvents.js
+++ b/src/webview/handleOutboundEvents.js
@@ -109,6 +109,7 @@ type WebViewOutboundEventError = {|
     source: string,
     line: number,
     column: number,
+    userAgent: string,
     error: Error,
   },
 |};

--- a/src/webview/js/generatedEs3.js
+++ b/src/webview/js/generatedEs3.js
@@ -405,11 +405,13 @@ var compiledWebviewJs = (function (exports) {
   };
 
   window.onerror = function (message, source, line, column, error) {
+    var userAgent = window.navigator.userAgent;
+
     if (window.enableWebViewErrorDisplay) {
       var elementJsError = document.getElementById('js-error-detailed');
 
       if (elementJsError) {
-        elementJsError.innerHTML = ["Message: ".concat(message), "Source: ".concat(source), "Line: ".concat(line, ":").concat(column), "Error: ".concat(JSON.stringify(error)), ''].map(escapeHtml).join('<br>');
+        elementJsError.innerHTML = ["Message: ".concat(message), "Source: ".concat(source), "Line: ".concat(line, ":").concat(column), "UserAgent: ".concat(userAgent), "Error: ".concat(JSON.stringify(error)), ''].map(escapeHtml).join('<br>');
       }
     } else {
       var _elementJsError = document.getElementById('js-error-plain');
@@ -431,6 +433,7 @@ var compiledWebviewJs = (function (exports) {
         source: source,
         line: line,
         column: column,
+        userAgent: userAgent,
         error: error
       }
     });

--- a/src/webview/js/generatedEs3.js
+++ b/src/webview/js/generatedEs3.js
@@ -405,13 +405,11 @@ var compiledWebviewJs = (function (exports) {
   };
 
   window.onerror = function (message, source, line, column, error) {
-    var userAgent = window.navigator.userAgent;
-
     if (window.enableWebViewErrorDisplay) {
       var elementJsError = document.getElementById('js-error-detailed');
 
       if (elementJsError) {
-        elementJsError.innerHTML = ["Message: ".concat(message), "Source: ".concat(source), "Line: ".concat(line, ":").concat(column), "UserAgent: ".concat(userAgent), "Error: ".concat(JSON.stringify(error)), ''].map(escapeHtml).join('<br>');
+        elementJsError.innerHTML = ["Message: ".concat(message), "Source: ".concat(source), "Line: ".concat(line, ":").concat(column), "Error: ".concat(JSON.stringify(error)), ''].map(escapeHtml).join('<br>');
       }
     } else {
       var _elementJsError = document.getElementById('js-error-plain');
@@ -426,6 +424,7 @@ var compiledWebviewJs = (function (exports) {
       }
     }
 
+    var userAgent = window.navigator.userAgent;
     sendMessage({
       type: 'error',
       details: {

--- a/src/webview/js/js.js
+++ b/src/webview/js/js.js
@@ -118,15 +118,14 @@ const escapeHtml = (text: string): string => {
 };
 
 window.onerror = (message: string, source: string, line: number, column: number, error: Error) => {
-  const userAgent = window.navigator.userAgent;
   if (window.enableWebViewErrorDisplay) {
+    // In development, show a detailed error banner for debugging.
     const elementJsError = document.getElementById('js-error-detailed');
     if (elementJsError) {
       elementJsError.innerHTML = [
         `Message: ${message}`,
         `Source: ${source}`,
         `Line: ${line}:${column}`,
-        `UserAgent: ${userAgent}`,
         `Error: ${JSON.stringify(error)}`,
         '',
       ]
@@ -134,6 +133,9 @@ window.onerror = (message: string, source: string, line: number, column: number,
         .join('<br>');
     }
   } else {
+    // In a release build published for normal use, just show a short,
+    // friendly, generic error message.  We'll report the error details
+    // via Sentry, below.
     const elementJsError = document.getElementById('js-error-plain');
     const elementSheetGenerated = document.getElementById('generated-styles');
     const elementSheetHide = document.getElementById('style-hide-js-error-plain');
@@ -152,6 +154,7 @@ window.onerror = (message: string, source: string, line: number, column: number,
     }
   }
 
+  const userAgent = window.navigator.userAgent;
   sendMessage({
     type: 'error',
     details: {

--- a/src/webview/js/js.js
+++ b/src/webview/js/js.js
@@ -118,6 +118,7 @@ const escapeHtml = (text: string): string => {
 };
 
 window.onerror = (message: string, source: string, line: number, column: number, error: Error) => {
+  const userAgent = window.navigator.userAgent;
   if (window.enableWebViewErrorDisplay) {
     const elementJsError = document.getElementById('js-error-detailed');
     if (elementJsError) {
@@ -125,6 +126,7 @@ window.onerror = (message: string, source: string, line: number, column: number,
         `Message: ${message}`,
         `Source: ${source}`,
         `Line: ${line}:${column}`,
+        `UserAgent: ${userAgent}`,
         `Error: ${JSON.stringify(error)}`,
         '',
       ]
@@ -157,6 +159,7 @@ window.onerror = (message: string, source: string, line: number, column: number,
       source,
       line,
       column,
+      userAgent,
       error,
     },
   });


### PR DESCRIPTION
## Description
I have updated the details object to include additional 
userAgent property which returns browser version during errors.

## Issue(s) linked to this PR
This PR closes #4452 

## Screenshots

In **react-native terminal**:

![Screenshot from 2021-02-18 01-46-10](https://user-images.githubusercontent.com/64399555/108265124-647adb80-718e-11eb-829b-86ef515829d5.png)

In **adb logcat**:

![Screenshot from 2021-02-18 01-46-28](https://user-images.githubusercontent.com/64399555/108265128-65ac0880-718e-11eb-92db-add2fc459ff8.png)

In **app**:

<img src='https://user-images.githubusercontent.com/64399555/108265172-6fce0700-718e-11eb-8892-d8b67f1f4b7b.png' width='400px'/>

