### PR TITLE
Add "bash" to `tools/postinstall`

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "postinstall": "tools/postinstall",
+    "postinstall": "bash tools/postinstall",
     "start": "react-native start",
     "ios": "react-native run-ios",
     "ios-min": "react-native run-ios --simulator 'iPhone 5s'",


### PR DESCRIPTION
When running `yarn` with git bash on windows, it errors with `tools\postinstall' is not recognized.`

Adding ['bash' before `tools/postinstall`](https://chat.zulip.org/#narrow/stream/48-mobile/topic/Setting.20up.20development.20environment.20for.20zulip-app/near/1102688) resolve this.

Fixes: zulip#4427