### PR TITLE
event: Log error but don't throw, if no active account at eventToAction.

### DIFF
--- a/src/events/eventToAction.js
+++ b/src/events/eventToAction.js
@@ -1,5 +1,4 @@
 /* @flow strict-local */
-import invariant from 'invariant';
 import { EventTypes } from '../api/eventTypes';
 
 import * as logging from '../utils/logging';
@@ -90,10 +89,9 @@ const actionTypeOfEventType = {
 // This FlowFixMe is because this function encodes a large number of
 // assumptions about the events the server sends, and doesn't check them.
 export default (state: GlobalState, event: $FlowFixMe): EventAction | null => {
-  invariant(
-    tryGetActiveAccount(state),
-    'Expected to have an active account when `eventToAction` was called.',
-  );
+  if (!tryGetActiveAccount(state)) {
+    logging.error('eventToAction: no active account');
+  }
 
   switch (event.type) {
     // For reference on each type of event, see:


### PR DESCRIPTION
Chris asked if adding this error was still a good idea:
  https://github.com/zulip/zulip-mobile/pull/4581#discussion_r607315106
as most event types will get by OK in this case.  It's a bug if we
hit this case, but perhaps we'd rather learn of such a bug without
causing an event to fail that didn't have to.

After merging the PR but while writing a reply to the comment, I
realized that there's a useful middle ground: we can log an error
without actually immediately failing.