### PR TITLE
Fix alignment of embedded link previews.

### DIFF
--- a/src/webview/static/base.css
+++ b/src/webview/static/base.css
@@ -484,12 +484,13 @@ time {
 }
 
 .message_inline_image {
-  text-align: center;
+  margin-top: 5px;
 }
 .message_inline_image img,
 .message_inline_ref img,
 .twitter-image img {
-  width: 100%;
+  width: auto; 
+  max-width: 100%; 
   height: 160px;
   object-fit: contain;
 }


### PR DESCRIPTION
Currently all embedded images are center aligned in mobile unlike in zulip
web where all are left aligned.Center-aligned images seems fine but for
different orientation images it becomes quite weird to view in mobile unlike
in zulip web.

So ,make the link previews left aligned.(Twitter images are already
within an enclosed box & it seems perfectly fine being centred so no change
in that.)

**Screenshot:**
![zulipAfter5](https://user-images.githubusercontent.com/42652941/111141179-3c25a780-85a9-11eb-9735-298742147d91.png)


Fixes : #4533
Signed-off-by: rajprakash00 <rajprakash1999@gmail.com>