### PR TITLE
i18n: Remove a duplicate message key.

### DIFF
--- a/static/translations/messages_en.json
+++ b/static/translations/messages_en.json
@@ -38,7 +38,6 @@
   "Why not start the conversation?": "Why not start the conversation?",
   "That conversation doesn't seem to exist.": "That conversation doesn't seem to exist.",
   "Request timed out.": "Request timed out.",
-  "Oops! Something went wrong.": "Oops! Something went wrong.",
   "Chat": "Chat",
   "Sign in with {method}": "Sign in with {method}",
   "Cannot connect to server": "Cannot connect to server",


### PR DESCRIPTION
I got the following error when I ran `tools/tx-sync`:

```
Step 3: Upload strings to translate...
+ tx --quiet push -s
tx ERROR: Error received from server: Duplicate string key ('Oops! Something went wrong\.') in line 247
tx ERROR: Could not upload source file. You can use --skip to ignore this error and continue the execution.
tx ERROR: Error received from server: Duplicate string key ('Oops! Something went wrong\.') in line 247
```

Looks like maybe a rebase error when I was working on #4754. The
string was already added, in #4829.