### PR TITLE
notifications: Match on realm domain, not href.

### DIFF
--- a/src/notification/index.js
+++ b/src/notification/index.js
@@ -48,7 +48,7 @@ export const getAccountFromNotificationData = (
 
   const urlMatches = [];
   identities.forEach((account, i) => {
-    if (account.realm.href === realmUrl.href) {
+    if (account.realm.origin === realmUrl.origin) {
       urlMatches.push(i);
     }
   });


### PR DESCRIPTION
We had a steady stream of errors in Sentry caused by differences between
the `known_urls` and `realm_uri`, where one of those had an extra `/` on
the end (or some more surprising junk, such as a `/join/` link). Since
we don't support running Zulip on a non-root path [1], we can simply
compare the domain instead of the href. This is probably more of a
band-aid than a real fix (we should figure out how the strange values
get into `known_urls` and fix that), but we might as well just check the
domain, since the path doesn't matter.

Related: #4309.

[1] https://chat.zulip.org/#narrow/stream/3-backend/topic/support.20for.20running.20on.20non-webroot.20url.3F