### PR TITLE
lightbox [nfc]: Remove meaningless properties in rnfb config.

### DIFF
--- a/src/lightbox/download.js
+++ b/src/lightbox/download.js
@@ -73,7 +73,4 @@ export const downloadFileToCache = async (tempUrl: string, fileName: string): Pr
   RNFetchBlob.config({
     path: `${RNFetchBlob.fs.dirs.CacheDir}/${fileName}`,
     fileCache: true,
-    useDownloadManager: true,
-    mime: getMimeTypeFromFileExtension(fileName.split('.').pop()),
-    title: fileName,
   }).fetch('GET', tempUrl);


### PR DESCRIPTION
Done in `downloadFileToCache`, the object passed to
`RNFetchBlob.config` contained some meaningless properties.

These property are technically the sub properties of the property
`addAndroidDownloads`. But we would want to remove them instead of
adding them there since these essentially configure the android
download manager to download the file, which we do not want in case
of this function.

Normally rnfb will use its internal implementation for downloading
based on the `OkHttp` android library.
Originally reported [here](https://chat.zulip.org/#narrow/stream/48-mobile/topic/Sharing.20from.20lightbox.20broken.20on.20Android/near/1223148)