### PR TITLE
Flow-related work on the path to RN v0.64 upgrade, part 4.

### DIFF
--- a/flow-typed/react-intl_vx.x.x.js
+++ b/flow-typed/react-intl_vx.x.x.js
@@ -158,19 +158,19 @@ declare module 'react-intl' {
     +MISSING_INTL_API: 'MISSING_INTL_API', // "MISSING_INTL_API"
   |};
   declare interface FieldData {
-    // $FlowFixMe - illegal name (these fixmes added in TS to Flow translation)
+    // $FlowFixMe[unsupported-syntax] - illegal name (these fixmes added in TS to Flow translation)
     '0'?: string;
-    // $FlowFixMe - illegal name
+    // $FlowFixMe[unsupported-syntax] - illegal name
     '1'?: string;
-    // $FlowFixMe - illegal name
+    // $FlowFixMe[unsupported-syntax] - illegal name
     '-1'?: string;
-    // $FlowFixMe - illegal name
+    // $FlowFixMe[unsupported-syntax] - illegal name
     '2'?: string;
-    // $FlowFixMe - illegal name
+    // $FlowFixMe[unsupported-syntax] - illegal name
     '-2'?: string;
-    // $FlowFixMe - illegal name
+    // $FlowFixMe[unsupported-syntax] - illegal name
     '3'?: string;
-    // $FlowFixMe - illegal name
+    // $FlowFixMe[unsupported-syntax] - illegal name
     '-3'?: string;
     future: RelativeTimeData;
     past: RelativeTimeData;

--- a/flow-typed/react-native-safe-area-context_vx.x.x.js
+++ b/flow-typed/react-native-safe-area-context_vx.x.x.js
@@ -57,7 +57,7 @@ declare module 'react-native-safe-area-context/SafeAreaContext' {
   declare export function useSafeAreaInsets(): EdgeInsets;
   declare export function useSafeAreaFrame(): Rect;
   declare export function withSafeAreaInsets<T>(
-    WrappedComponent: React.ComponentType<T>,
+    WrappedComponent: React$ComponentType<T>,
   ): React.ForwardRefExoticComponent<React.PropsWithoutRef<T> & React.RefAttributes<T>>;
 
   /**

--- a/src/RootErrorBoundary.js
+++ b/src/RootErrorBoundary.js
@@ -68,8 +68,8 @@ export default class ErrorBoundary extends React.Component<Props, State> {
 
 Component Stack:
 ${
-  /* $FlowFixMe - I've seen this empirically in debug and release
-     builds on iOS and Android */
+  /* $FlowFixMe[prop-missing] - I've seen this empirically in debug and
+     release builds on iOS and Android */
   error.componentStack ?? '<none available>'
 }
 

--- a/src/__flow-tests__/nav-test.js
+++ b/src/__flow-tests__/nav-test.js
@@ -22,14 +22,14 @@ function testRouteParamTypes() {
     const { params } = props.route;
 
     (params.userId: string);
-    // $FlowExpectedError
+    // $FlowExpectedError[incompatible-cast]
     (params.userId: empty);
 
     (('a': string): typeof params.userId);
-    // $FlowExpectedError
+    // $FlowExpectedError[incompatible-cast]
     (('a': mixed): typeof params.userId);
 
-    // $FlowExpectedError
+    // $FlowExpectedError[prop-missing]
     params.nonsense;
   }
 }
@@ -66,7 +66,7 @@ function testNavigatorTypes() {
     <Stack.Navigator>
       {/* Happy case is happy */}
       <Stack.Screen name="Profile" component={Profile} />
-      {/* $FlowExpectedError - mismatch of name with route prop */}
+      {/* $FlowExpectedError[incompatible-type] - mismatch of name with route prop */}
       <Stack.Screen name="Profile1" component={Profile12} />
       {/* Should error but doesn't! on mismatch of name with navigation prop */}
       <Stack.Screen name="Profile2" component={Profile12} />

--- a/src/__flow-tests__/nav-test.js
+++ b/src/__flow-tests__/nav-test.js
@@ -5,10 +5,7 @@
  */
 
 import React, { type ComponentType } from 'react';
-import {
-  createStackNavigator,
-  type StackNavigationProp,
-} from '@react-navigation/stack';
+import { createStackNavigator, type StackNavigationProp } from '@react-navigation/stack';
 
 import { type RouteProp, type RouteParamsOf } from '../react-navigation';
 

--- a/src/boot/TranslationProvider.js
+++ b/src/boot/TranslationProvider.js
@@ -10,7 +10,7 @@ import { useSelector } from '../react-redux';
 import { getSettings } from '../selectors';
 import messages from '../i18n/messages';
 
-// $FlowFixMe could put a well-typed mock value here, to help write tests
+// $FlowFixMe[incompatible-type] could put a well-typed mock value here, to help write tests
 export const TranslationContext: Context<GetText> = React.createContext(undefined);
 
 /**

--- a/src/boot/__tests__/ZulipAsyncStorage-test.js
+++ b/src/boot/__tests__/ZulipAsyncStorage-test.js
@@ -74,7 +74,7 @@ describe('getItem', () => {
     );
 
     // suppress `logging.error` output
-    // $FlowFixMe - teach Flow about mocks
+    // $FlowFixMe[prop-missing] - teach Flow about mocks
     logging.error.mockReturnValue();
   });
 

--- a/src/boot/reducers.js
+++ b/src/boot/reducers.js
@@ -51,8 +51,8 @@ function applyReducer<Key: $Keys<GlobalState>, State>(
     startMs = Date.now();
   }
 
-  /* $FlowFixMe - We make a small lie about the type, pretending that
-     globalState is not void.
+  /* $FlowFixMe[incompatible-type] - We make a small lie about the type,
+     pretending that globalState is not void.
 
      This is OK because it's only ever void at the initialization action,
      and no reducer should do anything there other than return its initial

--- a/src/boot/reducers.js
+++ b/src/boot/reducers.js
@@ -33,7 +33,7 @@ const migrations = (state: MigrationsState = NULL_OBJECT): MigrationsState => st
 
 const { enableReduxSlowReducerWarnings, slowReducersThreshold } = config;
 
-function maybeLogSlowReducer(action, key, startMs, endMs) {
+function maybeLogSlowReducer(action, key: $Keys<GlobalState>, startMs, endMs) {
   if (endMs - startMs >= slowReducersThreshold) {
     timing.add({ text: `${action.type} @ ${key}`, startMs, endMs });
   }

--- a/src/events/__tests__/eventToAction-test.js
+++ b/src/events/__tests__/eventToAction-test.js
@@ -7,14 +7,14 @@ describe('eventToAction', () => {
   const state = eg.plusReduxState;
 
   test('filter out unknown event type', () => {
-    // $FlowFixMe: teach Flow about Jest mocks
+    // $FlowFixMe[prop-missing]: teach Flow about Jest mocks
     logging.error.mockReturnValue();
 
     expect(eventToAction(state, { type: 'some unknown type' })).toBe(null);
 
-    // $FlowFixMe: teach Flow about Jest mocks
+    // $FlowFixMe[prop-missing]: teach Flow about Jest mocks
     expect(logging.error.mock.calls).toHaveLength(1);
-    // $FlowFixMe: teach Flow about Jest mocks
+    // $FlowFixMe[prop-missing]: teach Flow about Jest mocks
     logging.error.mockReset();
   });
 

--- a/src/presence/presenceReducer.js
+++ b/src/presence/presenceReducer.js
@@ -43,13 +43,13 @@ export default (state: PresenceState = initialState, action: Action): PresenceSt
         ...state,
         // Flow bug (unresolved):
         // https://github.com/facebook/flow/issues/8276
-        // $FlowIssue #8276
+        // $FlowIssue[cannot-spread-indexer] #8276
         [action.email]: {
           ...state[action.email],
           ...action.presence,
           // Flow bug (unresolved):
           // https://github.com/facebook/flow/issues/8276
-          // $FlowIssue #8276
+          // $FlowIssue[cannot-spread-indexer] #8276
           aggregated: getAggregatedPresence({
             ...state[action.email],
             ...action.presence,

--- a/src/session/sessionReducer.js
+++ b/src/session/sessionReducer.js
@@ -92,11 +92,12 @@ const initialState: SessionState = {
 const rehydrate = (state, action) => {
   const { payload } = action;
 
-  /* $FlowIgnore: The actual type allows any property to be null; narrow
-       that to just the one that `getHasAuth` will care about.  (What we
-       really want here is what the value of `getHasAuth` will be after the
-       rehydrate is complete.  So even if some other property is null in the
-       payload, we still do want to ask `getHasAuth` what it thinks.) */
+  /* $FlowIgnore[incompatible-cast]: The actual type allows any property to
+       be null; narrow that to just the one that `getHasAuth` will care
+       about.  (What we really want here is what the value of `getHasAuth`
+       will be after the rehydrate is complete.  So even if some other
+       property is null in the payload, we still do want to ask `getHasAuth`
+       what it thinks.) */
   const payloadForGetHasAuth = (payload: GlobalState | { accounts: null, ... } | void);
   const haveApiKey = !!(
     payloadForGetHasAuth

--- a/src/utils/objectEntries.js
+++ b/src/utils/objectEntries.js
@@ -6,8 +6,7 @@
 //    static entries(object: mixed): Array<[string, mixed]>;
 // .... which is almost useless.
 
-type EntriesType = <K: string, V>({| +[K]: V |}) => $ReadOnlyArray<[K, V]>;
-
-const objectEntries: EntriesType = obj => (Object.entries(obj): $FlowFixMe);
+const objectEntries = <K: string, V>(obj: {| +[K]: V |}): $ReadOnlyArray<[K, V]> =>
+  (Object.entries(obj): $FlowFixMe);
 
 export default objectEntries;

--- a/src/webview/html/template.js
+++ b/src/webview/html/template.js
@@ -15,7 +15,7 @@ import escape from 'lodash.escape';
  *   template`Hello $\!${&<world}` -> 'Hello $!&amp;&lt;world'
  */
 export default (strings: string[], ...values: Array<string | number>) => {
-  // $FlowIssue #2616 github.com/facebook/flow/issues/2616
+  // $FlowIssue[prop-missing] #2616 github.com/facebook/flow/issues/2616
   const raw: string[] = strings.raw; // eslint-disable-line prefer-destructuring
   const result = [];
   values.forEach((value, i) => {


### PR DESCRIPTION
Parts 1, 2, and 3 were #4518, #4520, and #4836.

This doesn't upgrade Flow at all or add any new config; it's just cleaning up some stuff that I noticed (one commit is another round like #4433, for example). These kinds of small messes could easily creep back in before we add config to prevent them for good, but might as well sweep things up as we see them.

After this, the work I see before the RN v0.64 upgrade (#4426) is:

- Types-first (as noted in the issue, we can probably do some selective suppressions there for now, but I'm not sure that'll hold in future Flow versions)
- Turning on `exact_by_default`
- (Maybe an issue with react-intl's libdef; see [discussion](https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/react-intl.20libdef/near/1228275))

For `exact_by_default`, I think I have a handle on all the little issues in our libraries' built-in Flow definitions, so that won't be hard unless new problems come up (e.g., with libraries or library versions we aren't using right now). One of those issues might best be solved with a small one-line PR to @react-native-community/cameraroll; hopefully they'd take it.
