### PR TITLE
actionsheet: Allow editing in all narrows

### DIFF
--- a/src/message/messageActionSheet.js
+++ b/src/message/messageActionSheet.js
@@ -17,7 +17,9 @@ import type {
 } from '../types';
 import {
   getNarrowForReply,
+  isHomeNarrow,
   isPmNarrow,
+  isSpecialNarrow,
   isStreamOrTopicNarrow,
   isTopicNarrow,
 } from '../utils/narrow';
@@ -301,8 +303,10 @@ export const constructMessageActionButtons = ({
   }
   if (
     message.sender_id === ownUser.user_id
-    // Our "edit message" UI only works in certain kinds of narrows.
-    && (isStreamOrTopicNarrow(narrow) || isPmNarrow(narrow))
+    && (isStreamOrTopicNarrow(narrow)
+      || isPmNarrow(narrow)
+      || isSpecialNarrow(narrow)
+      || isHomeNarrow(narrow))
   ) {
     buttons.push(editMessage);
   }


### PR DESCRIPTION
Earlier, the messageActionSheet only allowed the 'Edit message' UI for
stream, topic and PM (both 1:1 and group) narrows. This change now
allows editing in all types of narrows.
Fixes: #4671