### PR TITLE
AccountItem: Tweak the layout of "Signed out" text.

### DIFF
--- a/src/account/AccountItem.js
+++ b/src/account/AccountItem.js
@@ -35,12 +35,8 @@ const styles = createStyleSheet({
   },
   signedOutText: {
     fontStyle: 'italic',
-    fontSize: 12,
-    textAlign: 'right',
-    position: 'absolute',
-    end: 10,
-    top: 3,
     color: 'gray',
+    marginVertical: 2,
   },
 });
 
@@ -67,7 +63,6 @@ export default function AccountItem(props: Props) {
           { backgroundColor: backgroundItemColor },
         ]}
       >
-        {!isLoggedIn && <Label style={styles.signedOutText} text="Signed out" />}
         <View style={styles.details}>
           <RawLabel style={[styles.text, { color: textColor }]} text={email} numberOfLines={1} />
           <RawLabel
@@ -75,6 +70,9 @@ export default function AccountItem(props: Props) {
             text={realm.toString()}
             numberOfLines={1}
           />
+          {!isLoggedIn && (
+            <Label style={styles.signedOutText} text="Signed out" numberOfLines={1} />
+          )}
         </View>
         {!showDoneIcon ? (
           <IconTrash


### PR DESCRIPTION
(A proposed followup to #4583; tagging @vaibhavs2. 🙂 See screenshots of the current layout at that PR.)

The previous position of this text looked just a little odd: to my
eye, it didn't play nicely with the vertical centering of the
trash-can icon. Now, it joins the existing left-aligned labels as
the last child of the `styles.details` View.

I'm not sure I've arrived at the best layout choice, but at least
there can be no question about vertical centering. It also makes the
code slightly easier to reason about, since it mostly fits into an
existing pattern: it's just like the existing left-aligned labels,
except it's italic instead of bold (which I like).

<img width=300 src="https://user-images.githubusercontent.com/22248748/113489092-15fc7480-9490-11eb-85f7-9124ef1c6d75.png" /><img width=300 src="https://user-images.githubusercontent.com/22248748/113489110-27458100-9490-11eb-9f5f-682a5ba29aef.png" />
