### PR TITLE
webview errors: Terminate if HTMLTimeElement is undefined

### DIFF
--- a/docs/architecture/platform-versions.md
+++ b/docs/architecture/platform-versions.md
@@ -192,6 +192,21 @@ General policy:
     emulator image for some past Android release, for practicality of
     testing.
 
+ * Further, we allow *graceful degradation* on all but recent versions
+   of each browser.  This means that although core functionality needs
+   to work, for fancier features of Zulip it's acceptable for them not
+   to be available on older browsers.
+
+   * Typically this will apply to versions older than those shipped in
+     about the last two years' OS releases.  Like the minimum support
+     thresholds, these are described in the block comment at the top of
+     `js.js`.
+
+   * (Implicitly we do much the same thing with old OS versions; we
+     just have less code that interacts with specific OS versions than
+     with browser versions, so we don't write down explicit threshold
+     versions there.)
+
 
 ### Data and commentary
 
@@ -223,6 +238,8 @@ Empirical details on Android Chrome versions found in WebViews:
   * Android versions 5 L, 6 M, 7 N, 8 O had originally shipped
     with Chrome versions 37, 44, 51, 58 respectively (based on
     looking at stock emulator images.)
+    * Later data: Android 9, 10, 11 ship with Chrome versions
+      69, 74, 83 respectively.
   * At that time about 17% of our Android users were on Android
     versions <=6 M -- far more than the 2% or so of Android users with
     Chrome versions older than what shipped with Android 7 N.

--- a/src/webview/js/generatedEs3.js
+++ b/src/webview/js/generatedEs3.js
@@ -269,6 +269,10 @@ var compiledWebviewJs = (function (exports) {
   };
 
   var rewriteTime = function rewriteTime(element) {
+    if (typeof HTMLTimeElement !== 'function') {
+      return;
+    }
+
     var timeElements = [].concat(element instanceof HTMLTimeElement ? [element] : [], Array.from(element.getElementsByTagName('time')));
     timeElements.forEach(function (elem) {
       if (!(elem instanceof HTMLTimeElement)) {

--- a/src/webview/js/js.js
+++ b/src/webview/js/js.js
@@ -25,10 +25,10 @@ import { toggleSpoiler } from './spoilers';
  *   Graceful degradation is acceptable below iOS 13 / Mobile Safari 13.
  *
  * * For Android, core functionality needs to work on Chrome 44.
- *   Graceful degradation is acceptable below Chrome 58.
+ *   Graceful degradation is acceptable below Chrome 74.
  *
  *   * These versions are found in stock images for Android 6 Marshmallow
- *     and Android 8 Oreo, respectively, for convenient testing.
+ *     and Android 10, respectively, for convenient testing.
  *
  *   * (Note that Android's Chrome auto-updates independently of the OS, and
  *     the large majority of Android users have a fully-updated Chrome --

--- a/src/webview/js/rewriteHtml.js
+++ b/src/webview/js/rewriteHtml.js
@@ -70,6 +70,10 @@ const rewriteImageUrls = (auth: Auth, element: Element | Document) => {
  * 2. Adds 'original-text' attribrute, to show original text alert dialog on press.
  */
 const rewriteTime = (element: Element | Document) => {
+  // Terminate if HTMLTimeElement doesn't exist (for Chrome Versions < 62 and Safari Versions < 10)
+  if (typeof HTMLTimeElement !== 'function') {
+    return;
+  }
   // Find the time elements to act on.
   const timeElements = [].concat(
     element instanceof HTMLTimeElement ? [element] : [],

--- a/src/webview/js/rewriteHtml.js
+++ b/src/webview/js/rewriteHtml.js
@@ -70,10 +70,13 @@ const rewriteImageUrls = (auth: Auth, element: Element | Document) => {
  * 2. Adds 'original-text' attribrute, to show original text alert dialog on press.
  */
 const rewriteTime = (element: Element | Document) => {
-  // Terminate if HTMLTimeElement doesn't exist (for Chrome Versions < 62 and Safari Versions < 10)
+  // Skip trying to do this if we don't have the necessary browser feature.
+  // The time ends up shown with its literal text, which is an ISO 8601
+  // string.  This happens before Chrome 62 (and Safari 10).
   if (typeof HTMLTimeElement !== 'function') {
     return;
   }
+
   // Find the time elements to act on.
   const timeElements = [].concat(
     element instanceof HTMLTimeElement ? [element] : [],


### PR DESCRIPTION
## Description
HTMLTimeElement is supported from 62 in chrome android.

<img src='https://user-images.githubusercontent.com/64399555/108307508-e50ffb00-71d3-11eb-8a2b-99009b800d49.png' width='600px'/>

So, I checked whether it exists or not and ended the function if it doesn't exist
as it prevents the error which has further impacts as mentioned by @gnprice 
in #4451 

## Issue(s) linked to this PR

This PR closes #4451 

## Earlier

<img src='https://user-images.githubusercontent.com/64399555/108307474-d295c180-71d3-11eb-8229-2cc85064cd02.png' width='300px'/>

## Now

<img src='https://user-images.githubusercontent.com/64399555/108307479-d45f8500-71d3-11eb-95ad-6519503ea4c6.png' width='300px'/>
