### PR TITLE
android: Drop support for API < 23.

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         // The oldest Android version we support.  Increasing this stops updates
         // for users on old devices, but can simplify the system.  Synced with
         // our dev docs: docs/developer-guide.md
-        minSdkVersion = 21
+        minSdkVersion = 23
 
         // A bit subtle: we should try to keep this at the latest version,
         // but some testing is required and code changes are often required.

--- a/docs/architecture/platform-versions.md
+++ b/docs/architecture/platform-versions.md
@@ -94,6 +94,8 @@ History:
 * We [dropped iOS 11 support] in 2021-04. It was 0.1% of iOS users
   who tried Zulip. We started iOS 12 support at 12.1 because Xcode's
   dropdown for "Deployment Target" didn't have a 12.0.
+* We [dropped Android 5 Lollipop support][dropped-android-l] in
+  2021-08.
 <!-- When updating this, please update `docs/developer-guide.md` as well. -->
 
 [dropped-android-j]: https://chat.zulip.org/#narrow/stream/48-mobile/topic/platform.20versions/near/625585
@@ -101,6 +103,7 @@ History:
 [dropped iOS 9 support]: https://chat.zulip.org/#narrow/stream/48-mobile/topic/platform.20versions/near/771761
 [dropped-android-k]: https://chat.zulip.org/#narrow/stream/48-mobile/topic/platform.20versions/near/794551
 [dropped iOS 11 support]: https://chat.zulip.org/#narrow/stream/48-mobile/topic/platform.20versions/near/1165087
+[dropped-android-l]: https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/Updating.20.60minSdkVersion.60/near/1236327
 
 
 Related observations:

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -1,6 +1,6 @@
 # Developer guide
 
-We target operating systems >= Android 5 Lollipop (API 21)
+We target operating systems >= Android 6 Marshmallow (API 23)
 and >= iOS 12.1.  (Details [here](architecture/platform-versions.md).)
 
 ## Why React Native?

--- a/src/webview/js/generatedEs3.js
+++ b/src/webview/js/generatedEs3.js
@@ -434,12 +434,12 @@ var compiledWebviewJs = (function (exports) {
     sendMessage({
       type: 'error',
       details: {
-        message: message,
-        source: source,
-        line: line,
-        column: column,
-        userAgent: userAgent,
-        error: error
+        message,
+        source,
+        line,
+        column,
+        userAgent,
+        error
       }
     });
     return true;
@@ -593,8 +593,8 @@ var compiledWebviewJs = (function (exports) {
     walkElements(start, 'nextElementSibling');
     walkElements(start, 'previousElementSibling');
     return {
-      first: first,
-      last: last
+      first,
+      last
     };
   }
 
@@ -1022,7 +1022,7 @@ var compiledWebviewJs = (function (exports) {
         type: 'vote',
         messageId: requireNumericAttribute(_messageElement, 'data-msg-id'),
         key: requireAttribute(target, 'data-key'),
-        vote: vote
+        vote
       });
       target.setAttribute('data-voted', (!current_vote).toString());
       target.innerText = (parseInt(target.innerText, 10) + vote).toString();
@@ -1033,7 +1033,7 @@ var compiledWebviewJs = (function (exports) {
       var originalText = requireAttribute(target, 'original-text');
       sendMessage({
         type: 'time',
-        originalText: originalText
+        originalText
       });
     }
 

--- a/src/webview/js/js.js
+++ b/src/webview/js/js.js
@@ -35,10 +35,6 @@ import { ensureUnreachable } from '../../generics';
  *     the large majority of Android users have a fully-updated Chrome --
  *     more recent than the Safari on most iOS devices.)
  *
- *   * Below Chrome 44, it's possible (but rare) for a user to be on a
- *     version as old as Chrome 37, which shipped with Android 5 Lollipop.
- *     We sometimes fix issues affecting those versions, only when trivial.
- *
  * * See docs/architecture/platform-versions.md for data and discussion
  *   about our version-support strategy.
  */

--- a/tools/generate-webview-js
+++ b/tools/generate-webview-js
@@ -32,7 +32,7 @@ const targetPlatforms = {
   //
   // Keep this at the Chrome version originally shipped with the oldest
   // Android version we support.
-  chrome: 37,
+  chrome: 44,
 
   // (Babel accepts an "android" key here too.  But that refers to the old
   // Android System WebView, which Android 5 replaced with an auto-updating


### PR DESCRIPTION
As Discussed in [CZO](https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/Updating.20.60minSdkVersion.60/near/1236327), Last time (9-2020) we checked, the total
user base using API < 23 is less than 1 percent and hence it is
safe for us to update the API version (according to the [update
policy](https://github.com/zulip/zulip-mobile/blob/master/docs/architecture/platform-versions.md#android-and-ios-versions) [2] we have).

The advantage of this change would be simplification in some of the
code that we use / will be using which will be changed / added in
other commits.

The changes in this commit Involved:
* Changing `android/build.gradle`.
* Setting up chrome version to 44 (set according to what is
  written in `platform-versions.md`).
* Modifications to the documentation.

Marking P1 since Notification UI is built on top of this PR.