### PR TITLE
intl: Highlight in dev user-facing strings not added to messages_en.json.

### DIFF
--- a/src/boot/TranslationProvider.js
+++ b/src/boot/TranslationProvider.js
@@ -36,7 +36,18 @@ export function withGetText<P: { +_: GetText, ... }, C: ComponentType<P>>(
 
 const makeGetText = (intl: IntlShape): GetText => {
   const _ = (message, values) =>
-    intl.formatMessage({ id: message, defaultMessage: message }, values);
+    intl.formatMessage(
+      {
+        id: message,
+
+        // If you see this in dev, it means there's a user-facing
+        // string that hasn't been added to
+        // static/translations/messages_en.json. Please add it! :)
+        defaultMessage:
+          process.env.NODE_ENV === 'development' ? `UNTRANSLATED—${message}—UNTRANSLATED` : message,
+      },
+      values,
+    );
   _.intl = intl;
   return _;
 };

--- a/src/common/TranslatedText.js
+++ b/src/common/TranslatedText.js
@@ -18,5 +18,16 @@ export default ({ text }: Props) => {
   const message = typeof text === 'object' ? text.text : text;
   const values = typeof text === 'object' ? text.values : undefined;
 
-  return <FormattedMessage id={message} defaultMessage={message} values={values} />;
+  return (
+    <FormattedMessage
+      id={message}
+      // If you see this in dev, it means there's a user-facing string
+      // that hasn't been added to
+      // static/translations/messages_en.json. Please add it! :)
+      defaultMessage={
+        process.env.NODE_ENV === 'development' ? `UNTRANSLATED—${message}—UNTRANSLATED` : message
+      }
+      values={values}
+    />
+  );
 };

--- a/src/main/StreamTabsScreen.js
+++ b/src/main/StreamTabsScreen.js
@@ -1,12 +1,11 @@
 /* @flow strict-local */
 import React from 'react';
-import { Text } from 'react-native';
-import { FormattedMessage } from 'react-intl';
 import {
   createMaterialTopTabNavigator,
   type MaterialTopTabNavigationProp,
 } from '@react-navigation/material-top-tabs';
 
+import { Label } from '../common';
 import { createStyleSheet } from '../styles';
 import type { RouteProp, RouteParamsOf } from '../react-navigation';
 import type { MainTabsNavigationProp } from './MainTabsScreen';
@@ -55,22 +54,14 @@ export default function StreamTabsScreen(props: Props) {
         name="subscribed"
         component={SubscriptionsCard}
         options={{
-          tabBarLabel: ({ color }) => (
-            <Text style={[styles.tab, { color }]}>
-              <FormattedMessage id="Subscribed" defaultMessage="Subscribed" />
-            </Text>
-          ),
+          tabBarLabel: ({ color }) => <Label style={[styles.tab, { color }]} text="Subscribed" />,
         }}
       />
       <Tab.Screen
         name="allStreams"
         component={StreamListCard}
         options={{
-          tabBarLabel: ({ color }) => (
-            <Text style={[styles.tab, { color }]}>
-              <FormattedMessage id="All streams" defaultMessage="All streams" />
-            </Text>
-          ),
+          tabBarLabel: ({ color }) => <Label style={[styles.tab, { color }]} text="All streams" />,
         }}
       />
     </Tab.Navigator>

--- a/src/sharing/SharingScreen.js
+++ b/src/sharing/SharingScreen.js
@@ -1,11 +1,9 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
-import { Text } from 'react-native';
 import {
   createMaterialTopTabNavigator,
   type MaterialTopTabNavigationProp,
 } from '@react-navigation/material-top-tabs';
-import { FormattedMessage } from 'react-intl';
 
 import type { GlobalParamList } from '../nav/globalTypes';
 import type { RouteParamsOf, RouteProp } from '../react-navigation';
@@ -16,7 +14,7 @@ import type { Dispatch, Auth, SharedData } from '../types';
 import { createStyleSheet } from '../styles';
 import { materialTopTabNavigatorConfig } from '../styles/tabs';
 import { connect } from '../react-redux';
-import { Screen } from '../common';
+import { Label, Screen } from '../common';
 import { tryGetAuth } from '../selectors';
 import { navigateToAccountPicker } from '../nav/navActions';
 import ShareToStream from './ShareToStream';
@@ -76,11 +74,7 @@ class SharingScreen extends PureComponent<Props> {
             name="share-to-stream"
             component={ShareToStream}
             options={{
-              tabBarLabel: ({ color }) => (
-                <Text style={[styles.tab, { color }]}>
-                  <FormattedMessage id="Stream" defaultMessage="Stream" />
-                </Text>
-              ),
+              tabBarLabel: ({ color }) => <Label style={[styles.tab, { color }]} text="Stream" />,
             }}
           />
           <Tab.Screen
@@ -88,9 +82,7 @@ class SharingScreen extends PureComponent<Props> {
             component={ShareToPm}
             options={{
               tabBarLabel: ({ color }) => (
-                <Text style={[styles.tab, { color }]}>
-                  <FormattedMessage id="Private Message" defaultMessage="Private Message" />
-                </Text>
+                <Label style={[styles.tab, { color }]} text="Private Message" />
               ),
             }}
           />


### PR DESCRIPTION
As discussed around
  https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/Warn.20if.20user-facing.20strings.20untreated/near/1156727,
this seems pretty low-risk and high-reward.

-----

Also a follow-up commit that removes some places where we were passing `defaultMessage` to a `FormattedMessage` component. Those aren't suppressing any errors; I did check that the strings there were all in messages_en.json. But our habit has been to use `Label` instead of using `FormattedMessage` directly, so, do that.