### PR TITLE
AccountPickScreen [nfc]: Use `useSelector` instead of `connect`.

### DIFF
--- a/src/account/AccountPickScreen.js
+++ b/src/account/AccountPickScreen.js
@@ -1,6 +1,6 @@
 /* @flow strict-local */
 
-import React, { PureComponent } from 'react';
+import React, { useContext, useCallback } from 'react';
 import { Alert } from 'react-native';
 
 import * as api from '../api';
@@ -8,7 +8,7 @@ import { TranslationContext } from '../boot/TranslationProvider';
 import type { RouteProp } from '../react-navigation';
 import type { AppNavigationProp } from '../nav/AppNavigator';
 import * as NavigationService from '../nav/NavigationService';
-import type { GetText, Dispatch } from '../types';
+import type { Dispatch } from '../types';
 import { connect } from '../react-redux';
 import { getHasAuth, getAccountStatuses } from '../selectors';
 import type { AccountStatus } from './accountsSelectors';
@@ -32,93 +32,91 @@ type Props = $ReadOnly<{|
   hasAuth: boolean,
 |}>;
 
-class AccountPickScreen extends PureComponent<Props> {
-  static contextType = TranslationContext;
-  context: GetText;
+function AccountPickScreen(props: Props) {
+  const { accounts, hasAuth, dispatch } = props;
+  const _ = useContext(TranslationContext);
 
-  handleAccountSelect = async (index: number) => {
-    const _ = this.context;
-    const { accounts, dispatch } = this.props;
-    const { realm, isLoggedIn } = accounts[index];
-    if (isLoggedIn) {
-      setTimeout(() => {
-        dispatch(accountSwitch(index));
-      });
-    } else {
-      try {
-        const serverSettings: ApiResponseServerSettings = await api.getServerSettings(realm);
-        NavigationService.dispatch(navigateToAuth(serverSettings));
-      } catch (e) {
-        showErrorAlert(_('Failed to connect to server: {realm}', { realm: realm.toString() }));
-      }
-    }
-  };
-
-  handleAccountRemove = (index: number) => {
-    const { accounts, dispatch } = this.props;
-    const { realm, email } = accounts[index];
-    const _ = this.context;
-    Alert.alert(
-      _('Remove account?'),
-      _('This will make the mobile app on this device forget {email} on {realmUrl}.', {
-        realmUrl: realm.toString(),
-        email,
-      }),
-      [
-        { text: _('Cancel'), style: 'cancel' },
-        {
-          text: _('Remove account'),
-          style: 'destructive',
-          onPress: () => {
-            dispatch(removeAccount(index));
-          },
-        },
-      ],
-      { cancelable: true },
-    );
-  };
-
-  render() {
-    const { accounts, hasAuth } = this.props;
-
-    return (
-      <Screen
-        title="Pick account"
-        centerContent
-        padding
-        canGoBack={
-          // We can get here three ways:
-          //  * the "switch accounts" button
-          //  * the "log out" button
-          //  * as the initial screen, if we have a known account but no API key.
-          //
-          // The "log out" button is a bit exceptional because it's the user
-          // taking a navigational action... but the screen they just left
-          // required the login they've just discarded, so they can't go back.
-          //
-          // So, show a "navigate back" UI in the first case, but not the other two.
-          hasAuth
+  const handleAccountSelect = useCallback(
+    async (index: number) => {
+      const { realm, isLoggedIn } = accounts[index];
+      if (isLoggedIn) {
+        setTimeout(() => {
+          dispatch(accountSwitch(index));
+        });
+      } else {
+        try {
+          const serverSettings: ApiResponseServerSettings = await api.getServerSettings(realm);
+          NavigationService.dispatch(navigateToAuth(serverSettings));
+        } catch (e) {
+          showErrorAlert(_('Failed to connect to server: {realm}', { realm: realm.toString() }));
         }
-        shouldShowLoadingBanner={false}
-      >
-        <Centerer>
-          {accounts.length === 0 && <Logo />}
-          <AccountList
-            accounts={accounts}
-            onAccountSelect={this.handleAccountSelect}
-            onAccountRemove={this.handleAccountRemove}
-          />
-          <ViewPlaceholder height={16} />
-          <ZulipButton
-            text="Add new account"
-            onPress={() => {
-              NavigationService.dispatch(navigateToRealmInputScreen());
-            }}
-          />
-        </Centerer>
-      </Screen>
-    );
-  }
+      }
+    },
+    [accounts, _, dispatch],
+  );
+
+  const handleAccountRemove = useCallback(
+    (index: number) => {
+      const { realm, email } = accounts[index];
+      Alert.alert(
+        _('Remove account?'),
+        _('This will make the mobile app on this device forget {email} on {realmUrl}.', {
+          realmUrl: realm.toString(),
+          email,
+        }),
+        [
+          { text: _('Cancel'), style: 'cancel' },
+          {
+            text: _('Remove account'),
+            style: 'destructive',
+            onPress: () => {
+              dispatch(removeAccount(index));
+            },
+          },
+        ],
+        { cancelable: true },
+      );
+    },
+    [accounts, _, dispatch],
+  );
+
+  return (
+    <Screen
+      title="Pick account"
+      centerContent
+      padding
+      canGoBack={
+        // We can get here three ways:
+        //  * the "switch accounts" button
+        //  * the "log out" button
+        //  * as the initial screen, if we have a known account but no API key.
+        //
+        // The "log out" button is a bit exceptional because it's the user
+        // taking a navigational action... but the screen they just left
+        // required the login they've just discarded, so they can't go back.
+        //
+        // So, show a "navigate back" UI in the first case, but not the other two.
+        hasAuth
+      }
+      shouldShowLoadingBanner={false}
+    >
+      <Centerer>
+        {accounts.length === 0 && <Logo />}
+        <AccountList
+          accounts={accounts}
+          onAccountSelect={handleAccountSelect}
+          onAccountRemove={handleAccountRemove}
+        />
+        <ViewPlaceholder height={16} />
+        <ZulipButton
+          text="Add new account"
+          onPress={() => {
+            NavigationService.dispatch(navigateToRealmInputScreen());
+          }}
+        />
+      </Centerer>
+    </Screen>
+  );
 }
 
 export default connect(state => ({

--- a/src/account/AccountPickScreen.js
+++ b/src/account/AccountPickScreen.js
@@ -10,7 +10,7 @@ import type { AppNavigationProp } from '../nav/AppNavigator';
 import * as NavigationService from '../nav/NavigationService';
 import type { GetText, Dispatch } from '../types';
 import { connect } from '../react-redux';
-import { hasAuth, getAccountStatuses } from '../selectors';
+import { getHasAuth, getAccountStatuses } from '../selectors';
 import type { AccountStatus } from './accountsSelectors';
 import { Centerer, ZulipButton, Logo, Screen, ViewPlaceholder } from '../common';
 import AccountList from './AccountList';
@@ -123,5 +123,5 @@ class AccountPickScreen extends PureComponent<Props> {
 
 export default connect(state => ({
   accounts: getAccountStatuses(state),
-  hasAuth: hasAuth(state),
+  hasAuth: getHasAuth(state),
 }))(AccountPickScreen);

--- a/src/account/AccountPickScreen.js
+++ b/src/account/AccountPickScreen.js
@@ -9,7 +9,7 @@ import type { RouteProp } from '../react-navigation';
 import type { AppNavigationProp } from '../nav/AppNavigator';
 import * as NavigationService from '../nav/NavigationService';
 import { useSelector, useDispatch } from '../react-redux';
-import { getHasAuth, getAccountStatuses } from '../selectors';
+import { getAccountStatuses } from '../selectors';
 import { Centerer, ZulipButton, Logo, Screen, ViewPlaceholder } from '../common';
 import AccountList from './AccountList';
 import {
@@ -27,8 +27,8 @@ type Props = $ReadOnly<{|
 |}>;
 
 export default function AccountPickScreen(props: Props) {
+  const { navigation } = props;
   const accounts = useSelector(getAccountStatuses);
-  const hasAuth = useSelector(getHasAuth);
   const dispatch = useDispatch();
   const _ = useContext(TranslationContext);
 
@@ -81,19 +81,7 @@ export default function AccountPickScreen(props: Props) {
       title="Pick account"
       centerContent
       padding
-      canGoBack={
-        // We can get here three ways:
-        //  * the "switch accounts" button
-        //  * the "log out" button
-        //  * as the initial screen, if we have a known account but no API key.
-        //
-        // The "log out" button is a bit exceptional because it's the user
-        // taking a navigational action... but the screen they just left
-        // required the login they've just discarded, so they can't go back.
-        //
-        // So, show a "navigate back" UI in the first case, but not the other two.
-        hasAuth
-      }
+      canGoBack={navigation.canGoBack()}
       shouldShowLoadingBanner={false}
     >
       <Centerer>

--- a/src/account/AccountPickScreen.js
+++ b/src/account/AccountPickScreen.js
@@ -8,10 +8,8 @@ import { TranslationContext } from '../boot/TranslationProvider';
 import type { RouteProp } from '../react-navigation';
 import type { AppNavigationProp } from '../nav/AppNavigator';
 import * as NavigationService from '../nav/NavigationService';
-import type { Dispatch } from '../types';
-import { connect } from '../react-redux';
+import { useSelector, useDispatch } from '../react-redux';
 import { getHasAuth, getAccountStatuses } from '../selectors';
-import type { AccountStatus } from './accountsSelectors';
 import { Centerer, ZulipButton, Logo, Screen, ViewPlaceholder } from '../common';
 import AccountList from './AccountList';
 import {
@@ -26,14 +24,12 @@ import { showErrorAlert } from '../utils/info';
 type Props = $ReadOnly<{|
   navigation: AppNavigationProp<'account-pick'>,
   route: RouteProp<'account-pick', void>,
-
-  accounts: $ReadOnlyArray<AccountStatus>,
-  dispatch: Dispatch,
-  hasAuth: boolean,
 |}>;
 
-function AccountPickScreen(props: Props) {
-  const { accounts, hasAuth, dispatch } = props;
+export default function AccountPickScreen(props: Props) {
+  const accounts = useSelector(getAccountStatuses);
+  const hasAuth = useSelector(getHasAuth);
+  const dispatch = useDispatch();
   const _ = useContext(TranslationContext);
 
   const handleAccountSelect = useCallback(
@@ -118,8 +114,3 @@ function AccountPickScreen(props: Props) {
     </Screen>
   );
 }
-
-export default connect(state => ({
-  accounts: getAccountStatuses(state),
-  hasAuth: getHasAuth(state),
-}))(AccountPickScreen);

--- a/src/account/AccountPickScreen.js
+++ b/src/account/AccountPickScreen.js
@@ -78,27 +78,27 @@ class AccountPickScreen extends PureComponent<Props> {
     );
   };
 
-  // We can get here three ways:
-  //  * the "switch accounts" button
-  //  * the "log out" button
-  //  * as the initial screen, if we have a known account but no API key.
-  //
-  // The "log out" button is a bit exceptional because it's the user
-  // taking a navigational action... but the screen they just left
-  // required the login they've just discarded, so they can't go back.
-  //
-  // So, show a "navigate back" UI in the first case, but not the other two.
-  canGoBack = this.props.hasAuth;
-
   render() {
-    const { accounts } = this.props;
+    const { accounts, hasAuth } = this.props;
 
     return (
       <Screen
         title="Pick account"
         centerContent
         padding
-        canGoBack={this.canGoBack}
+        canGoBack={
+          // We can get here three ways:
+          //  * the "switch accounts" button
+          //  * the "log out" button
+          //  * as the initial screen, if we have a known account but no API key.
+          //
+          // The "log out" button is a bit exceptional because it's the user
+          // taking a navigational action... but the screen they just left
+          // required the login they've just discarded, so they can't go back.
+          //
+          // So, show a "navigate back" UI in the first case, but not the other two.
+          hasAuth
+        }
         shouldShowLoadingBanner={false}
       >
         <Centerer>

--- a/src/account/accountsSelectors.js
+++ b/src/account/accountsSelectors.js
@@ -108,7 +108,7 @@ export const tryGetAuth: Selector<Auth | void> = createSelector(tryGetActiveAcco
  *
  * See `tryGetAuth` for the meaning of "active, logged-in".
  */
-export const hasAuth = (state: GlobalState): boolean => !!tryGetAuth(state);
+export const getHasAuth = (state: GlobalState): boolean => !!tryGetAuth(state);
 
 /**
  * The auth object for the active, logged-in account; throws if none.

--- a/src/nav/AppNavigator.js
+++ b/src/nav/AppNavigator.js
@@ -9,7 +9,7 @@ import {
 
 import type { RouteParamsOf } from '../react-navigation';
 import { useSelector } from '../react-redux';
-import { hasAuth as getHasAuth, getAccounts } from '../selectors';
+import { getHasAuth, getAccounts } from '../selectors';
 import getInitialRouteInfo from './getInitialRouteInfo';
 import type { GlobalParamList } from './globalTypes';
 import AccountPickScreen from '../account/AccountPickScreen';

--- a/src/session/sessionReducer.js
+++ b/src/session/sessionReducer.js
@@ -16,7 +16,7 @@ import {
   LOGOUT,
   DISMISS_SERVER_COMPAT_NOTICE,
 } from '../actionConstants';
-import { hasAuth } from '../account/accountsSelectors';
+import { getHasAuth } from '../account/accountsSelectors';
 
 /**
  * Miscellaneous non-persistent state about this run of the app.
@@ -95,15 +95,15 @@ const rehydrate = (state, action) => {
   const { payload } = action;
 
   /* $FlowIgnore: The actual type allows any property to be null; narrow
-       that to just the one that `hasAuth` will care about.  (What we really
-       want here is what the value of `hasAuth` will be after the rehydrate
-       is complete.  So even if some other property is null in the payload,
-       we still do want to ask `hasAuth` what it thinks.) */
-  const payloadForHasAuth = (payload: GlobalState | { accounts: null, ... } | void);
+       that to just the one that `getHasAuth` will care about.  (What we
+       really want here is what the value of `getHasAuth` will be after the
+       rehydrate is complete.  So even if some other property is null in the
+       payload, we still do want to ask `getHasAuth` what it thinks.) */
+  const payloadForGetHasAuth = (payload: GlobalState | { accounts: null, ... } | void);
   const haveApiKey = !!(
-    payloadForHasAuth
-    && payloadForHasAuth.accounts
-    && hasAuth(payloadForHasAuth)
+    payloadForGetHasAuth
+    && payloadForGetHasAuth.accounts
+    && getHasAuth(payloadForGetHasAuth)
   );
 
   return {


### PR DESCRIPTION
An instance of #4837.

(The use of `navigation.canGoBack()` in the last commit in the branch is an independent, unrelated cleanup.)