### PR TITLE
Modernize / strip dead code (a little bit) from AppDelegate.m.

### DIFF
--- a/ios/ZulipMobile/AppDelegate.m
+++ b/ios/ZulipMobile/AppDelegate.m
@@ -77,11 +77,15 @@
   return [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index" fallbackResource:nil];
 }
 
-- (BOOL)application:(UIApplication *)application openURL:(NSURL *)url
-  sourceApplication:(NSString *)sourceApplication annotation:(id)annotation
+// Allow listening to incoming zulip:// links during the app's
+// execution; see https://reactnative.dev/docs/0.63/linking. Those
+// links are part of our social-auth protocol; see
+// https://chat.zulip.org/#narrow/stream/16-desktop/topic/desktop.20app.20OAuth/near/803919.
+- (BOOL)application:(UIApplication *)application
+   openURL:(NSURL *)url
+   options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options
 {
-  return [RCTLinkingManager application:application openURL:url
-                      sourceApplication:sourceApplication annotation:annotation];
+  return [RCTLinkingManager application:application openURL:url options:options];
 }
 
 // Required to register for notifications

--- a/ios/ZulipMobile/AppDelegate.m
+++ b/ios/ZulipMobile/AppDelegate.m
@@ -84,13 +84,6 @@
                       sourceApplication:sourceApplication annotation:annotation];
 }
 
-- (BOOL)application:(UIApplication *)application continueUserActivity:(NSUserActivity *)userActivity
- restorationHandler:(void (^)(NSArray * _Nullable))restorationHandler
-{
-  return [RCTLinkingManager application:application
-                   continueUserActivity:userActivity
-                     restorationHandler:restorationHandler];
-}
 // Required to register for notifications
 - (void)application:(UIApplication *)application didRegisterUserNotificationSettings:(UIUserNotificationSettings *)notificationSettings
 {


### PR DESCRIPTION
This is the result of searching #3116 for (1) clearly useful things that (2) haven't grown stale.

It's possible that we may have more to do before we start using Swift in our iOS code, but we should probably address that closer to the point where it becomes necessary, to avoid the risk of writing something that'll just go stale and need to be changed in the future.