### PR TITLE
webview: Remove highlight on scroll-to-bottom.

### DIFF
--- a/src/webview/static/base.css
+++ b/src/webview/static/base.css
@@ -205,6 +205,7 @@ body {
   z-index: 200;
   right: 5px;
   bottom: 15px;
+  border-radius: 50%;
 }
 #scroll-bottom a {
   display: block;
@@ -212,6 +213,7 @@ body {
   height: 32px;
   border-radius: 50%;
   background: hsla(170, 48%, 54%, 0.5);
+  -webkit-tap-highlight-color: transparent;
 }
 #scroll-bottom .text {
   clip: rect(0 0 0 0);
@@ -219,6 +221,9 @@ body {
   position: absolute;
   height: 1px;
   width: 1px;
+}
+#scroll-bottom:active{
+  background-color: hsl(170, 48%, 54%);
 }
 #scroll-bottom svg {
   width: 32px;


### PR DESCRIPTION
This adds transparency to the a tag and background-color
onpress after converting the button into a circle with
border-radius 50% so as to remove the default highlight
on tap.

## Earlier
![Screenshot from 2021-02-16 10-59-55](https://user-images.githubusercontent.com/64399555/108034966-4c0aa400-705c-11eb-9613-bf949ac9e9ba.png)

## Now
![Screenshot from 2021-02-16 11-53-48](https://user-images.githubusercontent.com/64399555/108035031-647abe80-705c-11eb-8721-ed47c1d24fa4.png)


Fixes: #3996