### PR TITLE
logging: Use Sentry's captureMessage and captureException in logToSentry.

### DIFF
--- a/flow-typed/@sentry/react-native_v2.x.x.js
+++ b/flow-typed/@sentry/react-native_v2.x.x.js
@@ -117,6 +117,11 @@ declare module '@sentry/react-native' {
   // More methods are available.
   declare export class Scope {
     /**
+     * Sets the level on the scope for future events.
+     * @param level string {@link Severity}
+     */
+    setLevel(level: SeverityType): this;
+    /**
      * Set an object that will be merged sent as tags data with the event.
      * @param tags Tags context object to merge into current context.
      */

--- a/src/utils/logging.js
+++ b/src/utils/logging.js
@@ -100,27 +100,27 @@ export function setTagsFromServerVersion(zulipVersion: ?ZulipVersion) {
  *
  * Returns a Sentry event_id, although this is not expected to be useful.
  */
-const logToSentry = (event: string | Error, level: SeverityType, extras: Extras): string => {
-  let message: string;
-  let hint: EventHint;
-
-  if (event instanceof Error) {
-    // eslint-disable-next-line prefer-destructuring
-    message = event.message;
-    hint = { originalException: event };
-  } else {
-    // Synthesize the event's stack trace. (The static API does this for us, at
-    // least sometimes; but we're calling in at one level lower.)
-    message = event;
-    try {
-      throw new Error(event);
-    } catch (err) {
-      hint = { syntheticException: err };
-    }
-  }
-
-  return withScope(scope => {
+const logToSentry = (event: string | Error, level: SeverityType, extras: Extras): string =>
+  withScope(scope => {
     scope.setExtras(extras);
+
+    let message: string;
+    let hint: EventHint;
+
+    if (event instanceof Error) {
+      // eslint-disable-next-line prefer-destructuring
+      message = event.message;
+      hint = { originalException: event };
+    } else {
+      // Synthesize the event's stack trace. (The static API does this for us, at
+      // least sometimes; but we're calling in at one level lower.)
+      message = event;
+      try {
+        throw new Error(event);
+      } catch (err) {
+        hint = { syntheticException: err };
+      }
+    }
 
     // The static API's `captureException` doesn't allow passing strings, and its
     // counterpart `captureMessage` doesn't allow passing stacktraces.
@@ -134,7 +134,6 @@ const logToSentry = (event: string | Error, level: SeverityType, extras: Extras)
     // synthesize, and which has no user-facing documentation.)
     return getCurrentHub().captureMessage(message, level, hint);
   });
-};
 
 type LogParams = {|
   consoleMethod: mixed => void,


### PR DESCRIPTION
captureException takes an Error object, and captureMessage takes a
string. It makes sense to use captureException when we have an
Error, then, and captureMessage when we have a string -- instead of
coercing both into a string and synthesizing a stack trace to
attach.

Greg said, about the comment "the static API's `captureException`
doesn't allow passing strings",

> [...] I think the idea of that comment is that we want to pass an
> `Error` when we have an `Error`, and just a string when we have
> just a string.
>
> And then implicitly it's looking for one method to use in both
> cases. Neither of those works, so they were both rejected.
>
> But the conditional seems like a fine solution to that problem.