### PR TITLE
[android] share to Zulip from other apps

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -44,6 +44,13 @@
                     android:host="login"
                     android:scheme="zulip" />
             </intent-filter>
+        </activity>
+
+        <activity
+            android:name=".HandleSendIntent"
+            android:label="@string/app_name"
+            android:launchMode="standard"
+        >
             <!-- Disabled while the feature is experimental.  See #117 and #4124.
             <intent-filter>
                 <action android:name="android.intent.action.SEND" />

--- a/android/app/src/main/java/com/zulipmobile/HandleSendIntent.kt
+++ b/android/app/src/main/java/com/zulipmobile/HandleSendIntent.kt
@@ -1,0 +1,17 @@
+package com.zulipmobile;
+
+import androidx.appcompat.app.AppCompatActivity;
+
+import android.content.Intent;
+import android.content.ComponentName;
+import android.os.Bundle;
+
+class HandleSendIntent : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        intent.component = ComponentName(applicationContext.packageName, "com.zulipmobile.MainActivity")
+        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        startActivity(intent)
+        finish()
+    }
+}

--- a/android/app/src/main/java/com/zulipmobile/MainActivity.kt
+++ b/android/app/src/main/java/com/zulipmobile/MainActivity.kt
@@ -64,7 +64,7 @@ open class MainActivity : ReactActivity() {
 
     private fun handleSend(intent: Intent) {
         // Intent is reused after quitting, skip it.
-        if ((getIntent().flags and Intent.FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY) != 0) {
+        if ((intent.flags and Intent.FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY) != 0) {
             return;
         }
 

--- a/android/app/src/main/java/com/zulipmobile/MainActivity.kt
+++ b/android/app/src/main/java/com/zulipmobile/MainActivity.kt
@@ -37,6 +37,11 @@ open class MainActivity : ReactActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         WebView.setWebContentsDebuggingEnabled(true)
+
+        // Intent is reused after quitting, skip it.
+        if ((intent.flags and Intent.FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY) != 0) {
+            return;
+        }
         maybeHandleIntent(intent)
     }
 
@@ -63,11 +68,6 @@ open class MainActivity : ReactActivity() {
     }
 
     private fun handleSend(intent: Intent) {
-        // Intent is reused after quitting, skip it.
-        if ((intent.flags and Intent.FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY) != 0) {
-            return;
-        }
-
         val params: WritableMap = try {
             getParamsFromIntent(intent)
         } catch (e: ShareParamsParseException) {

--- a/android/app/src/main/java/com/zulipmobile/sharing/SharingModule.kt
+++ b/android/app/src/main/java/com/zulipmobile/sharing/SharingModule.kt
@@ -10,8 +10,9 @@ internal class SharingModule(reactContext: ReactApplicationContext)
     }
 
     @ReactMethod
-    fun getInitialSharedContent(promise: Promise) {
+    fun readInitialSharedContent(promise: Promise) {
         promise.resolve(initialSharedData)
+        initialSharedData = null
     }
 
     companion object {

--- a/src/autocomplete/StreamAutocomplete.js
+++ b/src/autocomplete/StreamAutocomplete.js
@@ -34,6 +34,7 @@ class StreamAutocomplete extends PureComponent<Props> {
     return (
       <Popup>
         <FlatList
+          nestedScrollEnabled
           keyboardShouldPersistTaps="always"
           initialNumToRender={matchingSubscriptions.length}
           data={matchingSubscriptions}

--- a/src/autocomplete/TopicAutocomplete.js
+++ b/src/autocomplete/TopicAutocomplete.js
@@ -64,6 +64,7 @@ class TopicAutocomplete extends PureComponent<Props> {
       <AnimatedScaleComponent visible={topicsToSuggest.length > 0}>
         <Popup>
           <FlatList
+            nestedScrollEnabled
             keyboardShouldPersistTaps="always"
             initialNumToRender={10}
             data={topicsToSuggest}

--- a/src/sharing/ShareToStream.js
+++ b/src/sharing/ShareToStream.js
@@ -155,7 +155,7 @@ class ShareToStream extends React.Component<Props, State> {
 
     return (
       <>
-        <ScrollView style={styles.wrapper} keyboardShouldPersistTaps="always">
+        <ScrollView style={styles.wrapper} keyboardShouldPersistTaps="always" nestedScrollEnabled>
           <View style={styles.container}>
             {sharedData.type === 'image' && (
               <Image source={{ uri: sharedData.sharedImageUrl }} style={styles.imagePreview} />

--- a/src/sharing/SharingScreen.js
+++ b/src/sharing/SharingScreen.js
@@ -53,6 +53,7 @@ const styles = createStyleSheet({
 class SharingScreen extends PureComponent<Props> {
   render() {
     const { auth } = this.props;
+    const { params } = this.props.route;
 
     // If there is no active logged-in account, abandon the sharing attempt,
     // and present the account picker screen to the user.
@@ -73,6 +74,7 @@ class SharingScreen extends PureComponent<Props> {
           <Tab.Screen
             name="share-to-stream"
             component={ShareToStream}
+            initialParams={params}
             options={{
               tabBarLabel: ({ color }) => <Label style={[styles.tab, { color }]} text="Stream" />,
             }}
@@ -80,6 +82,7 @@ class SharingScreen extends PureComponent<Props> {
           <Tab.Screen
             name="share-to-pm"
             component={ShareToPm}
+            initialParams={params}
             options={{
               tabBarLabel: ({ color }) => (
                 <Label style={[styles.tab, { color }]} text="Private Message" />

--- a/src/sharing/index.js
+++ b/src/sharing/index.js
@@ -6,7 +6,7 @@ import type { Dispatch, SharedData, GetState } from '../types';
 import { navigateToSharing } from '../actions';
 
 const Sharing = NativeModules.Sharing ?? {
-  getInitialSharedContent: () =>
+  readInitialSharedContent: () =>
     // TODO: Implement on iOS.
     null,
 };
@@ -16,7 +16,7 @@ const goToSharing = (data: SharedData) => (dispatch: Dispatch, getState: GetStat
 };
 
 export const handleInitialShare = async (dispatch: Dispatch) => {
-  const initialSharedData: SharedData | null = await Sharing.getInitialSharedContent();
+  const initialSharedData: SharedData | null = await Sharing.readInitialSharedContent();
   if (initialSharedData !== null) {
     dispatch(goToSharing(initialSharedData));
   }

--- a/src/sharing/send.js
+++ b/src/sharing/send.js
@@ -3,6 +3,7 @@
 import type { SharedData, Auth, GetText, UserId } from '../types';
 import { showToast } from '../utils/info';
 import { sendMessage, uploadFile } from '../api';
+import * as logging from '../utils/logging';
 
 type SendStream = {|
   stream: string,
@@ -56,6 +57,7 @@ export const handleSend = async (data: SendStream | SendPm, auth: Auth, _: GetTe
     await sendMessage(auth, messageData);
   } catch (err) {
     showToast(_('Failed to send message'));
+    logging.error(err);
     return;
   }
   showToast(_('Message sent'));


### PR DESCRIPTION
Fixes #117
Continuation of work done in #4196 

## screen capture:
![share-to-zulip](https://user-images.githubusercontent.com/40268170/112153444-44b15a00-8c09-11eb-9e8f-af9601c46e3f.gif)


## work done:
- Rebased #4196 resolving merge conflicts.
- Enabled share intent so that Zulip appears in Share menu in Android.
- Somewhere between the works of #4196 and the current version of the app, the version of React Navigation was changed from v2 to v5, a major upgrade happened in React Navigation from v4 -> v5, because of this sharingScreen was broken since now params needed to be explicitly passed down Tab.Screen in its initialParams prop so added that.
See more details [here](https://reactnavigation.org/docs/upgrading-from-4.x/).
- Changed file name of the file that gets uploaded/displayed in message when shared to Zulip, previous functionality just took the last element of sharedFileUrl.split('/'), sometimes this file name did not have an extension causing the uploaded data to be stored as a binary file. this caused the shared images to not have any preview and the act of downloading such a file downloaded the binary version of that file. In my changes previously I gave the files a more generic name such as file.pdf for pdfs or image.jpeg for jpegs, this can be confusing, especially in the case of sharing multiple files (a feature also implemented), so in the final version of the share to Zulip the app shares the file with the actual name of the file deduced using ContentResolver.
- Fix a bug inside sharing screen where the list of streams/topics was not scrollable.
- Fix a bug that prevented sharing when app was launched from minimized state, to reproduce it:
    - checkout [previous commit](https://github.com/zulip/zulip-mobile/pull/4514/commits/90b3493a56f45bf3cefbc3857b7ae0608fec36f7).
    - install Zulip, (it can run in background, or not run at all doesn't matter).
    - share from any app to Zulip.
    - sharing screen appears, cancel the share from this screen, Zulip exits.
    - return back to Zulip by selecting it from minimized apps.
    - now go back to the previous app and share to Zulip again.
    - the sharing screen will not be visible.
According to me the section of code that was causing the problem in previous point was present in case someone opens the app from minimized apps after they have cancelled sharing, if it wasn't present they would still see the share screen since the SEND_INTENT that originally started the app persists in the minimized app, the placement of the code however was wrong (inside the handleSend method), this caused intents coming from onNewIntent methods to be ignored, when user has already cancelled/shared content once, and wanted to share again.
- App was quitting after share to Zulip concluded (if user pressed cancel or the share was completed), made it so that now it should redirect the user to the screen they shared the content to, or in case when user cancels it should navigate them back to the screen they were previously. (I can't verify what happens in case share is sent to a group of people since I can't find groups of people to share the content to, without disturbing anyone.)
- Added functionality to share multiple contents (any file type) to Zulip.
- Made the following enhancements:
    - Provide user the ability to remove any content they initially selected for sharing, from within the sharing screen.
    - Display the file name of content being shared.
    - Added Image placeholder for files. (Using material UI's file_present.png icon for this.)
- Double Initialization issue: it was present in a very specific case: when Zulip was started by another activity using startActivityForResult method. In this case it didn't matter if Zulip was in background, it's main activity starts within the calling app's task. To fix this I created a separate activity in android native. intent SEND/MULTIPLE_SEND were captured by this new activity, and they were redirected to the MainActivity using startActivity method, the new activity will open on top of the activity calling startActivityForResult and it would open the MainActivity in a separate task (or reuse a task that already contained it) hence preventing re-initialization of MainActivity.

## not addressed:
- User cannot select a realm to share content on, through the sharing screen. The sharing screen opens on whichever realm the user is currently logged into. (let me know if this feature is required, since the functionality works regardless, only the user flow gets affected.)