### PR TITLE
lightbox [nfc]: Remove `fileCache` property from rnfb config.

### DIFF
--- a/src/lightbox/download.js
+++ b/src/lightbox/download.js
@@ -72,5 +72,4 @@ export const downloadImage = async (url: string, fileName: string, auth: Auth): 
 export const downloadFileToCache = async (tempUrl: string, fileName: string): Promise<mixed> =>
   RNFetchBlob.config({
     path: `${RNFetchBlob.fs.dirs.CacheDir}/${fileName}`,
-    fileCache: true,
   }).fetch('GET', tempUrl);


### PR DESCRIPTION
This is not required as 'path' with `CacheDir` fulfills the same
purpose as `fileCache`.

The difference is 'path' gives specific path to the file while
`fileCache` gives a randomly generated path (including the
filename and its extension). See [1].

We would want to preserve the filename and its extension while
sharing from lightbox and hence `path` is used instead of
`fileCache`.

Originally reported at [2] by Greg.

reference:
[1] https://github.com/joltup/rn-fetch-blob#download-to-storage-directly
[2] https://chat.zulip.org/#narrow/stream/48-mobile/topic/Sharing.20from.20lightbox.20broken.20on.20Android/near/1226489

**tested to verify that this is nfc.**