### PR TITLE
generateInboundEvents: Remove early return on sending a 'content' event.

### DIFF
--- a/src/directSelectors.js
+++ b/src/directSelectors.js
@@ -66,9 +66,6 @@ export const getFetching = (state: GlobalState): FetchingState => state.fetching
 
 export const getFlags = (state: GlobalState): FlagsState => state.flags;
 
-export const getReadFlags = (state: GlobalState): {| [messageId: number]: boolean |} =>
-  state.flags.read;
-
 export const getAllNarrows = (state: GlobalState): NarrowsState => state.narrows;
 
 export const getSettings = (state: GlobalState): SettingsState => state.settings;

--- a/src/reduxTypes.js
+++ b/src/reduxTypes.js
@@ -106,20 +106,30 @@ export type FetchingState = {|
  *
  * Unlike almost all other subtrees of our state, this one can be
  * incomplete, always in exactly the same way that `MessagesState` is.
+ *
+ * We expect most of these flags to be very sparse: the number of messages
+ * you have starred, or where you're @-mentioned, is typically a very small
+ * fraction of the total number of messages you have. That's why it probably
+ * doesn't make sense for this data structure to explicitly indicate "not
+ * starred", "not @-mentioned", etc., for every known message. That could
+ * significantly increase the memory and storage requirement when we know
+ * about a lot of messages. If we need to distinguish "unknown message" from
+ * "message without flag", we can look up the message ID in
+ * `state.messages`.
  */
 export type FlagsState = {|
-  read: {| [messageId: number]: boolean |},
-  starred: {| [messageId: number]: boolean |},
-  collapsed: {| [messageId: number]: boolean |},
-  mentioned: {| [messageId: number]: boolean |},
-  wildcard_mentioned: {| [messageId: number]: boolean |},
-  summarize_in_home: {| [messageId: number]: boolean |},
-  summarize_in_stream: {| [messageId: number]: boolean |},
-  force_expand: {| [messageId: number]: boolean |},
-  force_collapse: {| [messageId: number]: boolean |},
-  has_alert_word: {| [messageId: number]: boolean |},
-  historical: {| [messageId: number]: boolean |},
-  is_me_message: {| [messageId: number]: boolean |},
+  read: {| [messageId: number]: true |},
+  starred: {| [messageId: number]: true |},
+  collapsed: {| [messageId: number]: true |},
+  mentioned: {| [messageId: number]: true |},
+  wildcard_mentioned: {| [messageId: number]: true |},
+  summarize_in_home: {| [messageId: number]: true |},
+  summarize_in_stream: {| [messageId: number]: true |},
+  force_expand: {| [messageId: number]: true |},
+  force_collapse: {| [messageId: number]: true |},
+  has_alert_word: {| [messageId: number]: true |},
+  historical: {| [messageId: number]: true |},
+  is_me_message: {| [messageId: number]: true |},
 |};
 
 export type FlagName = $Keys<FlagsState>;

--- a/src/webview/__tests__/generateInboundEvents-test.js
+++ b/src/webview/__tests__/generateInboundEvents-test.js
@@ -151,28 +151,6 @@ describe('generateInboundEvents', () => {
     expect(messages[1].type).toEqual('typing');
   });
 
-  test('when there are several diffs but messages differ too return only a single "content" message', () => {
-    const prevProps = {
-      ...baseProps,
-      fetching: { older: false, newer: false },
-      typingUsers: [],
-      htmlPieceDescriptorsForShownMessages: [],
-    };
-    const nextProps = {
-      ...baseProps,
-      fetching: { older: false, newer: true },
-      typingUsers: [eg.makeUser()],
-      htmlPieceDescriptorsForShownMessages: [
-        { key: 123, type: 'message', isBrief: false, message: eg.streamMessage() },
-      ],
-    };
-
-    const messages = generateInboundEvents(prevProps, nextProps);
-
-    expect(messages).toHaveLength(1);
-    expect(messages[0].type).toEqual('content');
-  });
-
   test('if a new message is read send a "read" update', () => {
     const message1 = eg.streamMessage({ id: 1 });
     const message2 = eg.streamMessage({ id: 2 });

--- a/src/webview/generateInboundEvents.js
+++ b/src/webview/generateInboundEvents.js
@@ -100,6 +100,8 @@ export default function generateInboundEvents(
   prevProps: Props,
   nextProps: Props,
 ): WebViewInboundEvent[] {
+  const uevents = [];
+
   if (
     !isEqual(
       prevProps.htmlPieceDescriptorsForShownMessages,
@@ -107,10 +109,8 @@ export default function generateInboundEvents(
     )
     || !equalFlagsExcludingRead(prevProps.backgroundData.flags, nextProps.backgroundData.flags)
   ) {
-    return [updateContent(prevProps, nextProps)];
+    uevents.push(updateContent(prevProps, nextProps));
   }
-
-  const uevents = [];
 
   if (prevProps.backgroundData.flags.read !== nextProps.backgroundData.flags.read) {
     // TODO: Don't consider messages outside the narrow we're viewing.

--- a/src/webview/generateInboundEvents.js
+++ b/src/webview/generateInboundEvents.js
@@ -114,6 +114,9 @@ export default function generateInboundEvents(
 
   if (prevProps.backgroundData.flags.read !== nextProps.backgroundData.flags.read) {
     // TODO: Don't consider messages outside the narrow we're viewing.
+    // TODO: Only include messages that we've just marked as read. We're
+    // currently including some read messages only because we've just
+    // learned about them from a fetch.
     const messageIds = Object.keys(nextProps.backgroundData.flags.read)
       .filter(id => !prevProps.backgroundData.flags.read[+id])
       .map(id => +id);

--- a/src/webview/generateInboundEvents.js
+++ b/src/webview/generateInboundEvents.js
@@ -113,6 +113,7 @@ export default function generateInboundEvents(
   const uevents = [];
 
   if (prevProps.backgroundData.flags.read !== nextProps.backgroundData.flags.read) {
+    // TODO: Don't consider messages outside the narrow we're viewing.
     const messageIds = Object.keys(nextProps.backgroundData.flags.read)
       .filter(id => !prevProps.backgroundData.flags.read[+id])
       .map(id => +id);


### PR DESCRIPTION
I've played around with this and inspected the code, and I haven't found any obvious issues yet.

Related: #3851