### PR TITLE
migrations: Add one that should have been added in #4491.

### DIFF
--- a/src/boot/store.js
+++ b/src/boot/store.js
@@ -276,6 +276,13 @@ const migrations: {| [string]: (GlobalState) => GlobalState |} = {
     };
   },
 
+  // Remove accounts with "in-progress" login state (empty `.email`),
+  // after #4491
+  '27': state => ({
+    ...state,
+    accounts: state.accounts.filter(a => a.email !== ''),
+  }),
+
   // TIP: When adding a migration, consider just using `dropCache`.
 };
 


### PR DESCRIPTION
(Related: #4491)

I think the effect of not having this migration, at this point,
isn't as bad as a crash. But we should have added such a migration
in 4efdcda7a, when we removed the only mechanism (the REALM_ADD
action) by which accounts could end up with the empty string at
`.email`. There, we implicitly introduced the invariant that no
accounts would ever have an empty `.email`. Had I made this more
explicit, I might have remembered to do the migration.

Luckily, 1af58afb1 (from later in the same PR) ensured that we'd
never take an account object with an empty-string `.email` and make
it the active account. If you tapped an in-progress-account item in
the list, typed good credentials, and logged in successfully, a new
account object would get created, with non-empty `.email` (and
`.apiKey`). The one with the empty `.email` sits harmlessly in the
accounts list, and the user can delete it if they wish.

I verified the non-crash at the tip of #4491, b570b262c.