### PR TITLE
Some tweaks to tools/generate-logos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,6 +79,9 @@ npm-debug.log
 /ios/webview
 # /android/app/build/... is already covered above
 
+# Generated for uploading to the Play Store, separate from any app version
+/zulip-icon-google-play.png
+
 # fastlane
 # See: https://docs.fastlane.tools/best-practices/source-control/
 /fastlane/report.xml

--- a/tools/generate-logos
+++ b/tools/generate-logos
@@ -138,7 +138,8 @@ make_webp() {
 }
 
 make_one_android_icon() {
-    local src="$1" sourceset="$2" restype="$3" name="$4" size_px="$5" density="$6"
+    # SET BY CALLER: src sourceset restype name
+    local size_px="$1" density="$2"
     local output=android/app/src/"${sourceset}"/res/"${restype}"-"${density}"/"${name}".webp
     mkdir -p "${output%/*}"
     make_webp "${src}" "${size_px}" "${output}"
@@ -151,16 +152,11 @@ make_android_icon() {
 
     # Scale factors from:
     #   https://developer.android.com/training/multiscreen/screendensities#TaskProvideAltBmp
-    make_one_android_icon "${src}" "${sourceset}" "${restype}" "${name}" \
-      "${size_dp}" mdpi
-    make_one_android_icon "${src}" "${sourceset}" "${restype}" "${name}" \
-      $(( size_dp * 3 / 2 )) hdpi
-    make_one_android_icon "${src}" "${sourceset}" "${restype}" "${name}" \
-      $(( size_dp * 2 )) xhdpi
-    make_one_android_icon "${src}" "${sourceset}" "${restype}" "${name}" \
-      $(( size_dp * 3 )) xxhdpi
-    make_one_android_icon "${src}" "${sourceset}" "${restype}" "${name}" \
-      $(( size_dp * 4 )) xxxhdpi
+    make_one_android_icon  "${size_dp}"          mdpi
+    make_one_android_icon $(( size_dp * 3 / 2 )) hdpi
+    make_one_android_icon $(( size_dp *   2   )) xhdpi
+    make_one_android_icon $(( size_dp *   3   )) xxhdpi
+    make_one_android_icon $(( size_dp *   4   )) xxxhdpi
 }
 
 make_android() {

--- a/tools/generate-logos
+++ b/tools/generate-logos
@@ -78,7 +78,7 @@ make_one_ios_app_icon() {
 }
 
 make_ios_app_icon() {
-    local iconset=ios/ZulipMobile/Images.xcassets/AppIcon.appiconset
+    local iconset=ios/ZulipMobile/Assets.xcassets/AppIcon.appiconset
     rm -rf "${iconset}"
     mkdir -p "${iconset}"
 

--- a/tools/generate-logos
+++ b/tools/generate-logos
@@ -1,7 +1,13 @@
 #!/usr/bin/env bash
 set -eu
 
-# This script isn't meant to be run routinely, so we let it be a bit
+# Generate the many different versions of our logo we need across the app.
+#
+# This script is not run as part of the build, in order to avoid introducing
+# its somewhat specialized dependencies as requirements for normal
+# development.  Instead, we keep its outputs checked into the repo.
+
+# Because this script isn't meant to be run routinely, we let it be a bit
 # rough-and-ready in its interface.  But it should error early if it's
 # missing anything it needs.
 #
@@ -180,3 +186,11 @@ inkscape "${src_icon_circle}" -w 160 --export-png=static/img/logo.png
 make_ios
 
 make_android
+
+cat <<'EOF'
+
+Done!
+
+If `git status` shows any changes in this script's outputs, be sure to
+commit those alongside your changes to the script itself.
+EOF


### PR DESCRIPTION
A followup to #4476.
* Fix it so that `git status` stays clean unless something changed.
* Document explicitly how we keep the output tracked in Git.
* Switch `make_one_android_icon` to something like named parameters rather than positional, as it now has 6 of them.

(@im-adithya fyi)
