### PR TITLE
Fix more avatar pixelation issues.

### DIFF
--- a/src/utils/__tests__/avatar-test.js
+++ b/src/utils/__tests__/avatar-test.js
@@ -139,20 +139,27 @@ describe('UploadedAvatarURL', () => {
     });
   });
 
-  test('if an absolute URL, just use it', () => {
+  test('s3 uploads: appends -medum.png for sizes over 100', () => {
     const instance = UploadedAvatarURL.validateAndConstructInstance({
       realm: new URL('https://chat.zulip.org'),
       absoluteOrRelativeUrl:
         'https://zulip-avatars.s3.amazonaws.com/13/430713047f2cffed661f84e139a64f864f17f286?x=x&version=5',
     });
-    SIZES_TO_TEST.forEach(size => {
-      expect(instance.get(size).toString()).toMatch(
+    const sizesOverDefault = SIZES_TO_TEST.filter(s => s > DEFAULT_UPLOAD_SIZE_PX);
+    const sizesAtMostDefault = SIZES_TO_TEST.filter(s => s <= DEFAULT_UPLOAD_SIZE_PX);
+    sizesOverDefault.forEach(size => {
+      expect(instance.get(size).toString()).toEqual(
+        'https://zulip-avatars.s3.amazonaws.com/13/430713047f2cffed661f84e139a64f864f17f286-medium.png?x=x&version=5',
+      );
+    });
+    sizesAtMostDefault.forEach(size => {
+      expect(instance.get(size).toString()).toEqual(
         'https://zulip-avatars.s3.amazonaws.com/13/430713047f2cffed661f84e139a64f864f17f286?x=x&version=5',
       );
     });
   });
 
-  test('converts *.png to *-medium.png for sizes over default', () => {
+  test('local uploads: converts *.png to *-medium.png for sizes over default', () => {
     const realm = new URL('https://chat.zulip.org');
     const instance = UploadedAvatarURL.validateAndConstructInstance({
       realm,

--- a/src/utils/__tests__/avatar-test.js
+++ b/src/utils/__tests__/avatar-test.js
@@ -139,7 +139,7 @@ describe('UploadedAvatarURL', () => {
     });
   });
 
-  test('s3 uploads: appends -medum.png for sizes over 100', () => {
+  test('s3 uploads: appends -medum.png for sizes over default', () => {
     const instance = UploadedAvatarURL.validateAndConstructInstance({
       realm: new URL('https://chat.zulip.org'),
       absoluteOrRelativeUrl:
@@ -202,7 +202,14 @@ describe('FallbackAvatarURL', () => {
       userId,
     });
 
-    SIZES_TO_TEST.forEach(size => {
+    const sizesOverDefault = SIZES_TO_TEST.filter(s => s > DEFAULT_UPLOAD_SIZE_PX);
+    const sizesAtMostDefault = SIZES_TO_TEST.filter(s => s <= DEFAULT_UPLOAD_SIZE_PX);
+    sizesOverDefault.forEach(size => {
+      expect(instance.get(size).toString()).toEqual(
+        `https://chat.zulip.org/avatar/${userId.toString()}/medium`,
+      );
+    });
+    sizesAtMostDefault.forEach(size => {
       expect(instance.get(size).toString()).toEqual(
         `https://chat.zulip.org/avatar/${userId.toString()}`,
       );

--- a/src/utils/__tests__/avatar-test.js
+++ b/src/utils/__tests__/avatar-test.js
@@ -58,6 +58,8 @@ describe('AvatarURL', () => {
 });
 
 const SIZES_TO_TEST = [24, 32, 48, 80, 200, DEFAULT_UPLOAD_SIZE_PX, MEDIUM_UPLOAD_SIZE_PX];
+const SIZES_OVER_DEFAULT = SIZES_TO_TEST.filter(s => s > DEFAULT_UPLOAD_SIZE_PX);
+const SIZES_AT_MOST_DEFAULT = SIZES_TO_TEST.filter(s => s <= DEFAULT_UPLOAD_SIZE_PX);
 
 describe('GravatarURL', () => {
   test('serializes/deserializes correctly', () => {
@@ -145,14 +147,12 @@ describe('UploadedAvatarURL', () => {
       absoluteOrRelativeUrl:
         'https://zulip-avatars.s3.amazonaws.com/13/430713047f2cffed661f84e139a64f864f17f286?x=x&version=5',
     });
-    const sizesOverDefault = SIZES_TO_TEST.filter(s => s > DEFAULT_UPLOAD_SIZE_PX);
-    const sizesAtMostDefault = SIZES_TO_TEST.filter(s => s <= DEFAULT_UPLOAD_SIZE_PX);
-    sizesOverDefault.forEach(size => {
+    SIZES_OVER_DEFAULT.forEach(size => {
       expect(instance.get(size).toString()).toEqual(
         'https://zulip-avatars.s3.amazonaws.com/13/430713047f2cffed661f84e139a64f864f17f286-medium.png?x=x&version=5',
       );
     });
-    sizesAtMostDefault.forEach(size => {
+    SIZES_AT_MOST_DEFAULT.forEach(size => {
       expect(instance.get(size).toString()).toEqual(
         'https://zulip-avatars.s3.amazonaws.com/13/430713047f2cffed661f84e139a64f864f17f286?x=x&version=5',
       );
@@ -166,14 +166,12 @@ describe('UploadedAvatarURL', () => {
       absoluteOrRelativeUrl:
         '/user_avatars/2/e35cdbc4771c5e4b94e705bf6ff7cca7fa1efcae.png?x=x&version=2',
     });
-    const sizesOverDefault = SIZES_TO_TEST.filter(s => s > DEFAULT_UPLOAD_SIZE_PX);
-    const sizesAtMostDefault = SIZES_TO_TEST.filter(s => s <= DEFAULT_UPLOAD_SIZE_PX);
-    sizesOverDefault.forEach(size => {
+    SIZES_OVER_DEFAULT.forEach(size => {
       expect(instance.get(size).toString()).toEqual(
         'https://chat.zulip.org/user_avatars/2/e35cdbc4771c5e4b94e705bf6ff7cca7fa1efcae-medium.png?x=x&version=2',
       );
     });
-    sizesAtMostDefault.forEach(size => {
+    SIZES_AT_MOST_DEFAULT.forEach(size => {
       expect(instance.get(size).toString()).toEqual(
         'https://chat.zulip.org/user_avatars/2/e35cdbc4771c5e4b94e705bf6ff7cca7fa1efcae.png?x=x&version=2',
       );
@@ -201,15 +199,12 @@ describe('FallbackAvatarURL', () => {
       realm: new URL('https://chat.zulip.org'),
       userId,
     });
-
-    const sizesOverDefault = SIZES_TO_TEST.filter(s => s > DEFAULT_UPLOAD_SIZE_PX);
-    const sizesAtMostDefault = SIZES_TO_TEST.filter(s => s <= DEFAULT_UPLOAD_SIZE_PX);
-    sizesOverDefault.forEach(size => {
+    SIZES_OVER_DEFAULT.forEach(size => {
       expect(instance.get(size).toString()).toEqual(
         `https://chat.zulip.org/avatar/${userId.toString()}/medium`,
       );
     });
-    sizesAtMostDefault.forEach(size => {
+    SIZES_AT_MOST_DEFAULT.forEach(size => {
       expect(instance.get(size).toString()).toEqual(
         `https://chat.zulip.org/avatar/${userId.toString()}`,
       );

--- a/src/utils/__tests__/avatar-test.js
+++ b/src/utils/__tests__/avatar-test.js
@@ -1,7 +1,14 @@
 /* @flow strict-local */
 import md5 from 'blueimp-md5';
 
-import { AvatarURL, GravatarURL, FallbackAvatarURL, UploadedAvatarURL } from '../avatar';
+import {
+  AvatarURL,
+  GravatarURL,
+  FallbackAvatarURL,
+  UploadedAvatarURL,
+  DEFAULT_UPLOAD_SIZE_PX,
+  MEDIUM_UPLOAD_SIZE_PX,
+} from '../avatar';
 import * as eg from '../../__tests__/lib/exampleData';
 
 describe('AvatarURL', () => {
@@ -50,7 +57,7 @@ describe('AvatarURL', () => {
   });
 });
 
-const SIZES_TO_TEST = [24, 32, 48, 80, 200];
+const SIZES_TO_TEST = [24, 32, 48, 80, 200, DEFAULT_UPLOAD_SIZE_PX, MEDIUM_UPLOAD_SIZE_PX];
 
 describe('GravatarURL', () => {
   test('serializes/deserializes correctly', () => {
@@ -145,21 +152,21 @@ describe('UploadedAvatarURL', () => {
     });
   });
 
-  test('converts *.png to *-medium.png for sizes over 100', () => {
+  test('converts *.png to *-medium.png for sizes over default', () => {
     const realm = new URL('https://chat.zulip.org');
     const instance = UploadedAvatarURL.validateAndConstructInstance({
       realm,
       absoluteOrRelativeUrl:
         '/user_avatars/2/e35cdbc4771c5e4b94e705bf6ff7cca7fa1efcae.png?x=x&version=2',
     });
-    const sizesOver100 = SIZES_TO_TEST.filter(s => s > 100);
-    const sizesAtMost100 = SIZES_TO_TEST.filter(s => s <= 100);
-    sizesOver100.forEach(size => {
+    const sizesOverDefault = SIZES_TO_TEST.filter(s => s > DEFAULT_UPLOAD_SIZE_PX);
+    const sizesAtMostDefault = SIZES_TO_TEST.filter(s => s <= DEFAULT_UPLOAD_SIZE_PX);
+    sizesOverDefault.forEach(size => {
       expect(instance.get(size).toString()).toEqual(
         'https://chat.zulip.org/user_avatars/2/e35cdbc4771c5e4b94e705bf6ff7cca7fa1efcae-medium.png?x=x&version=2',
       );
     });
-    sizesAtMost100.forEach(size => {
+    sizesAtMostDefault.forEach(size => {
       expect(instance.get(size).toString()).toEqual(
         'https://chat.zulip.org/user_avatars/2/e35cdbc4771c5e4b94e705bf6ff7cca7fa1efcae.png?x=x&version=2',
       );

--- a/src/utils/avatar.js
+++ b/src/utils/avatar.js
@@ -398,10 +398,10 @@ export class UploadedAvatarURL extends AvatarURL {
          */
       result = new URL(this._standardUrl);
 
-      const match = new RegExp(/(\w+)\.png/).exec(result.pathname);
-      if (match !== null) {
-        result.pathname = result.pathname.replace(match[0], `${match[1]}-medium.png`);
-      }
+      result.pathname = result.pathname.replace(
+        new RegExp(/(\w+)\.png/),
+        (_, p1) => `${p1}-medium.png`,
+      );
     }
     return result;
   }

--- a/src/utils/avatar.js
+++ b/src/utils/avatar.js
@@ -398,7 +398,12 @@ export class UploadedAvatarURL extends AvatarURL {
          */
       result = new URL(this._standardUrl);
 
-      result.pathname = result.pathname.replace(/\.png$/, '-medium.png');
+      result.pathname = result.pathname.replace(
+        // `.png` is optional: s3 uploads don't use it, local ones do.
+        // See TODO in zulip/zulip@c03615b98.
+        /(?:\.png)?$/,
+        '-medium.png',
+      );
     }
     return result;
   }

--- a/src/utils/avatar.js
+++ b/src/utils/avatar.js
@@ -398,7 +398,7 @@ export class UploadedAvatarURL extends AvatarURL {
          */
       result = new URL(this._standardUrl);
 
-      const match = new RegExp(/(\w+)\.png/g).exec(result.pathname);
+      const match = new RegExp(/(\w+)\.png/).exec(result.pathname);
       if (match !== null) {
         result.pathname = result.pathname.replace(match[0], `${match[1]}-medium.png`);
       }

--- a/src/utils/avatar.js
+++ b/src/utils/avatar.js
@@ -398,10 +398,7 @@ export class UploadedAvatarURL extends AvatarURL {
          */
       result = new URL(this._standardUrl);
 
-      result.pathname = result.pathname.replace(
-        new RegExp(/(\w+)\.png/),
-        (_, p1) => `${p1}-medium.png`,
-      );
+      result.pathname = result.pathname.replace(/(\w+)\.png/, (_, p1) => `${p1}-medium.png`);
     }
     return result;
   }

--- a/src/utils/avatar.js
+++ b/src/utils/avatar.js
@@ -398,7 +398,7 @@ export class UploadedAvatarURL extends AvatarURL {
          */
       result = new URL(this._standardUrl);
 
-      result.pathname = result.pathname.replace(/(\w+)\.png/, (_, p1) => `${p1}-medium.png`);
+      result.pathname = result.pathname.replace(/\.png$/, '-medium.png');
     }
     return result;
   }

--- a/src/utils/avatar.js
+++ b/src/utils/avatar.js
@@ -8,6 +8,15 @@ import { ensureUnreachable, type UserId } from '../types';
 import { isUrlAbsolute, isUrlPathAbsolute } from './url';
 
 /**
+ * Pixel dimensions of different size choices we have (they're all
+ * square) when requesting an uploaded avatar.
+ */
+// DEFAULT_AVATAR_SIZE in zerver/lib/upload.py.
+export const DEFAULT_UPLOAD_SIZE_PX = 100;
+// MEDIUM_AVATAR_SIZE in zerver/lib/upload.py.
+export const MEDIUM_UPLOAD_SIZE_PX = 500;
+
+/**
  * A way to get a standard avatar URL, or a sized one if available
  *
  * This class is abstract. Only instantiate its subclasses.
@@ -292,9 +301,9 @@ export class FallbackAvatarURL extends AvatarURL {
  * An avatar that was uploaded to the Zulip server.
  *
  * There are two size options; if `sizePhysicalPx` is greater than
- * 100, medium is chosen:
- *  * default: 100x100
- *  * medium: 500x500
+ * DEFAULT_UPLOAD_SIZE_PX, medium is chosen:
+ *  * default: DEFAULT_UPLOAD_SIZE_PX square
+ *  * medium: MEDIUM_UPLOAD_SIZE_PX square
  *
  * Don't send auth headers with requests to this type of avatar URL.
  * The s3 backend doesn't want them; it gives a 400 with an
@@ -382,7 +391,7 @@ export class UploadedAvatarURL extends AvatarURL {
     }
 
     let result: URL = this._standardUrl;
-    if (sizePhysicalPx > 100) {
+    if (sizePhysicalPx > DEFAULT_UPLOAD_SIZE_PX) {
       /* $FlowFixMe[incompatible-call]: Make a new URL to mutate,
          instead of mutating this._standardUrl
          https://github.com/zulip/zulip-mobile/pull/4230#discussion_r512351202

--- a/src/utils/avatar.js
+++ b/src/utils/avatar.js
@@ -221,7 +221,10 @@ export class GravatarURL extends AvatarURL {
  * Note that this endpoint needs authentication; we should send the
  * auth headers (see src/api/transport) with the request.
  *
- * This endpoint does not currently support size customization.
+ * This endpoint isn't known to support size customization if the
+ * image at the redirect is a Gravatar image, but does support
+ * default/medium sizing if it's an uploaded image (see note on
+ * `UploadedAvatarURL`).
  */
 export class FallbackAvatarURL extends AvatarURL {
   /**
@@ -280,11 +283,10 @@ export class FallbackAvatarURL extends AvatarURL {
   /**
    * Get a URL object for the given size.
    *
-   * Size customization isn't currently supported for
-   * FallbackAvatarURLs.
-   *
-   * Still, we'll take `sizePhysicalPx` (it should be an integer), to
-   * make it easy to support in the future.
+   * Not known to support size customization if the image at the
+   * redirect is a Gravatar image, but does support default/medium
+   * sizing if it's an uploaded image (see note on
+   * `UploadedAvatarURL`).
    */
   get(sizePhysicalPx: number): URL {
     // `this._standardUrl` may have begun its life as a string, to
@@ -293,7 +295,18 @@ export class FallbackAvatarURL extends AvatarURL {
       this._standardUrl = new URL(this._standardUrl);
     }
 
-    return this._standardUrl;
+    let result: URL = this._standardUrl;
+    if (sizePhysicalPx > DEFAULT_UPLOAD_SIZE_PX) {
+      /* $FlowFixMe[incompatible-call]: Make a new URL to mutate,
+         instead of mutating this._standardUrl
+         https://github.com/zulip/zulip-mobile/pull/4230#discussion_r512351202
+         */
+      result = new URL(this._standardUrl);
+
+      result.pathname += '/medium';
+    }
+
+    return result;
   }
 }
 


### PR DESCRIPTION
("More", since we fixed others in #4305.)

(cc @timabbott if you're interested; thanks for your help in the [chat thread](https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/.23M4614.20Avatars.20pixelated.20in.20user.20view/near/1156704).)

I think we can still end up with a pixelated image if we use the `/avatar/{user_id}` / `/avatar/{user_id}/medium` redirect and the image we end up with happens to be from Gravatar; I'm not aware that this endpoint forwards the default-vs.-medium size preference on to Gravatar, and there doesn't seem to be a way to pass an integer size, like we do when getting a Gravatar image directly.

But #4614 was pretty high-impact on zulipchat.com, so I'm glad to have that fixed, and to have the other, lower-impact improvement that follows in the branch, for using `/avatar/{user_id}/medium` at all.

Ideally, we'd show a pixelated image during the load time of a larger image, if possible; see the results of my brief exploration of this in [chat](https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/.23M4614.20Avatars.20pixelated.20in.20user.20view/near/1157651), that unfortunately didn't come up with anything.

Fixes: #4614