### PR TITLE
StatusBar: Fix bug causing invalid color names

### DIFF
--- a/src/common/ZulipStatusBar.js
+++ b/src/common/ZulipStatusBar.js
@@ -53,7 +53,10 @@ class ZulipStatusBar extends PureComponent<Props> {
           animated
           showHideTransition="slide"
           hidden={hidden && Platform.OS !== 'android'}
-          backgroundColor={Color(statusBarColor).darken(0.1)}
+          backgroundColor={Color(statusBarColor)
+            .darken(0.1)
+            .hsl()
+            .string()}
           barStyle={getStatusBarStyle(statusBarColor)}
         />
       )

--- a/src/nav/ChatNavBar.js
+++ b/src/nav/ChatNavBar.js
@@ -34,7 +34,12 @@ export default function ChatNavBar(props: Props) {
       edges={['top', 'right', 'left']}
       style={{
         borderColor:
-          streamColor === undefined ? 'hsla(0, 0%, 50%, 0.25)' : Color(streamColor).darken(0.1),
+          streamColor === undefined
+            ? 'hsla(0, 0%, 50%, 0.25)'
+            : Color(streamColor)
+                .darken(0.1)
+                .hsl()
+                .string(),
         borderBottomWidth: 1,
         backgroundColor: streamColor,
       }}


### PR DESCRIPTION
Color.darken() can return a color that is rounded in a way that causes
this error when used:

`StatusBar._updatePropsStack`: Color hsl(186.39999999999998, 51.9%, 70.9%) parsed to null or undefined

This seems to be because something cannot handle a color with that many
decimal points of precision. This doesn't result in a visible bug (my
guess is that it gets passed in as a string, and then the rendering
engine can handle it just fine, although I haven't validated that), but
it does create a bunch of noise in the logs, which this commit fixes.