### PR TITLE
Add reusable component for screens that need server data.

### DIFF
--- a/src/main/MainTabsScreen.js
+++ b/src/main/MainTabsScreen.js
@@ -20,7 +20,7 @@ import { IconInbox, IconSettings, IconStream } from '../common/Icons';
 import { OwnAvatar, OfflineNotice, ZulipStatusBar } from '../common';
 import IconUnreadConversations from '../nav/IconUnreadConversations';
 import ProfileScreen from '../account-info/ProfileScreen';
-import { connect } from '../react-redux';
+import { connect, useSelector } from '../react-redux';
 import { getHaveServerData } from '../selectors';
 import styles, { ThemeContext } from '../styles';
 import FullScreenLoading from '../common/FullScreenLoading';
@@ -43,9 +43,7 @@ const Tab = createBottomTabNavigator<
   MainTabsNavigationProp<>,
 >();
 
-type SelectorProps = $ReadOnly<{|
-  haveServerData: boolean,
-|}>;
+type SelectorProps = $ReadOnly<{||}>;
 
 type Props = $ReadOnly<{|
   navigation: AppNavigationProp<'main-tabs'>,
@@ -57,7 +55,7 @@ type Props = $ReadOnly<{|
 
 function MainTabsScreen(props: Props) {
   const { backgroundColor } = useContext(ThemeContext);
-  const { haveServerData } = props;
+  const haveServerData = useSelector(getHaveServerData);
 
   const insets = useSafeAreaInsets();
 
@@ -144,6 +142,4 @@ function MainTabsScreen(props: Props) {
 // was running -- and throwing an uncaught error -- on logout, and
 // `MainTabsScreen`'s early return on `!haveServerData` wasn't
 // preventing that from happening.
-export default connect(state => ({
-  haveServerData: getHaveServerData(state),
-}))(MainTabsScreen);
+export default connect<{||}, _, _>()(MainTabsScreen);

--- a/src/main/MainTabsScreen.js
+++ b/src/main/MainTabsScreen.js
@@ -55,20 +55,8 @@ type Props = $ReadOnly<{|
 
 function MainTabsScreen(props: Props) {
   const { backgroundColor } = useContext(ThemeContext);
-  const haveServerData = useSelector(getHaveServerData);
 
   const insets = useSafeAreaInsets();
-
-  if (!haveServerData) {
-    // Show a full-screen loading indicator while waiting for the
-    // initial fetch to complete, if we don't have potentially stale
-    // data to show instead. Also show it for the duration of the nav
-    // transition just after the user logs out (see our #4275).
-    //
-    // And avoid rendering any of our main UI, to maintain the
-    // guarantee that it can all rely on server data existing.
-    return <FullScreenLoading />;
-  }
 
   return (
     <View style={[styles.flexed, { backgroundColor }]}>
@@ -127,6 +115,20 @@ function MainTabsScreen(props: Props) {
   );
 }
 
+const ShowIfServerData = (props: Props) =>
+  useSelector(getHaveServerData) ? (
+    <MainTabsScreen {...props} />
+  ) : (
+    // Show a full-screen loading indicator while waiting for the
+    // initial fetch to complete, if we don't have potentially stale
+    // data to show instead. Also show it for the duration of the nav
+    // transition just after the user logs out (see our #4275).
+    //
+    // And avoid rendering any of our main UI, to maintain the
+    // guarantee that it can all rely on server data existing.
+    <FullScreenLoading />
+  );
+
 // `connect` does something useful for us that `useSelector` doesn't
 // do: it interposes a new `ReactReduxContext.Provider` component,
 // which proxies subscriptions so that the descendant components only
@@ -142,4 +144,4 @@ function MainTabsScreen(props: Props) {
 // was running -- and throwing an uncaught error -- on logout, and
 // `MainTabsScreen`'s early return on `!haveServerData` wasn't
 // preventing that from happening.
-export default connect<{||}, _, _>()(MainTabsScreen);
+export default connect<{||}, _, _>()(ShowIfServerData);

--- a/src/main/MainTabsScreen.js
+++ b/src/main/MainTabsScreen.js
@@ -1,5 +1,5 @@
 /* @flow strict-local */
-import React, { useContext } from 'react';
+import React, { useContext, type ComponentType } from 'react';
 import { Platform, View } from 'react-native';
 import {
   createBottomTabNavigator,
@@ -44,14 +44,9 @@ const Tab = createBottomTabNavigator<
   MainTabsNavigationProp<>,
 >();
 
-type SelectorProps = $ReadOnly<{||}>;
-
 type Props = $ReadOnly<{|
   navigation: AppNavigationProp<'main-tabs'>,
   route: RouteProp<'main-tabs', void>,
-
-  dispatch: Dispatch,
-  ...SelectorProps,
 |}>;
 
 function MainTabsScreen(props: Props) {
@@ -116,7 +111,7 @@ function MainTabsScreen(props: Props) {
   );
 }
 
-function withHaveServerDataGate(Comp) {
+function withHaveServerDataGate<P, C: ComponentType<P>>(Comp: C): ComponentType<P> {
   return compose(
     // `connect` does something useful for us that `useSelector` doesn't
     // do: it interposes a new `ReactReduxContext.Provider` component,
@@ -133,8 +128,8 @@ function withHaveServerDataGate(Comp) {
     // was running -- and throwing an uncaught error -- on logout, and
     // `MainTabsScreen`'s early return on `!haveServerData` wasn't
     // preventing that from happening.
-    connect<{||}, _, _>(),
-    CompInner => props =>
+    (connect<{||}, _, _>(): (ComponentType<P>) => ComponentType<P>),
+    CompInner => (props: P) =>
       useSelector(getHaveServerData) ? (
         <CompInner {...props} />
       ) : (
@@ -150,4 +145,4 @@ function withHaveServerDataGate(Comp) {
   )(Comp);
 }
 
-export default withHaveServerDataGate(MainTabsScreen);
+export default withHaveServerDataGate<Props, ComponentType<Props>>(MainTabsScreen);

--- a/src/main/MainTabsScreen.js
+++ b/src/main/MainTabsScreen.js
@@ -115,9 +115,9 @@ function MainTabsScreen(props: Props) {
   );
 }
 
-const ShowIfServerData = (props: Props) =>
+const withShowIfServerData = C => (props: Props) =>
   useSelector(getHaveServerData) ? (
-    <MainTabsScreen {...props} />
+    <C {...props} />
   ) : (
     // Show a full-screen loading indicator while waiting for the
     // initial fetch to complete, if we don't have potentially stale
@@ -144,4 +144,4 @@ const ShowIfServerData = (props: Props) =>
 // was running -- and throwing an uncaught error -- on logout, and
 // `MainTabsScreen`'s early return on `!haveServerData` wasn't
 // preventing that from happening.
-export default connect<{||}, _, _>()(ShowIfServerData);
+export default connect<{||}, _, _>()(withShowIfServerData(MainTabsScreen));

--- a/src/main/MainTabsScreen.js
+++ b/src/main/MainTabsScreen.js
@@ -134,9 +134,9 @@ function withHaveServerDataGate(Comp) {
     // `MainTabsScreen`'s early return on `!haveServerData` wasn't
     // preventing that from happening.
     connect<{||}, _, _>(),
-    C => props =>
+    CompInner => props =>
       useSelector(getHaveServerData) ? (
-        <C {...props} />
+        <CompInner {...props} />
       ) : (
         // Show a full-screen loading indicator while waiting for the
         // initial fetch to complete, if we don't have potentially stale

--- a/src/main/MainTabsScreen.js
+++ b/src/main/MainTabsScreen.js
@@ -116,20 +116,6 @@ function MainTabsScreen(props: Props) {
   );
 }
 
-const withShowIfServerData = C => (props: Props) =>
-  useSelector(getHaveServerData) ? (
-    <C {...props} />
-  ) : (
-    // Show a full-screen loading indicator while waiting for the
-    // initial fetch to complete, if we don't have potentially stale
-    // data to show instead. Also show it for the duration of the nav
-    // transition just after the user logs out (see our #4275).
-    //
-    // And avoid rendering any of our main UI, to maintain the
-    // guarantee that it can all rely on server data existing.
-    <FullScreenLoading />
-  );
-
 export default compose(
   // `connect` does something useful for us that `useSelector` doesn't
   // do: it interposes a new `ReactReduxContext.Provider` component,
@@ -147,5 +133,17 @@ export default compose(
   // `MainTabsScreen`'s early return on `!haveServerData` wasn't
   // preventing that from happening.
   connect<{||}, _, _>(),
-  withShowIfServerData,
+  C => (props: Props) =>
+    useSelector(getHaveServerData) ? (
+      <C {...props} />
+    ) : (
+      // Show a full-screen loading indicator while waiting for the
+      // initial fetch to complete, if we don't have potentially stale
+      // data to show instead. Also show it for the duration of the nav
+      // transition just after the user logs out (see our #4275).
+      //
+      // And avoid rendering any of our main UI, to maintain the
+      // guarantee that it can all rely on server data existing.
+      <FullScreenLoading />
+    ),
 )(MainTabsScreen);

--- a/src/main/MainTabsScreen.js
+++ b/src/main/MainTabsScreen.js
@@ -6,6 +6,7 @@ import {
   type BottomTabNavigationProp,
 } from '@react-navigation/bottom-tabs';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { compose } from 'redux';
 
 import type { RouteProp, RouteParamsOf } from '../react-navigation';
 import type { Dispatch } from '../types';
@@ -129,19 +130,22 @@ const withShowIfServerData = C => (props: Props) =>
     <FullScreenLoading />
   );
 
-// `connect` does something useful for us that `useSelector` doesn't
-// do: it interposes a new `ReactReduxContext.Provider` component,
-// which proxies subscriptions so that the descendant components only
-// rerender if this one continues to say their subtree should be kept
-// around. See
-//   https://github.com/zulip/zulip-mobile/pull/4454#discussion_r578140524
-// and some discussion around
-//   https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/converting.20to.20Hooks/near/1111970
-// where we describe some limits of our understanding.
-//
-// We found these things out while investigating an annoying crash: we
-// found that `mapStateToProps` on a descendant of `MainTabsScreen`
-// was running -- and throwing an uncaught error -- on logout, and
-// `MainTabsScreen`'s early return on `!haveServerData` wasn't
-// preventing that from happening.
-export default connect<{||}, _, _>()(withShowIfServerData(MainTabsScreen));
+export default compose(
+  // `connect` does something useful for us that `useSelector` doesn't
+  // do: it interposes a new `ReactReduxContext.Provider` component,
+  // which proxies subscriptions so that the descendant components only
+  // rerender if this one continues to say their subtree should be kept
+  // around. See
+  //   https://github.com/zulip/zulip-mobile/pull/4454#discussion_r578140524
+  // and some discussion around
+  //   https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/converting.20to.20Hooks/near/1111970
+  // where we describe some limits of our understanding.
+  //
+  // We found these things out while investigating an annoying crash: we
+  // found that `mapStateToProps` on a descendant of `MainTabsScreen`
+  // was running -- and throwing an uncaught error -- on logout, and
+  // `MainTabsScreen`'s early return on `!haveServerData` wasn't
+  // preventing that from happening.
+  connect<{||}, _, _>(),
+  withShowIfServerData,
+)(MainTabsScreen);

--- a/src/main/MainTabsScreen.js
+++ b/src/main/MainTabsScreen.js
@@ -116,34 +116,38 @@ function MainTabsScreen(props: Props) {
   );
 }
 
-export default compose(
-  // `connect` does something useful for us that `useSelector` doesn't
-  // do: it interposes a new `ReactReduxContext.Provider` component,
-  // which proxies subscriptions so that the descendant components only
-  // rerender if this one continues to say their subtree should be kept
-  // around. See
-  //   https://github.com/zulip/zulip-mobile/pull/4454#discussion_r578140524
-  // and some discussion around
-  //   https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/converting.20to.20Hooks/near/1111970
-  // where we describe some limits of our understanding.
-  //
-  // We found these things out while investigating an annoying crash: we
-  // found that `mapStateToProps` on a descendant of `MainTabsScreen`
-  // was running -- and throwing an uncaught error -- on logout, and
-  // `MainTabsScreen`'s early return on `!haveServerData` wasn't
-  // preventing that from happening.
-  connect<{||}, _, _>(),
-  C => (props: Props) =>
-    useSelector(getHaveServerData) ? (
-      <C {...props} />
-    ) : (
-      // Show a full-screen loading indicator while waiting for the
-      // initial fetch to complete, if we don't have potentially stale
-      // data to show instead. Also show it for the duration of the nav
-      // transition just after the user logs out (see our #4275).
-      //
-      // And avoid rendering any of our main UI, to maintain the
-      // guarantee that it can all rely on server data existing.
-      <FullScreenLoading />
-    ),
-)(MainTabsScreen);
+function withHaveServerDataGate(Comp) {
+  return compose(
+    // `connect` does something useful for us that `useSelector` doesn't
+    // do: it interposes a new `ReactReduxContext.Provider` component,
+    // which proxies subscriptions so that the descendant components only
+    // rerender if this one continues to say their subtree should be kept
+    // around. See
+    //   https://github.com/zulip/zulip-mobile/pull/4454#discussion_r578140524
+    // and some discussion around
+    //   https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/converting.20to.20Hooks/near/1111970
+    // where we describe some limits of our understanding.
+    //
+    // We found these things out while investigating an annoying crash: we
+    // found that `mapStateToProps` on a descendant of `MainTabsScreen`
+    // was running -- and throwing an uncaught error -- on logout, and
+    // `MainTabsScreen`'s early return on `!haveServerData` wasn't
+    // preventing that from happening.
+    connect<{||}, _, _>(),
+    C => props =>
+      useSelector(getHaveServerData) ? (
+        <C {...props} />
+      ) : (
+        // Show a full-screen loading indicator while waiting for the
+        // initial fetch to complete, if we don't have potentially stale
+        // data to show instead. Also show it for the duration of the nav
+        // transition just after the user logs out (see our #4275).
+        //
+        // And avoid rendering any of our main UI, to maintain the
+        // guarantee that it can all rely on server data existing.
+        <FullScreenLoading />
+      ),
+  )(Comp);
+}
+
+export default withHaveServerDataGate(MainTabsScreen);

--- a/src/withHaveServerDataGate.js
+++ b/src/withHaveServerDataGate.js
@@ -1,0 +1,41 @@
+/* @flow strict-local */
+import React, { type ComponentType } from 'react';
+import { compose } from 'redux';
+
+import { connect, useSelector } from './react-redux';
+import { getHaveServerData } from './selectors';
+import FullScreenLoading from './common/FullScreenLoading';
+
+export default function withHaveServerDataGate<P, C: ComponentType<P>>(Comp: C): ComponentType<P> {
+  return compose(
+    // `connect` does something useful for us that `useSelector` doesn't
+    // do: it interposes a new `ReactReduxContext.Provider` component,
+    // which proxies subscriptions so that the descendant components only
+    // rerender if this one continues to say their subtree should be kept
+    // around. See
+    //   https://github.com/zulip/zulip-mobile/pull/4454#discussion_r578140524
+    // and some discussion around
+    //   https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/converting.20to.20Hooks/near/1111970
+    // where we describe some limits of our understanding.
+    //
+    // We found these things out while investigating an annoying crash: we
+    // found that `mapStateToProps` on a descendant of `MainTabsScreen`
+    // was running -- and throwing an uncaught error -- on logout, and
+    // `MainTabsScreen`'s early return on `!haveServerData` wasn't
+    // preventing that from happening.
+    (connect<{||}, _, _>(): (ComponentType<P>) => ComponentType<P>),
+    CompInner => (props: P) =>
+      useSelector(getHaveServerData) ? (
+        <CompInner {...props} />
+      ) : (
+        // Show a full-screen loading indicator while waiting for the
+        // initial fetch to complete, if we don't have potentially stale
+        // data to show instead. Also show it for the duration of the nav
+        // transition just after the user logs out (see our #4275).
+        //
+        // And avoid rendering any of our main UI, to maintain the
+        // guarantee that it can all rely on server data existing.
+        <FullScreenLoading />
+      ),
+  )(Comp);
+}


### PR DESCRIPTION
As discussed [here](https://chat.zulip.org/#narrow/stream/48-mobile/topic/Android.3A.20White.20screen/near/1149960). The intention is to use this for `ChatScreen` which needs something like this, with at least P1 urgency; see [discussion](https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/converting.20to.20Hooks/near/1112199).

Marked as a draft because there are some Flow errors that I haven't managed to work through yet; I'd appreciate if @gnprice would take a look. 🙂

