### PR TITLE
RawLabel: Fix crash when text is empty string.

### DIFF
--- a/src/common/RawLabel.js
+++ b/src/common/RawLabel.js
@@ -30,7 +30,7 @@ export default class RawLabel extends PureComponent<Props> {
   render() {
     const { text, children, style, ...restProps } = this.props;
 
-    invariant(!!text !== !!children, 'pass either `text` or `children`');
+    invariant((text != null) !== (children != null), 'pass either `text` or `children`');
 
     // These attributes will be applied unless specifically overridden
     // with the `style` prop -- even if this `<RawLabel />` is nested


### PR DESCRIPTION
This was causing a crash when trying to autocomplete a user group with a
blank name. The empty string was passed into RawLabel, which caused this
invariant to incorrectly trigger.

Instead of using `!!` to check for undefined, we can do `!= null`, which
will trigger for undefined and null, but not an empty string.

If you want to trigger this on CZO, just type `@test` into the composebox :)