### PR TITLE
flow: Annotate some more exported React components.

### DIFF
--- a/src/RootErrorBoundary.js
+++ b/src/RootErrorBoundary.js
@@ -1,12 +1,13 @@
 /* @flow strict-local */
 import React from 'react';
+import type { Node } from 'react';
 import { View, Text, Clipboard, TextInput, ScrollView, Button, Platform } from 'react-native';
 import Toast from 'react-native-simple-toast';
 
 import * as logging from './utils/logging';
 
 type Props = $ReadOnly<{|
-  children: React$Node,
+  children: Node,
 |}>;
 
 type State = $ReadOnly<{|
@@ -61,7 +62,7 @@ export default class ErrorBoundary extends React.Component<Props, State> {
     error: null,
   };
 
-  render(): React$Node {
+  render(): Node {
     const { error } = this.state;
     if (error) {
       const details = `${error.toString()}

--- a/src/ZulipMobile.js
+++ b/src/ZulipMobile.js
@@ -1,5 +1,6 @@
 /* @flow strict-local */
 import React from 'react';
+import type { Node } from 'react';
 import { Platform, UIManager } from 'react-native';
 import 'react-native-url-polyfill/auto';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
@@ -37,7 +38,7 @@ if (Platform.OS === 'android') {
   UIManager.setLayoutAnimationEnabledExperimental(true);
 }
 
-export default (): React$Node => (
+export default (): Node => (
   <RootErrorBoundary>
     <CompatibilityChecker>
       <StoreProvider>

--- a/src/account-info/AwayStatusSwitch.js
+++ b/src/account-info/AwayStatusSwitch.js
@@ -1,5 +1,6 @@
 /* @flow strict-local */
 import React from 'react';
+import type { Node } from 'react';
 
 import { useSelector, useDispatch } from '../react-redux';
 import { SwitchRow } from '../common';
@@ -13,7 +14,7 @@ type Props = $ReadOnly<{||}>;
  *  * retrieves the current user's `user status` data and presents it
  *  * allows by switching it to control the `away` status
  */
-export default function AwayStatusSwitch(props: Props): React$Node {
+export default function AwayStatusSwitch(props: Props): Node {
   const awayStatus = useSelector(getSelfUserAwayStatus);
   const dispatch = useDispatch();
 

--- a/src/account-info/ProfileScreen.js
+++ b/src/account-info/ProfileScreen.js
@@ -1,5 +1,6 @@
 /* @flow strict-local */
 import React, { useContext } from 'react';
+import type { Node } from 'react';
 import { ScrollView, View, Alert } from 'react-native';
 
 import { TranslationContext } from '../boot/TranslationProvider';
@@ -102,7 +103,7 @@ type Props = $ReadOnly<{|
  *
  * The user can still open `AccountDetails` on themselves via the (i) icon in a chat screen.
  */
-export default function ProfileScreen(props: Props): React$Node {
+export default function ProfileScreen(props: Props): Node {
   const ownUser = useSelector(getOwnUser);
 
   return (

--- a/src/account/AccountItem.js
+++ b/src/account/AccountItem.js
@@ -1,5 +1,6 @@
 /* @flow strict-local */
 import React from 'react';
+import type { Node } from 'react';
 import { View } from 'react-native';
 
 import { BRAND_COLOR, createStyleSheet } from '../styles';
@@ -47,7 +48,7 @@ type Props = $ReadOnly<{|
   onRemove: (index: number) => Promise<void> | void,
 |}>;
 
-export default function AccountItem(props: Props): React$Node {
+export default function AccountItem(props: Props): Node {
   const { email, realm, isLoggedIn } = props.account;
 
   const showDoneIcon = props.index === 0 && isLoggedIn;

--- a/src/account/AccountList.js
+++ b/src/account/AccountList.js
@@ -1,5 +1,6 @@
 /* @flow strict-local */
 import React from 'react';
+import type { Node } from 'react';
 import { View, FlatList } from 'react-native';
 
 import type { AccountStatus } from './accountsSelectors';
@@ -12,7 +13,7 @@ type Props = $ReadOnly<{|
   onAccountRemove: number => Promise<void> | void,
 |}>;
 
-export default function AccountList(props: Props): React$Node {
+export default function AccountList(props: Props): Node {
   const { accounts, onAccountSelect, onAccountRemove } = props;
 
   return (

--- a/src/account/AccountPickScreen.js
+++ b/src/account/AccountPickScreen.js
@@ -1,6 +1,7 @@
 /* @flow strict-local */
 
 import React, { useContext, useCallback } from 'react';
+import type { Node } from 'react';
 import { Alert } from 'react-native';
 
 import * as api from '../api';
@@ -26,7 +27,7 @@ type Props = $ReadOnly<{|
   route: RouteProp<'account-pick', void>,
 |}>;
 
-export default function AccountPickScreen(props: Props): React$Node {
+export default function AccountPickScreen(props: Props): Node {
   const { navigation } = props;
   const accounts = useSelector(getAccountStatuses);
   const dispatch = useDispatch();

--- a/src/animation/AnimatedComponent.js
+++ b/src/animation/AnimatedComponent.js
@@ -1,6 +1,6 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
-import type { Node as React$Node } from 'react';
+import type { Node } from 'react';
 import { Animated, Easing } from 'react-native';
 
 import type { Style } from '../types';
@@ -8,7 +8,7 @@ import type { Style } from '../types';
 type Props = $ReadOnly<{|
   stylePropertyName: string,
   fullValue: number,
-  children: React$Node,
+  children: Node,
   style?: Style,
   visible: boolean,
   useNativeDriver: boolean,

--- a/src/animation/AnimatedComponent.js
+++ b/src/animation/AnimatedComponent.js
@@ -1,5 +1,5 @@
 /* @flow strict-local */
-import React, { PureComponent } from 'react';
+import React, { useRef, useCallback, useEffect } from 'react';
 import type { Node } from 'react';
 import { Animated, Easing } from 'react-native';
 
@@ -10,44 +10,41 @@ type Props = $ReadOnly<{|
   fullValue: number,
   children: Node,
   style?: Style,
-  visible: boolean,
-  useNativeDriver: boolean,
-  delay: number,
+  visible?: boolean,
+  useNativeDriver?: boolean,
+  delay?: number,
 |}>;
 
-export default class AnimatedComponent extends PureComponent<Props> {
-  static defaultProps = {
-    visible: true,
-    useNativeDriver: true,
-    delay: 0,
-  };
+export default function AnimatedComponent(props: Props) {
+  const {
+    visible = true,
+    useNativeDriver = true,
+    delay = 0,
+    fullValue,
+    children,
+    stylePropertyName,
+    style,
+  } = props;
 
-  animatedValue = new Animated.Value(0);
+  const animatedValue = useRef(new Animated.Value(0));
 
-  animate() {
-    Animated.timing(this.animatedValue, {
-      toValue: this.props.visible ? this.props.fullValue : 0,
-      delay: this.props.delay,
+  const animate = useCallback(() => {
+    Animated.timing(animatedValue.current, {
+      toValue: visible ? fullValue : 0,
+      delay,
       duration: 300,
-      useNativeDriver: this.props.useNativeDriver,
+      useNativeDriver,
       easing: Easing.out(Easing.poly(4)),
     }).start();
-  }
+  }, [delay, fullValue, useNativeDriver, visible]);
 
-  componentDidMount() {
-    this.animate();
-  }
+  useEffect(() => {
+    animate();
+  });
 
-  componentDidUpdate() {
-    this.animate();
-  }
+  const animatedStyle = {
+    [stylePropertyName]: animatedValue.current,
+  };
 
-  render() {
-    const { children, stylePropertyName, style } = this.props;
-    const animatedStyle = {
-      [stylePropertyName]: this.animatedValue,
-    };
-
-    return <Animated.View style={[animatedStyle, style]}>{children}</Animated.View>;
-  }
+  return <Animated.View style={[animatedStyle, style]}>{children}</Animated.View>;
 }

--- a/src/animation/AnimatedComponent.js
+++ b/src/animation/AnimatedComponent.js
@@ -26,17 +26,19 @@ export default function AnimatedComponent(props: Props) {
     style,
   } = props;
 
-  const animatedValue = useRef(new Animated.Value(visible === true ? fullValue : 0));
+  const targetValue = visible ? fullValue : 0;
+
+  const animatedValue = useRef(new Animated.Value(targetValue));
 
   const animate = useCallback(() => {
     Animated.timing(animatedValue.current, {
-      toValue: visible ? fullValue : 0,
+      toValue: targetValue,
       delay,
       duration: 300,
       useNativeDriver,
       easing: Easing.out(Easing.poly(4)),
     }).start();
-  }, [delay, fullValue, useNativeDriver, visible]);
+  }, [delay, targetValue, useNativeDriver]);
 
   useEffect(() => {
     animate();

--- a/src/animation/AnimatedComponent.js
+++ b/src/animation/AnimatedComponent.js
@@ -3,6 +3,7 @@ import React, { useRef, useCallback, useEffect } from 'react';
 import type { Node } from 'react';
 import { Animated, Easing } from 'react-native';
 
+import { usePrevious } from '../reactUtils';
 import type { Style } from '../types';
 
 type Props = $ReadOnly<{|
@@ -15,6 +16,9 @@ type Props = $ReadOnly<{|
   delay?: number,
 |}>;
 
+/**
+ * Animates the specified style property on visibility change.
+ */
 export default function AnimatedComponent(props: Props) {
   const {
     visible = true,
@@ -25,6 +29,8 @@ export default function AnimatedComponent(props: Props) {
     stylePropertyName,
     style,
   } = props;
+
+  const prevVisible = usePrevious(visible);
 
   const targetValue = visible ? fullValue : 0;
 
@@ -41,8 +47,10 @@ export default function AnimatedComponent(props: Props) {
   }, [delay, targetValue, useNativeDriver]);
 
   useEffect(() => {
-    animate();
-  });
+    if (prevVisible !== visible) {
+      animate();
+    }
+  }, [animate, prevVisible, visible]);
 
   const animatedStyle = {
     [stylePropertyName]: animatedValue.current,

--- a/src/animation/AnimatedComponent.js
+++ b/src/animation/AnimatedComponent.js
@@ -19,7 +19,7 @@ type Props = $ReadOnly<{|
 /**
  * Animates the specified style property on visibility change.
  */
-export default function AnimatedComponent(props: Props) {
+export default function AnimatedComponent(props: Props): Node {
   const {
     visible = true,
     useNativeDriver = true,

--- a/src/animation/AnimatedComponent.js
+++ b/src/animation/AnimatedComponent.js
@@ -26,7 +26,7 @@ export default function AnimatedComponent(props: Props) {
     style,
   } = props;
 
-  const animatedValue = useRef(new Animated.Value(0));
+  const animatedValue = useRef(new Animated.Value(visible === true ? fullValue : 0));
 
   const animate = useCallback(() => {
     Animated.timing(animatedValue.current, {

--- a/src/animation/AnimatedRotateComponent.js
+++ b/src/animation/AnimatedRotateComponent.js
@@ -1,6 +1,6 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
-import type { Node as React$Node } from 'react';
+import type { Node } from 'react';
 import { Animated, Easing } from 'react-native';
 import type AnimatedValue from 'react-native/Libraries/Animated/src/nodes/AnimatedValue';
 
@@ -8,7 +8,7 @@ import type { Style } from '../types';
 
 type Props = $ReadOnly<{|
   style?: Style,
-  children: React$Node,
+  children: Node,
 |}>;
 
 export default class AnimatedRotateComponent extends PureComponent<Props> {
@@ -24,7 +24,7 @@ export default class AnimatedRotateComponent extends PureComponent<Props> {
     }).start();
   }
 
-  render(): React$Node {
+  render(): Node {
     const { children, style } = this.props;
     const rotation = this.rotation.interpolate({
       inputRange: [0, 360],

--- a/src/animation/AnimatedScaleComponent.js
+++ b/src/animation/AnimatedScaleComponent.js
@@ -1,13 +1,13 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
-import type { Node as React$Node } from 'react';
+import type { Node } from 'react';
 import { Animated, Easing } from 'react-native';
 import type AnimatedValue from 'react-native/Libraries/Animated/src/nodes/AnimatedValue';
 
 import type { Style } from '../types';
 
 type Props = $ReadOnly<{|
-  children: React$Node,
+  children: Node,
   visible: boolean,
   style?: Style,
 |}>;
@@ -35,7 +35,7 @@ export default class AnimatedScaleComponent extends PureComponent<Props, State> 
     }).start(() => this.setState({ visible: nextProps.visible }));
   }
 
-  render(): React$Node {
+  render(): Node {
     const { children, style } = this.props;
     const { visible } = this.state;
     const animatedStyle = {

--- a/src/autocomplete/AutocompleteView.js
+++ b/src/autocomplete/AutocompleteView.js
@@ -1,5 +1,5 @@
 /* @flow strict-local */
-import React, { PureComponent } from 'react';
+import React, { useCallback } from 'react';
 
 import type { InputSelection } from '../types';
 import getAutocompletedText from './getAutocompletedText';
@@ -31,26 +31,25 @@ type Props = $ReadOnly<{|
   onAutocomplete: (input: string, completion: string, lastWordPrefix: string) => void,
 |}>;
 
-export default class AutocompleteView extends PureComponent<Props> {
-  handleAutocomplete = (autocomplete: string) => {
-    const { text, onAutocomplete, selection } = this.props;
-    const { lastWordPrefix } = getAutocompleteFilter(text, selection);
-    const newText = getAutocompletedText(text, autocomplete, selection);
-    onAutocomplete(newText, autocomplete, lastWordPrefix);
-  };
+export default function AutocompleteView(props: Props) {
+  const { isFocused, text, onAutocomplete, selection } = props;
 
-  render() {
-    const { isFocused, text, selection } = this.props;
-    const { lastWordPrefix, filter } = getAutocompleteFilter(text, selection);
-    const AutocompleteComponent = prefixToComponent[lastWordPrefix];
-    const shouldShow = isFocused && !!AutocompleteComponent && filter.length > 0;
+  const handleAutocomplete = useCallback(
+    (autocomplete: string) => {
+      const { lastWordPrefix } = getAutocompleteFilter(text, selection);
+      const newText = getAutocompletedText(text, autocomplete, selection);
+      onAutocomplete(newText, autocomplete, lastWordPrefix);
+    },
+    [onAutocomplete, selection, text],
+  );
 
-    return (
-      <AnimatedScaleComponent visible={shouldShow}>
-        {shouldShow && (
-          <AutocompleteComponent filter={filter} onAutocomplete={this.handleAutocomplete} />
-        )}
-      </AnimatedScaleComponent>
-    );
-  }
+  const { lastWordPrefix, filter } = getAutocompleteFilter(text, selection);
+  const AutocompleteComponent = prefixToComponent[lastWordPrefix];
+  const shouldShow = isFocused && !!AutocompleteComponent && filter.length > 0;
+
+  return (
+    <AnimatedScaleComponent visible={shouldShow}>
+      {shouldShow && <AutocompleteComponent filter={filter} onAutocomplete={handleAutocomplete} />}
+    </AnimatedScaleComponent>
+  );
 }

--- a/src/autocomplete/AutocompleteView.js
+++ b/src/autocomplete/AutocompleteView.js
@@ -1,5 +1,6 @@
 /* @flow strict-local */
 import React, { useCallback } from 'react';
+import type { Node } from 'react';
 
 import type { InputSelection } from '../types';
 import getAutocompletedText from './getAutocompletedText';
@@ -31,7 +32,7 @@ type Props = $ReadOnly<{|
   onAutocomplete: (input: string, completion: string, lastWordPrefix: string) => void,
 |}>;
 
-export default function AutocompleteView(props: Props) {
+export default function AutocompleteView(props: Props): Node {
   const { isFocused, text, onAutocomplete, selection } = props;
 
   const handleAutocomplete = useCallback(

--- a/src/autocomplete/EmojiAutocomplete.js
+++ b/src/autocomplete/EmojiAutocomplete.js
@@ -1,6 +1,7 @@
 /* @flow strict-local */
 
 import React from 'react';
+import type { Node } from 'react';
 import { FlatList } from 'react-native';
 
 import { Popup } from '../common';
@@ -16,7 +17,7 @@ type Props = $ReadOnly<{|
 
 const MAX_CHOICES = 30;
 
-export default function EmojiAutocomplete(props: Props): React$Node {
+export default function EmojiAutocomplete(props: Props): Node {
   const { filter, onAutocomplete } = props;
   const activeImageEmojiByName = useSelector(getActiveImageEmojiByName);
   const emojiNames = getFilteredEmojis(filter, activeImageEmojiByName);

--- a/src/autocomplete/PeopleAutocomplete.js
+++ b/src/autocomplete/PeopleAutocomplete.js
@@ -1,6 +1,7 @@
 /* @flow strict-local */
 
 import React, { useCallback } from 'react';
+import type { Node } from 'react';
 import { SectionList } from 'react-native';
 
 import type { UserGroup } from '../types';
@@ -21,7 +22,7 @@ type Props = $ReadOnly<{|
   onAutocomplete: (name: string) => void,
 |}>;
 
-export default function PeopleAutocomplete(props: Props): React$Node {
+export default function PeopleAutocomplete(props: Props): Node {
   const { filter, onAutocomplete } = props;
   const mutedUsers = useSelector(getMutedUsers);
   const ownUserId = useSelector(getOwnUserId);

--- a/src/autocomplete/StreamAutocomplete.js
+++ b/src/autocomplete/StreamAutocomplete.js
@@ -1,6 +1,7 @@
 /* @flow strict-local */
 
 import React, { useCallback } from 'react';
+import type { Node } from 'react';
 import { FlatList } from 'react-native';
 
 import { useSelector } from '../react-redux';
@@ -13,7 +14,7 @@ type Props = $ReadOnly<{|
   onAutocomplete: (name: string) => void,
 |}>;
 
-export default function StreamAutocomplete(props: Props): React$Node {
+export default function StreamAutocomplete(props: Props): Node {
   const { filter, onAutocomplete } = props;
   const subscriptions = useSelector(getSubscribedStreams);
 

--- a/src/boot/AppDataFetcher.js
+++ b/src/boot/AppDataFetcher.js
@@ -1,17 +1,17 @@
 /* @flow strict-local */
 
 import React from 'react';
+import type { Node } from 'react';
 
-import type { Node as React$Node } from 'react';
 import { useSelector, useDispatch } from '../react-redux';
 import { getSession } from '../directSelectors';
 import { doInitialFetch } from '../actions';
 
 type Props = $ReadOnly<{|
-  children: React$Node,
+  children: Node,
 |}>;
 
-export default function AppDataFetcher(props: Props): React$Node {
+export default function AppDataFetcher(props: Props): Node {
   const needsInitialFetch = useSelector(state => getSession(state).needsInitialFetch);
   const dispatch = useDispatch();
 

--- a/src/boot/AppEventHandlers.js
+++ b/src/boot/AppEventHandlers.js
@@ -1,12 +1,12 @@
 /* @flow strict-local */
 
 import React, { PureComponent } from 'react';
+import type { Node } from 'react';
 import { AppState, View, Platform, NativeModules } from 'react-native';
 // $FlowFixMe[untyped-import]
 import NetInfo from '@react-native-community/netinfo';
 import * as ScreenOrientation from 'expo-screen-orientation';
 
-import type { Node as React$Node } from 'react';
 import type { Dispatch, Orientation as OrientationT } from '../types';
 import { createStyleSheet } from '../styles';
 import { connect } from '../react-redux';
@@ -65,7 +65,7 @@ const styles = createStyleSheet({
 
 type Props = $ReadOnly<{|
   dispatch: Dispatch,
-  children: React$Node,
+  children: Node,
   unreadCount: number,
 |}>;
 

--- a/src/boot/CompatibilityChecker.js
+++ b/src/boot/CompatibilityChecker.js
@@ -1,12 +1,12 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
+import type { Node } from 'react';
 
-import type { Node as React$Node } from 'react';
 import * as api from '../api';
 import CompatibilityScreen from '../start/CompatibilityScreen';
 
 type Props = $ReadOnly<{|
-  children: React$Node,
+  children: Node,
 |}>;
 
 type State = {|
@@ -28,7 +28,7 @@ export default class CompatibilityChecker extends PureComponent<Props, State> {
     });
   }
 
-  render(): React$Node {
+  render(): Node {
     const { compatibilityCheckFail } = this.state;
 
     return compatibilityCheckFail ? <CompatibilityScreen /> : this.props.children;

--- a/src/boot/HideIfNotHydrated.js
+++ b/src/boot/HideIfNotHydrated.js
@@ -1,16 +1,17 @@
 /* @flow strict-local */
-import React, { type Node as React$Node } from 'react';
+import React from 'react';
+import type { Node } from 'react';
 import { useSelector } from 'react-redux';
 
 import { getIsHydrated } from '../selectors';
 
 type Props = $ReadOnly<{|
-  children: React$Node,
+  children: Node,
 
   PlaceholderComponent?: React$ComponentType<{||}>,
 |}>;
 
-export default function HideIfNotHydrated(props: Props): React$Node {
+export default function HideIfNotHydrated(props: Props): Node {
   const isHydrated = useSelector(getIsHydrated);
 
   const { children, PlaceholderComponent } = props;

--- a/src/boot/StoreProvider.js
+++ b/src/boot/StoreProvider.js
@@ -1,7 +1,7 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
+import type { Node } from 'react';
 import { Provider } from 'react-redux';
-import type { Node as React$Node } from 'react';
 
 import { observeStore } from '../redux';
 import * as logging from '../utils/logging';
@@ -10,7 +10,7 @@ import store, { restore } from './store';
 import timing from '../utils/timing';
 
 type Props = $ReadOnly<{|
-  children: React$Node,
+  children: Node,
 |}>;
 
 export default class StoreProvider extends PureComponent<Props> {
@@ -38,7 +38,7 @@ export default class StoreProvider extends PureComponent<Props> {
     }
   }
 
-  render(): React$Node {
+  render(): Node {
     return <Provider store={store}>{this.props.children}</Provider>;
   }
 }

--- a/src/boot/ThemeProvider.js
+++ b/src/boot/ThemeProvider.js
@@ -1,18 +1,18 @@
 /* @flow strict-local */
 
 import React from 'react';
+import type { Node } from 'react';
 
-import type { Node as React$Node } from 'react';
 import { useSelector } from '../react-redux';
 import { getSettings } from '../directSelectors';
 import { themeData, ThemeContext } from '../styles/theme';
 import { ZulipStatusBar } from '../common';
 
 type Props = $ReadOnly<{|
-  children: React$Node,
+  children: Node,
 |}>;
 
-export default function ThemeProvider(props: Props): React$Node {
+export default function ThemeProvider(props: Props): Node {
   const { children } = props;
   const theme = useSelector(state => getSettings(state).theme);
   return (

--- a/src/boot/TranslationProvider.js
+++ b/src/boot/TranslationProvider.js
@@ -1,6 +1,6 @@
 /* @flow strict-local */
 import React, { PureComponent, type Context } from 'react';
-import type { ComponentType, ElementConfig, Node as React$Node } from 'react';
+import type { ComponentType, ElementConfig, Node } from 'react';
 import { Text } from 'react-native';
 import { IntlProvider, IntlContext } from 'react-intl';
 import type { IntlShape } from 'react-intl';
@@ -58,7 +58,7 @@ const makeGetText = (intl: IntlShape): GetText => {
  * See the `GetTypes` type for why we like the new shape.
  */
 class TranslationContextTranslator extends PureComponent<{|
-  +children: React$Node,
+  +children: Node,
 |}> {
   static contextType = IntlContext;
   context: IntlShape;
@@ -73,10 +73,10 @@ class TranslationContextTranslator extends PureComponent<{|
 }
 
 type Props = $ReadOnly<{|
-  children: React$Node,
+  children: Node,
 |}>;
 
-export default function TranslationProvider(props: Props): React$Node {
+export default function TranslationProvider(props: Props): Node {
   const { children } = props;
   const language = useSelector(state => getSettings(state).language);
 

--- a/src/chat/ChatScreen.js
+++ b/src/chat/ChatScreen.js
@@ -1,5 +1,6 @@
 /* @flow strict-local */
 import React from 'react';
+import type { Node } from 'react';
 import { useIsFocused } from '@react-navigation/native';
 
 import { useSelector, useDispatch } from '../react-redux';
@@ -97,7 +98,7 @@ const useMessagesWithFetch = args => {
   return { fetchError, isFetching, messages, haveNoMessages, firstUnreadIdInNarrow };
 };
 
-export default function ChatScreen(props: Props): React$Node {
+export default function ChatScreen(props: Props): Node {
   const { route, navigation } = props;
   const { backgroundColor } = React.useContext(ThemeContext);
 

--- a/src/chat/FetchError.js
+++ b/src/chat/FetchError.js
@@ -1,6 +1,7 @@
 /* @flow strict-local */
 
 import React, { PureComponent } from 'react';
+import type { Node } from 'react';
 import { StyleSheet, View } from 'react-native';
 
 import type { Narrow } from '../types';
@@ -26,7 +27,7 @@ type Props = $ReadOnly<{|
 |}>;
 
 export default class FetchError extends PureComponent<Props> {
-  render(): React$Node {
+  render(): Node {
     return (
       <View style={styles.container}>
         {(() => {

--- a/src/chat/InvalidNarrow.js
+++ b/src/chat/InvalidNarrow.js
@@ -1,6 +1,7 @@
 /* @flow strict-local */
 
 import React, { PureComponent } from 'react';
+import type { Node } from 'react';
 import { StyleSheet, View } from 'react-native';
 
 import type { Narrow } from '../types';
@@ -24,7 +25,7 @@ type Props = $ReadOnly<{|
 |}>;
 
 export default class InvalidNarrow extends PureComponent<Props> {
-  render(): React$Node {
+  render(): Node {
     return (
       <View style={styles.container}>
         <Label style={styles.text} text="That conversation doesn't seem to exist." />

--- a/src/chat/MarkAsReadButton.js
+++ b/src/chat/MarkAsReadButton.js
@@ -1,6 +1,7 @@
 /* @flow strict-local */
 
 import React, { useCallback } from 'react';
+import type { Node } from 'react';
 
 import type { Narrow } from '../types';
 import { createStyleSheet } from '../styles';
@@ -29,7 +30,7 @@ type Props = $ReadOnly<{|
   narrow: Narrow,
 |}>;
 
-export default function MarkAsReadButton(props: Props): React$Node {
+export default function MarkAsReadButton(props: Props): Node {
   const { narrow } = props;
   const auth = useSelector(getAuth);
   const streams = useSelector(getStreams);

--- a/src/common/Centerer.js
+++ b/src/common/Centerer.js
@@ -1,9 +1,9 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
+import type { Node } from 'react';
 import { View } from 'react-native';
 import type { ViewStyleProp } from 'react-native/Libraries/StyleSheet/StyleSheet';
 
-import type { Node as React$Node } from 'react';
 import styles, { createStyleSheet } from '../styles';
 
 const componentStyles = createStyleSheet({
@@ -21,7 +21,7 @@ const componentStyles = createStyleSheet({
 
 type Props = $ReadOnly<{|
   style?: ViewStyleProp,
-  children: React$Node,
+  children: Node,
   padding: boolean,
 |}>;
 

--- a/src/common/ComponentList.js
+++ b/src/common/ComponentList.js
@@ -1,13 +1,13 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
-import type { Node as React$Node } from 'react';
+import type { Node } from 'react';
 import { View } from 'react-native';
 import type { ViewStyleProp } from 'react-native/Libraries/StyleSheet/StyleSheet';
 
 import type { Style } from '../types';
 
 type Props = $ReadOnly<{|
-  children: $ReadOnlyArray<React$Node>,
+  children: $ReadOnlyArray<Node>,
   spacing?: number,
   outerSpacing: boolean,
   style?: ViewStyleProp,

--- a/src/common/ComponentList.js
+++ b/src/common/ComponentList.js
@@ -1,5 +1,5 @@
 /* @flow strict-local */
-import React, { PureComponent } from 'react';
+import React from 'react';
 import type { Node } from 'react';
 import { View } from 'react-native';
 import type { ViewStyleProp } from 'react-native/Libraries/StyleSheet/StyleSheet';
@@ -9,7 +9,7 @@ import type { Style } from '../types';
 type Props = $ReadOnly<{|
   children: $ReadOnlyArray<Node>,
   spacing?: number,
-  outerSpacing: boolean,
+  outerSpacing?: boolean,
   style?: ViewStyleProp,
   itemStyle?: Style,
 |}>;
@@ -24,23 +24,16 @@ type Props = $ReadOnly<{|
  * @prop [style] - Style of the wrapper container.
  * @prop [itemStyle] - Style applied to each child.
  */
-export default class ComponentList extends PureComponent<Props> {
-  static defaultProps = {
-    outerSpacing: true,
-    spacing: 16,
-  };
+export default function ComponentList(props: Props) {
+  const { children, itemStyle, spacing = 16, outerSpacing = true, style } = props;
+  const outerStyle = outerSpacing ? { margin: spacing } : {};
+  const marginStyle = { marginBottom: spacing };
+  const childrenToRender = React.Children.toArray(children).filter(child => child);
+  const childrenWithStyles = childrenToRender.map((child, i) =>
+    React.cloneElement(child, {
+      style: [child.props.style, i + 1 < childrenToRender.length ? marginStyle : {}, itemStyle],
+    }),
+  );
 
-  render() {
-    const { children, itemStyle, spacing, outerSpacing, style } = this.props;
-    const outerStyle = outerSpacing ? { margin: spacing } : {};
-    const marginStyle = { marginBottom: spacing };
-    const childrenToRender = React.Children.toArray(children).filter(child => child);
-    const childrenWithStyles = childrenToRender.map((child, i) =>
-      React.cloneElement(child, {
-        style: [child.props.style, i + 1 < childrenToRender.length ? marginStyle : {}, itemStyle],
-      }),
-    );
-
-    return <View style={[style, outerStyle]}>{childrenWithStyles}</View>;
-  }
+  return <View style={[style, outerStyle]}>{childrenWithStyles}</View>;
 }

--- a/src/common/ComponentList.js
+++ b/src/common/ComponentList.js
@@ -24,7 +24,7 @@ type Props = $ReadOnly<{|
  * @prop [style] - Style of the wrapper container.
  * @prop [itemStyle] - Style applied to each child.
  */
-export default function ComponentList(props: Props) {
+export default function ComponentList(props: Props): Node {
   const { children, itemStyle, spacing = 16, outerSpacing = true, style } = props;
   const outerStyle = outerSpacing ? { margin: spacing } : {};
   const marginStyle = { marginBottom: spacing };

--- a/src/common/ComponentWithOverlay.js
+++ b/src/common/ComponentWithOverlay.js
@@ -54,7 +54,7 @@ type Props = $ReadOnly<{|
  * @prop overlayPosition - What corner to align the overlay to.
  * @prop [style] - Applied to a wrapper View.
  */
-export default function ComponentWithOverlay(props: Props) {
+export default function ComponentWithOverlay(props: Props): Node {
   const {
     children,
     style,

--- a/src/common/ComponentWithOverlay.js
+++ b/src/common/ComponentWithOverlay.js
@@ -1,8 +1,8 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
+import type { Node } from 'react';
 import { View } from 'react-native';
 import type { ViewStyleProp } from 'react-native/Libraries/StyleSheet/StyleSheet';
-import type { Node as React$Node } from 'react';
 
 import { createStyleSheet } from '../styles';
 
@@ -34,8 +34,8 @@ const styles = createStyleSheet({
 });
 
 type Props = $ReadOnly<{|
-  children: React$Node,
-  overlay: React$Node,
+  children: Node,
+  overlay: Node,
   showOverlay: boolean,
   overlaySize: number,
   overlayColor: string,

--- a/src/common/ComponentWithOverlay.js
+++ b/src/common/ComponentWithOverlay.js
@@ -1,5 +1,5 @@
 /* @flow strict-local */
-import React, { PureComponent } from 'react';
+import React from 'react';
 import type { Node } from 'react';
 import { View } from 'react-native';
 import type { ViewStyleProp } from 'react-native/Libraries/StyleSheet/StyleSheet';
@@ -36,7 +36,7 @@ const styles = createStyleSheet({
 type Props = $ReadOnly<{|
   children: Node,
   overlay: Node,
-  showOverlay: boolean,
+  showOverlay?: boolean,
   overlaySize: number,
   overlayColor: string,
   overlayPosition: 'top-right' | 'top-left' | 'bottom-right' | 'bottom-left',
@@ -54,40 +54,34 @@ type Props = $ReadOnly<{|
  * @prop overlayPosition - What corner to align the overlay to.
  * @prop [style] - Applied to a wrapper View.
  */
-export default class ComponentWithOverlay extends PureComponent<Props> {
-  static defaultProps = {
-    showOverlay: true,
-  };
+export default function ComponentWithOverlay(props: Props) {
+  const {
+    children,
+    style,
+    overlay,
+    showOverlay = true,
+    overlayPosition,
+    overlaySize,
+    overlayColor,
+  } = props;
 
-  render() {
-    const {
-      children,
-      style,
-      overlay,
-      showOverlay,
-      overlayPosition,
-      overlaySize,
-      overlayColor,
-    } = this.props;
+  const wrapperStyle = [styles.wrapper, style];
+  const overlayStyle = [
+    styles.wrapper,
+    styles.overlay,
+    styles[overlayPosition],
+    {
+      minWidth: overlaySize,
+      height: overlaySize,
+      borderRadius: overlaySize,
+      backgroundColor: overlayColor,
+    },
+  ];
 
-    const wrapperStyle = [styles.wrapper, style];
-    const overlayStyle = [
-      styles.wrapper,
-      styles.overlay,
-      styles[overlayPosition],
-      {
-        minWidth: overlaySize,
-        height: overlaySize,
-        borderRadius: overlaySize,
-        backgroundColor: overlayColor,
-      },
-    ];
-
-    return (
-      <View style={wrapperStyle}>
-        {children}
-        {showOverlay && overlaySize > 0 && <View style={overlayStyle}>{overlay}</View>}
-      </View>
-    );
-  }
+  return (
+    <View style={wrapperStyle}>
+      {children}
+      {showOverlay && overlaySize > 0 && <View style={overlayStyle}>{overlay}</View>}
+    </View>
+  );
 }

--- a/src/common/CountOverlay.js
+++ b/src/common/CountOverlay.js
@@ -1,6 +1,7 @@
 /* @flow strict-local */
 
 import React, { PureComponent } from 'react';
+import type { Node } from 'react';
 import { View } from 'react-native';
 
 // eslint-disable-next-line import/no-useless-path-segments
@@ -14,12 +15,12 @@ const styles = createStyleSheet({
 });
 
 type Props = $ReadOnly<{|
-  children: React$Node,
+  children: Node,
   unreadCount: number,
 |}>;
 
 export default class CountOverlay extends PureComponent<Props> {
-  render(): React$Node {
+  render(): Node {
     const { children, unreadCount } = this.props;
 
     return (

--- a/src/common/ErrorMsg.js
+++ b/src/common/ErrorMsg.js
@@ -1,5 +1,6 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
+import type { Node } from 'react';
 import { View } from 'react-native';
 
 import Label from './Label';
@@ -29,7 +30,7 @@ type Props = $ReadOnly<{|
  * @prop error - The error message string.
  */
 export default class ErrorMsg extends PureComponent<Props> {
-  render(): React$Node {
+  render(): Node {
     const { error } = this.props;
 
     if (!error) {

--- a/src/common/FloatingActionButton.js
+++ b/src/common/FloatingActionButton.js
@@ -1,5 +1,6 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
+import type { Node } from 'react';
 import { View } from 'react-native';
 import type { ViewStyleProp } from 'react-native/Libraries/StyleSheet/StyleSheet';
 
@@ -38,7 +39,7 @@ type Props = $ReadOnly<{|
  * @prop onPress - Event called on component press.
  */
 export default class FloatingActionButton extends PureComponent<Props> {
-  render(): React$Node {
+  render(): Node {
     const { style, size, disabled, onPress, Icon, accessibilityLabel } = this.props;
     const iconSize = Math.trunc(size / 2);
     const customWrapperStyle = {

--- a/src/common/FullScreenLoading.js
+++ b/src/common/FullScreenLoading.js
@@ -1,5 +1,6 @@
 /* @flow strict-local */
 import React from 'react';
+import type { Node } from 'react';
 import { View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
@@ -21,7 +22,7 @@ type Props = $ReadOnly<{||}>;
 /**
  * Meant to be used to cover the whole screen.
  */
-export default function FullScreenLoading(props: Props): React$Node {
+export default function FullScreenLoading(props: Props): Node {
   const insets = useSafeAreaInsets();
 
   return (

--- a/src/common/GroupAvatar.js
+++ b/src/common/GroupAvatar.js
@@ -1,8 +1,8 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
+import type { Node } from 'react';
 import { Text, View } from 'react-native';
 
-import type { Node as React$Node } from 'react';
 import Touchable from './Touchable';
 import { createStyleSheet } from '../styles';
 import { colorHashFromString, foregroundColorFromBackground } from '../utils/color';
@@ -20,7 +20,7 @@ const styles = createStyleSheet({
 type Props = $ReadOnly<{|
   names: string[],
   size: number,
-  children?: React$Node,
+  children?: Node,
   onPress?: () => void,
 |}>;
 
@@ -46,7 +46,7 @@ export const initialsForGroupIcon = (names: string[]): string => {
  * @prop onPress - Event fired on pressing the component.
  */
 export default class GroupAvatar extends PureComponent<Props> {
-  render(): React$Node {
+  render(): Node {
     const { children, names, size, onPress } = this.props;
 
     const frameSize = {

--- a/src/common/Input.js
+++ b/src/common/Input.js
@@ -1,5 +1,6 @@
 /* @flow strict-local */
 import React, { useState, useCallback, useContext } from 'react';
+import type { Node } from 'react';
 import { TextInput, Platform } from 'react-native';
 
 import type { LocalizableText } from '../types';
@@ -45,7 +46,7 @@ const componentStyles = createStyleSheet({
  * @prop ...all other TextInput props - Passed through verbatim to TextInput.
  *   See upstream: https://reactnative.dev/docs/textinput
  */
-export default function Input(props: Props) {
+export default function Input(props: Props): Node {
   const { style, placeholder, textInputRef, ...restProps } = props;
 
   const [isFocused, setIsFocused] = useState<boolean>(false);

--- a/src/common/Input.js
+++ b/src/common/Input.js
@@ -4,7 +4,7 @@ import { TextInput, Platform } from 'react-native';
 
 import type { LocalizableText, GetText } from '../types';
 import type { ThemeData } from '../styles';
-import { ThemeContext, HALF_COLOR, BORDER_COLOR } from '../styles';
+import { createStyleSheet, ThemeContext, HALF_COLOR, BORDER_COLOR } from '../styles';
 import { withGetText } from '../boot/TranslationProvider';
 
 export type Props = $ReadOnly<{|
@@ -25,6 +25,19 @@ type State = {|
   isFocused: boolean,
 |};
 
+const componentStyles = createStyleSheet({
+  input: {
+    ...Platform.select({
+      ios: {
+        borderWidth: 1,
+        borderColor: BORDER_COLOR,
+        borderRadius: 2,
+        padding: 8,
+      },
+    }),
+  },
+});
+
 /**
  * A light abstraction over the standard TextInput component
  * that allows us to seamlessly provide internationalization
@@ -42,19 +55,6 @@ type State = {|
 class Input extends PureComponent<Props, State> {
   static contextType = ThemeContext;
   context: ThemeData;
-
-  styles = {
-    input: {
-      ...Platform.select({
-        ios: {
-          borderWidth: 1,
-          borderColor: BORDER_COLOR,
-          borderRadius: 2,
-          padding: 8,
-        },
-      }),
-    },
-  };
 
   state = {
     isFocused: false,
@@ -82,7 +82,7 @@ class Input extends PureComponent<Props, State> {
 
     return (
       <TextInput
-        style={[this.styles.input, { color: this.context.color }, style]}
+        style={[componentStyles.input, { color: this.context.color }, style]}
         placeholder={_(fullPlaceholder.text, fullPlaceholder.values)}
         placeholderTextColor={HALF_COLOR}
         underlineColorAndroid={isFocused ? BORDER_COLOR : HALF_COLOR}

--- a/src/common/InputWithClearButton.js
+++ b/src/common/InputWithClearButton.js
@@ -1,5 +1,5 @@
 /* @flow strict-local */
-import React, { PureComponent } from 'react';
+import React, { useRef, useState, useCallback } from 'react';
 import { View } from 'react-native';
 
 import Input from './Input';
@@ -16,63 +16,47 @@ const componentStyles = createStyleSheet({
 
 type Props = $ReadOnly<$Diff<InputProps, {| textInputRef: mixed, value: mixed, _: mixed |}>>;
 
-type State = {|
-  text: string,
-|};
-
 /**
  * A component wrapping Input and providing an 'X' button
  * to clear the entered text.
  *
  * All props are passed through to `Input`.  See `Input` for descriptions.
  */
-export default class InputWithClearButton extends PureComponent<Props, State> {
-  state = {
-    text: '',
-  };
+export default function InputWithClearButton(props: Props) {
+  const { onChangeText } = props;
+
+  const [text, setText] = useState<string>('');
+
   // We should replace the fixme with
   // `React$ElementRef<typeof TextInput>` when we can. Currently, that
   // would make `.current` be `any(implicit)`, which we don't want;
   // this is probably down to bugs in Flow's special support for React.
-  textInputRef = React.createRef<$FlowFixMe>();
+  const textInputRef = useRef<$FlowFixMe>();
 
-  handleChangeText = (text: string) => {
-    this.setState({
-      text,
-    });
-    if (this.props.onChangeText) {
-      this.props.onChangeText(text);
-    }
-  };
+  const handleChangeText = useCallback(
+    (_text: string) => {
+      setText(_text);
+      if (onChangeText) {
+        onChangeText(_text);
+      }
+    },
+    [onChangeText],
+  );
 
-  handleClear = () => {
-    this.handleChangeText('');
-    if (this.textInputRef.current) {
+  const handleClear = useCallback(() => {
+    handleChangeText('');
+    if (textInputRef.current) {
       // `.current` is not type-checked; see definition.
-      this.textInputRef.current.clear();
+      textInputRef.current.clear();
     }
-  };
+  }, [handleChangeText]);
 
-  render() {
-    const { text } = this.state;
-
-    return (
-      <View style={styles.row}>
-        <Input
-          {...this.props}
-          textInputRef={this.textInputRef}
-          onChangeText={this.handleChangeText}
-          value={text}
-        />
-        {text.length > 0 && (
-          <Icon
-            name="x"
-            size={24}
-            onPress={this.handleClear}
-            style={componentStyles.clearButtonIcon}
-          />
-        )}
-      </View>
-    );
-  }
+  return (
+    <View style={styles.row}>
+      <Input {...props} textInputRef={textInputRef} onChangeText={handleChangeText} value={text} />
+      {text.length > 0 && (
+        <Icon name="x" size={24} onPress={handleClear} style={componentStyles.clearButtonIcon} />
+      )}
+    </View>
+  );
 }

--- a/src/common/InputWithClearButton.js
+++ b/src/common/InputWithClearButton.js
@@ -17,7 +17,6 @@ const componentStyles = createStyleSheet({
 type Props = $ReadOnly<$Diff<InputProps, {| textInputRef: mixed, value: mixed, _: mixed |}>>;
 
 type State = {|
-  canBeCleared: boolean,
   text: string,
 |};
 
@@ -29,7 +28,6 @@ type State = {|
  */
 export default class InputWithClearButton extends PureComponent<Props, State> {
   state = {
-    canBeCleared: false,
     text: '',
   };
   // We should replace the fixme with
@@ -40,7 +38,6 @@ export default class InputWithClearButton extends PureComponent<Props, State> {
 
   handleChangeText = (text: string) => {
     this.setState({
-      canBeCleared: text.length > 0,
       text,
     });
     if (this.props.onChangeText) {
@@ -57,7 +54,7 @@ export default class InputWithClearButton extends PureComponent<Props, State> {
   };
 
   render() {
-    const { canBeCleared, text } = this.state;
+    const { text } = this.state;
 
     return (
       <View style={styles.row}>
@@ -67,7 +64,7 @@ export default class InputWithClearButton extends PureComponent<Props, State> {
           onChangeText={this.handleChangeText}
           value={text}
         />
-        {canBeCleared && (
+        {text.length > 0 && (
           <Icon
             name="x"
             size={24}

--- a/src/common/InputWithClearButton.js
+++ b/src/common/InputWithClearButton.js
@@ -1,5 +1,6 @@
 /* @flow strict-local */
 import React, { useRef, useState, useCallback } from 'react';
+import type { Node } from 'react';
 import { View } from 'react-native';
 
 import Input from './Input';
@@ -22,7 +23,7 @@ type Props = $ReadOnly<$Diff<InputProps, {| textInputRef: mixed, value: mixed, _
  *
  * All props are passed through to `Input`.  See `Input` for descriptions.
  */
-export default function InputWithClearButton(props: Props) {
+export default function InputWithClearButton(props: Props): Node {
   const { onChangeText } = props;
 
   const [text, setText] = useState<string>('');

--- a/src/common/KeyboardAvoider.js
+++ b/src/common/KeyboardAvoider.js
@@ -1,12 +1,12 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
-import type { Node as React$Node } from 'react';
+import type { Node } from 'react';
 import { KeyboardAvoidingView, Platform, View } from 'react-native';
 import type { ViewStyleProp } from 'react-native/Libraries/StyleSheet/StyleSheet';
 
 type Props = $ReadOnly<{|
   behavior?: ?('height' | 'position' | 'padding'),
-  children: React$Node,
+  children: Node,
   style?: ViewStyleProp,
   contentContainerStyle?: ViewStyleProp,
 
@@ -38,7 +38,7 @@ type Props = $ReadOnly<{|
  * to that component.
  */
 export default class KeyboardAvoider extends PureComponent<Props> {
-  render(): React$Node {
+  render(): Node {
     const { behavior, children, style, contentContainerStyle, keyboardVerticalOffset } = this.props;
 
     if (Platform.OS === 'android') {

--- a/src/common/Label.js
+++ b/src/common/Label.js
@@ -1,5 +1,6 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
+import type { Node } from 'react';
 import TranslatedText from './TranslatedText';
 
 import type { BoundedDiff } from '../generics';
@@ -7,7 +8,7 @@ import RawLabel from './RawLabel';
 import type { LocalizableText } from '../types';
 
 type Props = $ReadOnly<{|
-  ...BoundedDiff<$Exact<React$ElementConfig<typeof RawLabel>>, {| children: ?React$Node |}>,
+  ...BoundedDiff<$Exact<React$ElementConfig<typeof RawLabel>>, {| children: ?Node |}>,
   text: LocalizableText,
 |}>;
 
@@ -20,7 +21,7 @@ type Props = $ReadOnly<{|
  * prop, and doesn't support `children`.
  */
 export default class Label extends PureComponent<Props> {
-  render(): React$Node {
+  render(): Node {
     const { text, ...restProps } = this.props;
 
     return (

--- a/src/common/LineSeparator.js
+++ b/src/common/LineSeparator.js
@@ -1,8 +1,7 @@
 /* @flow strict-local */
-import React, { PureComponent } from 'react';
+import React, { useContext } from 'react';
 import { View } from 'react-native';
 
-import type { ThemeData } from '../styles';
 import { ThemeContext, createStyleSheet } from '../styles';
 
 const componentStyles = createStyleSheet({
@@ -12,13 +11,9 @@ const componentStyles = createStyleSheet({
   },
 });
 
-export default class LineSeparator extends PureComponent<{||}> {
-  static contextType = ThemeContext;
-  context: ThemeData;
-
-  render() {
-    return (
-      <View style={[componentStyles.lineSeparator, { backgroundColor: this.context.cardColor }]} />
-    );
-  }
+export default function LineSeparator(props: {||}) {
+  const themeContext = useContext(ThemeContext);
+  return (
+    <View style={[componentStyles.lineSeparator, { backgroundColor: themeContext.cardColor }]} />
+  );
 }

--- a/src/common/LineSeparator.js
+++ b/src/common/LineSeparator.js
@@ -1,5 +1,6 @@
 /* @flow strict-local */
 import React, { useContext } from 'react';
+import type { Node } from 'react';
 import { View } from 'react-native';
 
 import { ThemeContext, createStyleSheet } from '../styles';
@@ -11,7 +12,7 @@ const componentStyles = createStyleSheet({
   },
 });
 
-export default function LineSeparator(props: {||}) {
+export default function LineSeparator(props: {||}): Node {
   const themeContext = useContext(ThemeContext);
   return (
     <View style={[componentStyles.lineSeparator, { backgroundColor: themeContext.cardColor }]} />

--- a/src/common/LineSeparator.js
+++ b/src/common/LineSeparator.js
@@ -3,22 +3,22 @@ import React, { PureComponent } from 'react';
 import { View } from 'react-native';
 
 import type { ThemeData } from '../styles';
-import { ThemeContext } from '../styles';
+import { ThemeContext, createStyleSheet } from '../styles';
+
+const componentStyles = createStyleSheet({
+  lineSeparator: {
+    height: 1,
+    margin: 4,
+  },
+});
 
 export default class LineSeparator extends PureComponent<{||}> {
   static contextType = ThemeContext;
   context: ThemeData;
 
-  styles = {
-    lineSeparator: {
-      height: 1,
-      margin: 4,
-    },
-  };
-
   render() {
     return (
-      <View style={[this.styles.lineSeparator, { backgroundColor: this.context.cardColor }]} />
+      <View style={[componentStyles.lineSeparator, { backgroundColor: this.context.cardColor }]} />
     );
   }
 }

--- a/src/common/LoadingIndicator.js
+++ b/src/common/LoadingIndicator.js
@@ -1,5 +1,6 @@
 /* @flow strict-local */
 import React from 'react';
+import type { Node } from 'react';
 import { Image, View } from 'react-native';
 
 import SpinningProgress from './SpinningProgress';
@@ -36,7 +37,7 @@ type Props = $ReadOnly<{|
  * @prop [showLogo] - Show or not a Zulip logo in the center.
  * @prop [size] - Diameter of the indicator in pixels.
  */
-export default function LoadingIndicator(props: Props) {
+export default function LoadingIndicator(props: Props): Node {
   const { color = 'default', showLogo = false, size = 40 } = props;
 
   return (

--- a/src/common/LoadingIndicator.js
+++ b/src/common/LoadingIndicator.js
@@ -1,5 +1,5 @@
 /* @flow strict-local */
-import React, { PureComponent } from 'react';
+import React from 'react';
 import { Image, View } from 'react-native';
 
 import SpinningProgress from './SpinningProgress';
@@ -22,9 +22,9 @@ const styles = createStyleSheet({
 });
 
 type Props = $ReadOnly<{|
-  color: 'default' | 'black' | 'white',
-  showLogo: boolean,
-  size: number,
+  color?: 'default' | 'black' | 'white',
+  showLogo?: boolean,
+  size?: number,
 |}>;
 
 /**
@@ -36,32 +36,24 @@ type Props = $ReadOnly<{|
  * @prop [showLogo] - Show or not a Zulip logo in the center.
  * @prop [size] - Diameter of the indicator in pixels.
  */
-export default class LoadingIndicator extends PureComponent<Props> {
-  static defaultProps = {
-    color: 'default',
-    showLogo: false,
-    size: 40,
-  };
+export default function LoadingIndicator(props: Props) {
+  const { color = 'default', showLogo = false, size = 40 } = props;
 
-  render() {
-    const { color, showLogo, size } = this.props;
-
-    return (
-      <View style={styles.wrapper}>
-        <View>
-          <SpinningProgress color={color} size={size} />
-          {showLogo && (
-            <Image
-              style={[
-                styles.logo,
-                { width: (size / 3) * 2, height: (size / 3) * 2, marginTop: size / 6 },
-              ]}
-              source={messageLoadingImg}
-              resizeMode="contain"
-            />
-          )}
-        </View>
+  return (
+    <View style={styles.wrapper}>
+      <View>
+        <SpinningProgress color={color} size={size} />
+        {showLogo && (
+          <Image
+            style={[
+              styles.logo,
+              { width: (size / 3) * 2, height: (size / 3) * 2, marginTop: size / 6 },
+            ]}
+            source={messageLoadingImg}
+            resizeMode="contain"
+          />
+        )}
       </View>
-    );
-  }
+    </View>
+  );
 }

--- a/src/common/Logo.js
+++ b/src/common/Logo.js
@@ -1,5 +1,6 @@
 /* @flow strict-local */
 import React from 'react';
+import type { Node } from 'react';
 import { Image } from 'react-native';
 
 import logoImg from '../../static/img/logo.png';
@@ -14,6 +15,4 @@ const styles = createStyleSheet({
   },
 });
 
-export default (): React$Node => (
-  <Image style={styles.logo} source={logoImg} resizeMode="contain" />
-);
+export default (): Node => <Image style={styles.logo} source={logoImg} resizeMode="contain" />;

--- a/src/common/NestedNavRow.js
+++ b/src/common/NestedNavRow.js
@@ -1,5 +1,6 @@
 /* @flow strict-local */
 import React, { useContext } from 'react';
+import type { Node } from 'react';
 import { View } from 'react-native';
 
 import Label from './Label';
@@ -22,7 +23,7 @@ type Props = $ReadOnly<{|
  * Shows a right-facing arrow to indicate its purpose. If you need a
  * selectable option row instead, use `SelectableOptionRow`.
  */
-export default function NestedNavRow(props: Props) {
+export default function NestedNavRow(props: Props): Node {
   const { label, onPress, Icon } = props;
 
   const themeContext = useContext(ThemeContext);

--- a/src/common/NestedNavRow.js
+++ b/src/common/NestedNavRow.js
@@ -1,12 +1,11 @@
 /* @flow strict-local */
-import React, { PureComponent } from 'react';
+import React, { useContext } from 'react';
 import { View } from 'react-native';
 
 import Label from './Label';
 import Touchable from './Touchable';
 import { IconRight } from './Icons';
 import type { SpecificIconType } from './Icons';
-import type { ThemeData } from '../styles';
 import styles, { ThemeContext } from '../styles';
 
 type Props = $ReadOnly<{|
@@ -23,25 +22,20 @@ type Props = $ReadOnly<{|
  * Shows a right-facing arrow to indicate its purpose. If you need a
  * selectable option row instead, use `SelectableOptionRow`.
  */
-export default class NestedNavRow extends PureComponent<Props> {
-  static contextType = ThemeContext;
-  context: ThemeData;
+export default function NestedNavRow(props: Props) {
+  const { label, onPress, Icon } = props;
 
-  render() {
-    const { label, onPress, Icon } = this.props;
+  const themeContext = useContext(ThemeContext);
 
-    return (
-      <Touchable onPress={onPress}>
-        <View style={styles.listItem}>
-          {!!Icon && (
-            <Icon size={24} style={[styles.settingsIcon, { color: this.context.color }]} />
-          )}
-          <Label text={label} />
-          <View style={styles.rightItem}>
-            <IconRight size={24} style={[styles.settingsIcon, { color: this.context.color }]} />
-          </View>
+  return (
+    <Touchable onPress={onPress}>
+      <View style={styles.listItem}>
+        {!!Icon && <Icon size={24} style={[styles.settingsIcon, { color: themeContext.color }]} />}
+        <Label text={label} />
+        <View style={styles.rightItem}>
+          <IconRight size={24} style={[styles.settingsIcon, { color: themeContext.color }]} />
         </View>
-      </Touchable>
-    );
-  }
+      </View>
+    </Touchable>
+  );
 }

--- a/src/common/OfflineNotice.js
+++ b/src/common/OfflineNotice.js
@@ -1,6 +1,7 @@
 /* @flow strict-local */
 
 import React from 'react';
+import type { Node } from 'react';
 import { View } from 'react-native';
 
 import { createStyleSheet, HALF_COLOR } from '../styles';
@@ -27,7 +28,7 @@ type Props = $ReadOnly<{||}>;
  * Displays a notice that the app is working in offline mode.
  * Not rendered if state is 'online'.
  */
-export default function OfflineNotice(props: Props): React$Node {
+export default function OfflineNotice(props: Props): Node {
   const isOnline = useSelector(state => getSession(state).isOnline);
   if (isOnline) {
     return null;

--- a/src/common/OptionDivider.js
+++ b/src/common/OptionDivider.js
@@ -1,8 +1,7 @@
 /* @flow strict-local */
-import React, { PureComponent } from 'react';
+import React, { useContext } from 'react';
 import { View } from 'react-native';
 
-import type { ThemeData } from '../styles';
 import { ThemeContext, createStyleSheet } from '../styles';
 
 const componentStyles = createStyleSheet({
@@ -11,13 +10,9 @@ const componentStyles = createStyleSheet({
   },
 });
 
-export default class OptionDivider extends PureComponent<{||}> {
-  static contextType = ThemeContext;
-  context: ThemeData;
-
-  render() {
-    return (
-      <View style={[componentStyles.divider, { borderBottomColor: this.context.dividerColor }]} />
-    );
-  }
+export default function OptionDivider(props: {||}) {
+  const themeContext = useContext(ThemeContext);
+  return (
+    <View style={[componentStyles.divider, { borderBottomColor: themeContext.dividerColor }]} />
+  );
 }

--- a/src/common/OptionDivider.js
+++ b/src/common/OptionDivider.js
@@ -1,5 +1,6 @@
 /* @flow strict-local */
 import React, { useContext } from 'react';
+import type { Node } from 'react';
 import { View } from 'react-native';
 
 import { ThemeContext, createStyleSheet } from '../styles';
@@ -10,7 +11,7 @@ const componentStyles = createStyleSheet({
   },
 });
 
-export default function OptionDivider(props: {||}) {
+export default function OptionDivider(props: {||}): Node {
   const themeContext = useContext(ThemeContext);
   return (
     <View style={[componentStyles.divider, { borderBottomColor: themeContext.dividerColor }]} />

--- a/src/common/OptionDivider.js
+++ b/src/common/OptionDivider.js
@@ -3,19 +3,21 @@ import React, { PureComponent } from 'react';
 import { View } from 'react-native';
 
 import type { ThemeData } from '../styles';
-import { ThemeContext } from '../styles';
+import { ThemeContext, createStyleSheet } from '../styles';
+
+const componentStyles = createStyleSheet({
+  divider: {
+    borderBottomWidth: 1,
+  },
+});
 
 export default class OptionDivider extends PureComponent<{||}> {
   static contextType = ThemeContext;
   context: ThemeData;
 
-  styles = {
-    divider: {
-      borderBottomWidth: 1,
-    },
-  };
-
   render() {
-    return <View style={[this.styles.divider, { borderBottomColor: this.context.dividerColor }]} />;
+    return (
+      <View style={[componentStyles.divider, { borderBottomColor: this.context.dividerColor }]} />
+    );
   }
 }

--- a/src/common/OwnAvatar.js
+++ b/src/common/OwnAvatar.js
@@ -1,5 +1,6 @@
 /* @flow strict-local */
 import React from 'react';
+import type { Node } from 'react';
 
 import { useSelector } from '../react-redux';
 import UserAvatar from './UserAvatar';
@@ -14,7 +15,7 @@ type Props = $ReadOnly<{|
  *
  * @prop size - Sets width and height in logical pixels.
  */
-export default function OwnAvatar(props: Props): React$Node {
+export default function OwnAvatar(props: Props): Node {
   const { size } = props;
   const user = useSelector(getOwnUser);
   return <UserAvatar avatarUrl={user.avatar_url} size={size} />;

--- a/src/common/PasswordInput.js
+++ b/src/common/PasswordInput.js
@@ -1,5 +1,5 @@
 /* @flow strict-local */
-import React, { PureComponent } from 'react';
+import React, { useState, useCallback } from 'react';
 import { View } from 'react-native';
 
 import Input from './Input';
@@ -29,42 +29,25 @@ type Props = $ReadOnly<$Diff<InputProps,
   // `InputProps` allows for these, don't allow them here."
   {| secureTextEntry: mixed, autoCorrect: mixed, autoCapitalize: mixed, _: mixed |}>>;
 
-type State = {|
-  isHidden: boolean,
-|};
-
 /**
  * A password input component using Input internally.
  * Provides a 'show'/'hide' button to show the password.
  *
  * All props are passed through to `Input`.  See `Input` for descriptions.
  */
-export default class PasswordInput extends PureComponent<Props, State> {
-  state = {
-    isHidden: true,
-  };
+export default function PasswordInput(props: Props) {
+  const [isHidden, setIsHidden] = useState<boolean>(true);
 
-  handleShow = () => {
-    this.setState(({ isHidden }) => ({
-      isHidden: !isHidden,
-    }));
-  };
+  const handleShow = useCallback(() => {
+    setIsHidden(prevIsHidden => !prevIsHidden);
+  }, []);
 
-  render() {
-    const { isHidden } = this.state;
-
-    return (
-      <View>
-        <Input
-          {...this.props}
-          secureTextEntry={isHidden}
-          autoCorrect={false}
-          autoCapitalize="none"
-        />
-        <Touchable style={styles.showPasswordButton} onPress={this.handleShow}>
-          <Label style={styles.showPasswordButtonText} text={isHidden ? 'show' : 'hide'} />
-        </Touchable>
-      </View>
-    );
-  }
+  return (
+    <View>
+      <Input {...props} secureTextEntry={isHidden} autoCorrect={false} autoCapitalize="none" />
+      <Touchable style={styles.showPasswordButton} onPress={handleShow}>
+        <Label style={styles.showPasswordButtonText} text={isHidden ? 'show' : 'hide'} />
+      </Touchable>
+    </View>
+  );
 }

--- a/src/common/PasswordInput.js
+++ b/src/common/PasswordInput.js
@@ -1,5 +1,6 @@
 /* @flow strict-local */
 import React, { useState, useCallback } from 'react';
+import type { Node } from 'react';
 import { View } from 'react-native';
 
 import Input from './Input';
@@ -35,7 +36,7 @@ type Props = $ReadOnly<$Diff<InputProps,
  *
  * All props are passed through to `Input`.  See `Input` for descriptions.
  */
-export default function PasswordInput(props: Props) {
+export default function PasswordInput(props: Props): Node {
   const [isHidden, setIsHidden] = useState<boolean>(true);
 
   const handleShow = useCallback(() => {

--- a/src/common/Popup.js
+++ b/src/common/Popup.js
@@ -1,6 +1,6 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
-import type { Node as React$Node } from 'react';
+import type { Node } from 'react';
 import { View } from 'react-native';
 
 import type { ThemeData } from '../styles';
@@ -19,7 +19,7 @@ const styles = createStyleSheet({
 });
 
 type Props = $ReadOnly<{|
-  children: React$Node,
+  children: Node,
 |}>;
 
 export default class Popup extends PureComponent<Props> {

--- a/src/common/Popup.js
+++ b/src/common/Popup.js
@@ -21,7 +21,7 @@ type Props = $ReadOnly<{|
   children: Node,
 |}>;
 
-export default function Popup(props: Props) {
+export default function Popup(props: Props): Node {
   const themeContext = useContext(ThemeContext);
   return (
     <View style={[{ backgroundColor: themeContext.backgroundColor }, styles.popup]}>

--- a/src/common/Popup.js
+++ b/src/common/Popup.js
@@ -1,9 +1,8 @@
 /* @flow strict-local */
-import React, { PureComponent } from 'react';
+import React, { useContext } from 'react';
 import type { Node } from 'react';
 import { View } from 'react-native';
 
-import type { ThemeData } from '../styles';
 import { ThemeContext, createStyleSheet } from '../styles';
 
 const styles = createStyleSheet({
@@ -22,15 +21,11 @@ type Props = $ReadOnly<{|
   children: Node,
 |}>;
 
-export default class Popup extends PureComponent<Props> {
-  static contextType = ThemeContext;
-  context: ThemeData;
-
-  render() {
-    return (
-      <View style={[{ backgroundColor: this.context.backgroundColor }, styles.popup]}>
-        {this.props.children}
-      </View>
-    );
-  }
+export default function Popup(props: Props) {
+  const themeContext = useContext(ThemeContext);
+  return (
+    <View style={[{ backgroundColor: themeContext.backgroundColor }, styles.popup]}>
+      {props.children}
+    </View>
+  );
 }

--- a/src/common/PresenceStatusIndicator.js
+++ b/src/common/PresenceStatusIndicator.js
@@ -1,5 +1,6 @@
 /* @flow strict-local */
 import React, { useContext } from 'react';
+import type { Node } from 'react';
 import { View } from 'react-native';
 import type { ViewStyleProp } from 'react-native/Libraries/StyleSheet/StyleSheet';
 
@@ -61,7 +62,7 @@ function MaybeOpaqueBackgroundWrapper(
   props: $ReadOnly<{|
     useOpaqueBackground: boolean,
     style?: ViewStyleProp,
-    children: React$Node,
+    children: Node,
   |}>,
 ) {
   const { useOpaqueBackground, style, children } = props;
@@ -113,7 +114,7 @@ type Props = $ReadOnly<{|
  * @prop email - email of the user whose status we are showing.
  * @prop hideIfOffline - Do not render for 'offline' state.
  */
-export default function PresenceStatusIndicator(props: Props): React$Node {
+export default function PresenceStatusIndicator(props: Props): Node {
   const { email, style, hideIfOffline, useOpaqueBackground } = props;
   const presence = useSelector(getPresence);
   const allUsersByEmail = useSelector(getAllUsersByEmail);

--- a/src/common/Screen.js
+++ b/src/common/Screen.js
@@ -1,7 +1,7 @@
 /* @flow strict-local */
 
 import React, { useContext } from 'react';
-import type { Node as React$Node } from 'react';
+import type { Node } from 'react';
 import { ScrollView } from 'react-native';
 import type { ViewStyleProp } from 'react-native/Libraries/StyleSheet/StyleSheet';
 import { SafeAreaView } from 'react-native-safe-area-context';
@@ -35,7 +35,7 @@ const componentStyles = createStyleSheet({
 
 type Props = $ReadOnly<{|
   centerContent?: boolean,
-  +children: React$Node,
+  +children: Node,
   keyboardShouldPersistTaps?: 'never' | 'always' | 'handled',
   padding?: boolean,
   scrollEnabled?: boolean,
@@ -71,7 +71,7 @@ type Props = $ReadOnly<{|
  * @prop [title] - Text shown as the title of the screen.
  *                 Required unless `search` is true.
  */
-export default function Screen(props: Props): React$Node {
+export default function Screen(props: Props): Node {
   const { backgroundColor } = useContext(ThemeContext);
   const {
     autoFocus = false,

--- a/src/common/SearchEmptyState.js
+++ b/src/common/SearchEmptyState.js
@@ -1,5 +1,6 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
+import type { Node } from 'react';
 import { View } from 'react-native';
 
 import Label from './Label';
@@ -23,7 +24,7 @@ type Props = $ReadOnly<{|
 |}>;
 
 export default class SearchEmptyState extends PureComponent<Props> {
-  render(): React$Node {
+  render(): Node {
     const { text } = this.props;
 
     return (

--- a/src/common/SearchInput.js
+++ b/src/common/SearchInput.js
@@ -1,5 +1,5 @@
 /* @flow strict-local */
-import React, { PureComponent } from 'react';
+import React from 'react';
 import { View } from 'react-native';
 import InputWithClearButton from './InputWithClearButton';
 import { createStyleSheet } from '../styles';
@@ -18,7 +18,7 @@ const styles = createStyleSheet({
 });
 
 type Props = $ReadOnly<{|
-  autoFocus: boolean,
+  autoFocus?: boolean,
   onChangeText: (text: string) => void,
 |}>;
 
@@ -29,29 +29,23 @@ type Props = $ReadOnly<{|
  * @prop [autoFocus] - should the component be focused when mounted.
  * @prop onChangeText - Event called when search query is edited.
  */
-export default class SearchInput extends PureComponent<Props> {
-  static defaultProps = {
-    autoFocus: true,
-  };
+export default function SearchInput(props: Props) {
+  const { autoFocus = true, onChangeText } = props;
 
-  render() {
-    const { autoFocus, onChangeText } = this.props;
-
-    return (
-      <View style={styles.wrapper}>
-        <InputWithClearButton
-          style={styles.input}
-          autoCorrect={false}
-          enablesReturnKeyAutomatically
-          selectTextOnFocus
-          underlineColorAndroid="transparent"
-          autoCapitalize="none"
-          placeholder="Search"
-          returnKeyType="search"
-          onChangeText={onChangeText}
-          autoFocus={autoFocus}
-        />
-      </View>
-    );
-  }
+  return (
+    <View style={styles.wrapper}>
+      <InputWithClearButton
+        style={styles.input}
+        autoCorrect={false}
+        enablesReturnKeyAutomatically
+        selectTextOnFocus
+        underlineColorAndroid="transparent"
+        autoCapitalize="none"
+        placeholder="Search"
+        returnKeyType="search"
+        onChangeText={onChangeText}
+        autoFocus={autoFocus}
+      />
+    </View>
+  );
 }

--- a/src/common/SearchInput.js
+++ b/src/common/SearchInput.js
@@ -1,5 +1,6 @@
 /* @flow strict-local */
 import React from 'react';
+import type { Node } from 'react';
 import { View } from 'react-native';
 import InputWithClearButton from './InputWithClearButton';
 import { createStyleSheet } from '../styles';
@@ -29,7 +30,7 @@ type Props = $ReadOnly<{|
  * @prop [autoFocus] - should the component be focused when mounted.
  * @prop onChangeText - Event called when search query is edited.
  */
-export default function SearchInput(props: Props) {
+export default function SearchInput(props: Props): Node {
   const { autoFocus = true, onChangeText } = props;
 
   return (

--- a/src/common/SectionSeparator.js
+++ b/src/common/SectionSeparator.js
@@ -1,5 +1,6 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
+import type { Node } from 'react';
 import { View } from 'react-native';
 
 import { createStyleSheet } from '../styles';
@@ -13,7 +14,7 @@ const styles = createStyleSheet({
 });
 
 export default class SectionSeparator extends PureComponent<{||}> {
-  render(): React$Node {
+  render(): Node {
     return <View style={styles.separator} />;
   }
 }

--- a/src/common/SectionSeparatorBetween.js
+++ b/src/common/SectionSeparatorBetween.js
@@ -1,5 +1,6 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
+import type { Node } from 'react';
 import SectionSeparator from './SectionSeparator';
 
 /*
@@ -13,7 +14,7 @@ type Props = $ReadOnly<{|
 
 /** Can be passed to RN's `SectionList` as `SectionSeparatorComponent`. */
 export default class SectionSeparatorBetween extends PureComponent<Props> {
-  render(): React$Node {
+  render(): Node {
     const { leadingItem, leadingSection } = this.props;
 
     if (leadingItem || !leadingSection || leadingSection.data.length === 0) {

--- a/src/common/SelectableOptionRow.js
+++ b/src/common/SelectableOptionRow.js
@@ -1,5 +1,6 @@
 /* @flow strict-local */
 import React from 'react';
+import type { Node } from 'react';
 import { View } from 'react-native';
 
 import { RawLabel, Touchable } from '.';
@@ -58,7 +59,7 @@ type Props<TItemKey: string | number> = $ReadOnly<{|
  */
 export default function SelectableOptionRow<TItemKey: string | number>(
   props: Props<TItemKey>,
-): React$Node {
+): Node {
   const { itemKey, title, subtitle, selected, onRequestSelectionChange } = props;
 
   return (

--- a/src/common/ServerCompatBanner.js
+++ b/src/common/ServerCompatBanner.js
@@ -1,6 +1,7 @@
 /* @flow strict-local */
 
 import React from 'react';
+import type { Node } from 'react';
 import { View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
@@ -49,7 +50,7 @@ type Props = $ReadOnly<{||}>;
 // https://material.io/components/banners. Please consult that before making
 // layout changes, and try to make them in a direction that brings us closer
 // to those guidelines.
-export default function ServerCompatBanner(props: Props): React$Node {
+export default function ServerCompatBanner(props: Props): Node {
   const dispatch = useDispatch();
   const hasDismissedServerCompatNotice = useSelector(
     state => getSession(state).hasDismissedServerCompatNotice,

--- a/src/common/SmartUrlInput.js
+++ b/src/common/SmartUrlInput.js
@@ -95,8 +95,10 @@ export default class SmartUrlInput extends PureComponent<Props, State> {
   handleChange = (value: string) => {
     this.setState({ value });
 
-    const { onChangeText, defaultProtocol: protocol, defaultDomain: domain } = this.props;
-    onChangeText(fixRealmUrl(autocompleteRealm(value, { protocol, domain })));
+    const { onChangeText, defaultProtocol, defaultDomain } = this.props;
+    onChangeText(
+      fixRealmUrl(autocompleteRealm(value, { protocol: defaultProtocol, domain: defaultDomain })),
+    );
   };
 
   urlPress = () => {

--- a/src/common/SmartUrlInput.js
+++ b/src/common/SmartUrlInput.js
@@ -1,5 +1,6 @@
 /* @flow strict-local */
 import React, { useState, useRef, useCallback, useContext } from 'react';
+import type { Node } from 'react';
 import { TextInput, TouchableWithoutFeedback, View } from 'react-native';
 import { useFocusEffect } from '@react-navigation/native';
 import type { ViewStyleProp } from 'react-native/Libraries/StyleSheet/StyleSheet';
@@ -54,7 +55,7 @@ type Props = $ReadOnly<{|
   enablesReturnKeyAutomatically: boolean,
 |}>;
 
-export default function SmartUrlInput(props: Props) {
+export default function SmartUrlInput(props: Props): Node {
   const {
     defaultProtocol,
     defaultOrganization,

--- a/src/common/SmartUrlInput.js
+++ b/src/common/SmartUrlInput.js
@@ -1,6 +1,7 @@
 /* @flow strict-local */
-import React, { useState, useRef, useCallback, useContext, useEffect } from 'react';
+import React, { useState, useRef, useCallback, useContext } from 'react';
 import { TextInput, TouchableWithoutFeedback, View } from 'react-native';
+import { useFocusEffect } from '@react-navigation/native';
 import type { ViewStyleProp } from 'react-native/Libraries/StyleSheet/StyleSheet';
 
 import type { AppNavigationProp } from '../nav/AppNavigator';
@@ -62,7 +63,6 @@ export default function SmartUrlInput(props: Props) {
     onChangeText,
     onSubmitEditing,
     enablesReturnKeyAutomatically,
-    navigation,
   } = props;
 
   // We should replace the fixme with
@@ -70,8 +70,6 @@ export default function SmartUrlInput(props: Props) {
   // would make `.current` be `any(implicit)`, which we don't want;
   // this is probably down to bugs in Flow's special support for React.
   const textInputRef = useRef<$FlowFixMe>();
-
-  const unsubscribeFocusListener = useRef<(() => void) | void>(undefined);
 
   /**
    * The actual input string, exactly as entered by the user,
@@ -81,20 +79,14 @@ export default function SmartUrlInput(props: Props) {
 
   const themeContext = useContext(ThemeContext);
 
-  const { addListener } = navigation;
-  useEffect(() => {
-    unsubscribeFocusListener.current = addListener('focus', () => {
+  useFocusEffect(
+    useCallback(() => {
       if (textInputRef.current) {
         // `.current` is not type-checked; see definition.
         textInputRef.current.focus();
       }
-    });
-    return () => {
-      if (unsubscribeFocusListener.current) {
-        unsubscribeFocusListener.current();
-      }
-    };
-  }, [addListener]);
+    }, []),
+  );
 
   const handleChange = useCallback(
     (_value: string) => {

--- a/src/common/SmartUrlInput.js
+++ b/src/common/SmartUrlInput.js
@@ -79,6 +79,9 @@ export default function SmartUrlInput(props: Props) {
 
   const themeContext = useContext(ThemeContext);
 
+  // When the route is focused in the navigation, focus the input.
+  // Otherwise, if you go back to this screen from the auth screen, the
+  // input won't be focused.
   useFocusEffect(
     useCallback(() => {
       if (textInputRef.current) {

--- a/src/common/SpinningProgress.js
+++ b/src/common/SpinningProgress.js
@@ -1,5 +1,6 @@
 /* @flow strict-local */
 import React from 'react';
+import type { Node } from 'react';
 import { Image } from 'react-native';
 
 import AnimatedRotateComponent from '../animation/AnimatedRotateComponent';
@@ -22,7 +23,7 @@ type Props = $ReadOnly<{|
  * @prop size - Diameter of the circle in pixels.
  */
 export default class SpinningProgress extends React.PureComponent<Props> {
-  render(): React$Node {
+  render(): Node {
     const { color, size } = this.props;
     const style = { width: size, height: size };
     const source = (() => {

--- a/src/common/SwitchRow.js
+++ b/src/common/SwitchRow.js
@@ -7,7 +7,7 @@ import type { SpecificIconType } from './Icons';
 import Label from './Label';
 import ZulipSwitch from './ZulipSwitch';
 import type { ThemeData } from '../styles';
-import styles, { ThemeContext } from '../styles';
+import styles, { ThemeContext, createStyleSheet } from '../styles';
 
 type Props = $ReadOnly<{|
   Icon?: SpecificIconType,
@@ -17,6 +17,12 @@ type Props = $ReadOnly<{|
   onValueChange: (newValue: boolean) => void,
 |}>;
 
+const componentStyles = createStyleSheet({
+  container: {
+    height: 56,
+  },
+});
+
 /**
  * A row with a label and a switch component.
  */
@@ -24,17 +30,11 @@ export default class SwitchRow extends PureComponent<Props> {
   static contextType = ThemeContext;
   context: ThemeData;
 
-  styles = {
-    container: {
-      height: 56,
-    },
-  };
-
   render() {
     const { label, value, onValueChange, style, Icon } = this.props;
 
     return (
-      <View style={[this.styles.container, styles.listItem, style]}>
+      <View style={[componentStyles.container, styles.listItem, style]}>
         {!!Icon && <Icon size={24} style={[styles.settingsIcon, { color: this.context.color }]} />}
         <Label text={label} style={styles.flexed} />
         <View style={styles.rightItem}>

--- a/src/common/SwitchRow.js
+++ b/src/common/SwitchRow.js
@@ -1,5 +1,6 @@
 /* @flow strict-local */
 import React, { useContext } from 'react';
+import type { Node } from 'react';
 import { View } from 'react-native';
 import type { ViewStyleProp } from 'react-native/Libraries/StyleSheet/StyleSheet';
 
@@ -25,7 +26,7 @@ const componentStyles = createStyleSheet({
 /**
  * A row with a label and a switch component.
  */
-export default function SwitchRow(props: Props) {
+export default function SwitchRow(props: Props): Node {
   const { label, value, onValueChange, style, Icon } = props;
 
   const themeContext = useContext(ThemeContext);

--- a/src/common/SwitchRow.js
+++ b/src/common/SwitchRow.js
@@ -1,12 +1,11 @@
 /* @flow strict-local */
-import React, { PureComponent } from 'react';
+import React, { useContext } from 'react';
 import { View } from 'react-native';
 import type { ViewStyleProp } from 'react-native/Libraries/StyleSheet/StyleSheet';
 
 import type { SpecificIconType } from './Icons';
 import Label from './Label';
 import ZulipSwitch from './ZulipSwitch';
-import type { ThemeData } from '../styles';
 import styles, { ThemeContext, createStyleSheet } from '../styles';
 
 type Props = $ReadOnly<{|
@@ -26,21 +25,18 @@ const componentStyles = createStyleSheet({
 /**
  * A row with a label and a switch component.
  */
-export default class SwitchRow extends PureComponent<Props> {
-  static contextType = ThemeContext;
-  context: ThemeData;
+export default function SwitchRow(props: Props) {
+  const { label, value, onValueChange, style, Icon } = props;
 
-  render() {
-    const { label, value, onValueChange, style, Icon } = this.props;
+  const themeContext = useContext(ThemeContext);
 
-    return (
-      <View style={[componentStyles.container, styles.listItem, style]}>
-        {!!Icon && <Icon size={24} style={[styles.settingsIcon, { color: this.context.color }]} />}
-        <Label text={label} style={styles.flexed} />
-        <View style={styles.rightItem}>
-          <ZulipSwitch value={value} onValueChange={onValueChange} />
-        </View>
+  return (
+    <View style={[componentStyles.container, styles.listItem, style]}>
+      {!!Icon && <Icon size={24} style={[styles.settingsIcon, { color: themeContext.color }]} />}
+      <Label text={label} style={styles.flexed} />
+      <View style={styles.rightItem}>
+        <ZulipSwitch value={value} onValueChange={onValueChange} />
       </View>
-    );
-  }
+    </View>
+  );
 }

--- a/src/common/Touchable.js
+++ b/src/common/Touchable.js
@@ -1,15 +1,15 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
+import type { Node } from 'react';
 import { TouchableHighlight, TouchableNativeFeedback, Platform, View } from 'react-native';
 import type { ViewStyleProp } from 'react-native/Libraries/StyleSheet/StyleSheet';
 
-import type { Node as React$Node } from 'react';
 import { HIGHLIGHT_COLOR } from '../styles';
 
 type Props = $ReadOnly<{|
   accessibilityLabel?: string,
   style?: ViewStyleProp,
-  children: React$Node,
+  children: Node,
   onPress?: () => void | Promise<void>,
   onLongPress?: () => void,
 |}>;
@@ -48,9 +48,9 @@ type Props = $ReadOnly<{|
  * @prop [onLongPress] - Passed through; see upstream docs.
  */
 export default class Touchable extends PureComponent<Props> {
-  render(): React$Node {
+  render(): Node {
     const { accessibilityLabel, style, onPress, onLongPress } = this.props;
-    const child: React$Node = React.Children.only(this.props.children);
+    const child: Node = React.Children.only(this.props.children);
 
     if (!onPress && !onLongPress) {
       return (

--- a/src/common/TranslatedText.js
+++ b/src/common/TranslatedText.js
@@ -1,5 +1,6 @@
 /* @flow strict-local */
 import React from 'react';
+import type { Node } from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import type { LocalizableText } from '../types';
@@ -14,7 +15,7 @@ type Props = $ReadOnly<{|
  *
  * @prop text - The text to be translated.
  */
-export default ({ text }: Props): React$Node => {
+export default ({ text }: Props): Node => {
   const message = typeof text === 'object' ? text.text : text;
   const values = typeof text === 'object' ? text.values : undefined;
 

--- a/src/common/UnreadCount.js
+++ b/src/common/UnreadCount.js
@@ -1,5 +1,6 @@
 /* @flow strict-local */
 import React from 'react';
+import type { Node } from 'react';
 import { Text, View } from 'react-native';
 import type { ViewStyleProp } from 'react-native/Libraries/StyleSheet/StyleSheet';
 
@@ -54,7 +55,7 @@ type Props = $ReadOnly<{|
  * @prop [inverse] - Indicate if styling should be inverted (dark on light).
  * @prop [limited] - If set values over 100 will display as `99+`.
  */
-export default function UnreadCount(props: Props) {
+export default function UnreadCount(props: Props): Node {
   const {
     style,
     isMuted = false,

--- a/src/common/UnreadCount.js
+++ b/src/common/UnreadCount.js
@@ -31,6 +31,7 @@ const styles = createStyleSheet({
   },
 });
 
+// TODO: Not all of these are used; can we tidy up?
 type Props = $ReadOnly<{|
   style?: ViewStyleProp,
   borderRadius?: number,

--- a/src/common/UnreadCount.js
+++ b/src/common/UnreadCount.js
@@ -1,5 +1,5 @@
 /* @flow strict-local */
-import React, { PureComponent } from 'react';
+import React from 'react';
 import { Text, View } from 'react-native';
 import type { ViewStyleProp } from 'react-native/Libraries/StyleSheet/StyleSheet';
 
@@ -33,12 +33,12 @@ const styles = createStyleSheet({
 
 type Props = $ReadOnly<{|
   style?: ViewStyleProp,
-  borderRadius: number,
-  color: string,
-  count: number,
-  isMuted: boolean,
-  inverse: boolean,
-  limited: boolean,
+  borderRadius?: number,
+  color?: string,
+  count?: number,
+  isMuted?: boolean,
+  inverse?: boolean,
+  limited?: boolean,
 |}>;
 
 /**
@@ -53,42 +53,39 @@ type Props = $ReadOnly<{|
  * @prop [inverse] - Indicate if styling should be inverted (dark on light).
  * @prop [limited] - If set values over 100 will display as `99+`.
  */
-export default class UnreadCount extends PureComponent<Props> {
-  static defaultProps = {
-    borderRadius: 2,
-    color: BRAND_COLOR,
-    count: 0,
-    isMuted: false,
-    inverse: false,
-    limited: false,
-  };
+export default function UnreadCount(props: Props) {
+  const {
+    style,
+    isMuted = false,
+    borderRadius = 2,
+    color = BRAND_COLOR,
+    count = 0,
+    inverse = false,
+    limited = false,
+  } = props;
 
-  render() {
-    const { style, isMuted, borderRadius, color, count, inverse, limited } = this.props;
-
-    if (!count) {
-      return null;
-    }
-
-    const frameStyle = [
-      styles.frame,
-      inverse && styles.frameInverse,
-      isMuted && styles.frameMuted,
-      { borderRadius },
-      { backgroundColor: color },
-      style,
-    ];
-
-    const textColor = foregroundColorFromBackground(color);
-    const textStyle = [styles.text, inverse && styles.textInverse, { color: textColor }];
-
-    const countString = limited && count >= 100 ? '99+' : count.toString();
-    return (
-      <View style={frameStyle}>
-        <Text style={textStyle} numberOfLines={1}>
-          {countString}
-        </Text>
-      </View>
-    );
+  if (!count) {
+    return null;
   }
+
+  const frameStyle = [
+    styles.frame,
+    inverse && styles.frameInverse,
+    isMuted && styles.frameMuted,
+    { borderRadius },
+    { backgroundColor: color },
+    style,
+  ];
+
+  const textColor = foregroundColorFromBackground(color);
+  const textStyle = [styles.text, inverse && styles.textInverse, { color: textColor }];
+
+  const countString = limited && count >= 100 ? '99+' : count.toString();
+  return (
+    <View style={frameStyle}>
+      <Text style={textStyle} numberOfLines={1}>
+        {countString}
+      </Text>
+    </View>
+  );
 }

--- a/src/common/UserAvatar.js
+++ b/src/common/UserAvatar.js
@@ -1,5 +1,6 @@
 /* @flow strict-local */
-import React, { type Node as React$Node, useContext } from 'react';
+import React, { useContext } from 'react';
+import type { Node } from 'react';
 import { Image, View, PixelRatio } from 'react-native';
 
 import { useSelector } from '../react-redux';
@@ -14,7 +15,7 @@ type Props = $ReadOnly<{|
   avatarUrl: AvatarURL,
   size: number,
   isMuted?: boolean,
-  children?: React$Node,
+  children?: Node,
   onPress?: () => void,
 |}>;
 
@@ -26,7 +27,7 @@ type Props = $ReadOnly<{|
  * @prop [children] - If provided, will render inside the component body.
  * @prop [onPress] - Event fired on pressing the component.
  */
-function UserAvatar(props: Props): React$Node {
+function UserAvatar(props: Props): Node {
   const { avatarUrl, children, size, isMuted = false, onPress } = props;
   const borderRadius = size / 8;
   const style = {

--- a/src/common/UserAvatarWithPresence.js
+++ b/src/common/UserAvatarWithPresence.js
@@ -1,5 +1,6 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
+import type { Node } from 'react';
 
 import type { UserId } from '../types';
 import { createStyleSheet } from '../styles';
@@ -38,7 +39,7 @@ type Props = $ReadOnly<{|
  * @prop [onPress] - Event fired on pressing the component.
  */
 export default class UserAvatarWithPresence extends PureComponent<Props> {
-  render(): React$Node {
+  render(): Node {
     const { avatarUrl, email, isMuted, size, onPress } = this.props;
 
     return (
@@ -69,7 +70,7 @@ export function UserAvatarWithPresenceById(
     ...$Diff<Props, {| avatarUrl: mixed, email: mixed |}>,
     userId: UserId,
   |}>,
-): React$Node {
+): Node {
   const { userId, ...restProps } = props;
 
   const user = useSelector(state => tryGetUserForId(state, userId));

--- a/src/common/ViewPlaceholder.js
+++ b/src/common/ViewPlaceholder.js
@@ -1,5 +1,6 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
+import type { Node } from 'react';
 import { View } from 'react-native';
 
 type Props = $ReadOnly<{|
@@ -16,7 +17,7 @@ type Props = $ReadOnly<{|
  * @prop [height] - Height of the component in pixels.
  */
 export default class ViewPlaceholder extends PureComponent<Props> {
-  render(): React$Node {
+  render(): Node {
     const { width, height } = this.props;
     const style = { width, height };
     return <View style={style} />;

--- a/src/common/WebLink.js
+++ b/src/common/WebLink.js
@@ -1,6 +1,7 @@
 /* @flow strict-local */
 
 import React from 'react';
+import type { Node } from 'react';
 
 import Label from './Label';
 import { openLinkEmbedded } from '../utils/openLink';
@@ -20,7 +21,7 @@ const componentStyles = createStyleSheet({
 /**
  * A button styled like a web link.
  */
-export default function WebLink(props: Props): React$Node {
+export default function WebLink(props: Props): Node {
   return (
     <Label
       style={componentStyles.link}

--- a/src/common/ZulipButton.js
+++ b/src/common/ZulipButton.js
@@ -1,5 +1,6 @@
 /* @flow strict-local */
 import React from 'react';
+import type { Node } from 'react';
 import { Text, View, ActivityIndicator } from 'react-native';
 import type { TextStyle, ViewStyle } from 'react-native/Libraries/StyleSheet/StyleSheet';
 import TranslatedText from './TranslatedText';
@@ -121,7 +122,7 @@ type Props = $ReadOnly<{|
  * @prop [secondary] - Less prominent styling, the button is not as important.
  * @prop onPress - Event called on button press.
  */
-export default function ZulipButton(props: Props) {
+export default function ZulipButton(props: Props): Node {
   const {
     style,
     text,

--- a/src/common/ZulipButton.js
+++ b/src/common/ZulipButton.js
@@ -1,5 +1,5 @@
 /* @flow strict-local */
-import React, { PureComponent } from 'react';
+import React from 'react';
 import { Text, View, ActivityIndicator } from 'react-native';
 import type { TextStyle, ViewStyle } from 'react-native/Libraries/StyleSheet/StyleSheet';
 import TranslatedText from './TranslatedText';
@@ -97,11 +97,11 @@ type Props = $ReadOnly<{|
     |},
   >,
   textStyle?: SubsetProperties<TextStyle, {| color?: mixed |}>,
-  progress: boolean,
-  disabled: boolean,
+  progress?: boolean,
+  disabled?: boolean,
   Icon?: SpecificIconType,
   text: LocalizableText,
-  secondary: boolean,
+  secondary?: boolean,
   onPress: () => void | Promise<void>,
 |}>;
 
@@ -121,54 +121,54 @@ type Props = $ReadOnly<{|
  * @prop [secondary] - Less prominent styling, the button is not as important.
  * @prop onPress - Event called on button press.
  */
-export default class ZulipButton extends PureComponent<Props> {
-  static defaultProps = {
-    secondary: false,
-    disabled: false,
-    progress: false,
-  };
+export default function ZulipButton(props: Props) {
+  const {
+    style,
+    text,
+    disabled = false,
+    secondary = false,
+    progress = false,
+    onPress,
+    Icon,
+  } = props;
+  const frameStyle = [
+    styles.frame,
+    // Prettier bug on nested ternary
+    /* prettier-ignore */
+    disabled
+      ? secondary
+        ? styles.disabledSecondaryFrame
+        : styles.disabledPrimaryFrame
+      : secondary
+        ? styles.secondaryFrame
+        : styles.primaryFrame,
+    style,
+  ];
+  const textStyle = [
+    styles.text,
+    disabled ? styles.disabledText : secondary ? styles.secondaryText : styles.primaryText,
+    props.textStyle,
+  ];
+  const iconStyle = [styles.icon, secondary ? styles.secondaryIcon : styles.primaryIcon];
 
-  render() {
-    const { style, text, disabled, secondary, progress, onPress, Icon } = this.props;
-    const frameStyle = [
-      styles.frame,
-      // Prettier bug on nested ternary
-      /* prettier-ignore */
-      disabled
-        ? secondary
-          ? styles.disabledSecondaryFrame
-          : styles.disabledPrimaryFrame
-        : secondary
-          ? styles.secondaryFrame
-          : styles.primaryFrame,
-      style,
-    ];
-    const textStyle = [
-      styles.text,
-      disabled ? styles.disabledText : secondary ? styles.secondaryText : styles.primaryText,
-      this.props.textStyle,
-    ];
-    const iconStyle = [styles.icon, secondary ? styles.secondaryIcon : styles.primaryIcon];
-
-    if (progress) {
-      return (
-        <View style={frameStyle}>
-          <ActivityIndicator color="white" />
-        </View>
-      );
-    }
-
+  if (progress) {
     return (
       <View style={frameStyle}>
-        <Touchable onPress={disabled ? undefined : onPress}>
-          <View style={styles.buttonContent}>
-            {!!Icon && <Icon style={iconStyle} size={25} />}
-            <Text style={textStyle}>
-              <TranslatedText text={text} />
-            </Text>
-          </View>
-        </Touchable>
+        <ActivityIndicator color="white" />
       </View>
     );
   }
+
+  return (
+    <View style={frameStyle}>
+      <Touchable onPress={disabled ? undefined : onPress}>
+        <View style={styles.buttonContent}>
+          {!!Icon && <Icon style={iconStyle} size={25} />}
+          <Text style={textStyle}>
+            <TranslatedText text={text} />
+          </Text>
+        </View>
+      </Touchable>
+    </View>
+  );
 }

--- a/src/common/ZulipSwitch.js
+++ b/src/common/ZulipSwitch.js
@@ -1,12 +1,12 @@
 /* @flow strict-local */
-import React, { PureComponent } from 'react';
+import React from 'react';
 import { Switch } from 'react-native';
 // $FlowFixMe[untyped-import]
 import Color from 'color';
 import { BRAND_COLOR } from '../styles';
 
 type Props = $ReadOnly<{|
-  disabled: boolean,
+  disabled?: boolean,
   value: boolean,
   onValueChange: (arg: boolean) => void,
 |}>;
@@ -19,39 +19,33 @@ type Props = $ReadOnly<{|
  * @prop value - value of the switch.
  * @prop onValueChange - Event called on switch.
  */
-export default class ZulipSwitch extends PureComponent<Props> {
-  static defaultProps = {
-    disabled: false,
-  };
-
-  render() {
-    const { disabled, onValueChange, value } = this.props;
-    return (
-      <Switch
-        value={value}
-        trackColor={{
-          false: 'hsl(0, 0%, 86%)',
-          true: Color(BRAND_COLOR)
-            .fade(0.3)
-            .toString(),
-        }}
-        thumbColor={
-          /* eslint-disable operator-linebreak */
-          value
-            ? // Material design would actually have this be a secondary
-              // color, not a primary color. See "Thumb attributes" at
-              // this doc:
-              //   https://material.io/components/switches/android#anatomy-and-key-properties
-              BRAND_COLOR
-            : // Material design would have this be `colorSurface`
-              // (see above-linked doc), which defaults to `#FFFFFF`,
-              // at least in light mode; see
-              //   https://material.io/develop/android/theming/color.
-              '#FFFFFF'
-        }
-        onValueChange={onValueChange}
-        disabled={disabled}
-      />
-    );
-  }
+export default function ZulipSwitch(props: Props) {
+  const { disabled = false, onValueChange, value } = props;
+  return (
+    <Switch
+      value={value}
+      trackColor={{
+        false: 'hsl(0, 0%, 86%)',
+        true: Color(BRAND_COLOR)
+          .fade(0.3)
+          .toString(),
+      }}
+      thumbColor={
+        /* eslint-disable operator-linebreak */
+        value
+          ? // Material design would actually have this be a secondary
+            // color, not a primary color. See "Thumb attributes" at
+            // this doc:
+            //   https://material.io/components/switches/android#anatomy-and-key-properties
+            BRAND_COLOR
+          : // Material design would have this be `colorSurface`
+            // (see above-linked doc), which defaults to `#FFFFFF`,
+            // at least in light mode; see
+            //   https://material.io/develop/android/theming/color.
+            '#FFFFFF'
+      }
+      onValueChange={onValueChange}
+      disabled={disabled}
+    />
+  );
 }

--- a/src/common/ZulipSwitch.js
+++ b/src/common/ZulipSwitch.js
@@ -1,5 +1,6 @@
 /* @flow strict-local */
 import React from 'react';
+import type { Node } from 'react';
 import { Switch } from 'react-native';
 // $FlowFixMe[untyped-import]
 import Color from 'color';
@@ -19,7 +20,7 @@ type Props = $ReadOnly<{|
  * @prop value - value of the switch.
  * @prop onValueChange - Event called on switch.
  */
-export default function ZulipSwitch(props: Props) {
+export default function ZulipSwitch(props: Props): Node {
   const { disabled = false, onValueChange, value } = props;
   return (
     <Switch

--- a/src/common/ZulipTextButton.js
+++ b/src/common/ZulipTextButton.js
@@ -1,5 +1,6 @@
 /* @flow strict-local */
 import React, { useMemo } from 'react';
+import type { Node } from 'react';
 import { View } from 'react-native';
 
 import type { LocalizableText } from '../types';
@@ -97,7 +98,7 @@ type Props = $ReadOnly<{|
 // (https://callstack.github.io/react-native-paper/button.html), encoding
 // things like project-specific styles and making any sensible adjustments
 // to the interface.
-export default function ZulipTextButton(props: Props): React$Node {
+export default function ZulipTextButton(props: Props): Node {
   const { variant = 'standard', leftMargin, rightMargin, label, onPress } = props;
 
   const variantStyles = useMemo(() => styleSheetForVariant(variant), [variant]);

--- a/src/diagnostics/DiagnosticsScreen.js
+++ b/src/diagnostics/DiagnosticsScreen.js
@@ -1,6 +1,7 @@
 /* @flow strict-local */
 
 import React, { PureComponent } from 'react';
+import type { Node } from 'react';
 import { nativeApplicationVersion } from 'expo-application';
 
 import type { RouteProp } from '../react-navigation';
@@ -28,7 +29,7 @@ type Props = $ReadOnly<{|
 |}>;
 
 export default class DiagnosticsScreen extends PureComponent<Props> {
-  render(): React$Node {
+  render(): Node {
     return (
       <Screen title="Diagnostics">
         <RawLabel style={styles.versionLabel} text={`v${nativeApplicationVersion ?? '?.?.?'}`} />

--- a/src/diagnostics/InfoItem.js
+++ b/src/diagnostics/InfoItem.js
@@ -1,5 +1,6 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
+import type { Node } from 'react';
 import { View } from 'react-native';
 
 import { RawLabel } from '../common';
@@ -26,7 +27,7 @@ type Props = $ReadOnly<{|
 |}>;
 
 export default class InfoItem extends PureComponent<Props> {
-  render(): React$Node {
+  render(): Node {
     const { label, value } = this.props;
 
     return (

--- a/src/diagnostics/SizeItem.js
+++ b/src/diagnostics/SizeItem.js
@@ -1,5 +1,6 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
+import type { Node } from 'react';
 import { View } from 'react-native';
 
 import { RawLabel } from '../common';
@@ -26,7 +27,7 @@ type Props = $ReadOnly<{|
 |}>;
 
 export default class SizeItem extends PureComponent<Props> {
-  render(): React$Node {
+  render(): Node {
     const { text, size } = this.props;
 
     return (

--- a/src/diagnostics/StorageScreen.js
+++ b/src/diagnostics/StorageScreen.js
@@ -1,6 +1,7 @@
 /* @flow strict-local */
 
 import React from 'react';
+import type { Node } from 'react';
 import { FlatList } from 'react-native';
 
 import type { RouteProp } from '../react-navigation';
@@ -22,7 +23,7 @@ type Props = $ReadOnly<{|
   route: RouteProp<'storage', void>,
 |}>;
 
-export default function StorageScreen(props: Props): React$Node {
+export default function StorageScreen(props: Props): Node {
   const state = useSelector(s => s);
   const storageSizes = calculateKeyStorageSizes(state);
 

--- a/src/diagnostics/TimeItem.js
+++ b/src/diagnostics/TimeItem.js
@@ -1,5 +1,6 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
+import type { Node } from 'react';
 import { View } from 'react-native';
 import format from 'date-fns/format';
 import type { TimingItemType } from '../types';
@@ -25,7 +26,7 @@ const styles = createStyleSheet({
 export default class TimeItem extends PureComponent<TimingItemType> {
   props: TimingItemType;
 
-  render(): React$Node {
+  render(): Node {
     const { text, startMs, endMs } = this.props;
     const startStr = format(startMs, 'HH:mm:ss.S'); // eslint-disable-line
     const durationStrMs = numberWithSeparators(endMs - startMs);

--- a/src/diagnostics/TimingScreen.js
+++ b/src/diagnostics/TimingScreen.js
@@ -1,5 +1,6 @@
 /* @flow strict-local */
 import React from 'react';
+import type { Node } from 'react';
 import { FlatList } from 'react-native';
 
 import type { RouteProp } from '../react-navigation';
@@ -13,7 +14,7 @@ type Props = $ReadOnly<{|
   route: RouteProp<'timing', void>,
 |}>;
 
-export default function TimingScreen(props: Props): React$Node {
+export default function TimingScreen(props: Props): Node {
   return (
     <Screen title="Timing" scrollEnabled={false}>
       <FlatList

--- a/src/diagnostics/VariablesScreen.js
+++ b/src/diagnostics/VariablesScreen.js
@@ -1,5 +1,6 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
+import type { Node } from 'react';
 import { FlatList } from 'react-native';
 
 import type { RouteProp } from '../react-navigation';
@@ -14,7 +15,7 @@ type Props = $ReadOnly<{|
 |}>;
 
 export default class VariablesScreen extends PureComponent<Props> {
-  render(): React$Node {
+  render(): Node {
     const variables = {
       enableReduxLogging: config.enableReduxLogging,
       enableReduxSlowReducerWarnings: config.enableReduxSlowReducerWarnings,

--- a/src/emoji/EmojiRow.js
+++ b/src/emoji/EmojiRow.js
@@ -1,5 +1,5 @@
 /* @flow strict-local */
-import React, { PureComponent } from 'react';
+import React, { useCallback } from 'react';
 import { View } from 'react-native';
 
 import type { EmojiType } from '../types';
@@ -25,22 +25,19 @@ type Props = $ReadOnly<{|
   onPress: (name: string) => void,
 |}>;
 
-export default class EmojiRow extends PureComponent<Props> {
-  handlePress = () => {
-    const { name, onPress } = this.props;
+export default function EmojiRow(props: Props) {
+  const { code, name, type, onPress } = props;
+
+  const handlePress = useCallback(() => {
     onPress(name);
-  };
+  }, [onPress, name]);
 
-  render() {
-    const { code, name, type } = this.props;
-
-    return (
-      <Touchable onPress={this.handlePress}>
-        <View style={styles.emojiRow}>
-          <Emoji code={code} type={type} />
-          <RawLabel style={styles.text} text={name} />
-        </View>
-      </Touchable>
-    );
-  }
+  return (
+    <Touchable onPress={handlePress}>
+      <View style={styles.emojiRow}>
+        <Emoji code={code} type={type} />
+        <RawLabel style={styles.text} text={name} />
+      </View>
+    </Touchable>
+  );
 }

--- a/src/emoji/EmojiRow.js
+++ b/src/emoji/EmojiRow.js
@@ -1,5 +1,6 @@
 /* @flow strict-local */
 import React, { useCallback } from 'react';
+import type { Node } from 'react';
 import { View } from 'react-native';
 
 import type { EmojiType } from '../types';
@@ -25,7 +26,7 @@ type Props = $ReadOnly<{|
   onPress: (name: string) => void,
 |}>;
 
-export default function EmojiRow(props: Props) {
+export default function EmojiRow(props: Props): Node {
   const { code, name, type, onPress } = props;
 
   const handlePress = useCallback(() => {

--- a/src/lightbox/Lightbox.js
+++ b/src/lightbox/Lightbox.js
@@ -1,6 +1,7 @@
 /* @flow strict-local */
 
 import React, { useState, useCallback } from 'react';
+import type { Node } from 'react';
 import { View, Dimensions, LayoutAnimation } from 'react-native';
 // $FlowFixMe[untyped-import]
 import PhotoView from 'react-native-photo-view';
@@ -44,7 +45,7 @@ type Props = $ReadOnly<{|
   message: Message,
 |}>;
 
-export default function Lightbox(props: Props): React$Node {
+export default function Lightbox(props: Props): Node {
   const [headerFooterVisible, setHeaderFooterVisible] = useState<boolean>(true);
   const showActionSheetWithOptions: ShowActionSheetWithOptions = useActionSheet()
     .showActionSheetWithOptions;

--- a/src/lightbox/LightboxFooter.js
+++ b/src/lightbox/LightboxFooter.js
@@ -1,5 +1,6 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
+import type { Node } from 'react';
 import { Text, View, Pressable } from 'react-native';
 import type { ViewStyleProp } from 'react-native/Libraries/StyleSheet/StyleSheet';
 import { SafeAreaView } from 'react-native-safe-area-context';
@@ -33,7 +34,7 @@ type Props = $ReadOnly<{|
 |}>;
 
 export default class LightboxFooter extends PureComponent<Props> {
-  render(): React$Node {
+  render(): Node {
     const { displayMessage, onOptionsPress, style } = this.props;
     return (
       <SafeAreaView mode="padding" edges={['right', 'bottom', 'left']}>

--- a/src/lightbox/LightboxHeader.js
+++ b/src/lightbox/LightboxHeader.js
@@ -1,5 +1,6 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
+import type { Node } from 'react';
 import { View, Text, Pressable } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
@@ -53,7 +54,7 @@ type Props = $ReadOnly<{|
  * @prop [onPressBack]
  */
 export default class LightboxHeader extends PureComponent<Props> {
-  render(): React$Node {
+  render(): Node {
     const { onPressBack, senderName, senderEmail, timestamp, avatarUrl } = this.props;
     const displayDate = humanDate(new Date(timestamp * 1000));
     const time = shortTime(new Date(timestamp * 1000));

--- a/src/lightbox/LightboxScreen.js
+++ b/src/lightbox/LightboxScreen.js
@@ -1,5 +1,6 @@
 /* @flow strict-local */
 import React from 'react';
+import type { Node } from 'react';
 import { View } from 'react-native';
 
 import type { Message } from '../types';
@@ -22,7 +23,7 @@ type Props = $ReadOnly<{|
   route: RouteProp<'lightbox', {| src: string, message: Message |}>,
 |}>;
 
-export default function LightboxScreen(props: Props): React$Node {
+export default function LightboxScreen(props: Props): Node {
   const { src, message } = props.route.params;
 
   return (

--- a/src/main/MainTabsScreen.js
+++ b/src/main/MainTabsScreen.js
@@ -1,5 +1,6 @@
 /* @flow strict-local */
 import React, { useContext } from 'react';
+import type { Node } from 'react';
 import { Platform } from 'react-native';
 import {
   createBottomTabNavigator,
@@ -44,7 +45,7 @@ type Props = $ReadOnly<{|
   route: RouteProp<'main-tabs', void>,
 |}>;
 
-export default function MainTabsScreen(props: Props): React$Node {
+export default function MainTabsScreen(props: Props): Node {
   const { backgroundColor } = useContext(ThemeContext);
 
   return (

--- a/src/main/StreamTabsScreen.js
+++ b/src/main/StreamTabsScreen.js
@@ -1,5 +1,6 @@
 /* @flow strict-local */
 import React from 'react';
+import type { Node } from 'react';
 import {
   createMaterialTopTabNavigator,
   type MaterialTopTabNavigationProp,
@@ -41,7 +42,7 @@ type Props = $ReadOnly<{|
   route: RouteProp<'stream-tabs', void>,
 |}>;
 
-export default function StreamTabsScreen(props: Props): React$Node {
+export default function StreamTabsScreen(props: Props): Node {
   return (
     <Tab.Navigator
       {...materialTopTabNavigatorConfig({

--- a/src/message/AnnouncementOnly.js
+++ b/src/message/AnnouncementOnly.js
@@ -1,12 +1,13 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
+import type { Node } from 'react';
 import { View } from 'react-native';
 
 import { Label } from '../common';
 import styles from '../styles';
 
 class AnnouncementOnly extends PureComponent<{||}> {
-  render(): React$Node {
+  render(): Node {
     return (
       <View style={styles.disabledComposeBox}>
         <Label

--- a/src/message/NoMessages.js
+++ b/src/message/NoMessages.js
@@ -1,6 +1,7 @@
 /* @flow strict-local */
 
 import React, { PureComponent } from 'react';
+import type { Node } from 'react';
 import { View } from 'react-native';
 
 import type { Narrow } from '../types';
@@ -51,7 +52,7 @@ type Props = $ReadOnly<{|
 |}>;
 
 export default class NoMessages extends PureComponent<Props> {
-  render(): React$Node {
+  render(): Node {
     const { narrow } = this.props;
 
     const message = messages.find(x => x.isFunc(narrow)) || {};

--- a/src/nav/AppNavigator.js
+++ b/src/nav/AppNavigator.js
@@ -1,5 +1,6 @@
 /* @flow strict-local */
 import React from 'react';
+import type { Node } from 'react';
 import { Platform } from 'react-native';
 import {
   createStackNavigator,
@@ -85,7 +86,7 @@ const Stack = createStackNavigator<GlobalParamList, AppNavigatorParamList, AppNa
 
 type Props = $ReadOnly<{||}>;
 
-export default function AppNavigator(props: Props): React$Node {
+export default function AppNavigator(props: Props): Node {
   const hasAuth = useSelector(getHasAuth);
   const accounts = useSelector(getAccounts);
 

--- a/src/nav/BackNavigationHandler.js
+++ b/src/nav/BackNavigationHandler.js
@@ -1,13 +1,13 @@
 /* @flow strict-local */
-import type { Node as React$Node } from 'react';
 import { PureComponent } from 'react';
+import type { Node } from 'react';
 import { BackHandler } from 'react-native';
 
 import * as NavigationService from './NavigationService';
 import { navigateBack } from '../actions';
 
 type Props = $ReadOnly<{|
-  children: React$Node,
+  children: Node,
 |}>;
 
 export default class BackNavigationHandler extends PureComponent<Props> {

--- a/src/nav/ChatNavBar.js
+++ b/src/nav/ChatNavBar.js
@@ -1,6 +1,7 @@
 /* @flow strict-local */
 
 import React, { useContext } from 'react';
+import type { Node } from 'react';
 import { View } from 'react-native';
 // $FlowFixMe[untyped-import]
 import Color from 'color';
@@ -21,7 +22,7 @@ type Props = $ReadOnly<{|
   editMessage: EditMessage | null,
 |}>;
 
-export default function ChatNavBar(props: Props): React$Node {
+export default function ChatNavBar(props: Props): Node {
   const { narrow, editMessage } = props;
   const streamColor = useSelector(state => getStreamColorForNarrow(state, narrow));
   const buttonColor =

--- a/src/nav/IconUnreadConversations.js
+++ b/src/nav/IconUnreadConversations.js
@@ -1,6 +1,7 @@
 /* @flow strict-local */
 
 import React from 'react';
+import type { Node } from 'react';
 import { View } from 'react-native';
 
 import { useSelector } from '../react-redux';
@@ -12,7 +13,7 @@ type Props = $ReadOnly<{|
   color: string,
 |}>;
 
-export default function IconUnreadConversations(props: Props): React$Node {
+export default function IconUnreadConversations(props: Props): Node {
   const { color } = props;
   const unreadHuddlesTotal = useSelector(getUnreadHuddlesTotal);
   const unreadPmsTotal = useSelector(getUnreadPmsTotal);

--- a/src/nav/IconUnreadMentions.js
+++ b/src/nav/IconUnreadMentions.js
@@ -1,6 +1,7 @@
 /* @flow strict-local */
 
 import React from 'react';
+import type { Node } from 'react';
 import { View } from 'react-native';
 
 import { useSelector } from '../react-redux';
@@ -12,7 +13,7 @@ type Props = $ReadOnly<{|
   color: string,
 |}>;
 
-export default function IconUnreadMentions(props: Props): React$Node {
+export default function IconUnreadMentions(props: Props): Node {
   const { color } = props;
   const unreadMentionsTotal = useSelector(getUnreadMentionsTotal);
 

--- a/src/nav/ModalNavBar.js
+++ b/src/nav/ModalNavBar.js
@@ -1,6 +1,7 @@
 /* @flow strict-local */
 
 import React, { useContext } from 'react';
+import type { Node } from 'react';
 import { View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
@@ -14,7 +15,7 @@ type Props = $ReadOnly<{|
   title: LocalizableText,
 |}>;
 
-export default function ModalNavBar(props: Props): React$Node {
+export default function ModalNavBar(props: Props): Node {
   const { canGoBack, title } = props;
   const { backgroundColor } = useContext(ThemeContext);
   const textStyle = [

--- a/src/nav/ModalSearchNavBar.js
+++ b/src/nav/ModalSearchNavBar.js
@@ -1,5 +1,6 @@
 /* @flow strict-local */
 import React, { useContext } from 'react';
+import type { Node } from 'react';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 import { ThemeContext } from '../styles';
@@ -12,7 +13,7 @@ type Props = $ReadOnly<{|
   canGoBack?: boolean,
 |}>;
 
-export default function ModalSearchNavBar(props: Props): React$Node {
+export default function ModalSearchNavBar(props: Props): Node {
   const { autoFocus, searchBarOnChange, canGoBack = true } = props;
   const { backgroundColor } = useContext(ThemeContext);
   return (

--- a/src/nav/NavBarBackButton.js
+++ b/src/nav/NavBarBackButton.js
@@ -1,5 +1,6 @@
 /* @flow strict-local */
 import React from 'react';
+import type { Node } from 'react';
 import { Platform } from 'react-native';
 
 import { navigateBack } from '../actions';
@@ -19,7 +20,7 @@ import * as NavigationService from './NavigationService';
  * https://material.io/design/navigation/understanding-navigation.html
  */
 // TODO: on iOS, give the right label for a back button
-export default function NavBarBackButton(props: {| +color?: string |}): React$Node {
+export default function NavBarBackButton(props: {| +color?: string |}): Node {
   const { color } = props;
   const iconName = Platform.OS === 'android' ? 'arrow-left' : 'chevron-left';
 

--- a/src/nav/NavButtonGeneral.js
+++ b/src/nav/NavButtonGeneral.js
@@ -12,22 +12,22 @@ type Props = $ReadOnly<{|
   accessibilityLabel?: string,
 |}>;
 
-export default class NavButtonGeneral extends PureComponent<Props> {
-  styles = createStyleSheet({
-    navButtonFrame: {
-      width: NAVBAR_SIZE,
-      height: NAVBAR_SIZE,
-      justifyContent: 'center',
-      alignItems: 'center',
-    },
-  });
+const componentStyles = createStyleSheet({
+  navButtonFrame: {
+    width: NAVBAR_SIZE,
+    height: NAVBAR_SIZE,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+});
 
+export default class NavButtonGeneral extends PureComponent<Props> {
   render() {
     const { children, onPress, accessibilityLabel } = this.props;
 
     return (
       <Touchable onPress={onPress} accessibilityLabel={accessibilityLabel}>
-        <View style={this.styles.navButtonFrame}>{children}</View>
+        <View style={componentStyles.navButtonFrame}>{children}</View>
       </Touchable>
     );
   }

--- a/src/nav/NavButtonGeneral.js
+++ b/src/nav/NavButtonGeneral.js
@@ -21,7 +21,7 @@ const componentStyles = createStyleSheet({
   },
 });
 
-export default function NavButtonGeneral(props: Props) {
+export default function NavButtonGeneral(props: Props): Node {
   const { children, onPress, accessibilityLabel } = props;
 
   return (

--- a/src/nav/NavButtonGeneral.js
+++ b/src/nav/NavButtonGeneral.js
@@ -1,5 +1,5 @@
 /* @flow strict-local */
-import React, { PureComponent } from 'react';
+import React from 'react';
 import type { Node } from 'react';
 import { View } from 'react-native';
 
@@ -21,14 +21,12 @@ const componentStyles = createStyleSheet({
   },
 });
 
-export default class NavButtonGeneral extends PureComponent<Props> {
-  render() {
-    const { children, onPress, accessibilityLabel } = this.props;
+export default function NavButtonGeneral(props: Props) {
+  const { children, onPress, accessibilityLabel } = props;
 
-    return (
-      <Touchable onPress={onPress} accessibilityLabel={accessibilityLabel}>
-        <View style={componentStyles.navButtonFrame}>{children}</View>
-      </Touchable>
-    );
-  }
+  return (
+    <Touchable onPress={onPress} accessibilityLabel={accessibilityLabel}>
+      <View style={componentStyles.navButtonFrame}>{children}</View>
+    </Touchable>
+  );
 }

--- a/src/nav/NavButtonGeneral.js
+++ b/src/nav/NavButtonGeneral.js
@@ -1,13 +1,13 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
+import type { Node } from 'react';
 import { View } from 'react-native';
-import type { Node as React$Node } from 'react';
 
 import { NAVBAR_SIZE, createStyleSheet } from '../styles';
 import { Touchable } from '../common';
 
 type Props = $ReadOnly<{|
-  children: React$Node,
+  children: Node,
   onPress: () => void,
   accessibilityLabel?: string,
 |}>;

--- a/src/pm-conversations/GroupPmConversationItem.js
+++ b/src/pm-conversations/GroupPmConversationItem.js
@@ -1,5 +1,6 @@
 /* @flow strict-local */
 import React, { useCallback, useContext } from 'react';
+import type { Node } from 'react';
 import { View } from 'react-native';
 
 import { useSelector } from '../react-redux';
@@ -28,7 +29,7 @@ type Props<U> = $ReadOnly<{|
  * */
 export default function GroupPmConversationItem<U: $ReadOnlyArray<UserOrBot>>(
   props: Props<U>,
-): React$Node {
+): Node {
   const { users, unreadCount, onPress } = props;
 
   const handlePress = useCallback(() => {

--- a/src/pm-conversations/PmConversationList.js
+++ b/src/pm-conversations/PmConversationList.js
@@ -1,5 +1,6 @@
 /* @flow strict-local */
 import React, { useCallback } from 'react';
+import type { Node } from 'react';
 import { FlatList } from 'react-native';
 import { useDispatch, useSelector } from '../react-redux';
 
@@ -26,7 +27,7 @@ type Props = $ReadOnly<{|
 /**
  * A list describing all PM conversations.
  * */
-export default function PmConversationList(props: Props): React$Node {
+export default function PmConversationList(props: Props): Node {
   const dispatch = useDispatch();
 
   const handleUserNarrow = useCallback(

--- a/src/pm-conversations/PmConversationsScreen.js
+++ b/src/pm-conversations/PmConversationsScreen.js
@@ -1,6 +1,7 @@
 /* @flow strict-local */
 
 import React, { useContext } from 'react';
+import type { Node } from 'react';
 import { View } from 'react-native';
 
 import type { RouteProp } from '../react-navigation';
@@ -41,7 +42,7 @@ type Props = $ReadOnly<{|
 /**
  * The "PMs" page in the main tabs navigation.
  * */
-export default function PmConversationsScreen(props: Props): React$Node {
+export default function PmConversationsScreen(props: Props): Node {
   const conversations = useSelector(getRecentConversations);
   const context = useContext(ThemeContext);
 

--- a/src/reactions/MessageReactionsScreen.js
+++ b/src/reactions/MessageReactionsScreen.js
@@ -1,5 +1,6 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
+import type { Node } from 'react';
 import { View } from 'react-native';
 import { createMaterialTopTabNavigator } from '@react-navigation/material-top-tabs';
 
@@ -70,7 +71,7 @@ class MessageReactionsScreen extends PureComponent<Props> {
     const { message, route, ownUserId } = this.props;
     const { reactionName } = route.params;
 
-    const content: React$Node = (() => {
+    const content: Node = (() => {
       if (message === undefined) {
         return <View style={styles.flexed} />;
       } else if (message.reactions.length === 0) {

--- a/src/reactions/ReactionUserList.js
+++ b/src/reactions/ReactionUserList.js
@@ -1,5 +1,6 @@
 /* @flow strict-local */
 import React from 'react';
+import type { Node } from 'react';
 import { FlatList } from 'react-native';
 
 import * as NavigationService from '../nav/NavigationService';
@@ -16,7 +17,7 @@ type Props = $ReadOnly<{|
  *
  * Used within `MessageReactionsScreen`.
  */
-export default function ReactionUserList(props: Props): React$Node {
+export default function ReactionUserList(props: Props): Node {
   const { reactedUserIds } = props;
 
   return (

--- a/src/search/SearchMessagesCard.js
+++ b/src/search/SearchMessagesCard.js
@@ -1,6 +1,7 @@
 /* @flow strict-local */
 
 import React, { PureComponent } from 'react';
+import type { Node } from 'react';
 import { View } from 'react-native';
 
 import type { Message, Narrow } from '../types';
@@ -21,7 +22,7 @@ type Props = $ReadOnly<{|
 |}>;
 
 export default class SearchMessagesCard extends PureComponent<Props> {
-  render(): React$Node {
+  render(): Node {
     const { isFetching, messages } = this.props;
 
     if (isFetching) {

--- a/src/settings/DebugScreen.js
+++ b/src/settings/DebugScreen.js
@@ -1,6 +1,7 @@
 /* @flow strict-local */
 
 import React from 'react';
+import type { Node } from 'react';
 import { View } from 'react-native';
 
 import type { RouteProp } from '../react-navigation';
@@ -12,7 +13,7 @@ type Props = $ReadOnly<{|
   route: RouteProp<'debug', void>,
 |}>;
 
-export default function DebugScreen(props: Props): React$Node {
+export default function DebugScreen(props: Props): Node {
   return (
     <Screen title="Debug">
       <View />

--- a/src/settings/LanguageScreen.js
+++ b/src/settings/LanguageScreen.js
@@ -1,6 +1,7 @@
 /* @flow strict-local */
 
 import React, { useState, useCallback } from 'react';
+import type { Node } from 'react';
 
 import type { RouteProp } from '../react-navigation';
 import type { AppNavigationProp } from '../nav/AppNavigator';
@@ -15,7 +16,7 @@ type Props = $ReadOnly<{|
   route: RouteProp<'language', void>,
 |}>;
 
-export default function LanguageScreen(props: Props): React$Node {
+export default function LanguageScreen(props: Props): Node {
   const dispatch = useDispatch();
   const language = useSelector(state => getSettings(state).language);
 

--- a/src/settings/LegalScreen.js
+++ b/src/settings/LegalScreen.js
@@ -1,6 +1,7 @@
 /* @flow strict-local */
 
 import React, { useCallback } from 'react';
+import type { Node } from 'react';
 
 import type { RouteProp } from '../react-navigation';
 import type { AppNavigationProp } from '../nav/AppNavigator';
@@ -14,7 +15,7 @@ type Props = $ReadOnly<{|
   route: RouteProp<'legal', void>,
 |}>;
 
-export default function LegalScreen(props: Props): React$Node {
+export default function LegalScreen(props: Props): Node {
   const realm = useSelector(getCurrentRealm);
 
   const openTermsOfService = useCallback(() => {

--- a/src/settings/NotificationsScreen.js
+++ b/src/settings/NotificationsScreen.js
@@ -1,6 +1,7 @@
 /* @flow strict-local */
 
 import React, { useCallback } from 'react';
+import type { Node } from 'react';
 
 import type { RouteProp } from '../react-navigation';
 import type { AppNavigationProp } from '../nav/AppNavigator';
@@ -15,7 +16,7 @@ type Props = $ReadOnly<{|
   route: RouteProp<'notifications', void>,
 |}>;
 
-export default function NotificationsScreen(props: Props): React$Node {
+export default function NotificationsScreen(props: Props): Node {
   const auth = useSelector(getAuth);
   const offlineNotification = useSelector(state => getSettings(state).offlineNotification);
   const onlineNotification = useSelector(state => getSettings(state).onlineNotification);

--- a/src/settings/SettingsScreen.js
+++ b/src/settings/SettingsScreen.js
@@ -1,6 +1,7 @@
 /* @flow strict-local */
 
 import React, { useCallback } from 'react';
+import type { Node } from 'react';
 import { ScrollView } from 'react-native';
 
 import type { RouteProp } from '../react-navigation';
@@ -36,7 +37,7 @@ type Props = $ReadOnly<{|
   route: RouteProp<'settings', void>,
 |}>;
 
-export default function SettingsScreen(props: Props): React$Node {
+export default function SettingsScreen(props: Props): Node {
   const theme = useSelector(state => getSettings(state).theme);
   const browser = useSelector(state => getSettings(state).browser);
   const doNotMarkMessagesAsRead = useSelector(state => getSettings(state).doNotMarkMessagesAsRead);

--- a/src/sharing/ChooseRecipientsScreen.js
+++ b/src/sharing/ChooseRecipientsScreen.js
@@ -12,8 +12,6 @@ export default function ChooseRecipientsScreen(props: Props) {
   const { onComplete } = props;
   const [filter, setFilter] = useState<string>('');
 
-  const handleFilterChange = useCallback((_filter: string) => setFilter(_filter), []);
-
   const handleComplete = useCallback(
     (selected: Array<UserOrBot>) => {
       onComplete(selected.map(u => u.user_id));
@@ -22,7 +20,7 @@ export default function ChooseRecipientsScreen(props: Props) {
   );
 
   return (
-    <Screen search scrollEnabled={false} searchBarOnChange={handleFilterChange} canGoBack={false}>
+    <Screen search scrollEnabled={false} searchBarOnChange={setFilter} canGoBack={false}>
       <UserPickerCard filter={filter} onComplete={handleComplete} />
     </Screen>
   );

--- a/src/sharing/ShareWrapper.js
+++ b/src/sharing/ShareWrapper.js
@@ -1,5 +1,6 @@
 /* @flow strict-local */
 import React from 'react';
+import type { Node } from 'react';
 import { FlatList, ImageBackground, ScrollView, View, Text } from 'react-native';
 
 import type { Auth, Dispatch, GetText, UserId } from '../types';
@@ -56,7 +57,7 @@ const styles = createStyleSheet({
 });
 
 type Props = $ReadOnly<{|
-  children: React$Node,
+  children: Node,
   isSendButtonEnabled: (message: string) => boolean,
   sendTo: SendTo,
   sharedData: SharedData,

--- a/src/sharing/SharingScreen.js
+++ b/src/sharing/SharingScreen.js
@@ -1,5 +1,6 @@
 /* @flow strict-local */
 import React from 'react';
+import type { Node } from 'react';
 import {
   createMaterialTopTabNavigator,
   type MaterialTopTabNavigationProp,
@@ -47,7 +48,7 @@ const styles = createStyleSheet({
   },
 });
 
-export default function SharingScreen(props: Props): React$Node {
+export default function SharingScreen(props: Props): Node {
   const { params } = props.route;
   const hasAuth = useSelector(getHasAuth);
 

--- a/src/start/IosCompliantAppleAuthButton/Custom.js
+++ b/src/start/IosCompliantAppleAuthButton/Custom.js
@@ -1,5 +1,6 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
+import type { Node } from 'react';
 import { Text, View, Image, TouchableWithoutFeedback } from 'react-native';
 import type { ViewStyleProp } from 'react-native/Libraries/StyleSheet/StyleSheet';
 
@@ -55,7 +56,7 @@ type Props = $ReadOnly<{|
  * button should be used.
  */
 export default class Custom extends PureComponent<Props> {
-  render(): React$Node {
+  render(): Node {
     const { style, onPress, theme } = this.props;
     const logoSource = theme === 'default' ? appleLogoBlackImg : appleLogoWhiteImg;
     const frameStyle = [

--- a/src/start/RealmInfo.js
+++ b/src/start/RealmInfo.js
@@ -1,5 +1,6 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
+import type { Node } from 'react';
 import { View, Image } from 'react-native';
 
 import { RawLabel } from '../common';
@@ -28,7 +29,7 @@ type Props = $ReadOnly<{|
 |}>;
 
 export default class RealmInfo extends PureComponent<Props> {
-  render(): React$Node {
+  render(): Node {
     const { name, iconUrl } = this.props;
 
     return (

--- a/src/streams/StreamCard.js
+++ b/src/streams/StreamCard.js
@@ -1,5 +1,6 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
+import type { Node } from 'react';
 import { View } from 'react-native';
 
 import type { Stream, Subscription } from '../types';
@@ -31,7 +32,7 @@ type Props = $ReadOnly<{|
 |}>;
 
 export default class StreamCard extends PureComponent<Props> {
-  render(): React$Node {
+  render(): Node {
     const { stream, subscription } = this.props;
 
     return (

--- a/src/streams/StreamIcon.js
+++ b/src/streams/StreamIcon.js
@@ -1,5 +1,6 @@
 /* @flow strict-local */
 import React from 'react';
+import type { Node } from 'react';
 import type { TextStyleProp } from 'react-native/Libraries/StyleSheet/StyleSheet';
 
 import { IconMute, IconStream, IconPrivate } from '../common/Icons';
@@ -12,7 +13,7 @@ type Props = $ReadOnly<{|
   style?: TextStyleProp,
 |}>;
 
-export default ({ color, style, isPrivate, isMuted, size }: Props): React$Node => {
+export default ({ color, style, isPrivate, isMuted, size }: Props): Node => {
   const StreamIcon = isMuted ? IconMute : isPrivate ? IconPrivate : IconStream;
 
   return <StreamIcon size={size} color={color} style={style} />;

--- a/src/streams/StreamItem.js
+++ b/src/streams/StreamItem.js
@@ -1,5 +1,6 @@
 /* @flow strict-local */
 import React, { useContext } from 'react';
+import type { Node } from 'react';
 import { View } from 'react-native';
 
 import styles, { createStyleSheet, ThemeContext } from '../styles';
@@ -58,7 +59,7 @@ type Props = $ReadOnly<{|
  * @prop onPress - press handler for the item; receives the stream name
  * @prop onSwitch - if switch exists; receives stream name and new value
  */
-export default function StreamItem(props: Props): React$Node {
+export default function StreamItem(props: Props): Node {
   const {
     name,
     description,

--- a/src/streams/StreamList.js
+++ b/src/streams/StreamList.js
@@ -1,5 +1,6 @@
 /* @flow strict-local */
 import React from 'react';
+import type { Node } from 'react';
 import { SectionList } from 'react-native';
 
 import type { Stream, Subscription } from '../types';
@@ -46,7 +47,7 @@ type Props = $ReadOnly<{|
   onSwitch?: (streamName: string, newValue: boolean) => void,
 |}>;
 
-export default function StreamList(props: Props) {
+export default function StreamList(props: Props): Node {
   const {
     streams = [],
     showDescriptions = false,

--- a/src/streams/StreamList.js
+++ b/src/streams/StreamList.js
@@ -1,5 +1,5 @@
 /* @flow strict-local */
-import React, { PureComponent } from 'react';
+import React from 'react';
 import { SectionList } from 'react-native';
 
 import type { Stream, Subscription } from '../types';
@@ -38,67 +38,65 @@ type PseudoSubscription =
     |}>;
 
 type Props = $ReadOnly<{|
-  showDescriptions: boolean,
-  showSwitch: boolean,
-  streams: $ReadOnlyArray<PseudoSubscription>,
-  unreadByStream: $ReadOnly<{| [number]: number |}>,
+  showDescriptions?: boolean,
+  showSwitch?: boolean,
+  streams?: $ReadOnlyArray<PseudoSubscription>,
+  unreadByStream?: $ReadOnly<{| [number]: number |}>,
   onPress: (streamName: string) => void,
   onSwitch?: (streamName: string, newValue: boolean) => void,
 |}>;
 
-export default class StreamList extends PureComponent<Props> {
-  static defaultProps = {
-    showDescriptions: false,
-    showSwitch: false,
-    streams: [],
-    unreadByStream: {},
-  };
+export default function StreamList(props: Props) {
+  const {
+    streams = [],
+    showDescriptions = false,
+    showSwitch = false,
+    unreadByStream = {},
+    onPress,
+    onSwitch,
+  } = props;
 
-  render() {
-    const { streams, showDescriptions, showSwitch, unreadByStream, onPress, onSwitch } = this.props;
-
-    if (streams.length === 0) {
-      return <SearchEmptyState text="No streams found" />;
-    }
-
-    const sortedStreams: PseudoSubscription[] = streams
-      .slice()
-      .sort((a, b) => caseInsensitiveCompareFunc(a.name, b.name));
-    const sections = [
-      {
-        key: 'Pinned',
-        data: sortedStreams.filter(x => x.pin_to_top),
-      },
-      {
-        key: 'Unpinned',
-        data: sortedStreams.filter(x => !x.pin_to_top),
-      },
-    ];
-
-    return (
-      <SectionList
-        style={styles.list}
-        sections={sections}
-        extraData={unreadByStream}
-        initialNumToRender={20}
-        keyExtractor={item => item.stream_id}
-        renderItem={({ item }: { item: PseudoSubscription, ... }) => (
-          <StreamItem
-            name={item.name}
-            iconSize={16}
-            isPrivate={item.invite_only}
-            description={showDescriptions ? item.description : ''}
-            color={item.color}
-            unreadCount={unreadByStream[item.stream_id]}
-            isMuted={item.in_home_view === false} // if 'undefined' is not muted
-            showSwitch={showSwitch}
-            isSubscribed={item.subscribed}
-            onPress={onPress}
-            onSwitch={onSwitch}
-          />
-        )}
-        SectionSeparatorComponent={SectionSeparatorBetween}
-      />
-    );
+  if (streams.length === 0) {
+    return <SearchEmptyState text="No streams found" />;
   }
+
+  const sortedStreams: PseudoSubscription[] = streams
+    .slice()
+    .sort((a, b) => caseInsensitiveCompareFunc(a.name, b.name));
+  const sections = [
+    {
+      key: 'Pinned',
+      data: sortedStreams.filter(x => x.pin_to_top),
+    },
+    {
+      key: 'Unpinned',
+      data: sortedStreams.filter(x => !x.pin_to_top),
+    },
+  ];
+
+  return (
+    <SectionList
+      style={styles.list}
+      sections={sections}
+      extraData={unreadByStream}
+      initialNumToRender={20}
+      keyExtractor={item => item.stream_id}
+      renderItem={({ item }: { item: PseudoSubscription, ... }) => (
+        <StreamItem
+          name={item.name}
+          iconSize={16}
+          isPrivate={item.invite_only}
+          description={showDescriptions ? item.description : ''}
+          color={item.color}
+          unreadCount={unreadByStream[item.stream_id]}
+          isMuted={item.in_home_view === false} // if 'undefined' is not muted
+          showSwitch={showSwitch}
+          isSubscribed={item.subscribed}
+          onPress={onPress}
+          onSwitch={onSwitch}
+        />
+      )}
+      SectionSeparatorComponent={SectionSeparatorBetween}
+    />
+  );
 }

--- a/src/streams/TopicItem.js
+++ b/src/streams/TopicItem.js
@@ -1,5 +1,6 @@
 /* @flow strict-local */
 import React, { useContext } from 'react';
+import type { Node } from 'react';
 import { View } from 'react-native';
 // $FlowFixMe[untyped-import]
 import { useActionSheet } from '@expo/react-native-action-sheet';
@@ -46,7 +47,7 @@ type Props = $ReadOnly<{|
   onPress: (stream: string, topic: string) => void,
 |}>;
 
-export default function TopicItem(props: Props): React$Node {
+export default function TopicItem(props: Props): Node {
   const { name, streamName, isMuted = false, isSelected = false, unreadCount = 0, onPress } = props;
 
   const showActionSheetWithOptions: ShowActionSheetWithOptions = useActionSheet()

--- a/src/title-buttons/ExtraNavButtonStream.js
+++ b/src/title-buttons/ExtraNavButtonStream.js
@@ -1,6 +1,7 @@
 /* @flow strict-local */
 
 import React from 'react';
+import type { Node } from 'react';
 
 import * as NavigationService from '../nav/NavigationService';
 import type { Narrow } from '../types';
@@ -15,7 +16,7 @@ type Props = $ReadOnly<{|
   color: string,
 |}>;
 
-export default function ExtraNavButtonStream(props: Props): React$Node {
+export default function ExtraNavButtonStream(props: Props): Node {
   const streams = useSelector(getStreams);
   const { color } = props;
 

--- a/src/title-buttons/InfoNavButtonGroup.js
+++ b/src/title-buttons/InfoNavButtonGroup.js
@@ -1,5 +1,6 @@
 /* @flow strict-local */
 import React from 'react';
+import type { Node } from 'react';
 
 import type { UserId } from '../types';
 import * as NavigationService from '../nav/NavigationService';
@@ -11,7 +12,7 @@ type Props = $ReadOnly<{|
   userIds: $ReadOnlyArray<UserId>,
 |}>;
 
-export default function InfoNavButtonGroup(props: Props): React$Node {
+export default function InfoNavButtonGroup(props: Props): Node {
   const { color } = props;
 
   return (

--- a/src/title-buttons/InfoNavButtonPrivate.js
+++ b/src/title-buttons/InfoNavButtonPrivate.js
@@ -1,5 +1,6 @@
 /* @flow strict-local */
 import React from 'react';
+import type { Node } from 'react';
 
 import type { UserId } from '../types';
 import * as NavigationService from '../nav/NavigationService';
@@ -11,7 +12,7 @@ type Props = $ReadOnly<{|
   userId: UserId,
 |}>;
 
-export default function InfoNavButtonPrivate(props: Props): React$Node {
+export default function InfoNavButtonPrivate(props: Props): Node {
   const { color } = props;
   return (
     <NavButton

--- a/src/title-buttons/InfoNavButtonStream.js
+++ b/src/title-buttons/InfoNavButtonStream.js
@@ -1,6 +1,7 @@
 /* @flow strict-local */
 
 import React from 'react';
+import type { Node } from 'react';
 
 import * as NavigationService from '../nav/NavigationService';
 import type { Narrow } from '../types';
@@ -15,7 +16,7 @@ type Props = $ReadOnly<{|
   color: string,
 |}>;
 
-export default function InfoNavButtonStream(props: Props): React$Node {
+export default function InfoNavButtonStream(props: Props): Node {
   const streams = useSelector(getStreams);
   const { color } = props;
 

--- a/src/title/Title.js
+++ b/src/title/Title.js
@@ -1,6 +1,7 @@
 /* @flow strict-local */
 
 import React, { PureComponent } from 'react';
+import type { Node } from 'react';
 
 import { caseNarrow } from '../utils/narrow';
 
@@ -18,7 +19,7 @@ type Props = $ReadOnly<{|
 |}>;
 
 export default class Title extends PureComponent<Props> {
-  render(): React$Node {
+  render(): Node {
     const { narrow, color, editMessage } = this.props;
     if (editMessage != null) {
       return <TitlePlain text="Edit message" color={color} />;

--- a/src/title/TitleGroup.js
+++ b/src/title/TitleGroup.js
@@ -1,6 +1,7 @@
 /* @flow strict-local */
 
 import React from 'react';
+import type { Node } from 'react';
 import { View } from 'react-native';
 
 import { useSelector } from '../react-redux';
@@ -21,7 +22,7 @@ const componentStyles = createStyleSheet({
   },
 });
 
-export default function TitleGroup(props: Props): React$Node {
+export default function TitleGroup(props: Props): Node {
   const { userIds } = props;
   const mutedUsers = useSelector(getMutedUsers);
 

--- a/src/title/TitlePlain.js
+++ b/src/title/TitlePlain.js
@@ -1,5 +1,6 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
+import type { Node } from 'react';
 import { Text } from 'react-native';
 
 import styles from '../styles';
@@ -10,7 +11,7 @@ type Props = $ReadOnly<{|
 |}>;
 
 export default class TitlePlain extends PureComponent<Props> {
-  render(): React$Node {
+  render(): Node {
     const { text, color } = this.props;
     return <Text style={[styles.navTitle, styles.flexed, { color }]}>{text}</Text>;
   }

--- a/src/title/TitlePrivate.js
+++ b/src/title/TitlePrivate.js
@@ -1,6 +1,7 @@
 /* @flow strict-local */
 
 import React from 'react';
+import type { Node } from 'react';
 import { Text, View } from 'react-native';
 
 import * as NavigationService from '../nav/NavigationService';
@@ -24,7 +25,7 @@ const componentStyles = createStyleSheet({
   textWrapper: { flex: 1 },
 });
 
-export default function TitlePrivate(props: Props): React$Node {
+export default function TitlePrivate(props: Props): Node {
   const { userId, color } = props;
   const user = useSelector(state => tryGetUserForId(state, userId));
   if (!user) {

--- a/src/title/TitleSpecial.js
+++ b/src/title/TitleSpecial.js
@@ -1,5 +1,6 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
+import type { Node } from 'react';
 import { View } from 'react-native';
 
 import { Label } from '../common';
@@ -19,7 +20,7 @@ type Props = $ReadOnly<{|
 |}>;
 
 export default class TitleSpecial extends PureComponent<Props> {
-  render(): React$Node {
+  render(): Node {
     const { code, color } = this.props;
     const { name, icon } = specials[code];
 

--- a/src/topics/TopicList.js
+++ b/src/topics/TopicList.js
@@ -1,5 +1,6 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
+import type { Node } from 'react';
 import { FlatList } from 'react-native';
 
 import type { Stream, TopicExtended } from '../types';
@@ -21,7 +22,7 @@ type Props = $ReadOnly<{|
 |}>;
 
 export default class TopicList extends PureComponent<Props> {
-  render(): React$Node {
+  render(): Node {
     const { stream, topics, onPress } = this.props;
 
     if (!topics) {

--- a/src/unread/UnreadCards.js
+++ b/src/unread/UnreadCards.js
@@ -1,6 +1,7 @@
 /* @flow strict-local */
 
 import React from 'react';
+import type { Node } from 'react';
 import { SectionList } from 'react-native';
 
 import type { UnreadStreamItem } from '../types';
@@ -15,7 +16,7 @@ import { doNarrow } from '../actions';
 
 type Props = $ReadOnly<{||}>;
 
-export default function UnreadCards(props: Props): React$Node {
+export default function UnreadCards(props: Props): Node {
   const dispatch = useDispatch();
   const conversations = useSelector(getUnreadConversations);
   const unreadStreamsAndTopics = useSelector(getUnreadStreamsAndTopicsSansMuted);

--- a/src/user-groups/CreateGroupScreen.js
+++ b/src/user-groups/CreateGroupScreen.js
@@ -24,8 +24,6 @@ export default function CreateGroupScreen(props: Props) {
 
   const [filter, setFilter] = useState<string>('');
 
-  const handleFilterChange = useCallback((_filter: string) => setFilter(_filter), []);
-
   const handleCreateGroup = useCallback(
     (selected: UserOrBot[]) => {
       NavigationService.dispatch(navigateBack());
@@ -35,7 +33,7 @@ export default function CreateGroupScreen(props: Props) {
   );
 
   return (
-    <Screen search scrollEnabled={false} searchBarOnChange={handleFilterChange}>
+    <Screen search scrollEnabled={false} searchBarOnChange={setFilter}>
       <UserPickerCard filter={filter} onComplete={handleCreateGroup} />
     </Screen>
   );

--- a/src/user-groups/UserGroupItem.js
+++ b/src/user-groups/UserGroupItem.js
@@ -1,5 +1,6 @@
 /* @flow strict-local */
 import React, { useCallback, useContext } from 'react';
+import type { Node } from 'react';
 import { View } from 'react-native';
 
 import { IconPeople } from '../common/Icons';
@@ -25,7 +26,7 @@ type Props = $ReadOnly<{|
   onPress: (name: string) => void,
 |}>;
 
-export default function UserGroupItem(props: Props) {
+export default function UserGroupItem(props: Props): Node {
   const { name, description, onPress } = props;
 
   const handlePress = useCallback(() => {

--- a/src/user-groups/UserGroupItem.js
+++ b/src/user-groups/UserGroupItem.js
@@ -1,11 +1,10 @@
 /* @flow strict-local */
-import React, { PureComponent } from 'react';
+import React, { useCallback, useContext } from 'react';
 import { View } from 'react-native';
 
 import { IconPeople } from '../common/Icons';
 import { RawLabel, Touchable } from '../common';
 import styles, { createStyleSheet, ThemeContext } from '../styles';
-import type { ThemeData } from '../styles';
 
 const componentStyles = createStyleSheet({
   text: {
@@ -26,38 +25,34 @@ type Props = $ReadOnly<{|
   onPress: (name: string) => void,
 |}>;
 
-export default class UserGroupItem extends PureComponent<Props> {
-  static contextType = ThemeContext;
-  context: ThemeData;
+export default function UserGroupItem(props: Props) {
+  const { name, description, onPress } = props;
 
-  handlePress = () => {
-    const { name, onPress } = this.props;
+  const handlePress = useCallback(() => {
     onPress(name);
-  };
+  }, [onPress, name]);
 
-  render() {
-    const { name, description } = this.props;
+  const themeContext = useContext(ThemeContext);
 
-    return (
-      <Touchable onPress={this.handlePress}>
-        <View style={styles.listItem}>
-          <IconPeople size={32} color={this.context.color} />
-          <View style={componentStyles.textWrapper}>
-            <RawLabel
-              style={componentStyles.text}
-              text={name}
-              numberOfLines={1}
-              ellipsizeMode="tail"
-            />
-            <RawLabel
-              style={[componentStyles.text, componentStyles.textEmail]}
-              text={description}
-              numberOfLines={1}
-              ellipsizeMode="tail"
-            />
-          </View>
+  return (
+    <Touchable onPress={handlePress}>
+      <View style={styles.listItem}>
+        <IconPeople size={32} color={themeContext.color} />
+        <View style={componentStyles.textWrapper}>
+          <RawLabel
+            style={componentStyles.text}
+            text={name}
+            numberOfLines={1}
+            ellipsizeMode="tail"
+          />
+          <RawLabel
+            style={[componentStyles.text, componentStyles.textEmail]}
+            text={description}
+            numberOfLines={1}
+            ellipsizeMode="tail"
+          />
         </View>
-      </Touchable>
-    );
-  }
+      </View>
+    </Touchable>
+  );
 }

--- a/src/user-picker/AvatarItem.js
+++ b/src/user-picker/AvatarItem.js
@@ -1,5 +1,6 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
+import type { Node } from 'react';
 import { Animated, Easing, View } from 'react-native';
 import type AnimatedValue from 'react-native/Libraries/Animated/src/nodes/AnimatedValue';
 
@@ -57,7 +58,7 @@ export default class AvatarItem extends PureComponent<Props> {
     }).start(() => onPress(user.user_id));
   };
 
-  render(): React$Node {
+  render(): Node {
     const { user } = this.props;
     const animatedStyle = {
       transform: [{ scale: this.animatedValue }],

--- a/src/user-picker/AvatarList.js
+++ b/src/user-picker/AvatarList.js
@@ -1,5 +1,6 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
+import type { Node } from 'react';
 import { FlatList } from 'react-native';
 
 import type { UserId, UserOrBot } from '../types';
@@ -12,7 +13,7 @@ type Props = $ReadOnly<{|
 |}>;
 
 export default class AvatarList extends PureComponent<Props> {
-  render(): React$Node {
+  render(): Node {
     const { listRef, users, onPress } = this.props;
 
     return (

--- a/src/users/UserItem.js
+++ b/src/users/UserItem.js
@@ -1,5 +1,6 @@
 /* @flow strict-local */
 import React, { type ElementConfig, useCallback, useContext } from 'react';
+import type { Node } from 'react';
 import { View } from 'react-native';
 
 import { TranslationContext } from '../boot/TranslationProvider';
@@ -50,7 +51,7 @@ type Props<UserT> = $ReadOnly<{|
  */
 export function UserItemRaw<UserT: { user_id: UserId, email: string, full_name: string, ... }>(
   props: Props<UserT>,
-): React$Node {
+): Node {
   const { user, isSelected = false, onPress, unreadCount, showEmail = false } = props;
   const _ = useContext(TranslationContext);
   const isMuted = useSelector(getMutedUsers).has(user.user_id);
@@ -108,7 +109,7 @@ type OuterProps = $ReadOnly<{|
  * encapsulate getting user data where it's needed.
  */
 // eslint-disable-next-line func-names
-export default function (props: OuterProps): React$Node {
+export default function (props: OuterProps): Node {
   const { userId, ...restProps } = props;
   const user = useSelector(state => getUserForId(state, userId));
   return <UserItemRaw {...restProps} user={user} />;

--- a/src/users/UserList.js
+++ b/src/users/UserList.js
@@ -1,5 +1,6 @@
 /* @flow strict-local */
 import React from 'react';
+import type { Node } from 'react';
 import { SectionList } from 'react-native';
 import { useSelector } from '../react-redux';
 
@@ -24,7 +25,7 @@ type Props = $ReadOnly<{|
   onPress: (user: UserOrBot) => void,
 |}>;
 
-export default function UserList(props: Props): React$Node {
+export default function UserList(props: Props): Node {
   const { filter, users, presences, onPress, selected = [] } = props;
   const mutedUsers = useSelector(getMutedUsers);
   const filteredUsers = filterUserList(users, filter).filter(user => !mutedUsers.has(user.user_id));

--- a/src/users/UsersScreen.js
+++ b/src/users/UsersScreen.js
@@ -1,5 +1,6 @@
 /* @flow strict-local */
 import React, { useState } from 'react';
+import type { Node } from 'react';
 
 import type { RouteProp } from '../react-navigation';
 import type { AppNavigationProp } from '../nav/AppNavigator';
@@ -11,7 +12,7 @@ type Props = $ReadOnly<{|
   route: RouteProp<'users', void>,
 |}>;
 
-export default function UsersScreen(props: Props) {
+export default function UsersScreen(props: Props): Node {
   const [filter, setFilter] = useState<string>('');
 
   return (

--- a/src/users/UsersScreen.js
+++ b/src/users/UsersScreen.js
@@ -1,5 +1,5 @@
 /* @flow strict-local */
-import React, { PureComponent } from 'react';
+import React, { useState, useCallback } from 'react';
 
 import type { RouteProp } from '../react-navigation';
 import type { AppNavigationProp } from '../nav/AppNavigator';
@@ -11,24 +11,14 @@ type Props = $ReadOnly<{|
   route: RouteProp<'users', void>,
 |}>;
 
-type State = {|
-  filter: string,
-|};
+export default function UsersScreen(props: Props) {
+  const [filter, setFilter] = useState<string>('');
 
-export default class UsersScreen extends PureComponent<Props, State> {
-  state = {
-    filter: '',
-  };
+  const handleFilterChange = useCallback((_filter: string) => setFilter(_filter), []);
 
-  handleFilterChange = (filter: string) => this.setState({ filter });
-
-  render() {
-    const { filter } = this.state;
-
-    return (
-      <Screen search autoFocus scrollEnabled={false} searchBarOnChange={this.handleFilterChange}>
-        <UsersCard filter={filter} />
-      </Screen>
-    );
-  }
+  return (
+    <Screen search autoFocus scrollEnabled={false} searchBarOnChange={handleFilterChange}>
+      <UsersCard filter={filter} />
+    </Screen>
+  );
 }

--- a/src/users/UsersScreen.js
+++ b/src/users/UsersScreen.js
@@ -1,5 +1,5 @@
 /* @flow strict-local */
-import React, { useState, useCallback } from 'react';
+import React, { useState } from 'react';
 
 import type { RouteProp } from '../react-navigation';
 import type { AppNavigationProp } from '../nav/AppNavigator';
@@ -14,10 +14,8 @@ type Props = $ReadOnly<{|
 export default function UsersScreen(props: Props) {
   const [filter, setFilter] = useState<string>('');
 
-  const handleFilterChange = useCallback((_filter: string) => setFilter(_filter), []);
-
   return (
-    <Screen search autoFocus scrollEnabled={false} searchBarOnChange={handleFilterChange}>
+    <Screen search autoFocus scrollEnabled={false} searchBarOnChange={setFilter}>
       <UsersCard filter={filter} />
     </Screen>
   );


### PR DESCRIPTION
Another bundle of these, after #4908, toward #4907.

In general, this turns out to be much easier to do for function components than class components, so most of this series is just doing those conversions. Then there's a commit at the end that adds the annotations.

Temporarily adding `well_formed_exports=true` shows that this series takes us from 205 down to 145 complaints of missing export annotations.