### PR TITLE
emoji: Fix keypad emoji, overriding broken codes from server's list.

### DIFF
--- a/src/emoji/__tests__/data-test.js
+++ b/src/emoji/__tests__/data-test.js
@@ -18,12 +18,16 @@ describe('codeToEmojiMap', () => {
   test('works for some single-codepoint emoji', () => {
     check('1f44d', '👍', '\u{1f44d}');
     check('1f308', '🌈', '\u{1f308}');
-    check('1f308', '🌈', '\u{1f308}');
   });
-  test('works for some multi-codepoint emoji', () => {
-    check('0030-20e3', '0⃣', '0\u{20e3}');
-    check('002a-20e3', '*⃣', '*\u{20e3}');
-    check('0023-20e3', '#⃣', '#\u{20e3}');
+
+  // test_('works for some multi-codepoint emoji', () => {
+  //   The only multi-codepoint emoji in the list are keypad emoji,
+  //   which are special in a different way.
+
+  test('works for some overridden keypad emoji', () => {
+    check('0030-20e3', '0️⃣', '0\u{fe0f}\u{20e3}');
+    check('002a-20e3', '*️⃣', '*\u{fe0f}\u{20e3}');
+    check('0023-20e3', '#️⃣', '#\u{fe0f}\u{20e3}');
   });
 });
 

--- a/src/emoji/codePointMap.js
+++ b/src/emoji/codePointMap.js
@@ -2,6 +2,22 @@
 
 /** Maps certain emoji to substitutes, for us to show instead. */
 export const override: {| [code: string]: string |} = {
+  // Fix the "keypad" emoji, which are broken in Zulip's emoji database;
+  // use the codepoint sequences for them that appear in the Unicode spec.
+  // https://chat.zulip.org/#narrow/stream/3-backend/topic/unicode.20emojis/near/759357
+  '0023-20e3': '0023-fe0f-20e3', // # (:hash:)
+  '002a-20e3': '002a-fe0f-20e3', // * (:asterisk:)
+  '0030-20e3': '0030-fe0f-20e3', // 0
+  '0031-20e3': '0031-fe0f-20e3', // 1
+  '0032-20e3': '0032-fe0f-20e3', // 2
+  '0033-20e3': '0033-fe0f-20e3', // 3
+  '0034-20e3': '0034-fe0f-20e3', // 4
+  '0035-20e3': '0035-fe0f-20e3', // 5
+  '0036-20e3': '0036-fe0f-20e3', // 6
+  '0037-20e3': '0037-fe0f-20e3', // 7
+  '0038-20e3': '0038-fe0f-20e3', // 8
+  '0039-20e3': '0039-fe0f-20e3', // 9
+
   // :check_mark: -> :check: because the former is invisible on a light
   // background, i.e. when not in night mode.
   '2714': '2705',

--- a/src/emoji/codePointMap.js
+++ b/src/emoji/codePointMap.js
@@ -18,6 +18,15 @@ export const override: {| [code: string]: string |} = {
   '0038-20e3': '0038-fe0f-20e3', // 8
   '0039-20e3': '0039-fe0f-20e3', // 9
 
+  // Fix the "letter" emoji.  The codes in Zulip's emoji database would give
+  // these a text-style rather than emoji-style presentation; that's subtler
+  // than we want, plus when not in night mode it's actually invisible.
+  '1f170': '1f170-fe0f', // :a:
+  '1f171': '1f171-fe0f', // :b:
+  '1f17e': '1f17e-fe0f', // :o:
+  '1f17f': '1f17f-fe0f', // :p:
+  // (Zulip only actually offers a handful of these letter emoji.)
+
   // :check_mark: -> :check: because the former is invisible on a light
   // background, i.e. when not in night mode.
   '2714': '2705',


### PR DESCRIPTION
The Zulip emoji database has codepoint sequences for these emoji that
aren't actually valid emoji sequences according to the Unicode spec.

Some browsers accept the forms we've been using, but others don't.
In particular, newer Chrome versions don't, since about 2019.
We discussed fixing the server's data here in 2019:
  https://chat.zulip.org/#narrow/stream/3-backend/topic/unicode.20emojis/near/758828
but never did, and then didn't come back to this.  Hopefully it
will get fixed sometime, but first let's just work around it here.

Fixes: #3517

---

Diagnosing this issue today caused me to look back at an earlier related report #3395. That one turns out to have a very similar fix, so I've just added that on to this PR:

---

emoji: Fix `:a:`, `:b:`, `:o:`, `:p:` to have emoji-style presentation.

This causes them to render (at least on Android) with bigger, colored
glyphs that look a lot like the glyphs we use in the webapp.

Without this, they render with text-style glyphs: transparent letter
on white background, which also means that in a light theme they're
completely invisible.

These are the only emoji we have in this range of letter characters.
There are some others like :ok: that are from neighboring characters
representing multiple letters, but those all seem to be doing fine
already.

Fixes: #3395
