### PR TITLE
Add 'bash' before 'tools/postinstall'

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "postinstall": "tools/postinstall",
+    "postinstall": "bash tools/postinstall",
     "start": "react-native start",
     "ios": "react-native run-ios",
     "ios-min": "react-native run-ios --simulator 'iPhone 5s'",


### PR DESCRIPTION
Why these changes ?
On windows when run `yarn` it give the following error :
`tools\postinstall' is not recognized`

What changes ?
In `package.json` change 'tools/postinstall' to 'bash tools/postinstall'

Tested on windowsOS

Fixes: #4427