### PR TITLE
InboundEventLogger: JSON.stringify inbound event items.

### DIFF
--- a/src/webview/js/InboundEventLogger.js
+++ b/src/webview/js/InboundEventLogger.js
@@ -128,7 +128,7 @@ export default class InboundEventLogger {
       details: {
         startTime: this._captureStartTime ?? null,
         endTime: this._captureEndTime ?? null,
-        inboundEventItems: this._capturedInboundEventItems,
+        inboundEventItems: JSON.stringify(this._capturedInboundEventItems),
       },
     });
   }

--- a/src/webview/js/generatedEs3.js
+++ b/src/webview/js/generatedEs3.js
@@ -146,7 +146,7 @@ var compiledWebviewJs = (function (exports) {
           details: {
             startTime: (_this$_captureStartTi = this._captureStartTime) !== null && _this$_captureStartTi !== void 0 ? _this$_captureStartTi : null,
             endTime: (_this$_captureEndTime = this._captureEndTime) !== null && _this$_captureEndTime !== void 0 ? _this$_captureEndTime : null,
-            inboundEventItems: this._capturedInboundEventItems
+            inboundEventItems: JSON.stringify(this._capturedInboundEventItems)
           }
         });
       }


### PR DESCRIPTION
`inboundEventItems[].scrubbedEvent` is getting reduced to
`[Object]`, which is accidental and unhelpful. The data should
already be scrubbed of sensitive information, so, send it in a way
that lets us read it.

See discussion at
  https://chat.zulip.org/#narrow/stream/176-mobile-core/topic/.22Webview.20warning.22/near/1216411.