### PR TITLE
Baby steps toward detangling `ComposeBox`.

### DIFF
--- a/src/api/modelTypes.js
+++ b/src/api/modelTypes.js
@@ -543,6 +543,12 @@ export type PmMessage = $ReadOnly<{|
    */
   display_recipient: $ReadOnlyArray<PmRecipientUser>,
 
+  /**
+   * PMs have (as far as we know) always had the empty string at this
+   * field. Though the doc warns that this might change if Zulip adds
+   * support for topics in PMs; see
+   *   https://chat.zulip.org/#narrow/stream/19-documentation/topic/.60subject.60.20on.20messages/near/1125819.
+   */
   subject: '',
 |}>;
 
@@ -560,6 +566,14 @@ export type StreamMessage = $ReadOnly<{|
 
   stream_id: number,
 
+  /**
+   * The topic.
+   *
+   * No stream message can be stored (and thus arrive on our doorstep)
+   * with an empty-string subject:
+   *   https://chat.zulip.org/#narrow/stream/19-documentation/topic/.60orig_subject.60.20in.20.60update_message.60.20events/near/1112709
+   * (see point 4). We assume this has always been the case.
+   */
   subject: string,
   subject_links: $ReadOnlyArray<string>,
 |}>;

--- a/src/compose/ComposeBox.js
+++ b/src/compose/ComposeBox.js
@@ -361,10 +361,7 @@ class ComposeBox extends PureComponent<Props, State> {
 
   UNSAFE_componentWillReceiveProps(nextProps: Props) {
     if (nextProps.editMessage !== this.props.editMessage) {
-      const topic =
-        isStreamNarrow(nextProps.narrow) && nextProps.editMessage
-          ? nextProps.editMessage.topic
-          : '';
+      const topic = nextProps.editMessage ? nextProps.editMessage.topic : '';
       const message = nextProps.editMessage ? nextProps.editMessage.content : '';
       this.setMessageInputValue(message);
       this.setTopicInputValue(topic);

--- a/src/compose/ComposeBox.js
+++ b/src/compose/ComposeBox.js
@@ -361,7 +361,9 @@ class ComposeBox extends PureComponent<Props, State> {
 
   UNSAFE_componentWillReceiveProps(nextProps: Props) {
     if (nextProps.editMessage !== this.props.editMessage) {
-      const topic = nextProps.editMessage ? nextProps.editMessage.topic : '';
+      const topic = nextProps.editMessage
+        ? nextProps.editMessage.topic
+        : nextProps.lastMessageTopic;
       const message = nextProps.editMessage ? nextProps.editMessage.content : '';
       this.setMessageInputValue(message);
       this.setTopicInputValue(topic);


### PR DESCRIPTION
Including a new comment on the `subject` field on our `Message` type, and fixes for some at least latent (though possibly not-super-common?) bugs.