### PR TITLE
css: Style headings to be similar to webapp.

### DIFF
--- a/src/webview/static/base.css
+++ b/src/webview/static/base.css
@@ -569,6 +569,17 @@ hr {
   border-top: 1px solid hsla(0, 0%, 50%, 0.5);
 }
 
+h1, h2, h3, h4, h5, h6 {
+  font-size: 100%;
+  font-weight: 600;
+  /* line-height doesn't seem to be needed on mobile, but it's here just for
+   * the sake of being consistent with the webapp */
+  line-height: 1.4;
+  margin-top: 0;
+  margin-bottom: 5px;
+  text-decoration: underline;
+}
+
 /* Our own "sorry, unsupported" message for widgets. */
 .special-message {
   display: flex;


### PR DESCRIPTION
The webapp styles the `<h1>` through `<h6>` tags to be all the same size,
bold, and underlined. This commit makes them look similar on mobile,
instead of the goofy giant text from the default sytlesheet that we had
previously.

old

![old](https://user-images.githubusercontent.com/5001092/115578634-0c7c6480-a2f8-11eb-9755-6c6cd812ad4f.png)

new

![new](https://user-images.githubusercontent.com/5001092/115578647-0dad9180-a2f8-11eb-9113-d5650f3f96c0.png)

webapp

![webapp](https://user-images.githubusercontent.com/5001092/115578680-143c0900-a2f8-11eb-83e0-1533d777a73d.png)
