### PR TITLE
deps: Upgrade to @react-native-community/cameraroll v4.0.4.

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -267,8 +267,8 @@ PODS:
     - React-cxxreact (= 0.63.4)
     - React-jsi (= 0.63.4)
   - React-jsinspector (0.63.4)
-  - react-native-cameraroll (4.0.1):
-    - React
+  - react-native-cameraroll (4.0.4):
+    - React-Core
   - react-native-image-picker (2.3.3):
     - React
   - react-native-netinfo (5.9.5):
@@ -674,7 +674,7 @@ SPEC CHECKSUMS:
   React-jsi: a0418934cf48f25b485631deb27c64dc40fb4c31
   React-jsiexecutor: 93bd528844ad21dc07aab1c67cb10abae6df6949
   React-jsinspector: 58aef7155bc9a9683f5b60b35eccea8722a4f53a
-  react-native-cameraroll: 60ba0068826eab1c8d43146191bafd4363ea58a7
+  react-native-cameraroll: 88f4e62d9ecd0e1f253abe4f685474f2ea14bfa2
   react-native-image-picker: 3d3f85baabca60a00b75fb8facc1376db7bbdafa
   react-native-netinfo: a53b00d949b6456913aaf507d9dba90c4008c611
   react-native-notifications: ce37363008fe2d6a226da4e721eace23b6ae3ad9

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@expo/react-native-action-sheet": "^3.8.0",
     "@react-native-community/async-storage": "^1.6.3",
-    "@react-native-community/cameraroll": "chrisbobbe/react-native-cameraroll#c118e022e",
+    "@react-native-community/cameraroll": "^4.0.4",
     "@react-native-community/masked-view": "^0.1.10",
     "@react-native-community/netinfo": "^5.9.5",
     "@react-navigation/bottom-tabs": "^5.10.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2115,9 +2115,10 @@
   resolved "https://registry.yarnpkg.com/@react-native-community/async-storage/-/async-storage-1.6.3.tgz#1a713e8c5cacd543ab8539080a5ce57ad917da88"
   integrity sha512-67K2akX90uc252zKMYJt1wISvaEH6ARtdTI9bUkwmOFXVPyVk1DfPnaRmyUzcVdeCBOO1n0xv9YO2GSppIormQ==
 
-"@react-native-community/cameraroll@chrisbobbe/react-native-cameraroll#c118e022e":
-  version "4.0.1"
-  resolved "https://codeload.github.com/chrisbobbe/react-native-cameraroll/tar.gz/c118e022ebcdc7b461f58c70561ef3c197edbb4f"
+"@react-native-community/cameraroll@^4.0.4":
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cameraroll/-/cameraroll-4.0.4.tgz#3e2567ce54e3985e8e0a51832dfa0e1c5317f75b"
+  integrity sha512-3SY96Xh1yQjV5M7dFisl5kQmrO/K09URarZwmTN801KEalOoo/opsd/e8Vu1dwSKe0NGCK7A2u0oJQpeNbWbnA==
 
 "@react-native-community/cli-debugger-ui@^4.13.1":
   version "4.13.1"


### PR DESCRIPTION
No breaking changes are identified in the release notes:
  https://github.com/react-native-cameraroll/react-native-cameraroll/tags.

Fixes: #4425