### PR TITLE
unreads: Don't add messages with "read" flag to unreads.

### DIFF
--- a/src/unread/__tests__/unreadHuddlesReducer-test.js
+++ b/src/unread/__tests__/unreadHuddlesReducer-test.js
@@ -118,7 +118,7 @@ describe('unreadHuddlesReducer', () => {
       expect(actualState).toBe(initialState);
     });
 
-    test('if message is sent by self, do not mutate state', () => {
+    test('if message has "read" flag, do not mutate state', () => {
       const selfUser = { ...eg.selfUser, user_id: makeUserId(1) };
       const user2 = { ...eg.otherUser, user_id: makeUserId(2) };
       const user3 = { ...eg.thirdUser, user_id: makeUserId(3) };
@@ -126,8 +126,9 @@ describe('unreadHuddlesReducer', () => {
       const initialState = deepFreeze([]);
 
       const message2 = eg.pmMessage({
-        sender: selfUser,
+        sender: user2,
         recipients: [selfUser, user2, user3],
+        flags: ['read'],
       });
 
       const action = deepFreeze({

--- a/src/unread/__tests__/unreadMentionsReducer-test.js
+++ b/src/unread/__tests__/unreadMentionsReducer-test.js
@@ -67,6 +67,22 @@ describe('unreadMentionsReducer', () => {
       expect(actualState).toBe(initialState);
     });
 
+    test('if message has "read" flag, do not mutate state', () => {
+      const initialState = deepFreeze([]);
+
+      const action = deepFreeze({
+        type: EVENT_NEW_MESSAGE,
+        message: {
+          id: 2,
+          flags: ['mentioned', 'read'],
+        },
+      });
+
+      const actualState = unreadMentionsReducer(initialState, action);
+
+      expect(actualState).toBe(initialState);
+    });
+
     test('if message id already exists, do not mutate state', () => {
       const initialState = deepFreeze([1, 2]);
 

--- a/src/unread/__tests__/unreadMentionsReducer-test.js
+++ b/src/unread/__tests__/unreadMentionsReducer-test.js
@@ -1,13 +1,12 @@
+/* @flow strict-local */
 import deepFreeze from 'deep-freeze';
+import Immutable from 'immutable';
 
 import unreadMentionsReducer from '../unreadMentionsReducer';
-import {
-  REALM_INIT,
-  ACCOUNT_SWITCH,
-  EVENT_NEW_MESSAGE,
-  EVENT_UPDATE_MESSAGE_FLAGS,
-} from '../../actionConstants';
+import { ACCOUNT_SWITCH, EVENT_UPDATE_MESSAGE_FLAGS } from '../../actionConstants';
 import { NULL_ARRAY } from '../../nullObjects';
+import * as eg from '../../__tests__/lib/exampleData';
+import { mkMessageAction } from './unread-testlib';
 
 describe('unreadMentionsReducer', () => {
   describe('ACCOUNT_SWITCH', () => {
@@ -16,6 +15,7 @@ describe('unreadMentionsReducer', () => {
 
       const action = deepFreeze({
         type: ACCOUNT_SWITCH,
+        index: 0,
       });
 
       const expectedState = [];
@@ -30,17 +30,19 @@ describe('unreadMentionsReducer', () => {
     test('received data from "unread_msgs.mentioned" key replaces the current state ', () => {
       const initialState = deepFreeze([]);
 
-      const action = deepFreeze({
-        type: REALM_INIT,
+      const action = {
+        ...eg.action.realm_init,
         data: {
+          ...eg.action.realm_init.data,
           unread_msgs: {
-            streams: [{}, {}],
-            huddles: [{}, {}, {}],
-            pms: [{}, {}, {}],
+            ...eg.action.realm_init.data.unread_msgs,
+            streams: [],
+            huddles: [],
+            pms: [],
             mentions: [1, 2, 3],
           },
         },
-      });
+      };
 
       const expectedState = [1, 2, 3];
 
@@ -54,13 +56,7 @@ describe('unreadMentionsReducer', () => {
     test('if message does not contain "mentioned" flag, do not mutate state', () => {
       const initialState = deepFreeze([]);
 
-      const action = deepFreeze({
-        type: EVENT_NEW_MESSAGE,
-        message: {
-          id: 2,
-          flags: [],
-        },
-      });
+      const action = mkMessageAction(eg.streamMessage({ flags: [] }));
 
       const actualState = unreadMentionsReducer(initialState, action);
 
@@ -70,13 +66,7 @@ describe('unreadMentionsReducer', () => {
     test('if message has "read" flag, do not mutate state', () => {
       const initialState = deepFreeze([]);
 
-      const action = deepFreeze({
-        type: EVENT_NEW_MESSAGE,
-        message: {
-          id: 2,
-          flags: ['mentioned', 'read'],
-        },
-      });
+      const action = mkMessageAction(eg.streamMessage({ flags: ['mentioned', 'read'] }));
 
       const actualState = unreadMentionsReducer(initialState, action);
 
@@ -86,13 +76,7 @@ describe('unreadMentionsReducer', () => {
     test('if message id already exists, do not mutate state', () => {
       const initialState = deepFreeze([1, 2]);
 
-      const action = deepFreeze({
-        type: EVENT_NEW_MESSAGE,
-        message: {
-          id: 2,
-          flags: ['mentioned'],
-        },
-      });
+      const action = mkMessageAction(eg.streamMessage({ id: 2, flags: ['mentioned', 'read'] }));
 
       const actualState = unreadMentionsReducer(initialState, action);
 
@@ -102,13 +86,7 @@ describe('unreadMentionsReducer', () => {
     test('if "mentioned" flag is set and message id does not exist, append to state', () => {
       const initialState = deepFreeze([1, 2]);
 
-      const action = deepFreeze({
-        type: EVENT_NEW_MESSAGE,
-        message: {
-          id: 3,
-          flags: ['mentioned'],
-        },
-      });
+      const action = mkMessageAction(eg.streamMessage({ id: 3, flags: ['mentioned'] }));
 
       const expectedState = [1, 2, 3];
 
@@ -124,6 +102,9 @@ describe('unreadMentionsReducer', () => {
 
       const action = {
         type: EVENT_UPDATE_MESSAGE_FLAGS,
+        id: 0,
+        all: false,
+        allMessages: Immutable.Map(),
         messages: [1, 2, 3],
         flag: 'star',
         op: 'add',
@@ -139,6 +120,9 @@ describe('unreadMentionsReducer', () => {
 
       const action = deepFreeze({
         type: EVENT_UPDATE_MESSAGE_FLAGS,
+        id: 0,
+        all: false,
+        allMessages: Immutable.Map(),
         messages: [2],
         flag: 'read',
         op: 'add',
@@ -154,6 +138,9 @@ describe('unreadMentionsReducer', () => {
 
       const action = deepFreeze({
         type: EVENT_UPDATE_MESSAGE_FLAGS,
+        id: 0,
+        all: false,
+        allMessages: Immutable.Map(),
         messages: [2, 3],
         flag: 'read',
         op: 'add',
@@ -171,6 +158,9 @@ describe('unreadMentionsReducer', () => {
 
       const action = deepFreeze({
         type: EVENT_UPDATE_MESSAGE_FLAGS,
+        id: 0,
+        all: false,
+        allMessages: Immutable.Map(),
         messages: [1, 2],
         flag: 'read',
         op: 'remove',
@@ -186,6 +176,8 @@ describe('unreadMentionsReducer', () => {
 
       const action = deepFreeze({
         type: EVENT_UPDATE_MESSAGE_FLAGS,
+        id: 0,
+        allMessages: Immutable.Map(),
         messages: [],
         flag: 'read',
         op: 'add',

--- a/src/unread/__tests__/unreadModel-test.js
+++ b/src/unread/__tests__/unreadModel-test.js
@@ -84,10 +84,10 @@ describe('stream substate', () => {
       expect(state.streams).toBe(baseState.streams);
     });
 
-    test('if message is sent by self, do not mutate state', () => {
+    test('if message has "read" flag, do not mutate state', () => {
       const state = reducer(
         baseState,
-        action(eg.streamMessage({ sender: eg.selfUser })),
+        action(eg.streamMessage({ sender: eg.selfUser, flags: ['read'] })),
         eg.plusReduxState,
       );
       expect(state).toBe(baseState);

--- a/src/unread/__tests__/unreadPmsReducer-test.js
+++ b/src/unread/__tests__/unreadPmsReducer-test.js
@@ -111,11 +111,12 @@ describe('unreadPmsReducer', () => {
       expect(actualState).toBe(initialState);
     });
 
-    test('if message is sent by self, do not mutate state', () => {
+    test('if message is marked read, do not mutate state', () => {
       const initialState = deepFreeze([]);
       const message1 = eg.pmMessage({
-        sender: eg.selfUser,
+        sender: eg.otherUser,
         recipients: [eg.otherUser, eg.selfUser],
+        flags: ['read'],
       });
 
       const action = deepFreeze({

--- a/src/unread/__tests__/unreadPmsReducer-test.js
+++ b/src/unread/__tests__/unreadPmsReducer-test.js
@@ -130,6 +130,31 @@ describe('unreadPmsReducer', () => {
       expect(actualState).toBe(initialState);
     });
 
+    test('if message is marked unread in self-PM, append to state', () => {
+      const initialState = deepFreeze([]);
+      const message1 = eg.pmMessage({
+        sender: eg.selfUser,
+        recipients: [eg.selfUser],
+      });
+
+      const action = deepFreeze({
+        ...eg.eventNewMessageActionBase,
+        message: message1,
+        ownUserId: eg.selfUser.user_id,
+      });
+
+      const expectedState = [
+        {
+          sender_id: eg.selfUser.user_id,
+          unread_message_ids: [message1.id],
+        },
+      ];
+
+      const actualState = unreadPmsReducer(initialState, action);
+
+      expect(actualState).toEqual(expectedState);
+    });
+
     test('if message id does not exist, append to state', () => {
       const message1 = eg.pmMessage({ id: 1, sender_id: 1 });
       const message2 = eg.pmMessage({ id: 2, sender_id: 1 });

--- a/src/unread/unreadHuddlesReducer.js
+++ b/src/unread/unreadHuddlesReducer.js
@@ -24,7 +24,14 @@ const eventNewMessage = (state, action) => {
     return state;
   }
 
-  if (action.ownUserId === action.message.sender_id) {
+  // TODO: In reality, we should error if `flags` is undefined, since it's
+  // always supposed to be set. However, our tests currently don't pass flags
+  // into these events, making it annoying to fix this. We should fix the
+  // tests, then change this to error if `flags` is undefined. See [1] for
+  // details.
+  //
+  // [1]: https://github.com/zulip/zulip-mobile/pull/4710/files#r627850775
+  if (action.message.flags?.includes('read')) {
     return state;
   }
 

--- a/src/unread/unreadMentionsReducer.js
+++ b/src/unread/unreadMentionsReducer.js
@@ -46,6 +46,9 @@ export default (state: UnreadMentionsState = initialState, action: Action): Unre
       if (!flags) {
         throw new Error('action.message.flags should be defined.');
       }
+      if (flags.includes('read')) {
+        return state;
+      }
       return (flags.includes('mentioned') || flags.includes('wildcard_mentioned'))
         && !state.includes(action.message.id)
         ? addItemsToArray(state, [action.message.id])

--- a/src/unread/unreadModel.js
+++ b/src/unread/unreadModel.js
@@ -22,7 +22,6 @@ import {
   MESSAGE_FETCH_COMPLETE,
   REALM_INIT,
 } from '../actionConstants';
-import { getOwnUserId } from '../users/userSelectors';
 
 //
 //
@@ -146,7 +145,14 @@ function streamsReducer(
         return state;
       }
 
-      if (message.sender_id === getOwnUserId(globalState)) {
+      // TODO: In reality, we should error if `flags` is undefined, since it's
+      // always supposed to be set. However, our tests currently don't pass flags
+      // into these events, making it annoying to fix this. We should fix the
+      // tests, then change this to error if `flags` is undefined. See [1] for
+      // details.
+      //
+      // [1]: https://github.com/zulip/zulip-mobile/pull/4710/files#r627850775
+      if (message.flags?.includes('read')) {
         return state;
       }
 

--- a/src/unread/unreadPmsReducer.js
+++ b/src/unread/unreadPmsReducer.js
@@ -24,7 +24,14 @@ const eventNewMessage = (state, action) => {
     return state;
   }
 
-  if (action.ownUserId === action.message.sender_id) {
+  // TODO: In reality, we should error if `flags` is undefined, since it's
+  // always supposed to be set. However, our tests currently don't pass flags
+  // into these events, making it annoying to fix this. We should fix the
+  // tests, then change this to error if `flags` is undefined. See [1] for
+  // details.
+  //
+  // [1]: https://github.com/zulip/zulip-mobile/pull/4710/files#r627850775
+  if (action.message.flags?.includes('read')) {
     return state;
   }
 

--- a/src/unread/unreadPmsReducer.js
+++ b/src/unread/unreadPmsReducer.js
@@ -20,7 +20,7 @@ const eventNewMessage = (state, action) => {
     return state;
   }
 
-  if (recipientsOfPrivateMessage(action.message).length !== 2) {
+  if (recipientsOfPrivateMessage(action.message).length > 2) {
     return state;
   }
 


### PR DESCRIPTION
Previously, the main (only?) case where we wouldn't add a message to
unreads was if we were the one who sent it. This check was not correct -
instead, we want to check to see if the message has the "read" flag,
which is set by the server.

In the past, these checks were very close to the same (with the
exception of "Notification Bot" announcing a stream that you created,
which would be "read" for you), but with the addition of muted users,
the check is now incorrect.

This commit removes the logic to not mark a message as read when we are
the one who sent it, and instead just looks at the server flag, since
that should be the canonical place for that information to be.