### PR TITLE
Flow-related work on the path to RN v0.64 upgrade, part 2.

### DIFF
--- a/src/actionTypes.js
+++ b/src/actionTypes.js
@@ -110,7 +110,7 @@ import type { ZulipVersion } from './utils/zulipVersion';
  */
 type RehydrateAction = {|
   type: typeof REHYDRATE,
-  payload: GlobalState | { accounts: null } | {||} | void,
+  payload: $ReadOnly<$ObjMap<$Rest<GlobalState, { ... }>, <V>(V) => V | null>> | void,
   error: mixed,
 |};
 

--- a/src/boot/store.js
+++ b/src/boot/store.js
@@ -8,6 +8,7 @@ import Immutable from 'immutable';
 import { persistStore, autoRehydrate } from '../third/redux-persist';
 import type { Config } from '../third/redux-persist';
 
+import type { ReadWrite } from '../generics';
 import { ZulipVersion } from '../utils/zulipVersion';
 import { stringify, parse } from './replaceRevive';
 import type { Action, GlobalState } from '../types';
@@ -88,13 +89,15 @@ export const cacheKeys: Array<$Keys<GlobalState>> = [
  * that happens.
  */
 function dropCache(state: GlobalState): $Shape<GlobalState> {
-  const result: $Shape<GlobalState> = {};
+  const result: $Shape<ReadWrite<GlobalState>> = {};
   storeKeys.forEach(key => {
-    /* $FlowFixMe[cannot-write]
-       This is well-typed only because it's the same `key` twice. It seems
-       like we should have to suppress an error about not having that
-       guarantee, in addition to the more minor-looking `cannot-write`. Not
-       sure why we don't. */
+    // $FlowFixMe[incompatible-indexer]
+    // $FlowFixMe[incompatible-exact]
+    // $FlowFixMe[prop-missing]
+    // $FlowFixMe[incompatible-variance]
+    // $FlowFixMe[incompatible-type-arg]
+    /* $FlowFixMe[incompatible-type]
+       This is well-typed only because it's the same `key` twice. */
     result[key] = state[key];
   });
   return result;

--- a/src/chat/narrowsSelectors.js
+++ b/src/chat/narrowsSelectors.js
@@ -113,7 +113,7 @@ export const getLastMessageId = (state: GlobalState, narrow: Narrow): number | v
 
 // Prettier mishandles this Flow syntax.
 // prettier-ignore
-// TODO: clean up what this returns.
+// TODO: clean up what this returns; possibly to just `Stream`
 export const getStreamInNarrow: Selector<Subscription | {| ...Stream, in_home_view: boolean |}, Narrow> = createSelector(
   (state, narrow) => narrow,
   state => getSubscriptions(state),

--- a/src/generics.js
+++ b/src/generics.js
@@ -48,6 +48,17 @@ export type BoundedDiff<-U, -L> = $Diff<
 >;
 
 /**
+ * The object type `T` with its readonly annotation stripped.
+ */
+// The implementation relies on facebook/flow#6225, so it will
+// naturally have to change when that gets fixed.
+//
+// See discussion for an alternative, with `$ObjMap`, that seemed like
+// it was going to work, but didn't:
+//   https://github.com/zulip/zulip-mobile/pull/4520#discussion_r593394451.
+export type ReadWrite<T: $ReadOnly<{ ... }>> = $Diff<T, {||}>;
+
+/**
  * An object type with a subset of T's properties, namely those in U.
  *
  * Gives an error unless all properties of U also appear in T.  Each

--- a/src/message/NotSubscribed.js
+++ b/src/message/NotSubscribed.js
@@ -12,7 +12,7 @@ import styles from '../styles';
 
 type SelectorProps = $ReadOnly<{|
   auth: Auth,
-  stream: { ...Stream },
+  stream: { ...Stream, ... },
 |}>;
 
 type Props = $ReadOnly<{|

--- a/src/notification/index.js
+++ b/src/notification/index.js
@@ -268,7 +268,7 @@ export class NotificationListener {
       // On iOS, `note` should be an IOSNotifications object. The notification
       // data it returns from `getData` is unvalidated -- it comes almost
       // straight off the wire from the server.
-      this.listen('notificationOpened', (note: { getData(): JSONableDict }) => {
+      this.listen('notificationOpened', (note: { getData(): JSONableDict, ... }) => {
         const data = fromAPNs(note.getData());
         if (data) {
           this.handleNotificationOpen(data);

--- a/src/redux-persist-migrate/index.js
+++ b/src/redux-persist-migrate/index.js
@@ -75,8 +75,6 @@ export function createMigrationImpl(
       throw new Error('createMigration: bad arguments');
     }
     if (action.type === REHYDRATE) {
-      // $FlowIgnore[prop-missing]
-      // $FlowIgnore[incompatible-exact]
       /* $FlowIgnore[incompatible-type]
          this really is a lie -- and kind of central to migration */
       const incomingState: State = action.payload;

--- a/src/session/sessionReducer.js
+++ b/src/session/sessionReducer.js
@@ -1,5 +1,5 @@
 /* @flow strict-local */
-import type { Debug, Orientation, Action } from '../types';
+import type { GlobalState, Debug, Orientation, Action } from '../types';
 import {
   REHYDRATE,
   DEAD_QUEUE,
@@ -93,7 +93,15 @@ const initialState: SessionState = {
 
 const rehydrate = (state, action) => {
   const { payload } = action;
-  const haveApiKey = !!(payload && payload.accounts && hasAuth(payload));
+  const haveApiKey = !!(
+    payload
+    && payload.accounts
+    && hasAuth(
+      /* $FlowFixMe: `payload` may have `null` at any of its
+         properties; see `RehydrateAction` type. */
+      (payload: GlobalState),
+    )
+  );
   return {
     ...state,
     isHydrated: true,

--- a/src/session/sessionReducer.js
+++ b/src/session/sessionReducer.js
@@ -93,23 +93,26 @@ const initialState: SessionState = {
 
 const rehydrate = (state, action) => {
   const { payload } = action;
+
+  /* $FlowIgnore: The actual type allows any property to be null; narrow
+       that to just the one that `hasAuth` will care about.  (What we really
+       want here is what the value of `hasAuth` will be after the rehydrate
+       is complete.  So even if some other property is null in the payload,
+       we still do want to ask `hasAuth` what it thinks.) */
+  const payloadForHasAuth = (payload: GlobalState | { accounts: null, ... } | void);
   const haveApiKey = !!(
-    payload
-    && payload.accounts
-    && hasAuth(
-      /* $FlowFixMe: `payload` may have `null` at any of its
-         properties; see `RehydrateAction` type. */
-      (payload: GlobalState),
-    )
+    payloadForHasAuth
+    && payloadForHasAuth.accounts
+    && hasAuth(payloadForHasAuth)
   );
+
   return {
     ...state,
     isHydrated: true,
     // On rehydration, do an initial fetch if we have access to an account
     // (indicated by the presence of an api key). Otherwise, the initial fetch
     // will be initiated on loginSuccess.
-    // NB `InitialNavigationDispatcher`'s `doInitialNavigation`
-    // depends intimately on this behavior.
+    // NB `getInitialRouteInfo` depends intimately on this behavior.
     needsInitialFetch: haveApiKey,
   };
 };


### PR DESCRIPTION
This addresses the portion of #3452 (which we should do before the RN v0.64 upgrade, #4426) in our own code, while leaving 36 sites in the libdefs, to be treated in another PR.

Done by temporarily adding `implicit-inexact-object=warn` to our .flowconfig and fixing all the warnings it flags, as Greg recommends in https://github.com/zulip/zulip-mobile/issues/3452#issuecomment-657778760.

My focus has been to satisfy the lint rule kind of quickly, using exact (over explicitly inexact) when it's convenient and obviously correct. It's quite possible that more of these could have been made exact—but I don't expect this to cause any type-checking regressions, as explicitly inexact is equivalent to implicitly inexact to the type-checker.

Please give special attention to the last two commits—the rehydrate payload type was looking pretty incorrect, and I think I've improved it. I found that that improvement was possible after making `GlobalState` readonly, which I do in the second-to-last commit; see [discussion](https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/.60type.20GlobalState.20.3D.20.24ReadOnly.3C.E2.80.A6.3E.60.3F/near/1129800) where I ask if this is OK.