### PR TITLE
Translate some user-facing strings added to an action sheet.

### DIFF
--- a/src/message/messageActionSheet.js
+++ b/src/message/messageActionSheet.js
@@ -57,11 +57,18 @@ type MessageArgs = {
 
 type Button<Args: HeaderArgs | MessageArgs> = {|
   (Args): void | Promise<void>,
+
+  /** The label for the button. */
+  // This UI string should be represented in messages_en.json.
   title: string,
 
-  /** The title of the alert-box that will be displayed if the callback throws. */
-  // Required even when the callback can't throw (e.g., "Cancel"), since we can't
-  // otherwise ensure that everything that _can_ throw has one.
+  /** The title of the alert-box that will be displayed if the
+   * callback throws. */
+  // Required even when the callback can't throw (e.g., "Cancel"),
+  // since we can't otherwise ensure that everything that _can_ throw
+  // has one.
+  //
+  // This UI string should be represented in messages_en.json.
   errorMessage: string,
 |};
 

--- a/static/translations/messages_en.json
+++ b/static/translations/messages_en.json
@@ -160,6 +160,8 @@
   "Failed to mute stream": "Failed to mute stream",
   "Failed to unmute stream": "Failed to unmute stream",
   "Failed to delete topic": "Failed to delete topic",
+  "Stream settings": "Stream settings",
+  "Failed to show stream settings": "Failed to show stream settings",
   "show": "show",
   "hide": "hide",
   "Debug": "Debug",

--- a/static/translations/messages_en.json
+++ b/static/translations/messages_en.json
@@ -91,6 +91,7 @@
   "Persian": "Persian",
   "Polish": "Polish",
   "Portuguese": "Portuguese",
+  "Portuguese (Portugal)": "Portuguese (Portugal)",
   "Romanian": "Romanian",
   "Russian": "Russian",
   "Serbian": "Serbian",


### PR DESCRIPTION
Followup as noted at https://github.com/zulip/zulip-mobile/pull/4612#issuecomment-815340027.

See also [discussion](https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/Warn.20if.20user-facing.20strings.20untreated/near/1156609), where I mentioned briefly a way we might automate something to help us remember to do this, since it's so easy to forget (especially since the `_(...)` call isn't right there in front of you).

(I haven't included that in this PR; if it seems too complicated, we can move on to other things. I've added some code comments that might be a bit useful, possibly not.)