### PR TITLE
webview: Initiate 'ready' handshake from WebView.

### DIFF
--- a/src/webview/js/generatedEs3.js
+++ b/src/webview/js/generatedEs3.js
@@ -821,10 +821,21 @@ var compiledWebviewJs = (function (exports) {
     }
   };
 
-  var handleInboundEventReady = function handleInboundEventReady(uevent) {
+  var readyRetryInterval = undefined;
+
+  var signalReadyForEvents = function signalReadyForEvents() {
     sendMessage({
       type: 'ready'
     });
+    readyRetryInterval = setInterval(function () {
+      sendMessage({
+        type: 'ready'
+      });
+    }, 100);
+  };
+
+  var handleInboundEventReady = function handleInboundEventReady(uevent) {
+    clearInterval(readyRetryInterval);
   };
 
   var handleInboundEventMessagesRead = function handleInboundEventMessagesRead(uevent) {
@@ -1072,6 +1083,7 @@ var compiledWebviewJs = (function (exports) {
   documentBody.addEventListener('drag', function (e) {
     clearTimeout(longPressTimeout);
   });
+  signalReadyForEvents();
 
   exports.handleInitialLoad = handleInitialLoad;
 


### PR DESCRIPTION
This is a performance optimization which according to my measurements
reduces the average load time from 487ms to 429ms, on the following
device:

* Pixel 3a
* Android 11
* Chrome 91.0.4472.101
* Release mode

Where load time was determined by calling `performance.now()` in
`componentDidMount` and again in `handleMessage` when the first ready
event is received, and comparing the results. The numbers above are an
average from 25 different runs. The standard deviation was also reduced,
from 58ms to 35ms.

This should still be as safe as it was before, since we still require a
roundtrip before exchanging any data, we just start that roundtrip in a
different place.

Starting the handshake from the webview does subtly change the
properties of the system, but not in a way that should cause any
problems. Specifically, if it was the case that the React Native ->
webview communication came up after the webview -> React Native
communication, there could be dropped message sent after the Webview
sent a 'ready' message but before it was able to receive messages.
However, due to the implementation of the React Native -> webview
channel, we expect that it will always be up by the time the code that
sends the 'ready' message to React Native runs.

This does change the retry frequency, since my testing showed that in
most cases, the retrying logic was unnecessary. Whereas previously we
sent a ready event every 30ms (and typically lost the first 3 or 4 ready
events while the webview was starting up), we now send a ready event
every 100ms in the (hopefully uncommon) case where the first one is
lost.

See CZO for more details and histograms:

https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/webview.20setup.20code