### PR TITLE
import: Work around broken imports of '.'.

### DIFF
--- a/src/common/CountOverlay.js
+++ b/src/common/CountOverlay.js
@@ -3,7 +3,8 @@
 import React, { PureComponent } from 'react';
 import { View } from 'react-native';
 
-import { ComponentWithOverlay, UnreadCount } from '.';
+// eslint-disable-next-line import/no-useless-path-segments
+import { ComponentWithOverlay, UnreadCount } from './'; // Like '.'; see #4818.
 import { BRAND_COLOR, createStyleSheet } from '../styles';
 
 const styles = createStyleSheet({

--- a/src/common/FullScreenLoading.js
+++ b/src/common/FullScreenLoading.js
@@ -4,7 +4,8 @@ import { View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { BRAND_COLOR, createStyleSheet } from '../styles';
-import { LoadingIndicator, ZulipStatusBar } from '.';
+// eslint-disable-next-line import/no-useless-path-segments
+import { LoadingIndicator, ZulipStatusBar } from './'; // Like '.'; see #4818.
 
 const componentStyles = createStyleSheet({
   center: {

--- a/src/common/LoadingBanner.js
+++ b/src/common/LoadingBanner.js
@@ -6,7 +6,8 @@ import { View } from 'react-native';
 import type { Dispatch } from '../types';
 import { connect } from '../react-redux';
 import { getLoading } from '../selectors';
-import { Label, LoadingIndicator } from '.';
+// eslint-disable-next-line import/no-useless-path-segments
+import { Label, LoadingIndicator } from './'; // Like '.'; see #4818.
 import type { ThemeData } from '../styles';
 import { ThemeContext, createStyleSheet } from '../styles';
 

--- a/src/common/ZulipTextButton.js
+++ b/src/common/ZulipTextButton.js
@@ -4,7 +4,8 @@ import { View } from 'react-native';
 
 import type { LocalizableText } from '../types';
 import { BRAND_COLOR, createStyleSheet } from '../styles';
-import { Label } from '.';
+// eslint-disable-next-line import/no-useless-path-segments
+import { Label } from './'; // Like '.'; see #4818.
 import Touchable from './Touchable';
 
 // When adding a variant, take care that it's legitimate, it addresses a

--- a/src/notification/notificationActions.js
+++ b/src/notification/notificationActions.js
@@ -8,7 +8,8 @@ import {
   tryStopNotifications as innerStopNotifications,
   getNarrowFromNotificationData,
   getAccountFromNotificationData,
-} from '.';
+  // eslint-disable-next-line import/no-useless-path-segments
+} from './'; // Like '.'; see #4818.
 import type { Notification } from './types';
 import { getAuth, getActiveAccount } from '../selectors';
 import { getSession, getAccounts } from '../directSelectors';


### PR DESCRIPTION
A bug somewhere in our stack -- presumably Metro or one of its
dependencies -- means that in src/notification/notificationActions.js
the import from `.` was getting resolved not to the module built from
its neighboring `index.js` file, as it should… but to the module
corresponding to the directory `src/common/`.

That also happens to be the directory where our only other imports
from `.` are found.  Seems like the bug may involve the resolution
of `.` being inappropriately shared globally.

In any case, the bug goes away when we make the import reference a
little less special-looking, as `./`.

Thread: https://chat.zulip.org/#narrow/stream/48-mobile/topic/Notification.20Crash/near/1215247
Fixes: #4818