### PR TITLE
Adding Alert for logout

### DIFF
--- a/src/account-info/ProfileScreen.js
+++ b/src/account-info/ProfileScreen.js
@@ -1,7 +1,8 @@
 /* @flow strict-local */
-import React from 'react';
-import { ScrollView, View } from 'react-native';
+import React, { useContext } from 'react';
+import { ScrollView, View, Alert } from 'react-native';
 
+import { TranslationContext } from '../boot/TranslationProvider';
 import type { RouteProp } from '../react-navigation';
 import type { MainTabsNavigationProp } from '../main/MainTabsScreen';
 import * as NavigationService from '../nav/NavigationService';
@@ -17,6 +18,7 @@ import {
 import AccountDetails from './AccountDetails';
 import AwayStatusSwitch from './AwayStatusSwitch';
 import { getOwnUser } from '../users/userSelectors';
+import { getActiveAccount } from '../account/accountsSelectors';
 
 const styles = createStyleSheet({
   buttonRow: {
@@ -57,14 +59,33 @@ function SwitchAccountButton(props: {||}) {
 
 function LogoutButton(props: {||}) {
   const dispatch = useDispatch();
+  const _ = useContext(TranslationContext);
+  const activeAccount = useSelector(getActiveAccount);
   return (
     <ZulipButton
       style={styles.button}
       secondary
       text="Log out"
       onPress={() => {
-        dispatch(tryStopNotifications());
-        dispatch(logout());
+        Alert.alert(
+          _('Log out?'),
+          _('This will log out {email} on {realmUrl} from the mobile app on this device.', {
+            email: activeAccount.email,
+            realmUrl: activeAccount.realm.toString(),
+          }),
+          [
+            { text: _('Cancel'), style: 'cancel' },
+            {
+              text: _('Log out'),
+              style: 'destructive',
+              onPress: () => {
+                dispatch(tryStopNotifications());
+                dispatch(logout());
+              },
+            },
+          ],
+          { cancelable: true },
+        );
       }}
     />
   );

--- a/static/translations/messages_en.json
+++ b/static/translations/messages_en.json
@@ -24,6 +24,8 @@
   "Enter": "Enter",
   "Switch account": "Switch account",
   "Log out": "Log out",
+  "Log out?": "Log out?",
+  "This will log out {email} on {realmUrl} from the mobile app on this device.": "This will log out {email} on {realmUrl} from the mobile app on this device.",
   "Add new account": "Add new account",
   "Search messages": "Search messages",
   "Search people": "Search people",


### PR DESCRIPTION
On the profile pic screen when we click on `logout` button then we suddenly logged out without any confirmation message or without any `Alert` which is not that good their must be an `Alert` message before someone logged out like in other apps.

So this PR added an `Alert` message before logout so that if user mistakenly clicks on logout button then it will not suddenly logged out. Attaching a video below which shows that logout `Alert` box


https://user-images.githubusercontent.com/56453541/108977036-27db4280-76ae-11eb-84e7-7e43e03910b0.mp4

Also we can add a spinner or loader before logging out to prevent that rapid log out effect @chrisbobbe @gnprice whats your opinion about that

Fixes: #4496 
