### PR TITLE
tools/deps: Fix hashbang

### DIFF
--- a/tools/deps
+++ b/tools/deps
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 this_file=$(readlink -f "${BASH_SOURCE[0]}")
 root=${this_file%/*/*}


### PR DESCRIPTION
`/usr/bin/env bash` is more portable than `/bin/bash`.