### PR TITLE
[android] Make wifi hardware requirement optional. (follow up to #4724)

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -24,6 +24,14 @@
         android:name="android.hardware.camera.autofocus"
         android:required="false" />
 
+    <!-- We use certain modules that adds the permission requirement for
+         `ACCESS_WIFI_STATE` in the final AndroidManifest of the app, which makes
+         wifi hardware a compulsary requirement to install the app. The following
+         statement makes the hardware requirement optional. -->
+    <uses-feature
+        android:name="android.hardware.wifi"
+        android:required="false" />
+
     <application
         android:name=".MainApplication"
         android:allowBackup="true"


### PR DESCRIPTION
Usage of `@react-native-community/netinfo` adds the permission
requirement for ACCESS_WIFI_STATE in the final AndroidManifest of
the app, which makes wifi hardware a compulsory requirement to
install the app.

Adding an appropriate `uses-feature` tag makes this requirement
optional.

This was discovered by looking into "Merged Manifest" option while
previewing `AndroidManifest.xml` in Android Studio.

Follow up to: #4724 as suggested by @gnprice.