### PR TITLE
actionTypes: Remove `email` from `EventSubscriptionUpdateAction`.

### DIFF
--- a/src/actionTypes.js
+++ b/src/actionTypes.js
@@ -274,11 +274,12 @@ type EventSubscriptionUpdateAction = {|
   ...ServerEvent,
   type: typeof EVENT_SUBSCRIPTION,
   op: 'update',
-  email: string,
   name: string,
   property: string,
   stream_id: number,
   value: boolean | number | string,
+
+  // email: string, // gone in 4.0; was the user's own email, so never useful
 |};
 
 type EventSubscriptionPeerAddAction = {|

--- a/src/subscriptions/__tests__/subscriptionsReducer-test.js
+++ b/src/subscriptions/__tests__/subscriptionsReducer-test.js
@@ -140,7 +140,6 @@ describe('subscriptionsReducer', () => {
         type: EVENT_SUBSCRIPTION,
         op: 'update',
         id: 2,
-        email: subNotInHomeView.email_address,
         stream_id: subNotInHomeView.stream_id,
         name: subNotInHomeView.name,
         property: 'in_home_view',


### PR DESCRIPTION
We don't use this, and Tim reports [1] that the server would like to
get rid of it.

[1] https://chat.zulip.org/#narrow/stream/3-backend/topic/stream.20administrators/near/1124276