### PR TITLE
caughtUp: Fix bug that overwrote CaughtUp state.

### DIFF
--- a/src/caughtup/caughtUpReducer.js
+++ b/src/caughtup/caughtUpReducer.js
@@ -93,7 +93,11 @@ export default (state: CaughtUpState = initialState, action: Action): CaughtUpSt
       let caughtUp = undefined;
       if (action.foundNewest !== undefined && action.foundOldest !== undefined) {
         /* This should always be the case for Zulip Server v1.8 or newer. */
-        caughtUp = { older: action.foundOldest, newer: action.foundNewest };
+        const { older: prevOlder, newer: prevNewer } = state[key] || DEFAULT_CAUGHTUP;
+        caughtUp = {
+          older: prevOlder || action.foundOldest,
+          newer: prevNewer || action.foundNewest,
+        };
       } else {
         caughtUp = legacyInferCaughtUp(state[key], action);
       }


### PR DESCRIPTION
When we made a request for a narrow, we would overwrite the CaughtUp
state for that narrow in the other direction - i.e. if we were fetching
old messages, then we would forget that we've seen the most recent
message.

This commit fixes that by only updating each bit of the CaughtUp state
from false to true (on a fetch-messages result), and never the other
way around.