### PR TITLE
PmConversationsScreen: Change "Create Group" label to "Group PM".

### DIFF
--- a/src/pm-conversations/PmConversationsScreen.js
+++ b/src/pm-conversations/PmConversationsScreen.js
@@ -53,7 +53,7 @@ export default function PmConversationsScreen(props: Props) {
           secondary
           Icon={IconPeople}
           style={styles.button}
-          text="Create group"
+          text="Group PM"
           onPress={() => {
             setTimeout(() => NavigationService.dispatch(navigateToCreateGroup()));
           }}

--- a/static/translations/messages_en.json
+++ b/static/translations/messages_en.json
@@ -137,7 +137,7 @@
   "Mark topic as read": "Mark topic as read",
   "unread message": "unread message",
   "unread messages": "unread messages",
-  "Create group": "Create group",
+  "Group PM": "Group PM",
   "Share": "Share",
   "Star message": "Star message",
   "Unstar message": "Unstar message",


### PR DESCRIPTION
**Changes Proposed**
Changed the "Create Group" label to "Group PM" to avoid confusion. Also added the string in `static/translations/messages-en.json`


Discussion of this in [CZO](https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/create.20group.20button/near/1153997) 