### PR TITLE
OfflineNotice: Use gray background instead of red, to be less jarring.

### DIFF
--- a/src/common/OfflineNotice.js
+++ b/src/common/OfflineNotice.js
@@ -3,9 +3,8 @@
 import React from 'react';
 import { View } from 'react-native';
 
-import type { Dispatch } from '../types';
 import { createStyleSheet } from '../styles';
-import { connect } from '../react-redux';
+import { useSelector } from '../react-redux';
 import { getSession } from '../selectors';
 import Label from './Label';
 
@@ -26,19 +25,14 @@ const styles = createStyleSheet({
   none: { display: 'none' },
 });
 
-type Props = $ReadOnly<{|
-  dispatch: Dispatch,
-  isOnline: boolean,
-|}>;
+type Props = $ReadOnly<{||}>;
 
 /**
  * Displays a notice that the app is working in offline mode.
  * Not rendered if state is 'online'.
- *
- * @prop isOnline - Provide the online/offline state.
  */
-function OfflineNotice(props: Props) {
-  const { isOnline } = props;
+export default function OfflineNotice(props: Props) {
+  const isOnline = useSelector(state => getSession(state).isOnline);
   if (isOnline) {
     return <View key={key} style={styles.none} />;
   }
@@ -49,7 +43,3 @@ function OfflineNotice(props: Props) {
     </View>
   );
 }
-
-export default connect(state => ({
-  isOnline: getSession(state).isOnline,
-}))(OfflineNotice);

--- a/src/common/OfflineNotice.js
+++ b/src/common/OfflineNotice.js
@@ -22,7 +22,6 @@ const styles = createStyleSheet({
     color: 'white',
     margin: 2,
   },
-  none: { display: 'none' },
 });
 
 type Props = $ReadOnly<{||}>;
@@ -34,7 +33,7 @@ type Props = $ReadOnly<{||}>;
 export default function OfflineNotice(props: Props) {
   const isOnline = useSelector(state => getSession(state).isOnline);
   if (isOnline) {
-    return <View key={key} style={styles.none} />;
+    return null;
   }
 
   return (

--- a/src/common/OfflineNotice.js
+++ b/src/common/OfflineNotice.js
@@ -3,7 +3,7 @@
 import React from 'react';
 import { View } from 'react-native';
 
-import { createStyleSheet } from '../styles';
+import { createStyleSheet, HALF_COLOR } from '../styles';
 import { useSelector } from '../react-redux';
 import { getSession } from '../selectors';
 import Label from './Label';
@@ -13,11 +13,10 @@ const styles = createStyleSheet({
     flexDirection: 'row',
     justifyContent: 'center',
     alignItems: 'center',
-    backgroundColor: 'hsl(6, 98%, 57%)',
+    backgroundColor: HALF_COLOR,
   },
   text: {
     fontSize: 14,
-    color: 'white',
     margin: 2,
   },
 });

--- a/src/common/OfflineNotice.js
+++ b/src/common/OfflineNotice.js
@@ -8,8 +8,6 @@ import { useSelector } from '../react-redux';
 import { getSession } from '../selectors';
 import Label from './Label';
 
-const key = 'OfflineNotice';
-
 const styles = createStyleSheet({
   block: {
     flexDirection: 'row',
@@ -37,7 +35,7 @@ export default function OfflineNotice(props: Props) {
   }
 
   return (
-    <View key={key} style={styles.block}>
+    <View style={styles.block}>
       <Label style={styles.text} text="No Internet connection" />
     </View>
   );

--- a/src/common/OfflineNotice.js
+++ b/src/common/OfflineNotice.js
@@ -1,6 +1,6 @@
 /* @flow strict-local */
 
-import React, { PureComponent } from 'react';
+import React from 'react';
 import { View } from 'react-native';
 
 import type { Dispatch } from '../types';
@@ -37,19 +37,17 @@ type Props = $ReadOnly<{|
  *
  * @prop isOnline - Provide the online/offline state.
  */
-class OfflineNotice extends PureComponent<Props> {
-  render() {
-    const { isOnline } = this.props;
-    if (isOnline) {
-      return <View key={key} style={styles.none} />;
-    }
-
-    return (
-      <View key={key} style={styles.block}>
-        <Label style={styles.text} text="No Internet connection" />
-      </View>
-    );
+function OfflineNotice(props: Props) {
+  const { isOnline } = props;
+  if (isOnline) {
+    return <View key={key} style={styles.none} />;
   }
+
+  return (
+    <View key={key} style={styles.block}>
+      <Label style={styles.text} text="No Internet connection" />
+    </View>
+  );
 }
 
 export default connect(state => ({


### PR DESCRIPTION
Before:
<img width=400 src="https://user-images.githubusercontent.com/22248748/118315764-e9db0700-b4c3-11eb-9d51-c82c497a953e.png" /><img width=400 src="https://user-images.githubusercontent.com/22248748/118315787-f2334200-b4c3-11eb-8840-497af081f7cf.png" />
After:
<img width=400 src="https://user-images.githubusercontent.com/22248748/118315653-c912b180-b4c3-11eb-83ba-22647d62fccc.png" /><img width=400 src="https://user-images.githubusercontent.com/22248748/118315683-d2038300-b4c3-11eb-9cec-ed7bbec1d1f6.png" />


-----

An offline state shouldn't be an error / failure state. The app's
capabilities will be reduced, so the user needs to be informed --
but it's not quite right to use a color that conveys that something
unhandled or unexpected has happened.

And switch to the theme-appropriate text color so it shows up in
light mode.