### PR TITLE
sentry: Document, and partly clean up, handling Sentry in release process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,6 +79,10 @@ npm-debug.log
 /ios/webview
 # /android/app/build/... is already covered above
 
+# Sentry config, with auth token for uploading a new release's sourcemap
+/android/sentry.properties
+/ios/sentry.properties
+
 # Generated for uploading to the Play Store, separate from any app version
 /zulip-icon-google-play.png
 

--- a/android/sentry.properties
+++ b/android/sentry.properties
@@ -1,5 +1,0 @@
-defaults.url=https://sentry.io/
-defaults.org=zulip
-defaults.project=zulip-mobile
-auth.token=ADD-TOKEN-HERE
-cli.executable=node_modules/@sentry/cli/bin/sentry-cli

--- a/docs/howto/release.md
+++ b/docs/howto/release.md
@@ -447,9 +447,39 @@ vulnerable.
 
 ### Configure Sentry error reporting
 
-* Add Sentry API key and account: file `sentry.properties` change `auth.token`
-
 * Set client key (DSN): file `config.js` set `sentryKey` value
+
+
+#### Sentry token for uploading a release and sourcemap
+
+1. Visit https://sentry.io/settings/account/api/auth-tokens/ , and
+   create a new auth token.  Give it the `project:releases` scope, and
+   no others.
+
+2. Create a file like this:
+
+   ```
+   defaults.url=https://sentry.io/
+   defaults.org=zulip
+   defaults.project=zulip-mobile
+   auth.token=01234567...YOUR-TOKEN-HERE...89abcdef
+   cli.executable=node_modules/@sentry/cli/bin/sentry-cli
+   ```
+
+   with your new auth token in the `auth.token=` line, and place
+   copies at both `android/sentry.properties` and
+   `ios/sentry.properties`.
+
+When preparing a release for publication, these files will be used for
+uploading to Sentry the sourcemap for the release, so that it can
+unminify the stack traces and add source-code snippets.
+
+(Our routine builds don't do this, regardless of debug or release
+mode; it's enabled by the `tools/android` and `tools/ios` scripts we
+use for preparing releases for publication.  They do this via setting
+the `-Psentry` Gradle property and the `USE_SENTRY` Xcode variable
+respectively, and those cause our build process to invoke a build-time
+script Sentry supplies.)
 
 
 ### Prepare Android

--- a/docs/howto/release.md
+++ b/docs/howto/release.md
@@ -98,6 +98,13 @@ simple terminology for the process we follow with both.
   tools/checkout-keystore
   ```
 
+* Apply the Sentry client key (using the local branch created for this
+  in initial setup):
+
+  ```
+  git rebase @ release-secrets
+  ```
+
 * Build the app, as both a good old-fashioned APK and a fancy new AAB:
 
   ```
@@ -139,6 +146,12 @@ simple terminology for the process we follow with both.
   navigate to the Zulip screen in the Play Store app, and it should
   already show an "Update" button.
 
+* Remember to switch back to a branch without the Sentry client key:
+
+  ```
+  git checkout master
+  ```
+
 [play-internal-testing]: https://play.google.com/console/developers/8060868091387311598/app/4976350040864490411/tracks/internal-testing
 [play-internal-app-sharing]: https://play.google.com/console/internal-app-sharing
 
@@ -154,6 +167,13 @@ simple terminology for the process we follow with both.
 
   (A nice improvement would be to script that -- probably folded into
   `tools/ios build`.)
+
+* Apply the Sentry client key (using the local branch created for this
+  in initial setup):
+
+  ```
+  git rebase @ release-secrets
+  ```
 
 * Build using our `tools/ios` script:
 
@@ -209,6 +229,12 @@ simple terminology for the process we follow with both.
   * Processing takes a few minutes, and we get an email from Apple
     when it's complete.  At this point, the new build automatically becomes
     available in alpha.
+
+* Remember to switch back to a branch without the Sentry client key:
+
+  ```
+  git checkout master
+  ```
 
 [app-store-connect]: https://appstoreconnect.apple.com/
 [asc-builds]: https://appstoreconnect.apple.com/apps/1203036395/recent/activity/ios/builds?m=
@@ -447,9 +473,6 @@ vulnerable.
 
 ### Configure Sentry error reporting
 
-* Set client key (DSN): file `config.js` set `sentryKey` value
-
-
 #### Sentry token for uploading a release and sourcemap
 
 1. Visit https://sentry.io/settings/account/api/auth-tokens/ , and
@@ -480,6 +503,43 @@ use for preparing releases for publication.  They do this via setting
 the `-Psentry` Gradle property and the `USE_SENTRY` Xcode variable
 respectively, and those cause our build process to invoke a build-time
 script Sentry supplies.)
+
+
+#### Sentry client key
+
+1. Visit https://sentry.io/settings/zulip/projects/zulip-mobile/keys/
+   and get the Sentry "client key" there, specifically in the format
+   Sentry calls a "DSN".
+
+2. Edit `src/sentryConfig.js` and save that string as the value of
+   `sentryKey`.  See the jsdoc and comment there for more about this
+   value.
+
+   You won't want to push that change, or to make builds with it
+   except when you're making a release build you intend to publish.
+   But you will want to have it handy to apply whenever you are making
+   a release build for publication.  So:
+
+3. Save this value in the form of a local Git branch you don't push,
+   using commands like:
+
+   ```
+   $ git checkout -b release-secrets
+   $ git commit -am 'SECRET: Add Sentry client key.'
+   $ git checkout master
+   ```
+
+   Then, as described in the main release steps above, when making a
+   build for publication you'll rebase or cherry-pick that
+   `release-secrets` commit temporarily before building.
+
+(Yes, this is kind of a hacky way to do this.  Eliminating that
+cherry-pick step at build time would be quite nice.  The key criteria
+this meets that an improved solution should also meet are: (a) the key
+shouldn't be in the public source tree, so it should live locally on
+each release manager's machine; (b) Sentry should only be enabled in
+builds explicitly meant for publication, and not in other builds a
+release manager happens to make, including builds in release mode.)
 
 
 ### Prepare Android

--- a/ios/sentry.properties
+++ b/ios/sentry.properties
@@ -1,5 +1,0 @@
-defaults.url=https://sentry.io/
-defaults.org=zulip
-defaults.project=zulip-mobile
-auth.token=ADD-TOKEN-HERE
-cli.executable=node_modules/@sentry/cli/bin/sentry-cli

--- a/src/config.js
+++ b/src/config.js
@@ -8,7 +8,6 @@ type Config = {|
   enableReduxSlowReducerWarnings: boolean,
   enableWebViewErrorDisplay: boolean,
   slowReducersThreshold: number,
-  sentryKey: string | null,
   enableErrorConsoleLogging: boolean,
   serverDataOnStartup: string[],
   appOwnDomains: string[],
@@ -21,7 +20,6 @@ const config: Config = {
   enableReduxSlowReducerWarnings: isDevelopment && !!global.btoa,
   enableWebViewErrorDisplay: isDevelopment,
   slowReducersThreshold: 5,
-  sentryKey: null, // add DSN here
   enableErrorConsoleLogging: true,
   serverDataOnStartup: [
     'alert_words',

--- a/src/sentry.js
+++ b/src/sentry.js
@@ -2,7 +2,7 @@
 import * as Sentry from '@sentry/react-native';
 import { nativeApplicationVersion } from 'expo-application';
 
-import config from './config';
+import { sentryKey } from './sentryConfig';
 
 export const isSentryActive = (): boolean => {
   // Hub#getClient() is documented as possibly returning undefined, but the
@@ -23,7 +23,7 @@ const preventNoise = (): void => {
   /* Sentry should not normally be used in debug mode. (For one thing, the
      debug-mode build process doesn't ordinarily create bundles or .map files,
      so you'll probably get nonsensical stack traces.) */
-  if (process.env.NODE_ENV === 'development' && config.sentryKey !== null) {
+  if (process.env.NODE_ENV === 'development' && sentryKey !== null) {
     /* If you have some reason to initialize Sentry in debug mode anyway, please
        change the app's version name (currently specified in `ios/Info.plist`
        and/or `android/app/build.gradle`) to something that doesn't look like a
@@ -50,7 +50,7 @@ export const initializeSentry = () => {
   // Check to make sure it's safe to run Sentry. Abort if not.
   preventNoise();
 
-  const key = config.sentryKey;
+  const key = sentryKey;
   if (key !== null) {
     // The DSN is formatted as an `https:` URL. Omit the scheme.
     const displayKey = `${key.slice(8, 12)}......`;

--- a/src/sentryConfig.js
+++ b/src/sentryConfig.js
@@ -1,0 +1,26 @@
+/* @flow strict-local */
+
+/**
+ * The Sentry "client key" aka "DSN".
+ *
+ * When non-null, this is the destination we send Sentry events to.
+ * When null, the app does not send anything to Sentry.
+ *
+ * For more on the meaning of this value, see Sentry upstream docs:
+ *   https://docs.sentry.io/platforms/react-native/configuration/options/#dsn
+ *   https://docs.sentry.io/product/sentry-basics/dsn-explainer/
+ */
+// The published official builds of the Zulip mobile app contain a non-null
+// value here.  Because the key is there in those published builds, it's
+// fundamentally not a secret.
+//
+// But it's important to make sure Zulip developers and people distributing
+// their own modified versions of the app don't accidentally end up sending
+// Sentry events that get mixed in amongst events from the official builds:
+// https://github.com/getsentry/sentry-docs/pull/1723#issuecomment-773479895
+// So we keep the key out of the public source tree, to ensure there's no
+// way to accidentally start using it.
+//
+// If you're making your own builds and want to use Sentry with them, please
+// create your own Sentry client key / DSN, and fill it in here.
+export const sentryKey: string | null = null;


### PR DESCRIPTION
There's a step in the process I've had for making releases which hasn't been written down in the release how-to doc, partly because it feels like kind of a silly way of doing it: I have a local branch with a commit that just fills in a couple of secrets, and I rebase it atop each release commit before building.

Here, convert one of the things that branch was doing into a more reasonable approach, and document it. And I didn't as easily find today a way to replace the other thing the branch was doing with some more reasonable approach, so for that one just document the existing local-branch solution.
