### PR TITLE
queueMarkAsRead: Don't do anything when array is empty.

### DIFF
--- a/src/api/__tests__/queueMarkAsRead-test.js
+++ b/src/api/__tests__/queueMarkAsRead-test.js
@@ -56,4 +56,13 @@ describe('queueMarkAsRead', () => {
     lolex.runOnlyPendingTimers();
     expect(messagesFlags.default).toHaveBeenCalledTimes(2);
   });
+
+  test('empty array should not cause anything to happen', () => {
+    queueMarkAsRead(eg.selfAuth, []);
+
+    lolex.advanceTimersByTime(2500);
+
+    lolex.runOnlyPendingTimers();
+    expect(messagesFlags.default).toHaveBeenCalledTimes(0);
+  });
 });

--- a/src/api/queueMarkAsRead.js
+++ b/src/api/queueMarkAsRead.js
@@ -17,7 +17,7 @@ export const resetAll = () => {
 };
 
 const processQueue = async (auth: Auth) => {
-  if (timeout !== null) {
+  if (timeout !== null || unackedMessageIds.length === 0) {
     return;
   }
 

--- a/src/webview/handleOutboundEvents.js
+++ b/src/webview/handleOutboundEvents.js
@@ -181,9 +181,7 @@ const markRead = (props: Props, event: WebViewOutboundEventScroll) => {
     event.startMessageId,
     event.endMessageId,
   );
-  if (unreadMessageIds.length > 0) {
-    api.queueMarkAsRead(auth, unreadMessageIds);
-  }
+  api.queueMarkAsRead(auth, unreadMessageIds);
 };
 
 const handleImage = (props: Props, src: string, messageId: number) => {


### PR DESCRIPTION
This should fix the following errors, which I see not infrequently in
the console and in Sentry:

```
{
  "httpStatus": 400,
  "json": {
    "code": "BAD_REQUEST",
    "msg": "Invalid message(s)",
    "result": "error"
  },
  "params": {
    "body": "messages=%5B%5D&flag=read&op=add",
    "method": "post"
  },
  "route": "messages/flags"
}
```