### PR TITLE
StoreProvider: Set server version tags on global scope, not one-off scope.

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -364,9 +364,9 @@ PODS:
     - React
   - RNReanimated (1.13.0):
     - React
-  - RNSentry (1.6.3):
-    - React
-    - Sentry (~> 5.1.8)
+  - RNSentry (2.2.1):
+    - React-Core
+    - Sentry (= 6.1.4)
   - RNSound (0.11.0):
     - React
     - RNSound/Core (= 0.11.0)
@@ -374,9 +374,9 @@ PODS:
     - React
   - RNVectorIcons (8.0.0):
     - React-Core
-  - Sentry (5.1.10):
-    - Sentry/Core (= 5.1.10)
-  - Sentry/Core (5.1.10)
+  - Sentry (6.1.4):
+    - Sentry/Core (= 6.1.4)
+  - Sentry/Core (6.1.4)
   - Toast (4.0.0)
   - UMAppLoader (1.2.0)
   - UMBarCodeScannerInterface (5.2.1)
@@ -700,10 +700,10 @@ SPEC CHECKSUMS:
   RNDeviceInfo: bdd61e8b070d13a1dd9d022091981075ed4cde16
   RNGestureHandler: 7a5833d0f788dbd107fbb913e09aa0c1ff333c39
   RNReanimated: 89f5e0a04d1dd52fbf27e7e7030d8f80a646a3fc
-  RNSentry: ae1e005e4f2655775475445a9c49c1d343e8e3a7
+  RNSentry: 7104cdfc1072ccb86015d9c8f210d81ae76806c1
   RNSound: da030221e6ac7e8290c6b43f2b5f2133a8e225b0
   RNVectorIcons: f67a1abce2ec73e62fe4606e8110e95a832bc859
-  Sentry: 8715e88b813bde9ad37aead365d5b04ac7302153
+  Sentry: 9d055e2de30a77685e86b219acf02e59b82091fc
   Toast: 91b396c56ee72a5790816f40d3a94dd357abc196
   UMAppLoader: 61049c8d55590b74e9ae1d5429bf68d96b4a2528
   UMBarCodeScannerInterface: e5e4c87797d3d01214e25cd1618866caf5d4f17f

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@react-navigation/material-top-tabs": "^5.2.19",
     "@react-navigation/native": "^5.7.6",
     "@react-navigation/stack": "^5.9.3",
-    "@sentry/react-native": "^1.0.9",
+    "@sentry/react-native": "^2.2.1",
     "@unimodules/core": "~5.3.0",
     "@zulip/shared": "^0.0.4",
     "base-64": "^0.1.0",

--- a/src/boot/StoreProvider.js
+++ b/src/boot/StoreProvider.js
@@ -1,8 +1,11 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
 import { Provider } from 'react-redux';
-
 import type { Node as React$Node } from 'react';
+
+import { observeStore } from '../redux';
+import * as logging from '../utils/logging';
+import { tryGetActiveAccount } from '../selectors';
 import store, { restore } from './store';
 import timing from '../utils/timing';
 
@@ -11,11 +14,28 @@ type Props = $ReadOnly<{|
 |}>;
 
 export default class StoreProvider extends PureComponent<Props> {
+  unsubscribeStoreObserver: () => void;
+
   componentDidMount() {
     timing.start('Store hydration');
     restore(() => {
       timing.end('Store hydration');
     });
+
+    this.unsubscribeStoreObserver = observeStore(
+      store,
+      // onChange will fire when this value changes
+      state => tryGetActiveAccount(state)?.zulipVersion,
+      zulipVersion => {
+        logging.setTagsFromServerVersion(zulipVersion);
+      },
+    );
+  }
+
+  componentWillUnmount() {
+    if (this.unsubscribeStoreObserver) {
+      this.unsubscribeStoreObserver();
+    }
   }
 
   render() {

--- a/src/redux.js
+++ b/src/redux.js
@@ -1,0 +1,36 @@
+/* @flow strict-local */
+import type { Store } from 'redux';
+
+import type { Selector, GlobalState, Action } from './reduxTypes';
+
+/**
+ * Call a function whenever a selected piece of state changes.
+ *
+ * When the return value of `select` isn't equal (===) to the previous
+ * value, `onChange` gets called, with the old and new value.
+ * `onChange` is called once, immediately and unconditionally, at the
+ * beginning.
+ *
+ * Returns a teardown function.
+ */
+export function observeStore<T>(
+  store: Store<GlobalState, Action>,
+  select: Selector<T>,
+  onChange: (state: T) => void,
+) {
+  // Start as a nonce object, so the initial `prevState !== state`
+  // must return true.
+  let prevState = {};
+
+  function handleChange() {
+    const state = select(store.getState());
+    if (prevState !== state) {
+      onChange(state);
+      prevState = state;
+    }
+  }
+
+  const unsubscribe = store.subscribe(handleChange);
+  handleChange();
+  return unsubscribe;
+}

--- a/src/utils/logging.js
+++ b/src/utils/logging.js
@@ -22,16 +22,29 @@ function withScope<R>(callback: Scope => R): R {
   return ((ret: $FlowFixMe): R);
 }
 
+type ServerVersionTags = {|
+  rawServerVersion: string | void,
+  coarseServerVersion: string | void,
+  fineServerVersion: string | void,
+|};
+
 /**
  * Get server-version tags at various levels of granularity.
+ *
+ * If the server version isn't found in the logging context, all the
+ * tags will be `undefined`.
  */
-const getServerVersionTags = () => {
+const getServerVersionTags = (): ServerVersionTags => {
   const zulipVersion = getLoggingContext()?.serverVersion;
 
   // Why might we not have the server version? If there's no active
   // account.
   if (!zulipVersion) {
-    return {};
+    return {
+      rawServerVersion: undefined,
+      coarseServerVersion: undefined,
+      fineServerVersion: undefined,
+    };
   }
 
   const raw = zulipVersion.raw();

--- a/src/utils/logging.js
+++ b/src/utils/logging.js
@@ -119,14 +119,8 @@ const logToSentry = (event: string | Error, level: SeverityType, extras: Extras)
     }
   }
 
-  const tags = {
-    // Tags can go here; they're useful for event aggregation. See
-    // https://docs.sentry.io/platforms/javascript/enriching-events/tags/.
-  };
-
   return withScope(scope => {
     scope.setExtras(extras);
-    scope.setTags(tags);
 
     // The static API's `captureException` doesn't allow passing strings, and its
     // counterpart `captureMessage` doesn't allow passing stacktraces.

--- a/src/utils/logging.js
+++ b/src/utils/logging.js
@@ -2,6 +2,7 @@
 import type { Scope, SeverityType, EventHint } from '@sentry/react-native';
 import { getCurrentHub, Severity, withScope as withScopeImpl } from '@sentry/react-native';
 
+import type { ZulipVersion } from './zulipVersion';
 import type { JSONable } from './jsonable';
 import objectEntries from './objectEntries';
 import config from '../config';
@@ -31,12 +32,10 @@ type ServerVersionTags = {|
 /**
  * Get server-version tags at various levels of granularity.
  *
- * If the server version isn't found in the logging context, all the
- * tags will be `undefined`.
+ * If the passed server version is falsy, all the tags will be
+ * `undefined`.
  */
-const getServerVersionTags = (): ServerVersionTags => {
-  const zulipVersion = getLoggingContext()?.serverVersion;
-
+const getServerVersionTags = (zulipVersion: ?ZulipVersion): ServerVersionTags => {
   // Why might we not have the server version? If there's no active
   // account.
   if (!zulipVersion) {
@@ -101,7 +100,7 @@ const logToSentry = (event: string | Error, level: SeverityType, extras: Extras)
   }
 
   const tags = {
-    ...getServerVersionTags(),
+    ...getServerVersionTags(getLoggingContext()?.serverVersion),
     // Other tags go here; they're useful for event aggregation. See
     // https://docs.sentry.io/platforms/javascript/enriching-events/tags/.
   };

--- a/src/utils/logging.js
+++ b/src/utils/logging.js
@@ -41,7 +41,9 @@ type ServerVersionTags = {|
  */
 const getServerVersionTags = (zulipVersion: ?ZulipVersion): ServerVersionTags => {
   // Why might we not have the server version? If there's no active
-  // account.
+  // account. N.B: an account may be the active account but not
+  // logged in; see
+  // https://github.com/zulip/zulip-mobile/blob/v27.158/docs/glossary.md#active-account.
   if (!zulipVersion) {
     return {
       rawServerVersion: undefined,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2345,14 +2345,14 @@
     dot "^1.1.1"
     svgo "^1.1.1"
 
-"@sentry/browser@^5.19.0":
-  version "5.20.1"
-  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-5.20.1.tgz#be59522d0914d58309e1367d997d4b3cd5385d7e"
-  integrity sha512-ClykuvrEsMKgAvifx5VHzRjchwYbJFX8YiIicYx+Wr3MXL2jLG6OEfHHJwJeyBL2C3vxd5O0KPK3pGMR9wPMLA==
+"@sentry/browser@6.2.0":
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-6.2.0.tgz#4113a92bc82f55e63f30cb16a94f717bd0b95817"
+  integrity sha512-4r3paHcHXLemj471BtNDhUs2kvJxk5XDRplz1dbC/LHXN5PWEXP4anhGILxOlxqi4y33r53PIZu3xXFjznaVZA==
   dependencies:
-    "@sentry/core" "5.20.1"
-    "@sentry/types" "5.20.1"
-    "@sentry/utils" "5.20.1"
+    "@sentry/core" "6.2.0"
+    "@sentry/types" "6.2.0"
+    "@sentry/utils" "6.2.0"
     tslib "^1.9.3"
 
 "@sentry/cli@^1.52.4":
@@ -2366,68 +2366,94 @@
     progress "^2.0.3"
     proxy-from-env "^1.1.0"
 
-"@sentry/core@5.20.1", "@sentry/core@^5.19.0":
-  version "5.20.1"
-  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-5.20.1.tgz#857cc7186931c37ff032a1bcb573600ebacde961"
-  integrity sha512-gG622/UY2TePruF6iUzgVrbIX5vN8w2cjlWFo1Est8MvCfQsz8agGaLMCAyl5hCGJ6K2qTUZDOlbCNIKoMclxg==
+"@sentry/core@6.2.0":
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-6.2.0.tgz#be1c33854fc94e1a4d867f7c2c311cf1cefb8ee9"
+  integrity sha512-oTr2b25l+0bv/+d6IgMamPuGleWV7OgJb0NFfd+WZhw6UDRgr7CdEJy2gW6tK8SerwXgPHdn4ervxsT3WIBiXw==
   dependencies:
-    "@sentry/hub" "5.20.1"
-    "@sentry/minimal" "5.20.1"
-    "@sentry/types" "5.20.1"
-    "@sentry/utils" "5.20.1"
+    "@sentry/hub" "6.2.0"
+    "@sentry/minimal" "6.2.0"
+    "@sentry/types" "6.2.0"
+    "@sentry/utils" "6.2.0"
     tslib "^1.9.3"
 
-"@sentry/hub@5.20.1", "@sentry/hub@^5.19.0":
-  version "5.20.1"
-  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-5.20.1.tgz#05e83ba972a96e9d7225a64c7d3728aa9fcefc4e"
-  integrity sha512-Nv5BXf14BEc08acDguW6eSqkAJLVf8wki283FczEvTsQZZuSBHM9cJ5Hnehr6n+mr8wWpYLgUUYM0oXXigUmzQ==
+"@sentry/hub@6.2.0":
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-6.2.0.tgz#e7502652bc9608cf8fb63e43cd49df9019a28f29"
+  integrity sha512-BDTEFK8vlJydWXp/KMX0stvv73V7od224iLi+w3k7BcPwMKXBuURBXPU8d5XIC4G8nwg8X6cnDvwL+zBBlBbkg==
   dependencies:
-    "@sentry/types" "5.20.1"
-    "@sentry/utils" "5.20.1"
+    "@sentry/types" "6.2.0"
+    "@sentry/utils" "6.2.0"
     tslib "^1.9.3"
 
-"@sentry/integrations@^5.19.0":
-  version "5.20.1"
-  resolved "https://registry.yarnpkg.com/@sentry/integrations/-/integrations-5.20.1.tgz#c42dd53c2162b96bf4da641cd1c2bd53c0bbdce3"
-  integrity sha512-VpeZHYT8Fvw1J5478MqXXORf3Ftpt34YM4e+sTPuGrmf4Gro7lXdyownqiSaa7kwwNVQEV3zMlRDczVZzXQThw==
+"@sentry/integrations@6.2.0":
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/@sentry/integrations/-/integrations-6.2.0.tgz#f3952cb07fd86aa1ea3923d51049fc4875b634a9"
+  integrity sha512-gvAhP61qs2fog2xCTDs94ZT8cZbWEjFZmOWfT1VXlZDIVopIporj5Qe6IgrLTiCWL61Yko5h5nFnPZ4mpjf+0w==
   dependencies:
-    "@sentry/types" "5.20.1"
-    "@sentry/utils" "5.20.1"
+    "@sentry/types" "6.2.0"
+    "@sentry/utils" "6.2.0"
+    localforage "^1.8.1"
     tslib "^1.9.3"
 
-"@sentry/minimal@5.20.1":
-  version "5.20.1"
-  resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-5.20.1.tgz#2e2b63d9cd265b7e2f593f3eab4e9874bd87eeef"
-  integrity sha512-2PeJKDTHNsUd1jtSLQBJ6oRI+xrIJrYDQmsyK/qs9D7HqHfs+zNAMUjYseiVeSAFGas5IcNSuZbPRV4BnuoZ0w==
+"@sentry/minimal@6.2.0":
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-6.2.0.tgz#718b70babb55912eeb38babaf7823d1bcdd77d1e"
+  integrity sha512-haxsx8/ZafhZUaGeeMtY7bJt9HbDlqeiaXrRMp1CxGtd0ZRQwHt60imEjl6IH1I73SEWxNfqScGsX2s3HzztMg==
   dependencies:
-    "@sentry/hub" "5.20.1"
-    "@sentry/types" "5.20.1"
+    "@sentry/hub" "6.2.0"
+    "@sentry/types" "6.2.0"
     tslib "^1.9.3"
 
-"@sentry/react-native@^1.0.9":
-  version "1.6.3"
-  resolved "https://registry.yarnpkg.com/@sentry/react-native/-/react-native-1.6.3.tgz#80c68d6bc7f10bd4b7eb12e1b028620a1fadbcc5"
-  integrity sha512-0nkPV/QWEXWQb67XKy4HY9x8zLEURzBT7xaal2KUGRWu2JGObfy5eYk8+k+XsGLVAMfelCkcLQWNneUY80reng==
+"@sentry/react-native@^2.2.1":
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/@sentry/react-native/-/react-native-2.2.1.tgz#6f88e19734d5a25bcf0e737c233811315f23b5f0"
+  integrity sha512-jFxPPDrUHNZfUvym34IzS8yV1HQvFyEYUAxSrSNfdmWaYCTRfnVZr2IYjaV+jSn+F4W32NhbW0m+1Gcg7XuR9Q==
   dependencies:
-    "@sentry/browser" "^5.19.0"
-    "@sentry/core" "^5.19.0"
-    "@sentry/hub" "^5.19.0"
-    "@sentry/integrations" "^5.19.0"
-    "@sentry/types" "^5.19.0"
-    "@sentry/utils" "^5.19.0"
+    "@sentry/browser" "6.2.0"
+    "@sentry/core" "6.2.0"
+    "@sentry/hub" "6.2.0"
+    "@sentry/integrations" "6.2.0"
+    "@sentry/react" "6.2.0"
+    "@sentry/tracing" "6.2.0"
+    "@sentry/types" "6.2.0"
+    "@sentry/utils" "6.2.0"
     "@sentry/wizard" "^1.1.4"
 
-"@sentry/types@5.20.1", "@sentry/types@^5.19.0":
-  version "5.20.1"
-  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-5.20.1.tgz#ccc4fa4c9d0f94d93014b04e674762d5d5cd30a2"
-  integrity sha512-OU+i/lcjGpDJv0XkNpsKrI2r1VPp8qX0H6Knq8NuZrlZe3AbvO3jRJJK0pH14xFv8Xok5jbZZpKKoQLxYfxqsw==
-
-"@sentry/utils@5.20.1", "@sentry/utils@^5.19.0":
-  version "5.20.1"
-  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-5.20.1.tgz#68cfae0d0e3b321b4649b59f30265024b29eae63"
-  integrity sha512-dhK6IdO6g7Q2CoxCbB+q8gwUapDUH5VjraFg0UBzgkrtNhtHLylqmwx0sWQvXCcp14Q/3MuzEbb4euvoh8o8oA==
+"@sentry/react@6.2.0":
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/@sentry/react/-/react-6.2.0.tgz#bf46c38762554f246ca9dec527e6a5b3168fb0b0"
+  integrity sha512-Jf3s7om1iLpApkN26O7c3Ult3lS91ekZNC4WKtcPb6b+KOBQ36sB0d1KhL3hGZ55UKLmgZu3jn2hd7bJ9EY3yA==
   dependencies:
-    "@sentry/types" "5.20.1"
+    "@sentry/browser" "6.2.0"
+    "@sentry/minimal" "6.2.0"
+    "@sentry/types" "6.2.0"
+    "@sentry/utils" "6.2.0"
+    hoist-non-react-statics "^3.3.2"
+    tslib "^1.9.3"
+
+"@sentry/tracing@6.2.0":
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/@sentry/tracing/-/tracing-6.2.0.tgz#76c17e5dd3f1e61c8a4e3bd090f904a63d674765"
+  integrity sha512-pzgM1dePPJysVnzaFCMp+BKtjM5q46HZeyShiR+KcQYvneD3fmUPJigDkkcsB2DcrY3mFvDcswjoqxaTIW7ZBQ==
+  dependencies:
+    "@sentry/hub" "6.2.0"
+    "@sentry/minimal" "6.2.0"
+    "@sentry/types" "6.2.0"
+    "@sentry/utils" "6.2.0"
+    tslib "^1.9.3"
+
+"@sentry/types@6.2.0":
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-6.2.0.tgz#ca020ff42913c6b9f88a9d0c375b5ee3965a2590"
+  integrity sha512-vN4P/a+QqAuVfWFB9G3nQ7d6bgnM9jd/RLVi49owMuqvM24pv5mTQHUk2Hk4S3k7ConrHFl69E7xH6Dv5VpQnQ==
+
+"@sentry/utils@6.2.0":
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-6.2.0.tgz#39c81ad5ba92cec54d690e3fa8ea4e777d8e9c2b"
+  integrity sha512-YToUC7xYf2E/pIluI7upYTlj8fKXOtdwoOBkcQZifHgX/dP+qDaHibbBFe5PyZwdmU2UiLnWFsBr0gjo0QFo1g==
+  dependencies:
+    "@sentry/types" "6.2.0"
     tslib "^1.9.3"
 
 "@sentry/wizard@^1.1.4":
@@ -6209,6 +6235,11 @@ image-size@^0.6.0:
   resolved "https://registry.yarnpkg.com/image-size/-/image-size-0.6.3.tgz#e7e5c65bb534bd7cdcedd6cb5166272a85f75fb2"
   integrity sha512-47xSUiQioGaB96nqtp5/q55m0aBQSQdyIloMOc/x+QVTDZLNmXE892IIDrJ0hM1A5vcNUDD5tDffkSP5lCaIIA==
 
+immediate@~3.0.5:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/immediate/-/immediate-3.0.6.tgz#9db1dbd0faf8de6fbe0f5dd5e56bb606280de69b"
+  integrity sha1-nbHb0Pr43m++D13V5Wu2BigN5ps=
+
 immutable-devtools@^0.1.5:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/immutable-devtools/-/immutable-devtools-0.1.5.tgz#32a653c8ba8258bfed37680a860a3b5fa2675693"
@@ -8023,6 +8054,13 @@ levn@^0.4.1:
     prelude-ls "^1.2.1"
     type-check "~0.4.0"
 
+lie@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/lie/-/lie-3.1.1.tgz#9a436b2cc7746ca59de7a41fa469b3efb76bd87e"
+  integrity sha1-mkNrLMd0bKWd56QfpGmz77dr2H4=
+  dependencies:
+    immediate "~3.0.5"
+
 lines-and-columns@^1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
@@ -8063,6 +8101,13 @@ load-pkg@^3.0.1:
   integrity sha1-kjCzfsBOVpADBgvFiVHj7VCNWU8=
   dependencies:
     find-pkg "^0.1.0"
+
+localforage@^1.8.1:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/localforage/-/localforage-1.9.0.tgz#f3e4d32a8300b362b4634cc4e066d9d00d2f09d1"
+  integrity sha512-rR1oyNrKulpe+VM9cYmcFn6tsHuokyVHFaCM3+osEmxaHTbEk8oQu6eGDfS6DQLWi/N67XRmB8ECG37OES368g==
+  dependencies:
+    lie "3.1.1"
 
 locate-path@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
We discovered [1] that we'd only been including the server version
tags when making a `logging.foo` call. This excludes the large
volume of Sentry events that come from uncaught exceptions.

So, set the tags on the global scope, and be sure to keep them
up-to-date by listening for changes to the server version stored in
Redux.

[1] https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/.23M4458.3A.20.22t.2Eget.20is.20not.20a.20function.22.20on.20state.2Enarrows.20at.20sta.2E.2E.2E/near/1119488
[2] https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/Custom.20tags.20for.20Sentry's.20exception.20tracking/near/1121623