### PR TITLE
example data: Better support EVENT_NEW_MESSAGE.

### DIFF
--- a/src/__tests__/lib/exampleData.js
+++ b/src/__tests__/lib/exampleData.js
@@ -722,6 +722,14 @@ export const eventNewMessageActionBase /* \: $Diff<EventNewMessageAction, {| mes
  * suffice.
  */
 
+/**
+ * An EVENT_NEW_MESSAGE action.
+ *
+ * The message argument can either have or omit a `flags` property; if
+ * omitted, it defaults to empty.  (The `message` property on an
+ * `EVENT_NEW_MESSAGE` action must have `flags`, while `Message` objects in
+ * some other contexts must not.  See comments on `Message` for details.)
+ */
 export const mkActionEventNewMessage = (message: Message) => ({
   ...eventNewMessageActionBase,
   message: { ...message, flags: message.flags ?? [] },

--- a/src/__tests__/lib/exampleData.js
+++ b/src/__tests__/lib/exampleData.js
@@ -329,6 +329,11 @@ const randMessageId: () => number = makeUniqueRandInt('message ID', 10000000);
  * A PM, by default a 1:1 from eg.otherUser to eg.selfUser.
  *
  * Beware! These values may not be representative.
+ *
+ * NB that the resulting value has no `flags` property.  This matches what
+ * we expect in `state.messages`, but not some other contexts; see comment
+ * on the `flags` property of `Message`.  For use in an `EVENT_NEW_MESSAGE`
+ * action, pass to `mkActionEventNewMessage`.
  */
 export const pmMessage = (args?: {|
   ...$Rest<PmMessage, { ... }>,
@@ -384,6 +389,11 @@ const messagePropertiesFromStream = (stream1: Stream) => {
  * A stream message, by default in eg.stream sent by eg.otherUser.
  *
  * Beware! These values may not be representative.
+ *
+ * NB that the resulting value has no `flags` property.  This matches what
+ * we expect in `state.messages`, but not some other contexts; see comment
+ * on the `flags` property of `Message`.  For use in an `EVENT_NEW_MESSAGE`
+ * action, pass to `mkActionEventNewMessage`.
  */
 export const streamMessage = (args?: {|
   ...$Rest<StreamMessage, { ... }>,

--- a/src/__tests__/lib/exampleData.js
+++ b/src/__tests__/lib/exampleData.js
@@ -693,39 +693,16 @@ export const action = deepFreeze({
 (action: {| [string]: Action |});
 
 /* ========================================================================
- * Action fragments
- *
- * Partial actions, for those action types where (a) there's some
- * boilerplate data that's useful to supply here, but (b) there's some other
- * places where a given test will almost always need to fill in specific
- * data of its own.
- *
- * The properties where each test will want to fill in its own specific data
- * should be left out of these fragments.  That way, Flow can ensure the
- * test explicitly supplies the data.
- */
-
-/** Consider using `mkActionEventNewMessage` instead. */
-export const eventNewMessageActionBase /* \: $Diff<EventNewMessageAction, {| message: Message |}> */ = {
-  type: EVENT_NEW_MESSAGE,
-  // These properties are boring for most or all tests.
-  id: 1001,
-  caughtUp: {},
-  ownUserId: selfUser.user_id,
-
-  // The details of this property are typically important to what a test is
-  // testing, so we provide it explicitly in each test.
-  // message: Message,
-};
-
-// If a given action is only relevant to a single test file, no need to
-// provide a generic fragment for it here; just define the test data there.
-
-/* ========================================================================
  * Action factories
  *
  * Useful for action types where a static object of boilerplate data doesn't
- * suffice.
+ * suffice.  Generally this is true where (a) there's some boilerplate data
+ * that's useful to supply here, but (b) there's some other places where a
+ * given test will almost always need to fill in specific data of its own.
+ *
+ * For action types without (b), a static example value `eg.action.foo` is
+ * enough.  For action types without (a), even that isn't necessary, because
+ * each test might as well define the action values it needs directly.
  */
 
 /**
@@ -741,8 +718,13 @@ export const mkActionEventNewMessage = (
   args?: {| caughtUp?: CaughtUpState, local_message_id?: number, ownUserId?: UserId |},
 ): Action =>
   deepFreeze({
-    ...eventNewMessageActionBase,
+    type: EVENT_NEW_MESSAGE,
+    id: 1001,
+    caughtUp: {},
+    ownUserId: selfUser.user_id,
+
     ...args,
+
     message: { ...message, flags: message.flags ?? [] },
   });
 

--- a/src/__tests__/lib/exampleData.js
+++ b/src/__tests__/lib/exampleData.js
@@ -699,6 +699,7 @@ export const action = deepFreeze({
  * test explicitly supplies the data.
  */
 
+/** Consider using `mkActionEventNewMessage` instead. */
 export const eventNewMessageActionBase /* \: $Diff<EventNewMessageAction, {| message: Message |}> */ = {
   type: EVENT_NEW_MESSAGE,
   // These properties are boring for most or all tests.
@@ -713,3 +714,18 @@ export const eventNewMessageActionBase /* \: $Diff<EventNewMessageAction, {| mes
 
 // If a given action is only relevant to a single test file, no need to
 // provide a generic fragment for it here; just define the test data there.
+
+/* ========================================================================
+ * Action factories
+ *
+ * Useful for action types where a static object of boilerplate data doesn't
+ * suffice.
+ */
+
+export const mkActionEventNewMessage = (message: Message) => ({
+  ...eventNewMessageActionBase,
+  message: { ...message, flags: message.flags ?? [] },
+});
+
+// If a given action is only relevant to a single test file, no need to
+// provide a generic factory for it here; just define the test data there.

--- a/src/__tests__/lib/exampleData.js
+++ b/src/__tests__/lib/exampleData.js
@@ -17,7 +17,13 @@ import type {
   UserId,
 } from '../../api/modelTypes';
 import { makeUserId } from '../../api/idTypes';
-import type { Action, GlobalState, MessagesState, RealmState } from '../../reduxTypes';
+import type {
+  Action,
+  GlobalState,
+  CaughtUpState,
+  MessagesState,
+  RealmState,
+} from '../../reduxTypes';
 import type { Auth, Account, OutboxBase, StreamOutbox } from '../../types';
 import { UploadedAvatarURL } from '../../utils/avatar';
 import { ZulipVersion } from '../../utils/zulipVersion';
@@ -730,9 +736,13 @@ export const eventNewMessageActionBase /* \: $Diff<EventNewMessageAction, {| mes
  * `EVENT_NEW_MESSAGE` action must have `flags`, while `Message` objects in
  * some other contexts must not.  See comments on `Message` for details.)
  */
-export const mkActionEventNewMessage = (message: Message) =>
+export const mkActionEventNewMessage = (
+  message: Message,
+  args?: {| caughtUp?: CaughtUpState, local_message_id?: number, ownUserId?: UserId |},
+): Action =>
   deepFreeze({
     ...eventNewMessageActionBase,
+    ...args,
     message: { ...message, flags: message.flags ?? [] },
   });
 

--- a/src/__tests__/lib/exampleData.js
+++ b/src/__tests__/lib/exampleData.js
@@ -730,10 +730,11 @@ export const eventNewMessageActionBase /* \: $Diff<EventNewMessageAction, {| mes
  * `EVENT_NEW_MESSAGE` action must have `flags`, while `Message` objects in
  * some other contexts must not.  See comments on `Message` for details.)
  */
-export const mkActionEventNewMessage = (message: Message) => ({
-  ...eventNewMessageActionBase,
-  message: { ...message, flags: message.flags ?? [] },
-});
+export const mkActionEventNewMessage = (message: Message) =>
+  deepFreeze({
+    ...eventNewMessageActionBase,
+    message: { ...message, flags: message.flags ?? [] },
+  });
 
 // If a given action is only relevant to a single test file, no need to
 // provide a generic factory for it here; just define the test data there.

--- a/src/chat/__tests__/flagsReducer-test.js
+++ b/src/chat/__tests__/flagsReducer-test.js
@@ -76,21 +76,6 @@ describe('flagsReducer', () => {
   });
 
   describe('EVENT_NEW_MESSAGE', () => {
-    test('when no flags key is passed, do not fail, do nothing', () => {
-      const prevState = NULL_OBJECT;
-
-      const action = deepFreeze({
-        type: EVENT_NEW_MESSAGE,
-        message: { id: 2 },
-      });
-
-      const expectedState = {};
-
-      const actualState = flagsReducer(prevState, action);
-
-      expect(actualState).toEqual(expectedState);
-    });
-
     test('adds to store flags from new message', () => {
       const prevState = NULL_OBJECT;
 

--- a/src/chat/__tests__/narrowsReducer-test.js
+++ b/src/chat/__tests__/narrowsReducer-test.js
@@ -37,10 +37,7 @@ describe('narrowsReducer', () => {
 
       const message = eg.streamMessage({ id: 3, flags: [] });
 
-      const action = deepFreeze({
-        ...eg.eventNewMessageActionBase,
-        message,
-      });
+      const action = eg.mkActionEventNewMessage(message);
 
       const newState = narrowsReducer(initialState, action);
 
@@ -54,9 +51,7 @@ describe('narrowsReducer', () => {
 
       const message = eg.streamMessage({ id: 3, flags: [] });
 
-      const action = deepFreeze({
-        ...eg.eventNewMessageActionBase,
-        message,
+      const action = eg.mkActionEventNewMessage(message, {
         caughtUp: {
           [HOME_NARROW_STR]: {
             older: false,
@@ -80,10 +75,7 @@ describe('narrowsReducer', () => {
 
       const message = eg.streamMessage({ id: 3, flags: [], stream: eg.makeStream() });
 
-      const action = deepFreeze({
-        ...eg.eventNewMessageActionBase,
-        message,
-      });
+      const action = eg.mkActionEventNewMessage(message);
 
       const newState = narrowsReducer(initialState, action);
 
@@ -101,9 +93,7 @@ describe('narrowsReducer', () => {
       recipients: [eg.selfUser, eg.otherUser, eg.thirdUser],
       flags: [],
     });
-    const action = deepFreeze({
-      ...eg.eventNewMessageActionBase,
-      message,
+    const action = eg.mkActionEventNewMessage(message, {
       caughtUp: {
         [ALL_PRIVATE_NARROW_STR]: { older: true, newer: true },
       },
@@ -122,9 +112,7 @@ describe('narrowsReducer', () => {
 
     const message = eg.streamMessage({ id: 3, flags: [] });
 
-    const action = deepFreeze({
-      ...eg.eventNewMessageActionBase,
-      message,
+    const action = eg.mkActionEventNewMessage(message, {
       caughtUp: {
         [HOME_NARROW_STR]: {
           older: false,
@@ -160,9 +148,7 @@ describe('narrowsReducer', () => {
       flags: [],
     });
 
-    const action = deepFreeze({
-      ...eg.eventNewMessageActionBase,
-      message,
+    const action = eg.mkActionEventNewMessage(message, {
       caughtUp: {
         [HOME_NARROW_STR]: { older: false, newer: true },
         [narrowWithSelfStr]: { older: false, newer: true },
@@ -192,9 +178,7 @@ describe('narrowsReducer', () => {
 
     const message = eg.streamMessage({ id: 5, flags: [] });
 
-    const action = deepFreeze({
-      ...eg.eventNewMessageActionBase,
-      message,
+    const action = eg.mkActionEventNewMessage(message, {
       caughtUp: {
         [HOME_NARROW_STR]: { older: false, newer: true },
         [streamNarrowStr]: { older: false, newer: true },
@@ -222,9 +206,7 @@ describe('narrowsReducer', () => {
 
     const message = eg.streamMessage({ id: 3, flags: [] });
 
-    const action = deepFreeze({
-      ...eg.eventNewMessageActionBase,
-      message,
+    const action = eg.mkActionEventNewMessage(message, {
       caughtUp: {
         [HOME_NARROW_STR]: { older: false, newer: true },
       },
@@ -257,9 +239,7 @@ describe('narrowsReducer', () => {
       recipients: [eg.selfUser, eg.otherUser],
     });
 
-    const action = deepFreeze({
-      ...eg.eventNewMessageActionBase,
-      message,
+    const action = eg.mkActionEventNewMessage(message, {
       caughtUp: initialState.map(_ => ({ older: false, newer: true })).toObject(),
     });
 

--- a/src/chat/flagsReducer.js
+++ b/src/chat/flagsReducer.js
@@ -1,4 +1,6 @@
 /* @flow strict-local */
+import invariant from 'invariant';
+
 import type { Action, FlagsState, Message } from '../types';
 import {
   REALM_INIT,
@@ -29,9 +31,9 @@ const initialState = {
 const addFlagsForMessages = (
   state: FlagsState,
   messages: $ReadOnlyArray<number>,
-  flags?: $ReadOnlyArray<string>,
+  flags: $ReadOnlyArray<string>,
 ): FlagsState => {
-  if (!messages || messages.length === 0 || !flags || flags.length === 0) {
+  if (messages.length === 0 || flags.length === 0) {
     return state;
   }
 
@@ -111,8 +113,10 @@ export default (state: FlagsState = initialState, action: Action): FlagsState =>
     case MESSAGE_FETCH_COMPLETE:
       return processFlagsForMessages(state, action.messages);
 
-    case EVENT_NEW_MESSAGE:
+    case EVENT_NEW_MESSAGE: {
+      invariant(action.message.flags, 'message in EVENT_NEW_MESSAGE must have flags');
       return addFlagsForMessages(state, [action.message.id], action.message.flags);
+    }
 
     case EVENT_UPDATE_MESSAGE_FLAGS:
       return eventUpdateMessageFlags(state, action);

--- a/src/message/__tests__/messagesReducer-test.js
+++ b/src/message/__tests__/messagesReducer-test.js
@@ -24,16 +24,13 @@ describe('messagesReducer', () => {
       const message3 = eg.streamMessage({ id: 3 });
 
       const prevState = eg.makeMessagesState([message1, message2]);
-      const action = deepFreeze({
-        ...eg.eventNewMessageActionBase,
+      const action = eg.mkActionEventNewMessage(message3, {
         caughtUp: {
           [HOME_NARROW_STR]: {
             older: true,
             newer: true,
           },
         },
-        // `flags` is present in EVENT_NEW_MESSAGE; see note at Message.
-        message: { ...message3, flags: [] },
       });
       const expectedState = eg.makeMessagesState([message1, message2, message3]);
       const newState = messagesReducer(prevState, action);
@@ -46,16 +43,13 @@ describe('messagesReducer', () => {
       const message2 = eg.streamMessage({ id: 2 });
       const message3 = eg.streamMessage({ id: 3 });
       const prevState = eg.makeMessagesState([message1, message2]);
-      const action = deepFreeze({
-        ...eg.eventNewMessageActionBase,
+      const action = eg.mkActionEventNewMessage(message3, {
         caughtUp: {
           [HOME_NARROW_STR]: {
             older: true,
             newer: false,
           },
         },
-        // `flags` is present in EVENT_NEW_MESSAGE; see note at Message.
-        message: { ...message3, flags: [] },
       });
       const newState = messagesReducer(prevState, action);
       expect(newState).toEqual(prevState);

--- a/src/outbox/__tests__/outboxReducer-test.js
+++ b/src/outbox/__tests__/outboxReducer-test.js
@@ -67,9 +67,7 @@ describe('outboxReducer', () => {
 
       const message = eg.streamMessage({ timestamp: 123 });
 
-      const action = deepFreeze({
-        ...eg.eventNewMessageActionBase,
-        message,
+      const action = eg.mkActionEventNewMessage(message, {
         local_message_id: message.timestamp,
       });
 
@@ -83,9 +81,7 @@ describe('outboxReducer', () => {
       const message3 = eg.streamOutbox({ timestamp: 150238594540 });
       const initialState = deepFreeze([message1, message2, message3]);
 
-      const action = deepFreeze({
-        ...eg.eventNewMessageActionBase,
-        message: eg.streamMessage(),
+      const action = eg.mkActionEventNewMessage(eg.streamMessage(), {
         local_message_id: 546,
       });
 
@@ -102,9 +98,7 @@ describe('outboxReducer', () => {
       const message3 = eg.streamOutbox({ timestamp: 150238594540 });
       const initialState = deepFreeze([message1, message2, message3]);
 
-      const action = deepFreeze({
-        ...eg.eventNewMessageActionBase,
-        message: eg.streamMessage(),
+      const action = eg.mkActionEventNewMessage(eg.streamMessage(), {
         local_message_id: 15023859,
       });
 

--- a/src/pm-conversations/__tests__/pmConversationsModel-test.js
+++ b/src/pm-conversations/__tests__/pmConversationsModel-test.js
@@ -86,7 +86,7 @@ describe('reducer', () => {
   });
 
   describe('EVENT_NEW_MESSAGE', () => {
-    const actionGeneral = message => ({ ...eg.eventNewMessageActionBase, message });
+    const actionGeneral = eg.mkActionEventNewMessage;
     const [user1, user2] = [eg.makeUser({ user_id: 1 }), eg.makeUser({ user_id: 2 })];
     const action = (id, otherUsers) =>
       actionGeneral(eg.pmMessageFromTo(eg.selfUser, otherUsers, { id }));

--- a/src/topics/__tests__/topicsSelectors-test.js
+++ b/src/topics/__tests__/topicsSelectors-test.js
@@ -5,7 +5,7 @@ import { getTopicsForNarrow, getLastMessageTopic, getTopicsForStream } from '../
 import { HOME_NARROW, streamNarrow, keyFromNarrow } from '../../utils/narrow';
 import { reducer as unreadReducer } from '../../unread/unreadModel';
 import * as eg from '../../__tests__/lib/exampleData';
-import { mkMessageAction } from '../../unread/__tests__/unread-testlib';
+import { mkActionEventNewMessage } from '../../unread/__tests__/unread-testlib';
 
 describe('getTopicsForNarrow', () => {
   test('when no topics return an empty list', () => {
@@ -113,7 +113,7 @@ describe('getTopicsForStream', () => {
         eg.streamMessage({ stream_id: 1, subject: 'topic 4', id: 7 }),
         eg.streamMessage({ stream_id: 1, subject: 'topic 4', id: 8 }),
       ].reduce(
-        (st, message) => unreadReducer(st, mkMessageAction(message), eg.plusReduxState),
+        (st, message) => unreadReducer(st, mkActionEventNewMessage(message), eg.plusReduxState),
         eg.plusReduxState.unread,
       ),
     });

--- a/src/topics/__tests__/topicsSelectors-test.js
+++ b/src/topics/__tests__/topicsSelectors-test.js
@@ -5,7 +5,6 @@ import { getTopicsForNarrow, getLastMessageTopic, getTopicsForStream } from '../
 import { HOME_NARROW, streamNarrow, keyFromNarrow } from '../../utils/narrow';
 import { reducer as unreadReducer } from '../../unread/unreadModel';
 import * as eg from '../../__tests__/lib/exampleData';
-import { mkActionEventNewMessage } from '../../unread/__tests__/unread-testlib';
 
 describe('getTopicsForNarrow', () => {
   test('when no topics return an empty list', () => {
@@ -113,7 +112,7 @@ describe('getTopicsForStream', () => {
         eg.streamMessage({ stream_id: 1, subject: 'topic 4', id: 7 }),
         eg.streamMessage({ stream_id: 1, subject: 'topic 4', id: 8 }),
       ].reduce(
-        (st, message) => unreadReducer(st, mkActionEventNewMessage(message), eg.plusReduxState),
+        (st, message) => unreadReducer(st, eg.mkActionEventNewMessage(message), eg.plusReduxState),
         eg.plusReduxState.unread,
       ),
     });

--- a/src/unread/__tests__/unread-testlib.js
+++ b/src/unread/__tests__/unread-testlib.js
@@ -10,7 +10,7 @@ export const initialState = reducer(
   eg.baseReduxState,
 );
 
-export const mkMessageAction = (message: Message) => ({
+export const mkActionEventNewMessage = (message: Message) => ({
   ...eg.eventNewMessageActionBase,
   message: { ...message, flags: message.flags ?? [] },
 });
@@ -53,7 +53,7 @@ export const selectorBaseState = (() => {
     eg.pmMessageFromTo(user4, [user1, user5], { id: 24 }),
     eg.pmMessageFromTo(user4, [user1, user5], { id: 25 }),
   ]) {
-    state = reducer(state, mkMessageAction(message), globalState);
+    state = reducer(state, mkActionEventNewMessage(message), globalState);
   }
   return state;
 })();

--- a/src/unread/__tests__/unread-testlib.js
+++ b/src/unread/__tests__/unread-testlib.js
@@ -1,6 +1,5 @@
 /* @flow strict-local */
 
-import type { Message } from '../../types';
 import { reducer } from '../unreadModel';
 import * as eg from '../../__tests__/lib/exampleData';
 
@@ -9,11 +8,6 @@ export const initialState = reducer(
   ({ type: eg.randString() }: $FlowFixMe),
   eg.baseReduxState,
 );
-
-export const mkActionEventNewMessage = (message: Message) => ({
-  ...eg.eventNewMessageActionBase,
-  message: { ...message, flags: message.flags ?? [] },
-});
 
 export const stream0 = { ...eg.makeStream({ name: 'stream 0' }), stream_id: 0 };
 export const stream2 = { ...eg.makeStream({ name: 'stream 2' }), stream_id: 2 };
@@ -53,7 +47,7 @@ export const selectorBaseState = (() => {
     eg.pmMessageFromTo(user4, [user1, user5], { id: 24 }),
     eg.pmMessageFromTo(user4, [user1, user5], { id: 25 }),
   ]) {
-    state = reducer(state, mkActionEventNewMessage(message), globalState);
+    state = reducer(state, eg.mkActionEventNewMessage(message), globalState);
   }
   return state;
 })();

--- a/src/unread/__tests__/unreadHuddlesReducer-test.js
+++ b/src/unread/__tests__/unreadHuddlesReducer-test.js
@@ -2,11 +2,7 @@
 import deepFreeze from 'deep-freeze';
 
 import unreadHuddlesReducer from '../unreadHuddlesReducer';
-import {
-  ACCOUNT_SWITCH,
-  EVENT_NEW_MESSAGE,
-  EVENT_UPDATE_MESSAGE_FLAGS,
-} from '../../actionConstants';
+import { ACCOUNT_SWITCH, EVENT_UPDATE_MESSAGE_FLAGS } from '../../actionConstants';
 import { NULL_ARRAY } from '../../nullObjects';
 import * as eg from '../../__tests__/lib/exampleData';
 import { makeUserId } from '../../api/idTypes';
@@ -87,11 +83,7 @@ describe('unreadHuddlesReducer', () => {
         },
       ]);
 
-      const action = deepFreeze({
-        type: EVENT_NEW_MESSAGE,
-        ...eg.eventNewMessageActionBase,
-        message: message2,
-      });
+      const action = eg.mkActionEventNewMessage(message2);
 
       const actualState = unreadHuddlesReducer(initialState, action);
 
@@ -107,11 +99,7 @@ describe('unreadHuddlesReducer', () => {
         },
       ]);
 
-      const action = deepFreeze({
-        type: EVENT_NEW_MESSAGE,
-        ...eg.eventNewMessageActionBase,
-        message: streamMessage,
-      });
+      const action = eg.mkActionEventNewMessage(streamMessage);
 
       const actualState = unreadHuddlesReducer(initialState, action);
 
@@ -131,12 +119,7 @@ describe('unreadHuddlesReducer', () => {
         flags: ['read'],
       });
 
-      const action = deepFreeze({
-        type: EVENT_NEW_MESSAGE,
-        ...eg.eventNewMessageActionBase,
-        message: message2,
-        ownUserId: selfUser.user_id,
-      });
+      const action = eg.mkActionEventNewMessage(message2, { ownUserId: selfUser.user_id });
 
       const actualState = unreadHuddlesReducer(initialState, action);
 
@@ -157,11 +140,7 @@ describe('unreadHuddlesReducer', () => {
         },
       ]);
 
-      const action = deepFreeze({
-        type: EVENT_NEW_MESSAGE,
-        ...eg.eventNewMessageActionBase,
-        message: message4,
-      });
+      const action = eg.mkActionEventNewMessage(message4);
 
       const expectedState = [
         {
@@ -188,11 +167,7 @@ describe('unreadHuddlesReducer', () => {
         },
       ]);
 
-      const action = deepFreeze({
-        type: EVENT_NEW_MESSAGE,
-        ...eg.eventNewMessageActionBase,
-        message: message4,
-      });
+      const action = eg.mkActionEventNewMessage(message4);
 
       const expectedState = [
         {

--- a/src/unread/__tests__/unreadMentionsReducer-test.js
+++ b/src/unread/__tests__/unreadMentionsReducer-test.js
@@ -6,7 +6,7 @@ import unreadMentionsReducer from '../unreadMentionsReducer';
 import { ACCOUNT_SWITCH, EVENT_UPDATE_MESSAGE_FLAGS } from '../../actionConstants';
 import { NULL_ARRAY } from '../../nullObjects';
 import * as eg from '../../__tests__/lib/exampleData';
-import { mkMessageAction } from './unread-testlib';
+import { mkActionEventNewMessage } from './unread-testlib';
 
 describe('unreadMentionsReducer', () => {
   describe('ACCOUNT_SWITCH', () => {
@@ -56,7 +56,7 @@ describe('unreadMentionsReducer', () => {
     test('if message does not contain "mentioned" flag, do not mutate state', () => {
       const initialState = deepFreeze([]);
 
-      const action = mkMessageAction(eg.streamMessage({ flags: [] }));
+      const action = mkActionEventNewMessage(eg.streamMessage({ flags: [] }));
 
       const actualState = unreadMentionsReducer(initialState, action);
 
@@ -66,7 +66,7 @@ describe('unreadMentionsReducer', () => {
     test('if message has "read" flag, do not mutate state', () => {
       const initialState = deepFreeze([]);
 
-      const action = mkMessageAction(eg.streamMessage({ flags: ['mentioned', 'read'] }));
+      const action = mkActionEventNewMessage(eg.streamMessage({ flags: ['mentioned', 'read'] }));
 
       const actualState = unreadMentionsReducer(initialState, action);
 
@@ -76,7 +76,9 @@ describe('unreadMentionsReducer', () => {
     test('if message id already exists, do not mutate state', () => {
       const initialState = deepFreeze([1, 2]);
 
-      const action = mkMessageAction(eg.streamMessage({ id: 2, flags: ['mentioned', 'read'] }));
+      const action = mkActionEventNewMessage(
+        eg.streamMessage({ id: 2, flags: ['mentioned', 'read'] }),
+      );
 
       const actualState = unreadMentionsReducer(initialState, action);
 
@@ -86,7 +88,7 @@ describe('unreadMentionsReducer', () => {
     test('if "mentioned" flag is set and message id does not exist, append to state', () => {
       const initialState = deepFreeze([1, 2]);
 
-      const action = mkMessageAction(eg.streamMessage({ id: 3, flags: ['mentioned'] }));
+      const action = mkActionEventNewMessage(eg.streamMessage({ id: 3, flags: ['mentioned'] }));
 
       const expectedState = [1, 2, 3];
 

--- a/src/unread/__tests__/unreadMentionsReducer-test.js
+++ b/src/unread/__tests__/unreadMentionsReducer-test.js
@@ -6,7 +6,6 @@ import unreadMentionsReducer from '../unreadMentionsReducer';
 import { ACCOUNT_SWITCH, EVENT_UPDATE_MESSAGE_FLAGS } from '../../actionConstants';
 import { NULL_ARRAY } from '../../nullObjects';
 import * as eg from '../../__tests__/lib/exampleData';
-import { mkActionEventNewMessage } from './unread-testlib';
 
 describe('unreadMentionsReducer', () => {
   describe('ACCOUNT_SWITCH', () => {
@@ -56,7 +55,7 @@ describe('unreadMentionsReducer', () => {
     test('if message does not contain "mentioned" flag, do not mutate state', () => {
       const initialState = deepFreeze([]);
 
-      const action = mkActionEventNewMessage(eg.streamMessage({ flags: [] }));
+      const action = eg.mkActionEventNewMessage(eg.streamMessage({ flags: [] }));
 
       const actualState = unreadMentionsReducer(initialState, action);
 
@@ -66,7 +65,7 @@ describe('unreadMentionsReducer', () => {
     test('if message has "read" flag, do not mutate state', () => {
       const initialState = deepFreeze([]);
 
-      const action = mkActionEventNewMessage(eg.streamMessage({ flags: ['mentioned', 'read'] }));
+      const action = eg.mkActionEventNewMessage(eg.streamMessage({ flags: ['mentioned', 'read'] }));
 
       const actualState = unreadMentionsReducer(initialState, action);
 
@@ -76,7 +75,7 @@ describe('unreadMentionsReducer', () => {
     test('if message id already exists, do not mutate state', () => {
       const initialState = deepFreeze([1, 2]);
 
-      const action = mkActionEventNewMessage(
+      const action = eg.mkActionEventNewMessage(
         eg.streamMessage({ id: 2, flags: ['mentioned', 'read'] }),
       );
 
@@ -88,7 +87,7 @@ describe('unreadMentionsReducer', () => {
     test('if "mentioned" flag is set and message id does not exist, append to state', () => {
       const initialState = deepFreeze([1, 2]);
 
-      const action = mkActionEventNewMessage(eg.streamMessage({ id: 3, flags: ['mentioned'] }));
+      const action = eg.mkActionEventNewMessage(eg.streamMessage({ id: 3, flags: ['mentioned'] }));
 
       const expectedState = [1, 2, 3];
 

--- a/src/unread/__tests__/unreadModel-test.js
+++ b/src/unread/__tests__/unreadModel-test.js
@@ -5,7 +5,7 @@ import { ACCOUNT_SWITCH, EVENT_UPDATE_MESSAGE_FLAGS } from '../../actionConstant
 import { reducer } from '../unreadModel';
 import { type UnreadState } from '../unreadModelTypes';
 import * as eg from '../../__tests__/lib/exampleData';
-import { initialState, mkMessageAction } from './unread-testlib';
+import { initialState, mkActionEventNewMessage } from './unread-testlib';
 
 // These are the tests corresponding to unreadStreamsReducer-test.js.
 // Ultimately we'll want to flip this way of organizing the tests, and
@@ -20,7 +20,11 @@ describe('stream substate', () => {
 
   describe('ACCOUNT_SWITCH', () => {
     test('resets state to initial state', () => {
-      const state = reducer(initialState, mkMessageAction(eg.streamMessage()), eg.plusReduxState);
+      const state = reducer(
+        initialState,
+        mkActionEventNewMessage(eg.streamMessage()),
+        eg.plusReduxState,
+      );
       expect(state).not.toEqual(initialState);
 
       const action = { type: ACCOUNT_SWITCH, index: 1 };
@@ -60,7 +64,7 @@ describe('stream substate', () => {
   });
 
   describe('EVENT_NEW_MESSAGE', () => {
-    const action = mkMessageAction;
+    const action = mkActionEventNewMessage;
 
     const baseState = (() => {
       let state = initialState;
@@ -146,7 +150,7 @@ describe('stream substate', () => {
       };
     };
 
-    const streamAction = args => mkMessageAction(eg.streamMessage(args));
+    const streamAction = args => mkActionEventNewMessage(eg.streamMessage(args));
 
     const baseState = (() => {
       const r = (state, action) => reducer(state, action, eg.plusReduxState);

--- a/src/unread/__tests__/unreadModel-test.js
+++ b/src/unread/__tests__/unreadModel-test.js
@@ -5,7 +5,7 @@ import { ACCOUNT_SWITCH, EVENT_UPDATE_MESSAGE_FLAGS } from '../../actionConstant
 import { reducer } from '../unreadModel';
 import { type UnreadState } from '../unreadModelTypes';
 import * as eg from '../../__tests__/lib/exampleData';
-import { initialState, mkActionEventNewMessage } from './unread-testlib';
+import { initialState } from './unread-testlib';
 
 // These are the tests corresponding to unreadStreamsReducer-test.js.
 // Ultimately we'll want to flip this way of organizing the tests, and
@@ -22,7 +22,7 @@ describe('stream substate', () => {
     test('resets state to initial state', () => {
       const state = reducer(
         initialState,
-        mkActionEventNewMessage(eg.streamMessage()),
+        eg.mkActionEventNewMessage(eg.streamMessage()),
         eg.plusReduxState,
       );
       expect(state).not.toEqual(initialState);
@@ -64,7 +64,7 @@ describe('stream substate', () => {
   });
 
   describe('EVENT_NEW_MESSAGE', () => {
-    const action = mkActionEventNewMessage;
+    const action = eg.mkActionEventNewMessage;
 
     const baseState = (() => {
       let state = initialState;
@@ -150,7 +150,7 @@ describe('stream substate', () => {
       };
     };
 
-    const streamAction = args => mkActionEventNewMessage(eg.streamMessage(args));
+    const streamAction = args => eg.mkActionEventNewMessage(eg.streamMessage(args));
 
     const baseState = (() => {
       const r = (state, action) => reducer(state, action, eg.plusReduxState);

--- a/src/unread/__tests__/unreadPmsReducer-test.js
+++ b/src/unread/__tests__/unreadPmsReducer-test.js
@@ -82,10 +82,7 @@ describe('unreadPmsReducer', () => {
         },
       ]);
 
-      const action = deepFreeze({
-        ...eg.eventNewMessageActionBase,
-        message: message1,
-      });
+      const action = eg.mkActionEventNewMessage(message1);
 
       const actualState = unreadPmsReducer(initialState, action);
 
@@ -101,10 +98,7 @@ describe('unreadPmsReducer', () => {
         },
       ]);
 
-      const action = deepFreeze({
-        ...eg.eventNewMessageActionBase,
-        message: message4,
-      });
+      const action = eg.mkActionEventNewMessage(message4);
 
       const actualState = unreadPmsReducer(initialState, action);
 
@@ -119,11 +113,7 @@ describe('unreadPmsReducer', () => {
         flags: ['read'],
       });
 
-      const action = deepFreeze({
-        ...eg.eventNewMessageActionBase,
-        message: message1,
-        ownUserId: eg.selfUser.user_id,
-      });
+      const action = eg.mkActionEventNewMessage(message1);
 
       const actualState = unreadPmsReducer(initialState, action);
 
@@ -137,11 +127,7 @@ describe('unreadPmsReducer', () => {
         recipients: [eg.selfUser],
       });
 
-      const action = deepFreeze({
-        ...eg.eventNewMessageActionBase,
-        message: message1,
-        ownUserId: eg.selfUser.user_id,
-      });
+      const action = eg.mkActionEventNewMessage(message1);
 
       const expectedState = [
         {
@@ -168,10 +154,7 @@ describe('unreadPmsReducer', () => {
         },
       ]);
 
-      const action = deepFreeze({
-        ...eg.eventNewMessageActionBase,
-        message: message4,
-      });
+      const action = eg.mkActionEventNewMessage(message4);
 
       const expectedState = [
         {
@@ -194,10 +177,7 @@ describe('unreadPmsReducer', () => {
         },
       ]);
 
-      const action = deepFreeze({
-        ...eg.eventNewMessageActionBase,
-        message: message4,
-      });
+      const action = eg.mkActionEventNewMessage(message4);
 
       const expectedState = [
         {

--- a/src/unread/__tests__/unreadSelectors-test.js
+++ b/src/unread/__tests__/unreadSelectors-test.js
@@ -15,11 +15,7 @@ import {
 } from '../unreadSelectors';
 
 import * as eg from '../../__tests__/lib/exampleData';
-import {
-  initialState,
-  mkActionEventNewMessage,
-  selectorBaseState as unreadState,
-} from './unread-testlib';
+import { initialState, selectorBaseState as unreadState } from './unread-testlib';
 
 describe('getUnreadByStream', () => {
   test('when no items in streams key, the result is an empty object', () => {
@@ -478,7 +474,7 @@ describe('getUnreadStreamsAndTopics', () => {
         eg.streamMessage({ stream_id: 1, subject: 'e topic', id: 10 }),
         eg.streamMessage({ stream_id: 1, subject: 'd topic', id: 9 }),
       ].reduce(
-        (st, message) => reducer(st, mkActionEventNewMessage(message), eg.plusReduxState),
+        (st, message) => reducer(st, eg.mkActionEventNewMessage(message), eg.plusReduxState),
         eg.plusReduxState.unread,
       ),
       mute: [['def stream', 'c topic']],

--- a/src/unread/__tests__/unreadSelectors-test.js
+++ b/src/unread/__tests__/unreadSelectors-test.js
@@ -15,7 +15,11 @@ import {
 } from '../unreadSelectors';
 
 import * as eg from '../../__tests__/lib/exampleData';
-import { initialState, mkMessageAction, selectorBaseState as unreadState } from './unread-testlib';
+import {
+  initialState,
+  mkActionEventNewMessage,
+  selectorBaseState as unreadState,
+} from './unread-testlib';
 
 describe('getUnreadByStream', () => {
   test('when no items in streams key, the result is an empty object', () => {
@@ -474,7 +478,7 @@ describe('getUnreadStreamsAndTopics', () => {
         eg.streamMessage({ stream_id: 1, subject: 'e topic', id: 10 }),
         eg.streamMessage({ stream_id: 1, subject: 'd topic', id: 9 }),
       ].reduce(
-        (st, message) => reducer(st, mkMessageAction(message), eg.plusReduxState),
+        (st, message) => reducer(st, mkActionEventNewMessage(message), eg.plusReduxState),
         eg.plusReduxState.unread,
       ),
       mute: [['def stream', 'c topic']],

--- a/src/unread/unreadHuddlesReducer.js
+++ b/src/unread/unreadHuddlesReducer.js
@@ -1,4 +1,6 @@
 /* @flow strict-local */
+import invariant from 'invariant';
+
 import type { Action } from '../types';
 import type { UnreadHuddlesState } from './unreadModelTypes';
 import {
@@ -24,14 +26,8 @@ const eventNewMessage = (state, action) => {
     return state;
   }
 
-  // TODO: In reality, we should error if `flags` is undefined, since it's
-  // always supposed to be set. However, our tests currently don't pass flags
-  // into these events, making it annoying to fix this. We should fix the
-  // tests, then change this to error if `flags` is undefined. See [1] for
-  // details.
-  //
-  // [1]: https://github.com/zulip/zulip-mobile/pull/4710/files#r627850775
-  if (action.message.flags?.includes('read')) {
+  invariant(action.message.flags, 'message in EVENT_NEW_MESSAGE must have flags');
+  if (action.message.flags.includes('read')) {
     return state;
   }
 

--- a/src/unread/unreadMentionsReducer.js
+++ b/src/unread/unreadMentionsReducer.js
@@ -1,4 +1,6 @@
 /* @flow strict-local */
+import invariant from 'invariant';
+
 import type { Action } from '../types';
 import type { UnreadMentionsState } from './unreadModelTypes';
 import {
@@ -43,9 +45,7 @@ export default (state: UnreadMentionsState = initialState, action: Action): Unre
 
     case EVENT_NEW_MESSAGE: {
       const { flags } = action.message;
-      if (!flags) {
-        throw new Error('action.message.flags should be defined.');
-      }
+      invariant(flags, 'message in EVENT_NEW_MESSAGE must have flags');
       if (flags.includes('read')) {
         return state;
       }

--- a/src/unread/unreadModel.js
+++ b/src/unread/unreadModel.js
@@ -1,5 +1,6 @@
 /* @flow strict-local */
 import Immutable from 'immutable';
+import invariant from 'invariant';
 
 import type { Action } from '../actionTypes';
 import type {
@@ -145,14 +146,8 @@ function streamsReducer(
         return state;
       }
 
-      // TODO: In reality, we should error if `flags` is undefined, since it's
-      // always supposed to be set. However, our tests currently don't pass flags
-      // into these events, making it annoying to fix this. We should fix the
-      // tests, then change this to error if `flags` is undefined. See [1] for
-      // details.
-      //
-      // [1]: https://github.com/zulip/zulip-mobile/pull/4710/files#r627850775
-      if (message.flags?.includes('read')) {
+      invariant(message.flags, 'message in EVENT_NEW_MESSAGE must have flags');
+      if (message.flags.includes('read')) {
         return state;
       }
 

--- a/src/unread/unreadPmsReducer.js
+++ b/src/unread/unreadPmsReducer.js
@@ -1,4 +1,6 @@
 /* @flow strict-local */
+import invariant from 'invariant';
+
 import type { Action } from '../types';
 import type { UnreadPmsState } from './unreadModelTypes';
 import {
@@ -24,14 +26,8 @@ const eventNewMessage = (state, action) => {
     return state;
   }
 
-  // TODO: In reality, we should error if `flags` is undefined, since it's
-  // always supposed to be set. However, our tests currently don't pass flags
-  // into these events, making it annoying to fix this. We should fix the
-  // tests, then change this to error if `flags` is undefined. See [1] for
-  // details.
-  //
-  // [1]: https://github.com/zulip/zulip-mobile/pull/4710/files#r627850775
-  if (action.message.flags?.includes('read')) {
+  invariant(action.message.flags, 'message in EVENT_NEW_MESSAGE must have flags');
+  if (action.message.flags.includes('read')) {
     return state;
   }
 


### PR DESCRIPTION
This follows up on the thread at https://github.com/zulip/zulip-mobile/pull/4710#discussion_r626113834.

We replace the "action fragments" idea with more-flexible factory functions. In particular all the places in test code where we used `eg.eventNewMessageActionBase` to create an `EVENT_NEW_MESSAGE` action now make a call to the new `eg.mkActionEventNewMessage` which subsumes it -- and unlike the old fragment, the new factory can ensure that `action.message.flags` is always present, as it should be.

Then that in turn lets us clean up some app code, in reducers, that had provided bogus default behavior in case of a missing `flags` in order to accommodate tests that didn't supply one.