### PR TITLE
deps: Use '@react-native-community/push-notification-ios'.

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -358,6 +358,8 @@ PODS:
     - React
   - RNCMaskedView (0.1.10):
     - React
+  - RNCPushNotificationIOS (1.8.0):
+    - React-Core
   - RNDeviceInfo (6.0.2):
     - React
   - RNGestureHandler (1.8.0):
@@ -467,6 +469,7 @@ DEPENDENCIES:
   - rn-fetch-blob (from `../node_modules/rn-fetch-blob`)
   - "RNCAsyncStorage (from `../node_modules/@react-native-community/async-storage`)"
   - "RNCMaskedView (from `../node_modules/@react-native-community/masked-view`)"
+  - "RNCPushNotificationIOS (from `../node_modules/@react-native-community/push-notification-ios`)"
   - RNDeviceInfo (from `../node_modules/react-native-device-info`)
   - RNGestureHandler (from `../node_modules/react-native-gesture-handler`)
   - RNReanimated (from `../node_modules/react-native-reanimated`)
@@ -598,6 +601,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/@react-native-community/async-storage"
   RNCMaskedView:
     :path: "../node_modules/@react-native-community/masked-view"
+  RNCPushNotificationIOS:
+    :path: "../node_modules/@react-native-community/push-notification-ios"
   RNDeviceInfo:
     :path: "../node_modules/react-native-device-info"
   RNGestureHandler:
@@ -697,6 +702,7 @@ SPEC CHECKSUMS:
   rn-fetch-blob: f525a73a78df9ed5d35e67ea65e79d53c15255bc
   RNCAsyncStorage: 3c304d1adfaea02ec732ac218801cb13897aa8c0
   RNCMaskedView: 5a8ec07677aa885546a0d98da336457e2bea557f
+  RNCPushNotificationIOS: 61a7c72bd1ebad3568025957d001e0f0e7b32191
   RNDeviceInfo: bdd61e8b070d13a1dd9d022091981075ed4cde16
   RNGestureHandler: 7a5833d0f788dbd107fbb913e09aa0c1ff333c39
   RNReanimated: 89f5e0a04d1dd52fbf27e7e7030d8f80a646a3fc
@@ -723,4 +729,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 0eb2bf1b0f7972fc7183f5eac73708f76355c614
 
-COCOAPODS: 1.10.1
+COCOAPODS: 1.10.0

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@react-native-community/cameraroll": "chrisbobbe/react-native-cameraroll#c118e022e",
     "@react-native-community/masked-view": "^0.1.10",
     "@react-native-community/netinfo": "^5.9.5",
+    "@react-native-community/push-notification-ios": "^1.8.0",
     "@react-navigation/bottom-tabs": "^5.10.6",
     "@react-navigation/drawer": "^5.9.3",
     "@react-navigation/material-top-tabs": "^5.2.19",

--- a/src/notification/index.js
+++ b/src/notification/index.js
@@ -1,5 +1,7 @@
 /* @flow strict-local */
-import { DeviceEventEmitter, NativeModules, Platform, PushNotificationIOS } from 'react-native';
+import { DeviceEventEmitter, NativeModules, Platform } from 'react-native';
+import PushNotificationIOS from '@react-native-community/push-notification-ios';
+
 import NotificationsIOS from 'react-native-notifications';
 
 import type { Notification } from './types';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2249,6 +2249,13 @@
   resolved "https://registry.yarnpkg.com/@react-native-community/netinfo/-/netinfo-5.9.5.tgz#3bad0d855d2e813be085ec305139d4175c512ccc"
   integrity sha512-PbSsRmhRwYIMdeVJTf9gJtvW0TVq/hmgz1xyjsrTIsQ7QS7wbMEiv1Eb/M/y6AEEsdUped5Axm5xykq9TGISHg==
 
+"@react-native-community/push-notification-ios@^1.8.0":
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/@react-native-community/push-notification-ios/-/push-notification-ios-1.8.0.tgz#7d43cb37b9e644ff3069aafa91befe71688a2dc4"
+  integrity sha512-vxvkeampafjmtDoQBN8Q4azP21l6cMX93+OQZemyIWZmG++OjCVDQVitobf/kWLm5zyGwdylejbpMGo75qo7rA==
+  dependencies:
+    invariant "^2.2.4"
+
 "@react-navigation/bottom-tabs@^5.10.6":
   version "5.11.2"
   resolved "https://registry.yarnpkg.com/@react-navigation/bottom-tabs/-/bottom-tabs-5.11.2.tgz#5b541612fcecdea2a5024a4028da35e4a727bde6"


### PR DESCRIPTION
**How I solved this issue?**
I used the react-native-community/push-notification-ios package. Instead of using PushNotificationIOS from react-native I used the same from the above-mentioned package in /src/notification/index.js. The docs of the package mentions the use of the PushNotificationIOS.
Fixes: #4510