### PR TITLE
ensure-coreutils: Work with arbitrary Homebrew prefix.

### DIFF
--- a/tools/lib/ensure-coreutils.sh
+++ b/tools/lib/ensure-coreutils.sh
@@ -20,6 +20,7 @@
 # it installed but just not in their PATH.  We write our scripts
 # for a GNU environment, so we bring it into the PATH.
 
+# Check, silently, for a working coreutils on the PATH.
 check_coreutils() {
     # Check a couple of commands for GNU-style --help and --version,
     # which macOS's default BSD-based implementations don't understand.
@@ -27,17 +28,56 @@ check_coreutils() {
     readlink --version 2>&1 | grep -q GNU
 }
 
+# Either get Homebrew's coreutils on the PATH, or error out.
+try_homebrew() {
+    local homebrew_prefix="$1"
+
+    # Homebrew provides names like `greadlink` on the PATH,
+    # but also provides the standard names in this directory.
+    homebrew_gnubin="${homebrew_prefix}"/opt/coreutils/libexec/gnubin
+    if ! [ -d "${homebrew_gnubin}" ]; then
+        cat >&2 <<EOF
+This script requires GNU coreutils.
+
+Found Homebrew at:
+  ${homebrew_prefix}
+but no coreutils at:
+  ${homebrew_gnubin}
+
+Try installing coreutils with:
+  brew install coreutils
+EOF
+        return 2
+    fi
+
+    export PATH="${homebrew_gnubin}":"$PATH"
+    if ! check_coreutils; then
+        cat >&2 <<EOF
+This script requires GNU coreutils.
+
+Found Homebrew installation of coreutils at:
+  ${homebrew_gnubin}
+but it doesn't seem to work.
+
+Please report this in #mobile on https://chat.zulip.org/
+and we'll help debug.
+EOF
+        return 2
+    fi
+}
+
 ensure_coreutils() {
     # If we already have it, then great.
     check_coreutils && return
 
-    # Homebrew provides names like `greadlink` on the PATH,
-    # but also provides the standard names in this directory.
-    # Try that.
-    homebrew_gnubin=/usr/local/opt/coreutils/libexec/gnubin
-    if [ -d "$homebrew_gnubin" ]; then
-        export PATH="$homebrew_gnubin":"$PATH"
-        check_coreutils && return
+    # Else try finding a Homebrew install of coreutils,
+    # and putting that on the PATH.
+    homebrew_prefix=$(brew --prefix || :)
+    if [ -n "${homebrew_prefix}" ]; then
+        # Found Homebrew.  Either use that, or if we can't then
+        # print an error with Homebrew-specific instructions.
+        try_homebrew "${homebrew_prefix}"
+        return
     fi
 
     cat >&2 <<EOF
@@ -45,8 +85,10 @@ This script requires GNU coreutils.
 
 Install from upstream:
   https://www.gnu.org/software/coreutils/
-or from your favorite package manager; for example:
-  brew install coreutils
+or from your favorite package manager.
+
+If you have any questions, ask in #mobile on https://chat.zulip.org/
+and we'll be happy to help.
 EOF
     return 2
 }

--- a/tools/lib/ensure-coreutils.sh
+++ b/tools/lib/ensure-coreutils.sh
@@ -1,3 +1,5 @@
+# shellcheck shell=bash
+#
 # Usage:
 #   . ensure-coreutils.sh
 #


### PR DESCRIPTION
In particular this lets it work with a default Homebrew install on
macOS ARM, which uses /opt/homebrew (hooray!) rather than their
unfortunate older choice of taking over /usr/local.

Debugging thread here:
  https://chat.zulip.org/#narrow/stream/48-mobile/topic/Error.20running.20zulip-mobile.20app/near/1158901