### PR TITLE
emoji picker: Allow searching for literal emoji.

### DIFF
--- a/src/emoji/__tests__/data-test.js
+++ b/src/emoji/__tests__/data-test.js
@@ -74,13 +74,6 @@ describe('getFilteredEmojis', () => {
     ]);
   });
 
-  // This is sort of odd behaviour in some sense: the UI is showing the user
-  // multiple emojis, when they can only react with one of them (if they
-  // react twice with :+1: and :thumbs_up:, it'll only be stored as a single
-  // reaction). We could canonicalize the emoji name in cases where there
-  // are multiple aliases, but it seems somewhat useful to allow the user to
-  // discover that the aliases exist, and unlikely to confuse in practice
-  // (since people will likely just pick an arbitrary one and be done with it)
   test('returns multiple literal emoji', () => {
     const list = getFilteredEmojis('👍', {});
     expect(list).toEqual([

--- a/src/emoji/__tests__/data-test.js
+++ b/src/emoji/__tests__/data-test.js
@@ -67,6 +67,28 @@ describe('getFilteredEmojis', () => {
     ]);
   });
 
+  test('returns literal emoji', () => {
+    const list = getFilteredEmojis('🖤', {});
+    expect(list).toEqual([
+      { emoji_type: 'unicode', code: '1f5a4',  name: 'black_heart' },
+    ]);
+  });
+
+  // This is sort of odd behaviour in some sense: the UI is showing the user
+  // multiple emojis, when they can only react with one of them (if they
+  // react twice with :+1: and :thumbs_up:, it'll only be stored as a single
+  // reaction). We could canonicalize the emoji name in cases where there
+  // are multiple aliases, but it seems somewhat useful to allow the user to
+  // discover that the aliases exist, and unlikely to confuse in practice
+  // (since people will likely just pick an arbitrary one and be done with it)
+  test('returns multiple literal emoji', () => {
+    const list = getFilteredEmojis('👍', {});
+    expect(list).toEqual([
+      { emoji_type: 'unicode', code: '1f44d',  name: '+1' },
+      { emoji_type: 'unicode', code: '1f44d',  name: 'thumbs_up' },
+    ]);
+  });
+
   test('search in realm emojis as well', () => {
     expect(
       getFilteredEmojis('qwerty', {

--- a/src/emoji/data.js
+++ b/src/emoji/data.js
@@ -23,7 +23,15 @@ export const codeToEmojiMap = objectFromEntries<string, string>(
 );
 
 /**
- * Names of all emoji matching the query, in an order to offer to the user.
+ * A list of emoji matching the query, in an order to offer to the user.
+ *
+ * Note that the same emoji may appear multiple times under different names.
+ * This allows the user to choose which name to use; the chosen name is the
+ * one that e.g. is shown to other users on hovering on a reaction.
+ *
+ * For example, 🗽, the Unicode emoji with code '1f5fd', has the names
+ * :new_york:, :statue:, and :statue_of_liberty:, and a search like "statu"
+ * or "🗽" itself will return two or all three of those, respectively.
  */
 export const getFilteredEmojis = (
   query: string,


### PR DESCRIPTION
This allows the user to use the system emoji picker to select reaction
emoji, should they prefer that to typing the emoji name.

There is some complexity around skin-tone modifiers that this commit
does not attempt to address, see the comment for details.

Fixes #3961.

![emoji_literal_search](https://user-images.githubusercontent.com/5001092/109119260-67be2a80-777f-11eb-8c01-30d7d09008f4.png)
![emoji_string_search](https://user-images.githubusercontent.com/5001092/109119267-6987ee00-777f-11eb-811c-23415a2c8178.png)
