### PR TITLE
Error-boundary followup (after #4585).

### DIFF
--- a/src/RootErrorBoundary.js
+++ b/src/RootErrorBoundary.js
@@ -1,6 +1,6 @@
 /* @flow strict-local */
 import React from 'react';
-import { View, Clipboard, TextInput, ScrollView, Button, Platform } from 'react-native';
+import { View, Text, Clipboard, TextInput, ScrollView, Button, Platform } from 'react-native';
 import Toast from 'react-native-simple-toast';
 
 import * as logging from './utils/logging';
@@ -91,8 +91,9 @@ ${error.stack}`;
             padding: 50,
           }}
         >
+          <Text>Ouch, there was an error.</Text>
           <Button
-            title="Ouch, there's been an error. Tap to copy the stack trace below."
+            title="Copy details"
             // If something in `onPress` fails, we shouldn't get a
             // white screen [1]: "Unlike the render method and
             // lifecycle methods, the event handlers don’t happen

--- a/src/RootErrorBoundary.js
+++ b/src/RootErrorBoundary.js
@@ -27,7 +27,8 @@ type State = $ReadOnly<{|
  * from this component itself. It doesn't depend on any external setup
  * except Sentry's initialization (without which we'd have no hope of
  * reporting the error to Sentry), e.g., from other React components
- * in the tree.
+ * in the tree. N.B., this means things like proper safe-area
+ * handling, light-dark theming, and translation won't work.
  *
  * [1] https://reactjs.org/docs/error-boundaries.html#how-about-event-handlers
  */


### PR DESCRIPTION
RootErrorBoundary: Separate explanatory text from tappable button.

As Greg suggests as a followup to #4585 [1].

[1] https://github.com/zulip/zulip-mobile/pull/4585#issuecomment-812746788