### PR TITLE
Experiment: Set up to use full-screen modals, React Navigation's way.

### DIFF
--- a/src/account-info/AccountDetailsScreen.js
+++ b/src/account-info/AccountDetailsScreen.js
@@ -2,7 +2,7 @@
 import React, { PureComponent } from 'react';
 
 import type { RouteProp } from '../react-navigation';
-import type { AppNavigationProp } from '../nav/AppNavigator';
+import type { MainStackNavigationProp } from '../nav/MainStackScreen';
 import type { Dispatch, UserOrBot, UserId } from '../types';
 import { createStyleSheet } from '../styles';
 import { connect } from '../react-redux';
@@ -31,7 +31,7 @@ type SelectorProps = $ReadOnly<{|
 |}>;
 
 type Props = $ReadOnly<{|
-  navigation: AppNavigationProp<'account-details'>,
+  navigation: MainStackNavigationProp<'account-details'>,
   route: RouteProp<'account-details', {| userId: UserId |}>,
 
   dispatch: Dispatch,

--- a/src/account/AccountPickScreen.js
+++ b/src/account/AccountPickScreen.js
@@ -6,7 +6,7 @@ import { Alert } from 'react-native';
 import * as api from '../api';
 import { TranslationContext } from '../boot/TranslationProvider';
 import type { RouteProp } from '../react-navigation';
-import type { AppNavigationProp } from '../nav/AppNavigator';
+import type { MainStackNavigationProp } from '../nav/MainStackScreen';
 import * as NavigationService from '../nav/NavigationService';
 import type { GetText, Dispatch } from '../types';
 import { connect } from '../react-redux';
@@ -24,7 +24,7 @@ import type { ApiResponseServerSettings } from '../api/settings/getServerSetting
 import { showErrorAlert } from '../utils/info';
 
 type Props = $ReadOnly<{|
-  navigation: AppNavigationProp<'account-pick'>,
+  navigation: MainStackNavigationProp<'account-pick'>,
   route: RouteProp<'account-pick', void>,
 
   accounts: $ReadOnlyArray<AccountStatus>,

--- a/src/chat/ChatScreen.js
+++ b/src/chat/ChatScreen.js
@@ -4,7 +4,7 @@ import { useIsFocused } from '@react-navigation/native';
 
 import { useSelector, useDispatch } from '../react-redux';
 import type { RouteProp } from '../react-navigation';
-import type { AppNavigationProp } from '../nav/AppNavigator';
+import type { MainStackNavigationProp } from '../nav/MainStackScreen';
 import { ThemeContext, createStyleSheet } from '../styles';
 import type { Narrow, EditMessage } from '../types';
 import { KeyboardAvoider, OfflineNotice } from '../common';
@@ -22,7 +22,7 @@ import { getFetchingForNarrow } from './fetchingSelectors';
 import { getShownMessagesForNarrow, isNarrowValid as getIsNarrowValid } from './narrowsSelectors';
 
 type Props = $ReadOnly<{|
-  navigation: AppNavigationProp<'chat'>,
+  navigation: MainStackNavigationProp<'chat'>,
   route: RouteProp<'chat', {| narrow: Narrow, editMessage: EditMessage | null |}>,
 |}>;
 

--- a/src/chat/GroupDetailsScreen.js
+++ b/src/chat/GroupDetailsScreen.js
@@ -3,7 +3,7 @@ import React, { PureComponent } from 'react';
 import { FlatList } from 'react-native';
 
 import type { RouteProp } from '../react-navigation';
-import type { AppNavigationProp } from '../nav/AppNavigator';
+import type { MainStackNavigationProp } from '../nav/MainStackScreen';
 import * as NavigationService from '../nav/NavigationService';
 import type { Dispatch, UserOrBot, UserId } from '../types';
 import { connect } from '../react-redux';
@@ -12,7 +12,7 @@ import UserItem from '../users/UserItem';
 import { navigateToAccountDetails } from '../actions';
 
 type Props = $ReadOnly<{|
-  navigation: AppNavigationProp<'group-details'>,
+  navigation: MainStackNavigationProp<'group-details'>,
   route: RouteProp<'group-details', {| recipients: $ReadOnlyArray<UserId> |}>,
 
   dispatch: Dispatch,

--- a/src/common/SmartUrlInput.js
+++ b/src/common/SmartUrlInput.js
@@ -3,7 +3,7 @@ import React, { PureComponent } from 'react';
 import { TextInput, TouchableWithoutFeedback, View } from 'react-native';
 import type { ViewStyleProp } from 'react-native/Libraries/StyleSheet/StyleSheet';
 
-import type { AppNavigationProp } from '../nav/AppNavigator';
+import type { MainStackNavigationProp } from '../nav/MainStackScreen';
 import type { ThemeData } from '../styles';
 import { ThemeContext, createStyleSheet } from '../styles';
 import { autocompleteRealmPieces, autocompleteRealm, fixRealmUrl } from '../utils/url';
@@ -46,8 +46,8 @@ type Props = $ReadOnly<{|
   defaultDomain: string,
   // TODO: Currently this type is acceptable because the only
   // `navigation` prop we pass to a `SmartUrlInput` instance is the
-  // one from a component on AppNavigator.
-  navigation: AppNavigationProp<>,
+  // one from a component on MainStackScreen.
+  navigation: MainStackNavigationProp<>,
   style?: ViewStyleProp,
   onChangeText: (value: string) => void,
   onSubmitEditing: () => Promise<void>,

--- a/src/diagnostics/DiagnosticsScreen.js
+++ b/src/diagnostics/DiagnosticsScreen.js
@@ -4,7 +4,7 @@ import React, { PureComponent } from 'react';
 import { nativeApplicationVersion } from 'expo-application';
 
 import type { RouteProp } from '../react-navigation';
-import type { AppNavigationProp } from '../nav/AppNavigator';
+import type { MainStackNavigationProp } from '../nav/MainStackScreen';
 import * as NavigationService from '../nav/NavigationService';
 import { createStyleSheet } from '../styles';
 import { OptionButton, OptionDivider, Screen, RawLabel } from '../common';
@@ -23,7 +23,7 @@ const styles = createStyleSheet({
 });
 
 type Props = $ReadOnly<{|
-  navigation: AppNavigationProp<'diagnostics'>,
+  navigation: MainStackNavigationProp<'diagnostics'>,
   route: RouteProp<'diagnostics', void>,
 |}>;
 

--- a/src/diagnostics/StorageScreen.js
+++ b/src/diagnostics/StorageScreen.js
@@ -4,7 +4,7 @@ import React, { PureComponent } from 'react';
 import { FlatList } from 'react-native';
 
 import type { RouteProp } from '../react-navigation';
-import type { AppNavigationProp } from '../nav/AppNavigator';
+import type { MainStackNavigationProp } from '../nav/MainStackScreen';
 import type { GlobalState, Dispatch } from '../types';
 import { connect } from '../react-redux';
 import { Screen } from '../common';
@@ -19,7 +19,7 @@ const calculateKeyStorageSizes = obj =>
     .sort((a, b) => b.size - a.size);
 
 type Props = $ReadOnly<{|
-  navigation: AppNavigationProp<'storage'>,
+  navigation: MainStackNavigationProp<'storage'>,
   route: RouteProp<'storage', void>,
 
   dispatch: Dispatch,

--- a/src/diagnostics/TimingScreen.js
+++ b/src/diagnostics/TimingScreen.js
@@ -3,13 +3,13 @@ import React from 'react';
 import { FlatList } from 'react-native';
 
 import type { RouteProp } from '../react-navigation';
-import type { AppNavigationProp } from '../nav/AppNavigator';
+import type { MainStackNavigationProp } from '../nav/MainStackScreen';
 import { Screen } from '../common';
 import TimeItem from './TimeItem';
 import timing from '../utils/timing';
 
 type Props = $ReadOnly<{|
-  navigation: AppNavigationProp<'timing'>,
+  navigation: MainStackNavigationProp<'timing'>,
   route: RouteProp<'timing', void>,
 |}>;
 

--- a/src/diagnostics/VariablesScreen.js
+++ b/src/diagnostics/VariablesScreen.js
@@ -3,13 +3,13 @@ import React, { PureComponent } from 'react';
 import { FlatList } from 'react-native';
 
 import type { RouteProp } from '../react-navigation';
-import type { AppNavigationProp } from '../nav/AppNavigator';
+import type { MainStackNavigationProp } from '../nav/MainStackScreen';
 import config from '../config';
 import { Screen } from '../common';
 import InfoItem from './InfoItem';
 
 type Props = $ReadOnly<{|
-  navigation: AppNavigationProp<'variables'>,
+  navigation: MainStackNavigationProp<'variables'>,
   route: RouteProp<'variables', void>,
 |}>;
 

--- a/src/emoji/EmojiPickerScreen.js
+++ b/src/emoji/EmojiPickerScreen.js
@@ -4,7 +4,7 @@ import React, { PureComponent } from 'react';
 import { FlatList } from 'react-native';
 
 import type { RouteProp } from '../react-navigation';
-import type { AppNavigationProp } from '../nav/AppNavigator';
+import type { MainStackNavigationProp } from '../nav/MainStackScreen';
 import * as NavigationService from '../nav/NavigationService';
 import * as api from '../api';
 import { unicodeCodeByName } from './codePointMap';
@@ -20,7 +20,7 @@ import * as logging from '../utils/logging';
 import { showToast } from '../utils/info';
 
 type Props = $ReadOnly<{|
-  navigation: AppNavigationProp<'emoji-picker'>,
+  navigation: MainStackNavigationProp<'emoji-picker'>,
   route: RouteProp<'emoji-picker', {| messageId: number |}>,
 
   activeImageEmojiByName: RealmEmojiById,

--- a/src/lightbox/LightboxScreen.js
+++ b/src/lightbox/LightboxScreen.js
@@ -4,7 +4,7 @@ import { View } from 'react-native';
 
 import type { Message } from '../types';
 import type { RouteProp } from '../react-navigation';
-import type { AppNavigationProp } from '../nav/AppNavigator';
+import type { MainStackNavigationProp } from '../nav/MainStackScreen';
 import { createStyleSheet } from '../styles';
 import Lightbox from './Lightbox';
 
@@ -18,7 +18,7 @@ const styles = createStyleSheet({
 });
 
 type Props = $ReadOnly<{|
-  navigation: AppNavigationProp<'lightbox'>,
+  navigation: MainStackNavigationProp<'lightbox'>,
   route: RouteProp<'lightbox', {| src: string, message: Message |}>,
 |}>;
 

--- a/src/main/MainTabsScreen.js
+++ b/src/main/MainTabsScreen.js
@@ -8,7 +8,7 @@ import {
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 import type { RouteProp, RouteParamsOf } from '../react-navigation';
-import type { AppNavigationProp } from '../nav/AppNavigator';
+import type { MainStackNavigationProp } from '../nav/MainStackScreen';
 import type { GlobalParamList } from '../nav/globalTypes';
 import { bottomTabNavigatorConfig } from '../styles/tabs';
 import HomeScreen from './HomeScreen';
@@ -40,7 +40,7 @@ const Tab = createBottomTabNavigator<
 >();
 
 type Props = $ReadOnly<{|
-  navigation: AppNavigationProp<'main-tabs'>,
+  navigation: MainStackNavigationProp<'main-tabs'>,
   route: RouteProp<'main-tabs', void>,
 |}>;
 

--- a/src/nav/MainStackScreen.js
+++ b/src/nav/MainStackScreen.js
@@ -31,7 +31,6 @@ import DiagnosticsScreen from '../diagnostics/DiagnosticsScreen';
 import VariablesScreen from '../diagnostics/VariablesScreen';
 import TimingScreen from '../diagnostics/TimingScreen';
 import StorageScreen from '../diagnostics/StorageScreen';
-import LightboxScreen from '../lightbox/LightboxScreen';
 import CreateGroupScreen from '../user-groups/CreateGroupScreen';
 import InviteUsersScreen from '../streams/InviteUsersScreen';
 import StreamSettingsScreen from '../streams/StreamSettingsScreen';
@@ -60,7 +59,6 @@ export type MainStackNavigatorParamList = {|
   'search-messages': RouteParamsOf<typeof SearchMessagesScreen>,
   users: RouteParamsOf<typeof UsersScreen>,
   language: RouteParamsOf<typeof LanguageScreen>,
-  lightbox: RouteParamsOf<typeof LightboxScreen>,
   'create-group': RouteParamsOf<typeof CreateGroupScreen>,
   'invite-users': RouteParamsOf<typeof InviteUsersScreen>,
   diagnostics: RouteParamsOf<typeof DiagnosticsScreen>,
@@ -132,7 +130,6 @@ export default function MainStackScreen(props: Props) {
       />
       <Stack.Screen name="users" component={useHaveServerDataGate(UsersScreen)} />
       <Stack.Screen name="language" component={useHaveServerDataGate(LanguageScreen)} />
-      <Stack.Screen name="lightbox" component={useHaveServerDataGate(LightboxScreen)} />
       <Stack.Screen name="create-group" component={useHaveServerDataGate(CreateGroupScreen)} />
       <Stack.Screen name="invite-users" component={useHaveServerDataGate(InviteUsersScreen)} />
       <Stack.Screen name="diagnostics" component={useHaveServerDataGate(DiagnosticsScreen)} />

--- a/src/nav/MainStackScreen.js
+++ b/src/nav/MainStackScreen.js
@@ -44,7 +44,7 @@ import UserStatusScreen from '../user-status/UserStatusScreen';
 import SharingScreen from '../sharing/SharingScreen';
 import { useHaveServerDataGate } from '../withHaveServerDataGate';
 
-export type AppNavigatorParamList = {|
+export type MainStackNavigatorParamList = {|
   'account-pick': RouteParamsOf<typeof AccountPickScreen>,
   'account-details': RouteParamsOf<typeof AccountDetailsScreen>,
   'group-details': RouteParamsOf<typeof GroupDetailsScreen>,
@@ -77,15 +77,19 @@ export type AppNavigatorParamList = {|
   sharing: RouteParamsOf<typeof SharingScreen>,
 |};
 
-export type AppNavigationProp<
-  +RouteName: $Keys<AppNavigatorParamList> = $Keys<AppNavigatorParamList>,
+export type MainStackNavigationProp<
+  +RouteName: $Keys<MainStackNavigatorParamList> = $Keys<MainStackNavigatorParamList>,
 > = StackNavigationProp<GlobalParamList, RouteName>;
 
-const Stack = createStackNavigator<GlobalParamList, AppNavigatorParamList, AppNavigationProp<>>();
+const Stack = createStackNavigator<
+  GlobalParamList,
+  MainStackNavigatorParamList,
+  MainStackNavigationProp<>,
+>();
 
 type Props = $ReadOnly<{||}>;
 
-export default function AppNavigator(props: Props) {
+export default function MainStackScreen(props: Props) {
   const hasAuth = useSelector(getHasAuth);
   const accounts = useSelector(getAccounts);
 

--- a/src/nav/MainStackScreen.js
+++ b/src/nav/MainStackScreen.js
@@ -7,11 +7,12 @@ import {
   TransitionPresets,
 } from '@react-navigation/stack';
 
-import type { RouteParamsOf } from '../react-navigation';
+import type { RouteProp, RouteParamsOf } from '../react-navigation';
 import { useSelector } from '../react-redux';
 import { hasAuth as getHasAuth, getAccounts } from '../selectors';
 import getInitialRouteInfo from './getInitialRouteInfo';
 import type { GlobalParamList } from './globalTypes';
+import type { RootStackNavigationProp } from './RootStackScreen';
 import AccountPickScreen from '../account/AccountPickScreen';
 import RealmInputScreen from '../start/RealmInputScreen';
 import AuthScreen from '../start/AuthScreen';
@@ -87,7 +88,10 @@ const Stack = createStackNavigator<
   MainStackNavigationProp<>,
 >();
 
-type Props = $ReadOnly<{||}>;
+type Props = $ReadOnly<{|
+  navigation: RootStackNavigationProp<'main-stack'>,
+  route: RouteProp<'main-stack', void>,
+|}>;
 
 export default function MainStackScreen(props: Props) {
   const hasAuth = useSelector(getHasAuth);

--- a/src/nav/RootStackScreen.js
+++ b/src/nav/RootStackScreen.js
@@ -5,9 +5,11 @@ import { createStackNavigator, type StackNavigationProp } from '@react-navigatio
 import type { RouteParamsOf } from '../react-navigation';
 import type { GlobalParamList } from './globalTypes';
 import MainStackScreen from './MainStackScreen';
+import LightboxScreen from '../lightbox/LightboxScreen';
 
 export type RootStackNavigatorParamList = {|
   'main-stack': RouteParamsOf<typeof MainStackScreen>,
+  lightbox: RouteParamsOf<typeof LightboxScreen>,
 |};
 
 export type RootStackNavigationProp<
@@ -28,6 +30,7 @@ export default function RootStackScreen(props: Props) {
       <Stack.Screen name="main-stack" component={MainStackScreen} />
 
       {/* Modal screens go here; see https://reactnavigation.org/docs/modal/. */}
+      <Stack.Screen name="lightbox" component={LightboxScreen} />
     </Stack.Navigator>
   );
 }

--- a/src/nav/RootStackScreen.js
+++ b/src/nav/RootStackScreen.js
@@ -1,0 +1,33 @@
+/* @flow strict-local */
+import React from 'react';
+import { createStackNavigator, type StackNavigationProp } from '@react-navigation/stack';
+
+import type { RouteParamsOf } from '../react-navigation';
+import type { GlobalParamList } from './globalTypes';
+import MainStackScreen from './MainStackScreen';
+
+export type RootStackNavigatorParamList = {|
+  'main-stack': RouteParamsOf<typeof MainStackScreen>,
+|};
+
+export type RootStackNavigationProp<
+  +RouteName: $Keys<RootStackNavigatorParamList> = $Keys<RootStackNavigatorParamList>,
+> = StackNavigationProp<GlobalParamList, RouteName>;
+
+const Stack = createStackNavigator<
+  GlobalParamList,
+  RootStackNavigatorParamList,
+  RootStackNavigationProp<>,
+>();
+
+type Props = $ReadOnly<{||}>;
+
+export default function RootStackScreen(props: Props) {
+  return (
+    <Stack.Navigator headerMode="none" mode="modal">
+      <Stack.Screen name="main-stack" component={MainStackScreen} />
+
+      {/* Modal screens go here; see https://reactnavigation.org/docs/modal/. */}
+    </Stack.Navigator>
+  );
+}

--- a/src/nav/ZulipNavigationContainer.js
+++ b/src/nav/ZulipNavigationContainer.js
@@ -8,7 +8,7 @@ import { ThemeContext } from '../styles';
 import * as NavigationService from './NavigationService';
 import type { Dispatch, ThemeName } from '../types';
 import { getSettings } from '../selectors';
-import MainStackScreen from './MainStackScreen';
+import RootStackScreen from './RootStackScreen';
 
 type SelectorProps = $ReadOnly<{|
   theme: ThemeName,
@@ -62,7 +62,7 @@ class ZulipAppContainer extends PureComponent<Props> {
         }}
         theme={theme}
       >
-        <MainStackScreen />
+        <RootStackScreen />
       </NavigationContainer>
     );
   }

--- a/src/nav/ZulipNavigationContainer.js
+++ b/src/nav/ZulipNavigationContainer.js
@@ -8,7 +8,7 @@ import { ThemeContext } from '../styles';
 import * as NavigationService from './NavigationService';
 import type { Dispatch, ThemeName } from '../types';
 import { getSettings } from '../selectors';
-import AppNavigator from './AppNavigator';
+import MainStackScreen from './MainStackScreen';
 
 type SelectorProps = $ReadOnly<{|
   theme: ThemeName,
@@ -62,7 +62,7 @@ class ZulipAppContainer extends PureComponent<Props> {
         }}
         theme={theme}
       >
-        <AppNavigator />
+        <MainStackScreen />
       </NavigationContainer>
     );
   }

--- a/src/nav/globalTypes.js
+++ b/src/nav/globalTypes.js
@@ -1,11 +1,13 @@
 /* @flow strict-local */
 
+import type { RootStackNavigatorParamList } from './RootStackScreen';
 import type { MainStackNavigatorParamList } from './MainStackScreen';
 import type { SharingNavigatorParamList } from '../sharing/SharingScreen';
 import type { StreamTabsNavigatorParamList } from '../main/StreamTabsScreen';
 import type { MainTabsNavigatorParamList } from '../main/MainTabsScreen';
 
 export type GlobalParamList = {|
+  ...RootStackNavigatorParamList,
   ...MainStackNavigatorParamList,
   ...SharingNavigatorParamList,
   ...StreamTabsNavigatorParamList,

--- a/src/nav/globalTypes.js
+++ b/src/nav/globalTypes.js
@@ -1,12 +1,12 @@
 /* @flow strict-local */
 
-import type { AppNavigatorParamList } from './AppNavigator';
+import type { MainStackNavigatorParamList } from './MainStackScreen';
 import type { SharingNavigatorParamList } from '../sharing/SharingScreen';
 import type { StreamTabsNavigatorParamList } from '../main/StreamTabsScreen';
 import type { MainTabsNavigatorParamList } from '../main/MainTabsScreen';
 
 export type GlobalParamList = {|
-  ...AppNavigatorParamList,
+  ...MainStackNavigatorParamList,
   ...SharingNavigatorParamList,
   ...StreamTabsNavigatorParamList,
   ...MainTabsNavigatorParamList,

--- a/src/nav/navActions.js
+++ b/src/nav/navActions.js
@@ -16,10 +16,16 @@ export const navigateBack = (): GenericNavigationAction => StackActions.pop(getS
  */
 
 export const resetToAccountPicker = (): GenericNavigationAction =>
-  CommonActions.reset({ index: 0, routes: [{ name: 'account-pick' }] });
+  CommonActions.reset({
+    index: 0,
+    routes: [{ name: 'main-stack', state: { index: 0, routes: [{ name: 'account-pick' }] } }],
+  });
 
 export const resetToMainTabs = (): GenericNavigationAction =>
-  CommonActions.reset({ index: 0, routes: [{ name: 'main-tabs' }] });
+  CommonActions.reset({
+    index: 0,
+    routes: [{ name: 'main-stack', state: { index: 0, routes: [{ name: 'main-tabs' }] } }],
+  });
 
 /*
  * Ordinary "push" actions that will push to the stack.

--- a/src/reactions/MessageReactionsScreen.js
+++ b/src/reactions/MessageReactionsScreen.js
@@ -4,7 +4,7 @@ import { View } from 'react-native';
 import { createMaterialTopTabNavigator } from '@react-navigation/material-top-tabs';
 
 import type { RouteProp } from '../react-navigation';
-import type { AppNavigationProp } from '../nav/AppNavigator';
+import type { MainStackNavigationProp } from '../nav/MainStackScreen';
 import * as NavigationService from '../nav/NavigationService';
 import * as logging from '../utils/logging';
 import ReactionUserList from './ReactionUserList';
@@ -33,7 +33,7 @@ type SelectorProps = $ReadOnly<{|
 |}>;
 
 type Props = $ReadOnly<{|
-  navigation: AppNavigationProp<'message-reactions'>,
+  navigation: MainStackNavigationProp<'message-reactions'>,
   route: RouteProp<'message-reactions', {| reactionName?: string, messageId: number |}>,
 
   dispatch: Dispatch,

--- a/src/search/SearchMessagesScreen.js
+++ b/src/search/SearchMessagesScreen.js
@@ -2,7 +2,7 @@
 import React, { PureComponent } from 'react';
 
 import type { RouteProp } from '../react-navigation';
-import type { AppNavigationProp } from '../nav/AppNavigator';
+import type { MainStackNavigationProp } from '../nav/MainStackScreen';
 import type { Auth, Dispatch, Message } from '../types';
 import { Screen } from '../common';
 import SearchMessagesCard from './SearchMessagesCard';
@@ -14,7 +14,7 @@ import { getAuth } from '../account/accountsSelectors';
 import { fetchMessages } from '../message/fetchActions';
 
 type Props = $ReadOnly<{|
-  navigation: AppNavigationProp<'search-messages'>,
+  navigation: MainStackNavigationProp<'search-messages'>,
   route: RouteProp<'search-messages', void>,
 
   auth: Auth,

--- a/src/settings/DebugScreen.js
+++ b/src/settings/DebugScreen.js
@@ -3,7 +3,7 @@
 import React, { PureComponent } from 'react';
 
 import type { RouteProp } from '../react-navigation';
-import type { AppNavigationProp } from '../nav/AppNavigator';
+import type { MainStackNavigationProp } from '../nav/MainStackScreen';
 import type { Debug, Dispatch } from '../types';
 import { connect } from '../react-redux';
 import { getSession } from '../selectors';
@@ -11,7 +11,7 @@ import { OptionRow, Screen } from '../common';
 import { debugFlagToggle } from '../actions';
 
 type Props = $ReadOnly<{|
-  navigation: AppNavigationProp<'debug'>,
+  navigation: MainStackNavigationProp<'debug'>,
   route: RouteProp<'debug', void>,
 
   debug: Debug,

--- a/src/settings/LanguageScreen.js
+++ b/src/settings/LanguageScreen.js
@@ -3,7 +3,7 @@
 import React, { PureComponent } from 'react';
 
 import type { RouteProp } from '../react-navigation';
-import type { AppNavigationProp } from '../nav/AppNavigator';
+import type { MainStackNavigationProp } from '../nav/MainStackScreen';
 import type { Dispatch } from '../types';
 import { connect } from '../react-redux';
 import { Screen } from '../common';
@@ -12,7 +12,7 @@ import { getSettings } from '../selectors';
 import { settingsChange } from '../actions';
 
 type Props = $ReadOnly<{|
-  navigation: AppNavigationProp<'language'>,
+  navigation: MainStackNavigationProp<'language'>,
   route: RouteProp<'language', void>,
 
   dispatch: Dispatch,

--- a/src/settings/LegalScreen.js
+++ b/src/settings/LegalScreen.js
@@ -3,7 +3,7 @@
 import React, { PureComponent } from 'react';
 
 import type { RouteProp } from '../react-navigation';
-import type { AppNavigationProp } from '../nav/AppNavigator';
+import type { MainStackNavigationProp } from '../nav/MainStackScreen';
 import type { Dispatch } from '../types';
 import { connect } from '../react-redux';
 import { Screen, OptionButton } from '../common';
@@ -11,7 +11,7 @@ import { openLinkEmbedded } from '../utils/openLink';
 import { getCurrentRealm } from '../selectors';
 
 type Props = $ReadOnly<{|
-  navigation: AppNavigationProp<'legal'>,
+  navigation: MainStackNavigationProp<'legal'>,
   route: RouteProp<'legal', void>,
 
   dispatch: Dispatch,

--- a/src/settings/NotificationsScreen.js
+++ b/src/settings/NotificationsScreen.js
@@ -3,7 +3,7 @@
 import React, { PureComponent } from 'react';
 
 import type { RouteProp } from '../react-navigation';
-import type { AppNavigationProp } from '../nav/AppNavigator';
+import type { MainStackNavigationProp } from '../nav/MainStackScreen';
 import type { Auth, Dispatch } from '../types';
 import { connect } from '../react-redux';
 import { getAuth, getSettings } from '../selectors';
@@ -12,7 +12,7 @@ import * as api from '../api';
 import { settingsChange } from '../actions';
 
 type Props = $ReadOnly<{|
-  navigation: AppNavigationProp<'notifications'>,
+  navigation: MainStackNavigationProp<'notifications'>,
   route: RouteProp<'notifications', void>,
 
   auth: Auth,

--- a/src/sharing/SharingScreen.js
+++ b/src/sharing/SharingScreen.js
@@ -8,7 +8,7 @@ import {
 import type { GlobalParamList } from '../nav/globalTypes';
 import type { RouteParamsOf, RouteProp } from '../react-navigation';
 
-import type { AppNavigationProp } from '../nav/AppNavigator';
+import type { MainStackNavigationProp } from '../nav/MainStackScreen';
 import * as NavigationService from '../nav/NavigationService';
 import type { Dispatch, Auth, SharedData } from '../types';
 import { createStyleSheet } from '../styles';
@@ -36,7 +36,7 @@ const Tab = createMaterialTopTabNavigator<
 >();
 
 type Props = $ReadOnly<{|
-  navigation: AppNavigationProp<'sharing'>,
+  navigation: MainStackNavigationProp<'sharing'>,
   route: RouteProp<'sharing', {| sharedData: SharedData |}>,
 
   auth: Auth | void,

--- a/src/start/AuthScreen.js
+++ b/src/start/AuthScreen.js
@@ -11,7 +11,7 @@ import type {
   ExternalAuthenticationMethod,
 } from '../api/settings/getServerSettings';
 import type { RouteProp } from '../react-navigation';
-import type { AppNavigationProp } from '../nav/AppNavigator';
+import type { MainStackNavigationProp } from '../nav/MainStackScreen';
 import * as NavigationService from '../nav/NavigationService';
 import config from '../config';
 import type { Dispatch } from '../types';
@@ -168,7 +168,7 @@ export const activeAuthentications = (
 };
 
 type Props = $ReadOnly<{|
-  navigation: AppNavigationProp<'auth'>,
+  navigation: MainStackNavigationProp<'auth'>,
   route: RouteProp<'auth', {| serverSettings: ApiResponseServerSettings |}>,
 
   dispatch: Dispatch,

--- a/src/start/DevAuthScreen.js
+++ b/src/start/DevAuthScreen.js
@@ -4,7 +4,7 @@ import React, { PureComponent } from 'react';
 import { ActivityIndicator, View, FlatList } from 'react-native';
 
 import type { RouteProp } from '../react-navigation';
-import type { AppNavigationProp } from '../nav/AppNavigator';
+import type { MainStackNavigationProp } from '../nav/MainStackScreen';
 import type { DevUser, Dispatch } from '../types';
 import styles, { createStyleSheet } from '../styles';
 import { connect } from '../react-redux';
@@ -28,7 +28,7 @@ const componentStyles = createStyleSheet({
 });
 
 type Props = $ReadOnly<{|
-  navigation: AppNavigationProp<'dev-auth'>,
+  navigation: MainStackNavigationProp<'dev-auth'>,
   route: RouteProp<'dev-auth', {| realm: URL |}>,
 
   dispatch: Dispatch,

--- a/src/start/PasswordAuthScreen.js
+++ b/src/start/PasswordAuthScreen.js
@@ -3,7 +3,7 @@ import React, { PureComponent } from 'react';
 import { View } from 'react-native';
 
 import type { RouteProp } from '../react-navigation';
-import type { AppNavigationProp } from '../nav/AppNavigator';
+import type { MainStackNavigationProp } from '../nav/MainStackScreen';
 import type { Dispatch } from '../types';
 import { createStyleSheet } from '../styles';
 import { connect } from '../react-redux';
@@ -32,7 +32,7 @@ const styles = createStyleSheet({
 });
 
 type Props = $ReadOnly<{|
-  navigation: AppNavigationProp<'password-auth'>,
+  navigation: MainStackNavigationProp<'password-auth'>,
   route: RouteProp<'password-auth', {| realm: URL, requireEmailFormat: boolean |}>,
 
   dispatch: Dispatch,

--- a/src/start/RealmInputScreen.js
+++ b/src/start/RealmInputScreen.js
@@ -3,7 +3,7 @@ import React, { PureComponent } from 'react';
 import { Keyboard } from 'react-native';
 
 import type { RouteProp } from '../react-navigation';
-import type { AppNavigationProp } from '../nav/AppNavigator';
+import type { MainStackNavigationProp } from '../nav/MainStackScreen';
 import * as NavigationService from '../nav/NavigationService';
 import type { ApiResponseServerSettings } from '../api/settings/getServerSettings';
 import { ErrorMsg, Label, SmartUrlInput, Screen, ZulipButton } from '../common';
@@ -12,7 +12,7 @@ import * as api from '../api';
 import { navigateToAuth } from '../actions';
 
 type Props = $ReadOnly<{|
-  navigation: AppNavigationProp<'realm-input'>,
+  navigation: MainStackNavigationProp<'realm-input'>,
   route: RouteProp<'realm-input', {| initial: boolean | void |}>,
 |}>;
 

--- a/src/streams/CreateStreamScreen.js
+++ b/src/streams/CreateStreamScreen.js
@@ -2,7 +2,7 @@
 import React, { PureComponent } from 'react';
 
 import type { RouteProp } from '../react-navigation';
-import type { AppNavigationProp } from '../nav/AppNavigator';
+import type { MainStackNavigationProp } from '../nav/MainStackScreen';
 import * as NavigationService from '../nav/NavigationService';
 import type { Dispatch } from '../types';
 import { connect } from '../react-redux';
@@ -12,7 +12,7 @@ import { Screen } from '../common';
 import EditStreamCard from './EditStreamCard';
 
 type Props = $ReadOnly<{|
-  navigation: AppNavigationProp<'create-stream'>,
+  navigation: MainStackNavigationProp<'create-stream'>,
   route: RouteProp<'create-stream', void>,
 
   dispatch: Dispatch,

--- a/src/streams/EditStreamScreen.js
+++ b/src/streams/EditStreamScreen.js
@@ -2,7 +2,7 @@
 import React, { PureComponent } from 'react';
 
 import type { RouteProp } from '../react-navigation';
-import type { AppNavigationProp } from '../nav/AppNavigator';
+import type { MainStackNavigationProp } from '../nav/MainStackScreen';
 import * as NavigationService from '../nav/NavigationService';
 import type { Dispatch, Stream } from '../types';
 import { connect } from '../react-redux';
@@ -16,7 +16,7 @@ type SelectorProps = $ReadOnly<{|
 |}>;
 
 type Props = $ReadOnly<{|
-  navigation: AppNavigationProp<'edit-stream'>,
+  navigation: MainStackNavigationProp<'edit-stream'>,
   route: RouteProp<'edit-stream', {| streamId: number |}>,
 
   dispatch: Dispatch,

--- a/src/streams/InviteUsersScreen.js
+++ b/src/streams/InviteUsersScreen.js
@@ -2,7 +2,7 @@
 import React, { PureComponent } from 'react';
 
 import type { RouteProp } from '../react-navigation';
-import type { AppNavigationProp } from '../nav/AppNavigator';
+import type { MainStackNavigationProp } from '../nav/MainStackScreen';
 import * as NavigationService from '../nav/NavigationService';
 import type { Auth, Dispatch, Stream, UserOrBot } from '../types';
 import { connect } from '../react-redux';
@@ -18,7 +18,7 @@ type SelectorProps = $ReadOnly<{|
 |}>;
 
 type Props = $ReadOnly<{|
-  navigation: AppNavigationProp<'invite-users'>,
+  navigation: MainStackNavigationProp<'invite-users'>,
   route: RouteProp<'invite-users', {| streamId: number |}>,
 
   dispatch: Dispatch,

--- a/src/streams/StreamSettingsScreen.js
+++ b/src/streams/StreamSettingsScreen.js
@@ -3,7 +3,7 @@ import React, { PureComponent } from 'react';
 import { View } from 'react-native';
 
 import type { RouteProp } from '../react-navigation';
-import type { AppNavigationProp } from '../nav/AppNavigator';
+import type { MainStackNavigationProp } from '../nav/MainStackScreen';
 import * as NavigationService from '../nav/NavigationService';
 import type { Auth, Dispatch, Stream, Subscription } from '../types';
 import { connect } from '../react-redux';
@@ -31,7 +31,7 @@ type SelectorProps = $ReadOnly<{|
 |}>;
 
 type Props = $ReadOnly<{|
-  navigation: AppNavigationProp<'stream-settings'>,
+  navigation: MainStackNavigationProp<'stream-settings'>,
   route: RouteProp<'stream-settings', {| streamId: number |}>,
 
   dispatch: Dispatch,

--- a/src/topics/TopicListScreen.js
+++ b/src/topics/TopicListScreen.js
@@ -3,7 +3,7 @@
 import React, { PureComponent } from 'react';
 
 import type { RouteProp } from '../react-navigation';
-import type { AppNavigationProp } from '../nav/AppNavigator';
+import type { MainStackNavigationProp } from '../nav/MainStackScreen';
 import type { Dispatch, Stream, TopicExtended } from '../types';
 import { connect } from '../react-redux';
 import { Screen } from '../common';
@@ -19,7 +19,7 @@ type SelectorProps = $ReadOnly<{|
 |}>;
 
 type Props = $ReadOnly<{|
-  navigation: AppNavigationProp<'topic-list'>,
+  navigation: MainStackNavigationProp<'topic-list'>,
   route: RouteProp<'topic-list', {| streamId: number |}>,
 
   dispatch: Dispatch,

--- a/src/user-groups/CreateGroupScreen.js
+++ b/src/user-groups/CreateGroupScreen.js
@@ -2,7 +2,7 @@
 import React, { PureComponent } from 'react';
 
 import type { RouteProp } from '../react-navigation';
-import type { AppNavigationProp } from '../nav/AppNavigator';
+import type { MainStackNavigationProp } from '../nav/MainStackScreen';
 import * as NavigationService from '../nav/NavigationService';
 import type { Dispatch, UserId, UserOrBot } from '../types';
 import { connect } from '../react-redux';
@@ -18,7 +18,7 @@ type SelectorProps = {|
 |};
 
 type Props = $ReadOnly<{|
-  navigation: AppNavigationProp<'create-group'>,
+  navigation: MainStackNavigationProp<'create-group'>,
   route: RouteProp<'create-group', void>,
 
   dispatch: Dispatch,

--- a/src/user-status/UserStatusScreen.js
+++ b/src/user-status/UserStatusScreen.js
@@ -5,7 +5,7 @@ import { TranslationContext } from '../boot/TranslationProvider';
 import { createStyleSheet } from '../styles';
 
 import type { RouteProp } from '../react-navigation';
-import type { AppNavigationProp } from '../nav/AppNavigator';
+import type { MainStackNavigationProp } from '../nav/MainStackScreen';
 import * as NavigationService from '../nav/NavigationService';
 import type { GetText, Dispatch } from '../types';
 import { connect } from '../react-redux';
@@ -30,7 +30,7 @@ const styles = createStyleSheet({
 });
 
 type Props = $ReadOnly<{|
-  navigation: AppNavigationProp<'user-status'>,
+  navigation: MainStackNavigationProp<'user-status'>,
   route: RouteProp<'user-status', void>,
 
   dispatch: Dispatch,

--- a/src/users/UsersScreen.js
+++ b/src/users/UsersScreen.js
@@ -2,12 +2,12 @@
 import React, { PureComponent } from 'react';
 
 import type { RouteProp } from '../react-navigation';
-import type { AppNavigationProp } from '../nav/AppNavigator';
+import type { MainStackNavigationProp } from '../nav/MainStackScreen';
 import { Screen } from '../common';
 import UsersCard from './UsersCard';
 
 type Props = $ReadOnly<{|
-  navigation: AppNavigationProp<'users'>,
+  navigation: MainStackNavigationProp<'users'>,
   route: RouteProp<'users', void>,
 |}>;
 


### PR DESCRIPTION
EDIT: I haven't compared this approach with using React Native's [`Modal`](https://reactnative.dev/docs/modal).

-----

@gnprice and I discussed this on the phone the other day, and we're a bit cautious about trusting React Navigation's magic here, but we thought it'd be good to try this out and see if we like it. The main question to answer is whether this setup, using React Navigation's API, is helpful; individual details about the lightbox might be good to talk about but won't necessarily answer that conclusively.

Here we have a few nav-structure-changing commits, followed by turning the lightbox into a full-screen modal.

On iOS, I like how you can swipe down from the top to dismiss the modal (#4039). It doesn't seem to work if your finger starts out _on_ the image, which makes some sense because the image handles gestures to pan/zoom. Still, other apps manage to handle both types of gestures: I see that Facebook on iOS lets you pan/zoom an image that's open in a lightbox modal, but it also recognizes when it's impossible to pan (the image is fully visible and zoomed out; this is the image's initial state anyway) and in that case a swipe-down closes the modal. More awkwardly, while I seem to be able to dismiss the modal by swiping down from a point *above* the image, I don't seem to be able to dismiss it by swiping down from a point *below* the image. I'm not sure how much of this is due to React Navigation, and how much to our react-native-photo-view.

See Apple's [HIG document on modals](https://developer.apple.com/design/human-interface-guidelines/ios/app-architecture/modality/). I'm not sure what the corresponding doc for Android might be; [this "Dialogs" page](https://developer.android.com/guide/topics/ui/dialogs) comes up first in my search, but a brief look suggests it's mostly for "yes/no/OK" dialogs, not something like the lightbox? Does the lightbox not deserve special treatment on Android, as I think it does on iOS?