### PR TITLE
compose: Fix quoting exception message in GroupPM

### DIFF
--- a/src/compose/MentionWarnings.js
+++ b/src/compose/MentionWarnings.js
@@ -7,7 +7,7 @@ import { useSelector } from 'react-redux';
 import type { Stream, Narrow, UserOrBot, Subscription, UserId } from '../types';
 import { TranslationContext } from '../boot/TranslationProvider';
 import { getAllUsersById, getAuth } from '../selectors';
-import { is1to1PmNarrow } from '../utils/narrow';
+import { isPmNarrow } from '../utils/narrow';
 import * as api from '../api';
 import { showToast } from '../utils/info';
 
@@ -96,7 +96,7 @@ function MentionWarningsInner(props: Props, ref): Node {
     ref,
     () => ({
       handleMentionSubscribedCheck: async (completion: string) => {
-        if (is1to1PmNarrow(narrow)) {
+        if (isPmNarrow(narrow)) {
           return;
         }
         const mentionedUser = getUserFromMention(completion);
@@ -142,7 +142,7 @@ function MentionWarningsInner(props: Props, ref): Node {
     );
   }, []);
 
-  if (is1to1PmNarrow(narrow)) {
+  if (isPmNarrow(narrow)) {
     return null;
   }
 


### PR DESCRIPTION
The `handleMentionSubscribedCheck` function in MentionWarnings used to
bail out correctly only when the narrow was a 1:1 PM thread. This showed
an exception message when using quotations in groupPMs. Changing
`is1to1PmNarrow` instances to `isPmNarrow` inside MentionWarnings fixes
this issue.

Fixes: #4745