### PR TITLE
deps: Remove prop-types from devDependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,7 +124,6 @@
     "prettier": "^1.18.2",
     "prettier-eslint": "^12.0.0",
     "prettier-eslint-cli": "^5.0.0",
-    "prop-types": "^15.7.2",
     "react-dom": "16.11.0",
     "react-native-cli": "^2.0.1",
     "react-native-web": "^0.13.3",


### PR DESCRIPTION
We added it in 5b6014e83 to silence a peer-dep warning that
react-intl hasn't been throwing for a while:
  https://github.com/formatjs/formatjs/issues/1382

Note that react-intl's package.json doesn't have prop-types in its
peerDependencies anymore:
  https://github.com/formatjs/formatjs/blob/react-intl%405.8.6/packages/react-intl/package.json#L144-L147

The package is for runtime checking for React props; we don't need
it because we use Flow:
  https://www.npmjs.com/package/prop-types