### PR TITLE
webview styles: Let LaTeX equations scroll horizontally.

### DIFF
--- a/src/webview/static/base.css
+++ b/src/webview/static/base.css
@@ -572,6 +572,16 @@ hr {
   border-radius: 0.5rem;
 }
 
+/* LaTeX styling */
+.katex-display {
+   /* KaTeX sometimes overdraws its bounding box by a little, so we
+      enlarge its scrolling area by stealing 3px from the margin
+      of the enclosing <p>. */
+  margin: -3px 0;
+  padding: 3px 0;
+  overflow: auto hidden;
+}
+
 /* Taken from the `.spoiler-block` section of the webapp's styles, as
    of zulip/zulip@1cb040647, translated from SCSS to plain CSS. */
 .spoiler-block {


### PR DESCRIPTION
Currently a long LaTeX equation gets cut off from the right
instead of scrolling.

So, add horizontal scrolling effect.Also take care of bug
involving vertical cut off of superscripts in same way as
zulip web https://github.com/zulip/zulip/pull/17829 .

**Screenshots/Media**:

https://user-images.githubusercontent.com/42652941/112796727-004e1000-9088-11eb-9111-8640b2b2c530.mp4



Fixes: #4017
Signed-off-by: rajprakash00 <rajprakash1999@gmail.com>