### PR TITLE
Followups on stream settings #4718

### DIFF
--- a/src/streams/StreamCard.js
+++ b/src/streams/StreamCard.js
@@ -34,9 +34,6 @@ export default class StreamCard extends PureComponent<Props> {
   render() {
     const { stream, subscription } = this.props;
 
-    const name = subscription?.name || stream.name;
-    const description = subscription?.description || stream.description;
-
     return (
       <View style={styles.padding}>
         <View style={componentStyles.streamRow}>
@@ -50,13 +47,13 @@ export default class StreamCard extends PureComponent<Props> {
           />
           <RawLabel
             style={componentStyles.streamText}
-            text={name}
+            text={stream.name}
             numberOfLines={1}
             ellipsizeMode="tail"
           />
         </View>
-        {description.length > 0 && (
-          <RawLabel style={componentStyles.descriptionText} text={description} />
+        {stream.description.length > 0 && (
+          <RawLabel style={componentStyles.descriptionText} text={stream.description} />
         )}
       </View>
     );

--- a/src/streams/StreamCard.js
+++ b/src/streams/StreamCard.js
@@ -43,7 +43,6 @@ export default class StreamCard extends PureComponent<Props> {
             color={subscription?.color || NULL_SUBSCRIPTION.color}
             isMuted={subscription ? !subscription.in_home_view : false}
             isPrivate={stream && stream.invite_only}
-            isSubscribed={!!subscription}
           />
           <RawLabel
             style={componentStyles.streamText}

--- a/src/streams/StreamIcon.js
+++ b/src/streams/StreamIcon.js
@@ -8,13 +8,12 @@ type Props = $ReadOnly<{|
   color?: string,
   isPrivate: boolean,
   isMuted: boolean,
-  isSubscribed: boolean,
   size: number,
   style?: TextStyleProp,
 |}>;
 
-export default ({ color, style, isPrivate, isMuted, isSubscribed, size }: Props) => {
-  const StreamIcon = isSubscribed && isMuted ? IconMute : isPrivate ? IconPrivate : IconStream;
+export default ({ color, style, isPrivate, isMuted, size }: Props) => {
+  const StreamIcon = isMuted ? IconMute : isPrivate ? IconPrivate : IconStream;
 
   return <StreamIcon size={size} color={color} style={style} />;
 };

--- a/src/streams/StreamItem.js
+++ b/src/streams/StreamItem.js
@@ -91,13 +91,7 @@ export default function StreamItem(props: Props) {
   return (
     <Touchable onPress={() => onPress(name)}>
       <View style={wrapperStyle}>
-        <StreamIcon
-          size={iconSize}
-          color={iconColor}
-          isMuted={isMuted}
-          isPrivate={isPrivate}
-          isSubscribed={isSubscribed}
-        />
+        <StreamIcon size={iconSize} color={iconColor} isMuted={isMuted} isPrivate={isPrivate} />
         <View style={componentStyles.text}>
           <RawLabel
             numberOfLines={1}

--- a/src/title/TitleStream.js
+++ b/src/title/TitleStream.js
@@ -51,7 +51,6 @@ type Props = $ReadOnly<{|
 
 const TitleStream = (props: Props) => {
   const { narrow, stream, color, dispatch, backgroundData } = props;
-  const subscribed = backgroundData.subscriptions.some(s => s.stream_id === stream.stream_id);
   const componentStyles = createStyleSheet({
     outer: {
       flex: 1,
@@ -91,7 +90,6 @@ const TitleStream = (props: Props) => {
             style={styles.halfMarginRight}
             isMuted={!stream.in_home_view}
             isPrivate={stream.invite_only}
-            isSubscribed={subscribed}
             color={color}
             size={20}
           />


### PR DESCRIPTION
These follow up on https://github.com/zulip/zulip-mobile/pull/4718#pullrequestreview-683615309 .

---

StreamIcon [nfc]: Revert "Don't show as muted when unsubscribed."

This reverts commit 532ff81e8.

Before that commit, it was already the case that we don't show the
"muted" icon when not subscribed to a stream:

 * In `TitleStream` (the title in the app bar on a stream narrow),
   this is arranged by `getStreamInNarrow`.

 * In `StreamCard` (used by `StreamSettingsScreen`, this is arranged
   by the following line in the `<StreamIcon … />` call:

       isMuted={subscription ? !subscription.in_home_view : false}

 * The remaining callers don't show streams that we aren't subscribed to.

Of those, the `StreamCard` logic hadn't been working until recently;
in 9dd501406 we introduced the regrettable NULL_SUBSCRIPTION in its
caller, and that caused the `subscription ? …` to take the truthy
branch, treating the bogus NULL_SUBSCRIPTION as real data.  But we
fixed that in d963d36cc by removing that use of NULL_SUBSCRIPTION.

So this didn't have any functional effect.

This component's interface is certainly kind of a mess.  Instead of
taking `isMuted` and `isPrivate` separately, and instead of requiring
each caller to have the right logic for handling unsubscribed
streams, it'd be better for this component to take whole Stream and
Subscription objects -- or possibly just a stream ID, and do its own
`connect` to get the data from Redux -- and handle that logic
for itself.

But adding one more prop that's also ultimately derived from
subscription data doesn't really make things any cleaner; at least it
doesn't while the callers still have their own copies of the
unsubscribed-vs-muted logic.

------------------------------------

StreamCard [nfc]: Use name/description straight from stream, not subscription.

These properties belong logically to the stream; they're duplicated on
the subscription object but should always have exactly the same value.

In particular, `subscriptionsReducer.js` updates them on a
`stream/update` event just like `streamsReducer.js` does.

So, just use them directly from the Stream object without first
looking for them on the Subscription.

The origin of these fallbacks appears to be c2094ddc7 back in 2017,
where they replaced just looking them up on the Subscription.  That
was indeed buggy, because the Subscription was potentially the bogus
value NULL_SUBSCRIPTION, which has empty name and description.  But
there was never a good reason to look at the Subscription for these
in the first place.
