### PR TITLE
Clarify some message-list code (part 2).

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -78,6 +78,7 @@ const projectForPlatform = platform => {
     globals: {
       __TEST__: true,
     },
+    globalSetup: './jest/globalSetup.js',
     setupFiles: [
       './jest/globalFetch.js',
       './node_modules/react-native-gesture-handler/jestSetup.js',

--- a/jest/globalSetup.js
+++ b/jest/globalSetup.js
@@ -1,0 +1,14 @@
+/* @flow strict-local */
+
+module.exports = async () => {
+  // Where this has any effect (macOS and Linux), set Node's timezone to
+  // UTC, to help make snapshot tests be consistent in local testing and in
+  // CI. To handle places this doesn't have an effect (Windows), we should
+  // also modify our code (e.g., in src/utils/date.js) so that, only when
+  // testing, they negate the UTC offset of a `Date` object before using it.
+  //
+  // This is in `globalSetup.js` so that it runs as early as possible; we
+  // don't want a wrong TZ value to be cached and then used instead of UTC:
+  //   https://github.com/nodejs/node/issues/3449#issuecomment-149583284
+  process.env.TZ = 'UTC';
+};

--- a/src/__tests__/lib/exampleData.js
+++ b/src/__tests__/lib/exampleData.js
@@ -38,6 +38,7 @@ import {
 import rootReducer from '../../boot/reducers';
 import { authOfAccount } from '../../account/accountMisc';
 import { HOME_NARROW } from '../../utils/narrow';
+import type { BackgroundData } from '../../webview/MessageList';
 
 /* ========================================================================
  * Utilities
@@ -740,3 +741,21 @@ export const mkActionEventNewMessage = (
 
 // If a given action is only relevant to a single test file, no need to
 // provide a generic factory for it here; just define the test data there.
+
+/* ========================================================================
+ * Miscellaneous
+ */
+
+export const backgroundData: BackgroundData = deepFreeze({
+  alertWords: [],
+  allImageEmojiById: action.realm_init.data.realm_emoji,
+  auth: selfAuth,
+  debug: baseReduxState.session.debug,
+  flags: baseReduxState.flags,
+  mute: [],
+  mutedUsers: Immutable.Map(),
+  ownUser: selfUser,
+  subscriptions: [],
+  theme: 'default',
+  twentyFourHourTime: false,
+});

--- a/src/message/__tests__/getHtmlPieceDescriptors-test.js
+++ b/src/message/__tests__/getHtmlPieceDescriptors-test.js
@@ -15,7 +15,8 @@ describe('getHtmlPieceDescriptors', () => {
   });
 
   test('renders time, header and message for a single input', () => {
-    const messages = deepFreeze([{ ...eg.streamMessage({ id: 12345 }), timestamp: 123 }]);
+    const message = { ...eg.streamMessage({ id: 12345 }), timestamp: 123 };
+    const messages = deepFreeze([message]);
 
     const htmlPieceDescriptors = getHtmlPieceDescriptors(messages, narrow);
 

--- a/src/message/__tests__/getHtmlPieceDescriptors-test.js
+++ b/src/message/__tests__/getHtmlPieceDescriptors-test.js
@@ -1,6 +1,5 @@
 /* @flow strict-local */
 import deepFreeze from 'deep-freeze';
-import invariant from 'invariant';
 
 import * as eg from '../../__tests__/lib/exampleData';
 import { HOME_NARROW } from '../../utils/narrow';
@@ -9,9 +8,9 @@ import getHtmlPieceDescriptors from '../getHtmlPieceDescriptors';
 describe('getHtmlPieceDescriptors', () => {
   const narrow = deepFreeze(HOME_NARROW);
 
-  test('empty messages results in a single empty section', () => {
+  test('empty messages results in no pieces', () => {
     const htmlPieceDescriptors = getHtmlPieceDescriptors([], HOME_NARROW);
-    expect(htmlPieceDescriptors).toEqual([{ key: 0, message: null, data: [] }]);
+    expect(htmlPieceDescriptors).toEqual([]);
   });
 
   test('renders time, header and message for a single input', () => {
@@ -20,9 +19,11 @@ describe('getHtmlPieceDescriptors', () => {
 
     const htmlPieceDescriptors = getHtmlPieceDescriptors(messages, narrow);
 
-    expect(htmlPieceDescriptors).toHaveLength(2);
-    expect(htmlPieceDescriptors[0].data[0].key).toEqual('time123');
-    expect(htmlPieceDescriptors[1].data[0].key).toEqual(12345);
+    expect(htmlPieceDescriptors).toMatchObject([
+      { type: 'time', key: 'time123' },
+      { type: 'header', key: 'header12345' },
+      { type: 'message', key: 12345 },
+    ]);
   });
 
   test('several messages in same stream, from same person result in time row, header for the stream, three messages, only first of which is full detail', () => {
@@ -37,13 +38,13 @@ describe('getHtmlPieceDescriptors', () => {
 
     const htmlPieceDescriptors = getHtmlPieceDescriptors(messages, narrow);
 
-    const messageKeys = htmlPieceDescriptors[1].data.map(x => x.key);
-    const messageBriefs = htmlPieceDescriptors[1].data.map(x => {
-      invariant(x.type === 'message', 'expected message item');
-      return x.isBrief;
-    });
-    expect(messageKeys).toEqual([1, 2, 3]);
-    expect(messageBriefs).toEqual([false, true, true]);
+    expect(htmlPieceDescriptors).toMatchObject([
+      { type: 'time' },
+      { type: 'header' },
+      { type: 'message', key: 1, isBrief: false },
+      { type: 'message', key: 2, isBrief: true },
+      { type: 'message', key: 3, isBrief: true },
+    ]);
   });
 
   test('several messages in same stream, from different people result in time row, header for the stream, three messages, only all full detail', () => {
@@ -57,13 +58,13 @@ describe('getHtmlPieceDescriptors', () => {
 
     const htmlPieceDescriptors = getHtmlPieceDescriptors(messages, narrow);
 
-    const messageKeys = htmlPieceDescriptors[1].data.map(x => x.key);
-    const messageBriefs = htmlPieceDescriptors[1].data.map(x => {
-      invariant(x.type === 'message', 'expected message item');
-      return x.isBrief;
-    });
-    expect(messageKeys).toEqual([1, 2, 3]);
-    expect(messageBriefs).toEqual([false, false, false]);
+    expect(htmlPieceDescriptors).toMatchObject([
+      { type: 'time' },
+      { type: 'header' },
+      { type: 'message', key: 1, isBrief: false },
+      { type: 'message', key: 2, isBrief: false },
+      { type: 'message', key: 3, isBrief: false },
+    ]);
   });
 
   test('private messages between two people, results in time row, header and two full messages', () => {
@@ -74,12 +75,11 @@ describe('getHtmlPieceDescriptors', () => {
 
     const htmlPieceDescriptors = getHtmlPieceDescriptors(messages, narrow);
 
-    const messageKeys = htmlPieceDescriptors[1].data.map(x => x.key);
-    const messageBriefs = htmlPieceDescriptors[1].data.map(x => {
-      invariant(x.type === 'message', 'expected message item');
-      return x.isBrief;
-    });
-    expect(messageKeys).toEqual([1, 2]);
-    expect(messageBriefs).toEqual([false, false]);
+    expect(htmlPieceDescriptors).toMatchObject([
+      { type: 'time' },
+      { type: 'header' },
+      { type: 'message', key: 1, isBrief: false },
+      { type: 'message', key: 2, isBrief: false },
+    ]);
   });
 });

--- a/src/message/__tests__/messageActionSheet-test.js
+++ b/src/message/__tests__/messageActionSheet-test.js
@@ -6,19 +6,6 @@ import { streamNameOfStreamMessage } from '../../utils/recipient';
 import * as eg from '../../__tests__/lib/exampleData';
 import { constructMessageActionButtons, constructHeaderActionButtons } from '../messageActionSheet';
 
-const baseBackgroundData = deepFreeze({
-  alertWords: [],
-  allImageEmojiById: eg.action.realm_init.data.realm_emoji,
-  auth: eg.selfAuth,
-  debug: eg.baseReduxState.session.debug,
-  flags: eg.baseReduxState.flags,
-  mute: [],
-  ownUser: eg.selfUser,
-  subscriptions: [],
-  theme: 'default',
-  twentyFourHourTime: false,
-});
-
 const buttonTitles = buttons => buttons.map(button => button.title);
 
 describe('constructActionButtons', () => {
@@ -26,9 +13,9 @@ describe('constructActionButtons', () => {
 
   test('show star message option if message is not starred', () => {
     const message = eg.streamMessage();
-    const flags = { ...baseBackgroundData.flags, starred: {} };
+    const flags = { ...eg.backgroundData.flags, starred: {} };
     const buttons = constructMessageActionButtons({
-      backgroundData: { ...baseBackgroundData, flags },
+      backgroundData: { ...eg.backgroundData, flags },
       message,
       narrow,
     });
@@ -37,9 +24,9 @@ describe('constructActionButtons', () => {
 
   test('show unstar message option if message is starred', () => {
     const message = eg.streamMessage();
-    const flags = { ...baseBackgroundData.flags, starred: { [message.id]: true } };
+    const flags = { ...eg.backgroundData.flags, starred: { [message.id]: true } };
     const buttons = constructMessageActionButtons({
-      backgroundData: { ...baseBackgroundData, flags },
+      backgroundData: { ...eg.backgroundData, flags },
       message,
       narrow,
     });
@@ -48,7 +35,7 @@ describe('constructActionButtons', () => {
 
   test('show reactions option if message is has at least one reaction', () => {
     const buttons = constructMessageActionButtons({
-      backgroundData: baseBackgroundData,
+      backgroundData: eg.backgroundData,
       message: eg.streamMessage({ reactions: [eg.unicodeEmojiReaction] }),
       narrow,
     });
@@ -60,7 +47,7 @@ describe('constructHeaderActionButtons', () => {
   test('show Unmute topic option if topic is muted', () => {
     const mute = deepFreeze([['electron issues', 'issue #556']]);
     const buttons = constructHeaderActionButtons({
-      backgroundData: { ...baseBackgroundData, mute },
+      backgroundData: { ...eg.backgroundData, mute },
       stream: 'electron issues',
       topic: 'issue #556',
     });
@@ -69,7 +56,7 @@ describe('constructHeaderActionButtons', () => {
 
   test('show mute topic option if topic is not muted', () => {
     const buttons = constructHeaderActionButtons({
-      backgroundData: { ...baseBackgroundData, mute: [] },
+      backgroundData: { ...eg.backgroundData, mute: [] },
       stream: streamNameOfStreamMessage(eg.streamMessage()),
       topic: eg.streamMessage().subject,
     });
@@ -79,7 +66,7 @@ describe('constructHeaderActionButtons', () => {
   test('show Unmute stream option if stream is not in home view', () => {
     const subscriptions = [{ ...eg.subscription, in_home_view: false }];
     const buttons = constructHeaderActionButtons({
-      backgroundData: { ...baseBackgroundData, subscriptions },
+      backgroundData: { ...eg.backgroundData, subscriptions },
       stream: streamNameOfStreamMessage(eg.streamMessage()),
       topic: eg.streamMessage().subject,
     });
@@ -89,7 +76,7 @@ describe('constructHeaderActionButtons', () => {
   test('show mute stream option if stream is in home view', () => {
     const subscriptions = [{ ...eg.subscription, in_home_view: true }];
     const buttons = constructHeaderActionButtons({
-      backgroundData: { ...baseBackgroundData, subscriptions },
+      backgroundData: { ...eg.backgroundData, subscriptions },
       stream: streamNameOfStreamMessage(eg.streamMessage()),
       topic: eg.streamMessage().subject,
     });
@@ -99,7 +86,7 @@ describe('constructHeaderActionButtons', () => {
   test('show delete topic option if current user is an admin', () => {
     const ownUser = { ...eg.selfUser, is_admin: true };
     const buttons = constructHeaderActionButtons({
-      backgroundData: { ...baseBackgroundData, ownUser },
+      backgroundData: { ...eg.backgroundData, ownUser },
       stream: streamNameOfStreamMessage(eg.streamMessage()),
       topic: eg.streamMessage().subject,
     });
@@ -108,7 +95,7 @@ describe('constructHeaderActionButtons', () => {
 
   test('do not show delete topic option if current user is not an admin', () => {
     const buttons = constructHeaderActionButtons({
-      backgroundData: baseBackgroundData,
+      backgroundData: eg.backgroundData,
       stream: streamNameOfStreamMessage(eg.streamMessage()),
       topic: eg.streamMessage().subject,
     });

--- a/src/message/getHtmlPieceDescriptors.js
+++ b/src/message/getHtmlPieceDescriptors.js
@@ -11,7 +11,7 @@ export default (
   const showHeader = !isPmNarrow(narrow) && !isTopicNarrow(narrow);
 
   let prevMessage = undefined;
-  const sections = [{ key: 0, data: [], message: null }];
+  const pieces: HtmlPieceDescriptor[] = [];
   messages.forEach(message => {
     const diffDays =
       !!prevMessage
@@ -23,15 +23,15 @@ export default (
         timestamp: message.timestamp,
         subsequentMessage: message,
       };
-      sections[sections.length - 1].data.push(renderedTimeDescriptor);
+      pieces.push(renderedTimeDescriptor);
     }
 
     const diffRecipient = !isSameRecipient(prevMessage, message);
     if (showHeader && diffRecipient) {
-      sections.push({
+      pieces.push({
+        type: 'header',
         key: `header${message.id}`,
-        message,
-        data: [],
+        subsequentMessage: message,
       });
     }
 
@@ -44,9 +44,9 @@ export default (
       isBrief: shouldGroupWithPrev,
       message,
     };
-    sections[sections.length - 1].data.push(renderedMessageDescriptor);
+    pieces.push(renderedMessageDescriptor);
 
     prevMessage = message;
   });
-  return sections;
+  return pieces;
 };

--- a/src/message/getHtmlPieceDescriptors.js
+++ b/src/message/getHtmlPieceDescriptors.js
@@ -17,12 +17,13 @@ export default (
       !!prevMessage
       && !isSameDay(new Date(prevMessage.timestamp * 1000), new Date(message.timestamp * 1000));
     if (!prevMessage || diffDays) {
-      sections[sections.length - 1].data.push({
+      const renderedTimeDescriptor = {
         key: `time${message.timestamp}`,
         type: 'time',
         timestamp: message.timestamp,
         subsequentMessage: message,
-      });
+      };
+      sections[sections.length - 1].data.push(renderedTimeDescriptor);
     }
 
     const diffRecipient = !isSameRecipient(prevMessage, message);
@@ -37,12 +38,13 @@ export default (
     const shouldGroupWithPrev =
       !diffRecipient && !diffDays && !!prevMessage && prevMessage.sender_id === message.sender_id;
 
-    sections[sections.length - 1].data.push({
+    const renderedMessageDescriptor = {
       key: message.id,
       type: 'message',
       isBrief: shouldGroupWithPrev,
       message,
-    });
+    };
+    sections[sections.length - 1].data.push(renderedMessageDescriptor);
 
     prevMessage = message;
   });

--- a/src/message/getHtmlPieceDescriptors.js
+++ b/src/message/getHtmlPieceDescriptors.js
@@ -19,13 +19,12 @@ export default (
       !!prevMessage
       && !isSameDay(new Date(prevMessage.timestamp * 1000), new Date(message.timestamp * 1000));
     if (!prevMessage || diffDays) {
-      const renderedTimeDescriptor = {
+      pieces.push({
         key: `time${message.timestamp}`,
         type: 'time',
         timestamp: message.timestamp,
         subsequentMessage: message,
-      };
-      pieces.push(renderedTimeDescriptor);
+      });
     }
 
     const diffRecipient = !isSameRecipient(prevMessage, message);
@@ -40,13 +39,12 @@ export default (
     const shouldGroupWithPrev =
       !diffRecipient && !diffDays && !!prevMessage && prevMessage.sender_id === message.sender_id;
 
-    const renderedMessageDescriptor = {
+    pieces.push({
       key: message.id,
       type: 'message',
       isBrief: shouldGroupWithPrev,
       message,
-    };
-    pieces.push(renderedMessageDescriptor);
+    });
   }
   return pieces;
 };

--- a/src/message/getHtmlPieceDescriptors.js
+++ b/src/message/getHtmlPieceDescriptors.js
@@ -10,9 +10,11 @@ export default (
 ): $ReadOnlyArray<HtmlPieceDescriptor> => {
   const showHeader = !isPmNarrow(narrow) && !isTopicNarrow(narrow);
 
-  let prevMessage = undefined;
   const pieces: HtmlPieceDescriptor[] = [];
-  messages.forEach(message => {
+  for (let i = 0; i < messages.length; i++) {
+    const message = messages[i];
+    const prevMessage: typeof message | void = messages[i - 1];
+
     const diffDays =
       !!prevMessage
       && !isSameDay(new Date(prevMessage.timestamp * 1000), new Date(message.timestamp * 1000));
@@ -45,8 +47,6 @@ export default (
       message,
     };
     pieces.push(renderedMessageDescriptor);
-
-    prevMessage = message;
-  });
+  }
   return pieces;
 };

--- a/src/message/getHtmlPieceDescriptors.js
+++ b/src/message/getHtmlPieceDescriptors.js
@@ -7,7 +7,7 @@ import { isSameDay } from '../utils/date';
 export default (
   messages: $ReadOnlyArray<Message | Outbox>,
   narrow: Narrow,
-): HtmlPieceDescriptor[] => {
+): $ReadOnlyArray<HtmlPieceDescriptor> => {
   const showHeader = !isPmNarrow(narrow) && !isTopicNarrow(narrow);
 
   let prevMessage = undefined;

--- a/src/types.js
+++ b/src/types.js
@@ -326,25 +326,30 @@ export type UnreadStreamItem = {|
   |}>,
 |};
 
-export type RenderedTimeDescriptor = {|
+export type TimePieceDescriptor = {|
   type: 'time',
   key: string,
   timestamp: number,
   subsequentMessage: Message | Outbox,
 |};
 
-export type RenderedMessageDescriptor = {|
+export type MessagePieceDescriptor = {|
   type: 'message',
   key: number,
   message: Message | Outbox,
   isBrief: boolean,
 |};
 
-export type HtmlPieceDescriptor = {|
-  key: string | number,
-  message: Message | Outbox | null,
-  data: $ReadOnlyArray<RenderedMessageDescriptor | RenderedTimeDescriptor>,
+export type HeaderPieceDescriptor = {|
+  type: 'header',
+  key: string,
+  subsequentMessage: Message | Outbox,
 |};
+
+export type HtmlPieceDescriptor =
+  | TimePieceDescriptor
+  | MessagePieceDescriptor
+  | HeaderPieceDescriptor;
 
 export type TimingItemType = {|
   text: string,

--- a/src/types.js
+++ b/src/types.js
@@ -328,14 +328,14 @@ export type UnreadStreamItem = {|
 
 export type RenderedTimeDescriptor = {|
   type: 'time',
-  key: number | string,
+  key: string,
   timestamp: number,
   subsequentMessage: Message | Outbox,
 |};
 
 export type RenderedMessageDescriptor = {|
   type: 'message',
-  key: number | string,
+  key: number,
   message: Message | Outbox,
   isBrief: boolean,
 |};

--- a/src/utils/__tests__/date-test.js
+++ b/src/utils/__tests__/date-test.js
@@ -1,13 +1,24 @@
 import { shortTime, shortDate, longDate, daysInDate, humanDate } from '../date';
 
+describe('Timezones (for test environment only)', () => {
+  test('Timezone has been set to UTC, unless on Windows', () => {
+    expect(
+      new Date().getTimezoneOffset() === 0
+        // 'win32' is the only possible value that would indicate Windows:
+        // https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/Snapshot.20tests/near/1167560
+        || process.platform === 'win32',
+    ).toBe(true);
+  });
+});
+
 describe('shortTime', () => {
   test('returns only hour and minutes', () => {
-    const date = new Date(2000, 0, 1, 20, 10);
+    const date = new Date(Date.UTC(2000, 0, 1, 20, 10));
     expect(shortTime(date)).toBe('8:10 PM');
   });
 
   test('returns as 24hrs time format, when true passed as second parameter', () => {
-    const date = new Date(2000, 0, 1, 20, 10);
+    const date = new Date(Date.UTC(2000, 0, 1, 20, 10));
     expect(shortTime(date, true)).toBe('20:10');
   });
 });

--- a/src/utils/date.js
+++ b/src/utils/date.js
@@ -3,12 +3,31 @@ import format from 'date-fns/format';
 import isToday from 'date-fns/is_today';
 import isYesterday from 'date-fns/is_yesterday';
 import isSameYear from 'date-fns/is_same_year';
+import addMinutes from 'date-fns/add_minutes';
 import tz from 'timezone/loaded';
 
 export { default as isSameDay } from 'date-fns/is_same_day';
 
+/**
+ * Use consistent timezone (UTC) in local and CI tests, for snapshot tests.
+ */
+// We're only counting on this if we can't set the timezone `Date` uses to
+// UTC in the first place; see note where we attempt to do that in
+// jest/globalSetup.js.
+function maybeAsUtc(date: Date) {
+  /* eslint-disable operator-linebreak */
+  /* eslint-disable-next-line id-match,no-underscore-dangle */
+  return global.__TEST__
+    ? // Negate the UTC offset, using an offset we get from `date` itself, so
+      // it'll be correct for DST-type changes through the year.
+      // Empirically, the sign seems to be correct:
+      //   https://github.com/zulip/zulip-mobile/pull/4670#discussion_r648702356
+      addMinutes(date, date.getTimezoneOffset())
+    : date;
+}
+
 export const shortTime = (date: Date, twentyFourHourTime: boolean = false): string =>
-  format(date, twentyFourHourTime ? 'H:mm' : 'h:mm A');
+  format(maybeAsUtc(date), twentyFourHourTime ? 'H:mm' : 'h:mm A');
 
 export const shortDate = (date: Date): string => format(date, 'MMM D');
 

--- a/src/webview/MessageList.js
+++ b/src/webview/MessageList.js
@@ -100,7 +100,7 @@ type SelectorProps = {|
   // particular messages we're displaying.  Data that's independent of those
   // should go in `BackgroundData`, above.
   fetching: Fetching,
-  htmlPieceDescriptorsForShownMessages: HtmlPieceDescriptor[],
+  htmlPieceDescriptorsForShownMessages: $ReadOnlyArray<HtmlPieceDescriptor>,
   typingUsers: $ReadOnlyArray<UserOrBot>,
 |};
 

--- a/src/webview/__tests__/generateInboundEvents-test.js
+++ b/src/webview/__tests__/generateInboundEvents-test.js
@@ -115,16 +115,12 @@ describe('generateInboundEvents', () => {
   test('when the rendered messages differ (even deeply) a "content" message is returned', () => {
     const prevProps = {
       ...baseProps,
-      htmlPieceDescriptorsForShownMessages: [{ key: 0, data: [], message: null }],
+      htmlPieceDescriptorsForShownMessages: [],
     };
     const nextProps = {
       ...baseProps,
       htmlPieceDescriptorsForShownMessages: [
-        {
-          key: 0,
-          data: [{ key: 123, type: 'message', isBrief: false, message: eg.streamMessage() }],
-          message: null,
-        },
+        { key: 123, type: 'message', isBrief: false, message: eg.streamMessage() },
       ],
     };
 
@@ -160,18 +156,14 @@ describe('generateInboundEvents', () => {
       ...baseProps,
       fetching: { older: false, newer: false },
       typingUsers: [],
-      htmlPieceDescriptorsForShownMessages: [{ key: 0, data: [], message: null }],
+      htmlPieceDescriptorsForShownMessages: [],
     };
     const nextProps = {
       ...baseProps,
       fetching: { older: false, newer: true },
       typingUsers: [eg.makeUser()],
       htmlPieceDescriptorsForShownMessages: [
-        {
-          key: 0,
-          data: [{ key: 123, type: 'message', isBrief: false, message: eg.streamMessage() }],
-          message: null,
-        },
+        { key: 123, type: 'message', isBrief: false, message: eg.streamMessage() },
       ],
     };
 

--- a/src/webview/__tests__/generateInboundEvents-test.js
+++ b/src/webview/__tests__/generateInboundEvents-test.js
@@ -1,6 +1,5 @@
 /* @flow strict-local */
 import deepFreeze from 'deep-freeze';
-import Immutable from 'immutable';
 
 import generateInboundEvents from '../generateInboundEvents';
 import { flagsStateToStringList } from '../html/messageAsHtml';
@@ -9,22 +8,8 @@ import * as eg from '../../__tests__/lib/exampleData';
 import type { Props } from '../MessageList';
 
 describe('generateInboundEvents', () => {
-  const baseBackgroundData = deepFreeze({
-    alertWords: [],
-    allImageEmojiById: eg.action.realm_init.data.realm_emoji,
-    auth: eg.selfAuth,
-    debug: eg.baseReduxState.session.debug,
-    flags: eg.baseReduxState.flags,
-    mute: [],
-    mutedUsers: Immutable.Map(),
-    ownUser: eg.selfUser,
-    subscriptions: [],
-    theme: 'default',
-    twentyFourHourTime: false,
-  });
-
   const baseSelectorProps = deepFreeze({
-    backgroundData: baseBackgroundData,
+    backgroundData: eg.backgroundData,
     initialScrollMessageId: null,
     fetching: { older: false, newer: false },
     messages: [],
@@ -204,9 +189,9 @@ describe('generateInboundEvents', () => {
     const prevProps = {
       ...baseProps,
       backgroundData: {
-        ...baseBackgroundData,
+        ...eg.backgroundData,
         flags: {
-          ...baseBackgroundData.flags,
+          ...eg.backgroundData.flags,
           read: { [message2.id]: true },
         },
       },
@@ -214,9 +199,9 @@ describe('generateInboundEvents', () => {
     const nextProps = {
       ...baseProps,
       backgroundData: {
-        ...baseBackgroundData,
+        ...eg.backgroundData,
         flags: {
-          ...baseBackgroundData.flags,
+          ...eg.backgroundData.flags,
           read: { [message1.id]: true, [message2.id]: true, [message3.id]: true },
         },
       },

--- a/src/webview/html/__tests__/__snapshots__/contentHtmlFromPieceDescriptors-test.js.snap.android
+++ b/src/webview/html/__tests__/__snapshots__/contentHtmlFromPieceDescriptors-test.js.snap.android
@@ -1,0 +1,4398 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_NARROW 1`] = `
+"
+  <div class=\\"timerow\\" data-msg-id=\\"1024\\">
+    <div class=\\"timerow-left\\"></div>
+    Feb 5, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+<div class=\\"header-wrapper header stream-header topic-header\\"
+    data-msg-id=\\"1024\\"
+    data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAx\\">
+  <div class=\\"header stream-text\\"
+       style=\\"color: black;
+              background: hsl(0, 0%, 80%)\\"
+       data-narrow=\\"c3RyZWFtOnM6c3RyZWFtIDE=\\">
+    # stream 1
+  </div>
+  <div class=\\"topic-text\\">topic 1</div>
+  <div class=\\"topic-date\\">Feb 5, 1995</div>
+</div>
+    
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-1024\\"
+     data-msg-id=\\"1024\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example stream message.
+
+
+
+
+  </div>
+  
+</div>
+
+
+    <div
+     class=\\"message message-brief\\"
+     id=\\"msg-1598\\"
+     data-msg-id=\\"1598\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"content\\">
+    
+<div class=\\"time-container\\">
+  <div class=\\"msg-timestamp \\">
+    12:00 PM
+  </div>
+</div>
+
+    
+This is an example stream message.
+
+
+
+
+  </div>
+</div>
+"
+`;
+
+exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_NARROW 2`] = `
+"
+  <div class=\\"timerow\\" data-msg-id=\\"7938\\">
+    <div class=\\"timerow-left\\"></div>
+    Mar 5, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+<div class=\\"header-wrapper header stream-header topic-header\\"
+    data-msg-id=\\"7938\\"
+    data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAx\\">
+  <div class=\\"header stream-text\\"
+       style=\\"color: black;
+              background: hsl(0, 0%, 80%)\\"
+       data-narrow=\\"c3RyZWFtOnM6c3RyZWFtIDE=\\">
+    # stream 1
+  </div>
+  <div class=\\"topic-text\\">topic 1</div>
+  <div class=\\"topic-date\\">Mar 5, 1995</div>
+</div>
+    
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-7938\\"
+     data-msg-id=\\"7938\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example stream message.
+
+
+
+
+  </div>
+  
+</div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-8060\\"
+     data-msg-id=\\"8060\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20two.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name two User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example stream message.
+
+
+
+
+  </div>
+  
+</div>
+"
+`;
+
+exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_NARROW 3`] = `
+"
+  <div class=\\"timerow\\" data-msg-id=\\"4948\\">
+    <div class=\\"timerow-left\\"></div>
+    Feb 19, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+<div class=\\"header-wrapper header stream-header topic-header\\"
+    data-msg-id=\\"4948\\"
+    data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAx\\">
+  <div class=\\"header stream-text\\"
+       style=\\"color: black;
+              background: hsl(0, 0%, 80%)\\"
+       data-narrow=\\"c3RyZWFtOnM6c3RyZWFtIDE=\\">
+    # stream 1
+  </div>
+  <div class=\\"topic-text\\">topic 1</div>
+  <div class=\\"topic-date\\">Feb 19, 1995</div>
+</div>
+    
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-4948\\"
+     data-msg-id=\\"4948\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example stream message.
+
+
+
+
+  </div>
+  
+</div>
+
+<div class=\\"header-wrapper header stream-header topic-header\\"
+    data-msg-id=\\"5083\\"
+    data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAy\\">
+  <div class=\\"header stream-text\\"
+       style=\\"color: black;
+              background: hsl(0, 0%, 80%)\\"
+       data-narrow=\\"c3RyZWFtOnM6c3RyZWFtIDE=\\">
+    # stream 1
+  </div>
+  <div class=\\"topic-text\\">topic 2</div>
+  <div class=\\"topic-date\\">Feb 19, 1995</div>
+</div>
+    
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-5083\\"
+     data-msg-id=\\"5083\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example stream message.
+
+
+
+
+  </div>
+  
+</div>
+"
+`;
+
+exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_NARROW 4`] = `
+"
+  <div class=\\"timerow\\" data-msg-id=\\"6789\\">
+    <div class=\\"timerow-left\\"></div>
+    Mar 5, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+<div class=\\"header-wrapper header stream-header topic-header\\"
+    data-msg-id=\\"6789\\"
+    data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAx\\">
+  <div class=\\"header stream-text\\"
+       style=\\"color: black;
+              background: hsl(0, 0%, 80%)\\"
+       data-narrow=\\"c3RyZWFtOnM6c3RyZWFtIDE=\\">
+    # stream 1
+  </div>
+  <div class=\\"topic-text\\">topic 1</div>
+  <div class=\\"topic-date\\">Mar 5, 1995</div>
+</div>
+    
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-6789\\"
+     data-msg-id=\\"6789\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example stream message.
+
+
+
+
+  </div>
+  
+</div>
+
+<div class=\\"header-wrapper header stream-header topic-header\\"
+    data-msg-id=\\"7727\\"
+    data-narrow=\\"dG9waWM6czpzdHJlYW0gMgB0b3BpYyAy\\">
+  <div class=\\"header stream-text\\"
+       style=\\"color: black;
+              background: hsl(0, 0%, 80%)\\"
+       data-narrow=\\"c3RyZWFtOnM6c3RyZWFtIDI=\\">
+    # stream 2
+  </div>
+  <div class=\\"topic-text\\">topic 2</div>
+  <div class=\\"topic-date\\">Mar 5, 1995</div>
+</div>
+    
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-7727\\"
+     data-msg-id=\\"7727\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example stream message.
+
+
+
+
+  </div>
+  
+</div>
+"
+`;
+
+exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_NARROW 5`] = `
+"
+  <div class=\\"timerow\\" data-msg-id=\\"9181\\">
+    <div class=\\"timerow-left\\"></div>
+    Mar 5, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+<div class=\\"header-wrapper header stream-header topic-header\\"
+    data-msg-id=\\"9181\\"
+    data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAx\\">
+  <div class=\\"header stream-text\\"
+       style=\\"color: black;
+              background: hsl(0, 0%, 80%)\\"
+       data-narrow=\\"c3RyZWFtOnM6c3RyZWFtIDE=\\">
+    # stream 1
+  </div>
+  <div class=\\"topic-text\\">topic 1</div>
+  <div class=\\"topic-date\\">Mar 5, 1995</div>
+</div>
+    
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-9181\\"
+     data-msg-id=\\"9181\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example stream message.
+
+
+
+
+  </div>
+  
+</div>
+
+  <div class=\\"timerow\\" data-msg-id=\\"9815\\">
+    <div class=\\"timerow-left\\"></div>
+    Mar 12, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-9815\\"
+     data-msg-id=\\"9815\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example stream message.
+
+
+
+
+  </div>
+  
+</div>
+"
+`;
+
+exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_NARROW 6`] = `
+"
+  <div class=\\"timerow\\" data-msg-id=\\"8849\\">
+    <div class=\\"timerow-left\\"></div>
+    Mar 5, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+<div class=\\"header-wrapper private-header header\\"
+     data-narrow=\\"cG06MSwy\\"
+     data-msg-id=\\"8849\\">
+  Nonrandom name one User, Nonrandom name two User
+</div>
+    
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-8849\\"
+     data-msg-id=\\"8849\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+
+
+    <div
+     class=\\"message message-brief\\"
+     id=\\"msg-8917\\"
+     data-msg-id=\\"8917\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"content\\">
+    
+<div class=\\"time-container\\">
+  <div class=\\"msg-timestamp \\">
+    12:00 PM
+  </div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+</div>
+"
+`;
+
+exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_NARROW 7`] = `
+"
+  <div class=\\"timerow\\" data-msg-id=\\"5287\\">
+    <div class=\\"timerow-left\\"></div>
+    Feb 19, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+<div class=\\"header-wrapper private-header header\\"
+     data-narrow=\\"cG06MSwy\\"
+     data-msg-id=\\"5287\\">
+  Nonrandom name one User, Nonrandom name two User
+</div>
+    
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-5287\\"
+     data-msg-id=\\"5287\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-5309\\"
+     data-msg-id=\\"5309\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20two.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name two User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+"
+`;
+
+exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_NARROW 8`] = `
+"
+  <div class=\\"timerow\\" data-msg-id=\\"5829\\">
+    <div class=\\"timerow-left\\"></div>
+    Feb 19, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+<div class=\\"header-wrapper private-header header\\"
+     data-narrow=\\"cG06MSwy\\"
+     data-msg-id=\\"5829\\">
+  Nonrandom name one User, Nonrandom name two User
+</div>
+    
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-5829\\"
+     data-msg-id=\\"5829\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+
+  <div class=\\"timerow\\" data-msg-id=\\"5963\\">
+    <div class=\\"timerow-left\\"></div>
+    Feb 26, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-5963\\"
+     data-msg-id=\\"5963\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+"
+`;
+
+exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_NARROW 9`] = `
+"
+  <div class=\\"timerow\\" data-msg-id=\\"5377\\">
+    <div class=\\"timerow-left\\"></div>
+    Feb 19, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+<div class=\\"header-wrapper private-header header\\"
+     data-narrow=\\"cG06MSwyLDM=\\"
+     data-msg-id=\\"5377\\">
+  Nonrandom name one User, Nonrandom name three User, Nonrandom name two User
+</div>
+    
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-5377\\"
+     data-msg-id=\\"5377\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+
+
+    <div
+     class=\\"message message-brief\\"
+     id=\\"msg-5620\\"
+     data-msg-id=\\"5620\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"content\\">
+    
+<div class=\\"time-container\\">
+  <div class=\\"msg-timestamp \\">
+    12:00 PM
+  </div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+</div>
+"
+`;
+
+exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_NARROW 10`] = `
+"
+  <div class=\\"timerow\\" data-msg-id=\\"5637\\">
+    <div class=\\"timerow-left\\"></div>
+    Feb 19, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+<div class=\\"header-wrapper private-header header\\"
+     data-narrow=\\"cG06MSwyLDM=\\"
+     data-msg-id=\\"5637\\">
+  Nonrandom name one User, Nonrandom name three User, Nonrandom name two User
+</div>
+    
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-5637\\"
+     data-msg-id=\\"5637\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-5727\\"
+     data-msg-id=\\"5727\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20two.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name two User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+"
+`;
+
+exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_NARROW 11`] = `
+"
+  <div class=\\"timerow\\" data-msg-id=\\"2794\\">
+    <div class=\\"timerow-left\\"></div>
+    Feb 5, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+<div class=\\"header-wrapper private-header header\\"
+     data-narrow=\\"cG06MSwyLDM=\\"
+     data-msg-id=\\"2794\\">
+  Nonrandom name one User, Nonrandom name three User, Nonrandom name two User
+</div>
+    
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-2794\\"
+     data-msg-id=\\"2794\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+
+  <div class=\\"timerow\\" data-msg-id=\\"4581\\">
+    <div class=\\"timerow-left\\"></div>
+    Feb 12, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-4581\\"
+     data-msg-id=\\"4581\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+"
+`;
+
+exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_NARROW 12`] = `
+"
+  <div class=\\"timerow\\" data-msg-id=\\"1024\\">
+    <div class=\\"timerow-left\\"></div>
+    Feb 5, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+<div class=\\"header-wrapper header stream-header topic-header\\"
+    data-msg-id=\\"1024\\"
+    data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAx\\">
+  <div class=\\"header stream-text\\"
+       style=\\"color: black;
+              background: hsl(0, 0%, 80%)\\"
+       data-narrow=\\"c3RyZWFtOnM6c3RyZWFtIDE=\\">
+    # stream 1
+  </div>
+  <div class=\\"topic-text\\">topic 1</div>
+  <div class=\\"topic-date\\">Feb 5, 1995</div>
+</div>
+    
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-1024\\"
+     data-msg-id=\\"1024\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example stream message.
+
+
+
+
+  </div>
+  
+</div>
+
+
+    <div
+     class=\\"message message-brief\\"
+     id=\\"msg-1598\\"
+     data-msg-id=\\"1598\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"content\\">
+    
+<div class=\\"time-container\\">
+  <div class=\\"msg-timestamp \\">
+    12:00 PM
+  </div>
+</div>
+
+    
+This is an example stream message.
+
+
+
+
+  </div>
+</div>
+
+<div class=\\"header-wrapper private-header header\\"
+     data-narrow=\\"cG06MSwyLDM=\\"
+     data-msg-id=\\"2794\\">
+  Nonrandom name one User, Nonrandom name three User, Nonrandom name two User
+</div>
+    
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-2794\\"
+     data-msg-id=\\"2794\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+
+  <div class=\\"timerow\\" data-msg-id=\\"4581\\">
+    <div class=\\"timerow-left\\"></div>
+    Feb 12, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-4581\\"
+     data-msg-id=\\"4581\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+
+  <div class=\\"timerow\\" data-msg-id=\\"4948\\">
+    <div class=\\"timerow-left\\"></div>
+    Feb 19, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+<div class=\\"header-wrapper header stream-header topic-header\\"
+    data-msg-id=\\"4948\\"
+    data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAx\\">
+  <div class=\\"header stream-text\\"
+       style=\\"color: black;
+              background: hsl(0, 0%, 80%)\\"
+       data-narrow=\\"c3RyZWFtOnM6c3RyZWFtIDE=\\">
+    # stream 1
+  </div>
+  <div class=\\"topic-text\\">topic 1</div>
+  <div class=\\"topic-date\\">Feb 19, 1995</div>
+</div>
+    
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-4948\\"
+     data-msg-id=\\"4948\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example stream message.
+
+
+
+
+  </div>
+  
+</div>
+
+<div class=\\"header-wrapper header stream-header topic-header\\"
+    data-msg-id=\\"5083\\"
+    data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAy\\">
+  <div class=\\"header stream-text\\"
+       style=\\"color: black;
+              background: hsl(0, 0%, 80%)\\"
+       data-narrow=\\"c3RyZWFtOnM6c3RyZWFtIDE=\\">
+    # stream 1
+  </div>
+  <div class=\\"topic-text\\">topic 2</div>
+  <div class=\\"topic-date\\">Feb 19, 1995</div>
+</div>
+    
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-5083\\"
+     data-msg-id=\\"5083\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example stream message.
+
+
+
+
+  </div>
+  
+</div>
+
+<div class=\\"header-wrapper private-header header\\"
+     data-narrow=\\"cG06MSwy\\"
+     data-msg-id=\\"5287\\">
+  Nonrandom name one User, Nonrandom name two User
+</div>
+    
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-5287\\"
+     data-msg-id=\\"5287\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-5309\\"
+     data-msg-id=\\"5309\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20two.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name two User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+
+<div class=\\"header-wrapper private-header header\\"
+     data-narrow=\\"cG06MSwyLDM=\\"
+     data-msg-id=\\"5377\\">
+  Nonrandom name one User, Nonrandom name three User, Nonrandom name two User
+</div>
+    
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-5377\\"
+     data-msg-id=\\"5377\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+
+
+    <div
+     class=\\"message message-brief\\"
+     id=\\"msg-5620\\"
+     data-msg-id=\\"5620\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"content\\">
+    
+<div class=\\"time-container\\">
+  <div class=\\"msg-timestamp \\">
+    12:00 PM
+  </div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+</div>
+
+
+    <div
+     class=\\"message message-brief\\"
+     id=\\"msg-5637\\"
+     data-msg-id=\\"5637\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"content\\">
+    
+<div class=\\"time-container\\">
+  <div class=\\"msg-timestamp \\">
+    12:00 PM
+  </div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+</div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-5727\\"
+     data-msg-id=\\"5727\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20two.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name two User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+
+<div class=\\"header-wrapper private-header header\\"
+     data-narrow=\\"cG06MSwy\\"
+     data-msg-id=\\"5829\\">
+  Nonrandom name one User, Nonrandom name two User
+</div>
+    
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-5829\\"
+     data-msg-id=\\"5829\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+
+  <div class=\\"timerow\\" data-msg-id=\\"5963\\">
+    <div class=\\"timerow-left\\"></div>
+    Feb 26, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-5963\\"
+     data-msg-id=\\"5963\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+
+  <div class=\\"timerow\\" data-msg-id=\\"6789\\">
+    <div class=\\"timerow-left\\"></div>
+    Mar 5, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+<div class=\\"header-wrapper header stream-header topic-header\\"
+    data-msg-id=\\"6789\\"
+    data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAx\\">
+  <div class=\\"header stream-text\\"
+       style=\\"color: black;
+              background: hsl(0, 0%, 80%)\\"
+       data-narrow=\\"c3RyZWFtOnM6c3RyZWFtIDE=\\">
+    # stream 1
+  </div>
+  <div class=\\"topic-text\\">topic 1</div>
+  <div class=\\"topic-date\\">Mar 5, 1995</div>
+</div>
+    
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-6789\\"
+     data-msg-id=\\"6789\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example stream message.
+
+
+
+
+  </div>
+  
+</div>
+
+<div class=\\"header-wrapper header stream-header topic-header\\"
+    data-msg-id=\\"7727\\"
+    data-narrow=\\"dG9waWM6czpzdHJlYW0gMgB0b3BpYyAy\\">
+  <div class=\\"header stream-text\\"
+       style=\\"color: black;
+              background: hsl(0, 0%, 80%)\\"
+       data-narrow=\\"c3RyZWFtOnM6c3RyZWFtIDI=\\">
+    # stream 2
+  </div>
+  <div class=\\"topic-text\\">topic 2</div>
+  <div class=\\"topic-date\\">Mar 5, 1995</div>
+</div>
+    
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-7727\\"
+     data-msg-id=\\"7727\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example stream message.
+
+
+
+
+  </div>
+  
+</div>
+
+<div class=\\"header-wrapper header stream-header topic-header\\"
+    data-msg-id=\\"7938\\"
+    data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAx\\">
+  <div class=\\"header stream-text\\"
+       style=\\"color: black;
+              background: hsl(0, 0%, 80%)\\"
+       data-narrow=\\"c3RyZWFtOnM6c3RyZWFtIDE=\\">
+    # stream 1
+  </div>
+  <div class=\\"topic-text\\">topic 1</div>
+  <div class=\\"topic-date\\">Mar 5, 1995</div>
+</div>
+    
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-7938\\"
+     data-msg-id=\\"7938\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example stream message.
+
+
+
+
+  </div>
+  
+</div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-8060\\"
+     data-msg-id=\\"8060\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20two.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name two User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example stream message.
+
+
+
+
+  </div>
+  
+</div>
+
+<div class=\\"header-wrapper private-header header\\"
+     data-narrow=\\"cG06MSwy\\"
+     data-msg-id=\\"8849\\">
+  Nonrandom name one User, Nonrandom name two User
+</div>
+    
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-8849\\"
+     data-msg-id=\\"8849\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+
+
+    <div
+     class=\\"message message-brief\\"
+     id=\\"msg-8917\\"
+     data-msg-id=\\"8917\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"content\\">
+    
+<div class=\\"time-container\\">
+  <div class=\\"msg-timestamp \\">
+    12:00 PM
+  </div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+</div>
+
+<div class=\\"header-wrapper header stream-header topic-header\\"
+    data-msg-id=\\"9181\\"
+    data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAx\\">
+  <div class=\\"header stream-text\\"
+       style=\\"color: black;
+              background: hsl(0, 0%, 80%)\\"
+       data-narrow=\\"c3RyZWFtOnM6c3RyZWFtIDE=\\">
+    # stream 1
+  </div>
+  <div class=\\"topic-text\\">topic 1</div>
+  <div class=\\"topic-date\\">Mar 5, 1995</div>
+</div>
+    
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-9181\\"
+     data-msg-id=\\"9181\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example stream message.
+
+
+
+
+  </div>
+  
+</div>
+
+  <div class=\\"timerow\\" data-msg-id=\\"9815\\">
+    <div class=\\"timerow-left\\"></div>
+    Mar 12, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-9815\\"
+     data-msg-id=\\"9815\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example stream message.
+
+
+
+
+  </div>
+  
+</div>
+"
+`;
+
+exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm 1`] = `
+"
+  <div class=\\"timerow\\" data-msg-id=\\"8849\\">
+    <div class=\\"timerow-left\\"></div>
+    Mar 5, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+<div class=\\"header-wrapper private-header header\\"
+     data-narrow=\\"cG06MSwy\\"
+     data-msg-id=\\"8849\\">
+  Nonrandom name one User, Nonrandom name two User
+</div>
+    
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-8849\\"
+     data-msg-id=\\"8849\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+
+
+    <div
+     class=\\"message message-brief\\"
+     id=\\"msg-8917\\"
+     data-msg-id=\\"8917\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"content\\">
+    
+<div class=\\"time-container\\">
+  <div class=\\"msg-timestamp \\">
+    12:00 PM
+  </div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+</div>
+"
+`;
+
+exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm 2`] = `
+"
+  <div class=\\"timerow\\" data-msg-id=\\"5287\\">
+    <div class=\\"timerow-left\\"></div>
+    Feb 19, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+<div class=\\"header-wrapper private-header header\\"
+     data-narrow=\\"cG06MSwy\\"
+     data-msg-id=\\"5287\\">
+  Nonrandom name one User, Nonrandom name two User
+</div>
+    
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-5287\\"
+     data-msg-id=\\"5287\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-5309\\"
+     data-msg-id=\\"5309\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20two.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name two User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+"
+`;
+
+exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm 3`] = `
+"
+  <div class=\\"timerow\\" data-msg-id=\\"5829\\">
+    <div class=\\"timerow-left\\"></div>
+    Feb 19, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+<div class=\\"header-wrapper private-header header\\"
+     data-narrow=\\"cG06MSwy\\"
+     data-msg-id=\\"5829\\">
+  Nonrandom name one User, Nonrandom name two User
+</div>
+    
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-5829\\"
+     data-msg-id=\\"5829\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+
+  <div class=\\"timerow\\" data-msg-id=\\"5963\\">
+    <div class=\\"timerow-left\\"></div>
+    Feb 26, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-5963\\"
+     data-msg-id=\\"5963\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+"
+`;
+
+exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm 4`] = `
+"
+  <div class=\\"timerow\\" data-msg-id=\\"5377\\">
+    <div class=\\"timerow-left\\"></div>
+    Feb 19, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+<div class=\\"header-wrapper private-header header\\"
+     data-narrow=\\"cG06MSwyLDM=\\"
+     data-msg-id=\\"5377\\">
+  Nonrandom name one User, Nonrandom name three User, Nonrandom name two User
+</div>
+    
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-5377\\"
+     data-msg-id=\\"5377\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+
+
+    <div
+     class=\\"message message-brief\\"
+     id=\\"msg-5620\\"
+     data-msg-id=\\"5620\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"content\\">
+    
+<div class=\\"time-container\\">
+  <div class=\\"msg-timestamp \\">
+    12:00 PM
+  </div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+</div>
+"
+`;
+
+exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm 5`] = `
+"
+  <div class=\\"timerow\\" data-msg-id=\\"5637\\">
+    <div class=\\"timerow-left\\"></div>
+    Feb 19, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+<div class=\\"header-wrapper private-header header\\"
+     data-narrow=\\"cG06MSwyLDM=\\"
+     data-msg-id=\\"5637\\">
+  Nonrandom name one User, Nonrandom name three User, Nonrandom name two User
+</div>
+    
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-5637\\"
+     data-msg-id=\\"5637\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-5727\\"
+     data-msg-id=\\"5727\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20two.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name two User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+"
+`;
+
+exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm 6`] = `
+"
+  <div class=\\"timerow\\" data-msg-id=\\"2794\\">
+    <div class=\\"timerow-left\\"></div>
+    Feb 5, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+<div class=\\"header-wrapper private-header header\\"
+     data-narrow=\\"cG06MSwyLDM=\\"
+     data-msg-id=\\"2794\\">
+  Nonrandom name one User, Nonrandom name three User, Nonrandom name two User
+</div>
+    
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-2794\\"
+     data-msg-id=\\"2794\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+
+  <div class=\\"timerow\\" data-msg-id=\\"4581\\">
+    <div class=\\"timerow-left\\"></div>
+    Feb 12, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-4581\\"
+     data-msg-id=\\"4581\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+"
+`;
+
+exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm 7`] = `
+"
+  <div class=\\"timerow\\" data-msg-id=\\"2794\\">
+    <div class=\\"timerow-left\\"></div>
+    Feb 5, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+<div class=\\"header-wrapper private-header header\\"
+     data-narrow=\\"cG06MSwyLDM=\\"
+     data-msg-id=\\"2794\\">
+  Nonrandom name one User, Nonrandom name three User, Nonrandom name two User
+</div>
+    
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-2794\\"
+     data-msg-id=\\"2794\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+
+  <div class=\\"timerow\\" data-msg-id=\\"4581\\">
+    <div class=\\"timerow-left\\"></div>
+    Feb 12, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-4581\\"
+     data-msg-id=\\"4581\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+
+  <div class=\\"timerow\\" data-msg-id=\\"5287\\">
+    <div class=\\"timerow-left\\"></div>
+    Feb 19, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+<div class=\\"header-wrapper private-header header\\"
+     data-narrow=\\"cG06MSwy\\"
+     data-msg-id=\\"5287\\">
+  Nonrandom name one User, Nonrandom name two User
+</div>
+    
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-5287\\"
+     data-msg-id=\\"5287\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-5309\\"
+     data-msg-id=\\"5309\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20two.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name two User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+
+<div class=\\"header-wrapper private-header header\\"
+     data-narrow=\\"cG06MSwyLDM=\\"
+     data-msg-id=\\"5377\\">
+  Nonrandom name one User, Nonrandom name three User, Nonrandom name two User
+</div>
+    
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-5377\\"
+     data-msg-id=\\"5377\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+
+
+    <div
+     class=\\"message message-brief\\"
+     id=\\"msg-5620\\"
+     data-msg-id=\\"5620\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"content\\">
+    
+<div class=\\"time-container\\">
+  <div class=\\"msg-timestamp \\">
+    12:00 PM
+  </div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+</div>
+
+
+    <div
+     class=\\"message message-brief\\"
+     id=\\"msg-5637\\"
+     data-msg-id=\\"5637\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"content\\">
+    
+<div class=\\"time-container\\">
+  <div class=\\"msg-timestamp \\">
+    12:00 PM
+  </div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+</div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-5727\\"
+     data-msg-id=\\"5727\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20two.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name two User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+
+<div class=\\"header-wrapper private-header header\\"
+     data-narrow=\\"cG06MSwy\\"
+     data-msg-id=\\"5829\\">
+  Nonrandom name one User, Nonrandom name two User
+</div>
+    
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-5829\\"
+     data-msg-id=\\"5829\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+
+  <div class=\\"timerow\\" data-msg-id=\\"5963\\">
+    <div class=\\"timerow-left\\"></div>
+    Feb 26, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-5963\\"
+     data-msg-id=\\"5963\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+
+  <div class=\\"timerow\\" data-msg-id=\\"8849\\">
+    <div class=\\"timerow-left\\"></div>
+    Mar 5, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-8849\\"
+     data-msg-id=\\"8849\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+
+
+    <div
+     class=\\"message message-brief\\"
+     id=\\"msg-8917\\"
+     data-msg-id=\\"8917\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"content\\">
+    
+<div class=\\"time-container\\">
+  <div class=\\"msg-timestamp \\">
+    12:00 PM
+  </div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+</div>
+"
+`;
+
+exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2 1`] = `
+"
+  <div class=\\"timerow\\" data-msg-id=\\"8849\\">
+    <div class=\\"timerow-left\\"></div>
+    Mar 5, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-8849\\"
+     data-msg-id=\\"8849\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+
+
+    <div
+     class=\\"message message-brief\\"
+     id=\\"msg-8917\\"
+     data-msg-id=\\"8917\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"content\\">
+    
+<div class=\\"time-container\\">
+  <div class=\\"msg-timestamp \\">
+    12:00 PM
+  </div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+</div>
+"
+`;
+
+exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2 2`] = `
+"
+  <div class=\\"timerow\\" data-msg-id=\\"5287\\">
+    <div class=\\"timerow-left\\"></div>
+    Feb 19, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-5287\\"
+     data-msg-id=\\"5287\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-5309\\"
+     data-msg-id=\\"5309\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20two.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name two User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+"
+`;
+
+exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2 3`] = `
+"
+  <div class=\\"timerow\\" data-msg-id=\\"5829\\">
+    <div class=\\"timerow-left\\"></div>
+    Feb 19, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-5829\\"
+     data-msg-id=\\"5829\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+
+  <div class=\\"timerow\\" data-msg-id=\\"5963\\">
+    <div class=\\"timerow-left\\"></div>
+    Feb 26, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-5963\\"
+     data-msg-id=\\"5963\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+"
+`;
+
+exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2 4`] = `
+"
+  <div class=\\"timerow\\" data-msg-id=\\"5287\\">
+    <div class=\\"timerow-left\\"></div>
+    Feb 19, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-5287\\"
+     data-msg-id=\\"5287\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-5309\\"
+     data-msg-id=\\"5309\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20two.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name two User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-5829\\"
+     data-msg-id=\\"5829\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+
+  <div class=\\"timerow\\" data-msg-id=\\"5963\\">
+    <div class=\\"timerow-left\\"></div>
+    Feb 26, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-5963\\"
+     data-msg-id=\\"5963\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+
+  <div class=\\"timerow\\" data-msg-id=\\"8849\\">
+    <div class=\\"timerow-left\\"></div>
+    Mar 5, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-8849\\"
+     data-msg-id=\\"8849\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+
+
+    <div
+     class=\\"message message-brief\\"
+     id=\\"msg-8917\\"
+     data-msg-id=\\"8917\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"content\\">
+    
+<div class=\\"time-container\\">
+  <div class=\\"msg-timestamp \\">
+    12:00 PM
+  </div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+</div>
+"
+`;
+
+exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2,3 1`] = `
+"
+  <div class=\\"timerow\\" data-msg-id=\\"5377\\">
+    <div class=\\"timerow-left\\"></div>
+    Feb 19, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-5377\\"
+     data-msg-id=\\"5377\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+
+
+    <div
+     class=\\"message message-brief\\"
+     id=\\"msg-5620\\"
+     data-msg-id=\\"5620\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"content\\">
+    
+<div class=\\"time-container\\">
+  <div class=\\"msg-timestamp \\">
+    12:00 PM
+  </div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+</div>
+"
+`;
+
+exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2,3 2`] = `
+"
+  <div class=\\"timerow\\" data-msg-id=\\"5637\\">
+    <div class=\\"timerow-left\\"></div>
+    Feb 19, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-5637\\"
+     data-msg-id=\\"5637\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-5727\\"
+     data-msg-id=\\"5727\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20two.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name two User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+"
+`;
+
+exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2,3 3`] = `
+"
+  <div class=\\"timerow\\" data-msg-id=\\"2794\\">
+    <div class=\\"timerow-left\\"></div>
+    Feb 5, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-2794\\"
+     data-msg-id=\\"2794\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+
+  <div class=\\"timerow\\" data-msg-id=\\"4581\\">
+    <div class=\\"timerow-left\\"></div>
+    Feb 12, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-4581\\"
+     data-msg-id=\\"4581\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+"
+`;
+
+exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2,3 4`] = `
+"
+  <div class=\\"timerow\\" data-msg-id=\\"2794\\">
+    <div class=\\"timerow-left\\"></div>
+    Feb 5, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-2794\\"
+     data-msg-id=\\"2794\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+
+  <div class=\\"timerow\\" data-msg-id=\\"4581\\">
+    <div class=\\"timerow-left\\"></div>
+    Feb 12, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-4581\\"
+     data-msg-id=\\"4581\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+
+  <div class=\\"timerow\\" data-msg-id=\\"5377\\">
+    <div class=\\"timerow-left\\"></div>
+    Feb 19, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-5377\\"
+     data-msg-id=\\"5377\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+
+
+    <div
+     class=\\"message message-brief\\"
+     id=\\"msg-5620\\"
+     data-msg-id=\\"5620\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"content\\">
+    
+<div class=\\"time-container\\">
+  <div class=\\"msg-timestamp \\">
+    12:00 PM
+  </div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+</div>
+
+
+    <div
+     class=\\"message message-brief\\"
+     id=\\"msg-5637\\"
+     data-msg-id=\\"5637\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"content\\">
+    
+<div class=\\"time-container\\">
+  <div class=\\"msg-timestamp \\">
+    12:00 PM
+  </div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+</div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-5727\\"
+     data-msg-id=\\"5727\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20two.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name two User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+"
+`;
+
+exports[`messages -> piece descriptors -> content HTML is stable/sensible stream:s:stream 1 1`] = `
+"
+  <div class=\\"timerow\\" data-msg-id=\\"1024\\">
+    <div class=\\"timerow-left\\"></div>
+    Feb 5, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+<div
+  class=\\"header-wrapper header topic-header\\"
+  data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAx\\"
+  data-msg-id=\\"1024\\"
+>
+  <div class=\\"topic-text\\">topic 1</div>
+  <div class=\\"topic-date\\">Feb 5, 1995</div>
+</div>
+    
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-1024\\"
+     data-msg-id=\\"1024\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example stream message.
+
+
+
+
+  </div>
+  
+</div>
+
+
+    <div
+     class=\\"message message-brief\\"
+     id=\\"msg-1598\\"
+     data-msg-id=\\"1598\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"content\\">
+    
+<div class=\\"time-container\\">
+  <div class=\\"msg-timestamp \\">
+    12:00 PM
+  </div>
+</div>
+
+    
+This is an example stream message.
+
+
+
+
+  </div>
+</div>
+"
+`;
+
+exports[`messages -> piece descriptors -> content HTML is stable/sensible stream:s:stream 1 2`] = `
+"
+  <div class=\\"timerow\\" data-msg-id=\\"7938\\">
+    <div class=\\"timerow-left\\"></div>
+    Mar 5, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+<div
+  class=\\"header-wrapper header topic-header\\"
+  data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAx\\"
+  data-msg-id=\\"7938\\"
+>
+  <div class=\\"topic-text\\">topic 1</div>
+  <div class=\\"topic-date\\">Mar 5, 1995</div>
+</div>
+    
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-7938\\"
+     data-msg-id=\\"7938\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example stream message.
+
+
+
+
+  </div>
+  
+</div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-8060\\"
+     data-msg-id=\\"8060\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20two.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name two User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example stream message.
+
+
+
+
+  </div>
+  
+</div>
+"
+`;
+
+exports[`messages -> piece descriptors -> content HTML is stable/sensible stream:s:stream 1 3`] = `
+"
+  <div class=\\"timerow\\" data-msg-id=\\"4948\\">
+    <div class=\\"timerow-left\\"></div>
+    Feb 19, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+<div
+  class=\\"header-wrapper header topic-header\\"
+  data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAx\\"
+  data-msg-id=\\"4948\\"
+>
+  <div class=\\"topic-text\\">topic 1</div>
+  <div class=\\"topic-date\\">Feb 19, 1995</div>
+</div>
+    
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-4948\\"
+     data-msg-id=\\"4948\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example stream message.
+
+
+
+
+  </div>
+  
+</div>
+
+<div
+  class=\\"header-wrapper header topic-header\\"
+  data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAy\\"
+  data-msg-id=\\"5083\\"
+>
+  <div class=\\"topic-text\\">topic 2</div>
+  <div class=\\"topic-date\\">Feb 19, 1995</div>
+</div>
+    
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-5083\\"
+     data-msg-id=\\"5083\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example stream message.
+
+
+
+
+  </div>
+  
+</div>
+"
+`;
+
+exports[`messages -> piece descriptors -> content HTML is stable/sensible stream:s:stream 1 4`] = `
+"
+  <div class=\\"timerow\\" data-msg-id=\\"9181\\">
+    <div class=\\"timerow-left\\"></div>
+    Mar 5, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+<div
+  class=\\"header-wrapper header topic-header\\"
+  data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAx\\"
+  data-msg-id=\\"9181\\"
+>
+  <div class=\\"topic-text\\">topic 1</div>
+  <div class=\\"topic-date\\">Mar 5, 1995</div>
+</div>
+    
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-9181\\"
+     data-msg-id=\\"9181\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example stream message.
+
+
+
+
+  </div>
+  
+</div>
+
+  <div class=\\"timerow\\" data-msg-id=\\"9815\\">
+    <div class=\\"timerow-left\\"></div>
+    Mar 12, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-9815\\"
+     data-msg-id=\\"9815\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example stream message.
+
+
+
+
+  </div>
+  
+</div>
+"
+`;
+
+exports[`messages -> piece descriptors -> content HTML is stable/sensible stream:s:stream 1 5`] = `
+"
+  <div class=\\"timerow\\" data-msg-id=\\"1024\\">
+    <div class=\\"timerow-left\\"></div>
+    Feb 5, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+<div
+  class=\\"header-wrapper header topic-header\\"
+  data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAx\\"
+  data-msg-id=\\"1024\\"
+>
+  <div class=\\"topic-text\\">topic 1</div>
+  <div class=\\"topic-date\\">Feb 5, 1995</div>
+</div>
+    
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-1024\\"
+     data-msg-id=\\"1024\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example stream message.
+
+
+
+
+  </div>
+  
+</div>
+
+
+    <div
+     class=\\"message message-brief\\"
+     id=\\"msg-1598\\"
+     data-msg-id=\\"1598\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"content\\">
+    
+<div class=\\"time-container\\">
+  <div class=\\"msg-timestamp \\">
+    12:00 PM
+  </div>
+</div>
+
+    
+This is an example stream message.
+
+
+
+
+  </div>
+</div>
+
+  <div class=\\"timerow\\" data-msg-id=\\"4948\\">
+    <div class=\\"timerow-left\\"></div>
+    Feb 19, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-4948\\"
+     data-msg-id=\\"4948\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example stream message.
+
+
+
+
+  </div>
+  
+</div>
+
+<div
+  class=\\"header-wrapper header topic-header\\"
+  data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAy\\"
+  data-msg-id=\\"5083\\"
+>
+  <div class=\\"topic-text\\">topic 2</div>
+  <div class=\\"topic-date\\">Feb 19, 1995</div>
+</div>
+    
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-5083\\"
+     data-msg-id=\\"5083\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example stream message.
+
+
+
+
+  </div>
+  
+</div>
+
+  <div class=\\"timerow\\" data-msg-id=\\"7938\\">
+    <div class=\\"timerow-left\\"></div>
+    Mar 5, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+<div
+  class=\\"header-wrapper header topic-header\\"
+  data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAx\\"
+  data-msg-id=\\"7938\\"
+>
+  <div class=\\"topic-text\\">topic 1</div>
+  <div class=\\"topic-date\\">Mar 5, 1995</div>
+</div>
+    
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-7938\\"
+     data-msg-id=\\"7938\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example stream message.
+
+
+
+
+  </div>
+  
+</div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-8060\\"
+     data-msg-id=\\"8060\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20two.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name two User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example stream message.
+
+
+
+
+  </div>
+  
+</div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-9181\\"
+     data-msg-id=\\"9181\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example stream message.
+
+
+
+
+  </div>
+  
+</div>
+
+  <div class=\\"timerow\\" data-msg-id=\\"9815\\">
+    <div class=\\"timerow-left\\"></div>
+    Mar 12, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-9815\\"
+     data-msg-id=\\"9815\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example stream message.
+
+
+
+
+  </div>
+  
+</div>
+"
+`;
+
+exports[`messages -> piece descriptors -> content HTML is stable/sensible topic:s:stream 1 topic 1 1`] = `
+"
+  <div class=\\"timerow\\" data-msg-id=\\"1024\\">
+    <div class=\\"timerow-left\\"></div>
+    Feb 5, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-1024\\"
+     data-msg-id=\\"1024\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example stream message.
+
+
+
+
+  </div>
+  
+</div>
+
+
+    <div
+     class=\\"message message-brief\\"
+     id=\\"msg-1598\\"
+     data-msg-id=\\"1598\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"content\\">
+    
+<div class=\\"time-container\\">
+  <div class=\\"msg-timestamp \\">
+    12:00 PM
+  </div>
+</div>
+
+    
+This is an example stream message.
+
+
+
+
+  </div>
+</div>
+"
+`;
+
+exports[`messages -> piece descriptors -> content HTML is stable/sensible topic:s:stream 1 topic 1 2`] = `
+"
+  <div class=\\"timerow\\" data-msg-id=\\"7938\\">
+    <div class=\\"timerow-left\\"></div>
+    Mar 5, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-7938\\"
+     data-msg-id=\\"7938\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example stream message.
+
+
+
+
+  </div>
+  
+</div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-8060\\"
+     data-msg-id=\\"8060\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20two.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name two User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example stream message.
+
+
+
+
+  </div>
+  
+</div>
+"
+`;
+
+exports[`messages -> piece descriptors -> content HTML is stable/sensible topic:s:stream 1 topic 1 3`] = `
+"
+  <div class=\\"timerow\\" data-msg-id=\\"9181\\">
+    <div class=\\"timerow-left\\"></div>
+    Mar 5, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-9181\\"
+     data-msg-id=\\"9181\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example stream message.
+
+
+
+
+  </div>
+  
+</div>
+
+  <div class=\\"timerow\\" data-msg-id=\\"9815\\">
+    <div class=\\"timerow-left\\"></div>
+    Mar 12, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-9815\\"
+     data-msg-id=\\"9815\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example stream message.
+
+
+
+
+  </div>
+  
+</div>
+"
+`;
+
+exports[`messages -> piece descriptors -> content HTML is stable/sensible topic:s:stream 1 topic 1 4`] = `
+"
+  <div class=\\"timerow\\" data-msg-id=\\"1024\\">
+    <div class=\\"timerow-left\\"></div>
+    Feb 5, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-1024\\"
+     data-msg-id=\\"1024\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example stream message.
+
+
+
+
+  </div>
+  
+</div>
+
+
+    <div
+     class=\\"message message-brief\\"
+     id=\\"msg-1598\\"
+     data-msg-id=\\"1598\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"content\\">
+    
+<div class=\\"time-container\\">
+  <div class=\\"msg-timestamp \\">
+    12:00 PM
+  </div>
+</div>
+
+    
+This is an example stream message.
+
+
+
+
+  </div>
+</div>
+
+  <div class=\\"timerow\\" data-msg-id=\\"7938\\">
+    <div class=\\"timerow-left\\"></div>
+    Mar 5, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-7938\\"
+     data-msg-id=\\"7938\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example stream message.
+
+
+
+
+  </div>
+  
+</div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-8060\\"
+     data-msg-id=\\"8060\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20two.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name two User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example stream message.
+
+
+
+
+  </div>
+  
+</div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-9181\\"
+     data-msg-id=\\"9181\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example stream message.
+
+
+
+
+  </div>
+  
+</div>
+
+  <div class=\\"timerow\\" data-msg-id=\\"9815\\">
+    <div class=\\"timerow-left\\"></div>
+    Mar 12, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-9815\\"
+     data-msg-id=\\"9815\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example stream message.
+
+
+
+
+  </div>
+  
+</div>
+"
+`;

--- a/src/webview/html/__tests__/__snapshots__/contentHtmlFromPieceDescriptors-test.js.snap.android
+++ b/src/webview/html/__tests__/__snapshots__/contentHtmlFromPieceDescriptors-test.js.snap.android
@@ -455,7 +455,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
      data-msg-id=\\"8849\\">
   Nonrandom name one User, Nonrandom name two User
 </div>
-    
+
 
     <div
      class=\\"message message-full\\"
@@ -526,7 +526,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
      data-msg-id=\\"5287\\">
   Nonrandom name one User, Nonrandom name two User
 </div>
-    
+
 
     <div
      class=\\"message message-full\\"
@@ -602,7 +602,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
      data-msg-id=\\"5829\\">
   Nonrandom name one User, Nonrandom name two User
 </div>
-    
+
 
     <div
      class=\\"message message-full\\"
@@ -684,7 +684,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
      data-msg-id=\\"5377\\">
   Nonrandom name one User, Nonrandom name three User, Nonrandom name two User
 </div>
-    
+
 
     <div
      class=\\"message message-full\\"
@@ -755,7 +755,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
      data-msg-id=\\"5637\\">
   Nonrandom name one User, Nonrandom name three User, Nonrandom name two User
 </div>
-    
+
 
     <div
      class=\\"message message-full\\"
@@ -831,7 +831,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
      data-msg-id=\\"2794\\">
   Nonrandom name one User, Nonrandom name three User, Nonrandom name two User
 </div>
-    
+
 
     <div
      class=\\"message message-full\\"
@@ -981,7 +981,7 @@ This is an example stream message.
      data-msg-id=\\"2794\\">
   Nonrandom name one User, Nonrandom name three User, Nonrandom name two User
 </div>
-    
+
 
     <div
      class=\\"message message-full\\"
@@ -1145,7 +1145,7 @@ This is an example stream message.
      data-msg-id=\\"5287\\">
   Nonrandom name one User, Nonrandom name two User
 </div>
-    
+
 
     <div
      class=\\"message message-full\\"
@@ -1211,7 +1211,7 @@ This is an example PM message.
      data-msg-id=\\"5377\\">
   Nonrandom name one User, Nonrandom name three User, Nonrandom name two User
 </div>
-    
+
 
     <div
      class=\\"message message-full\\"
@@ -1327,7 +1327,7 @@ This is an example PM message.
      data-msg-id=\\"5829\\">
   Nonrandom name one User, Nonrandom name two User
 </div>
-    
+
 
     <div
      class=\\"message message-full\\"
@@ -1564,7 +1564,7 @@ This is an example stream message.
      data-msg-id=\\"8849\\">
   Nonrandom name one User, Nonrandom name two User
 </div>
-    
+
 
     <div
      class=\\"message message-full\\"
@@ -1714,7 +1714,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm
      data-msg-id=\\"8849\\">
   Nonrandom name one User, Nonrandom name two User
 </div>
-    
+
 
     <div
      class=\\"message message-full\\"
@@ -1785,7 +1785,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm
      data-msg-id=\\"5287\\">
   Nonrandom name one User, Nonrandom name two User
 </div>
-    
+
 
     <div
      class=\\"message message-full\\"
@@ -1861,7 +1861,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm
      data-msg-id=\\"5829\\">
   Nonrandom name one User, Nonrandom name two User
 </div>
-    
+
 
     <div
      class=\\"message message-full\\"
@@ -1943,7 +1943,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm
      data-msg-id=\\"5377\\">
   Nonrandom name one User, Nonrandom name three User, Nonrandom name two User
 </div>
-    
+
 
     <div
      class=\\"message message-full\\"
@@ -2014,7 +2014,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm
      data-msg-id=\\"5637\\">
   Nonrandom name one User, Nonrandom name three User, Nonrandom name two User
 </div>
-    
+
 
     <div
      class=\\"message message-full\\"
@@ -2090,7 +2090,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm
      data-msg-id=\\"2794\\">
   Nonrandom name one User, Nonrandom name three User, Nonrandom name two User
 </div>
-    
+
 
     <div
      class=\\"message message-full\\"
@@ -2172,7 +2172,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm
      data-msg-id=\\"2794\\">
   Nonrandom name one User, Nonrandom name three User, Nonrandom name two User
 </div>
-    
+
 
     <div
      class=\\"message message-full\\"
@@ -2250,7 +2250,7 @@ This is an example PM message.
      data-msg-id=\\"5287\\">
   Nonrandom name one User, Nonrandom name two User
 </div>
-    
+
 
     <div
      class=\\"message message-full\\"
@@ -2316,7 +2316,7 @@ This is an example PM message.
      data-msg-id=\\"5377\\">
   Nonrandom name one User, Nonrandom name three User, Nonrandom name two User
 </div>
-    
+
 
     <div
      class=\\"message message-full\\"
@@ -2432,7 +2432,7 @@ This is an example PM message.
      data-msg-id=\\"5829\\">
   Nonrandom name one User, Nonrandom name two User
 </div>
-    
+
 
     <div
      class=\\"message message-full\\"

--- a/src/webview/html/__tests__/__snapshots__/contentHtmlFromPieceDescriptors-test.js.snap.ios
+++ b/src/webview/html/__tests__/__snapshots__/contentHtmlFromPieceDescriptors-test.js.snap.ios
@@ -1,0 +1,4398 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_NARROW 1`] = `
+"
+  <div class=\\"timerow\\" data-msg-id=\\"1024\\">
+    <div class=\\"timerow-left\\"></div>
+    Feb 5, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+<div class=\\"header-wrapper header stream-header topic-header\\"
+    data-msg-id=\\"1024\\"
+    data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAx\\">
+  <div class=\\"header stream-text\\"
+       style=\\"color: black;
+              background: hsl(0, 0%, 80%)\\"
+       data-narrow=\\"c3RyZWFtOnM6c3RyZWFtIDE=\\">
+    # stream 1
+  </div>
+  <div class=\\"topic-text\\">topic 1</div>
+  <div class=\\"topic-date\\">Feb 5, 1995</div>
+</div>
+    
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-1024\\"
+     data-msg-id=\\"1024\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example stream message.
+
+
+
+
+  </div>
+  
+</div>
+
+
+    <div
+     class=\\"message message-brief\\"
+     id=\\"msg-1598\\"
+     data-msg-id=\\"1598\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"content\\">
+    
+<div class=\\"time-container\\">
+  <div class=\\"msg-timestamp \\">
+    12:00 PM
+  </div>
+</div>
+
+    
+This is an example stream message.
+
+
+
+
+  </div>
+</div>
+"
+`;
+
+exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_NARROW 2`] = `
+"
+  <div class=\\"timerow\\" data-msg-id=\\"7938\\">
+    <div class=\\"timerow-left\\"></div>
+    Mar 5, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+<div class=\\"header-wrapper header stream-header topic-header\\"
+    data-msg-id=\\"7938\\"
+    data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAx\\">
+  <div class=\\"header stream-text\\"
+       style=\\"color: black;
+              background: hsl(0, 0%, 80%)\\"
+       data-narrow=\\"c3RyZWFtOnM6c3RyZWFtIDE=\\">
+    # stream 1
+  </div>
+  <div class=\\"topic-text\\">topic 1</div>
+  <div class=\\"topic-date\\">Mar 5, 1995</div>
+</div>
+    
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-7938\\"
+     data-msg-id=\\"7938\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example stream message.
+
+
+
+
+  </div>
+  
+</div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-8060\\"
+     data-msg-id=\\"8060\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20two.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name two User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example stream message.
+
+
+
+
+  </div>
+  
+</div>
+"
+`;
+
+exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_NARROW 3`] = `
+"
+  <div class=\\"timerow\\" data-msg-id=\\"4948\\">
+    <div class=\\"timerow-left\\"></div>
+    Feb 19, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+<div class=\\"header-wrapper header stream-header topic-header\\"
+    data-msg-id=\\"4948\\"
+    data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAx\\">
+  <div class=\\"header stream-text\\"
+       style=\\"color: black;
+              background: hsl(0, 0%, 80%)\\"
+       data-narrow=\\"c3RyZWFtOnM6c3RyZWFtIDE=\\">
+    # stream 1
+  </div>
+  <div class=\\"topic-text\\">topic 1</div>
+  <div class=\\"topic-date\\">Feb 19, 1995</div>
+</div>
+    
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-4948\\"
+     data-msg-id=\\"4948\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example stream message.
+
+
+
+
+  </div>
+  
+</div>
+
+<div class=\\"header-wrapper header stream-header topic-header\\"
+    data-msg-id=\\"5083\\"
+    data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAy\\">
+  <div class=\\"header stream-text\\"
+       style=\\"color: black;
+              background: hsl(0, 0%, 80%)\\"
+       data-narrow=\\"c3RyZWFtOnM6c3RyZWFtIDE=\\">
+    # stream 1
+  </div>
+  <div class=\\"topic-text\\">topic 2</div>
+  <div class=\\"topic-date\\">Feb 19, 1995</div>
+</div>
+    
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-5083\\"
+     data-msg-id=\\"5083\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example stream message.
+
+
+
+
+  </div>
+  
+</div>
+"
+`;
+
+exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_NARROW 4`] = `
+"
+  <div class=\\"timerow\\" data-msg-id=\\"6789\\">
+    <div class=\\"timerow-left\\"></div>
+    Mar 5, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+<div class=\\"header-wrapper header stream-header topic-header\\"
+    data-msg-id=\\"6789\\"
+    data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAx\\">
+  <div class=\\"header stream-text\\"
+       style=\\"color: black;
+              background: hsl(0, 0%, 80%)\\"
+       data-narrow=\\"c3RyZWFtOnM6c3RyZWFtIDE=\\">
+    # stream 1
+  </div>
+  <div class=\\"topic-text\\">topic 1</div>
+  <div class=\\"topic-date\\">Mar 5, 1995</div>
+</div>
+    
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-6789\\"
+     data-msg-id=\\"6789\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example stream message.
+
+
+
+
+  </div>
+  
+</div>
+
+<div class=\\"header-wrapper header stream-header topic-header\\"
+    data-msg-id=\\"7727\\"
+    data-narrow=\\"dG9waWM6czpzdHJlYW0gMgB0b3BpYyAy\\">
+  <div class=\\"header stream-text\\"
+       style=\\"color: black;
+              background: hsl(0, 0%, 80%)\\"
+       data-narrow=\\"c3RyZWFtOnM6c3RyZWFtIDI=\\">
+    # stream 2
+  </div>
+  <div class=\\"topic-text\\">topic 2</div>
+  <div class=\\"topic-date\\">Mar 5, 1995</div>
+</div>
+    
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-7727\\"
+     data-msg-id=\\"7727\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example stream message.
+
+
+
+
+  </div>
+  
+</div>
+"
+`;
+
+exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_NARROW 5`] = `
+"
+  <div class=\\"timerow\\" data-msg-id=\\"9181\\">
+    <div class=\\"timerow-left\\"></div>
+    Mar 5, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+<div class=\\"header-wrapper header stream-header topic-header\\"
+    data-msg-id=\\"9181\\"
+    data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAx\\">
+  <div class=\\"header stream-text\\"
+       style=\\"color: black;
+              background: hsl(0, 0%, 80%)\\"
+       data-narrow=\\"c3RyZWFtOnM6c3RyZWFtIDE=\\">
+    # stream 1
+  </div>
+  <div class=\\"topic-text\\">topic 1</div>
+  <div class=\\"topic-date\\">Mar 5, 1995</div>
+</div>
+    
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-9181\\"
+     data-msg-id=\\"9181\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example stream message.
+
+
+
+
+  </div>
+  
+</div>
+
+  <div class=\\"timerow\\" data-msg-id=\\"9815\\">
+    <div class=\\"timerow-left\\"></div>
+    Mar 12, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-9815\\"
+     data-msg-id=\\"9815\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example stream message.
+
+
+
+
+  </div>
+  
+</div>
+"
+`;
+
+exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_NARROW 6`] = `
+"
+  <div class=\\"timerow\\" data-msg-id=\\"8849\\">
+    <div class=\\"timerow-left\\"></div>
+    Mar 5, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+<div class=\\"header-wrapper private-header header\\"
+     data-narrow=\\"cG06MSwy\\"
+     data-msg-id=\\"8849\\">
+  Nonrandom name one User, Nonrandom name two User
+</div>
+    
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-8849\\"
+     data-msg-id=\\"8849\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+
+
+    <div
+     class=\\"message message-brief\\"
+     id=\\"msg-8917\\"
+     data-msg-id=\\"8917\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"content\\">
+    
+<div class=\\"time-container\\">
+  <div class=\\"msg-timestamp \\">
+    12:00 PM
+  </div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+</div>
+"
+`;
+
+exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_NARROW 7`] = `
+"
+  <div class=\\"timerow\\" data-msg-id=\\"5287\\">
+    <div class=\\"timerow-left\\"></div>
+    Feb 19, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+<div class=\\"header-wrapper private-header header\\"
+     data-narrow=\\"cG06MSwy\\"
+     data-msg-id=\\"5287\\">
+  Nonrandom name one User, Nonrandom name two User
+</div>
+    
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-5287\\"
+     data-msg-id=\\"5287\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-5309\\"
+     data-msg-id=\\"5309\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20two.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name two User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+"
+`;
+
+exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_NARROW 8`] = `
+"
+  <div class=\\"timerow\\" data-msg-id=\\"5829\\">
+    <div class=\\"timerow-left\\"></div>
+    Feb 19, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+<div class=\\"header-wrapper private-header header\\"
+     data-narrow=\\"cG06MSwy\\"
+     data-msg-id=\\"5829\\">
+  Nonrandom name one User, Nonrandom name two User
+</div>
+    
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-5829\\"
+     data-msg-id=\\"5829\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+
+  <div class=\\"timerow\\" data-msg-id=\\"5963\\">
+    <div class=\\"timerow-left\\"></div>
+    Feb 26, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-5963\\"
+     data-msg-id=\\"5963\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+"
+`;
+
+exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_NARROW 9`] = `
+"
+  <div class=\\"timerow\\" data-msg-id=\\"5377\\">
+    <div class=\\"timerow-left\\"></div>
+    Feb 19, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+<div class=\\"header-wrapper private-header header\\"
+     data-narrow=\\"cG06MSwyLDM=\\"
+     data-msg-id=\\"5377\\">
+  Nonrandom name one User, Nonrandom name three User, Nonrandom name two User
+</div>
+    
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-5377\\"
+     data-msg-id=\\"5377\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+
+
+    <div
+     class=\\"message message-brief\\"
+     id=\\"msg-5620\\"
+     data-msg-id=\\"5620\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"content\\">
+    
+<div class=\\"time-container\\">
+  <div class=\\"msg-timestamp \\">
+    12:00 PM
+  </div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+</div>
+"
+`;
+
+exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_NARROW 10`] = `
+"
+  <div class=\\"timerow\\" data-msg-id=\\"5637\\">
+    <div class=\\"timerow-left\\"></div>
+    Feb 19, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+<div class=\\"header-wrapper private-header header\\"
+     data-narrow=\\"cG06MSwyLDM=\\"
+     data-msg-id=\\"5637\\">
+  Nonrandom name one User, Nonrandom name three User, Nonrandom name two User
+</div>
+    
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-5637\\"
+     data-msg-id=\\"5637\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-5727\\"
+     data-msg-id=\\"5727\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20two.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name two User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+"
+`;
+
+exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_NARROW 11`] = `
+"
+  <div class=\\"timerow\\" data-msg-id=\\"2794\\">
+    <div class=\\"timerow-left\\"></div>
+    Feb 5, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+<div class=\\"header-wrapper private-header header\\"
+     data-narrow=\\"cG06MSwyLDM=\\"
+     data-msg-id=\\"2794\\">
+  Nonrandom name one User, Nonrandom name three User, Nonrandom name two User
+</div>
+    
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-2794\\"
+     data-msg-id=\\"2794\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+
+  <div class=\\"timerow\\" data-msg-id=\\"4581\\">
+    <div class=\\"timerow-left\\"></div>
+    Feb 12, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-4581\\"
+     data-msg-id=\\"4581\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+"
+`;
+
+exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_NARROW 12`] = `
+"
+  <div class=\\"timerow\\" data-msg-id=\\"1024\\">
+    <div class=\\"timerow-left\\"></div>
+    Feb 5, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+<div class=\\"header-wrapper header stream-header topic-header\\"
+    data-msg-id=\\"1024\\"
+    data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAx\\">
+  <div class=\\"header stream-text\\"
+       style=\\"color: black;
+              background: hsl(0, 0%, 80%)\\"
+       data-narrow=\\"c3RyZWFtOnM6c3RyZWFtIDE=\\">
+    # stream 1
+  </div>
+  <div class=\\"topic-text\\">topic 1</div>
+  <div class=\\"topic-date\\">Feb 5, 1995</div>
+</div>
+    
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-1024\\"
+     data-msg-id=\\"1024\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example stream message.
+
+
+
+
+  </div>
+  
+</div>
+
+
+    <div
+     class=\\"message message-brief\\"
+     id=\\"msg-1598\\"
+     data-msg-id=\\"1598\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"content\\">
+    
+<div class=\\"time-container\\">
+  <div class=\\"msg-timestamp \\">
+    12:00 PM
+  </div>
+</div>
+
+    
+This is an example stream message.
+
+
+
+
+  </div>
+</div>
+
+<div class=\\"header-wrapper private-header header\\"
+     data-narrow=\\"cG06MSwyLDM=\\"
+     data-msg-id=\\"2794\\">
+  Nonrandom name one User, Nonrandom name three User, Nonrandom name two User
+</div>
+    
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-2794\\"
+     data-msg-id=\\"2794\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+
+  <div class=\\"timerow\\" data-msg-id=\\"4581\\">
+    <div class=\\"timerow-left\\"></div>
+    Feb 12, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-4581\\"
+     data-msg-id=\\"4581\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+
+  <div class=\\"timerow\\" data-msg-id=\\"4948\\">
+    <div class=\\"timerow-left\\"></div>
+    Feb 19, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+<div class=\\"header-wrapper header stream-header topic-header\\"
+    data-msg-id=\\"4948\\"
+    data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAx\\">
+  <div class=\\"header stream-text\\"
+       style=\\"color: black;
+              background: hsl(0, 0%, 80%)\\"
+       data-narrow=\\"c3RyZWFtOnM6c3RyZWFtIDE=\\">
+    # stream 1
+  </div>
+  <div class=\\"topic-text\\">topic 1</div>
+  <div class=\\"topic-date\\">Feb 19, 1995</div>
+</div>
+    
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-4948\\"
+     data-msg-id=\\"4948\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example stream message.
+
+
+
+
+  </div>
+  
+</div>
+
+<div class=\\"header-wrapper header stream-header topic-header\\"
+    data-msg-id=\\"5083\\"
+    data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAy\\">
+  <div class=\\"header stream-text\\"
+       style=\\"color: black;
+              background: hsl(0, 0%, 80%)\\"
+       data-narrow=\\"c3RyZWFtOnM6c3RyZWFtIDE=\\">
+    # stream 1
+  </div>
+  <div class=\\"topic-text\\">topic 2</div>
+  <div class=\\"topic-date\\">Feb 19, 1995</div>
+</div>
+    
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-5083\\"
+     data-msg-id=\\"5083\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example stream message.
+
+
+
+
+  </div>
+  
+</div>
+
+<div class=\\"header-wrapper private-header header\\"
+     data-narrow=\\"cG06MSwy\\"
+     data-msg-id=\\"5287\\">
+  Nonrandom name one User, Nonrandom name two User
+</div>
+    
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-5287\\"
+     data-msg-id=\\"5287\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-5309\\"
+     data-msg-id=\\"5309\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20two.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name two User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+
+<div class=\\"header-wrapper private-header header\\"
+     data-narrow=\\"cG06MSwyLDM=\\"
+     data-msg-id=\\"5377\\">
+  Nonrandom name one User, Nonrandom name three User, Nonrandom name two User
+</div>
+    
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-5377\\"
+     data-msg-id=\\"5377\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+
+
+    <div
+     class=\\"message message-brief\\"
+     id=\\"msg-5620\\"
+     data-msg-id=\\"5620\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"content\\">
+    
+<div class=\\"time-container\\">
+  <div class=\\"msg-timestamp \\">
+    12:00 PM
+  </div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+</div>
+
+
+    <div
+     class=\\"message message-brief\\"
+     id=\\"msg-5637\\"
+     data-msg-id=\\"5637\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"content\\">
+    
+<div class=\\"time-container\\">
+  <div class=\\"msg-timestamp \\">
+    12:00 PM
+  </div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+</div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-5727\\"
+     data-msg-id=\\"5727\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20two.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name two User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+
+<div class=\\"header-wrapper private-header header\\"
+     data-narrow=\\"cG06MSwy\\"
+     data-msg-id=\\"5829\\">
+  Nonrandom name one User, Nonrandom name two User
+</div>
+    
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-5829\\"
+     data-msg-id=\\"5829\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+
+  <div class=\\"timerow\\" data-msg-id=\\"5963\\">
+    <div class=\\"timerow-left\\"></div>
+    Feb 26, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-5963\\"
+     data-msg-id=\\"5963\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+
+  <div class=\\"timerow\\" data-msg-id=\\"6789\\">
+    <div class=\\"timerow-left\\"></div>
+    Mar 5, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+<div class=\\"header-wrapper header stream-header topic-header\\"
+    data-msg-id=\\"6789\\"
+    data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAx\\">
+  <div class=\\"header stream-text\\"
+       style=\\"color: black;
+              background: hsl(0, 0%, 80%)\\"
+       data-narrow=\\"c3RyZWFtOnM6c3RyZWFtIDE=\\">
+    # stream 1
+  </div>
+  <div class=\\"topic-text\\">topic 1</div>
+  <div class=\\"topic-date\\">Mar 5, 1995</div>
+</div>
+    
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-6789\\"
+     data-msg-id=\\"6789\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example stream message.
+
+
+
+
+  </div>
+  
+</div>
+
+<div class=\\"header-wrapper header stream-header topic-header\\"
+    data-msg-id=\\"7727\\"
+    data-narrow=\\"dG9waWM6czpzdHJlYW0gMgB0b3BpYyAy\\">
+  <div class=\\"header stream-text\\"
+       style=\\"color: black;
+              background: hsl(0, 0%, 80%)\\"
+       data-narrow=\\"c3RyZWFtOnM6c3RyZWFtIDI=\\">
+    # stream 2
+  </div>
+  <div class=\\"topic-text\\">topic 2</div>
+  <div class=\\"topic-date\\">Mar 5, 1995</div>
+</div>
+    
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-7727\\"
+     data-msg-id=\\"7727\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example stream message.
+
+
+
+
+  </div>
+  
+</div>
+
+<div class=\\"header-wrapper header stream-header topic-header\\"
+    data-msg-id=\\"7938\\"
+    data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAx\\">
+  <div class=\\"header stream-text\\"
+       style=\\"color: black;
+              background: hsl(0, 0%, 80%)\\"
+       data-narrow=\\"c3RyZWFtOnM6c3RyZWFtIDE=\\">
+    # stream 1
+  </div>
+  <div class=\\"topic-text\\">topic 1</div>
+  <div class=\\"topic-date\\">Mar 5, 1995</div>
+</div>
+    
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-7938\\"
+     data-msg-id=\\"7938\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example stream message.
+
+
+
+
+  </div>
+  
+</div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-8060\\"
+     data-msg-id=\\"8060\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20two.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name two User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example stream message.
+
+
+
+
+  </div>
+  
+</div>
+
+<div class=\\"header-wrapper private-header header\\"
+     data-narrow=\\"cG06MSwy\\"
+     data-msg-id=\\"8849\\">
+  Nonrandom name one User, Nonrandom name two User
+</div>
+    
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-8849\\"
+     data-msg-id=\\"8849\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+
+
+    <div
+     class=\\"message message-brief\\"
+     id=\\"msg-8917\\"
+     data-msg-id=\\"8917\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"content\\">
+    
+<div class=\\"time-container\\">
+  <div class=\\"msg-timestamp \\">
+    12:00 PM
+  </div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+</div>
+
+<div class=\\"header-wrapper header stream-header topic-header\\"
+    data-msg-id=\\"9181\\"
+    data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAx\\">
+  <div class=\\"header stream-text\\"
+       style=\\"color: black;
+              background: hsl(0, 0%, 80%)\\"
+       data-narrow=\\"c3RyZWFtOnM6c3RyZWFtIDE=\\">
+    # stream 1
+  </div>
+  <div class=\\"topic-text\\">topic 1</div>
+  <div class=\\"topic-date\\">Mar 5, 1995</div>
+</div>
+    
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-9181\\"
+     data-msg-id=\\"9181\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example stream message.
+
+
+
+
+  </div>
+  
+</div>
+
+  <div class=\\"timerow\\" data-msg-id=\\"9815\\">
+    <div class=\\"timerow-left\\"></div>
+    Mar 12, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-9815\\"
+     data-msg-id=\\"9815\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example stream message.
+
+
+
+
+  </div>
+  
+</div>
+"
+`;
+
+exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm 1`] = `
+"
+  <div class=\\"timerow\\" data-msg-id=\\"8849\\">
+    <div class=\\"timerow-left\\"></div>
+    Mar 5, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+<div class=\\"header-wrapper private-header header\\"
+     data-narrow=\\"cG06MSwy\\"
+     data-msg-id=\\"8849\\">
+  Nonrandom name one User, Nonrandom name two User
+</div>
+    
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-8849\\"
+     data-msg-id=\\"8849\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+
+
+    <div
+     class=\\"message message-brief\\"
+     id=\\"msg-8917\\"
+     data-msg-id=\\"8917\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"content\\">
+    
+<div class=\\"time-container\\">
+  <div class=\\"msg-timestamp \\">
+    12:00 PM
+  </div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+</div>
+"
+`;
+
+exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm 2`] = `
+"
+  <div class=\\"timerow\\" data-msg-id=\\"5287\\">
+    <div class=\\"timerow-left\\"></div>
+    Feb 19, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+<div class=\\"header-wrapper private-header header\\"
+     data-narrow=\\"cG06MSwy\\"
+     data-msg-id=\\"5287\\">
+  Nonrandom name one User, Nonrandom name two User
+</div>
+    
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-5287\\"
+     data-msg-id=\\"5287\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-5309\\"
+     data-msg-id=\\"5309\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20two.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name two User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+"
+`;
+
+exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm 3`] = `
+"
+  <div class=\\"timerow\\" data-msg-id=\\"5829\\">
+    <div class=\\"timerow-left\\"></div>
+    Feb 19, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+<div class=\\"header-wrapper private-header header\\"
+     data-narrow=\\"cG06MSwy\\"
+     data-msg-id=\\"5829\\">
+  Nonrandom name one User, Nonrandom name two User
+</div>
+    
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-5829\\"
+     data-msg-id=\\"5829\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+
+  <div class=\\"timerow\\" data-msg-id=\\"5963\\">
+    <div class=\\"timerow-left\\"></div>
+    Feb 26, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-5963\\"
+     data-msg-id=\\"5963\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+"
+`;
+
+exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm 4`] = `
+"
+  <div class=\\"timerow\\" data-msg-id=\\"5377\\">
+    <div class=\\"timerow-left\\"></div>
+    Feb 19, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+<div class=\\"header-wrapper private-header header\\"
+     data-narrow=\\"cG06MSwyLDM=\\"
+     data-msg-id=\\"5377\\">
+  Nonrandom name one User, Nonrandom name three User, Nonrandom name two User
+</div>
+    
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-5377\\"
+     data-msg-id=\\"5377\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+
+
+    <div
+     class=\\"message message-brief\\"
+     id=\\"msg-5620\\"
+     data-msg-id=\\"5620\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"content\\">
+    
+<div class=\\"time-container\\">
+  <div class=\\"msg-timestamp \\">
+    12:00 PM
+  </div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+</div>
+"
+`;
+
+exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm 5`] = `
+"
+  <div class=\\"timerow\\" data-msg-id=\\"5637\\">
+    <div class=\\"timerow-left\\"></div>
+    Feb 19, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+<div class=\\"header-wrapper private-header header\\"
+     data-narrow=\\"cG06MSwyLDM=\\"
+     data-msg-id=\\"5637\\">
+  Nonrandom name one User, Nonrandom name three User, Nonrandom name two User
+</div>
+    
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-5637\\"
+     data-msg-id=\\"5637\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-5727\\"
+     data-msg-id=\\"5727\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20two.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name two User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+"
+`;
+
+exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm 6`] = `
+"
+  <div class=\\"timerow\\" data-msg-id=\\"2794\\">
+    <div class=\\"timerow-left\\"></div>
+    Feb 5, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+<div class=\\"header-wrapper private-header header\\"
+     data-narrow=\\"cG06MSwyLDM=\\"
+     data-msg-id=\\"2794\\">
+  Nonrandom name one User, Nonrandom name three User, Nonrandom name two User
+</div>
+    
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-2794\\"
+     data-msg-id=\\"2794\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+
+  <div class=\\"timerow\\" data-msg-id=\\"4581\\">
+    <div class=\\"timerow-left\\"></div>
+    Feb 12, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-4581\\"
+     data-msg-id=\\"4581\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+"
+`;
+
+exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm 7`] = `
+"
+  <div class=\\"timerow\\" data-msg-id=\\"2794\\">
+    <div class=\\"timerow-left\\"></div>
+    Feb 5, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+<div class=\\"header-wrapper private-header header\\"
+     data-narrow=\\"cG06MSwyLDM=\\"
+     data-msg-id=\\"2794\\">
+  Nonrandom name one User, Nonrandom name three User, Nonrandom name two User
+</div>
+    
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-2794\\"
+     data-msg-id=\\"2794\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+
+  <div class=\\"timerow\\" data-msg-id=\\"4581\\">
+    <div class=\\"timerow-left\\"></div>
+    Feb 12, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-4581\\"
+     data-msg-id=\\"4581\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+
+  <div class=\\"timerow\\" data-msg-id=\\"5287\\">
+    <div class=\\"timerow-left\\"></div>
+    Feb 19, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+<div class=\\"header-wrapper private-header header\\"
+     data-narrow=\\"cG06MSwy\\"
+     data-msg-id=\\"5287\\">
+  Nonrandom name one User, Nonrandom name two User
+</div>
+    
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-5287\\"
+     data-msg-id=\\"5287\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-5309\\"
+     data-msg-id=\\"5309\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20two.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name two User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+
+<div class=\\"header-wrapper private-header header\\"
+     data-narrow=\\"cG06MSwyLDM=\\"
+     data-msg-id=\\"5377\\">
+  Nonrandom name one User, Nonrandom name three User, Nonrandom name two User
+</div>
+    
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-5377\\"
+     data-msg-id=\\"5377\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+
+
+    <div
+     class=\\"message message-brief\\"
+     id=\\"msg-5620\\"
+     data-msg-id=\\"5620\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"content\\">
+    
+<div class=\\"time-container\\">
+  <div class=\\"msg-timestamp \\">
+    12:00 PM
+  </div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+</div>
+
+
+    <div
+     class=\\"message message-brief\\"
+     id=\\"msg-5637\\"
+     data-msg-id=\\"5637\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"content\\">
+    
+<div class=\\"time-container\\">
+  <div class=\\"msg-timestamp \\">
+    12:00 PM
+  </div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+</div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-5727\\"
+     data-msg-id=\\"5727\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20two.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name two User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+
+<div class=\\"header-wrapper private-header header\\"
+     data-narrow=\\"cG06MSwy\\"
+     data-msg-id=\\"5829\\">
+  Nonrandom name one User, Nonrandom name two User
+</div>
+    
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-5829\\"
+     data-msg-id=\\"5829\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+
+  <div class=\\"timerow\\" data-msg-id=\\"5963\\">
+    <div class=\\"timerow-left\\"></div>
+    Feb 26, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-5963\\"
+     data-msg-id=\\"5963\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+
+  <div class=\\"timerow\\" data-msg-id=\\"8849\\">
+    <div class=\\"timerow-left\\"></div>
+    Mar 5, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-8849\\"
+     data-msg-id=\\"8849\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+
+
+    <div
+     class=\\"message message-brief\\"
+     id=\\"msg-8917\\"
+     data-msg-id=\\"8917\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"content\\">
+    
+<div class=\\"time-container\\">
+  <div class=\\"msg-timestamp \\">
+    12:00 PM
+  </div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+</div>
+"
+`;
+
+exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2 1`] = `
+"
+  <div class=\\"timerow\\" data-msg-id=\\"8849\\">
+    <div class=\\"timerow-left\\"></div>
+    Mar 5, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-8849\\"
+     data-msg-id=\\"8849\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+
+
+    <div
+     class=\\"message message-brief\\"
+     id=\\"msg-8917\\"
+     data-msg-id=\\"8917\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"content\\">
+    
+<div class=\\"time-container\\">
+  <div class=\\"msg-timestamp \\">
+    12:00 PM
+  </div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+</div>
+"
+`;
+
+exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2 2`] = `
+"
+  <div class=\\"timerow\\" data-msg-id=\\"5287\\">
+    <div class=\\"timerow-left\\"></div>
+    Feb 19, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-5287\\"
+     data-msg-id=\\"5287\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-5309\\"
+     data-msg-id=\\"5309\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20two.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name two User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+"
+`;
+
+exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2 3`] = `
+"
+  <div class=\\"timerow\\" data-msg-id=\\"5829\\">
+    <div class=\\"timerow-left\\"></div>
+    Feb 19, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-5829\\"
+     data-msg-id=\\"5829\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+
+  <div class=\\"timerow\\" data-msg-id=\\"5963\\">
+    <div class=\\"timerow-left\\"></div>
+    Feb 26, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-5963\\"
+     data-msg-id=\\"5963\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+"
+`;
+
+exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2 4`] = `
+"
+  <div class=\\"timerow\\" data-msg-id=\\"5287\\">
+    <div class=\\"timerow-left\\"></div>
+    Feb 19, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-5287\\"
+     data-msg-id=\\"5287\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-5309\\"
+     data-msg-id=\\"5309\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20two.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name two User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-5829\\"
+     data-msg-id=\\"5829\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+
+  <div class=\\"timerow\\" data-msg-id=\\"5963\\">
+    <div class=\\"timerow-left\\"></div>
+    Feb 26, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-5963\\"
+     data-msg-id=\\"5963\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+
+  <div class=\\"timerow\\" data-msg-id=\\"8849\\">
+    <div class=\\"timerow-left\\"></div>
+    Mar 5, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-8849\\"
+     data-msg-id=\\"8849\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+
+
+    <div
+     class=\\"message message-brief\\"
+     id=\\"msg-8917\\"
+     data-msg-id=\\"8917\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"content\\">
+    
+<div class=\\"time-container\\">
+  <div class=\\"msg-timestamp \\">
+    12:00 PM
+  </div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+</div>
+"
+`;
+
+exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2,3 1`] = `
+"
+  <div class=\\"timerow\\" data-msg-id=\\"5377\\">
+    <div class=\\"timerow-left\\"></div>
+    Feb 19, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-5377\\"
+     data-msg-id=\\"5377\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+
+
+    <div
+     class=\\"message message-brief\\"
+     id=\\"msg-5620\\"
+     data-msg-id=\\"5620\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"content\\">
+    
+<div class=\\"time-container\\">
+  <div class=\\"msg-timestamp \\">
+    12:00 PM
+  </div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+</div>
+"
+`;
+
+exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2,3 2`] = `
+"
+  <div class=\\"timerow\\" data-msg-id=\\"5637\\">
+    <div class=\\"timerow-left\\"></div>
+    Feb 19, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-5637\\"
+     data-msg-id=\\"5637\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-5727\\"
+     data-msg-id=\\"5727\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20two.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name two User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+"
+`;
+
+exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2,3 3`] = `
+"
+  <div class=\\"timerow\\" data-msg-id=\\"2794\\">
+    <div class=\\"timerow-left\\"></div>
+    Feb 5, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-2794\\"
+     data-msg-id=\\"2794\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+
+  <div class=\\"timerow\\" data-msg-id=\\"4581\\">
+    <div class=\\"timerow-left\\"></div>
+    Feb 12, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-4581\\"
+     data-msg-id=\\"4581\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+"
+`;
+
+exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2,3 4`] = `
+"
+  <div class=\\"timerow\\" data-msg-id=\\"2794\\">
+    <div class=\\"timerow-left\\"></div>
+    Feb 5, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-2794\\"
+     data-msg-id=\\"2794\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+
+  <div class=\\"timerow\\" data-msg-id=\\"4581\\">
+    <div class=\\"timerow-left\\"></div>
+    Feb 12, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-4581\\"
+     data-msg-id=\\"4581\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+
+  <div class=\\"timerow\\" data-msg-id=\\"5377\\">
+    <div class=\\"timerow-left\\"></div>
+    Feb 19, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-5377\\"
+     data-msg-id=\\"5377\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+
+
+    <div
+     class=\\"message message-brief\\"
+     id=\\"msg-5620\\"
+     data-msg-id=\\"5620\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"content\\">
+    
+<div class=\\"time-container\\">
+  <div class=\\"msg-timestamp \\">
+    12:00 PM
+  </div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+</div>
+
+
+    <div
+     class=\\"message message-brief\\"
+     id=\\"msg-5637\\"
+     data-msg-id=\\"5637\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"content\\">
+    
+<div class=\\"time-container\\">
+  <div class=\\"msg-timestamp \\">
+    12:00 PM
+  </div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+</div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-5727\\"
+     data-msg-id=\\"5727\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20two.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name two User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example PM message.
+
+
+
+
+  </div>
+  
+</div>
+"
+`;
+
+exports[`messages -> piece descriptors -> content HTML is stable/sensible stream:s:stream 1 1`] = `
+"
+  <div class=\\"timerow\\" data-msg-id=\\"1024\\">
+    <div class=\\"timerow-left\\"></div>
+    Feb 5, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+<div
+  class=\\"header-wrapper header topic-header\\"
+  data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAx\\"
+  data-msg-id=\\"1024\\"
+>
+  <div class=\\"topic-text\\">topic 1</div>
+  <div class=\\"topic-date\\">Feb 5, 1995</div>
+</div>
+    
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-1024\\"
+     data-msg-id=\\"1024\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example stream message.
+
+
+
+
+  </div>
+  
+</div>
+
+
+    <div
+     class=\\"message message-brief\\"
+     id=\\"msg-1598\\"
+     data-msg-id=\\"1598\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"content\\">
+    
+<div class=\\"time-container\\">
+  <div class=\\"msg-timestamp \\">
+    12:00 PM
+  </div>
+</div>
+
+    
+This is an example stream message.
+
+
+
+
+  </div>
+</div>
+"
+`;
+
+exports[`messages -> piece descriptors -> content HTML is stable/sensible stream:s:stream 1 2`] = `
+"
+  <div class=\\"timerow\\" data-msg-id=\\"7938\\">
+    <div class=\\"timerow-left\\"></div>
+    Mar 5, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+<div
+  class=\\"header-wrapper header topic-header\\"
+  data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAx\\"
+  data-msg-id=\\"7938\\"
+>
+  <div class=\\"topic-text\\">topic 1</div>
+  <div class=\\"topic-date\\">Mar 5, 1995</div>
+</div>
+    
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-7938\\"
+     data-msg-id=\\"7938\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example stream message.
+
+
+
+
+  </div>
+  
+</div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-8060\\"
+     data-msg-id=\\"8060\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20two.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name two User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example stream message.
+
+
+
+
+  </div>
+  
+</div>
+"
+`;
+
+exports[`messages -> piece descriptors -> content HTML is stable/sensible stream:s:stream 1 3`] = `
+"
+  <div class=\\"timerow\\" data-msg-id=\\"4948\\">
+    <div class=\\"timerow-left\\"></div>
+    Feb 19, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+<div
+  class=\\"header-wrapper header topic-header\\"
+  data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAx\\"
+  data-msg-id=\\"4948\\"
+>
+  <div class=\\"topic-text\\">topic 1</div>
+  <div class=\\"topic-date\\">Feb 19, 1995</div>
+</div>
+    
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-4948\\"
+     data-msg-id=\\"4948\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example stream message.
+
+
+
+
+  </div>
+  
+</div>
+
+<div
+  class=\\"header-wrapper header topic-header\\"
+  data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAy\\"
+  data-msg-id=\\"5083\\"
+>
+  <div class=\\"topic-text\\">topic 2</div>
+  <div class=\\"topic-date\\">Feb 19, 1995</div>
+</div>
+    
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-5083\\"
+     data-msg-id=\\"5083\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example stream message.
+
+
+
+
+  </div>
+  
+</div>
+"
+`;
+
+exports[`messages -> piece descriptors -> content HTML is stable/sensible stream:s:stream 1 4`] = `
+"
+  <div class=\\"timerow\\" data-msg-id=\\"9181\\">
+    <div class=\\"timerow-left\\"></div>
+    Mar 5, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+<div
+  class=\\"header-wrapper header topic-header\\"
+  data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAx\\"
+  data-msg-id=\\"9181\\"
+>
+  <div class=\\"topic-text\\">topic 1</div>
+  <div class=\\"topic-date\\">Mar 5, 1995</div>
+</div>
+    
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-9181\\"
+     data-msg-id=\\"9181\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example stream message.
+
+
+
+
+  </div>
+  
+</div>
+
+  <div class=\\"timerow\\" data-msg-id=\\"9815\\">
+    <div class=\\"timerow-left\\"></div>
+    Mar 12, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-9815\\"
+     data-msg-id=\\"9815\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example stream message.
+
+
+
+
+  </div>
+  
+</div>
+"
+`;
+
+exports[`messages -> piece descriptors -> content HTML is stable/sensible stream:s:stream 1 5`] = `
+"
+  <div class=\\"timerow\\" data-msg-id=\\"1024\\">
+    <div class=\\"timerow-left\\"></div>
+    Feb 5, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+<div
+  class=\\"header-wrapper header topic-header\\"
+  data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAx\\"
+  data-msg-id=\\"1024\\"
+>
+  <div class=\\"topic-text\\">topic 1</div>
+  <div class=\\"topic-date\\">Feb 5, 1995</div>
+</div>
+    
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-1024\\"
+     data-msg-id=\\"1024\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example stream message.
+
+
+
+
+  </div>
+  
+</div>
+
+
+    <div
+     class=\\"message message-brief\\"
+     id=\\"msg-1598\\"
+     data-msg-id=\\"1598\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"content\\">
+    
+<div class=\\"time-container\\">
+  <div class=\\"msg-timestamp \\">
+    12:00 PM
+  </div>
+</div>
+
+    
+This is an example stream message.
+
+
+
+
+  </div>
+</div>
+
+  <div class=\\"timerow\\" data-msg-id=\\"4948\\">
+    <div class=\\"timerow-left\\"></div>
+    Feb 19, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-4948\\"
+     data-msg-id=\\"4948\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example stream message.
+
+
+
+
+  </div>
+  
+</div>
+
+<div
+  class=\\"header-wrapper header topic-header\\"
+  data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAy\\"
+  data-msg-id=\\"5083\\"
+>
+  <div class=\\"topic-text\\">topic 2</div>
+  <div class=\\"topic-date\\">Feb 19, 1995</div>
+</div>
+    
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-5083\\"
+     data-msg-id=\\"5083\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example stream message.
+
+
+
+
+  </div>
+  
+</div>
+
+  <div class=\\"timerow\\" data-msg-id=\\"7938\\">
+    <div class=\\"timerow-left\\"></div>
+    Mar 5, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+<div
+  class=\\"header-wrapper header topic-header\\"
+  data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAx\\"
+  data-msg-id=\\"7938\\"
+>
+  <div class=\\"topic-text\\">topic 1</div>
+  <div class=\\"topic-date\\">Mar 5, 1995</div>
+</div>
+    
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-7938\\"
+     data-msg-id=\\"7938\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example stream message.
+
+
+
+
+  </div>
+  
+</div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-8060\\"
+     data-msg-id=\\"8060\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20two.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name two User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example stream message.
+
+
+
+
+  </div>
+  
+</div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-9181\\"
+     data-msg-id=\\"9181\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example stream message.
+
+
+
+
+  </div>
+  
+</div>
+
+  <div class=\\"timerow\\" data-msg-id=\\"9815\\">
+    <div class=\\"timerow-left\\"></div>
+    Mar 12, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-9815\\"
+     data-msg-id=\\"9815\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example stream message.
+
+
+
+
+  </div>
+  
+</div>
+"
+`;
+
+exports[`messages -> piece descriptors -> content HTML is stable/sensible topic:s:stream 1 topic 1 1`] = `
+"
+  <div class=\\"timerow\\" data-msg-id=\\"1024\\">
+    <div class=\\"timerow-left\\"></div>
+    Feb 5, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-1024\\"
+     data-msg-id=\\"1024\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example stream message.
+
+
+
+
+  </div>
+  
+</div>
+
+
+    <div
+     class=\\"message message-brief\\"
+     id=\\"msg-1598\\"
+     data-msg-id=\\"1598\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"content\\">
+    
+<div class=\\"time-container\\">
+  <div class=\\"msg-timestamp \\">
+    12:00 PM
+  </div>
+</div>
+
+    
+This is an example stream message.
+
+
+
+
+  </div>
+</div>
+"
+`;
+
+exports[`messages -> piece descriptors -> content HTML is stable/sensible topic:s:stream 1 topic 1 2`] = `
+"
+  <div class=\\"timerow\\" data-msg-id=\\"7938\\">
+    <div class=\\"timerow-left\\"></div>
+    Mar 5, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-7938\\"
+     data-msg-id=\\"7938\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example stream message.
+
+
+
+
+  </div>
+  
+</div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-8060\\"
+     data-msg-id=\\"8060\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20two.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name two User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example stream message.
+
+
+
+
+  </div>
+  
+</div>
+"
+`;
+
+exports[`messages -> piece descriptors -> content HTML is stable/sensible topic:s:stream 1 topic 1 3`] = `
+"
+  <div class=\\"timerow\\" data-msg-id=\\"9181\\">
+    <div class=\\"timerow-left\\"></div>
+    Mar 5, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-9181\\"
+     data-msg-id=\\"9181\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example stream message.
+
+
+
+
+  </div>
+  
+</div>
+
+  <div class=\\"timerow\\" data-msg-id=\\"9815\\">
+    <div class=\\"timerow-left\\"></div>
+    Mar 12, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-9815\\"
+     data-msg-id=\\"9815\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example stream message.
+
+
+
+
+  </div>
+  
+</div>
+"
+`;
+
+exports[`messages -> piece descriptors -> content HTML is stable/sensible topic:s:stream 1 topic 1 4`] = `
+"
+  <div class=\\"timerow\\" data-msg-id=\\"1024\\">
+    <div class=\\"timerow-left\\"></div>
+    Feb 5, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-1024\\"
+     data-msg-id=\\"1024\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example stream message.
+
+
+
+
+  </div>
+  
+</div>
+
+
+    <div
+     class=\\"message message-brief\\"
+     id=\\"msg-1598\\"
+     data-msg-id=\\"1598\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"content\\">
+    
+<div class=\\"time-container\\">
+  <div class=\\"msg-timestamp \\">
+    12:00 PM
+  </div>
+</div>
+
+    
+This is an example stream message.
+
+
+
+
+  </div>
+</div>
+
+  <div class=\\"timerow\\" data-msg-id=\\"7938\\">
+    <div class=\\"timerow-left\\"></div>
+    Mar 5, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-7938\\"
+     data-msg-id=\\"7938\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example stream message.
+
+
+
+
+  </div>
+  
+</div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-8060\\"
+     data-msg-id=\\"8060\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20two.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name two User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example stream message.
+
+
+
+
+  </div>
+  
+</div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-9181\\"
+     data-msg-id=\\"9181\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example stream message.
+
+
+
+
+  </div>
+  
+</div>
+
+  <div class=\\"timerow\\" data-msg-id=\\"9815\\">
+    <div class=\\"timerow-left\\"></div>
+    Mar 12, 1995
+    <div class=\\"timerow-right\\"></div>
+  </div>
+
+
+    <div
+     class=\\"message message-full\\"
+     id=\\"msg-9815\\"
+     data-msg-id=\\"9815\\"
+     data-mute-state=\\"shown\\"
+     
+    >
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+  </div>
+  <div class=\\"content\\">
+    
+<div class=\\"subheader\\">
+  <div class=\\"username\\">
+    Nonrandom name one User
+  </div>
+  <div class=\\"static-timestamp\\">12:00 PM</div>
+</div>
+
+    
+This is an example stream message.
+
+
+
+
+  </div>
+  
+</div>
+"
+`;

--- a/src/webview/html/__tests__/__snapshots__/contentHtmlFromPieceDescriptors-test.js.snap.ios
+++ b/src/webview/html/__tests__/__snapshots__/contentHtmlFromPieceDescriptors-test.js.snap.ios
@@ -455,7 +455,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
      data-msg-id=\\"8849\\">
   Nonrandom name one User, Nonrandom name two User
 </div>
-    
+
 
     <div
      class=\\"message message-full\\"
@@ -526,7 +526,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
      data-msg-id=\\"5287\\">
   Nonrandom name one User, Nonrandom name two User
 </div>
-    
+
 
     <div
      class=\\"message message-full\\"
@@ -602,7 +602,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
      data-msg-id=\\"5829\\">
   Nonrandom name one User, Nonrandom name two User
 </div>
-    
+
 
     <div
      class=\\"message message-full\\"
@@ -684,7 +684,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
      data-msg-id=\\"5377\\">
   Nonrandom name one User, Nonrandom name three User, Nonrandom name two User
 </div>
-    
+
 
     <div
      class=\\"message message-full\\"
@@ -755,7 +755,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
      data-msg-id=\\"5637\\">
   Nonrandom name one User, Nonrandom name three User, Nonrandom name two User
 </div>
-    
+
 
     <div
      class=\\"message message-full\\"
@@ -831,7 +831,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
      data-msg-id=\\"2794\\">
   Nonrandom name one User, Nonrandom name three User, Nonrandom name two User
 </div>
-    
+
 
     <div
      class=\\"message message-full\\"
@@ -981,7 +981,7 @@ This is an example stream message.
      data-msg-id=\\"2794\\">
   Nonrandom name one User, Nonrandom name three User, Nonrandom name two User
 </div>
-    
+
 
     <div
      class=\\"message message-full\\"
@@ -1145,7 +1145,7 @@ This is an example stream message.
      data-msg-id=\\"5287\\">
   Nonrandom name one User, Nonrandom name two User
 </div>
-    
+
 
     <div
      class=\\"message message-full\\"
@@ -1211,7 +1211,7 @@ This is an example PM message.
      data-msg-id=\\"5377\\">
   Nonrandom name one User, Nonrandom name three User, Nonrandom name two User
 </div>
-    
+
 
     <div
      class=\\"message message-full\\"
@@ -1327,7 +1327,7 @@ This is an example PM message.
      data-msg-id=\\"5829\\">
   Nonrandom name one User, Nonrandom name two User
 </div>
-    
+
 
     <div
      class=\\"message message-full\\"
@@ -1564,7 +1564,7 @@ This is an example stream message.
      data-msg-id=\\"8849\\">
   Nonrandom name one User, Nonrandom name two User
 </div>
-    
+
 
     <div
      class=\\"message message-full\\"
@@ -1714,7 +1714,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm
      data-msg-id=\\"8849\\">
   Nonrandom name one User, Nonrandom name two User
 </div>
-    
+
 
     <div
      class=\\"message message-full\\"
@@ -1785,7 +1785,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm
      data-msg-id=\\"5287\\">
   Nonrandom name one User, Nonrandom name two User
 </div>
-    
+
 
     <div
      class=\\"message message-full\\"
@@ -1861,7 +1861,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm
      data-msg-id=\\"5829\\">
   Nonrandom name one User, Nonrandom name two User
 </div>
-    
+
 
     <div
      class=\\"message message-full\\"
@@ -1943,7 +1943,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm
      data-msg-id=\\"5377\\">
   Nonrandom name one User, Nonrandom name three User, Nonrandom name two User
 </div>
-    
+
 
     <div
      class=\\"message message-full\\"
@@ -2014,7 +2014,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm
      data-msg-id=\\"5637\\">
   Nonrandom name one User, Nonrandom name three User, Nonrandom name two User
 </div>
-    
+
 
     <div
      class=\\"message message-full\\"
@@ -2090,7 +2090,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm
      data-msg-id=\\"2794\\">
   Nonrandom name one User, Nonrandom name three User, Nonrandom name two User
 </div>
-    
+
 
     <div
      class=\\"message message-full\\"
@@ -2172,7 +2172,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm
      data-msg-id=\\"2794\\">
   Nonrandom name one User, Nonrandom name three User, Nonrandom name two User
 </div>
-    
+
 
     <div
      class=\\"message message-full\\"
@@ -2250,7 +2250,7 @@ This is an example PM message.
      data-msg-id=\\"5287\\">
   Nonrandom name one User, Nonrandom name two User
 </div>
-    
+
 
     <div
      class=\\"message message-full\\"
@@ -2316,7 +2316,7 @@ This is an example PM message.
      data-msg-id=\\"5377\\">
   Nonrandom name one User, Nonrandom name three User, Nonrandom name two User
 </div>
-    
+
 
     <div
      class=\\"message message-full\\"
@@ -2432,7 +2432,7 @@ This is an example PM message.
      data-msg-id=\\"5829\\">
   Nonrandom name one User, Nonrandom name two User
 </div>
-    
+
 
     <div
      class=\\"message message-full\\"

--- a/src/webview/html/__tests__/contentHtmlFromPieceDescriptors-test.js
+++ b/src/webview/html/__tests__/contentHtmlFromPieceDescriptors-test.js
@@ -1,0 +1,364 @@
+/* @flow strict-local */
+import invariant from 'invariant';
+
+import * as eg from '../../../__tests__/lib/exampleData';
+import {
+  HOME_NARROW,
+  streamNarrow,
+  topicNarrow,
+  pmNarrowFromUsersUnsafe,
+  keyFromNarrow,
+  ALL_PRIVATE_NARROW,
+} from '../../../utils/narrow';
+import type { Message } from '../../../types';
+import contentHtmlFromPieceDescriptors from '../contentHtmlFromPieceDescriptors';
+import getHtmlPieceDescriptors from '../../../message/getHtmlPieceDescriptors';
+
+/**
+ * Highlight changes in content-HTML generation.
+ *
+ * Test failures here (which we expect to happen often) will have two
+ * major flavors:
+ *
+ * - Your changes caused different content HTML to be generated from
+ *   the same input (list of messages, backgroundData, etc.). You
+ *   should examine the changes and see if we want them.
+ *   - If they look correct, please follow Jest's instructions to
+ *     update the snapshots, and commit the result.
+ *   - If they don't look correct, look for bugs that were caused or
+ *     revealed by your changes. Please fix them and run the tests
+ *     again.
+ *
+ * - Different input was given on this run of the tests, and naturally
+ *   our code produced different output.
+ *   - This will be the case when extending these tests to increase
+ *     coverage. Thanks for doing that! :)
+ *   - But one big "gotcha!" is that we can't vary the input
+ *     programmatically with every run of the tests. That's why the
+ *     data objects in the input have hard-coded IDs, names, etc.,
+ *     instead of random ones (even as `exampleData` is happy to give
+ *     us random data, which is often what we want!). If we allow
+ *     something in the input to randomly change between test runs,
+ *     we're inviting the output to change randomly too, and if that
+ *     happens, the snapshots won't match, and the tests will fail. We
+ *     should avoid meaningless failures like that; strong tests have
+ *     meaningful results.
+ *
+ * This is our first attempt at testing UI logic with snapshot tests,
+ * done in part to help check a refactor of `getHtmlPieceDescriptors`
+ * and `contentHtmlFromPieceDescriptors`.
+ */
+describe('messages -> piece descriptors -> content HTML is stable/sensible', () => {
+  // Tell ESLint to recognize `check` as a helper function that runs
+  // assertions.
+  /* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["expect", "check"] }] */
+  const check = ({
+    // TODO: Test with a variety of different things in
+    // `backgroundData`.
+    backgroundData = eg.backgroundData,
+    narrow,
+    messages,
+  }) => {
+    invariant(
+      messages.every((message, i, allMessages) => {
+        const prevMessage: Message | void = allMessages[i - 1];
+        return (
+          prevMessage === undefined
+          || (prevMessage.id < message.id && prevMessage.timestamp < message.timestamp)
+        );
+      }),
+      'Problem with test data: `messages` should increase monotonically in both `id` and `timestamp`.',
+    );
+    expect(
+      contentHtmlFromPieceDescriptors({
+        backgroundData,
+        htmlPieceDescriptors: getHtmlPieceDescriptors(messages, narrow),
+        narrow,
+        _: m => m,
+      }),
+    ).toMatchSnapshot();
+  };
+
+  const user1 = eg.makeUser({ user_id: 1, name: 'nonrandom name one' });
+  const user2 = eg.makeUser({ user_id: 2, name: 'nonrandom name two' });
+  const user3 = eg.makeUser({ user_id: 3, name: 'nonrandom name three' });
+
+  const stream1 = { ...eg.makeStream({ name: 'stream 1' }), stream_id: 1 };
+  const stream2 = { ...eg.makeStream({ name: 'stream 2' }), stream_id: 2 };
+
+  const topic1 = 'topic 1';
+  const topic2 = 'topic 2';
+
+  // Same sender, stream, topic, day
+  const streamMessages1 = [
+    eg.streamMessage({
+      id: 1024,
+      timestamp: 791985600,
+      sender: user1,
+      stream: stream1,
+      subject: topic1,
+    }),
+    eg.streamMessage({
+      id: 1598,
+      timestamp: 791985601,
+      sender: user1,
+      stream: stream1,
+      subject: topic1,
+    }),
+  ];
+  // Different senders; same stream, topic, day
+  const streamMessages2 = [
+    eg.streamMessage({
+      id: 7938,
+      timestamp: 794404812,
+      sender: user1,
+      stream: stream1,
+      subject: topic1,
+    }),
+    eg.streamMessage({
+      id: 8060,
+      timestamp: 794404813,
+      sender: user2,
+      stream: stream1,
+      subject: topic1,
+    }),
+  ];
+  // Same sender, stream, day; different topics
+  const streamMessages3 = [
+    eg.streamMessage({
+      id: 4948,
+      timestamp: 793195202,
+      sender: user1,
+      stream: stream1,
+      subject: topic1,
+    }),
+    eg.streamMessage({
+      id: 5083,
+      timestamp: 793195203,
+      sender: user1,
+      stream: stream1,
+      subject: topic2,
+    }),
+  ];
+  // Same sender, day; different streams, topics
+  const streamMessages4 = [
+    eg.streamMessage({
+      id: 6789,
+      timestamp: 794404810,
+      sender: user1,
+      stream: stream1,
+      subject: topic1,
+    }),
+    eg.streamMessage({
+      id: 7727,
+      timestamp: 794404811,
+      sender: user1,
+      stream: stream2,
+      subject: topic2,
+    }),
+  ];
+  // Same sender, stream, topic; different days
+  const streamMessages5 = [
+    eg.streamMessage({
+      id: 9181,
+      timestamp: 794404816,
+      sender: user1,
+      stream: stream1,
+      subject: topic1,
+    }),
+    eg.streamMessage({
+      id: 9815,
+      timestamp: 795009616,
+      sender: user1,
+      stream: stream1,
+      subject: topic1,
+    }),
+  ];
+
+  // 1:1 PM, same sender, day
+  const pmMessages1 = [
+    eg.pmMessage({ id: 8849, timestamp: 794404814, sender: user1, recipients: [user1, user2] }),
+    eg.pmMessage({ id: 8917, timestamp: 794404815, sender: user1, recipients: [user1, user2] }),
+  ];
+  // 1:1 PM, different senders; same day
+  const pmMessages2 = [
+    eg.pmMessage({ id: 5287, timestamp: 793195204, sender: user1, recipients: [user1, user2] }),
+    eg.pmMessage({ id: 5309, timestamp: 793195205, sender: user2, recipients: [user1, user2] }),
+  ];
+  // 1:1 PM, same sender; different day
+  const pmMessages3 = [
+    eg.pmMessage({ id: 5829, timestamp: 793195210, sender: user1, recipients: [user1, user2] }),
+    eg.pmMessage({ id: 5963, timestamp: 793800010, sender: user1, recipients: [user1, user2] }),
+  ];
+  // Group PM, same sender, day
+  const pmMessages4 = [
+    eg.pmMessage({
+      id: 5377,
+      timestamp: 793195206,
+      sender: user1,
+      recipients: [user1, user2, user3],
+    }),
+    eg.pmMessage({
+      id: 5620,
+      timestamp: 793195207,
+      sender: user1,
+      recipients: [user1, user2, user3],
+    }),
+  ];
+  // Group PM, different senders; same day
+  const pmMessages5 = [
+    eg.pmMessage({
+      id: 5637,
+      timestamp: 793195208,
+      sender: user1,
+      recipients: [user1, user2, user3],
+    }),
+    eg.pmMessage({
+      id: 5727,
+      timestamp: 793195209,
+      sender: user2,
+      recipients: [user1, user2, user3],
+    }),
+  ];
+  // Group PM, same sender; different day
+  const pmMessages6 = [
+    eg.pmMessage({
+      id: 2794,
+      timestamp: 791985602,
+      sender: user1,
+      recipients: [user1, user2, user3],
+    }),
+    eg.pmMessage({
+      id: 4581,
+      timestamp: 792590402,
+      sender: user1,
+      recipients: [user1, user2, user3],
+    }),
+  ];
+
+  test('HOME_NARROW', () => {
+    [
+      { narrow: HOME_NARROW, messages: streamMessages1 },
+      { narrow: HOME_NARROW, messages: streamMessages2 },
+      { narrow: HOME_NARROW, messages: streamMessages3 },
+      { narrow: HOME_NARROW, messages: streamMessages4 },
+      { narrow: HOME_NARROW, messages: streamMessages5 },
+      { narrow: HOME_NARROW, messages: pmMessages1 },
+      { narrow: HOME_NARROW, messages: pmMessages2 },
+      { narrow: HOME_NARROW, messages: pmMessages3 },
+      { narrow: HOME_NARROW, messages: pmMessages4 },
+      { narrow: HOME_NARROW, messages: pmMessages5 },
+      { narrow: HOME_NARROW, messages: pmMessages6 },
+      {
+        narrow: HOME_NARROW,
+        // All together, sorted by ID. (Which basically means jumbled;
+        // the IDs in each sub-list are only internally sorted.)
+        messages: [
+          ...streamMessages1,
+          ...streamMessages2,
+          ...streamMessages3,
+          ...streamMessages4,
+          ...streamMessages5,
+          ...pmMessages1,
+          ...pmMessages2,
+          ...pmMessages3,
+          ...pmMessages4,
+          ...pmMessages5,
+          ...pmMessages6,
+        ].sort((a, b) => a.id - b.id),
+      },
+    ].forEach(testCase => check(testCase));
+  });
+
+  const streamNarrow1 = streamNarrow(stream1.name);
+  test(`${keyFromNarrow(streamNarrow1)}`, () => {
+    [
+      { narrow: streamNarrow1, messages: streamMessages1 },
+      { narrow: streamNarrow1, messages: streamMessages2 },
+      { narrow: streamNarrow1, messages: streamMessages3 },
+      { narrow: streamNarrow1, messages: streamMessages5 },
+      {
+        narrow: streamNarrow1,
+        // All together, sorted by ID. (Which basically means jumbled;
+        // the IDs in each sub-list are only internally sorted.)
+        messages: [
+          ...streamMessages1,
+          ...streamMessages2,
+          ...streamMessages3,
+          ...streamMessages5,
+        ].sort((a, b) => a.id - b.id),
+      },
+    ].forEach(testCase => check(testCase));
+  });
+
+  const topicNarrow1 = topicNarrow(stream1.name, topic1);
+  test(`${keyFromNarrow(topicNarrow1)}`, () => {
+    [
+      { narrow: topicNarrow1, messages: streamMessages1 },
+      { narrow: topicNarrow1, messages: streamMessages2 },
+      { narrow: topicNarrow1, messages: streamMessages5 },
+      {
+        narrow: topicNarrow1,
+        // All together, sorted by ID. (Which basically means jumbled;
+        // the IDs in each sub-list are only internally sorted.)
+        messages: [...streamMessages1, ...streamMessages2, ...streamMessages5].sort(
+          (a, b) => a.id - b.id,
+        ),
+      },
+    ].forEach(testCase => check(testCase));
+  });
+
+  const pmNarrow1to1 = pmNarrowFromUsersUnsafe([user1, user2]);
+  test(`${keyFromNarrow(pmNarrow1to1)}`, () => {
+    [
+      { narrow: pmNarrow1to1, messages: pmMessages1 },
+      { narrow: pmNarrow1to1, messages: pmMessages2 },
+      { narrow: pmNarrow1to1, messages: pmMessages3 },
+      {
+        narrow: pmNarrow1to1,
+        // All together, sorted by ID. (Which basically means jumbled;
+        // the IDs in each sub-list are only internally sorted.)
+        messages: [...pmMessages1, ...pmMessages2, ...pmMessages3].sort((a, b) => a.id - b.id),
+      },
+    ].forEach(testCase => check(testCase));
+  });
+
+  const pmNarrowGroup = pmNarrowFromUsersUnsafe([user1, user2, user3]);
+  test(`${keyFromNarrow(pmNarrowGroup)}`, () => {
+    [
+      { narrow: pmNarrowGroup, messages: pmMessages4 },
+      { narrow: pmNarrowGroup, messages: pmMessages5 },
+      { narrow: pmNarrowGroup, messages: pmMessages6 },
+      {
+        narrow: pmNarrowGroup,
+        // All together, sorted by ID. (Which basically means jumbled;
+        // the IDs in each sub-list are only internally sorted.)
+        messages: [...pmMessages4, ...pmMessages5, ...pmMessages6].sort((a, b) => a.id - b.id),
+      },
+    ].forEach(testCase => check(testCase));
+  });
+
+  test(`${keyFromNarrow(ALL_PRIVATE_NARROW)}`, () => {
+    [
+      { narrow: ALL_PRIVATE_NARROW, messages: pmMessages1 },
+      { narrow: ALL_PRIVATE_NARROW, messages: pmMessages2 },
+      { narrow: ALL_PRIVATE_NARROW, messages: pmMessages3 },
+      { narrow: ALL_PRIVATE_NARROW, messages: pmMessages4 },
+      { narrow: ALL_PRIVATE_NARROW, messages: pmMessages5 },
+      { narrow: ALL_PRIVATE_NARROW, messages: pmMessages6 },
+      {
+        narrow: ALL_PRIVATE_NARROW,
+        // All together, sorted by ID. (Which basically means jumbled;
+        // the IDs in each sub-list are only internally sorted.)
+        messages: [
+          ...pmMessages1,
+          ...pmMessages2,
+          ...pmMessages3,
+          ...pmMessages4,
+          ...pmMessages5,
+          ...pmMessages6,
+        ].sort((a, b) => a.id - b.id),
+      },
+    ].forEach(testCase => check(testCase));
+  });
+});

--- a/src/webview/html/contentHtmlFromPieceDescriptors.js
+++ b/src/webview/html/contentHtmlFromPieceDescriptors.js
@@ -1,4 +1,5 @@
 /* @flow strict-local */
+import invariant from 'invariant';
 import type { GetText, Narrow, HtmlPieceDescriptor } from '../../types';
 import type { BackgroundData } from '../MessageList';
 
@@ -18,8 +19,9 @@ export default ({
   _: GetText,
 |}): string => {
   const pieces = [];
-  htmlPieceDescriptors.forEach(section => {
-    if (section.message !== null) {
+  htmlPieceDescriptors.forEach((section, index) => {
+    if (index > 0) {
+      invariant(section.message !== null, 'only first section has null `.message`');
       pieces.push(messageHeaderAsHtml(backgroundData, narrow, section.message));
     }
     section.data.forEach(item => {

--- a/src/webview/html/contentHtmlFromPieceDescriptors.js
+++ b/src/webview/html/contentHtmlFromPieceDescriptors.js
@@ -15,7 +15,7 @@ export default ({
 }: {|
   backgroundData: BackgroundData,
   narrow: Narrow,
-  htmlPieceDescriptors: HtmlPieceDescriptor[],
+  htmlPieceDescriptors: $ReadOnlyArray<HtmlPieceDescriptor>,
   _: GetText,
 |}): string =>
   htmlPieceDescriptors

--- a/src/webview/html/messageHeaderAsHtml.js
+++ b/src/webview/html/messageHeaderAsHtml.js
@@ -101,7 +101,7 @@ export default (
     .sort()
     .join(', ')}
 </div>
-    `;
+`;
   }
 
   return '';


### PR DESCRIPTION
EDIT: See https://github.com/zulip/zulip-mobile/pull/4670#issuecomment-821586117 where I mention the cause of the CI failures.

-----

A continued resumption of #3913 (which has grown stale), toward #3851. Part 1 was #4406 .

This PR focuses on the refactor to flatten the funny shape of `HtmlPieceDescriptor[]`, and it has tests specifically aimed at confirming the refactor.

Those tests are snapshot tests, something I think it could be neat to explore. I'd like to know if there's a better file I can put them in (I've made a `contentHtmlFromPieceDescriptors-test.js` and put them there); they test how `getHtmlPieceDescriptors` and `contentHtmlFromPieceDescriptors` work together, not separately. But I don't think I run on enough caffeine to work with a filename that concatenates those names 🤔.

