### PR TITLE
accountsReducer [nfc]: Followups on handling restart events

### DIFF
--- a/src/account/accountsReducer.js
+++ b/src/account/accountsReducer.js
@@ -117,22 +117,23 @@ export default (state: AccountsState = initialState, action: Action): AccountsSt
       switch (event.type) {
         case EventTypes.restart: {
           const { zulip_feature_level, zulip_version } = event;
-          return zulip_feature_level !== undefined && zulip_version !== undefined
-            ? [
-                {
-                  ...state[0],
+          if (zulip_feature_level === undefined || zulip_version === undefined) {
+            return state;
+          }
+          return [
+            {
+              ...state[0],
 
-                  // TODO (?): Detect if these are different from the values
-                  // we had before, so we know it's an upgrade, not just a
-                  // restart. Then, implement logic like "be sure to refetch
-                  // from scratch within N hours" (to avoid thundering
-                  // herding the server).
-                  zulipVersion: new ZulipVersion(zulip_version),
-                  zulipFeatureLevel: zulip_feature_level,
-                },
-                ...state.slice(1),
-              ]
-            : state;
+              // TODO (?): Detect if these are different from the values
+              // we had before, so we know it's an upgrade, not just a
+              // restart. Then, implement logic like "be sure to refetch
+              // from scratch within N hours" (to avoid thundering
+              // herding the server).
+              zulipVersion: new ZulipVersion(zulip_version),
+              zulipFeatureLevel: zulip_feature_level,
+            },
+            ...state.slice(1),
+          ];
         }
         default:
           return state;

--- a/src/account/accountsReducer.js
+++ b/src/account/accountsReducer.js
@@ -120,15 +120,12 @@ export default (state: AccountsState = initialState, action: Action): AccountsSt
           if (zulip_feature_level === undefined || zulip_version === undefined) {
             return state;
           }
+
+          // TODO: Detect if the feature level has changed, indicating an upgrade;
+          //   if so, trigger a full refetch of server data.  See #4793.
           return [
             {
               ...state[0],
-
-              // TODO (?): Detect if these are different from the values
-              // we had before, so we know it's an upgrade, not just a
-              // restart. Then, implement logic like "be sure to refetch
-              // from scratch within N hours" (to avoid thundering
-              // herding the server).
               zulipVersion: new ZulipVersion(zulip_version),
               zulipFeatureLevel: zulip_feature_level,
             },

--- a/src/account/accountsReducer.js
+++ b/src/account/accountsReducer.js
@@ -9,7 +9,7 @@ import {
   LOGOUT,
   ACCOUNT_REMOVE,
 } from '../actionConstants';
-
+import { EventTypes } from '../api/eventTypes';
 import type { AccountsState, Identity, Action } from '../types';
 import { NULL_ARRAY } from '../nullObjects';
 import { ZulipVersion } from '../utils/zulipVersion';
@@ -115,7 +115,7 @@ export default (state: AccountsState = initialState, action: Action): AccountsSt
     case EVENT: {
       const { event } = action;
       switch (event.type) {
-        case 'restart': {
+        case EventTypes.restart: {
           const { zulip_feature_level, zulip_version } = event;
           return zulip_feature_level !== undefined && zulip_version !== undefined
             ? [


### PR DESCRIPTION
These are some small tweaks in the handy new `restart`-event implementation added in #4707.
