### PR TITLE
Markdown tables: Add horizontal scrolling.

### DIFF
--- a/src/webview/static/base.css
+++ b/src/webview/static/base.css
@@ -437,7 +437,9 @@ blockquote {
 
 table {
   border-collapse: collapse;
-  width: 100%;
+  max-width: fit-content;
+  display: block;
+  overflow-x: auto;
 }
 table, th, td {
   border: 1px solid hsla(0, 0%, 50%, 0.25);


### PR DESCRIPTION
Currently a markdown table having long text gets cut off from the right side
instead of scrolling.

Added horizontal scrolling effect.

**ScreenShots/Media**:

https://user-images.githubusercontent.com/42652941/111325017-4e7b1080-8691-11eb-8d26-9b935eddf39a.mp4



Fixes : #4530
Signed-off-by: rajprakash00 <rajprakash1999@gmail.com>