### PR TITLE
Structure redux-persist code toward doing writes in batches with `AsyncStorage.multiSet`.

### DIFF
--- a/src/third/redux-persist/createPersistor.js
+++ b/src/third/redux-persist/createPersistor.js
@@ -49,13 +49,17 @@ export default function createPersistor (store, config) {
   async function writeOnce(state) {
     writeInProgress = true
 
-    const updatedSubstates = []
-
-    Object.keys(state).forEach((key) => {
-      if (!passWhitelistBlacklist(key)) return
-      if (lastWrittenState[key] === state[key]) return
-      updatedSubstates.push([key, state[key]])
-    });
+    // Atomically collect the subtrees that need to be written out.
+    const updatedSubstates = [];
+    for (const key of Object.keys(state)) {
+      if (!passWhitelistBlacklist(key)) {
+        continue;
+      }
+      if (state[key] === lastWrittenState[key]) {
+        continue;
+      }
+      updatedSubstates.push([key, state[key]]);
+    }
 
     const writes = []
     while (updatedSubstates.length > 0) {

--- a/src/third/redux-persist/createPersistor.js
+++ b/src/third/redux-persist/createPersistor.js
@@ -61,11 +61,10 @@ export default function createPersistor (store, config) {
       updatedSubstates.push([key, state[key]]);
     }
 
+    // Serialize those subtrees, with yields after each one.
     const writes = []
-    while (updatedSubstates.length > 0) {
-      const [key, substate] = updatedSubstates.shift()
+    for (const [key, substate] of updatedSubstates) {
       writes.push([key, serializer(substate)])
-
       await new Promise(r => setTimeout(r, 0));
     }
 

--- a/src/third/redux-persist/createPersistor.js
+++ b/src/third/redux-persist/createPersistor.js
@@ -48,18 +48,14 @@ export default function createPersistor (store, config) {
     });
 
     (async () => {
-      while (true) { // eslint-disable-line no-constant-condition
+      while (updatedSubstates.length > 0) {
         await new Promise(r => setTimeout(r, 0));
-
-        if (updatedSubstates.length === 0) {
-          writeInProgress = false
-          break
-        }
 
         const [key, substate] = updatedSubstates.shift()
         const storageKey = createStorageKey(key)
         storage.setItem(storageKey, serializer(substate)).catch(warnIfSetError(key))
       }
+      writeInProgress = false
     })()
 
     lastState = state

--- a/src/third/redux-persist/createPersistor.js
+++ b/src/third/redux-persist/createPersistor.js
@@ -47,12 +47,10 @@ export default function createPersistor (store, config) {
       storesToProcess.push(key)
     })
 
-    const len = storesToProcess.length
-
     if (!writeInProgress) {
       writeInProgress = true
       const timeIterator = setInterval(() => {
-        if ((paused && len === storesToProcess.length) || storesToProcess.length === 0) {
+        if (storesToProcess.length === 0) {
           clearInterval(timeIterator)
           writeInProgress = false
           return

--- a/src/third/redux-persist/createPersistor.js
+++ b/src/third/redux-persist/createPersistor.js
@@ -33,7 +33,7 @@ export default function createPersistor (store, config) {
   let lastState = {}
   let paused = false
   let storesToProcess = []
-  let timeIterator = null
+  let writeInProgress = false
 
   store.subscribe(() => {
     if (paused) return
@@ -49,12 +49,12 @@ export default function createPersistor (store, config) {
 
     const len = storesToProcess.length
 
-    // time iterator (read: debounce)
-    if (timeIterator === null) {
-      timeIterator = setInterval(() => {
+    if (!writeInProgress) {
+      writeInProgress = true
+      const timeIterator = setInterval(() => {
         if ((paused && len === storesToProcess.length) || storesToProcess.length === 0) {
           clearInterval(timeIterator)
-          timeIterator = null
+          writeInProgress = false
           return
         }
 

--- a/src/third/redux-persist/createPersistor.js
+++ b/src/third/redux-persist/createPersistor.js
@@ -93,7 +93,13 @@ export default function createPersistor (store, config) {
           writes.map(([key, serializedSubstate]) => [createStorageKey(key), serializedSubstate])
         )
       } catch (e) {
-        warnIfSetError(writes.map(([key, _]) => key))(e)
+        logging.warn(
+          e,
+          {
+            message: 'An error was encountered while trying to persist this set of keys',
+            keys: writes.map(([key, _]) => key)
+          }
+        );
         throw e
       }
     }
@@ -150,20 +156,6 @@ export default function createPersistor (store, config) {
      *   https://github.com/zulip/zulip-mobile/pull/4694#discussion_r691739007.
      */
     _resetLastWrittenState: () => { lastWrittenState = store.getState() }
-  }
-}
-
-function warnIfSetError (keys) {
-  return function setError (err) {
-    if (err) {
-      logging.warn(
-        err,
-        {
-          message: 'An error was encountered while trying to persist this set of keys',
-          keys
-        }
-      );
-    }
   }
 }
 

--- a/src/third/redux-persist/createPersistor.js
+++ b/src/third/redux-persist/createPersistor.js
@@ -39,24 +39,24 @@ export default function createPersistor (store, config) {
     writeInProgress = true
 
     const state = store.getState()
-    const storesToProcess = []
+    const updatedSubstates = []
 
     Object.keys(state).forEach((key) => {
       if (!passWhitelistBlacklist(key)) return
       if (lastState[key] === state[key]) return
-      storesToProcess.push(key)
+      updatedSubstates.push([key, state[key]])
     })
 
     const timeIterator = setInterval(() => {
-      if (storesToProcess.length === 0) {
+      if (updatedSubstates.length === 0) {
         clearInterval(timeIterator)
         writeInProgress = false
         return
       }
 
-      const key = storesToProcess.shift()
+      const [key, substate] = updatedSubstates.shift()
       const storageKey = createStorageKey(key)
-      storage.setItem(storageKey, serializer(state[key])).catch(warnIfSetError(key))
+      storage.setItem(storageKey, serializer(substate)).catch(warnIfSetError(key))
     }, 0)
 
     lastState = state

--- a/src/third/redux-persist/createPersistor.js
+++ b/src/third/redux-persist/createPersistor.js
@@ -69,6 +69,7 @@ export default function createPersistor (store, config) {
     }
 
     if (writes.length > 0) { // `multiSet` doesn't like an empty array
+      // Write them all out, in one `storage.multiSet` operation.
       try {
         // Warning: not guaranteed to be done in a transaction.
         await storage.multiSet(
@@ -80,6 +81,7 @@ export default function createPersistor (store, config) {
       }
     }
 
+    // Record success.
     writeInProgress = false
     lastWrittenState = state
   }

--- a/src/third/redux-persist/createPersistor.js
+++ b/src/third/redux-persist/createPersistor.js
@@ -63,10 +63,10 @@ export default function createPersistor (store, config) {
 
     const writes = []
     while (updatedSubstates.length > 0) {
-      await new Promise(r => setTimeout(r, 0));
-
       const [key, substate] = updatedSubstates.shift()
       writes.push([key, serializer(substate)])
+
+      await new Promise(r => setTimeout(r, 0));
     }
 
     if (writes.length > 0) { // `multiSet` doesn't like an empty array

--- a/src/third/redux-persist/createPersistor.js
+++ b/src/third/redux-persist/createPersistor.js
@@ -49,13 +49,18 @@ export default function createPersistor (store, config) {
         updatedSubstates.push([key, state[key]])
       });
 
+      const writes = []
       while (updatedSubstates.length > 0) {
         await new Promise(r => setTimeout(r, 0));
 
         const [key, substate] = updatedSubstates.shift()
-        const storageKey = createStorageKey(key)
-        storage.setItem(storageKey, serializer(substate)).catch(warnIfSetError(key))
+        writes.push([key, serializer(substate)])
       }
+
+      writes.forEach(([key, serializedSubstate]) => {
+        storage.setItem(createStorageKey(key), serializedSubstate).catch(warnIfSetError(key))
+      })
+
       writeInProgress = false
       lastState = state
     })()

--- a/src/third/redux-persist/persistStore.js
+++ b/src/third/redux-persist/persistStore.js
@@ -92,9 +92,9 @@ export default function persistStore (store, config = {}, onComplete) {
             //
             // So, fix that by still resetting `lastState` with the
             // result of `REHYDRATE` when the persistor is paused; we
-            // can do that because we've exposed `_resetLastState` on
+            // can do that because we've exposed `_resetLastWrittenState` on
             // the persistor.
-            persistor._resetLastState()
+            persistor._resetLastWrittenState()
           }
         } finally {
           complete(err, restoredState)


### PR DESCRIPTION
I'd like this to be reviewed/merged after #4709. While that PR is advertised as just adding some tests, it also does its own cleanup of some stuff in redux-persist, so I'd rather not go through reordering it with this PR if it can be avoided.

-----

I ended up doing this more incrementally than I think we'd said I needed to, on the call today. But it's a tricky and important area, and it doesn't have any tests, so this'll hopefully make it easier to track bugs in review than if I'd done it in just a commit or two. I also found that this incremental approach wasn't unusually hard, after all—at least, not when making the changes to get to this point. (It might get harder later on.)

After this series of commits, I believe we give `AsyncStorage` instructions to write out the right updates, in the right order. One flaw that remains after this series is that we don't wait for one write to complete before starting the next. We'll want to fix that, probably after changes like these have landed (but could do it before if we found a good way).

Related: #4587, #4588