### PR TITLE
i18n: Tag "Oops! Something went wrong." for translation.

### DIFF
--- a/static/translations/messages_en.json
+++ b/static/translations/messages_en.json
@@ -242,5 +242,6 @@
   "Signed out": "Signed out",
   "Remove account?": "Remove account?",
   "This will make the mobile app on this device forget {email} on {realmUrl}.": "This will make the mobile app on this device forget {email} on {realmUrl}.",
+  "Oops! Something went wrong.": "Oops! Something went wrong.",
   "Remove account": "Remove account"
 }


### PR DESCRIPTION
This string appears in `src/chat/FetchError.js`.