### PR TITLE
UserAvatar: Ignore color inversion on iOS.

### DIFF
--- a/src/common/UserAvatar.js
+++ b/src/common/UserAvatar.js
@@ -56,7 +56,7 @@ function UserAvatar(props: Props) {
 
   return (
     <Touchable onPress={onPress}>
-      <View>
+      <View accessibilityIgnoresInvertColors>
         {!isMuted ? (
           <Image
             source={{


### PR DESCRIPTION
ed69e1ec0 inadvertently removed this when we switched away from
ImageBackground, but it seems like something that we should include,
since avatars will look better non-inverted, and inverting arbitrary
images isn't likely to be very useful for contrast/accessibility
reasons.

Fixes: #4765