### PR TITLE
webview: Remove "Possible infinite loop" error.

### DIFF
--- a/src/webview/MessageList.js
+++ b/src/webview/MessageList.js
@@ -154,14 +154,6 @@ class MessageListInner extends Component<Props> {
   sendInboundEventsIsReady: boolean;
   unsentInboundEvents: WebViewInboundEvent[] = [];
 
-  componentDidMount() {
-    setTimeout(() => {
-      if (!this.sendInboundEventsIsReady) {
-        logging.warn('Possible infinite loop in WebView "ready" setup');
-      }
-    }, 1000);
-  }
-
   handleError = (event: mixed) => {
     console.error(event); // eslint-disable-line
   };


### PR DESCRIPTION
This error wasn't something we expected to actually happen, but because
we set the threshold far too low, it's actually our most common error.
Given that we just changed the webview setup code in a way that we
expect to make this error more impossible than we previously thought, we
might as well just get rid of it and save ourselves the noise in Sentry.