### PR TITLE
Muted users placeholder in reactions screen

### DIFF
--- a/src/common/Icons.js
+++ b/src/common/Icons.js
@@ -8,6 +8,7 @@ import type { FeatherGlyphs } from 'react-native-vector-icons/Feather';
 import IoniconsIcon from 'react-native-vector-icons/Ionicons';
 import MaterialIcon from 'react-native-vector-icons/MaterialIcons';
 import SimpleLineIcons from 'react-native-vector-icons/SimpleLineIcons';
+import FontAwesome from 'react-native-vector-icons/FontAwesome';
 
 /**
  * The props actually accepted by icon components in r-n-vector-icons.
@@ -85,3 +86,4 @@ export const IconMoreHorizontal = makeIcon(Feather, 'more-horizontal');
 export const IconEdit = makeIcon(Feather, 'edit');
 export const IconPlusSquare = makeIcon(Feather, 'plus-square');
 export const IconVideo = makeIcon(Feather, 'video');
+export const IconUserMuted = makeIcon(FontAwesome, 'user');

--- a/src/common/UserAvatar.js
+++ b/src/common/UserAvatar.js
@@ -1,5 +1,5 @@
 /* @flow strict-local */
-import React, { type Node as React$Node } from 'react';
+import React, { type Node as React$Node, useContext } from 'react';
 import { Image, View, PixelRatio } from 'react-native';
 
 import { useSelector } from '../react-redux';
@@ -7,10 +7,13 @@ import { getAuthHeaders } from '../api/transport';
 import { tryGetAuth } from '../account/accountsSelectors';
 import Touchable from './Touchable';
 import { AvatarURL, FallbackAvatarURL } from '../utils/avatar';
+import { IconUserMuted } from './Icons';
+import { ThemeContext } from '../styles';
 
 type Props = $ReadOnly<{|
   avatarUrl: AvatarURL,
   size: number,
+  isMuted?: boolean,
   children?: React$Node,
   onPress?: () => void,
 |}>;
@@ -24,13 +27,20 @@ type Props = $ReadOnly<{|
  * @prop [onPress] - Event fired on pressing the component.
  */
 function UserAvatar(props: Props) {
-  const { avatarUrl, children, size, onPress } = props;
+  const { avatarUrl, children, size, isMuted = false, onPress } = props;
   const borderRadius = size / 8;
   const style = {
     height: size,
     width: size,
     borderRadius,
   };
+  const iconStyle = {
+    height: size,
+    width: size,
+    textAlign: 'center',
+  };
+
+  const { color } = useContext(ThemeContext);
 
   const auth = useSelector(state => tryGetAuth(state));
   if (!auth) {
@@ -48,16 +58,20 @@ function UserAvatar(props: Props) {
     <View>
       <Touchable onPress={onPress}>
         <View>
-          <Image
-            source={{
-              uri: avatarUrl.get(PixelRatio.getPixelSizeForLayoutSize(size)).toString(),
-              ...(avatarUrl instanceof FallbackAvatarURL
-                ? { headers: getAuthHeaders(auth) }
-                : undefined),
-            }}
-            style={style}
-            resizeMode="cover"
-          />
+          {!isMuted ? (
+            <Image
+              source={{
+                uri: avatarUrl.get(PixelRatio.getPixelSizeForLayoutSize(size)).toString(),
+                ...(avatarUrl instanceof FallbackAvatarURL
+                  ? { headers: getAuthHeaders(auth) }
+                  : undefined),
+              }}
+              style={style}
+              resizeMode="cover"
+            />
+          ) : (
+            <IconUserMuted size={size} color={color} style={iconStyle} />
+          )}
           {children}
         </View>
       </Touchable>

--- a/src/common/UserAvatar.js
+++ b/src/common/UserAvatar.js
@@ -1,6 +1,6 @@
 /* @flow strict-local */
 import React, { type Node as React$Node } from 'react';
-import { ImageBackground, View, PixelRatio } from 'react-native';
+import { Image, View, PixelRatio } from 'react-native';
 
 import { useSelector } from '../react-redux';
 import { getAuthHeaders } from '../api/transport';
@@ -46,21 +46,20 @@ function UserAvatar(props: Props) {
 
   return (
     <View>
-      <Touchable onPress={onPress} style={style}>
-        <ImageBackground
-          style={style}
-          source={{
-            uri: avatarUrl.get(PixelRatio.getPixelSizeForLayoutSize(size)).toString(),
-            ...(avatarUrl instanceof FallbackAvatarURL
-              ? { headers: getAuthHeaders(auth) }
-              : undefined),
-          }}
-          resizeMode="cover"
-          /* ImageBackground seems to ignore `style.borderRadius`. */
-          borderRadius={borderRadius}
-        >
+      <Touchable onPress={onPress}>
+        <View>
+          <Image
+            source={{
+              uri: avatarUrl.get(PixelRatio.getPixelSizeForLayoutSize(size)).toString(),
+              ...(avatarUrl instanceof FallbackAvatarURL
+                ? { headers: getAuthHeaders(auth) }
+                : undefined),
+            }}
+            style={style}
+            resizeMode="cover"
+          />
           {children}
-        </ImageBackground>
+        </View>
       </Touchable>
     </View>
   );

--- a/src/common/UserAvatar.js
+++ b/src/common/UserAvatar.js
@@ -55,27 +55,25 @@ function UserAvatar(props: Props) {
   }
 
   return (
-    <View>
-      <Touchable onPress={onPress}>
-        <View>
-          {!isMuted ? (
-            <Image
-              source={{
-                uri: avatarUrl.get(PixelRatio.getPixelSizeForLayoutSize(size)).toString(),
-                ...(avatarUrl instanceof FallbackAvatarURL
-                  ? { headers: getAuthHeaders(auth) }
-                  : undefined),
-              }}
-              style={style}
-              resizeMode="cover"
-            />
-          ) : (
-            <IconUserMuted size={size} color={color} style={iconStyle} />
-          )}
-          {children}
-        </View>
-      </Touchable>
-    </View>
+    <Touchable onPress={onPress}>
+      <View>
+        {!isMuted ? (
+          <Image
+            source={{
+              uri: avatarUrl.get(PixelRatio.getPixelSizeForLayoutSize(size)).toString(),
+              ...(avatarUrl instanceof FallbackAvatarURL
+                ? { headers: getAuthHeaders(auth) }
+                : undefined),
+            }}
+            style={style}
+            resizeMode="cover"
+          />
+        ) : (
+          <IconUserMuted size={size} color={color} style={iconStyle} />
+        )}
+        {children}
+      </View>
+    </Touchable>
   );
 }
 

--- a/src/common/UserAvatarWithPresence.js
+++ b/src/common/UserAvatarWithPresence.js
@@ -22,6 +22,7 @@ type Props = $ReadOnly<{|
   size: number,
   onPress?: () => void,
   email: string,
+  isMuted?: boolean,
 |}>;
 
 /**
@@ -38,10 +39,10 @@ type Props = $ReadOnly<{|
  */
 export default class UserAvatarWithPresence extends PureComponent<Props> {
   render() {
-    const { avatarUrl, email, size, onPress } = this.props;
+    const { avatarUrl, email, isMuted, size, onPress } = this.props;
 
     return (
-      <UserAvatar avatarUrl={avatarUrl} size={size} onPress={onPress}>
+      <UserAvatar avatarUrl={avatarUrl} size={size} isMuted={isMuted} onPress={onPress}>
         <PresenceStatusIndicator
           style={styles.status}
           email={email}

--- a/src/users/UserItem.js
+++ b/src/users/UserItem.js
@@ -1,5 +1,5 @@
 /* @flow strict-local */
-import React, { type ElementConfig, PureComponent } from 'react';
+import React, { type ElementConfig, useCallback } from 'react';
 import { View } from 'react-native';
 
 import type { UserId } from '../types';
@@ -30,8 +30,8 @@ const componentStyles = createStyleSheet({
 
 type Props<UserT> = $ReadOnly<{|
   user: UserT,
-  isSelected: boolean,
-  showEmail: boolean,
+  isSelected?: boolean,
+  showEmail?: boolean,
   unreadCount?: number,
   onPress?: UserT => void,
 |}>;
@@ -46,57 +46,49 @@ type Props<UserT> = $ReadOnly<{|
  * user, one that doesn't exist in the database.  (But anywhere we're doing
  * that, there's probably a better UI anyway than showing a fake user.)
  */
-export class UserItemRaw<
-  UserT: { user_id: UserId, email: string, full_name: string, ... },
-> extends PureComponent<Props<UserT>> {
-  static defaultProps = {
-    isSelected: false,
-    showEmail: false,
-  };
+export function UserItemRaw<UserT: { user_id: UserId, email: string, full_name: string, ... }>(
+  props: Props<UserT>,
+) {
+  const { user, isSelected = false, onPress, unreadCount, showEmail = false } = props;
 
-  handlePress = () => {
-    const { user, onPress } = this.props;
+  const handlePress = useCallback(() => {
     if (onPress) {
       onPress(user);
     }
-  };
+  }, [onPress, user]);
 
-  render() {
-    const { user, isSelected, onPress, unreadCount, showEmail } = this.props;
-
-    return (
-      <Touchable onPress={onPress && this.handlePress}>
-        <View style={[styles.listItem, isSelected && componentStyles.selectedRow]}>
-          <UserAvatarWithPresenceById
-            size={48}
-            userId={user.user_id}
-            onPress={onPress && this.handlePress}
+  return (
+    <Touchable onPress={onPress && handlePress}>
+      <View style={[styles.listItem, isSelected && componentStyles.selectedRow]}>
+        <UserAvatarWithPresenceById
+          size={48}
+          userId={user.user_id}
+          onPress={onPress && handlePress}
+        />
+        <View style={componentStyles.textWrapper}>
+          <RawLabel
+            style={[componentStyles.text, isSelected && componentStyles.selectedText]}
+            text={user.full_name}
+            numberOfLines={1}
+            ellipsizeMode="tail"
           />
-          <View style={componentStyles.textWrapper}>
+          {showEmail && (
             <RawLabel
-              style={[componentStyles.text, isSelected && componentStyles.selectedText]}
-              text={user.full_name}
+              style={[
+                componentStyles.text,
+                componentStyles.textEmail,
+                isSelected && componentStyles.selectedText,
+              ]}
+              text={user.email}
               numberOfLines={1}
               ellipsizeMode="tail"
             />
-            {showEmail && (
-              <RawLabel
-                style={[
-                  componentStyles.text,
-                  componentStyles.textEmail,
-                  isSelected && componentStyles.selectedText,
-                ]}
-                text={user.email}
-                numberOfLines={1}
-                ellipsizeMode="tail"
-              />
-            )}
-          </View>
-          <UnreadCount count={unreadCount} inverse={isSelected} />
+          )}
         </View>
-      </Touchable>
-    );
-  }
+        <UnreadCount count={unreadCount} inverse={isSelected} />
+      </View>
+    </Touchable>
+  );
 }
 
 type OuterProps = $ReadOnly<{|

--- a/src/users/UserItem.js
+++ b/src/users/UserItem.js
@@ -1,13 +1,15 @@
 /* @flow strict-local */
-import React, { type ElementConfig, useCallback } from 'react';
+import React, { type ElementConfig, useCallback, useContext } from 'react';
 import { View } from 'react-native';
 
+import { TranslationContext } from '../boot/TranslationProvider';
 import type { UserId } from '../types';
 import { RawLabel, Touchable, UnreadCount } from '../common';
 import { UserAvatarWithPresenceById } from '../common/UserAvatarWithPresence';
 import styles, { createStyleSheet, BRAND_COLOR } from '../styles';
 import { useSelector } from '../react-redux';
 import { getUserForId } from './userSelectors';
+import { getMutedUsers } from '../selectors';
 
 const componentStyles = createStyleSheet({
   selectedRow: {
@@ -50,6 +52,8 @@ export function UserItemRaw<UserT: { user_id: UserId, email: string, full_name: 
   props: Props<UserT>,
 ) {
   const { user, isSelected = false, onPress, unreadCount, showEmail = false } = props;
+  const _ = useContext(TranslationContext);
+  const isMuted = useSelector(getMutedUsers).has(user.user_id);
 
   const handlePress = useCallback(() => {
     if (onPress) {
@@ -63,16 +67,17 @@ export function UserItemRaw<UserT: { user_id: UserId, email: string, full_name: 
         <UserAvatarWithPresenceById
           size={48}
           userId={user.user_id}
+          isMuted={isMuted}
           onPress={onPress && handlePress}
         />
         <View style={componentStyles.textWrapper}>
           <RawLabel
             style={[componentStyles.text, isSelected && componentStyles.selectedText]}
-            text={user.full_name}
+            text={isMuted ? _('Muted user') : user.full_name}
             numberOfLines={1}
             ellipsizeMode="tail"
           />
-          {showEmail && (
+          {showEmail && !isMuted && (
             <RawLabel
               style={[
                 componentStyles.text,


### PR DESCRIPTION
This commit shows a placeholder for the name/avatar of a muted user in the reactions list (and anywhere else that uses `UserItem`, but I think we've filtered out muted users in most of the other places `UserItem` shows up).

I've pulled in a modified version of a FontAwesome icon for this, and I'm not sure exactly what attribution is required for it — would love to hear thoughts on that.

![Screenshot_20210507-142257](https://user-images.githubusercontent.com/5001092/117408610-c273bf80-af42-11eb-8ba2-0ed3a820a66e.png)
![Screenshot_20210507-142233](https://user-images.githubusercontent.com/5001092/117408615-c3a4ec80-af42-11eb-8275-6098aa83e652.png)
