### PR TITLE
MentionWarnings [nfc]: Convert to function component.

### DIFF
--- a/src/compose/ComposeBox.js
+++ b/src/compose/ComposeBox.js
@@ -138,14 +138,7 @@ class ComposeBox extends PureComponent<Props, State> {
   messageInputRef = React.createRef<$FlowFixMe>();
   topicInputRef = React.createRef<$FlowFixMe>();
 
-  // TODO: Type-check this, once we've adjusted our `react-redux`
-  // wrapper to do the right thing. It should be
-  //
-  //   mentionWarnings = React.createRef<React$ElementRef<MentionWarnings>>()
-  //
-  // but we need our `react-redux` wrapper to be aware of
-  // `{ forwardRef: true }`, since we use that.
-  mentionWarnings = React.createRef();
+  mentionWarnings = React.createRef<React$ElementRef<typeof MentionWarnings>>();
 
   inputBlurTimeoutId: ?TimeoutID = null;
 
@@ -503,10 +496,6 @@ class ComposeBox extends PureComponent<Props, State> {
 
     return (
       <View style={this.styles.wrapper}>
-        {/*
-          $FlowFixMe[incompatible-use]:
-          `MentionWarnings` should use a type-checked `connect`
-        */}
         <MentionWarnings narrow={narrow} stream={stream} ref={this.mentionWarnings} />
         <View style={[this.styles.autocompleteWrapper, { marginBottom: height }]}>
           <TopicAutocomplete

--- a/src/compose/MentionWarnings.js
+++ b/src/compose/MentionWarnings.js
@@ -19,7 +19,19 @@ type Props = $ReadOnly<{|
 |}>;
 
 type ImperativeHandle = {|
+  /**
+   * Check whether the message text entered by the user contains
+   * an @-mention to a user unsubscribed to the current stream, and if
+   * so, shows a warning.
+   *
+   * This function is expected to be called by `ComposeBox` using a ref
+   * to this component.
+   *
+   * @param completion The autocomplete option chosend by the user.
+      See JSDoc for AutoCompleteView for details.
+   */
   handleMentionSubscribedCheck(completion: string): Promise<void>,
+
   clearMentionWarnings(): void,
 |};
 
@@ -81,17 +93,6 @@ function MentionWarnings(props: Props, ref) {
   useImperativeHandle(
     ref,
     () => ({
-      /**
-       * Check whether the message text entered by the user contains
-       * an @-mention to a user unsubscribed to the current stream, and if
-       * so, shows a warning.
-       *
-       * This function is expected to be called by `ComposeBox` using a ref
-       * to this component.
-       *
-       * @param completion The autocomplete option chosend by the user.
-          See JSDoc for AutoCompleteView for details.
-       */
       handleMentionSubscribedCheck: async (completion: string) => {
         if (is1to1PmNarrow(narrow)) {
           return;

--- a/src/compose/MentionWarnings.js
+++ b/src/compose/MentionWarnings.js
@@ -1,9 +1,9 @@
 /* @flow strict-local */
 
-import { connect } from 'react-redux';
 import React, { useState, useCallback, useContext, forwardRef, useImperativeHandle } from 'react';
+import { useSelector } from 'react-redux';
 
-import type { Auth, Stream, Dispatch, Narrow, UserOrBot, Subscription, UserId } from '../types';
+import type { Stream, Narrow, UserOrBot, Subscription, UserId } from '../types';
 import { TranslationContext } from '../boot/TranslationProvider';
 import { getAllUsersById, getAuth } from '../selectors';
 import { is1to1PmNarrow } from '../utils/narrow';
@@ -13,17 +13,9 @@ import { showToast } from '../utils/info';
 import MentionedUserNotSubscribed from '../message/MentionedUserNotSubscribed';
 import { makeUserId } from '../api/idTypes';
 
-type SelectorProps = {|
-  auth: Auth,
-  allUsersById: Map<UserId, UserOrBot>,
-|};
-
 type Props = $ReadOnly<{|
   narrow: Narrow,
   stream: Subscription | {| ...Stream, in_home_view: boolean |},
-
-  dispatch: Dispatch,
-  ...SelectorProps,
 |}>;
 
 type ImperativeHandle = {|
@@ -32,7 +24,10 @@ type ImperativeHandle = {|
 |};
 
 function MentionWarnings(props: Props, ref) {
-  const { stream, narrow, auth, allUsersById } = props;
+  const { stream, narrow } = props;
+
+  const auth = useSelector(getAuth);
+  const allUsersById = useSelector(getAllUsersById);
 
   const [unsubscribedMentions, setUnsubscribedMentions] = useState<UserId[]>([]);
 
@@ -169,13 +164,4 @@ function MentionWarnings(props: Props, ref) {
   return mentionWarnings;
 }
 
-// $FlowFixMe[missing-annot]. TODO: Use a type checked connect call.
-export default connect(
-  state => ({
-    auth: getAuth(state),
-    allUsersById: getAllUsersById(state),
-  }),
-  null,
-  null,
-  { forwardRef: true },
-)(forwardRef<Props, ImperativeHandle>(MentionWarnings));
+export default forwardRef<Props, ImperativeHandle>(MentionWarnings);

--- a/src/compose/MentionWarnings.js
+++ b/src/compose/MentionWarnings.js
@@ -18,17 +18,18 @@ type Props = $ReadOnly<{|
   stream: Subscription | {| ...Stream, in_home_view: boolean |},
 |}>;
 
+/**
+ * Functions expected to be called by ComposeBox using a ref to this
+ *   component.
+ */
 type ImperativeHandle = {|
   /**
    * Check whether the message text entered by the user contains
    * an @-mention to a user unsubscribed to the current stream, and if
    * so, shows a warning.
    *
-   * This function is expected to be called by `ComposeBox` using a ref
-   * to this component.
-   *
    * @param completion The autocomplete option chosend by the user.
-      See JSDoc for AutoCompleteView for details.
+   * See JSDoc for AutoCompleteView for details.
    */
   handleMentionSubscribedCheck(completion: string): Promise<void>,
 

--- a/src/compose/MentionWarnings.js
+++ b/src/compose/MentionWarnings.js
@@ -1,6 +1,7 @@
 /* @flow strict-local */
 
 import React, { useState, useCallback, useContext, forwardRef, useImperativeHandle } from 'react';
+import type { AbstractComponent, Node } from 'react';
 import { useSelector } from 'react-redux';
 
 import type { Stream, Narrow, UserOrBot, Subscription, UserId } from '../types';
@@ -36,7 +37,7 @@ type ImperativeHandle = {|
   clearMentionWarnings(): void,
 |};
 
-function MentionWarnings(props: Props, ref) {
+function MentionWarningsInner(props: Props, ref): Node {
   const { stream, narrow } = props;
 
   const auth = useSelector(getAuth);
@@ -166,4 +167,8 @@ function MentionWarnings(props: Props, ref) {
   return mentionWarnings;
 }
 
-export default forwardRef<Props, ImperativeHandle>(MentionWarnings);
+const MentionWarnings: AbstractComponent<Props, ImperativeHandle> = forwardRef(
+  MentionWarningsInner,
+);
+
+export default MentionWarnings;


### PR DESCRIPTION
For annotating the default export of `MentionWarnings`, for #4907, I think it actually may be easier to first convert it to a function component and remove the `connect` call. This is a little surprising because it had been on my list of components that I thought would be pretty tricky to convert.

I didn't find a way to get thorough type-checking of `MentionWarnings`'s methods that `ComposeBox` was calling on a `ref`, until I converted `MentionWarnings` to a function component. After this PR, we should get that type-checking, without having to manually repeat any types.

I tested the component on my iPhone and it worked as I expected it to.