### PR TITLE
eventToAction: Use `op` on `update_message_flags` when possible.

### DIFF
--- a/src/__tests__/lib/exampleData.js
+++ b/src/__tests__/lib/exampleData.js
@@ -506,7 +506,7 @@ export const reduxState = (extra?: $Rest<GlobalState, { ... }>): GlobalState =>
  * See `baseReduxState` for a minimal version of the state.
  */
 export const plusReduxState: GlobalState = reduxState({
-  // TODO add .accounts, reflecting selfAuth, zulipVersion, zulipFeatureLevel
+  accounts: [{ ...selfAuth, ackedPushToken: null, zulipVersion, zulipFeatureLevel }],
   realm: { ...baseReduxState.realm, user_id: selfUser.user_id, email: selfUser.email },
   // TODO add crossRealmBot
   users: [selfUser, otherUser, thirdUser],

--- a/src/actionTypes.js
+++ b/src/actionTypes.js
@@ -399,7 +399,7 @@ type EventUpdateMessageFlagsAction = {|
   allMessages: MessagesState,
   flag: string,
   messages: number[],
-  operation: 'add' | 'remove',
+  op: 'add' | 'remove',
 |};
 
 type EventUserAddAction = {|

--- a/src/api/eventTypes.js
+++ b/src/api/eventTypes.js
@@ -134,7 +134,12 @@ export type StreamEvent =
 export type UpdateMessageFlagsEvent = {|
   ...EventCommon,
   type: typeof EventTypes.update_message_flags,
-  operation: 'add' | 'remove',
+
+  // Servers with feature level 32+ send `op`. Servers will eventually
+  // stop sending `operation`; see #4238.
+  operation?: 'add' | 'remove',
+  op?: 'add' | 'remove',
+
   flag: empty, // TODO fill in
   all: boolean,
   messages: number[],

--- a/src/chat/__tests__/flagsReducer-test.js
+++ b/src/chat/__tests__/flagsReducer-test.js
@@ -119,7 +119,7 @@ describe('flagsReducer', () => {
         type: EVENT_UPDATE_MESSAGE_FLAGS,
         messages: [1],
         flag: 'starred',
-        operation: 'add',
+        op: 'add',
       });
 
       const expectedState = {
@@ -144,7 +144,7 @@ describe('flagsReducer', () => {
         type: EVENT_UPDATE_MESSAGE_FLAGS,
         messages: [1],
         flag: 'starred',
-        operation: 'add',
+        op: 'add',
       });
 
       const expectedState = {
@@ -169,7 +169,7 @@ describe('flagsReducer', () => {
         type: EVENT_UPDATE_MESSAGE_FLAGS,
         messages: [1],
         flag: 'read',
-        operation: 'add',
+        op: 'add',
       });
 
       const expectedState = {
@@ -200,7 +200,7 @@ describe('flagsReducer', () => {
         type: EVENT_UPDATE_MESSAGE_FLAGS,
         messages: [1, 2, 3],
         flag: 'starred',
-        operation: 'add',
+        op: 'add',
       });
 
       const expectedState = {
@@ -230,7 +230,7 @@ describe('flagsReducer', () => {
         type: EVENT_UPDATE_MESSAGE_FLAGS,
         messages: [1],
         flag: 'read',
-        operation: 'remove',
+        op: 'remove',
       });
 
       const expectedState = {
@@ -249,7 +249,7 @@ describe('flagsReducer', () => {
         type: EVENT_UPDATE_MESSAGE_FLAGS,
         messages: [1],
         flag: 'read',
-        operation: 'remove',
+        op: 'remove',
       });
 
       const expectedState = {
@@ -277,7 +277,7 @@ describe('flagsReducer', () => {
         type: EVENT_UPDATE_MESSAGE_FLAGS,
         messages: [1, 2, 3, 4],
         flag: 'starred',
-        operation: 'remove',
+        op: 'remove',
       });
 
       const expectedState = {
@@ -305,7 +305,7 @@ describe('flagsReducer', () => {
         type: EVENT_UPDATE_MESSAGE_FLAGS,
         messages: [],
         flag: 'read',
-        operation: 'add',
+        op: 'add',
         all: true,
         allMessages: {
           1: {},

--- a/src/chat/__tests__/narrowsReducer-test.js
+++ b/src/chat/__tests__/narrowsReducer-test.js
@@ -533,7 +533,7 @@ describe('narrowsReducer', () => {
         allMessages,
         all: false,
         flag: 'starred',
-        operation: 'add',
+        op: 'add',
         messages: [4, 2],
       });
 
@@ -550,7 +550,7 @@ describe('narrowsReducer', () => {
         id: 1,
         all: false,
         allMessages,
-        operation: 'add',
+        op: 'add',
         messages: [1],
         flag: 'read',
       });
@@ -572,7 +572,7 @@ describe('narrowsReducer', () => {
           allMessages,
           all: false,
           flag: 'starred',
-          operation: 'add',
+          op: 'add',
           messages: [4, 2],
         });
 
@@ -598,7 +598,7 @@ describe('narrowsReducer', () => {
           allMessages,
           all: false,
           flag: 'starred',
-          operation: 'remove',
+          op: 'remove',
           messages: [4, 2],
         });
 

--- a/src/chat/flagsReducer.js
+++ b/src/chat/flagsReducer.js
@@ -89,11 +89,11 @@ const eventUpdateMessageFlags = (state, action) => {
     return addFlagsForMessages(initialState, Object.keys(action.allMessages).map(Number), ['read']);
   }
 
-  if (action.operation === 'add') {
+  if (action.op === 'add') {
     return addFlagsForMessages(state, action.messages, [action.flag]);
   }
 
-  if (action.operation === 'remove') {
+  if (action.op === 'remove') {
     return removeFlagForMessages(state, action.messages, action.flag);
   }
 

--- a/src/chat/narrowsReducer.js
+++ b/src/chat/narrowsReducer.js
@@ -114,12 +114,12 @@ const eventMessageDelete = (state, action) => {
   return stateChange ? newState : state;
 };
 
-const updateFlagNarrow = (state, narrowStr, operation, messageIds): NarrowsState => {
+const updateFlagNarrow = (state, narrowStr, op, messageIds): NarrowsState => {
   const value = state.get(narrowStr);
   if (!value) {
     return state;
   }
-  switch (operation) {
+  switch (op) {
     case 'add': {
       return state.set(narrowStr, [...value, ...messageIds].sort((a, b) => a - b));
     }
@@ -128,17 +128,17 @@ const updateFlagNarrow = (state, narrowStr, operation, messageIds): NarrowsState
       return state.set(narrowStr, value.filter(id => !messageIdSet.has(id)));
     }
     default:
-      ensureUnreachable(operation);
-      throw new Error(`Unexpected operation ${operation} in an EVENT_UPDATE_MESSAGE_FLAGS action`);
+      ensureUnreachable(op);
+      throw new Error(`Unexpected operation ${op} in an EVENT_UPDATE_MESSAGE_FLAGS action`);
   }
 };
 
 const eventUpdateMessageFlags = (state, action) => {
-  const { flag, operation, messages: messageIds } = action;
+  const { flag, op, messages: messageIds } = action;
   if (flag === 'starred') {
-    return updateFlagNarrow(state, STARRED_NARROW_STR, operation, messageIds);
+    return updateFlagNarrow(state, STARRED_NARROW_STR, op, messageIds);
   } else if (['mentioned', 'wildcard_mentioned'].includes(flag)) {
-    return updateFlagNarrow(state, MENTIONED_NARROW_STR, operation, messageIds);
+    return updateFlagNarrow(state, MENTIONED_NARROW_STR, op, messageIds);
   }
   return state;
 };

--- a/src/events/eventToAction.js
+++ b/src/events/eventToAction.js
@@ -1,4 +1,5 @@
 /* @flow strict-local */
+import invariant from 'invariant';
 import { EventTypes } from '../api/eventTypes';
 
 import * as logging from '../utils/logging';
@@ -34,7 +35,7 @@ import {
 } from '../actionConstants';
 import { getOwnUserId, tryGetUserForId } from '../users/userSelectors';
 import { AvatarURL } from '../utils/avatar';
-import { getCurrentRealm } from '../account/accountsSelectors';
+import { tryGetActiveAccount, getCurrentRealm } from '../account/accountsSelectors';
 
 const opToActionUserGroup = {
   add: EVENT_USER_GROUP_ADD,
@@ -89,6 +90,11 @@ const actionTypeOfEventType = {
 // This FlowFixMe is because this function encodes a large number of
 // assumptions about the events the server sends, and doesn't check them.
 export default (state: GlobalState, event: $FlowFixMe): EventAction | null => {
+  invariant(
+    tryGetActiveAccount(state),
+    'Expected to have an active account when `eventToAction` was called.',
+  );
+
   switch (event.type) {
     // For reference on each type of event, see:
     // https://zulip.com/api/get-events#events

--- a/src/events/eventToAction.js
+++ b/src/events/eventToAction.js
@@ -253,6 +253,11 @@ export default (state: GlobalState, event: $FlowFixMe): EventAction | null => {
       return {
         ...event,
         type: EVENT_UPDATE_MESSAGE_FLAGS,
+
+        // Servers with feature level 32+ send `op`. Servers will eventually
+        // stop sending `operation`; see #4238.
+        op: event.op ?? event.operation,
+
         allMessages: state.messages,
       };
 

--- a/src/unread/__tests__/unreadHuddlesReducer-test.js
+++ b/src/unread/__tests__/unreadHuddlesReducer-test.js
@@ -221,7 +221,7 @@ describe('unreadHuddlesReducer', () => {
         allMessages: eg.makeMessagesState([]),
         messages: [1, 2, 3],
         flag: 'star',
-        operation: 'add',
+        op: 'add',
       };
 
       const actualState = unreadHuddlesReducer(initialState, action);
@@ -248,7 +248,7 @@ describe('unreadHuddlesReducer', () => {
         allMessages: eg.makeMessagesState([]),
         messages: [6, 7],
         flag: 'read',
-        operation: 'add',
+        op: 'add',
       });
 
       const actualState = unreadHuddlesReducer(initialState, action);
@@ -275,7 +275,7 @@ describe('unreadHuddlesReducer', () => {
         allMessages: eg.makeMessagesState([]),
         messages: [3, 4, 5, 6],
         flag: 'read',
-        operation: 'add',
+        op: 'add',
       });
 
       const expectedState = [
@@ -305,7 +305,7 @@ describe('unreadHuddlesReducer', () => {
         allMessages: eg.makeMessagesState([]),
         messages: [1, 2],
         flag: 'read',
-        operation: 'remove',
+        op: 'remove',
       });
 
       const actualState = unreadHuddlesReducer(initialState, action);
@@ -328,7 +328,7 @@ describe('unreadHuddlesReducer', () => {
         allMessages: eg.makeMessagesState([]),
         messages: [],
         flag: 'read',
-        operation: 'add',
+        op: 'add',
       });
 
       const actualState = unreadHuddlesReducer(initialState, action);

--- a/src/unread/__tests__/unreadMentionsReducer-test.js
+++ b/src/unread/__tests__/unreadMentionsReducer-test.js
@@ -110,7 +110,7 @@ describe('unreadMentionsReducer', () => {
         type: EVENT_UPDATE_MESSAGE_FLAGS,
         messages: [1, 2, 3],
         flag: 'star',
-        operation: 'add',
+        op: 'add',
       };
 
       const actualState = unreadMentionsReducer(initialState, action);
@@ -125,7 +125,7 @@ describe('unreadMentionsReducer', () => {
         type: EVENT_UPDATE_MESSAGE_FLAGS,
         messages: [2],
         flag: 'read',
-        operation: 'add',
+        op: 'add',
       });
 
       const actualState = unreadMentionsReducer(initialState, action);
@@ -140,7 +140,7 @@ describe('unreadMentionsReducer', () => {
         type: EVENT_UPDATE_MESSAGE_FLAGS,
         messages: [2, 3],
         flag: 'read',
-        operation: 'add',
+        op: 'add',
       });
 
       const expectedState = [1];
@@ -157,7 +157,7 @@ describe('unreadMentionsReducer', () => {
         type: EVENT_UPDATE_MESSAGE_FLAGS,
         messages: [1, 2],
         flag: 'read',
-        operation: 'remove',
+        op: 'remove',
       });
 
       const actualState = unreadMentionsReducer(initialState, action);
@@ -172,7 +172,7 @@ describe('unreadMentionsReducer', () => {
         type: EVENT_UPDATE_MESSAGE_FLAGS,
         messages: [],
         flag: 'read',
-        operation: 'add',
+        op: 'add',
         all: true,
       });
 

--- a/src/unread/__tests__/unreadModel-test.js
+++ b/src/unread/__tests__/unreadModel-test.js
@@ -134,7 +134,7 @@ describe('stream substate', () => {
 
   describe('EVENT_UPDATE_MESSAGE_FLAGS', () => {
     const mkAction = args => {
-      const { all = false, messages, flag = 'read', operation = 'add' } = args;
+      const { all = false, messages, flag = 'read', op = 'add' } = args;
       return {
         id: 1,
         type: EVENT_UPDATE_MESSAGE_FLAGS,
@@ -142,7 +142,7 @@ describe('stream substate', () => {
         all,
         messages,
         flag,
-        operation,
+        op,
       };
     };
 
@@ -220,7 +220,7 @@ describe('stream substate', () => {
     });
 
     test('when operation is "remove" do nothing', () => {
-      const action = mkAction({ messages: [1, 2], operation: 'remove' });
+      const action = mkAction({ messages: [1, 2], op: 'remove' });
       expect(reducer(baseState, action, baseGlobalState)).toBe(baseState);
     });
 

--- a/src/unread/__tests__/unreadPmsReducer-test.js
+++ b/src/unread/__tests__/unreadPmsReducer-test.js
@@ -201,7 +201,7 @@ describe('unreadPmsReducer', () => {
         allMessages: eg.makeMessagesState([]),
         messages: [1, 2, 3],
         flag: 'star',
-        operation: 'add',
+        op: 'add',
       };
 
       const actualState = unreadPmsReducer(initialState, action);
@@ -228,7 +228,7 @@ describe('unreadPmsReducer', () => {
         allMessages: eg.makeMessagesState([]),
         messages: [6, 7],
         flag: 'read',
-        operation: 'add',
+        op: 'add',
       });
 
       const actualState = unreadPmsReducer(initialState, action);
@@ -255,7 +255,7 @@ describe('unreadPmsReducer', () => {
         allMessages: eg.makeMessagesState([]),
         messages: [3, 4, 5, 6],
         flag: 'read',
-        operation: 'add',
+        op: 'add',
       });
 
       const expectedState = [
@@ -285,7 +285,7 @@ describe('unreadPmsReducer', () => {
         allMessages: eg.makeMessagesState([]),
         messages: [1, 2],
         flag: 'read',
-        operation: 'remove',
+        op: 'remove',
       });
 
       const actualState = unreadPmsReducer(initialState, action);
@@ -308,7 +308,7 @@ describe('unreadPmsReducer', () => {
         allMessages: eg.makeMessagesState([]),
         messages: [],
         flag: 'read',
-        operation: 'add',
+        op: 'add',
       });
 
       const actualState = unreadPmsReducer(initialState, action);

--- a/src/unread/unreadHuddlesReducer.js
+++ b/src/unread/unreadHuddlesReducer.js
@@ -40,9 +40,9 @@ const eventUpdateMessageFlags = (state, action) => {
     return initialState;
   }
 
-  if (action.operation === 'add') {
+  if (action.op === 'add') {
     return removeItemsDeeply(state, action.messages);
-  } else if (action.operation === 'remove') {
+  } else if (action.op === 'remove') {
     // we do not support that operation
   }
 

--- a/src/unread/unreadMentionsReducer.js
+++ b/src/unread/unreadMentionsReducer.js
@@ -23,9 +23,9 @@ const eventUpdateMessageFlags = (state, action) => {
     return initialState;
   }
 
-  if (action.operation === 'add') {
+  if (action.op === 'add') {
     return removeItemsFromArray(state, action.messages);
-  } else if (action.operation === 'remove') {
+  } else if (action.op === 'remove') {
     // we do not support that operation
   }
 

--- a/src/unread/unreadModel.js
+++ b/src/unread/unreadModel.js
@@ -282,7 +282,7 @@ function streamsReducer(
         return initialStreamsState;
       }
 
-      if (action.operation === 'remove') {
+      if (action.op === 'remove') {
         // Zulip doesn't support un-reading a message.  Ignore it.
         return state;
       }

--- a/src/unread/unreadPmsReducer.js
+++ b/src/unread/unreadPmsReducer.js
@@ -40,9 +40,9 @@ const eventUpdateMessageFlags = (state, action) => {
     return initialState;
   }
 
-  if (action.operation === 'add') {
+  if (action.op === 'add') {
     return removeItemsDeeply(state, action.messages);
-  } else if (action.operation === 'remove') {
+  } else if (action.op === 'remove') {
     // we do not support that operation
   }
 


### PR DESCRIPTION
Fixes: #4238