### PR TITLE
messageActionSheet : using `Modal` instead of `@expo/react-native-action-sheet`

### DIFF
--- a/src/chat/ChatScreen.js
+++ b/src/chat/ChatScreen.js
@@ -1,8 +1,7 @@
 /* @flow strict-local */
-import React from 'react';
+import React, { useState } from 'react';
 import { View } from 'react-native';
 import { useIsFocused } from '@react-navigation/native';
-import { ActionSheetProvider } from '@expo/react-native-action-sheet';
 
 import { useSelector, useDispatch } from '../react-redux';
 import type { RouteProp } from '../react-navigation';
@@ -23,6 +22,7 @@ import { getLoading, getSession } from '../directSelectors';
 import { getFetchingForNarrow } from './fetchingSelectors';
 import { getShownMessagesForNarrow, isNarrowValid as getIsNarrowValid } from './narrowsSelectors';
 import { getStreamColorForNarrow } from '../subscriptions/subscriptionSelectors';
+import { ActionSheetModalHandler } from '../message/messageActionSheet';
 
 type Props = $ReadOnly<{|
   navigation: AppNavigationProp<'chat'>,
@@ -113,43 +113,48 @@ export default function ChatScreen(props: Props) {
   const showMessagePlaceholders = haveNoMessages && isFetching;
   const sayNoMessages = haveNoMessages && !isFetching;
   const showComposeBox = canSendToNarrow(narrow) && !showMessagePlaceholders;
+  const [modalVisible, setModalVisible] = useState(false);
 
   const streamColor = useSelector(state => getStreamColorForNarrow(state, narrow));
 
+  const longPressModalHandler = () => {
+    setModalVisible(!modalVisible);
+  };
+
   return (
-    <ActionSheetProvider>
-      <View style={[componentStyles.screen, { backgroundColor }]}>
-        <KeyboardAvoider style={styles.flexed} behavior="padding">
-          <ZulipStatusBar backgroundColor={streamColor} />
-          <ChatNavBar narrow={narrow} editMessage={editMessage} />
-          <OfflineNotice />
-          <UnreadNotice narrow={narrow} />
-          {(() => {
-            if (!isNarrowValid) {
-              return <InvalidNarrow narrow={narrow} />;
-            } else if (fetchError !== null) {
-              return <FetchError narrow={narrow} error={fetchError} />;
-            } else if (sayNoMessages) {
-              return <NoMessages narrow={narrow} />;
-            } else {
-              return (
-                <MessageList
-                  narrow={narrow}
-                  showMessagePlaceholders={showMessagePlaceholders}
-                  startEditMessage={setEditMessage}
-                />
-              );
-            }
-          })()}
-          {showComposeBox && (
-            <ComposeBox
-              narrow={narrow}
-              editMessage={editMessage}
-              completeEditMessage={() => setEditMessage(null)}
-            />
-          )}
-        </KeyboardAvoider>
-      </View>
-    </ActionSheetProvider>
+    <View style={[componentStyles.screen, { backgroundColor }]}>
+      <KeyboardAvoider style={styles.flexed} behavior="padding">
+        <ZulipStatusBar backgroundColor={streamColor} />
+        <ChatNavBar narrow={narrow} editMessage={editMessage} />
+        <OfflineNotice />
+        <UnreadNotice narrow={narrow} />
+        {(() => {
+          if (!isNarrowValid) {
+            return <InvalidNarrow narrow={narrow} />;
+          } else if (fetchError !== null) {
+            return <FetchError narrow={narrow} error={fetchError} />;
+          } else if (sayNoMessages) {
+            return <NoMessages narrow={narrow} />;
+          } else {
+            return (
+              <MessageList
+                narrow={narrow}
+                showMessagePlaceholders={showMessagePlaceholders}
+                startEditMessage={setEditMessage}
+                handleLongPressModal={longPressModalHandler}
+              />
+            );
+          }
+        })()}
+        {showComposeBox && (
+          <ComposeBox
+            narrow={narrow}
+            editMessage={editMessage}
+            completeEditMessage={() => setEditMessage(null)}
+          />
+        )}
+        <ActionSheetModalHandler modalVisible={modalVisible} modalHandler={longPressModalHandler} />
+      </KeyboardAvoider>
+    </View>
   );
 }

--- a/src/webview/MessageList.js
+++ b/src/webview/MessageList.js
@@ -102,6 +102,7 @@ export type Props = $ReadOnly<{|
   narrow: Narrow,
   showMessagePlaceholders: boolean,
   startEditMessage: (editMessage: EditMessage) => void,
+  handleLongPressModal: () => {},
 
   dispatch: Dispatch,
   ...SelectorProps,

--- a/src/webview/__tests__/generateInboundEvents-test.js
+++ b/src/webview/__tests__/generateInboundEvents-test.js
@@ -44,6 +44,7 @@ describe('generateInboundEvents', () => {
     dispatch: jest.fn(),
     ...baseSelectorProps,
     showActionSheetWithOptions: jest.fn(),
+    handleLongPressModal: jest.fn(),
 
     _: jest.fn(),
   });

--- a/src/webview/handleOutboundEvents.js
+++ b/src/webview/handleOutboundEvents.js
@@ -152,6 +152,7 @@ type Props = $ReadOnly<{
   narrow: Narrow,
   showActionSheetWithOptions: ShowActionSheetWithOptions,
   startEditMessage: (editMessage: EditMessage) => void,
+  handleLongPressModal: () => {},
 }>;
 
 const fetchMore = (props: Props, event: WebViewOutboundEventScroll) => {
@@ -206,12 +207,20 @@ const handleLongPress = (
   if (!message) {
     return;
   }
-  const { dispatch, showActionSheetWithOptions, backgroundData, narrow, startEditMessage } = props;
+  const {
+    dispatch,
+    showActionSheetWithOptions,
+    backgroundData,
+    narrow,
+    startEditMessage,
+    handleLongPressModal,
+  } = props;
   showActionSheet(
     target === 'header',
     showActionSheetWithOptions,
     { dispatch, startEditMessage, _ },
     { backgroundData, message, narrow },
+    handleLongPressModal,
   );
 };
 


### PR DESCRIPTION
@nikhilmaske-2001 reported an issue #4407 that is :
when we long press on any message then `messageActionSheet` opens up and it took a extra black screen on `Share` option when we share our message 
![104544801-b344cb00-564e-11eb-9558-70ed9ffd1ced](https://user-images.githubusercontent.com/56453541/108552672-a420ff00-7317-11eb-9f6b-cfc1f2df4572.png)

[here](https://chat.zulip.org/#narrow/stream/48-mobile/topic/Black.20screen.20appears.20when.20user.20click.20on.20.60Share.60.20option.2E/near/1106837) i and @gnprice have discussed about the problem and found that this issue coming from `@expo/react-native-action-sheet` for which i have made a tiny app and report this issue on facebook/expo page [here](https://github.com/expo/react-native-action-sheet/issues/203) and also created a snack for better explaination of the issue [here](https://appetize.io/embed/xc1w6f1krd589zhp22a0mgftyw?autoplay=false&debug=true&device=nexus5&deviceColor=black&embed=true&launchUrl=exp:%2F%2Fexpo.io%2F@abhi0504%2F0d4260%2BIjv94!N!zI&orientation=portrait&screenOnly=false&xDocMsg=true&xdocMsg=true&params=%7B%22EXKernelLaunchUrlDefaultsKey%22:%22exp:%2F%2Fexpo.io%2F@abhi0504%2F0d4260%2BIjv94!N!zI%22,%22EXKernelDisableNuxDefaultsKey%22:true%7D&scale=75&osVersion=8.1)

then we have decide to use  `Modal` instead of @expo/react-native-action-sheet` as it restricts us upto a certain extent on basis
of UI for eg if we use `Modal` instead of `@expo/react-native-action-sheet` then we have many options for eg colored messageActionSheet , popping out with diff animations , can set some icons before any option which and greg have
already discussed [here](https://chat.zulip.org/#narrow/stream/48-mobile/topic/Black.20screen.20appears.20when.20user.20click.20on.20.60Share.60.20option.2E/near/1113084)

Also we can do many things if we use `Modal` and can tweak our `messageActionSheet`'s UI to an another level for eg 
![WhatsApp-Image-2021-02-04-at-3 18 02-PM](https://user-images.githubusercontent.com/56453541/108554086-9b312d00-7319-11eb-913d-6ff98719f883.jpeg)

- We can add icons in starting of different options of our `messageActionSheet` 
- We can make our text colorful in `messageActionSheet`
- We can add different animations in our `messageActionSheet` 

Fixes: #4407 
