### PR TITLE
Make `getInitialNotification` a consumer.

### DIFF
--- a/android/app/src/main/java/com/zulipmobile/notifications/NotificationsModule.java
+++ b/android/app/src/main/java/com/zulipmobile/notifications/NotificationsModule.java
@@ -40,11 +40,12 @@ class NotificationsModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void getInitialNotification(Promise promise) {
+    public void readInitialNotification(Promise promise) {
         if (null == initialNotification) {
             promise.resolve(null);
         } else {
             promise.resolve(Arguments.fromBundle(initialNotification));
+            initialNotification = null;
         }
     }
 }

--- a/src/notification/index.js
+++ b/src/notification/index.js
@@ -111,6 +111,14 @@ export const getNarrowFromNotificationData = (
   return pmNarrowFromRecipients(pmKeyRecipientsFromIds(ids, ownUserId));
 };
 
+/**
+ * Read the notification the app was started from, if any.
+ *
+ * This consumes the data; if called a second time, the result is always
+ * null.
+ *
+ * (TODO: Well, it does on Android, anyway.  #4763 is for doing so on iOS.)
+ */
 const readInitialNotification = async (): Promise<Notification | null> => {
   if (Platform.OS === 'android') {
     const { Notifications } = NativeModules;
@@ -132,6 +140,16 @@ const readInitialNotification = async (): Promise<Notification | null> => {
   return fromAPNs(data) || null;
 };
 
+/**
+ * Act on the notification-opening the app was started from, if any.
+ *
+ * That is, if the app was started by the user opening a notification, act
+ * on that; in particular, navigate to the conversation the notification was
+ * from.
+ *
+ * This consumes the relevant data; if called multiple times after the user
+ * only once opened a notification, it'll only do anything once.
+ */
 export const handleInitialNotification = async (dispatch: Dispatch) => {
   const data = await readInitialNotification();
   dispatch(narrowToNotification(data));

--- a/src/notification/index.js
+++ b/src/notification/index.js
@@ -111,10 +111,10 @@ export const getNarrowFromNotificationData = (
   return pmNarrowFromRecipients(pmKeyRecipientsFromIds(ids, ownUserId));
 };
 
-const getInitialNotification = async (): Promise<Notification | null> => {
+const readInitialNotification = async (): Promise<Notification | null> => {
   if (Platform.OS === 'android') {
     const { Notifications } = NativeModules;
-    return Notifications.getInitialNotification();
+    return Notifications.readInitialNotification();
   }
 
   const notification: ?PushNotificationIOS = await PushNotificationIOS.getInitialNotification();
@@ -133,7 +133,7 @@ const getInitialNotification = async (): Promise<Notification | null> => {
 };
 
 export const handleInitialNotification = async (dispatch: Dispatch) => {
-  const data = await getInitialNotification();
+  const data = await readInitialNotification();
   dispatch(narrowToNotification(data));
 };
 


### PR DESCRIPTION
Quoting from commit of this PR:

> It is speculated that when an app quits android system does not
flush the entire memory of the app until absolutely necessary
(to facilitate faster startup next time). This also involves the
static variable `initialNotification`.

> This situation creates a problem when the app is started next time,
where it processes `initialNotification` again and falsely navigates
to its narrow.

Fixes: #4758