### PR TITLE
ActionSheets: Refactor to tighten up types

### DIFF
--- a/src/message/__tests__/messageActionSheet-test.js
+++ b/src/message/__tests__/messageActionSheet-test.js
@@ -18,6 +18,8 @@ const baseBackgroundData = deepFreeze({
   twentyFourHourTime: false,
 });
 
+const buttonTitles = buttons => buttons.map(button => button.title);
+
 describe('constructActionButtons', () => {
   const narrow = deepFreeze(HOME_NARROW);
 
@@ -29,7 +31,7 @@ describe('constructActionButtons', () => {
       message,
       narrow,
     });
-    expect(buttons).toContain('starMessage');
+    expect(buttonTitles(buttons)).toContain('Star message');
   });
 
   test('show unstar message option if message is starred', () => {
@@ -40,7 +42,7 @@ describe('constructActionButtons', () => {
       message,
       narrow,
     });
-    expect(buttons).toContain('unstarMessage');
+    expect(buttonTitles(buttons)).toContain('Unstar message');
   });
 
   test('show reactions option if message is has at least one reaction', () => {
@@ -49,7 +51,7 @@ describe('constructActionButtons', () => {
       message: eg.streamMessage({ reactions: [eg.unicodeEmojiReaction] }),
       narrow,
     });
-    expect(buttons).toContain('showReactions');
+    expect(buttonTitles(buttons)).toContain('See who reacted');
   });
 });
 
@@ -64,7 +66,7 @@ describe('constructHeaderActionButtons', () => {
       backgroundData: { ...baseBackgroundData, mute },
       message,
     });
-    expect(buttons).toContain('unmuteTopic');
+    expect(buttonTitles(buttons)).toContain('Unmute topic');
   });
 
   test('show mute topic option if topic is not muted', () => {
@@ -72,7 +74,7 @@ describe('constructHeaderActionButtons', () => {
       backgroundData: { ...baseBackgroundData, mute: [] },
       message: eg.streamMessage(),
     });
-    expect(buttons).toContain('muteTopic');
+    expect(buttonTitles(buttons)).toContain('Mute topic');
   });
 
   test('show Unmute stream option if stream is not in home view', () => {
@@ -81,7 +83,7 @@ describe('constructHeaderActionButtons', () => {
       backgroundData: { ...baseBackgroundData, subscriptions },
       message: eg.streamMessage(),
     });
-    expect(buttons).toContain('unmuteStream');
+    expect(buttonTitles(buttons)).toContain('Unmute stream');
   });
 
   test('show mute stream option if stream is in home view', () => {
@@ -90,7 +92,7 @@ describe('constructHeaderActionButtons', () => {
       backgroundData: { ...baseBackgroundData, subscriptions },
       message: eg.streamMessage(),
     });
-    expect(buttons).toContain('muteStream');
+    expect(buttonTitles(buttons)).toContain('Mute stream');
   });
 
   test('show delete topic option if current user is an admin', () => {
@@ -99,7 +101,7 @@ describe('constructHeaderActionButtons', () => {
       backgroundData: { ...baseBackgroundData, ownUser },
       message: eg.streamMessage(),
     });
-    expect(buttons).toContain('deleteTopic');
+    expect(buttonTitles(buttons)).toContain('Delete topic');
   });
 
   test('do not show delete topic option if current user is not an admin', () => {
@@ -107,6 +109,6 @@ describe('constructHeaderActionButtons', () => {
       backgroundData: baseBackgroundData,
       message: eg.streamMessage(),
     });
-    expect(buttons).not.toContain('deleteTopic');
+    expect(buttonTitles(buttons)).not.toContain('Delete topic');
   });
 });

--- a/src/message/__tests__/messageActionSheet-test.js
+++ b/src/message/__tests__/messageActionSheet-test.js
@@ -54,8 +54,6 @@ describe('constructActionButtons', () => {
 });
 
 describe('constructHeaderActionButtons', () => {
-  const narrow = deepFreeze(HOME_NARROW);
-
   test('show Unmute topic option if topic is muted', () => {
     const mute = deepFreeze([['electron issues', 'issue #556']]);
     const message = eg.streamMessage({
@@ -65,7 +63,6 @@ describe('constructHeaderActionButtons', () => {
     const buttons = constructHeaderActionButtons({
       backgroundData: { ...baseBackgroundData, mute },
       message,
-      narrow,
     });
     expect(buttons).toContain('unmuteTopic');
   });
@@ -74,7 +71,6 @@ describe('constructHeaderActionButtons', () => {
     const buttons = constructHeaderActionButtons({
       backgroundData: { ...baseBackgroundData, mute: [] },
       message: eg.streamMessage(),
-      narrow,
     });
     expect(buttons).toContain('muteTopic');
   });
@@ -84,7 +80,6 @@ describe('constructHeaderActionButtons', () => {
     const buttons = constructHeaderActionButtons({
       backgroundData: { ...baseBackgroundData, subscriptions },
       message: eg.streamMessage(),
-      narrow,
     });
     expect(buttons).toContain('unmuteStream');
   });
@@ -94,7 +89,6 @@ describe('constructHeaderActionButtons', () => {
     const buttons = constructHeaderActionButtons({
       backgroundData: { ...baseBackgroundData, subscriptions },
       message: eg.streamMessage(),
-      narrow,
     });
     expect(buttons).toContain('muteStream');
   });
@@ -104,7 +98,6 @@ describe('constructHeaderActionButtons', () => {
     const buttons = constructHeaderActionButtons({
       backgroundData: { ...baseBackgroundData, ownUser },
       message: eg.streamMessage(),
-      narrow,
     });
     expect(buttons).toContain('deleteTopic');
   });
@@ -113,7 +106,6 @@ describe('constructHeaderActionButtons', () => {
     const buttons = constructHeaderActionButtons({
       backgroundData: baseBackgroundData,
       message: eg.streamMessage(),
-      narrow,
     });
     expect(buttons).not.toContain('deleteTopic');
   });

--- a/src/message/__tests__/messageActionSheet-test.js
+++ b/src/message/__tests__/messageActionSheet-test.js
@@ -1,6 +1,7 @@
 // @flow strict-local
 import deepFreeze from 'deep-freeze';
 import { HOME_NARROW } from '../../utils/narrow';
+import { streamNameOfStreamMessage } from '../../utils/recipient';
 
 import * as eg from '../../__tests__/lib/exampleData';
 import { constructMessageActionButtons, constructHeaderActionButtons } from '../messageActionSheet';
@@ -58,13 +59,10 @@ describe('constructActionButtons', () => {
 describe('constructHeaderActionButtons', () => {
   test('show Unmute topic option if topic is muted', () => {
     const mute = deepFreeze([['electron issues', 'issue #556']]);
-    const message = eg.streamMessage({
-      display_recipient: 'electron issues',
-      subject: 'issue #556',
-    });
     const buttons = constructHeaderActionButtons({
       backgroundData: { ...baseBackgroundData, mute },
-      message,
+      stream: 'electron issues',
+      topic: 'issue #556',
     });
     expect(buttonTitles(buttons)).toContain('Unmute topic');
   });
@@ -72,7 +70,8 @@ describe('constructHeaderActionButtons', () => {
   test('show mute topic option if topic is not muted', () => {
     const buttons = constructHeaderActionButtons({
       backgroundData: { ...baseBackgroundData, mute: [] },
-      message: eg.streamMessage(),
+      stream: streamNameOfStreamMessage(eg.streamMessage()),
+      topic: eg.streamMessage().subject,
     });
     expect(buttonTitles(buttons)).toContain('Mute topic');
   });
@@ -81,7 +80,8 @@ describe('constructHeaderActionButtons', () => {
     const subscriptions = [{ ...eg.subscription, in_home_view: false }];
     const buttons = constructHeaderActionButtons({
       backgroundData: { ...baseBackgroundData, subscriptions },
-      message: eg.streamMessage(),
+      stream: streamNameOfStreamMessage(eg.streamMessage()),
+      topic: eg.streamMessage().subject,
     });
     expect(buttonTitles(buttons)).toContain('Unmute stream');
   });
@@ -90,7 +90,8 @@ describe('constructHeaderActionButtons', () => {
     const subscriptions = [{ ...eg.subscription, in_home_view: true }];
     const buttons = constructHeaderActionButtons({
       backgroundData: { ...baseBackgroundData, subscriptions },
-      message: eg.streamMessage(),
+      stream: streamNameOfStreamMessage(eg.streamMessage()),
+      topic: eg.streamMessage().subject,
     });
     expect(buttonTitles(buttons)).toContain('Mute stream');
   });
@@ -99,7 +100,8 @@ describe('constructHeaderActionButtons', () => {
     const ownUser = { ...eg.selfUser, is_admin: true };
     const buttons = constructHeaderActionButtons({
       backgroundData: { ...baseBackgroundData, ownUser },
-      message: eg.streamMessage(),
+      stream: streamNameOfStreamMessage(eg.streamMessage()),
+      topic: eg.streamMessage().subject,
     });
     expect(buttonTitles(buttons)).toContain('Delete topic');
   });
@@ -107,7 +109,8 @@ describe('constructHeaderActionButtons', () => {
   test('do not show delete topic option if current user is not an admin', () => {
     const buttons = constructHeaderActionButtons({
       backgroundData: baseBackgroundData,
-      message: eg.streamMessage(),
+      stream: streamNameOfStreamMessage(eg.streamMessage()),
+      topic: eg.streamMessage().subject,
     });
     expect(buttonTitles(buttons)).not.toContain('Delete topic');
   });

--- a/src/message/messageActionSheet.js
+++ b/src/message/messageActionSheet.js
@@ -263,6 +263,7 @@ export const constructMessageActionButtons = ({
   backgroundData: $ReadOnly<{
     ownUser: User,
     flags: FlagsState,
+    ...
   }>,
   message: Message,
   narrow: Narrow,
@@ -338,6 +339,7 @@ export const showMessageActionSheet = ({
     subscriptions: Subscription[],
     ownUser: User,
     flags: FlagsState,
+    ...
   }>,
   message: Message | Outbox,
   narrow: Narrow,
@@ -385,6 +387,7 @@ export const showHeaderActionSheet = ({
     subscriptions: Subscription[],
     ownUser: User,
     flags: FlagsState,
+    ...
   }>,
   stream: string,
   topic: string,

--- a/src/message/messageActionSheet.js
+++ b/src/message/messageActionSheet.js
@@ -1,5 +1,4 @@
 /* @flow strict-local */
-import invariant from 'invariant';
 import { Clipboard, Share, Alert } from 'react-native';
 
 import * as NavigationService from '../nav/NavigationService';
@@ -27,7 +26,6 @@ import * as api from '../api';
 import { showToast } from '../utils/info';
 import { doNarrow, deleteOutboxMessage, navigateToEmojiPicker } from '../actions';
 import { navigateToMessageReactionScreen } from '../nav/navActions';
-import { streamNameOfStreamMessage } from '../utils/recipient';
 import { deleteMessagesForTopic } from '../topics/topicActions';
 import * as logging from '../utils/logging';
 
@@ -373,7 +371,8 @@ export const showHeaderActionSheet = ({
   showActionSheetWithOptions,
   callbacks,
   backgroundData,
-  message,
+  topic,
+  stream,
 }: {|
   showActionSheetWithOptions: ShowActionSheetWithOptions,
   callbacks: {|
@@ -388,13 +387,13 @@ export const showHeaderActionSheet = ({
     ownUser: User,
     flags: FlagsState,
   }>,
-  message: Message | Outbox,
+  stream: string,
+  topic: string,
 |}): void => {
-  invariant(message.type === 'stream', 'showHeaderActionSheet: got PM');
   const buttonList = constructHeaderActionButtons({
     backgroundData,
-    stream: streamNameOfStreamMessage(message),
-    topic: message.subject,
+    stream,
+    topic,
   });
   const callback = buttonIndex => {
     (async () => {
@@ -403,8 +402,8 @@ export const showHeaderActionSheet = ({
         await pressedButton({
           ...backgroundData,
           ...callbacks,
-          stream: streamNameOfStreamMessage(message),
-          topic: message.subject,
+          stream,
+          topic,
         });
       } catch (err) {
         Alert.alert(callbacks._(pressedButton.errorMessage), err.message);
@@ -413,7 +412,7 @@ export const showHeaderActionSheet = ({
   };
   showActionSheetWithOptions(
     {
-      title: `#${streamNameOfStreamMessage(message)} > ${message.subject}`,
+      title: `#${stream} > ${topic}`,
       options: buttonList.map(button => callbacks._(button.title)),
       cancelButtonIndex: buttonList.length - 1,
     },

--- a/src/message/messageActionSheet.js
+++ b/src/message/messageActionSheet.js
@@ -245,7 +245,6 @@ const allButtons: {| [ButtonCode]: ButtonDescription |} = allButtonsRaw;
 export const constructHeaderActionButtons = ({
   backgroundData: { mute, subscriptions, ownUser },
   message,
-  narrow,
 }: {|
   backgroundData: $ReadOnly<{
     mute: MuteState,
@@ -254,7 +253,6 @@ export const constructHeaderActionButtons = ({
     ...
   }>,
   message: Message | Outbox,
-  narrow: Narrow,
 |}): ButtonCode[] => {
   const buttons: ButtonCode[] = [];
   if (message.type === 'stream') {
@@ -420,7 +418,6 @@ export const showHeaderActionSheet = ({
   callbacks,
   backgroundData,
   message,
-  narrow,
 }: {|
   showActionSheetWithOptions: ShowActionSheetWithOptions,
   callbacks: {|
@@ -436,9 +433,8 @@ export const showHeaderActionSheet = ({
     flags: FlagsState,
   }>,
   message: Message | Outbox,
-  narrow: Narrow,
 |}): void => {
-  const optionCodes = constructHeaderActionButtons({ backgroundData, message, narrow });
+  const optionCodes = constructHeaderActionButtons({ backgroundData, message });
   const callback = buttonIndex => {
     (async () => {
       const pressedButton: ButtonDescription = allButtons[optionCodes[buttonIndex]];

--- a/src/message/messageActionSheet.js
+++ b/src/message/messageActionSheet.js
@@ -377,7 +377,6 @@ export const showHeaderActionSheet = ({
   showActionSheetWithOptions: ShowActionSheetWithOptions,
   callbacks: {|
     dispatch: Dispatch,
-    startEditMessage: (editMessage: EditMessage) => void,
     _: GetText,
   |},
   backgroundData: $ReadOnly<{

--- a/src/webview/handleOutboundEvents.js
+++ b/src/webview/handleOutboundEvents.js
@@ -216,7 +216,7 @@ const handleLongPress = (
     if (message.type === 'stream') {
       showHeaderActionSheet({
         showActionSheetWithOptions,
-        callbacks: { dispatch, startEditMessage, _ },
+        callbacks: { dispatch, _ },
         backgroundData,
         stream: streamNameOfStreamMessage(message),
         topic: message.subject,

--- a/src/webview/handleOutboundEvents.js
+++ b/src/webview/handleOutboundEvents.js
@@ -217,7 +217,6 @@ const handleLongPress = (
       callbacks: { dispatch, startEditMessage, _ },
       backgroundData,
       message,
-      narrow,
     });
   } else if (target === 'message') {
     showMessageActionSheet({

--- a/src/webview/handleOutboundEvents.js
+++ b/src/webview/handleOutboundEvents.js
@@ -22,7 +22,7 @@ import {
   navigateToLightbox,
   messageLinkPress,
 } from '../actions';
-import { showActionSheet } from '../message/messageActionSheet';
+import { showHeaderActionSheet, showMessageActionSheet } from '../message/messageActionSheet';
 import { ensureUnreachable } from '../types';
 import { base64Utf8Decode } from '../utils/encoding';
 
@@ -211,12 +211,19 @@ const handleLongPress = (
     return;
   }
   const { dispatch, showActionSheetWithOptions, backgroundData, narrow, startEditMessage } = props;
-  showActionSheet(
-    target === 'header',
-    showActionSheetWithOptions,
-    { dispatch, startEditMessage, _ },
-    { backgroundData, message, narrow },
-  );
+  if (target === 'header') {
+    showHeaderActionSheet(
+      showActionSheetWithOptions,
+      { dispatch, startEditMessage, _ },
+      { backgroundData, message, narrow },
+    );
+  } else if (target === 'message') {
+    showMessageActionSheet(
+      showActionSheetWithOptions,
+      { dispatch, startEditMessage, _ },
+      { backgroundData, message, narrow },
+    );
+  }
 };
 
 export const handleWebViewOutboundEvent = (

--- a/src/webview/handleOutboundEvents.js
+++ b/src/webview/handleOutboundEvents.js
@@ -212,17 +212,21 @@ const handleLongPress = (
   }
   const { dispatch, showActionSheetWithOptions, backgroundData, narrow, startEditMessage } = props;
   if (target === 'header') {
-    showHeaderActionSheet(
+    showHeaderActionSheet({
       showActionSheetWithOptions,
-      { dispatch, startEditMessage, _ },
-      { backgroundData, message, narrow },
-    );
+      callbacks: { dispatch, startEditMessage, _ },
+      backgroundData,
+      message,
+      narrow,
+    });
   } else if (target === 'message') {
-    showMessageActionSheet(
+    showMessageActionSheet({
       showActionSheetWithOptions,
-      { dispatch, startEditMessage, _ },
-      { backgroundData, message, narrow },
-    );
+      callbacks: { dispatch, startEditMessage, _ },
+      backgroundData,
+      message,
+      narrow,
+    });
   }
 };
 

--- a/src/webview/handleOutboundEvents.js
+++ b/src/webview/handleOutboundEvents.js
@@ -9,6 +9,7 @@ import type { BackgroundData } from './MessageList';
 import type { ShowActionSheetWithOptions } from '../message/messageActionSheet';
 import type { JSONableDict } from '../utils/jsonable';
 import { showToast } from '../utils/info';
+import { pmUiRecipientsFromMessage } from '../utils/recipient';
 import { isUrlAnImage } from '../utils/url';
 import * as logging from '../utils/logging';
 import { filterUnreadMessagesInRange } from '../utils/unread';
@@ -212,12 +213,20 @@ const handleLongPress = (
   }
   const { dispatch, showActionSheetWithOptions, backgroundData, narrow, startEditMessage } = props;
   if (target === 'header') {
-    showHeaderActionSheet({
-      showActionSheetWithOptions,
-      callbacks: { dispatch, startEditMessage, _ },
-      backgroundData,
-      message,
-    });
+    if (message.type === 'stream') {
+      showHeaderActionSheet({
+        showActionSheetWithOptions,
+        callbacks: { dispatch, startEditMessage, _ },
+        backgroundData,
+        message,
+      });
+    } else if (message.type === 'private') {
+      const label = pmUiRecipientsFromMessage(message, backgroundData.ownUser.user_id)
+        .map(r => r.full_name)
+        .sort()
+        .join(', ');
+      showToast(label);
+    }
   } else if (target === 'message') {
     showMessageActionSheet({
       showActionSheetWithOptions,

--- a/src/webview/handleOutboundEvents.js
+++ b/src/webview/handleOutboundEvents.js
@@ -9,7 +9,7 @@ import type { BackgroundData } from './MessageList';
 import type { ShowActionSheetWithOptions } from '../message/messageActionSheet';
 import type { JSONableDict } from '../utils/jsonable';
 import { showToast } from '../utils/info';
-import { pmUiRecipientsFromMessage } from '../utils/recipient';
+import { streamNameOfStreamMessage, pmUiRecipientsFromMessage } from '../utils/recipient';
 import { isUrlAnImage } from '../utils/url';
 import * as logging from '../utils/logging';
 import { filterUnreadMessagesInRange } from '../utils/unread';
@@ -218,7 +218,8 @@ const handleLongPress = (
         showActionSheetWithOptions,
         callbacks: { dispatch, startEditMessage, _ },
         backgroundData,
-        message,
+        stream: streamNameOfStreamMessage(message),
+        topic: message.subject,
       });
     } else if (message.type === 'private') {
       const label = pmUiRecipientsFromMessage(message, backgroundData.ownUser.user_id)


### PR DESCRIPTION
This will allow us to use the shared messageActionSheet code in the
React Native parts of the codebase, rather than only the webview parts
of the codebase. It's also generally a cleaner and more type-safe
approach.

The test coverage for this seems not great, but I manually tested
clicking on most of the buttons on both styles of action sheet in the
app.