### PR TITLE
Make `PmMessage` and `StreamMessage` types.

### DIFF
--- a/src/__tests__/lib/exampleData.js
+++ b/src/__tests__/lib/exampleData.js
@@ -298,7 +298,6 @@ const messagePropertiesBase = deepFreeze({
   is_me_message: false,
   // last_edit_timestamp omitted
   reactions: [],
-  subject_links: [],
   submessages: [],
 });
 
@@ -398,6 +397,7 @@ export const streamMessage = (args?: {|
     content_type: 'text/markdown',
     id: randMessageId(),
     subject: 'example topic',
+    subject_links: [],
     timestamp: 1556579727,
     type: 'stream',
   };

--- a/src/__tests__/lib/exampleData.js
+++ b/src/__tests__/lib/exampleData.js
@@ -7,6 +7,7 @@ import type {
   CrossRealmBot,
   Message,
   PmMessage,
+  StreamMessage,
   PmRecipientUser,
   Reaction,
   Stream,
@@ -381,15 +382,15 @@ const messagePropertiesFromStream = (stream1: Stream) => {
  * Beware! These values may not be representative.
  */
 export const streamMessage = (args?: {|
-  ...$Rest<Message, { ... }>,
+  ...$Rest<StreamMessage, { ... }>,
   stream?: Stream,
   sender?: User,
-|}): Message => {
+|}): StreamMessage => {
   // The `Object.freeze` is to work around a Flow issue:
   //   https://github.com/facebook/flow/issues/2386#issuecomment-695064325
   const { stream: streamInner = stream, sender = otherUser, ...extra } = args ?? Object.freeze({});
 
-  const baseMessage: Message = {
+  const baseMessage: StreamMessage = {
     ...messagePropertiesBase,
     ...messagePropertiesFromSender(sender),
     ...messagePropertiesFromStream(streamInner),

--- a/src/__tests__/lib/exampleData.js
+++ b/src/__tests__/lib/exampleData.js
@@ -348,7 +348,6 @@ export const pmMessage = (args?: {|
     // in real messages.  (See comments on the Message type.)
     display_recipient: recipients.map(displayRecipientFromUser),
     id: randMessageId(),
-    recipient_id: 2342,
     stream_id: -1,
     subject: '',
     timestamp: 1556579160,
@@ -367,7 +366,6 @@ export const pmMessageFromTo = (from: User, to: User[], extra?: $Rest<Message, {
 const messagePropertiesFromStream = (stream1: Stream) => {
   const { stream_id, name: display_recipient } = stream1;
   return deepFreeze({
-    recipient_id: 2567,
     display_recipient,
     stream_id,
   });

--- a/src/__tests__/lib/exampleData.js
+++ b/src/__tests__/lib/exampleData.js
@@ -6,6 +6,7 @@ import Immutable from 'immutable';
 import type {
   CrossRealmBot,
   Message,
+  PmMessage,
   PmRecipientUser,
   Reaction,
   Stream,
@@ -324,11 +325,11 @@ const randMessageId: () => number = makeUniqueRandInt('message ID', 10000000);
  * Beware! These values may not be representative.
  */
 export const pmMessage = (args?: {|
-  ...$Rest<Message, { ... }>,
+  ...$Rest<PmMessage, { ... }>,
   sender?: User,
   recipients?: User[],
   sender_id?: number, // accept a plain number, for convenience in tests
-|}): Message => {
+|}): PmMessage => {
   // The `Object.freeze` is to work around a Flow issue:
   //   https://github.com/facebook/flow/issues/2386#issuecomment-695064325
   const {
@@ -338,7 +339,7 @@ export const pmMessage = (args?: {|
     ...extra
   } = args ?? Object.freeze({});
 
-  const baseMessage: Message = {
+  const baseMessage: PmMessage = {
     ...messagePropertiesBase,
     ...messagePropertiesFromSender(sender),
 
@@ -360,8 +361,11 @@ export const pmMessage = (args?: {|
   });
 };
 
-export const pmMessageFromTo = (from: User, to: User[], extra?: $Rest<Message, { ... }>): Message =>
-  pmMessage({ sender: from, recipients: [from, ...to], ...extra });
+export const pmMessageFromTo = (
+  from: User,
+  to: User[],
+  extra?: $Rest<PmMessage, { ... }>,
+): PmMessage => pmMessage({ sender: from, recipients: [from, ...to], ...extra });
 
 const messagePropertiesFromStream = (stream1: Stream) => {
   const { stream_id, name: display_recipient } = stream1;

--- a/src/__tests__/lib/exampleData.js
+++ b/src/__tests__/lib/exampleData.js
@@ -350,7 +350,6 @@ export const pmMessage = (args?: {|
     // in real messages.  (See comments on the Message type.)
     display_recipient: recipients.map(displayRecipientFromUser),
     id: randMessageId(),
-    stream_id: -1,
     subject: '',
     timestamp: 1556579160,
     type: 'private',

--- a/src/api/messages/getMessages.js
+++ b/src/api/messages/getMessages.js
@@ -46,27 +46,22 @@ type ServerApiResponseMessages = {|
 
 /** Exported for tests only. */
 export const migrateMessages = (messages: ServerMessage[], identity: Identity): Message[] =>
-  messages.map(message => {
-    /* eslint-disable-next-line no-unused-vars */
-    const { reactions, avatar_url: rawAvatarUrl, ...restMessage } = message;
-
-    return {
-      ...message,
-      avatar_url: AvatarURL.fromUserOrBotData({
-        rawAvatarUrl: message.avatar_url,
-        email: message.sender_email,
-        userId: message.sender_id,
-        realm: identity.realm,
-      }),
-      reactions: message.reactions.map(reaction => {
-        const { user, ...restReaction } = reaction;
-        return {
-          ...restReaction,
-          user_id: user.id,
-        };
-      }),
-    };
-  });
+  messages.map(message => ({
+    ...message,
+    avatar_url: AvatarURL.fromUserOrBotData({
+      rawAvatarUrl: message.avatar_url,
+      email: message.sender_email,
+      userId: message.sender_id,
+      realm: identity.realm,
+    }),
+    reactions: message.reactions.map(reaction => {
+      const { user, ...restReaction } = reaction;
+      return {
+        ...restReaction,
+        user_id: user.id,
+      };
+    }),
+  }));
 
 const migrateResponse = (response, identity: Identity) => {
   const { messages, ...restResponse } = response;

--- a/src/api/messages/getMessages.js
+++ b/src/api/messages/getMessages.js
@@ -51,7 +51,7 @@ export const migrateMessages = (messages: ServerMessage[], identity: Identity): 
     const { reactions, avatar_url: rawAvatarUrl, ...restMessage } = message;
 
     return {
-      ...restMessage,
+      ...message,
       avatar_url: AvatarURL.fromUserOrBotData({
         rawAvatarUrl: message.avatar_url,
         email: message.sender_email,

--- a/src/api/messages/getMessages.js
+++ b/src/api/messages/getMessages.js
@@ -45,7 +45,10 @@ type ServerApiResponseMessages = {|
 |};
 
 /** Exported for tests only. */
-export const migrateMessages = (messages: ServerMessage[], identity: Identity): Message[] =>
+export const migrateMessages = (
+  messages: $ReadOnlyArray<ServerMessage>,
+  identity: Identity,
+): Message[] =>
   messages.map(message => ({
     ...message,
     avatar_url: AvatarURL.fromUserOrBotData({

--- a/src/api/messages/getMessages.js
+++ b/src/api/messages/getMessages.js
@@ -47,17 +47,18 @@ type ServerApiResponseMessages = {|
 /** Exported for tests only. */
 export const migrateMessages = (messages: ServerMessage[], identity: Identity): Message[] =>
   messages.map(message => {
+    /* eslint-disable-next-line no-unused-vars */
     const { reactions, avatar_url: rawAvatarUrl, ...restMessage } = message;
 
     return {
       ...restMessage,
       avatar_url: AvatarURL.fromUserOrBotData({
-        rawAvatarUrl,
+        rawAvatarUrl: message.avatar_url,
         email: message.sender_email,
         userId: message.sender_id,
         realm: identity.realm,
       }),
-      reactions: reactions.map(reaction => {
+      reactions: message.reactions.map(reaction => {
         const { user, ...restReaction } = reaction;
         return {
           ...restReaction,

--- a/src/api/modelTypes.js
+++ b/src/api/modelTypes.js
@@ -513,6 +513,16 @@ type MessageBase = $ReadOnly<{|
   // Properties that behave differently for stream vs. private messages.
   // TODO: Move all these to `PmMessage` and `StreamMessage`.
 
+  subject: string,
+  subject_links: $ReadOnlyArray<string>,
+|}>;
+
+export type PmMessage = $ReadOnly<{|
+  ...MessageBase,
+
+  // TODO: Put PM-message fields here.
+  type: 'private',
+
   // Notes from studying the server code:
   //  * Notes are primarily from the server as of 2020-04 at cb85763c7, but
   //    this logic is very stable; confirmed all points about behavior as of
@@ -531,27 +541,15 @@ type MessageBase = $ReadOnly<{|
   //      it sorted by user ID; so, best not to assume current behavior.
   //
   /**
-   * The set of all users in the thread, for a PM; else the stream name.
+   * The set of all users in the thread.
    *
-   * For a private message, this lists the sender as well as all (other)
-   * recipients, and it lists each user just once.  In particular the
-   * self-user is always included.
+   * This lists the sender as well as all (other) recipients, and it
+   * lists each user just once.  In particular the self-user is always
+   * included.
    *
    * The ordering is less well specified; if it matters, sort first.
-   *
-   * For stream messages, prefer `stream_id`; see #3918.
    */
-  display_recipient: string | $ReadOnlyArray<PmRecipientUser>, // `string` for type stream, else PmRecipientUser[]
-
-  subject: string,
-  subject_links: $ReadOnlyArray<string>,
-|}>;
-
-export type PmMessage = $ReadOnly<{|
-  ...MessageBase,
-
-  // TODO: Put PM-message fields here.
-  type: 'private',
+  display_recipient: $ReadOnlyArray<PmRecipientUser>,
 |}>;
 
 export type StreamMessage = $ReadOnly<{|
@@ -559,6 +557,13 @@ export type StreamMessage = $ReadOnly<{|
 
   // TODO: Put stream-message fields here.
   type: 'stream',
+
+  /**
+   * The stream name.
+   *
+   * Prefer `stream_id`; see #3918.
+   */
+  display_recipient: string,
 
   stream_id: number,
 |}>;

--- a/src/api/modelTypes.js
+++ b/src/api/modelTypes.js
@@ -513,7 +513,6 @@ type MessageBase = $ReadOnly<{|
   // Properties that behave differently for stream vs. private messages.
   // TODO: Move all these to `PmMessage` and `StreamMessage`.
 
-  subject: string,
   subject_links: $ReadOnlyArray<string>,
 |}>;
 
@@ -550,6 +549,8 @@ export type PmMessage = $ReadOnly<{|
    * The ordering is less well specified; if it matters, sort first.
    */
   display_recipient: $ReadOnlyArray<PmRecipientUser>,
+
+  subject: '',
 |}>;
 
 export type StreamMessage = $ReadOnly<{|
@@ -566,6 +567,8 @@ export type StreamMessage = $ReadOnly<{|
   display_recipient: string,
 
   stream_id: number,
+
+  subject: string,
 |}>;
 
 /**

--- a/src/api/modelTypes.js
+++ b/src/api/modelTypes.js
@@ -508,18 +508,11 @@ type MessageBase = $ReadOnly<{|
 
   /** Deprecated; a server implementation detail not useful in a client. */
   // recipient_id: number,
-
-  //
-  // Properties that behave differently for stream vs. private messages.
-  // TODO: Move all these to `PmMessage` and `StreamMessage`.
-
-  subject_links: $ReadOnlyArray<string>,
 |}>;
 
 export type PmMessage = $ReadOnly<{|
   ...MessageBase,
 
-  // TODO: Put PM-message fields here.
   type: 'private',
 
   // Notes from studying the server code:
@@ -556,7 +549,6 @@ export type PmMessage = $ReadOnly<{|
 export type StreamMessage = $ReadOnly<{|
   ...MessageBase,
 
-  // TODO: Put stream-message fields here.
   type: 'stream',
 
   /**
@@ -569,6 +561,7 @@ export type StreamMessage = $ReadOnly<{|
   stream_id: number,
 
   subject: string,
+  subject_links: $ReadOnlyArray<string>,
 |}>;
 
 /**

--- a/src/api/modelTypes.js
+++ b/src/api/modelTypes.js
@@ -445,48 +445,10 @@ export type Submessage = $ReadOnly<{|
 |}>;
 
 /**
- * A Zulip message.
- *
- * This type is mainly intended to represent the data the server sends as
- * the `message` property of an event of type `message`.  Caveat lector: we
- * pass these around to a lot of places, and do a lot of further munging, so
- * this type may not quite represent that.  Any differences should
- * definitely be commented, and perhaps refactored.
- *
- * The server's behavior here is undocumented and the source is very
- * complex; this is naturally a place where a large fraction of all the
- * features of Zulip have to appear.
- *
- * Major appearances of this type include
- *  * `message: Message` on a server event of type `message`, and our
- *    `EVENT_NEW_MESSAGE` Redux action for the event;
- *  * `messages: Message[]` in a `/messages` (our `getMessages`) response,
- *    and our resulting `MESSAGE_FETCH_COMPLETE` Redux action;
- *  * `messages: {| [id]: Message |}` in our global Redux state.
- *
- * References include:
- *  * the two example events at https://zulip.com/api/get-events-from-queue
- *  * `process_message_event` in zerver/tornado/event_queue.py; the call
- *    `client.add_event(user_event)` makes the final determination of what
- *    goes into the event, so `message_dict` is the final value of `message`
- *  * `MessageDict.wide_dict` and its helpers in zerver/lib/message.py;
- *    via `do_send_messages` in `zerver/lib/actions.py`, these supply most
- *    of the data ultimately handled by `process_message_event`
- *  * `messages_for_ids` and its helpers in zerver/lib/message.py; via
- *    `get_messages_backend`, these supply the data ultimately returned by
- *    `/messages`
- *  * the `Message` and `AbstractMessage` models in zerver/models.py, but
- *    with caution; many fields are adjusted between the DB row and the event
- *  * empirical study looking at Redux events logged [to the
- *    console](docs/howto/debugging.md).
- *
- * See also `Outbox`, which is deliberately similar so that we can use
- * the type `Message | Outbox` in many places.
- *
- * See also `MessagesState` for discussion of how we fetch and store message
- * data.
+ * Properties in common among the two different flavors of a
+ * `Message`: `PmMessage` and `StreamMessage`.
  */
-export type Message = $ReadOnly<{|
+type MessageBase = $ReadOnly<{|
   /** Our own flag; if true, really type `Outbox`. */
   isOutbox: false,
 
@@ -549,6 +511,7 @@ export type Message = $ReadOnly<{|
 
   //
   // Properties that behave differently for stream vs. private messages.
+  // TODO: Move all these to `PmMessage` and `StreamMessage`.
 
   type: 'stream' | 'private',
 
@@ -587,6 +550,62 @@ export type Message = $ReadOnly<{|
   subject: string,
   subject_links: $ReadOnlyArray<string>,
 |}>;
+
+export type PmMessage = $ReadOnly<{|
+  ...MessageBase,
+
+  // TODO: Put PM-message fields here.
+|}>;
+
+export type StreamMessage = $ReadOnly<{|
+  ...MessageBase,
+
+  // TODO: Put stream-message fields here.
+|}>;
+
+/**
+ * A Zulip message.
+ *
+ * This type is mainly intended to represent the data the server sends as
+ * the `message` property of an event of type `message`.  Caveat lector: we
+ * pass these around to a lot of places, and do a lot of further munging, so
+ * this type may not quite represent that.  Any differences should
+ * definitely be commented, and perhaps refactored.
+ *
+ * The server's behavior here is undocumented and the source is very
+ * complex; this is naturally a place where a large fraction of all the
+ * features of Zulip have to appear.
+ *
+ * Major appearances of this type include
+ *  * `message: Message` on a server event of type `message`, and our
+ *    `EVENT_NEW_MESSAGE` Redux action for the event;
+ *  * `messages: Message[]` in a `/messages` (our `getMessages`) response,
+ *    and our resulting `MESSAGE_FETCH_COMPLETE` Redux action;
+ *  * `messages: {| [id]: Message |}` in our global Redux state.
+ *
+ * References include:
+ *  * the two example events at https://zulip.com/api/get-events-from-queue
+ *  * `process_message_event` in zerver/tornado/event_queue.py; the call
+ *    `client.add_event(user_event)` makes the final determination of what
+ *    goes into the event, so `message_dict` is the final value of `message`
+ *  * `MessageDict.wide_dict` and its helpers in zerver/lib/message.py;
+ *    via `do_send_messages` in `zerver/lib/actions.py`, these supply most
+ *    of the data ultimately handled by `process_message_event`
+ *  * `messages_for_ids` and its helpers in zerver/lib/message.py; via
+ *    `get_messages_backend`, these supply the data ultimately returned by
+ *    `/messages`
+ *  * the `Message` and `AbstractMessage` models in zerver/models.py, but
+ *    with caution; many fields are adjusted between the DB row and the event
+ *  * empirical study looking at Redux events logged [to the
+ *    console](docs/howto/debugging.md).
+ *
+ * See also `Outbox`, which is deliberately similar so that we can use
+ * the type `Message | Outbox` in many places.
+ *
+ * See also `MessagesState` for discussion of how we fetch and store message
+ * data.
+ */
+export type Message = MessageBase;
 
 //
 //

--- a/src/api/modelTypes.js
+++ b/src/api/modelTypes.js
@@ -544,6 +544,9 @@ export type Message = $ReadOnly<{|
 
   timestamp: number,
 
+  /** Deprecated; a server implementation detail not useful in a client. */
+  recipient_id: number,
+
   //
   // Properties that behave differently for stream vs. private messages.
 
@@ -578,9 +581,6 @@ export type Message = $ReadOnly<{|
    * For stream messages, prefer `stream_id`; see #3918.
    */
   display_recipient: string | $ReadOnlyArray<PmRecipientUser>, // `string` for type stream, else PmRecipientUser[]
-
-  /** Deprecated; a server implementation detail not useful in a client. */
-  recipient_id: number,
 
   stream_id: number, // FixMe: actually only for type `stream`, else absent.
 

--- a/src/api/modelTypes.js
+++ b/src/api/modelTypes.js
@@ -605,7 +605,7 @@ export type StreamMessage = $ReadOnly<{|
  * See also `MessagesState` for discussion of how we fetch and store message
  * data.
  */
-export type Message = MessageBase;
+export type Message = PmMessage | StreamMessage;
 
 //
 //

--- a/src/api/modelTypes.js
+++ b/src/api/modelTypes.js
@@ -543,8 +543,6 @@ type MessageBase = $ReadOnly<{|
    */
   display_recipient: string | $ReadOnlyArray<PmRecipientUser>, // `string` for type stream, else PmRecipientUser[]
 
-  stream_id: number, // FixMe: actually only for type `stream`, else absent.
-
   subject: string,
   subject_links: $ReadOnlyArray<string>,
 |}>;
@@ -561,6 +559,8 @@ export type StreamMessage = $ReadOnly<{|
 
   // TODO: Put stream-message fields here.
   type: 'stream',
+
+  stream_id: number,
 |}>;
 
 /**

--- a/src/api/modelTypes.js
+++ b/src/api/modelTypes.js
@@ -513,8 +513,6 @@ type MessageBase = $ReadOnly<{|
   // Properties that behave differently for stream vs. private messages.
   // TODO: Move all these to `PmMessage` and `StreamMessage`.
 
-  type: 'stream' | 'private',
-
   // Notes from studying the server code:
   //  * Notes are primarily from the server as of 2020-04 at cb85763c7, but
   //    this logic is very stable; confirmed all points about behavior as of
@@ -555,12 +553,14 @@ export type PmMessage = $ReadOnly<{|
   ...MessageBase,
 
   // TODO: Put PM-message fields here.
+  type: 'private',
 |}>;
 
 export type StreamMessage = $ReadOnly<{|
   ...MessageBase,
 
   // TODO: Put stream-message fields here.
+  type: 'stream',
 |}>;
 
 /**

--- a/src/api/modelTypes.js
+++ b/src/api/modelTypes.js
@@ -545,7 +545,7 @@ export type Message = $ReadOnly<{|
   timestamp: number,
 
   /** Deprecated; a server implementation detail not useful in a client. */
-  recipient_id: number,
+  // recipient_id: number,
 
   //
   // Properties that behave differently for stream vs. private messages.

--- a/src/message/__tests__/fetchActions-test.js
+++ b/src/message/__tests__/fetchActions-test.js
@@ -2,7 +2,6 @@
 import invariant from 'invariant';
 import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
-import omit from 'lodash.omit';
 import Immutable from 'immutable';
 
 import type { GlobalState } from '../../reduxTypes';
@@ -15,7 +14,6 @@ import {
   tryFetch,
 } from '../fetchActions';
 import { FIRST_UNREAD_ANCHOR } from '../../anchor';
-import type { Message } from '../../api/modelTypes';
 import type { ServerMessage } from '../../api/messages/getMessages';
 import { streamNarrow, HOME_NARROW, HOME_NARROW_STR, keyFromNarrow } from '../../utils/narrow';
 import { GravatarURL } from '../../utils/avatar';
@@ -118,15 +116,13 @@ describe('fetchActions', () => {
     };
     const message1 = eg.streamMessage({ id: 1, sender });
 
-    type CommonFields = $Diff<Message, {| reactions: mixed, avatar_url: mixed |}>;
-
     // message1 exactly as we receive it from the server, before our
     // own transformations.
     //
     // TODO: Deduplicate this logic with similar logic in
     // migrateMessages-test.js.
     const serverMessage1: ServerMessage = {
-      ...(omit(message1, 'reactions', 'avatar_url'): CommonFields),
+      ...message1,
       reactions: [],
       avatar_url: null, // Null in server data will be transformed to a GravatarURL
     };

--- a/src/message/messagesReducer.js
+++ b/src/message/messagesReducer.js
@@ -133,40 +133,51 @@ export default (state: MessagesState = initialState, action: Action): MessagesSt
       return state.deleteAll(action.messageIds);
 
     case EVENT_UPDATE_MESSAGE:
-      return state.update(
-        action.message_id,
-        <M: Message>(oldMessage: M): M =>
-          oldMessage && {
-            ...(oldMessage: M),
-            content: action.rendered_content || oldMessage.content,
-            subject: action.subject || oldMessage.subject,
-            subject_links: action.subject_links || oldMessage.subject_links,
-            edit_history: [
-              action.orig_rendered_content
-                ? action.orig_subject !== undefined
-                  ? {
-                      prev_rendered_content: action.orig_rendered_content,
-                      prev_subject: oldMessage.subject,
-                      timestamp: action.edit_timestamp,
-                      prev_rendered_content_version: action.prev_rendered_content_version,
-                      user_id: action.user_id,
-                    }
-                  : {
-                      prev_rendered_content: action.orig_rendered_content,
-                      timestamp: action.edit_timestamp,
-                      prev_rendered_content_version: action.prev_rendered_content_version,
-                      user_id: action.user_id,
-                    }
-                : {
+      return state.update(action.message_id, <M: Message>(oldMessage: M): M => {
+        if (!oldMessage) {
+          return oldMessage;
+        }
+        const messageWithNewCommonFields: M = {
+          ...(oldMessage: M),
+          content: action.rendered_content || oldMessage.content,
+          subject: action.subject || oldMessage.subject,
+          subject_links: action.subject_links || oldMessage.subject_links,
+          edit_history: [
+            action.orig_rendered_content
+              ? action.orig_subject !== undefined
+                ? {
+                    prev_rendered_content: action.orig_rendered_content,
                     prev_subject: oldMessage.subject,
                     timestamp: action.edit_timestamp,
+                    prev_rendered_content_version: action.prev_rendered_content_version,
                     user_id: action.user_id,
-                  },
-              ...(oldMessage.edit_history || NULL_ARRAY),
-            ],
-            last_edit_timestamp: action.edit_timestamp,
-          },
-      );
+                  }
+                : {
+                    prev_rendered_content: action.orig_rendered_content,
+                    timestamp: action.edit_timestamp,
+                    prev_rendered_content_version: action.prev_rendered_content_version,
+                    user_id: action.user_id,
+                  }
+              : {
+                  prev_subject: oldMessage.subject,
+                  timestamp: action.edit_timestamp,
+                  user_id: action.user_id,
+                },
+            ...(oldMessage.edit_history || NULL_ARRAY),
+          ],
+          last_edit_timestamp: action.edit_timestamp,
+        };
+
+        return messageWithNewCommonFields.type === 'stream'
+          ? {
+              ...messageWithNewCommonFields,
+              // stream-message fields will go here
+            }
+          : {
+              ...messageWithNewCommonFields,
+              // pm-message fields will go here
+            };
+      });
 
     default:
       return state;

--- a/src/message/messagesReducer.js
+++ b/src/message/messagesReducer.js
@@ -140,7 +140,6 @@ export default (state: MessagesState = initialState, action: Action): MessagesSt
         const messageWithNewCommonFields: M = {
           ...(oldMessage: M),
           content: action.rendered_content || oldMessage.content,
-          subject: action.subject || oldMessage.subject,
           subject_links: action.subject_links || oldMessage.subject_links,
           edit_history: [
             action.orig_rendered_content
@@ -171,11 +170,10 @@ export default (state: MessagesState = initialState, action: Action): MessagesSt
         return messageWithNewCommonFields.type === 'stream'
           ? {
               ...messageWithNewCommonFields,
-              // stream-message fields will go here
+              subject: action.subject || oldMessage.subject,
             }
           : {
               ...messageWithNewCommonFields,
-              // pm-message fields will go here
             };
       });
 

--- a/src/message/messagesReducer.js
+++ b/src/message/messagesReducer.js
@@ -140,7 +140,6 @@ export default (state: MessagesState = initialState, action: Action): MessagesSt
         const messageWithNewCommonFields: M = {
           ...(oldMessage: M),
           content: action.rendered_content || oldMessage.content,
-          subject_links: action.subject_links || oldMessage.subject_links,
           edit_history: [
             action.orig_rendered_content
               ? action.orig_subject !== undefined
@@ -170,7 +169,8 @@ export default (state: MessagesState = initialState, action: Action): MessagesSt
         return messageWithNewCommonFields.type === 'stream'
           ? {
               ...messageWithNewCommonFields,
-              subject: action.subject || oldMessage.subject,
+              subject: action.subject || messageWithNewCommonFields.subject,
+              subject_links: action.subject_links || messageWithNewCommonFields.subject_links,
             }
           : {
               ...messageWithNewCommonFields,

--- a/src/message/messagesReducer.js
+++ b/src/message/messagesReducer.js
@@ -2,7 +2,7 @@
 import omit from 'lodash.omit';
 import Immutable from 'immutable';
 
-import type { MessagesState, Action } from '../types';
+import type { MessagesState, Message, Action } from '../types';
 import {
   REALM_INIT,
   LOGOUT,
@@ -83,9 +83,9 @@ export default (state: MessagesState = initialState, action: Action): MessagesSt
     case EVENT_REACTION_ADD:
       return state.update(
         action.message_id,
-        oldMessage =>
+        <M: Message>(oldMessage: M): M =>
           oldMessage && {
-            ...oldMessage,
+            ...(oldMessage: M),
             reactions: oldMessage.reactions.concat({
               emoji_name: action.emoji_name,
               user_id: action.user_id,
@@ -98,9 +98,9 @@ export default (state: MessagesState = initialState, action: Action): MessagesSt
     case EVENT_REACTION_REMOVE:
       return state.update(
         action.message_id,
-        oldMessage =>
+        <M: Message>(oldMessage: M): M =>
           oldMessage && {
-            ...oldMessage,
+            ...(oldMessage: M),
             reactions: oldMessage.reactions.filter(
               x => !(x.emoji_name === action.emoji_name && x.user_id === action.user_id),
             ),
@@ -113,9 +113,9 @@ export default (state: MessagesState = initialState, action: Action): MessagesSt
     case EVENT_SUBMESSAGE:
       return state.update(
         action.message_id,
-        message =>
+        <M: Message>(message: M): M =>
           message && {
-            ...message,
+            ...(message: M),
             submessages: [
               ...(message.submessages || []),
               {
@@ -135,9 +135,9 @@ export default (state: MessagesState = initialState, action: Action): MessagesSt
     case EVENT_UPDATE_MESSAGE:
       return state.update(
         action.message_id,
-        oldMessage =>
+        <M: Message>(oldMessage: M): M =>
           oldMessage && {
-            ...oldMessage,
+            ...(oldMessage: M),
             content: action.rendered_content || oldMessage.content,
             subject: action.subject || oldMessage.subject,
             subject_links: action.subject_links || oldMessage.subject_links,


### PR DESCRIPTION
(Removed some outdated text here as our thinking proceeded.)

There's a site in the last commit where the handling for `subject` isn't great, and things get worse at that same site when I try to do `subject_links`; it seems to panic a bit (complaining about things other than `subject_links`; it's like it's forgotten some things it would otherwise know) unless I remove the code that gives `subject_links` a new value. So I'll pause on this for today and take a fresh look tomorrow (and you could give it a go if you like 🙂).

But what do you think of this general approach, @gnprice? I think it's similar to what you proposed [in CZO](https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/.60PmMessage.60.2C.20.60StreamMessage.60.20types.3F/near/1126689) but it doesn't use `MessageBase`; in fact, that can remain unexported, which I kind of like (since it doesn't represent a whole object we'd actually pass around anywhere).

You might find it helpful to start by looking at these two consecutive commits:

5c008bc18cc142cc946e3339887024a782b1ea60 messagesReducer types: Handle `Message` being `PmMessage` | `StreamMessage`.
68c67426a7b9df8c0546faa27564d8a6e424170e getMessages types: Handle `Message` being `PmMessage` | `StreamMessage`.