### PR TITLE
ComposeBox: Don't require caughtUp to send in stream narrow.

### DIFF
--- a/src/compose/ComposeBox.js
+++ b/src/compose/ComposeBox.js
@@ -323,7 +323,7 @@ class ComposeBox extends PureComponent<Props, State> {
     const { dispatch, narrow, caughtUp, _ } = this.props;
     const { message } = this.state;
 
-    if (!caughtUp.newer) {
+    if (!caughtUp.newer && !isStreamNarrow(this.props.narrow)) {
       showErrorAlert(_('Failed to send message'));
       return;
     }


### PR DESCRIPTION
See CZO [1] for some background on this. There are many reasons why the
destination narrow might not be the caughtUp narrow in the stream view,
and it's worse to prevent the user from sending with a cryptic error
message than it is to allow them to send to a narrow they aren't fully
caught up in.

[1]: https://chat.zulip.org/#narrow/stream/48-mobile/topic/Failed.20to.20send.20on.20Android