### PR TITLE
MainTabsScreen: Turn off lazy loading.

### DIFF
--- a/src/main/MainTabsScreen.js
+++ b/src/main/MainTabsScreen.js
@@ -60,6 +60,7 @@ export default function MainTabsScreen(props: Props) {
           showLabel: Platform.OS === 'ios' && Platform.isPad,
           showIcon: true,
         })}
+        lazy={false}
         backBehavior="none"
       >
         <Tab.Screen


### PR DESCRIPTION
This prevents the delay when loading a tab for the first time after app
open, which can often be significant.