### PR TITLE
dependabot: Add config file.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5

--- a/src/__flow-tests__/nav-test.js
+++ b/src/__flow-tests__/nav-test.js
@@ -8,7 +8,6 @@ import React, { type ComponentType } from 'react';
 import {
   createStackNavigator,
   type StackNavigationProp,
-  TransitionPresets,
 } from '@react-navigation/stack';
 
 import { type RouteProp, type RouteParamsOf } from '../react-navigation';

--- a/src/unread/unreadModelTypes.js
+++ b/src/unread/unreadModelTypes.js
@@ -1,5 +1,5 @@
 /* @flow strict-local */
-import Immutable from 'immutable';
+import type Immutable from 'immutable';
 
 import type { HuddlesUnreadItem, PmsUnreadItem } from '../api/apiTypes';
 


### PR DESCRIPTION
Currently, dependabot will automatically open PRs to address
reported security vulnerabilities in packages. I'm interested to see
if it can help us be better about keeping our packages up-to-date in
general.

There are plenty of config options we can choose from (see the
linked doc). For now, I'm just curious to see what it does with this
simple config.