### PR TITLE
MessageReactionsScreen: Set `scrollEnabled` to true.

### DIFF
--- a/src/reactions/MessageReactionsScreen.js
+++ b/src/reactions/MessageReactionsScreen.js
@@ -99,6 +99,7 @@ class MessageReactionsScreen extends PureComponent<Props> {
                 },
               })}
               swipeEnabled
+              tabBarOptions={{ scrollEnabled: true }}
             >
               {
                 // Generate tabs for the reaction list. The tabs depend


### PR DESCRIPTION
Currently in `MessageReactionsScreen` when we have a bunch of emojis then
the emoji tabs are overlapping with each other making it hard for any user
to view emojis & it's reaction count.

So add a scrolling effect by setting `scrollEnabled` to true in `Tab.Navigator`.

**Screenshots/Media**:

https://user-images.githubusercontent.com/42652941/109989091-2ead2980-7d2e-11eb-9e15-dbc52016c9e2.mp4



Fixes : #4508
Signed-off-by: rajprakash00 <rajprakash1999@gmail.com>