### PR TITLE
api types: Drop `name` from subscription update events.

### DIFF
--- a/src/actionTypes.js
+++ b/src/actionTypes.js
@@ -274,10 +274,11 @@ type EventSubscriptionUpdateAction = {|
   ...ServerEvent,
   type: typeof EVENT_SUBSCRIPTION,
   op: 'update',
-  name: string,
-  property: string,
   stream_id: number,
+  property: string,
   value: boolean | number | string,
+
+  // name: string, // exists pre-4.0, but expected to be removed soon
 
   // email: string, // gone in 4.0; was the user's own email, so never useful
 |};

--- a/src/subscriptions/__tests__/subscriptionsReducer-test.js
+++ b/src/subscriptions/__tests__/subscriptionsReducer-test.js
@@ -141,7 +141,6 @@ describe('subscriptionsReducer', () => {
         op: 'update',
         id: 2,
         stream_id: subNotInHomeView.stream_id,
-        name: subNotInHomeView.name,
         property: 'in_home_view',
         value: true,
       });


### PR DESCRIPTION
A quick followup to #4501.

We already ignore this in favor of `stream_id`.  On the server side
we intend to stop sending it soon, because neither mobile nor
terminal is using it:
  https://chat.zulip.org/#narrow/stream/3-backend/topic/stream.20administrators/near/1124277

While we're here, also reorder the remaining properties a bit to be
more logically in general-to-specific order.
