### PR TITLE
Input: Fix text color in landscape orientation in nightmode.

### DIFF
--- a/src/common/Input.js
+++ b/src/common/Input.js
@@ -82,7 +82,7 @@ class Input extends PureComponent<Props, State> {
 
     return (
       <TextInput
-        style={[this.styles.input, { color: this.context.color }, style]}
+        style={[this.styles.input, { color: this.context.textColor }, style]}
         placeholder={_(fullPlaceholder.text, fullPlaceholder.values)}
         placeholderTextColor={HALF_COLOR}
         underlineColorAndroid={isFocused ? BORDER_COLOR : HALF_COLOR}

--- a/src/styles/theme.js
+++ b/src/styles/theme.js
@@ -6,6 +6,7 @@ import type { ThemeName } from '../reduxTypes';
 
 export type ThemeData = {|
   color: string,
+  textColor: string,
   backgroundColor: string,
   cardColor: string,
   dividerColor: string,
@@ -14,6 +15,7 @@ export type ThemeData = {|
 export const themeData: { [name: ThemeName | 'light']: ThemeData } = {
   night: {
     color: 'hsl(210, 11%, 85%)',
+    textColor: 'hsl(200, 11%, 65%)',
     backgroundColor: 'hsl(212, 28%, 18%)',
     cardColor: 'hsl(212, 31%, 21%)',
     // Dividers follow Material Design: opacity 12% black or 12% white.
@@ -22,6 +24,7 @@ export const themeData: { [name: ThemeName | 'light']: ThemeData } = {
   },
   light: {
     color: 'hsl(0, 0%, 20%)',
+    textColor: 'hsl(0, 0%, 20%)',
     backgroundColor: 'white',
     cardColor: 'hsl(0, 0%, 97%)',
     // Dividers follow Material Design: opacity 12% black or 12% white.


### PR DESCRIPTION
**Description:**
In landscape orientation in night mode,the color of text written in
`<TextInput>` was too much transparent to be viewed properly.
Applied a different shade of previous color to fix it.

**Screenshots:**

![zulipAfter2](https://user-images.githubusercontent.com/42652941/108347081-21f4e580-7206-11eb-909e-bc23660ea81b.png)
![zulipAfterPortrait2](https://user-images.githubusercontent.com/42652941/108347121-2d481100-7206-11eb-8f1e-db0b4e104b8f.png)


Fixes: #4480
Signed-off-by: rajprakash00 <rajprakash1999@gmail.com>