### PR TITLE
queueMarkAsRead: Reduce debouncing time to 500ms.

### DIFF
--- a/src/api/queueMarkAsRead.js
+++ b/src/api/queueMarkAsRead.js
@@ -3,7 +3,7 @@ import type { Auth } from './transportTypes';
 import messagesFlags from './messages/messagesFlags';
 
 /** We batch up requests to avoid sending them twice in this much time. */
-const debouncePeriodMs = 2000;
+const debouncePeriodMs = 500;
 
 let unackedMessageIds = [];
 let lastSentTime = -Infinity;


### PR DESCRIPTION
This debouncing doesn't buy us a lot (the webapp doesn't do anything
equivalent, from looking at the network tab as I mark messages as read),
and we have a strong reason not to make this take too long - our unread
messages banner is based on when we get the flag updates back from the
server, so the sooner we send them, the more responsive it will be.

We added this debouncing in 70295bd in order to fix #374, which wasn't
solving a particularly active problem - it was in order to avoid
possible API rate limits. The default rate limit for the server is 200
requests per minute [1], which works out to a request every 300 ms.
Given that, doing a request every 500ms should give us plenty of
breathing room to also request messages/etc, even in the unlikely case
that someone is pretty continuously scrolling through unread messages.

While we should make an effective local echo solution for marking
messages as read (#3549), this change is an good way to make things
better until we do that.

[1] https://chat.zulip.org/#narrow/stream/378-api-design/topic/Rate.20limits/near/1215716