### PR TITLE
Add basic support for polls (viewing and voting)

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@react-navigation/stack": "^5.9.3",
     "@sentry/react-native": "^2.4.3",
     "@unimodules/core": "~5.3.0",
-    "@zulip/shared": "^0.0.5",
+    "@zulip/shared": "^0.0.6",
     "base-64": "^0.1.0",
     "blueimp-md5": "^2.10.0",
     "color": "^3.0.0",

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -40,6 +40,7 @@ import toggleMobilePushSettings from './settings/toggleMobilePushSettings';
 import createStream from './streams/createStream';
 import getStreams from './streams/getStreams';
 import updateStream from './streams/updateStream';
+import sendSubmessage from './submessages/sendSubmessage';
 import getSubscriptions from './subscriptions/getSubscriptions';
 import subscriptionAdd from './subscriptions/subscriptionAdd';
 import subscriptionRemove from './subscriptions/subscriptionRemove';
@@ -86,6 +87,7 @@ export {
   createStream,
   getStreams,
   updateStream,
+  sendSubmessage,
   getSubscriptions,
   setTopicMute,
   subscriptionAdd,

--- a/src/api/submessages/sendSubmessage.js
+++ b/src/api/submessages/sendSubmessage.js
@@ -1,0 +1,13 @@
+/* @flow strict-local */
+
+import type { ApiResponse, Auth } from '../transportTypes';
+import { apiPost } from '../apiFetch';
+
+/** See https://zulip.readthedocs.io/en/latest/subsystems/widgets.html#poll-todo-lists-and-games */
+// `msg_type` only exists as widget at the moment, see #3205.
+export default async (auth: Auth, messageId: number, content: string): Promise<ApiResponse> =>
+  apiPost(auth, 'submessage', {
+    message_id: messageId,
+    msg_type: 'widget',
+    content,
+  });

--- a/src/webview/css/cssNight.js
+++ b/src/webview/css/cssNight.js
@@ -5,6 +5,9 @@ body {
   color: hsl(210, 11%, 85%);
   background: hsl(212, 28%, 18%);
 }
+.poll-vote {
+  color: hsl(210, 11%, 85%);
+}
 .topic-header {
   background: hsl(212, 13%, 38%);
 }

--- a/src/webview/handleOutboundEvents.js
+++ b/src/webview/handleOutboundEvents.js
@@ -132,6 +132,13 @@ type WebViewOutboundEventTimeDetails = {|
   originalText: string,
 |};
 
+type WebViewOutboundEventVote = {|
+  type: 'vote',
+  messageId: number,
+  key: string,
+  vote: number,
+|};
+
 export type WebViewOutboundEvent =
   | WebViewOutboundEventReady
   | WebViewOutboundEventScroll
@@ -146,7 +153,8 @@ export type WebViewOutboundEvent =
   | WebViewOutboundEventWarn
   | WebViewOutboundEventError
   | WebViewOutboundEventMention
-  | WebViewOutboundEventTimeDetails;
+  | WebViewOutboundEventTimeDetails
+  | WebViewOutboundEventVote;
 
 // TODO: Consider completing this and making it exact, once
 // `MessageList`'s props are type-checked.
@@ -310,6 +318,19 @@ export const handleWebViewOutboundEvent = (
         originalText: event.originalText,
       });
       Alert.alert('', alertText);
+      break;
+    }
+
+    case 'vote': {
+      api.sendSubmessage(
+        props.backgroundData.auth,
+        event.messageId,
+        JSON.stringify({
+          type: 'vote',
+          key: event.key,
+          vote: event.vote,
+        }),
+      );
       break;
     }
 

--- a/src/webview/js/generatedEs3.js
+++ b/src/webview/js/generatedEs3.js
@@ -993,6 +993,26 @@ var compiledWebviewJs = (function (exports) {
       return;
     }
 
+    if (target.matches('.poll-vote')) {
+      var _messageElement = target.closest('.message');
+
+      if (!_messageElement) {
+        throw new Error('Message element not found');
+      }
+
+      var current_vote = requireAttribute(target, 'data-voted') === 'true';
+      var vote = current_vote ? -1 : 1;
+      sendMessage({
+        type: 'vote',
+        messageId: requireNumericAttribute(_messageElement, 'data-msg-id'),
+        key: requireAttribute(target, 'data-key'),
+        vote: vote
+      });
+      target.setAttribute('data-voted', (!current_vote).toString());
+      target.innerText = (parseInt(target.innerText, 10) + vote).toString();
+      return;
+    }
+
     if (target.matches('time')) {
       var originalText = requireAttribute(target, 'original-text');
       sendMessage({

--- a/src/webview/js/js.js
+++ b/src/webview/js/js.js
@@ -918,6 +918,27 @@ documentBody.addEventListener('click', (e: MouseEvent) => {
     return;
   }
 
+  if (target.matches('.poll-vote')) {
+    const messageElement = target.closest('.message');
+    if (!messageElement) {
+      throw new Error('Message element not found');
+    }
+    // This duplicates some logic from PollData.handle.vote.outbound in
+    // @zulip/shared/js/poll_data.js, but it's much simpler to just duplicate
+    // it than it is to thread a callback all the way over here.
+    const current_vote = requireAttribute(target, 'data-voted') === 'true';
+    const vote = current_vote ? -1 : 1;
+    sendMessage({
+      type: 'vote',
+      messageId: requireNumericAttribute(messageElement, 'data-msg-id'),
+      key: requireAttribute(target, 'data-key'),
+      vote,
+    });
+    target.setAttribute('data-voted', (!current_vote).toString());
+    target.innerText = (parseInt(target.innerText, 10) + vote).toString();
+    return;
+  }
+
   if (target.matches('time')) {
     const originalText = requireAttribute(target, 'original-text');
     sendMessage({

--- a/src/webview/static/base.css
+++ b/src/webview/static/base.css
@@ -696,3 +696,50 @@ h1, h2, h3, h4, h5, h6 {
 .spoiler-block .spoiler-arrow.spoiler-button-open::after {
   transform: rotate(90deg) translate(10px, 0);
 }
+
+/* Poll styling */
+
+.poll-widget {
+  border: hsl(0, 0%, 50%) 1px solid;
+  padding: 2px 8px 2px 10px;
+  border-radius: 10px;
+}
+
+.poll-question {
+  font-size: 1.2rem;
+  margin-bottom: 8px;
+  border-bottom: 1px solid hsla(0, 0%, 60%, 0.2);
+}
+
+.poll-widget > ul {
+  padding: 0px;
+}
+
+.poll-widget > ul > li {
+  list-style: none;
+  margin-bottom: 4px;
+  display: flex;
+  align-items: center;
+}
+
+.poll-vote {
+  background-color: hsla(0, 0%, 0%, 0);
+  border: 1.5px solid hsl(0, 0%, 50%);
+  border-radius: 8px;
+  height: 36px;
+  min-width: 36px;
+  padding: 1px 8px;
+  font-weight: bold;
+  font-size: 18px;
+  flex-shrink: 0;
+}
+
+.poll-vote[data-voted="true"] {
+  border: 1.5px solid hsl(222, 99%, 69%);
+  background-color: hsla(222, 99%, 69%, 25%);
+}
+
+.poll-option {
+  margin-left: 8px;
+  width: 100%;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2857,10 +2857,10 @@
   resolved "https://registry.yarnpkg.com/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz#e77a97fbd345b76d83245edcd17d393b1b41fb31"
   integrity sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==
 
-"@zulip/shared@^0.0.5":
-  version "0.0.5"
-  resolved "https://registry.yarnpkg.com/@zulip/shared/-/shared-0.0.5.tgz#6c5984cecb3b56b415ebfa82d4f17eab14ef75e3"
-  integrity sha512-mQNuFO4IvsvCRXTppLAAarBTdtObHE9cpqlGIqJD5rsQSv1wq3PTFxUgQuEAA+9p2L9ND2ucHzFFbMIku587JQ==
+"@zulip/shared@^0.0.6":
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/@zulip/shared/-/shared-0.0.6.tgz#024450692670b572b6eb095845a1203d3001890e"
+  integrity sha512-17Shi/YJMln4h/B1CE3I2JiEO99tZDClTDEEXEk/XI2SGYCi1Tdb4hB48QKnlV0cy9k93KAX3oC6cydZyZUwiQ==
   dependencies:
     katex "^0.12.0"
     lodash "^4.17.19"


### PR DESCRIPTION
This PR adds basic support for viewing and voting on polls.

Some notes:

* It's pretty ugly, largely because the underlying widget/submessage/polls code is ugly. I'm open to changing things where it's easy, but I don't want to go down the rabbit hole of cleaning up the fundamental way that polls work.
* I've implemented local echo, although I don't know how I feel about it — if the `sendSubmessage` fails, we wouldn't communicate that to the user. Happy to have thoughts on what the right approach is here. One thought is that maybe we want to change the background color, but not the number? That would be pretty ugly, but could communicate what's going on without building a bunch more UI. We could also add a loading spinner like we do on outbox messages.
* I have a `$FlowFixMe` for adding types to `PollData`. I'm would like to do this, although probably not complete types: there are some fundamental limits to how much we can get from typing here, since there's so much dynamism in how widgets work.
* I made the poll buttons 36x36px, since 48x48 seemed really large. I understand that we usually aim for 48x48px touch targets, but I think that for instance, reaction emoji are good precedent here for not doing that.

![screenshot](https://user-images.githubusercontent.com/5001092/116582987-77591b80-a948-11eb-9e4c-71dc6dd120bb.png)
