### PR TITLE
[nitpick] Fix parameter order for `onPress`.

### DIFF
--- a/src/streams/TopicItem.js
+++ b/src/streams/TopicItem.js
@@ -32,7 +32,7 @@ type Props = $ReadOnly<{|
   isMuted?: boolean,
   isSelected?: boolean,
   unreadCount?: number,
-  onPress: (topic: string, stream: string) => void,
+  onPress: (stream: string, topic: string) => void,
 |}>;
 
 export default function TopicItem(props: Props) {


### PR DESCRIPTION
nitpick
It was listed as
```javascript
onPress: (topic: string, stream: string) => void,
```
it Should be 
```javascript
onPress: (stream: string, topic: string) => void,
```