### PR TITLE
deps: Use `@react-native-clipboard/clipboard`

### DIFF
--- a/flow-typed/@react-native-clipboard/clipboard_vx.x.x.js
+++ b/flow-typed/@react-native-clipboard/clipboard_vx.x.x.js
@@ -1,0 +1,11 @@
+// node_modules/@react-native-clipboard/clipboard/dist/Clipboard.d.ts
+declare module '@react-native-clipboard/clipboard' {
+  declare export default {
+    /**
+     * Set content of string type.
+     *
+     * @param the content to be stored in the clipboard.
+     */
+    setString(content: string): void,
+  };
+}

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   },
   "dependencies": {
     "@expo/react-native-action-sheet": "^3.8.0",
+    "@react-native-clipboard/clipboard": "^1.7.0",
     "@react-native-community/async-storage": "^1.6.3",
     "@react-native-community/cameraroll": "^4.0.4",
     "@react-native-community/masked-view": "^0.1.10",

--- a/src/message/messageActionSheet.js
+++ b/src/message/messageActionSheet.js
@@ -1,5 +1,6 @@
 /* @flow strict-local */
-import { Clipboard, Share, Alert } from 'react-native';
+import { Share, Alert } from 'react-native';
+import Clipboard from '@react-native-clipboard/clipboard';
 
 import * as NavigationService from '../nav/NavigationService';
 import type {

--- a/src/webview/handleOutboundEvents.js
+++ b/src/webview/handleOutboundEvents.js
@@ -1,5 +1,6 @@
 /* @flow strict-local */
-import { Clipboard, Alert } from 'react-native';
+import { Alert } from 'react-native';
+import Clipboard from '@react-native-clipboard/clipboard';
 
 import * as NavigationService from '../nav/NavigationService';
 import * as api from '../api';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2110,6 +2110,11 @@
   dependencies:
     "@types/node" ">= 8"
 
+"@react-native-clipboard/clipboard@^1.7.0":
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/@react-native-clipboard/clipboard/-/clipboard-1.7.0.tgz#43320841870b82b2f311f375dd5f178da46e244e"
+  integrity sha512-i5dJgR+wM8Om+hFEB/PqNb65/x5WxpaZG+UjEBX2/gmmIrmAWI72tI9rVL1gjPA9RWNpdpzvp+ioGjpdl7MyWQ==
+
 "@react-native-community/async-storage@^1.6.3":
   version "1.6.3"
   resolved "https://registry.yarnpkg.com/@react-native-community/async-storage/-/async-storage-1.6.3.tgz#1a713e8c5cacd543ab8539080a5ce57ad917da88"


### PR DESCRIPTION
`Clipboard` in React Native core is deprecated. See [here](https://reactnative.dev/docs/clipboard).
 Although no visible bug occurs but warning errors are 
shown in console  to use `@react-native-community/clipboard`
which was recently migrated to `@react-native-clipboard/clipboard` [here](https://github.com/react-native-clipboard/clipboard/pull/87).

So,migrated to it.

**Steps to reproduce the bug**:
- Go to any message-view
- try copying the message using **Copy to Clipboard**
- See console for warning errors

**Additional Context:**
Since I don't have MacOS so haven't linked & tested it in iOS.

Signed-off-by: rajprakash00 <rajprakash1999@gmail.com>