### PR TITLE
notifications: Add Timestamp.

### DIFF
--- a/android/app/src/main/java/com/zulipmobile/notifications/FCMPushNotifications.kt
+++ b/android/app/src/main/java/com/zulipmobile/notifications/FCMPushNotifications.kt
@@ -103,7 +103,7 @@ private fun getNotificationBuilder(
     viewIntent.putExtra(EXTRA_NOTIFICATION_DATA, fcmMessage.dataForOpen())
     val viewPendingIntent = PendingIntent.getService(context, 0, viewIntent, 0)
     builder.setContentIntent(viewPendingIntent)
-
+    builder.setShowWhen(true)
     builder.setAutoCancel(true)
 
     val totalMessagesCount = extractTotalMessagesCount(conversations)

--- a/android/app/src/main/java/com/zulipmobile/notifications/FCMPushNotifications.kt
+++ b/android/app/src/main/java/com/zulipmobile/notifications/FCMPushNotifications.kt
@@ -103,7 +103,6 @@ private fun getNotificationBuilder(
     viewIntent.putExtra(EXTRA_NOTIFICATION_DATA, fcmMessage.dataForOpen())
     val viewPendingIntent = PendingIntent.getService(context, 0, viewIntent, 0)
     builder.setContentIntent(viewPendingIntent)
-    builder.setShowWhen(true)
     builder.setAutoCancel(true)
 
     val totalMessagesCount = extractTotalMessagesCount(conversations)
@@ -151,6 +150,8 @@ private fun getNotificationBuilder(
     }
 
     builder.setWhen(fcmMessage.timeMs)
+    builder.setShowWhen(true)
+
     val vPattern = longArrayOf(0, 100, 200, 100)
     // NB the DEFAULT_VIBRATE flag below causes this to have no effect.
     // TODO: choose a vibration pattern we like, and unset DEFAULT_VIBRATE.


### PR DESCRIPTION
## Description
This adds a setShowWhen method to set timestamps
to true as it is set to false by default.

More information can be found [here](https://developer.android.com/reference/android/app/Notification.Builder#setWhen(long))

## Screenshot
![Screenshot_1617606370](https://user-images.githubusercontent.com/64399555/113548843-dfe4ff00-960d-11eb-9076-8f735de94a5b.png)

Fixes: #4595

