### PR TITLE
Fix getting Android push token on startup.

### DIFF
--- a/android/app/src/main/java/com/zulipmobile/notifications/NotificationsModule.java
+++ b/android/app/src/main/java/com/zulipmobile/notifications/NotificationsModule.java
@@ -51,6 +51,14 @@ class NotificationsModule extends ReactContextBaseJavaModule {
         NotifyReact.emit(reactContext, "remoteNotificationsRegistered", token);
     }
 
+    /**
+     * Grab the token and return it to the JavaScript caller.
+     */
+    @ReactMethod
+    public void getToken(Promise promise) {
+        promise.resolve(FirebaseInstanceId.getInstance().getToken());
+    }
+
     @ReactMethod
     public void getInitialNotification(Promise promise) {
         if (null == initialNotification) {

--- a/android/app/src/main/java/com/zulipmobile/notifications/NotificationsModule.java
+++ b/android/app/src/main/java/com/zulipmobile/notifications/NotificationsModule.java
@@ -21,30 +21,10 @@ class NotificationsModule extends ReactContextBaseJavaModule {
         return "Notifications";
     }
 
-    @Override
-    public void initialize() {
-        // This can be considered dead code.
-        //
-        // 3730be4c8 introduced a bug where the JavaScript didn't act
-        // on the event containing the token, either as it was emitted
-        // here or by the FCM framework (via `onRefreshToken`) on
-        // startup. We should give control to the JavaScript by
-        // exposing a method to return the token, for the JavaScript
-        // to call at its convenience.
-        emitToken(getReactApplicationContext());
-    }
-
     static void emitToken(@Nullable ReactContext reactContext) {
         final String token = FirebaseInstanceId.getInstance().getToken();
         if (reactContext == null) {
             // Perhaps this is possible if InstanceIDListenerService gets invoked?
-            // If so, the next time the app is launched, this method will be invoked again
-            // by our NotificationsModule#initialize, by which point there certainly is
-            // a React context; so we'll learn the new token then.
-            // (But see the comment on `initialize` for a problem we
-            // should fix soon, where the `emitToken` there is ignored
-            // by the JavaScript.)
-            Log.w(TAG, "Got token before React context initialized");
             return;
         }
         Log.i(TAG, "Got token; emitting event");

--- a/android/app/src/main/java/com/zulipmobile/notifications/NotificationsModule.java
+++ b/android/app/src/main/java/com/zulipmobile/notifications/NotificationsModule.java
@@ -23,11 +23,14 @@ class NotificationsModule extends ReactContextBaseJavaModule {
 
     @Override
     public void initialize() {
-        // Invoking `emitToken` here is a bit belt-and-suspenders: the FCM framework
-        // already invokes it (via `onRefreshToken`) at app startup.  But that can be
-        // before React is ready.  With some more care we could hang on to it and emit
-        // the event a bit later, but instead we just redundantly emit here when we
-        // know things have started up.
+        // This can be considered dead code.
+        //
+        // 3730be4c8 introduced a bug where the JavaScript didn't act
+        // on the event containing the token, either as it was emitted
+        // here or by the FCM framework (via `onRefreshToken`) on
+        // startup. We should give control to the JavaScript by
+        // exposing a method to return the token, for the JavaScript
+        // to call at its convenience.
         emitToken(getReactApplicationContext());
     }
 
@@ -38,6 +41,9 @@ class NotificationsModule extends ReactContextBaseJavaModule {
             // If so, the next time the app is launched, this method will be invoked again
             // by our NotificationsModule#initialize, by which point there certainly is
             // a React context; so we'll learn the new token then.
+            // (But see the comment on `initialize` for a problem we
+            // should fix soon, where the `emitToken` there is ignored
+            // by the JavaScript.)
             Log.w(TAG, "Got token before React context initialized");
             return;
         }

--- a/src/notification/index.js
+++ b/src/notification/index.js
@@ -241,11 +241,19 @@ export class NotificationListener {
   };
 
   /** Start listening.  Don't call twice without intervening `stop`. */
-  start() {
+  async start() {
     if (Platform.OS === 'android') {
       // On Android, the object passed to the handler is constructed in
       // FcmMessage.kt, and will always be a Notification.
       this.listen('notificationOpened', this.handleNotificationOpen);
+
+      // A bug was introduced in 3730be4c8 that delayed the setup of
+      // our listener for 'remoteNotificationsRegistered' until a time
+      // after the event was emitted from the native code. Until we
+      // settle on a better, more consistent architecture, just grab
+      // the token here and do the same thing our handler does (by
+      // just calling the handler).
+      this.handleDeviceToken(await NativeModules.Notifications.getToken());
     } else {
       // On iOS, `note` should be an IOSNotifications object. The notification
       // data it returns from `getData` is unvalidated -- it comes almost

--- a/src/notification/notificationActions.js
+++ b/src/notification/notificationActions.js
@@ -91,13 +91,15 @@ export const sendAllPushToken = () => async (dispatch: Dispatch, getState: GetSt
 export const initNotifications = () => async (dispatch: Dispatch, getState: GetState) => {
   const { pushToken } = getSession(getState());
   if (pushToken === null) {
-    // We don't have the token yet.  When we learn it, the listener
-    // will update this and all other logged-in servers.  Try to learn
-    // it.
+    // Probably, we just don't have the token yet.  When we learn it,
+    // the listener will update this and all other logged-in servers.
+    // Try to learn it.
     //
-    // On Android this shouldn't happen -- our Android-native code
-    // requests the token early in startup and fires the event that
-    // tells it to our JS code -- but it's harmless to try again.
+    // Or, if we *have* gotten something for the token and it was
+    // `null`, we're probably on Android; see note on
+    // `SessionState.pushToken`. It's harmless to call
+    // `getNotificationToken` in that case; it does nothing on
+    // Android.
     //
     // On iOS this is normal because getting the token may involve
     // showing the user a permissions modal, so we defer that until

--- a/src/notification/notificationActions.js
+++ b/src/notification/notificationActions.js
@@ -91,15 +91,17 @@ export const sendAllPushToken = () => async (dispatch: Dispatch, getState: GetSt
 export const initNotifications = () => async (dispatch: Dispatch, getState: GetState) => {
   const { pushToken } = getSession(getState());
   if (pushToken === null) {
-    // We don't have the token yet.  When we learn it, the listener will
-    // update this and all other logged-in servers.  Try to learn it.
+    // We don't have the token yet.  When we learn it, the listener
+    // will update this and all other logged-in servers.  Try to learn
+    // it.
     //
-    // On Android this shouldn't happen -- our Android-native code requests
-    // the token early in startup and fires the event that tells it to our
-    // JS code -- but it's harmless to try again.
+    // On Android this shouldn't happen -- our Android-native code
+    // requests the token early in startup and fires the event that
+    // tells it to our JS code -- but it's harmless to try again.
     //
-    // On iOS this is normal because getting the token may involve showing
-    // the user a permissions modal, so we defer that until this point.
+    // On iOS this is normal because getting the token may involve
+    // showing the user a permissions modal, so we defer that until
+    // this point.
     getNotificationToken();
     return;
   }


### PR DESCRIPTION
There are further, more involved improvements we'd like to make, but this should fix an important bug amplified in v27.158 where Android hasn't been registering for push notifications. See discussion around https://chat.zulip.org/#narrow/stream/48-mobile/topic/.60remoteNotificationsRegistered.60.20listener.20too.20late/near/1147378.

I've also included a tweak to comments in `initNotifications` that I expect are orthogonal to the fix.