### PR TITLE
Replace switch with pressable-icon and rename props,Fixes: #4658

### DIFF
--- a/src/common/Icons.js
+++ b/src/common/Icons.js
@@ -84,3 +84,4 @@ export const IconMoreHorizontal = makeIcon(Feather, 'more-horizontal');
 export const IconEdit = makeIcon(Feather, 'edit');
 export const IconPlusSquare = makeIcon(Feather, 'plus-square');
 export const IconVideo = makeIcon(Feather, 'video');
+export const IconPlus = makeIcon(Feather, 'plus');

--- a/src/common/ZulipSubscribe.js
+++ b/src/common/ZulipSubscribe.js
@@ -1,0 +1,41 @@
+/* @flow strict-local */
+import React, { useState } from 'react';
+import { Pressable } from 'react-native';
+import { IconPlus, IconDone } from './Icons';
+import { BRAND_COLOR } from '../styles';
+
+type Props = $ReadOnly<{|
+  isSubscribed: boolean,
+  disabled: boolean,
+  onPress: (arg: boolean) => void,
+|}>;
+
+export default function ZulipSubscribe(props: Props) {
+  const [getSubscribed, setSubscribed] = useState(props.isSubscribed);
+  const { disabled, onPress } = props;
+
+  const onIconPress = () => {
+    onPress(!getSubscribed);
+    setSubscribed(!getSubscribed);
+  };
+
+  return (
+    <Pressable
+      onPress={onIconPress}
+      disabled={disabled}
+      style={{ marginLeft: 12 }}
+      hitSlop={{
+        bottom: 5,
+        left: 10,
+        right: 12,
+        top: 5,
+      }}
+    >
+      {getSubscribed ? (
+        <IconDone size={24} color={BRAND_COLOR} />
+      ) : (
+        <IconPlus size={24} color="hsla(0,0%,50%,0.5)" />
+      )}
+    </Pressable>
+  );
+}

--- a/src/common/index.js
+++ b/src/common/index.js
@@ -40,3 +40,4 @@ export { default as WebLink } from './WebLink';
 export { default as ZulipButton } from './ZulipButton';
 export { default as ZulipStatusBar } from './ZulipStatusBar';
 export { default as ZulipSwitch } from './ZulipSwitch';
+export { default as ZulipSubscribe } from './ZulipSubscribe';

--- a/src/streams/StreamItem.js
+++ b/src/streams/StreamItem.js
@@ -3,7 +3,7 @@ import React, { useContext } from 'react';
 import { View } from 'react-native';
 
 import styles, { createStyleSheet, ThemeContext } from '../styles';
-import { RawLabel, Touchable, UnreadCount, ZulipSwitch } from '../common';
+import { RawLabel, Touchable, UnreadCount, ZulipSubscribe } from '../common';
 import { foregroundColorFromBackground } from '../utils/color';
 import StreamIcon from './StreamIcon';
 
@@ -32,10 +32,10 @@ type Props = $ReadOnly<{|
 
   unreadCount?: number,
   iconSize: number,
-  showSwitch?: boolean,
-  isSwitchedOn?: boolean,
+  showToSubscribe?: boolean,
+  isSubscribed?: boolean,
   onPress: (name: string) => void,
-  onSwitch?: (name: string, newValue: boolean) => void,
+  onSubscribe?: (name: string, newValue: boolean) => void,
 |}>;
 
 /**
@@ -53,10 +53,10 @@ type Props = $ReadOnly<{|
  *
  * @prop unreadCount - number of unread messages
  * @prop iconSize
- * @prop showSwitch - whether to show a toggle switch (ZulipSwitch)
- * @prop isSwitchedOn - initial value of the toggle switch, if present
+ * @prop showToSubscribe - whether to show a button to subscirbe or unsubscribe stream (ZulipSubscribe)
+ * @prop isSubscribed - initial value for subscribe button, if present
  * @prop onPress - press handler for the item; receives the stream name
- * @prop onSwitch - if switch exists; receives stream name and new value
+ * @prop onSubscribe - if (ZulipSubscribe) button exists; receives stream name and new value
  */
 export default function StreamItem(props: Props) {
   const {
@@ -67,11 +67,11 @@ export default function StreamItem(props: Props) {
     isPrivate = false,
     isMuted = false,
     iconSize,
-    showSwitch = false,
-    isSwitchedOn = false,
+    showToSubscribe = false,
+    isSubscribed = false,
     unreadCount,
     onPress,
-    onSwitch,
+    onSubscribe,
   } = props;
 
   const { backgroundColor: themeBackgroundColor, color: themeColor } = useContext(ThemeContext);
@@ -109,15 +109,15 @@ export default function StreamItem(props: Props) {
           )}
         </View>
         <UnreadCount color={iconColor} count={unreadCount} />
-        {showSwitch && (
-          <ZulipSwitch
-            value={!!isSwitchedOn}
-            onValueChange={(newValue: boolean) => {
-              if (onSwitch) {
-                onSwitch(name, newValue);
+        {showToSubscribe && (
+          <ZulipSubscribe
+            isSubscribed={isSubscribed}
+            onPress={(newValue: boolean) => {
+              if (onSubscribe) {
+                onSubscribe(name, newValue);
               }
             }}
-            disabled={!isSwitchedOn && isPrivate}
+            disabled={!isSubscribed && isPrivate}
           />
         )}
       </View>

--- a/src/streams/StreamList.js
+++ b/src/streams/StreamList.js
@@ -19,23 +19,30 @@ type PseudoSubscription = Subscription | {| ...Stream, subscribed: boolean, pin_
 
 type Props = $ReadOnly<{|
   showDescriptions: boolean,
-  showSwitch: boolean,
+  showToSubscribe: boolean,
   streams: $ReadOnlyArray<PseudoSubscription>,
   unreadByStream: $ReadOnly<{| [number]: number |}>,
   onPress: (streamName: string) => void,
-  onSwitch?: (streamName: string, newValue: boolean) => void,
+  onSubscribe?: (streamName: string, value: boolean) => void,
 |}>;
 
 export default class StreamList extends PureComponent<Props> {
   static defaultProps = {
     showDescriptions: false,
-    showSwitch: false,
+    showToSubscribe: false,
     streams: [],
     unreadByStream: {},
   };
 
   render() {
-    const { streams, showDescriptions, showSwitch, unreadByStream, onPress, onSwitch } = this.props;
+    const {
+      streams,
+      showDescriptions,
+      showToSubscribe,
+      unreadByStream,
+      onPress,
+      onSubscribe,
+    } = this.props;
 
     if (streams.length === 0) {
       return <SearchEmptyState text="No streams found" />;
@@ -71,10 +78,10 @@ export default class StreamList extends PureComponent<Props> {
             color={item.color}
             unreadCount={unreadByStream[item.stream_id]}
             isMuted={item.in_home_view === false} // if 'undefined' is not muted
-            showSwitch={showSwitch}
-            isSwitchedOn={item.subscribed}
+            showToSubscribe={showToSubscribe}
+            isSubscribed={item.subscribed}
             onPress={onPress}
-            onSwitch={onSwitch}
+            onSubscribe={onSubscribe}
           />
         )}
         SectionSeparatorComponent={SectionSeparatorBetween}

--- a/src/subscriptions/StreamListCard.js
+++ b/src/subscriptions/StreamListCard.js
@@ -38,10 +38,10 @@ type Props = $ReadOnly<{|
 |}>;
 
 class StreamListCard extends PureComponent<Props> {
-  handleSwitchChange = (streamName: string, switchValue: boolean) => {
+  handleSubscribe = (streamName: string, value: boolean) => {
     const { auth } = this.props;
 
-    if (switchValue) {
+    if (value) {
       api.subscriptionAdd(auth, [{ name: streamName }]);
     } else {
       api.subscriptionRemove(auth, [streamName]);
@@ -77,9 +77,9 @@ class StreamListCard extends PureComponent<Props> {
         )}
         <StreamList
           streams={subsAndStreams}
-          showSwitch
+          showToSubscribe
           showDescriptions
-          onSwitch={this.handleSwitchChange}
+          onSubscribe={this.handleSubscribe}
           onPress={this.handleNarrow}
         />
       </View>


### PR DESCRIPTION
Fix: #4658 
I tried [pressable](https://reactnative.dev/docs/pressable) here,

|<img src="https://user-images.githubusercontent.com/31806059/114830892-5a6e0580-9dea-11eb-8897-66c1d6e36e9a.png" height="480"/>|<img src="https://user-images.githubusercontent.com/31806059/114839220-24814f00-9df3-11eb-8af8-592e8bf1f199.png" height="480"/>|

- The image below, if I use padding

<img src="https://user-images.githubusercontent.com/31806059/114830855-517d3400-9dea-11eb-8fe9-f8c6faacbbc7.jpg"/>

-  Still the sensible area is equal to above(padding) which will recieve touch event (for icon-button). I used [hitSlop](https://reactnative.dev/docs/pressable#hitslop) to do it(without padding)
<img src="https://user-images.githubusercontent.com/31806059/114830860-52ae6100-9dea-11eb-88cd-92eaefa117e8.jpg"/>
