### PR TITLE
[Android] Improve notification UI.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ npm-debug.log
 # VS Code: default Java extension
 /android/.project
 /android/.settings/
+/android/app/.project
 
 # VS Code: debugger
 /.vscode/.react/

--- a/android/app/src/main/java/com/zulipmobile/MainApplication.java
+++ b/android/app/src/main/java/com/zulipmobile/MainApplication.java
@@ -20,19 +20,12 @@ import org.unimodules.adapters.react.ReactModuleRegistryProvider;
 import org.unimodules.core.interfaces.SingletonModule;
 
 import com.zulipmobile.generated.BasePackageList;
-import com.zulipmobile.notifications.ConversationMap;
 import com.zulipmobile.notifications.FCMPushNotifications;
 import com.zulipmobile.notifications.NotificationsPackage;
 import com.zulipmobile.sharing.SharingPackage;
 
 public class MainApplication extends Application implements ReactApplication {
     private final ReactModuleRegistryProvider mModuleRegistryProvider = new ReactModuleRegistryProvider(new BasePackageList().getPackageList(), null);
-
-    private ConversationMap conversations;
-
-    public ConversationMap getConversations() {
-        return conversations;
-    }
 
     private final ReactNativeHost mReactNativeHost = new ReactNativeHost(this) {
         @Override
@@ -79,7 +72,6 @@ public class MainApplication extends Application implements ReactApplication {
         FCMPushNotifications.createNotificationChannel(this);
         SoLoader.init(this, /* native exopackage */ false);
         initializeFlipper(this, getReactNativeHost().getReactInstanceManager());
-        conversations = new ConversationMap();
     }
 
     /**

--- a/android/app/src/main/java/com/zulipmobile/notifications/FCMPushNotifications.kt
+++ b/android/app/src/main/java/com/zulipmobile/notifications/FCMPushNotifications.kt
@@ -125,6 +125,30 @@ private fun getActiveNotification(context: Context, conversationKey: String): No
     return null
 }
 
+// TODO: Add a Text saying n messages in m conversations. (this will
+// only be visible in API < 24)
+private fun createSummaryNotification(
+    context: Context,
+    fcmMessage: MessageFcmMessage,
+    groupKey: String
+): NotificationCompat.Builder {
+    val realmUri = fcmMessage.identity.realmUri.toString()
+    return NotificationCompat.Builder(context, CHANNEL_ID).apply {
+        color = context.getColor(R.color.brandColor)
+        if (BuildConfig.DEBUG) {
+            setSmallIcon(R.mipmap.ic_launcher)
+        } else {
+            setSmallIcon(R.drawable.zulip_notification)
+        }
+        setStyle(NotificationCompat.InboxStyle()
+            .setSummaryText(realmUri)
+        )
+        setGroup(groupKey)
+        setGroupSummary(true)
+        setAutoCancel(true)
+    }
+}
+
 private fun updateNotification(
     context: Context, conversations: ConversationMap, fcmMessage: MessageFcmMessage) {
     if (conversations.isEmpty()) {

--- a/android/app/src/main/java/com/zulipmobile/notifications/FCMPushNotifications.kt
+++ b/android/app/src/main/java/com/zulipmobile/notifications/FCMPushNotifications.kt
@@ -80,6 +80,13 @@ internal fun onReceived(context: Context, conversations: ConversationMap, mapDat
     }
 }
 
+fun createViewPendingIntent(fcmMessage: MessageFcmMessage, context: Context): PendingIntent {
+    val uri = Uri.fromParts("zulip", "msgid:${fcmMessage.zulipMessageId}", "")
+    val viewIntent = Intent(Intent.ACTION_VIEW, uri, context, NotificationIntentService::class.java)
+    viewIntent.putExtra(EXTRA_NOTIFICATION_DATA, fcmMessage.dataForOpen())
+    return PendingIntent.getService(context, 0, viewIntent, 0)
+}
+
 private fun updateNotification(
     context: Context, conversations: ConversationMap, fcmMessage: MessageFcmMessage) {
     if (conversations.isEmpty()) {
@@ -100,10 +107,7 @@ private fun getNotificationBuilder(
     context: Context, conversations: ConversationMap, fcmMessage: MessageFcmMessage): NotificationCompat.Builder {
     val builder = NotificationCompat.Builder(context, CHANNEL_ID)
 
-    val uri = Uri.fromParts("zulip", "msgid:${fcmMessage.zulipMessageId}", "")
-    val viewIntent = Intent(Intent.ACTION_VIEW, uri, context, NotificationIntentService::class.java)
-    viewIntent.putExtra(EXTRA_NOTIFICATION_DATA, fcmMessage.dataForOpen())
-    val viewPendingIntent = PendingIntent.getService(context, 0, viewIntent, 0)
+    val viewPendingIntent = createViewPendingIntent(fcmMessage, context)
     builder.setContentIntent(viewPendingIntent)
     builder.setAutoCancel(true)
 

--- a/android/app/src/main/java/com/zulipmobile/notifications/FCMPushNotifications.kt
+++ b/android/app/src/main/java/com/zulipmobile/notifications/FCMPushNotifications.kt
@@ -9,6 +9,7 @@ import android.app.NotificationManager
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
+import android.media.AudioAttributes
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
@@ -34,6 +35,8 @@ val ACTION_CLEAR = "ACTION_CLEAR"
 val EXTRA_NOTIFICATION_DATA = "data"
 
 fun createNotificationChannel(context: Context) {
+    val audioAttr: AudioAttributes = AudioAttributes.Builder()
+        .setUsage(AudioAttributes.USAGE_NOTIFICATION).build()
     if (Build.VERSION.SDK_INT >= 26) {
         val name = context.getString(R.string.notification_channel_name)
 
@@ -44,6 +47,7 @@ fun createNotificationChannel(context: Context) {
             NotificationChannel(CHANNEL_ID, name, NotificationManagerCompat.IMPORTANCE_HIGH).apply {
                 enableLights(true)
                 enableVibration(true)
+                setSound(getNotificationSoundUri(), audioAttr)
             }
         NotificationManagerCompat.from(context).createNotificationChannel(channel)
     }
@@ -159,7 +163,7 @@ private fun updateNotification(
     NotificationManagerCompat.from(context).notify(NOTIFICATION_ID, notification)
 }
 
-private fun getNotificationSoundUri(context: Context): Uri {
+private fun getNotificationSoundUri(): Uri {
     // Note: Provide default notification sound until we found a good sound
     // return Uri.parse("${ContentResolver.SCHEME_ANDROID_RESOURCE}://${context.packageName}/${R.raw.zulip}")
     return Settings.System.DEFAULT_NOTIFICATION_URI
@@ -230,7 +234,7 @@ private fun getNotificationBuilder(
 
     builder.addAction(createDismissAction(context))
 
-    val soundUri = getNotificationSoundUri(context)
+    val soundUri = getNotificationSoundUri()
     builder.setSound(soundUri)
     return builder
 }

--- a/android/app/src/main/java/com/zulipmobile/notifications/FCMPushNotifications.kt
+++ b/android/app/src/main/java/com/zulipmobile/notifications/FCMPushNotifications.kt
@@ -9,7 +9,6 @@ import android.app.NotificationManager
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
-import android.graphics.Color
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
@@ -158,8 +157,7 @@ private fun getNotificationBuilder(
         builder.setSmallIcon(R.drawable.zulip_notification)
     }
 
-    // This should agree with `BRAND_COLOR` in the JS code.
-    builder.setColor(Color.rgb(100, 146, 254))
+    builder.color = context.getColor(R.color.brandColor)
 
     val nameList = extractNames(conversations)
 

--- a/android/app/src/main/java/com/zulipmobile/notifications/FCMPushNotifications.kt
+++ b/android/app/src/main/java/com/zulipmobile/notifications/FCMPushNotifications.kt
@@ -80,11 +80,22 @@ internal fun onReceived(context: Context, conversations: ConversationMap, mapDat
     }
 }
 
-fun createViewPendingIntent(fcmMessage: MessageFcmMessage, context: Context): PendingIntent {
+private fun createViewPendingIntent(fcmMessage: MessageFcmMessage, context: Context): PendingIntent {
     val uri = Uri.fromParts("zulip", "msgid:${fcmMessage.zulipMessageId}", "")
     val viewIntent = Intent(Intent.ACTION_VIEW, uri, context, NotificationIntentService::class.java)
     viewIntent.putExtra(EXTRA_NOTIFICATION_DATA, fcmMessage.dataForOpen())
     return PendingIntent.getService(context, 0, viewIntent, 0)
+}
+
+private fun createDismissAction(context: Context): NotificationCompat.Action {
+    val dismissIntent = Intent(context, NotificationIntentService::class.java)
+    dismissIntent.action = ACTION_CLEAR
+    val piDismiss = PendingIntent.getService(context, 0, dismissIntent, 0)
+    return NotificationCompat.Action(
+        android.R.drawable.ic_menu_close_clear_cancel,
+        "Clear",
+        piDismiss
+    )
 }
 
 private fun updateNotification(
@@ -167,11 +178,7 @@ private fun getNotificationBuilder(
 
     builder.setDefaults(NotificationCompat.DEFAULT_VIBRATE or NotificationCompat.DEFAULT_LIGHTS)
 
-    val dismissIntent = Intent(context, NotificationIntentService::class.java)
-    dismissIntent.action = ACTION_CLEAR
-    val piDismiss = PendingIntent.getService(context, 0, dismissIntent, 0)
-    val action = NotificationCompat.Action(android.R.drawable.ic_menu_close_clear_cancel, "Clear", piDismiss)
-    builder.addAction(action)
+    builder.addAction(createDismissAction(context))
 
     val soundUri = getNotificationSoundUri(context)
     builder.setSound(soundUri)

--- a/android/app/src/main/java/com/zulipmobile/notifications/FCMPushNotifications.kt
+++ b/android/app/src/main/java/com/zulipmobile/notifications/FCMPushNotifications.kt
@@ -313,7 +313,6 @@ private fun getNotificationBuilder(
 internal fun onOpened(application: ReactApplication, conversations: ConversationMap, data: Bundle) {
     logNotificationData("notif opened", data)
     notifyReact(application, data)
-    NotificationManagerCompat.from(application as Context).cancelAll()
     clearConversations(conversations)
     try {
         ShortcutBadger.removeCount(application as Context)
@@ -325,5 +324,4 @@ internal fun onOpened(application: ReactApplication, conversations: Conversation
 
 internal fun onClear(context: Context, conversations: ConversationMap) {
     clearConversations(conversations)
-    NotificationManagerCompat.from(context).cancelAll()
 }

--- a/android/app/src/main/java/com/zulipmobile/notifications/FCMPushNotifications.kt
+++ b/android/app/src/main/java/com/zulipmobile/notifications/FCMPushNotifications.kt
@@ -3,7 +3,9 @@
 package com.zulipmobile.notifications
 
 import android.annotation.SuppressLint
+import android.app.Notification
 import android.app.NotificationChannel
+import android.app.NotificationManager
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
@@ -96,6 +98,32 @@ private fun createDismissAction(context: Context): NotificationCompat.Action {
         "Clear",
         piDismiss
     )
+}
+
+/**
+ * @param context
+ * @param conversationKey Unique Key identifying a conversation, the current
+ * implementation assumes that each notification corresponds to 1 and only 1
+ * conversation.
+ *
+ * A conversation can be any of: Topic in Stream, GroupPM or PM for a
+ * specific user in a specific realm.
+ */
+private fun getActiveNotification(context: Context, conversationKey: String): Notification? {
+    // activeNotifications are not available in NotificationCompatManager
+    // Hence we have to use instance of NotificationManager.
+    val notificationManager =
+        context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager?
+
+    val activeStatusBarNotifications = notificationManager?.activeNotifications
+    if (activeStatusBarNotifications != null) {
+        for (statusBarNotification in activeStatusBarNotifications) {
+            if (statusBarNotification.tag == conversationKey) {
+                return statusBarNotification.notification
+            }
+        }
+    }
+    return null
 }
 
 private fun updateNotification(

--- a/android/app/src/main/java/com/zulipmobile/notifications/FcmListenerService.java
+++ b/android/app/src/main/java/com/zulipmobile/notifications/FcmListenerService.java
@@ -15,9 +15,7 @@ public class FcmListenerService extends FirebaseMessagingService {
         if (!(applicationContext instanceof MainApplication)) {
             return;
         }
-        final ConversationMap conversations =
-                ((MainApplication) applicationContext).getConversations();
-        FCMPushNotifications.onReceived(this, conversations, message.getData());
+        FCMPushNotifications.onReceived(this, message.getData());
     }
 
     @Override

--- a/android/app/src/main/java/com/zulipmobile/notifications/NotificationHelper.kt
+++ b/android/app/src/main/java/com/zulipmobile/notifications/NotificationHelper.kt
@@ -2,33 +2,15 @@
 
 package com.zulipmobile.notifications
 
-import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
-import android.text.Spannable
-import android.text.SpannableStringBuilder
-import android.text.TextUtils
-import android.text.style.StyleSpan
-import android.util.TypedValue
-import androidx.core.app.NotificationCompat
-import com.zulipmobile.ZLog
 import java.io.IOException
 import java.io.InputStream
 import java.net.URL
-import java.util.*
+import com.zulipmobile.ZLog
 
 @JvmField
 val TAG = "ZulipNotif"
-
-/**
- * All Zulip messages we're showing in notifications.
- *
- * Each key identifies a conversation; see [buildKeyString].
- *
- * Each value is the messages in the conversation, in the order we
- * received them.
- */
-class ConversationMap : LinkedHashMap<String, MutableList<MessageFcmMessage>>()
 
 fun fetchBitmap(url: URL): Bitmap? {
     return try {
@@ -40,102 +22,4 @@ fun fetchBitmap(url: URL): Bitmap? {
         ZLog.e(TAG, e)
         null
     }
-}
-
-fun sizedURL(context: Context, url: URL, dpSize: Float): URL {
-    // From http://stackoverflow.com/questions/4605527/
-    val r = context.resources
-    val px = TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP,
-        dpSize, r.displayMetrics)
-    val query = if (url.query != null) "${url.query}&s=$px" else "s=$px"
-    return URL(url, "?$query")
-}
-
-fun buildNotificationContent(conversations: ConversationMap, inboxStyle: NotificationCompat.InboxStyle) {
-    for (conversation in conversations.values) {
-        // TODO ensure latest sender is shown last?  E.g. Gmail-style A, B, ..., A.
-        val seenSenders = HashSet<String>()
-        val names = ArrayList<String>()
-        for (message in conversation) {
-            if (seenSenders.contains(message.sender.email))
-                continue;
-            seenSenders.add(message.sender.email)
-            names.add(message.sender.fullName)
-        }
-
-        val builder = SpannableStringBuilder()
-        builder.append(TextUtils.join(", ", names))
-        builder.setSpan(StyleSpan(android.graphics.Typeface.BOLD),
-            0, builder.length, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
-        builder.append(": ")
-        builder.append(conversation.last().content)
-        inboxStyle.addLine(builder)
-    }
-}
-
-fun extractTotalMessagesCount(conversations: ConversationMap): Int {
-    var totalNumber = 0
-    for ((_, value) in conversations) {
-        totalNumber += value.size
-    }
-    return totalNumber
-}
-
-/**
- * Formats -
- * stream message - fullName:streamName:'stream'
- * group message - fullName:Recipients:'group'
- * private message - fullName:Email:'private'
- */
-private fun buildKeyString(fcmMessage: MessageFcmMessage): String {
-    val recipient = fcmMessage.recipient
-    return when (recipient) {
-        is Recipient.Stream -> String.format("%s:stream", recipient.stream)
-        is Recipient.GroupPm -> String.format("%s:group", recipient.getPmUsersString())
-        is Recipient.Pm -> String.format("%s:private", fcmMessage.sender.email)
-    }
-}
-
-fun extractNames(conversations: ConversationMap): ArrayList<String> {
-    val namesSet = LinkedHashSet<String>()
-    for (fcmMessages in conversations.values) {
-        for (fcmMessage in fcmMessages) {
-            namesSet.add(fcmMessage.sender.fullName)
-        }
-    }
-    return ArrayList(namesSet)
-}
-
-fun addConversationToMap(fcmMessage: MessageFcmMessage, conversations: ConversationMap) {
-    val key = buildKeyString(fcmMessage)
-    var messages: MutableList<MessageFcmMessage>? = conversations[key]
-    if (messages == null) {
-        messages = ArrayList()
-    }
-    messages.add(fcmMessage)
-    conversations[key] = messages
-}
-
-fun removeMessagesFromMap(conversations: ConversationMap, removeFcmMessage: RemoveFcmMessage) {
-    // We don't have the information to compute what key we ought to find each message under,
-    // so just walk the whole thing.  If the user has >100 notifications, this linear scan
-    // won't be their worst problem anyway...
-    //
-    // TODO redesign this whole data structure, for many reasons.
-    val it = conversations.values.iterator()
-    while (it.hasNext()) {
-        val messages: MutableList<MessageFcmMessage> = it.next()
-        for (i in messages.indices.reversed()) {
-            if (removeFcmMessage.messageIds.contains(messages[i].zulipMessageId)) {
-                messages.removeAt(i)
-            }
-        }
-        if (messages.isEmpty()) {
-            it.remove()
-        }
-    }
-}
-
-fun clearConversations(conversations: ConversationMap) {
-    conversations.clear()
 }

--- a/android/app/src/main/java/com/zulipmobile/notifications/NotificationIntentService.java
+++ b/android/app/src/main/java/com/zulipmobile/notifications/NotificationIntentService.java
@@ -13,7 +13,9 @@ import static com.zulipmobile.notifications.FCMPushNotifications.ACTION_CLEAR;
 import static com.zulipmobile.notifications.FCMPushNotifications.EXTRA_NOTIFICATION_DATA;
 
 public class NotificationIntentService extends IntentService {
-    public NotificationIntentService() { super("NotificationIntentService"); }
+    public NotificationIntentService() {
+        super("NotificationIntentService");
+    }
 
     @Override
     protected void onHandleIntent(Intent intent) {
@@ -21,13 +23,9 @@ public class NotificationIntentService extends IntentService {
         if (!(applicationContext instanceof MainApplication)) {
             return;
         }
-        final ConversationMap conversations =
-                ((MainApplication) applicationContext).getConversations();
         if (ACTION_VIEW.equals(intent.getAction())) {
             final Bundle data = intent.getBundleExtra(EXTRA_NOTIFICATION_DATA);
-            FCMPushNotifications.onOpened((ReactApplication) getApplication(), conversations, data);
-        } else if (ACTION_CLEAR.equals(intent.getAction())) {
-            FCMPushNotifications.onClear(this, conversations);
+            FCMPushNotifications.onOpened((ReactApplication) getApplication(), data);
         }
     }
 }

--- a/android/app/src/main/res/values/color.xml
+++ b/android/app/src/main/res/values/color.xml
@@ -2,4 +2,6 @@
 <resources>
     <color name="primaryColor">#ffffff</color>
     <color name="primaryColorDark">#d7ccc8</color>
+    <!--  This should agree with `BRAND_COLOR` in the JS code.  -->
+    <color name="brandColor">#6492fe</color>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -7,4 +7,9 @@
         <item quantity="other">%d conversations</item>
     </plurals>
     <string name="send_to">Share To</string>
+    <plurals name="group_pm">
+        <item quantity="one">Group PM from %1$s with %2$s other.</item>
+        <item quantity="other">Group PM from %1$s with %2$s others.</item>
+    </plurals>
+    <string name="selfUser">You</string>
 </resources>


### PR DESCRIPTION
The first 3 commits are updating some related code.

The next 4 commits are adding/removing some data structures to facilitate building up of this UI.

The last 2 commits are involved in changing the notification structure
- first one makes it so that the app shows 1 notifications per conversation.
- second one groups the notification.

Summary notification is not yet implemented correctly in this PR, and will show incorrect information (gives summary for all notifications on a summary notification for 1 realm) when API < 24 and user is logged in with multiple realms.

Some methods may no longer be needed, yet are not removed because they may prove useful in implementing other features.

This skips #4633 and fixes part of #2691, part of because summary notification is not yet implemented properly.

some screenshots of the same:
## Summary notification:
![WhatsApp Image 2021-07-01 at 7 55 32 PM (4)](https://user-images.githubusercontent.com/40268170/124141037-aa35a200-daa6-11eb-8447-c520a27a8e0b.jpeg)

## Summary expanded
![WhatsApp Image 2021-07-01 at 7 55 32 PM (3)](https://user-images.githubusercontent.com/40268170/124141028-a86bde80-daa6-11eb-9f65-4ddc57dfbd0b.jpeg)

## Individually Expanded
![WhatsApp Image 2021-07-01 at 7 55 32 PM (2)](https://user-images.githubusercontent.com/40268170/124141021-a6a21b00-daa6-11eb-90b0-9009857c8613.jpeg)

## Message from Another realm
![WhatsApp Image 2021-07-01 at 7 55 32 PM](https://user-images.githubusercontent.com/40268170/124141015-a4d85780-daa6-11eb-980c-cb37b94f3c29.jpeg)

## Future Work
- Provide a proper summary notification.
- Add action buttons to mark as read, mute topic and reply from notification.
- Add custom sound.
- Remove redundant code.