### PR TITLE
webview: Mark messages as read when bottom comes into view

### DIFF
--- a/src/webview/static/base.css
+++ b/src/webview/static/base.css
@@ -131,10 +131,14 @@ body {
 .loading {
   display: flex;
   word-wrap: break-word;
+  /* This value is used for messageReadSlop in src/webview/js/js.js, if
+   * updating one, please update the other */
   padding: 16px;
   -webkit-tap-highlight-color: transparent;
 }
 .message-brief {
+  /* This value is used for messageReadSlop in src/webview/js/js.js, if
+   * updating one, please update the other */
   padding: 0 16px 16px 80px;
 }
 


### PR DESCRIPTION
Previously, we marked messages as read as soon as 20px of the message
was visible. However, this is a poor experience: messages are marked as
read before the user has seen the entire message. It's also different
from what the webapp does: in the webapp, it's impossible to mark a
message as read by scrolling until the bottom is in view.

We can't just change `isVisible` to do this, since that's used in
someVisibleMessage, which is used to find a message for resetting the
scroll position - my understanding is that that assumes that if there
are any messages loaded, at least one will be visible. However, it's
possible for a single large message to be the only thing that's visible,
but we don't want to mark it as read, since the bottom hasn't come into
view yet. Hence, this commit adds a `isRead` which is used in
conjunction with `isVisible` to choose when to mark messages as read.