### PR TITLE
notifications: Add more detail to "realm_uri ambiguous" error.

### DIFF
--- a/src/notification/index.js
+++ b/src/notification/index.js
@@ -77,6 +77,8 @@ export const getAccountFromNotificationData = (
       realm_uri,
       parsed_url: realmUrl,
       match_count: urlMatches.length,
+      unique_identities_count: new Set(urlMatches.map(matchIndex => identities[matchIndex].email))
+        .size,
     });
     // TODO get user_id into accounts data, and use that
     return null;


### PR DESCRIPTION
There are a lot of users seeing this - more than I would expect to have
multiple accounts on the same server. I want to collect this data so
that we can have a more complete picture of what's going on in these
cases.

This is somewhat personal data (URLs of self-hosted realms), but we log
this same array elsewhere, so it's not changing the status quo
significantly to log it here.