### PR TITLE
action sheet: Add "edit message" option for admins to edit any topic.

### DIFF
--- a/src/message/messageActionSheet.js
+++ b/src/message/messageActionSheet.js
@@ -300,9 +300,13 @@ export const constructMessageActionButtons = ({
     buttons.push(shareMessage);
   }
   if (
-    message.sender_id === ownUser.user_id
-    // Our "edit message" UI only works in certain kinds of narrows.
-    && (isStreamOrTopicNarrow(narrow) || isPmNarrow(narrow))
+    (message.sender_id === ownUser.user_id
+      // Our "edit message" UI only works in certain kinds of narrows.
+      && (isStreamOrTopicNarrow(narrow) || isPmNarrow(narrow)))
+    // "edit message" UI for admin irrespective of any sent messages
+    // from that admin in that narrow since admin can edit any topic
+    // name in stream and topic narrows.
+    || (ownUser.is_admin && isStreamOrTopicNarrow(narrow))
   ) {
     buttons.push(editMessage);
   }


### PR DESCRIPTION
Currently in zulip web any admin can edit any topic name
irrespective of whether admin has any sent messages in that
topic or not.

So, add that feature in zulip mobile.

**Before**: 

https://user-images.githubusercontent.com/42652941/115412997-74587f80-a212-11eb-8329-1102af8cb235.mp4

**After** :

https://user-images.githubusercontent.com/42652941/115413194-9baf4c80-a212-11eb-9e87-e24519678949.mp4




Signed-off-by: rajprakash00 <rajprakash1999@gmail.com>