### PR TITLE
Do not mark as read for Search and Special Narrows.

### DIFF
--- a/src/search/SearchMessagesCard.js
+++ b/src/search/SearchMessagesCard.js
@@ -3,10 +3,9 @@
 import React, { PureComponent } from 'react';
 import { View } from 'react-native';
 
-import type { Message } from '../types';
+import type { Message, Narrow } from '../types';
 import { createStyleSheet } from '../styles';
 import { LoadingIndicator, SearchEmptyState } from '../common';
-import { HOME_NARROW } from '../utils/narrow';
 import MessageList from '../webview/MessageList';
 
 const styles = createStyleSheet({
@@ -17,6 +16,7 @@ const styles = createStyleSheet({
 
 type Props = $ReadOnly<{|
   messages: Message[] | null,
+  narrow: Narrow,
   isFetching: boolean,
 |}>;
 
@@ -40,9 +40,6 @@ export default class SearchMessagesCard extends PureComponent<Props> {
       return <SearchEmptyState text="No results" />;
     }
 
-    // TODO: This is kind of a hack.
-    const narrow = HOME_NARROW;
-
     return (
       <View style={styles.results}>
         <MessageList
@@ -52,7 +49,7 @@ export default class SearchMessagesCard extends PureComponent<Props> {
             messages[messages.length - 1].id
           }
           messages={messages}
-          narrow={narrow}
+          narrow={this.props.narrow}
           showMessagePlaceholders={false}
           // TODO: handle editing a message from the search results,
           // or make this prop optional

--- a/src/search/SearchMessagesScreen.js
+++ b/src/search/SearchMessagesScreen.js
@@ -41,10 +41,6 @@ type State = {|
 
 class SearchMessagesScreen extends PureComponent<Props, State> {
   state = {
-    // TODO remove disable-next-line once we start using
-    // `this.state.query` to provide `SEARCH_NARROW` in
-    // `SearchMessagesCard`.
-    // eslint-disable-next-line react/no-unused-state
     query: '',
     messages: null,
     isFetching: false,
@@ -89,10 +85,6 @@ class SearchMessagesScreen extends PureComponent<Props, State> {
       // The empty query can be resolved without a network call.
       this.lastIdReceived = id;
       this.lastIdSuccess = id;
-      // TODO remove disable-next-line once we start using
-      // `this.state.query` to provide `SEARCH_NARROW` in
-      // `SearchMessagesCard`.
-      // eslint-disable-next-line react/no-unused-state
       this.setState({ query, messages: null, isFetching: false });
       return;
     }
@@ -104,10 +96,6 @@ class SearchMessagesScreen extends PureComponent<Props, State> {
       // Update `state.messages` if this is our new latest result.
       if (id > this.lastIdSuccess) {
         this.lastIdSuccess = id;
-        // TODO remove disable-next-line once we start using
-        // `this.state.query` to provide `SEARCH_NARROW` in
-        // `SearchMessagesCard`.
-        // eslint-disable-next-line react/no-unused-state
         this.setState({ query, messages });
       }
     } finally {
@@ -141,7 +129,11 @@ class SearchMessagesScreen extends PureComponent<Props, State> {
         searchBarOnChange={this.handleQueryChangeWrapper}
         style={styles.flexed}
       >
-        <SearchMessagesCard messages={messages} isFetching={isFetching} />
+        <SearchMessagesCard
+          messages={messages}
+          isFetching={isFetching}
+          narrow={SEARCH_NARROW(this.state.query)}
+        />
       </Screen>
     );
   }

--- a/src/search/SearchMessagesScreen.js
+++ b/src/search/SearchMessagesScreen.js
@@ -24,11 +24,17 @@ type Props = $ReadOnly<{|
 |}>;
 
 type State = {|
+  /** The latest search query we have results for. */
   query: string,
-  /** The list of messages returned for the latest query, or `null` if there is
-   *  effectively no "latest query" to have results from.
+
+  /**
+   * The list of messages found as results for `query`.
+   *
+   * This is `null` if `query` is empty, representing an empty search box
+   * and so effectively not a query to have results from at all.
    */
   messages: Message[] | null,
+
   /** Whether there is currently an active valid network request. */
   isFetching: boolean,
 |};

--- a/src/search/SearchMessagesScreen.js
+++ b/src/search/SearchMessagesScreen.js
@@ -24,6 +24,7 @@ type Props = $ReadOnly<{|
 |}>;
 
 type State = {|
+  query: string,
   /** The list of messages returned for the latest query, or `null` if there is
    *  effectively no "latest query" to have results from.
    */
@@ -34,6 +35,11 @@ type State = {|
 
 class SearchMessagesScreen extends PureComponent<Props, State> {
   state = {
+    // TODO remove disable-next-line once we start using
+    // `this.state.query` to provide `SEARCH_NARROW` in
+    // `SearchMessagesCard`.
+    // eslint-disable-next-line react/no-unused-state
+    query: '',
     messages: null,
     isFetching: false,
   };
@@ -77,7 +83,11 @@ class SearchMessagesScreen extends PureComponent<Props, State> {
       // The empty query can be resolved without a network call.
       this.lastIdReceived = id;
       this.lastIdSuccess = id;
-      this.setState({ messages: null, isFetching: false });
+      // TODO remove disable-next-line once we start using
+      // `this.state.query` to provide `SEARCH_NARROW` in
+      // `SearchMessagesCard`.
+      // eslint-disable-next-line react/no-unused-state
+      this.setState({ query, messages: null, isFetching: false });
       return;
     }
 
@@ -88,7 +98,11 @@ class SearchMessagesScreen extends PureComponent<Props, State> {
       // Update `state.messages` if this is our new latest result.
       if (id > this.lastIdSuccess) {
         this.lastIdSuccess = id;
-        this.setState({ messages });
+        // TODO remove disable-next-line once we start using
+        // `this.state.query` to provide `SEARCH_NARROW` in
+        // `SearchMessagesCard`.
+        // eslint-disable-next-line react/no-unused-state
+        this.setState({ query, messages });
       }
     } finally {
       // Updating `isFetching` is the same for success or failure.

--- a/src/webview/MessageList.js
+++ b/src/webview/MessageList.js
@@ -60,6 +60,7 @@ import * as logging from '../utils/logging';
 import { tryParseUrl } from '../utils/url';
 import type { UnreadState } from '../unread/unreadModelTypes';
 import { getUnread } from '../unread/unreadModel';
+import { caseNarrow } from '../utils/narrow';
 
 // ESLint doesn't notice how `this.props` escapes, and complains about some
 // props not being used here.
@@ -300,6 +301,18 @@ class MessageListInner extends Component<Props> {
   }
 }
 
+const marksMessagesAsRead = (narrow: Narrow): boolean =>
+  caseNarrow(narrow, {
+    stream: () => true,
+    topic: () => true,
+    pm: () => true,
+    search: () => false,
+    home: () => true,
+    starred: () => false,
+    mentioned: () => false,
+    allPrivate: () => true,
+  });
+
 const MessageList: ComponentType<OuterProps> = connect<SelectorProps, _, _>(
   (state, props: OuterProps) => {
     // TODO Ideally this ought to be a caching selector that doesn't change
@@ -311,7 +324,8 @@ const MessageList: ComponentType<OuterProps> = connect<SelectorProps, _, _>(
       allImageEmojiById: getAllImageEmojiById(state),
       auth: getAuth(state),
       debug: getDebug(state),
-      doNotMarkMessagesAsRead: getSettings(state).doNotMarkMessagesAsRead,
+      doNotMarkMessagesAsRead:
+        !marksMessagesAsRead(props.narrow) || getSettings(state).doNotMarkMessagesAsRead,
       flags: getFlags(state),
       mute: getMute(state),
       mutedUsers: getMutedUsers(state),

--- a/src/webview/MessageList.js
+++ b/src/webview/MessageList.js
@@ -301,16 +301,35 @@ class MessageListInner extends Component<Props> {
   }
 }
 
+/**
+ * Whether reading messages in this narrow can mark them as read.
+ *
+ * "Can", not "will": other conditions can mean we don't want to mark
+ * messages as read even when in a narrow where this is true.
+ */
 const marksMessagesAsRead = (narrow: Narrow): boolean =>
+  // Generally we want these to agree with the web/desktop app, so that user
+  // expectations transfer between the different apps.
   caseNarrow(narrow, {
-    stream: () => true,
+    // These narrows show one conversation in full.  Each message appears
+    // in its full context, so it makes sense to say the user's read it
+    // and doesn't need to be shown it as unread again.
     topic: () => true,
     pm: () => true,
-    search: () => false,
+
+    // These narrows show several conversations interleaved.  They always
+    // show entire conversations, so each message still appears in its
+    // full context and it still makes sense to mark it as read.
+    stream: () => true,
     home: () => true,
+    allPrivate: () => true,
+
+    // These narrows show selected messages out of context.  The user will
+    // typically still want to see them another way, in context, before
+    // letting them disappear from their list of unread messages.
+    search: () => false,
     starred: () => false,
     mentioned: () => false,
-    allPrivate: () => true,
   });
 
 const MessageList: ComponentType<OuterProps> = connect<SelectorProps, _, _>(


### PR DESCRIPTION
I am concerned about the changes I made in the very first commit of this PR, search screen `MessageList` was being provided `HOME_NARROW` which was creating problems with my second commit. Is there a particular reason for why it was that way?

Fixes: #4852