### PR TITLE
postinstall: Don't run `pod install` unless it's necessary.

### DIFF
--- a/tools/postinstall
+++ b/tools/postinstall
@@ -18,7 +18,15 @@ EOF
         exit 1
     fi
 
-    pod install --project-directory="$ROOT_DIR/ios"
+    # Do nothing if the installed pods already match the Podfile.lock.
+    # If they don't match, run `pod install`. Conditional copied from
+    # the `[CP] Check Pods Manifest.lock` shell-script build phase in
+    # `project.pbxproj`.
+    if diff "$ROOT_DIR/ios/Podfile.lock" "$ROOT_DIR/ios/Pods/Manifest.lock" > /dev/null; then
+        echo "Skipping \`pod install\` (pods already in sync with Podfile.lock)"
+    else
+        pod install --project-directory="$ROOT_DIR/ios"
+    fi
 }
 
 jetify() {


### PR DESCRIPTION
This takes several seconds each time I run `yarn`.