### PR TITLE
css: Don't show mention highlight for muted messages.

### DIFF
--- a/src/webview/static/base.css
+++ b/src/webview/static/base.css
@@ -299,7 +299,8 @@ body {
  Inside a message, outside its contents.
  */
 
-[data-mentioned="true"], [data-wildcard_mentioned="true"] {
+[data-mentioned="true"][data-mute-state="shown"],
+[data-wildcard_mentioned="true"][data-mute-state="shown"] {
   background: hsla(0, 100%, 50%, 0.05);
 }
 .message:not([data-read="true"]) {


### PR DESCRIPTION
We don't want messages that are muted and hidden to show the user that
they are mentioned in the message.