### PR TITLE
Simplify "update strategy" logic

### DIFF
--- a/src/message/__tests__/messageUpdates-test.js
+++ b/src/message/__tests__/messageUpdates-test.js
@@ -1,181 +1,11 @@
 /* @flow strict-local */
 import { streamNarrow } from '../../utils/narrow';
-import { getMessageTransitionProps, getMessageUpdateStrategy } from '../messageUpdates';
+import { getMessageUpdateStrategy } from '../messageUpdates';
 
 import * as eg from '../../__tests__/lib/exampleData';
 
 const someNarrow = streamNarrow(eg.stream.name);
 const anotherNarrow = streamNarrow(eg.makeStream().name);
-
-describe('getMessageTransitionProps', () => {
-  test('recognize when messages are the same and the narrows are the same', () => {
-    const prevProps = {
-      messages: [],
-      narrow: someNarrow,
-    };
-    const nextProps = {
-      messages: [],
-      narrow: someNarrow,
-    };
-
-    const result = getMessageTransitionProps(prevProps, nextProps);
-
-    expect(result).toEqual({
-      newMessagesAdded: false,
-      noMessages: true,
-      noNewMessages: true,
-      allNewMessages: false,
-      oldMessagesAdded: false,
-      onlyOneNewMessage: false,
-      sameNarrow: true,
-      messagesReplaced: false,
-    });
-  });
-
-  test('recognize when more old messages are loaded', () => {
-    const prevProps = {
-      messages: [{ id: 2 }, { id: 3 }, { id: 4 }],
-      narrow: someNarrow,
-    };
-    const nextProps = {
-      messages: [{ id: 0 }, { id: 1 }, { id: 3 }, { id: 4 }],
-      narrow: someNarrow,
-    };
-
-    const result = getMessageTransitionProps(prevProps, nextProps);
-
-    expect(result).toEqual({
-      newMessagesAdded: false,
-      noMessages: false,
-      noNewMessages: false,
-      allNewMessages: false,
-      oldMessagesAdded: true,
-      onlyOneNewMessage: false,
-      sameNarrow: true,
-      messagesReplaced: false,
-    });
-  });
-
-  test('recognize when more new messages are loaded', () => {
-    const prevProps = {
-      messages: [{ id: 2 }, { id: 3 }, { id: 4 }],
-      narrow: someNarrow,
-    };
-    const nextProps = {
-      messages: [{ id: 2 }, { id: 3 }, { id: 4 }, { id: 5 }, { id: 6 }, { id: 7 }],
-      narrow: someNarrow,
-    };
-
-    const result = getMessageTransitionProps(prevProps, nextProps);
-
-    expect(result).toEqual({
-      newMessagesAdded: true,
-      noMessages: false,
-      noNewMessages: false,
-      allNewMessages: false,
-      oldMessagesAdded: false,
-      onlyOneNewMessage: false,
-      sameNarrow: true,
-      messagesReplaced: false,
-    });
-  });
-
-  test('recognize when only one new message is loaded', () => {
-    const prevProps = {
-      messages: [{ id: 2 }, { id: 3 }, { id: 4 }],
-      narrow: someNarrow,
-    };
-    const nextProps = {
-      messages: [{ id: 2 }, { id: 3 }, { id: 4 }, { id: 5 }],
-      narrow: someNarrow,
-    };
-
-    const result = getMessageTransitionProps(prevProps, nextProps);
-
-    expect(result).toEqual({
-      newMessagesAdded: true,
-      noMessages: false,
-      noNewMessages: false,
-      allNewMessages: false,
-      oldMessagesAdded: false,
-      onlyOneNewMessage: true,
-      sameNarrow: true,
-      messagesReplaced: false,
-    });
-  });
-
-  test('when different narrows do not consider new message', () => {
-    const prevProps = {
-      messages: [{ id: 2 }, { id: 3 }, { id: 4 }],
-      narrow: someNarrow,
-    };
-    const nextProps = {
-      messages: [{ id: 2 }, { id: 3 }, { id: 4 }, { id: 5 }],
-      narrow: anotherNarrow,
-    };
-
-    const result = getMessageTransitionProps(prevProps, nextProps);
-
-    expect(result).toEqual({
-      newMessagesAdded: false,
-      noMessages: false,
-      noNewMessages: false,
-      allNewMessages: false,
-      oldMessagesAdded: false,
-      onlyOneNewMessage: false,
-      sameNarrow: false,
-      messagesReplaced: false,
-    });
-  });
-
-  test('recognize when all messages are loaded', () => {
-    const prevProps = {
-      messages: [],
-      narrow: someNarrow,
-    };
-    const nextProps = {
-      messages: [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }],
-      narrow: someNarrow,
-    };
-
-    const result = getMessageTransitionProps(prevProps, nextProps);
-
-    expect(result).toEqual({
-      newMessagesAdded: false,
-      noMessages: false,
-      noNewMessages: false,
-      allNewMessages: true,
-      oldMessagesAdded: false,
-      onlyOneNewMessage: false,
-      sameNarrow: true,
-      messagesReplaced: false,
-    });
-  });
-
-  test('recognize when messages are invalidated and replaced', () => {
-    const prevProps = {
-      messages: [{ id: 1 }, { id: 2 }],
-      narrow: someNarrow,
-    };
-    const nextProps = {
-      messages: [{ id: 4 }, { id: 5 }, { id: 6 }],
-      narrow: someNarrow,
-    };
-
-    const result = getMessageTransitionProps(prevProps, nextProps);
-
-    expect(result).toEqual({
-      newMessagesAdded: true,
-      noMessages: false,
-      noNewMessages: false,
-      allNewMessages: false,
-      oldMessagesAdded: false,
-      onlyOneNewMessage: false,
-      sameNarrow: true,
-      messagesReplaced: true,
-    });
-  });
-});
 
 describe('getMessageUpdateStrategy', () => {
   test('initial load positions at anchor (first unread)', () => {
@@ -236,6 +66,22 @@ describe('getMessageUpdateStrategy', () => {
     const result = getMessageUpdateStrategy(prevProps, nextProps);
 
     expect(result).toEqual('scroll-to-anchor');
+  });
+
+  // (It's not clear this test case makes sense.)
+  test('when older messages loaded (plus one lost) preserve scroll position', () => {
+    const prevProps = {
+      messages: [{ id: 2 }, { id: 3 }, { id: 4 }],
+      narrow: someNarrow,
+    };
+    const nextProps = {
+      messages: [{ id: 0 }, { id: 1 }, { id: 3 }, { id: 4 }],
+      narrow: someNarrow,
+    };
+
+    const result = getMessageUpdateStrategy(prevProps, nextProps);
+
+    expect(result).toEqual('preserve-position');
   });
 
   test('when older messages loaded preserve scroll position', () => {

--- a/src/message/__tests__/messageUpdates-test.js
+++ b/src/message/__tests__/messageUpdates-test.js
@@ -1,14 +1,21 @@
+/* @flow strict-local */
+import { streamNarrow } from '../../utils/narrow';
 import { getMessageTransitionProps, getMessageUpdateStrategy } from '../messageUpdates';
+
+import * as eg from '../../__tests__/lib/exampleData';
+
+const someNarrow = streamNarrow(eg.stream.name);
+const anotherNarrow = streamNarrow(eg.makeStream().name);
 
 describe('getMessageTransitionProps', () => {
   test('recognize when messages are the same and the narrows are the same', () => {
     const prevProps = {
       messages: [],
-      narrow: 'some narrow',
+      narrow: someNarrow,
     };
     const nextProps = {
       messages: [],
-      narrow: 'some narrow',
+      narrow: someNarrow,
     };
 
     const result = getMessageTransitionProps(prevProps, nextProps);
@@ -28,11 +35,11 @@ describe('getMessageTransitionProps', () => {
   test('recognize when more old messages are loaded', () => {
     const prevProps = {
       messages: [{ id: 2 }, { id: 3 }, { id: 4 }],
-      narrow: 'some narrow',
+      narrow: someNarrow,
     };
     const nextProps = {
       messages: [{ id: 0 }, { id: 1 }, { id: 3 }, { id: 4 }],
-      narrow: 'some narrow',
+      narrow: someNarrow,
     };
 
     const result = getMessageTransitionProps(prevProps, nextProps);
@@ -52,11 +59,11 @@ describe('getMessageTransitionProps', () => {
   test('recognize when more new messages are loaded', () => {
     const prevProps = {
       messages: [{ id: 2 }, { id: 3 }, { id: 4 }],
-      narrow: 'some narrow',
+      narrow: someNarrow,
     };
     const nextProps = {
       messages: [{ id: 2 }, { id: 3 }, { id: 4 }, { id: 5 }, { id: 6 }, { id: 7 }],
-      narrow: 'some narrow',
+      narrow: someNarrow,
     };
 
     const result = getMessageTransitionProps(prevProps, nextProps);
@@ -76,11 +83,11 @@ describe('getMessageTransitionProps', () => {
   test('recognize when only one new message is loaded', () => {
     const prevProps = {
       messages: [{ id: 2 }, { id: 3 }, { id: 4 }],
-      narrow: 'some narrow',
+      narrow: someNarrow,
     };
     const nextProps = {
       messages: [{ id: 2 }, { id: 3 }, { id: 4 }, { id: 5 }],
-      narrow: 'some narrow',
+      narrow: someNarrow,
     };
 
     const result = getMessageTransitionProps(prevProps, nextProps);
@@ -100,11 +107,11 @@ describe('getMessageTransitionProps', () => {
   test('when different narrows do not consider new message', () => {
     const prevProps = {
       messages: [{ id: 2 }, { id: 3 }, { id: 4 }],
-      narrow: 'some narrow',
+      narrow: someNarrow,
     };
     const nextProps = {
       messages: [{ id: 2 }, { id: 3 }, { id: 4 }, { id: 5 }],
-      narrow: 'another narrow',
+      narrow: anotherNarrow,
     };
 
     const result = getMessageTransitionProps(prevProps, nextProps);
@@ -124,11 +131,11 @@ describe('getMessageTransitionProps', () => {
   test('recognize when all messages are loaded', () => {
     const prevProps = {
       messages: [],
-      narrow: 'some narrow',
+      narrow: someNarrow,
     };
     const nextProps = {
       messages: [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }],
-      narrow: 'some narrow',
+      narrow: someNarrow,
     };
 
     const result = getMessageTransitionProps(prevProps, nextProps);
@@ -148,11 +155,11 @@ describe('getMessageTransitionProps', () => {
   test('recognize when messages are invalidated and replaced', () => {
     const prevProps = {
       messages: [{ id: 1 }, { id: 2 }],
-      narrow: 'some narrow',
+      narrow: someNarrow,
     };
     const nextProps = {
       messages: [{ id: 4 }, { id: 5 }, { id: 6 }],
-      narrow: 'some narrow',
+      narrow: someNarrow,
     };
 
     const result = getMessageTransitionProps(prevProps, nextProps);
@@ -174,10 +181,11 @@ describe('getMessageUpdateStrategy', () => {
   test('initial load positions at anchor (first unread)', () => {
     const prevProps = {
       messages: [],
+      narrow: someNarrow,
     };
     const nextProps = {
       messages: [{ id: 1 }, { id: 2 }, { id: 3 }],
-      narrow: 'some narrow',
+      narrow: someNarrow,
     };
 
     const result = getMessageUpdateStrategy(getMessageTransitionProps(prevProps, nextProps));
@@ -188,11 +196,11 @@ describe('getMessageUpdateStrategy', () => {
   test('switching narrows position at anchor (first unread)', () => {
     const prevProps = {
       messages: [{ id: 1 }, { id: 2 }, { id: 3 }],
-      narrow: 'some narrow',
+      narrow: someNarrow,
     };
     const nextProps = {
       messages: [{ id: 2 }, { id: 3 }, { id: 5 }, { id: 6 }],
-      narrow: 'another narrow',
+      narrow: anotherNarrow,
     };
 
     const result = getMessageUpdateStrategy(getMessageTransitionProps(prevProps, nextProps));
@@ -203,11 +211,11 @@ describe('getMessageUpdateStrategy', () => {
   test('when no messages just replace content', () => {
     const prevProps = {
       messages: [],
-      narrow: 'some narrow',
+      narrow: someNarrow,
     };
     const nextProps = {
       messages: [],
-      narrow: 'some other narrow',
+      narrow: anotherNarrow,
     };
 
     const result = getMessageUpdateStrategy(getMessageTransitionProps(prevProps, nextProps));
@@ -218,11 +226,11 @@ describe('getMessageUpdateStrategy', () => {
   test('when messages replaced go to anchor', () => {
     const prevProps = {
       messages: [{ id: 1 }, { id: 2 }, { id: 3 }],
-      narrow: 'some narrow',
+      narrow: someNarrow,
     };
     const nextProps = {
       messages: [{ id: 5 }, { id: 6 }, { id: 7 }],
-      narrow: 'some narrow',
+      narrow: someNarrow,
     };
 
     const result = getMessageUpdateStrategy(getMessageTransitionProps(prevProps, nextProps));
@@ -233,11 +241,11 @@ describe('getMessageUpdateStrategy', () => {
   test('when older messages loaded preserve scroll position', () => {
     const prevProps = {
       messages: [{ id: 4 }, { id: 5 }, { id: 6 }],
-      narrow: 'some narrow',
+      narrow: someNarrow,
     };
     const nextProps = {
       messages: [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }, { id: 5 }, { id: 6 }],
-      narrow: 'some narrow',
+      narrow: someNarrow,
     };
 
     const result = getMessageUpdateStrategy(getMessageTransitionProps(prevProps, nextProps));
@@ -248,11 +256,11 @@ describe('getMessageUpdateStrategy', () => {
   test('when newer messages loaded preserve scroll position', () => {
     const prevProps = {
       messages: [{ id: 4 }, { id: 5 }, { id: 6 }],
-      narrow: 'some narrow',
+      narrow: someNarrow,
     };
     const nextProps = {
       messages: [{ id: 4 }, { id: 5 }, { id: 6 }, { id: 7 }, { id: 8 }, { id: 9 }],
-      narrow: 'some narrow',
+      narrow: someNarrow,
     };
 
     const result = getMessageUpdateStrategy(getMessageTransitionProps(prevProps, nextProps));
@@ -263,11 +271,11 @@ describe('getMessageUpdateStrategy', () => {
   test('if only one new message scroll to bottom if near bottom', () => {
     const prevProps = {
       messages: [{ id: 4 }, { id: 5 }, { id: 6 }],
-      narrow: 'some narrow',
+      narrow: someNarrow,
     };
     const nextProps = {
       messages: [{ id: 4 }, { id: 5 }, { id: 6 }, { id: 7 }],
-      narrow: 'some narrow',
+      narrow: someNarrow,
     };
 
     const result = getMessageUpdateStrategy(getMessageTransitionProps(prevProps, nextProps));
@@ -278,11 +286,11 @@ describe('getMessageUpdateStrategy', () => {
   test('when loading new messages, scroll to anchor', () => {
     const prevProps = {
       messages: [],
-      narrow: 'some narrow',
+      narrow: someNarrow,
     };
     const nextProps = {
       messages: [{ id: 1 }, { id: 2 }, { id: 3 }],
-      narrow: 'some narrow',
+      narrow: someNarrow,
     };
 
     const result = getMessageUpdateStrategy(getMessageTransitionProps(prevProps, nextProps));

--- a/src/message/__tests__/messageUpdates-test.js
+++ b/src/message/__tests__/messageUpdates-test.js
@@ -188,7 +188,7 @@ describe('getMessageUpdateStrategy', () => {
       narrow: someNarrow,
     };
 
-    const result = getMessageUpdateStrategy(getMessageTransitionProps(prevProps, nextProps));
+    const result = getMessageUpdateStrategy(prevProps, nextProps);
 
     expect(result).toEqual('scroll-to-anchor');
   });
@@ -203,7 +203,7 @@ describe('getMessageUpdateStrategy', () => {
       narrow: anotherNarrow,
     };
 
-    const result = getMessageUpdateStrategy(getMessageTransitionProps(prevProps, nextProps));
+    const result = getMessageUpdateStrategy(prevProps, nextProps);
 
     expect(result).toEqual('scroll-to-anchor');
   });
@@ -218,7 +218,7 @@ describe('getMessageUpdateStrategy', () => {
       narrow: anotherNarrow,
     };
 
-    const result = getMessageUpdateStrategy(getMessageTransitionProps(prevProps, nextProps));
+    const result = getMessageUpdateStrategy(prevProps, nextProps);
 
     expect(result).toEqual('replace');
   });
@@ -233,7 +233,7 @@ describe('getMessageUpdateStrategy', () => {
       narrow: someNarrow,
     };
 
-    const result = getMessageUpdateStrategy(getMessageTransitionProps(prevProps, nextProps));
+    const result = getMessageUpdateStrategy(prevProps, nextProps);
 
     expect(result).toEqual('scroll-to-anchor');
   });
@@ -248,7 +248,7 @@ describe('getMessageUpdateStrategy', () => {
       narrow: someNarrow,
     };
 
-    const result = getMessageUpdateStrategy(getMessageTransitionProps(prevProps, nextProps));
+    const result = getMessageUpdateStrategy(prevProps, nextProps);
 
     expect(result).toEqual('preserve-position');
   });
@@ -263,7 +263,7 @@ describe('getMessageUpdateStrategy', () => {
       narrow: someNarrow,
     };
 
-    const result = getMessageUpdateStrategy(getMessageTransitionProps(prevProps, nextProps));
+    const result = getMessageUpdateStrategy(prevProps, nextProps);
 
     expect(result).toEqual('preserve-position');
   });
@@ -278,7 +278,7 @@ describe('getMessageUpdateStrategy', () => {
       narrow: someNarrow,
     };
 
-    const result = getMessageUpdateStrategy(getMessageTransitionProps(prevProps, nextProps));
+    const result = getMessageUpdateStrategy(prevProps, nextProps);
 
     expect(result).toEqual('scroll-to-bottom-if-near-bottom');
   });
@@ -293,7 +293,7 @@ describe('getMessageUpdateStrategy', () => {
       narrow: someNarrow,
     };
 
-    const result = getMessageUpdateStrategy(getMessageTransitionProps(prevProps, nextProps));
+    const result = getMessageUpdateStrategy(prevProps, nextProps);
 
     expect(result).toEqual('scroll-to-anchor');
   });

--- a/src/message/messageUpdates.js
+++ b/src/message/messageUpdates.js
@@ -29,27 +29,26 @@ export const getMessageUpdateStrategy = (prevProps: Props, nextProps: Props): Up
     return 'scroll-to-anchor';
   }
 
+  if (prevProps.messages.length === 0) {
+    // All new messages.
+    return 'scroll-to-anchor';
+  }
+
   const noNewMessages = prevProps.messages.length === nextProps.messages.length;
-  const allNewMessages = prevProps.messages.length === 0;
-  const oldMessagesAdded =
-    prevProps.messages.length > 0 && prevProps.messages[0].id > nextProps.messages[0].id;
+  const oldMessagesAdded = prevProps.messages[0].id > nextProps.messages[0].id;
   const newMessagesAdded =
-    prevProps.messages.length > 0
-    && prevProps.messages[prevProps.messages.length - 1].id
-      < nextProps.messages[nextProps.messages.length - 1].id;
+    prevProps.messages[prevProps.messages.length - 1].id
+    < nextProps.messages[nextProps.messages.length - 1].id;
   const onlyOneNewMessage =
-    prevProps.messages.length > 0
-    && nextProps.messages.length > 1
+    nextProps.messages.length > 1
     && prevProps.messages[prevProps.messages.length - 1].id
       === nextProps.messages[nextProps.messages.length - 2].id;
   const messagesReplaced =
-    prevProps.messages.length > 0
-    && prevProps.messages[prevProps.messages.length - 1].id < nextProps.messages[0].id;
+    prevProps.messages[prevProps.messages.length - 1].id < nextProps.messages[0].id;
 
   // prettier-ignore
   if (
-    allNewMessages
-    || messagesReplaced
+    messagesReplaced
   ) {
     return 'scroll-to-anchor';
   } else if (

--- a/src/message/messageUpdates.js
+++ b/src/message/messageUpdates.js
@@ -19,20 +19,21 @@ export type UpdateStrategy =
   | 'scroll-to-bottom-if-near-bottom';
 
 export const getMessageUpdateStrategy = (prevProps: Props, nextProps: Props): UpdateStrategy => {
+  if (nextProps.messages.length === 0) {
+    // No messages.
+    return 'replace';
+  }
+
   const sameNarrow = isEqual(prevProps.narrow, nextProps.narrow);
-  const noMessages = nextProps.messages.length === 0;
   const noNewMessages = sameNarrow && prevProps.messages.length === nextProps.messages.length;
-  const allNewMessages =
-    sameNarrow && prevProps.messages.length === 0 && nextProps.messages.length > 0;
+  const allNewMessages = sameNarrow && prevProps.messages.length === 0;
   const oldMessagesAdded =
     sameNarrow
     && prevProps.messages.length > 0
-    && nextProps.messages.length > 0
     && prevProps.messages[0].id > nextProps.messages[0].id;
   const newMessagesAdded =
     sameNarrow
     && prevProps.messages.length > 0
-    && nextProps.messages.length > 0
     && prevProps.messages[prevProps.messages.length - 1].id
       < nextProps.messages[nextProps.messages.length - 1].id;
   const onlyOneNewMessage =
@@ -44,13 +45,10 @@ export const getMessageUpdateStrategy = (prevProps: Props, nextProps: Props): Up
   const messagesReplaced =
     sameNarrow
     && prevProps.messages.length > 0
-    && nextProps.messages.length > 0
     && prevProps.messages[prevProps.messages.length - 1].id < nextProps.messages[0].id;
 
   // prettier-ignore
-  if (noMessages) {
-    return 'replace';
-  } else if (
+  if (
     !sameNarrow
     || allNewMessages
     || messagesReplaced

--- a/src/message/messageUpdates.js
+++ b/src/message/messageUpdates.js
@@ -57,13 +57,12 @@ export const getMessageUpdateStrategy = (prevProps: Props, nextProps: Props): Up
     && prevProps.messages[prevProps.messages.length - 1].id
       === nextProps.messages[nextProps.messages.length - 2].id;
 
-  // prettier-ignore
-  if (
-    (newMessagesAdded && !onlyOneNewMessage)
-  ) {
-    return 'preserve-position';
-  } else if (onlyOneNewMessage) {
+  if (onlyOneNewMessage) {
     return 'scroll-to-bottom-if-near-bottom';
+  }
+
+  if (newMessagesAdded) {
+    return 'preserve-position';
   }
 
   return 'default';

--- a/src/message/messageUpdates.js
+++ b/src/message/messageUpdates.js
@@ -49,19 +49,20 @@ export const getMessageUpdateStrategy = (prevProps: Props, nextProps: Props): Up
     return 'preserve-position';
   }
 
-  const newMessagesAdded =
-    prevProps.messages[prevProps.messages.length - 1].id
-    < nextProps.messages[nextProps.messages.length - 1].id;
-  const onlyOneNewMessage =
+  if (
     nextProps.messages.length > 1
     && prevProps.messages[prevProps.messages.length - 1].id
-      === nextProps.messages[nextProps.messages.length - 2].id;
-
-  if (onlyOneNewMessage) {
+      === nextProps.messages[nextProps.messages.length - 2].id
+  ) {
+    // Only one new message.
     return 'scroll-to-bottom-if-near-bottom';
   }
 
-  if (newMessagesAdded) {
+  if (
+    prevProps.messages[prevProps.messages.length - 1].id
+    < nextProps.messages[nextProps.messages.length - 1].id
+  ) {
+    // New messages added.
     return 'preserve-position';
   }
 

--- a/src/message/messageUpdates.js
+++ b/src/message/messageUpdates.js
@@ -29,6 +29,7 @@ export type UpdateStrategy =
   | 'scroll-to-anchor'
   | 'scroll-to-bottom-if-near-bottom';
 
+/** Private; exported only for tests. */
 export const getMessageTransitionProps = (prevProps: Props, nextProps: Props): TransitionProps => {
   const sameNarrow = isEqual(prevProps.narrow, nextProps.narrow);
   const noMessages = nextProps.messages.length === 0;
@@ -70,7 +71,9 @@ export const getMessageTransitionProps = (prevProps: Props, nextProps: Props): T
   };
 };
 
-export const getMessageUpdateStrategy = (transitionProps: TransitionProps): UpdateStrategy => {
+export const getMessageUpdateStrategy = (prevProps: Props, nextProps: Props): UpdateStrategy => {
+  const transitionProps = getMessageTransitionProps(prevProps, nextProps);
+
   if (transitionProps.noMessages) {
     return 'replace';
   } else if (

--- a/src/message/messageUpdates.js
+++ b/src/message/messageUpdates.js
@@ -34,8 +34,21 @@ export const getMessageUpdateStrategy = (prevProps: Props, nextProps: Props): Up
     return 'scroll-to-anchor';
   }
 
-  const noNewMessages = prevProps.messages.length === nextProps.messages.length;
-  const oldMessagesAdded = prevProps.messages[0].id > nextProps.messages[0].id;
+  if (prevProps.messages[prevProps.messages.length - 1].id < nextProps.messages[0].id) {
+    // Messages replaced.
+    return 'scroll-to-anchor';
+  }
+
+  if (prevProps.messages.length === nextProps.messages.length) {
+    // No new messages.
+    return 'preserve-position';
+  }
+
+  if (prevProps.messages[0].id > nextProps.messages[0].id) {
+    // Old messages added.
+    return 'preserve-position';
+  }
+
   const newMessagesAdded =
     prevProps.messages[prevProps.messages.length - 1].id
     < nextProps.messages[nextProps.messages.length - 1].id;
@@ -43,18 +56,10 @@ export const getMessageUpdateStrategy = (prevProps: Props, nextProps: Props): Up
     nextProps.messages.length > 1
     && prevProps.messages[prevProps.messages.length - 1].id
       === nextProps.messages[nextProps.messages.length - 2].id;
-  const messagesReplaced =
-    prevProps.messages[prevProps.messages.length - 1].id < nextProps.messages[0].id;
 
   // prettier-ignore
   if (
-    messagesReplaced
-  ) {
-    return 'scroll-to-anchor';
-  } else if (
-    noNewMessages
-    || oldMessagesAdded
-    || (newMessagesAdded && !onlyOneNewMessage)
+    (newMessagesAdded && !onlyOneNewMessage)
   ) {
     return 'preserve-position';
   } else if (onlyOneNewMessage) {

--- a/src/message/messageUpdates.js
+++ b/src/message/messageUpdates.js
@@ -24,33 +24,31 @@ export const getMessageUpdateStrategy = (prevProps: Props, nextProps: Props): Up
     return 'replace';
   }
 
-  const sameNarrow = isEqual(prevProps.narrow, nextProps.narrow);
-  const noNewMessages = sameNarrow && prevProps.messages.length === nextProps.messages.length;
-  const allNewMessages = sameNarrow && prevProps.messages.length === 0;
+  if (!isEqual(prevProps.narrow, nextProps.narrow)) {
+    // Different narrow.
+    return 'scroll-to-anchor';
+  }
+
+  const noNewMessages = prevProps.messages.length === nextProps.messages.length;
+  const allNewMessages = prevProps.messages.length === 0;
   const oldMessagesAdded =
-    sameNarrow
-    && prevProps.messages.length > 0
-    && prevProps.messages[0].id > nextProps.messages[0].id;
+    prevProps.messages.length > 0 && prevProps.messages[0].id > nextProps.messages[0].id;
   const newMessagesAdded =
-    sameNarrow
-    && prevProps.messages.length > 0
+    prevProps.messages.length > 0
     && prevProps.messages[prevProps.messages.length - 1].id
       < nextProps.messages[nextProps.messages.length - 1].id;
   const onlyOneNewMessage =
-    sameNarrow
-    && prevProps.messages.length > 0
+    prevProps.messages.length > 0
     && nextProps.messages.length > 1
     && prevProps.messages[prevProps.messages.length - 1].id
       === nextProps.messages[nextProps.messages.length - 2].id;
   const messagesReplaced =
-    sameNarrow
-    && prevProps.messages.length > 0
+    prevProps.messages.length > 0
     && prevProps.messages[prevProps.messages.length - 1].id < nextProps.messages[0].id;
 
   // prettier-ignore
   if (
-    !sameNarrow
-    || allNewMessages
+    allNewMessages
     || messagesReplaced
   ) {
     return 'scroll-to-anchor';

--- a/src/message/messageUpdates.js
+++ b/src/message/messageUpdates.js
@@ -11,17 +11,6 @@ type Props = $ReadOnly<{
   ...
 }>;
 
-type TransitionProps = {|
-  sameNarrow: boolean,
-  noMessages: boolean,
-  noNewMessages: boolean,
-  allNewMessages: boolean,
-  onlyOneNewMessage: boolean,
-  oldMessagesAdded: boolean,
-  newMessagesAdded: boolean,
-  messagesReplaced: boolean,
-|};
-
 export type UpdateStrategy =
   | 'default'
   | 'replace'
@@ -29,7 +18,7 @@ export type UpdateStrategy =
   | 'scroll-to-anchor'
   | 'scroll-to-bottom-if-near-bottom';
 
-const getMessageTransitionProps = (prevProps: Props, nextProps: Props): TransitionProps => {
+export const getMessageUpdateStrategy = (prevProps: Props, nextProps: Props): UpdateStrategy => {
   const sameNarrow = isEqual(prevProps.narrow, nextProps.narrow);
   const noMessages = nextProps.messages.length === 0;
   const noNewMessages = sameNarrow && prevProps.messages.length === nextProps.messages.length;
@@ -57,30 +46,6 @@ const getMessageTransitionProps = (prevProps: Props, nextProps: Props): Transiti
     && prevProps.messages.length > 0
     && nextProps.messages.length > 0
     && prevProps.messages[prevProps.messages.length - 1].id < nextProps.messages[0].id;
-
-  return {
-    sameNarrow,
-    noMessages,
-    noNewMessages,
-    allNewMessages,
-    onlyOneNewMessage,
-    oldMessagesAdded,
-    newMessagesAdded,
-    messagesReplaced,
-  };
-};
-
-export const getMessageUpdateStrategy = (prevProps: Props, nextProps: Props): UpdateStrategy => {
-  const {
-    sameNarrow,
-    noMessages,
-    noNewMessages,
-    allNewMessages,
-    onlyOneNewMessage,
-    oldMessagesAdded,
-    newMessagesAdded,
-    messagesReplaced,
-  } = getMessageTransitionProps(prevProps, nextProps);
 
   // prettier-ignore
   if (noMessages) {

--- a/src/message/messageUpdates.js
+++ b/src/message/messageUpdates.js
@@ -12,7 +12,6 @@ type Props = $ReadOnly<{
 }>;
 
 export type UpdateStrategy =
-  | 'default'
   | 'replace'
   | 'preserve-position'
   | 'scroll-to-anchor'
@@ -60,10 +59,5 @@ export const getMessageUpdateStrategy = (prevProps: Props, nextProps: Props): Up
     return 'scroll-to-bottom-if-near-bottom';
   }
 
-  if (prevMessages[prevMessages.length - 1].id < nextMessages[nextMessages.length - 1].id) {
-    // New messages added.
-    return 'preserve-position';
-  }
-
-  return 'default';
+  return 'preserve-position';
 };

--- a/src/message/messageUpdates.js
+++ b/src/message/messageUpdates.js
@@ -19,7 +19,10 @@ export type UpdateStrategy =
   | 'scroll-to-bottom-if-near-bottom';
 
 export const getMessageUpdateStrategy = (prevProps: Props, nextProps: Props): UpdateStrategy => {
-  if (nextProps.messages.length === 0) {
+  const prevMessages = prevProps.messages;
+  const nextMessages = nextProps.messages;
+
+  if (nextMessages.length === 0) {
     // No messages.
     return 'replace';
   }
@@ -29,39 +32,35 @@ export const getMessageUpdateStrategy = (prevProps: Props, nextProps: Props): Up
     return 'scroll-to-anchor';
   }
 
-  if (prevProps.messages.length === 0) {
+  if (prevMessages.length === 0) {
     // All new messages.
     return 'scroll-to-anchor';
   }
 
-  if (prevProps.messages[prevProps.messages.length - 1].id < nextProps.messages[0].id) {
+  if (prevMessages[prevMessages.length - 1].id < nextMessages[0].id) {
     // Messages replaced.
     return 'scroll-to-anchor';
   }
 
-  if (prevProps.messages.length === nextProps.messages.length) {
+  if (prevMessages.length === nextMessages.length) {
     // No new messages.
     return 'preserve-position';
   }
 
-  if (prevProps.messages[0].id > nextProps.messages[0].id) {
+  if (prevMessages[0].id > nextMessages[0].id) {
     // Old messages added.
     return 'preserve-position';
   }
 
   if (
-    nextProps.messages.length > 1
-    && prevProps.messages[prevProps.messages.length - 1].id
-      === nextProps.messages[nextProps.messages.length - 2].id
+    nextMessages.length > 1
+    && prevMessages[prevMessages.length - 1].id === nextMessages[nextMessages.length - 2].id
   ) {
     // Only one new message.
     return 'scroll-to-bottom-if-near-bottom';
   }
 
-  if (
-    prevProps.messages[prevProps.messages.length - 1].id
-    < nextProps.messages[nextProps.messages.length - 1].id
-  ) {
+  if (prevMessages[prevMessages.length - 1].id < nextMessages[nextMessages.length - 1].id) {
     // New messages added.
     return 'preserve-position';
   }

--- a/src/message/messageUpdates.js
+++ b/src/message/messageUpdates.js
@@ -72,23 +72,33 @@ export const getMessageTransitionProps = (prevProps: Props, nextProps: Props): T
 };
 
 export const getMessageUpdateStrategy = (prevProps: Props, nextProps: Props): UpdateStrategy => {
-  const transitionProps = getMessageTransitionProps(prevProps, nextProps);
+  const {
+    sameNarrow,
+    noMessages,
+    noNewMessages,
+    allNewMessages,
+    onlyOneNewMessage,
+    oldMessagesAdded,
+    newMessagesAdded,
+    messagesReplaced,
+  } = getMessageTransitionProps(prevProps, nextProps);
 
-  if (transitionProps.noMessages) {
+  // prettier-ignore
+  if (noMessages) {
     return 'replace';
   } else if (
-    !transitionProps.sameNarrow
-    || transitionProps.allNewMessages
-    || transitionProps.messagesReplaced
+    !sameNarrow
+    || allNewMessages
+    || messagesReplaced
   ) {
     return 'scroll-to-anchor';
   } else if (
-    transitionProps.noNewMessages
-    || transitionProps.oldMessagesAdded
-    || (transitionProps.newMessagesAdded && !transitionProps.onlyOneNewMessage)
+    noNewMessages
+    || oldMessagesAdded
+    || (newMessagesAdded && !onlyOneNewMessage)
   ) {
     return 'preserve-position';
-  } else if (transitionProps.onlyOneNewMessage) {
+  } else if (onlyOneNewMessage) {
     return 'scroll-to-bottom-if-near-bottom';
   }
 

--- a/src/message/messageUpdates.js
+++ b/src/message/messageUpdates.js
@@ -29,8 +29,7 @@ export type UpdateStrategy =
   | 'scroll-to-anchor'
   | 'scroll-to-bottom-if-near-bottom';
 
-/** Private; exported only for tests. */
-export const getMessageTransitionProps = (prevProps: Props, nextProps: Props): TransitionProps => {
+const getMessageTransitionProps = (prevProps: Props, nextProps: Props): TransitionProps => {
   const sameNarrow = isEqual(prevProps.narrow, nextProps.narrow);
   const noMessages = nextProps.messages.length === 0;
   const noNewMessages = sameNarrow && prevProps.messages.length === nextProps.messages.length;

--- a/src/webview/generateInboundEvents.js
+++ b/src/webview/generateInboundEvents.js
@@ -8,7 +8,7 @@ import type { UpdateStrategy } from '../message/messageUpdates';
 import htmlBody from './html/htmlBody';
 import contentHtmlFromPieceDescriptors from './html/contentHtmlFromPieceDescriptors';
 import messageTypingAsHtml from './html/messageTypingAsHtml';
-import { getMessageTransitionProps, getMessageUpdateStrategy } from '../message/messageUpdates';
+import { getMessageUpdateStrategy } from '../message/messageUpdates';
 
 export type WebViewInboundEventContent = {|
   type: 'content',
@@ -56,8 +56,7 @@ const updateContent = (prevProps: Props, nextProps: Props): WebViewInboundEventC
     }),
     nextProps.showMessagePlaceholders,
   );
-  const transitionProps = getMessageTransitionProps(prevProps, nextProps);
-  const updateStrategy = getMessageUpdateStrategy(transitionProps);
+  const updateStrategy = getMessageUpdateStrategy(prevProps, nextProps);
 
   return {
     type: 'content',

--- a/src/webview/js/generatedEs3.js
+++ b/src/webview/js/generatedEs3.js
@@ -756,23 +756,37 @@ var compiledWebviewJs = (function (exports) {
   };
 
   var handleInboundEventContent = function handleInboundEventContent(uevent) {
+    var updateStrategy = uevent.updateStrategy;
     var target;
 
-    if (uevent.updateStrategy === 'replace') {
-      target = {
-        type: 'none'
-      };
-    } else if (uevent.updateStrategy === 'scroll-to-anchor') {
-      target = {
-        type: 'anchor',
-        messageId: uevent.scrollMessageId
-      };
-    } else if (uevent.updateStrategy === 'scroll-to-bottom-if-near-bottom' && isNearBottom()) {
+    switch (updateStrategy) {
+      case 'replace':
         target = {
-          type: 'bottom'
+          type: 'none'
         };
-      } else {
-      target = findPreserveTarget();
+        break;
+
+      case 'scroll-to-anchor':
+        target = {
+          type: 'anchor',
+          messageId: uevent.scrollMessageId
+        };
+        break;
+
+      case 'scroll-to-bottom-if-near-bottom':
+        target = isNearBottom() ? {
+          type: 'bottom'
+        } : findPreserveTarget();
+        break;
+
+      case 'preserve-position':
+      case 'default':
+        target = findPreserveTarget();
+        break;
+
+      default:
+        target = findPreserveTarget();
+        break;
     }
 
     documentBody.innerHTML = uevent.content;

--- a/src/webview/js/generatedEs3.js
+++ b/src/webview/js/generatedEs3.js
@@ -780,7 +780,6 @@ var compiledWebviewJs = (function (exports) {
         break;
 
       case 'preserve-position':
-      case 'default':
         target = findPreserveTarget();
         break;
 

--- a/src/webview/js/js.js
+++ b/src/webview/js/js.js
@@ -664,7 +664,6 @@ const handleInboundEventContent = (uevent: WebViewInboundEventContent) => {
       target = isNearBottom() ? { type: 'bottom' } : findPreserveTarget();
       break;
     case 'preserve-position':
-    case 'default':
       target = findPreserveTarget();
       break;
     default:


### PR DESCRIPTION
As discussed here:
https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/getMessageTransitionProps/near/1243171

This cleans up the structure of this code a bit, hopefully making it easier to work out exactly what it's doing and to change what it's doing.

The actual behavior is unchanged. Some of the conditions don't seem to make a ton of sense -- in particular they seem like they can at best be heuristics for what the names (converted here to comments) suggest they're trying to get at, and it's not at all clear (and there are no comments to explain) why those particular conditions should lead to these particular behaviors. So there's plenty of room to change the behavior from here; in particular, we don't need to give the existing code a lot of deference in being super careful about preserving the existing behavior, as long as we're doing some thinking about the desired new behavior with any changes.
