### PR TITLE
Handle the unnecessary double quotes while editing Stream name / description.

### DIFF
--- a/src/streams/streamsActions.js
+++ b/src/streams/streamsActions.js
@@ -18,17 +18,10 @@ export const updateExistingStream = (
   newValues: {| name: string, description: string, isPrivate: boolean |},
 ) => async (dispatch: Dispatch, getState: GetState) => {
   if (initialValues.name !== newValues.name) {
-    // Stream names might contain unsafe characters so we must encode it first.
-    await api.updateStream(getAuth(getState()), id, 'new_name', JSON.stringify(newValues.name));
+    await api.updateStream(getAuth(getState()), id, 'new_name', newValues.name);
   }
   if (initialValues.description !== newValues.description) {
-    // Description might contain unsafe characters so we must encode it first.
-    await api.updateStream(
-      getAuth(getState()),
-      id,
-      'description',
-      JSON.stringify(newValues.description),
-    );
+    await api.updateStream(getAuth(getState()), id, 'description', newValues.description);
   }
   if (initialValues.invite_only !== newValues.isPrivate) {
     await api.updateStream(getAuth(getState()), id, 'is_private', newValues.isPrivate);


### PR DESCRIPTION
**Earlier**
https://user-images.githubusercontent.com/53913514/118182566-c8900180-b456-11eb-9e8a-f69305ae05bc.mov

**After**
Removed the `JSON.stringify()` method from `updateExistingStream` function. There is no need to take care of the safe characters and encoding since it was removed from these parameters from Zulip 4.0.
Link to the docs -> https://zulip.com/api/update-stream#parameter-description
https://user-images.githubusercontent.com/53913514/118183002-40f6c280-b457-11eb-9bd0-3b1e08f2052a.mov


Fixes: #4747 

