### PR TITLE
android: styles.xml change for dark theme, on the path to RN v0.64 upgrade.

### DIFF
--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -1,7 +1,7 @@
 <resources>
 
     <!-- Base application theme. -->
-    <style name="AppTheme" parent="Theme.AppCompat.Light.NoActionBar">
+    <style name="AppTheme" parent="Theme.AppCompat.DayNight.NoActionBar">
         <!-- Customize your theme here. -->
         <item name="colorPrimary">@color/primaryColor</item>
         <item name="colorPrimaryDark">@color/primaryColorDark</item>


### PR DESCRIPTION
We need to test on Android 10 and record any changes; the linked doc says the dark theme is available in Android 10 (API level 29) and higher. I've tested on the office Android device, a Samsung Galaxy S9, but it's running Android 9 and I'm not sure it's time to upgrade it yet (I'm not sure if we can go back to Android 9 after doing so).

I found no visible changes in the app on Android 9 when switching the system-level dark theme setting on and off. I'm not sure how I was able to switch that setting on and off when the doc says that the Dark theme is available starting in Android 10. Anyway, best to test on Android 10.

@AkashDhiman, would you be interested in testing on a device running Android 10?

Related: #4426 
Related: #4009