### PR TITLE
Fix bug in AndroidManifest that prevented play store from displaying Zulip to certain user as an installable app.

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -15,6 +15,15 @@
         android:name="android.hardware.touchscreen"
         android:required="false" />
 
+    <!-- The CAMERA permission causes these two camera-related features to be
+         implicitly treated as required, so we have to explicitly say they're not. -->
+    <uses-feature
+        android:name="android.hardware.camera"
+        android:required="false" />
+    <uses-feature
+        android:name="android.hardware.camera.autofocus"
+        android:required="false" />
+
     <application
         android:name=".MainApplication"
         android:allowBackup="true"

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -8,9 +8,7 @@
     <uses-permission
         android:name="android.permission.READ_PHONE_STATE"
         tools:node="remove" />
-    <uses-permission
-        android:name="android.permission.CAMERA"
-        android:required="false" />
+    <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 
     <uses-feature


### PR DESCRIPTION
Fixes: #4722

All of the relevant documentation is given in https://developer.android.com/guide/topics/manifest/uses-feature-element, it explains how play store filtering works and what a developer can do to control that.

gist is explained in the commit message of https://github.com/zulip/zulip-mobile/commit/199b73b6a72fe4f3c74fdba6e5a305bea13b67c1 of this PR.

> Google Play filters which app to display to a user based on `uses-sdk`,
`uses-permission` and `uses-feature` tags.

> In case `uses-feature` is not declared `uses-permission` is used to do
this filtering, and by default it treats the permission it needs as a
compulsory requirement for the app. Hence our app will not show in play
store for devices without the hardware of concern.

> With `uses-feature` we override the filtering done by `uses-permission`
and by setting the required attribute to false we say that our app isn't
dependent on the hardware of concern to work properly (camera in case of
this commit).

**Why did I specifically add `android.hardware.camera` and `android.hardware.camera.autofocus` in `uses-feature`?**
Table 2 at https://developer.android.com/guide/topics/manifest/uses-feature-element#permissions gives a list which hardware requirements are affected by which specific permission. I am speculating here that without `android.hardware.camera.autofocus` an android device with camera but without autofocus hardware won't be shown our app as well.

I am wondering now what exactly will happen if a user without camera does press the button to access camera in our app, and if something like [checking hardware availability](https://developer.android.com/training/permissions/declaring#determine-hardware-availability) be required?