### PR TITLE
Annotate most exported `connect`ed components.

### DIFF
--- a/src/boot/AppEventHandlers.js
+++ b/src/boot/AppEventHandlers.js
@@ -1,7 +1,7 @@
 /* @flow strict-local */
 
 import React, { PureComponent } from 'react';
-import type { Node } from 'react';
+import type { Node, ComponentType } from 'react';
 import { AppState, View, Platform, NativeModules } from 'react-native';
 // $FlowFixMe[untyped-import]
 import NetInfo from '@react-native-community/netinfo';
@@ -91,7 +91,7 @@ const orientationLookup: OrientationLookup = {
   [ScreenOrientation.Orientation.LANDSCAPE_RIGHT]: 'LANDSCAPE',
 };
 
-class AppEventHandlers extends PureComponent<Props> {
+class AppEventHandlersInner extends PureComponent<Props> {
   /** NetInfo disconnection callback. */
   netInfoDisconnectCallback: (() => void) | null = null;
 
@@ -161,6 +161,8 @@ class AppEventHandlers extends PureComponent<Props> {
   }
 }
 
-export default connect(state => ({
+const AppEventHandlers: ComponentType<OuterProps> = connect(state => ({
   unreadCount: getUnreadByHuddlesMentionsAndPMs(state),
-}))(AppEventHandlers);
+}))(AppEventHandlersInner);
+
+export default AppEventHandlers;

--- a/src/boot/AppEventHandlers.js
+++ b/src/boot/AppEventHandlers.js
@@ -63,10 +63,20 @@ const styles = createStyleSheet({
   },
 });
 
-type Props = $ReadOnly<{|
-  dispatch: Dispatch,
+type OuterProps = $ReadOnly<{|
   children: Node,
+|}>;
+
+type SelectorProps = $ReadOnly<{|
   unreadCount: number,
+|}>;
+
+type Props = $ReadOnly<{|
+  ...OuterProps,
+
+  // from `connect`
+  dispatch: Dispatch,
+  ...SelectorProps,
 |}>;
 
 type OrientationLookup = {|

--- a/src/compose/ComposeBox.js
+++ b/src/compose/ComposeBox.js
@@ -75,18 +75,24 @@ type SelectorProps = {|
   stream: Subscription | {| ...Stream, in_home_view: boolean |},
 |};
 
-type Props = $ReadOnly<{|
-  insets: EdgeInsets,
-
+type OuterProps = $ReadOnly<{|
   narrow: Narrow,
   editMessage: EditMessage | null,
   completeEditMessage: () => void,
+|}>;
 
-  dispatch: Dispatch,
-  ...SelectorProps,
+type Props = $ReadOnly<{|
+  ...OuterProps,
 
   // From 'withGetText'
   _: GetText,
+
+  // from withSafeAreaInsets
+  insets: EdgeInsets,
+
+  // from `connect`
+  dispatch: Dispatch,
+  ...SelectorProps,
 |}>;
 
 type State = {|

--- a/src/compose/ComposeBox.js
+++ b/src/compose/ComposeBox.js
@@ -1,5 +1,6 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
+import type { ComponentType } from 'react';
 import { Platform, View, findNodeHandle } from 'react-native';
 import type { DocumentPickerResponse } from 'react-native-document-picker';
 import type { LayoutEvent } from 'react-native/Libraries/Types/CoreEventTypes';
@@ -133,7 +134,7 @@ const updateTextInput = (textInput, text) => {
   }
 };
 
-class ComposeBox extends PureComponent<Props, State> {
+class ComposeBoxInner extends PureComponent<Props, State> {
   static contextType = ThemeContext;
   context: ThemeData;
 
@@ -571,7 +572,7 @@ class ComposeBox extends PureComponent<Props, State> {
   }
 }
 
-export default compose(
+const ComposeBox: ComponentType<OuterProps> = compose(
   connect<SelectorProps, _, _>((state, props) => ({
     auth: getAuth(state),
     ownUserId: getOwnUserId(state),
@@ -586,4 +587,6 @@ export default compose(
     videoChatProvider: getVideoChatProvider(state),
   })),
   withSafeAreaInsets,
-)(withGetText(ComposeBox));
+)(withGetText(ComposeBoxInner));
+
+export default ComposeBox;

--- a/src/compose/ComposeMenu.js
+++ b/src/compose/ComposeMenu.js
@@ -20,13 +20,22 @@ import {
 import AnimatedComponent from '../animation/AnimatedComponent';
 import { uploadFile } from '../actions';
 
-type Props = $ReadOnly<{|
-  dispatch: Dispatch,
+type OuterProps = $ReadOnly<{|
   expanded: boolean,
   destinationNarrow: Narrow,
   insertAttachment: (DocumentPickerResponse[]) => Promise<void>,
   insertVideoCallLink: (() => void) | null,
   onExpandContract: () => void,
+|}>;
+
+type SelectorProps = $ReadOnly<{||}>;
+
+type Props = $ReadOnly<{|
+  ...OuterProps,
+
+  // from `connect`
+  ...SelectorProps,
+  dispatch: Dispatch,
 |}>;
 
 /**
@@ -208,4 +217,4 @@ class ComposeMenu extends PureComponent<Props> {
   }
 }
 
-export default connect<{||}, _, _>()(ComposeMenu);
+export default connect<SelectorProps, _, _>()(ComposeMenu);

--- a/src/compose/ComposeMenu.js
+++ b/src/compose/ComposeMenu.js
@@ -1,5 +1,6 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
+import type { ComponentType } from 'react';
 import { Platform, View } from 'react-native';
 import type { DocumentPickerResponse } from 'react-native-document-picker';
 // $FlowFixMe[untyped-import]
@@ -69,7 +70,7 @@ export const chooseUploadImageFilename = (uri: string, fileName: ?string): strin
   return name;
 };
 
-class ComposeMenu extends PureComponent<Props> {
+class ComposeMenuInner extends PureComponent<Props> {
   uploadFile = (uri: string, fileName: ?string) => {
     const { dispatch, destinationNarrow } = this.props;
     dispatch(uploadFile(destinationNarrow, uri, chooseUploadImageFilename(uri, fileName)));
@@ -217,4 +218,6 @@ class ComposeMenu extends PureComponent<Props> {
   }
 }
 
-export default connect<SelectorProps, _, _>()(ComposeMenu);
+const ComposeMenu: ComponentType<OuterProps> = connect<SelectorProps, _, _>()(ComposeMenuInner);
+
+export default ComposeMenu;

--- a/src/presence/PresenceHeartbeat.js
+++ b/src/presence/PresenceHeartbeat.js
@@ -1,5 +1,6 @@
 // @flow strict-local
 import { PureComponent } from 'react';
+import type { ComponentType } from 'react';
 import { AppState } from 'react-native';
 import type { Auth, Dispatch } from '../types';
 
@@ -32,7 +33,7 @@ type Props = $ReadOnly<{|
 // (This is merely a misnomer on React's part, rather than a functional error. A
 // `PureComponent` is simply one which never updates except when its props have
 // changed -- which is exactly what we want.)
-class PresenceHeartbeat extends PureComponent<Props> {
+class PresenceHeartbeatInner extends PureComponent<Props> {
   /** Callback for Heartbeat object. */
   onHeartbeat = () => {
     if (this.props.auth) {
@@ -71,6 +72,8 @@ class PresenceHeartbeat extends PureComponent<Props> {
   }
 }
 
-export default connect(state => ({
+const PresenceHeartbeat: ComponentType<OuterProps> = connect(state => ({
   auth: tryGetAuth(state),
-}))(PresenceHeartbeat);
+}))(PresenceHeartbeatInner);
+
+export default PresenceHeartbeat;

--- a/src/presence/PresenceHeartbeat.js
+++ b/src/presence/PresenceHeartbeat.js
@@ -8,9 +8,18 @@ import { tryGetAuth } from '../account/accountsSelectors';
 import { reportPresence } from '../actions';
 import Heartbeat from './heartbeat';
 
-type Props = $ReadOnly<{|
-  dispatch: Dispatch,
+type OuterProps = $ReadOnly<{||}>;
+
+type SelectorProps = $ReadOnly<{|
   auth: Auth | void,
+|}>;
+
+type Props = $ReadOnly<{|
+  ...OuterProps,
+
+  // from `connect`
+  dispatch: Dispatch,
+  ...SelectorProps,
 |}>;
 
 /**

--- a/src/reactions/MessageReactionsScreen.js
+++ b/src/reactions/MessageReactionsScreen.js
@@ -1,6 +1,6 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
-import type { Node } from 'react';
+import type { Node, ComponentType } from 'react';
 import { View } from 'react-native';
 import { createMaterialTopTabNavigator } from '@react-navigation/material-top-tabs';
 
@@ -53,7 +53,7 @@ type Props = $ReadOnly<{|
  * The `reactionName` nav-prop controls what reaction is focused when the
  * screen first appears.
  */
-class MessageReactionsScreen extends PureComponent<Props> {
+class MessageReactionsScreenInner extends PureComponent<Props> {
   componentDidMount() {
     if (this.props.message === undefined) {
       const { messageId } = this.props.route.params;
@@ -144,8 +144,12 @@ class MessageReactionsScreen extends PureComponent<Props> {
   }
 }
 
-export default connect<SelectorProps, _, _>((state, props) => ({
-  // message *can* be undefined; see componentDidUpdate for explanation and handling.
-  message: state.messages.get(props.route.params.messageId),
-  ownUserId: getOwnUserId(state),
-}))(MessageReactionsScreen);
+const MessageReactionsScreen: ComponentType<OuterProps> = connect<SelectorProps, _, _>(
+  (state, props) => ({
+    // message *can* be undefined; see componentDidUpdate for explanation and handling.
+    message: state.messages.get(props.route.params.messageId),
+    ownUserId: getOwnUserId(state),
+  }),
+)(MessageReactionsScreenInner);
+
+export default MessageReactionsScreen;

--- a/src/reactions/MessageReactionsScreen.js
+++ b/src/reactions/MessageReactionsScreen.js
@@ -28,15 +28,21 @@ const emojiTypeFromReactionType = (reactionType: ReactionType): EmojiType => {
   return 'image';
 };
 
+type OuterProps = $ReadOnly<{|
+  // These should be passed from React Navigation
+  navigation: AppNavigationProp<'message-reactions'>,
+  route: RouteProp<'message-reactions', {| reactionName?: string, messageId: number |}>,
+|}>;
+
 type SelectorProps = $ReadOnly<{|
   message: Message | void,
   ownUserId: UserId,
 |}>;
 
 type Props = $ReadOnly<{|
-  navigation: AppNavigationProp<'message-reactions'>,
-  route: RouteProp<'message-reactions', {| reactionName?: string, messageId: number |}>,
+  ...OuterProps,
 
+  // from `connect`
   dispatch: Dispatch,
   ...SelectorProps,
 |}>;

--- a/src/search/SearchMessagesScreen.js
+++ b/src/search/SearchMessagesScreen.js
@@ -1,5 +1,6 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
+import type { ComponentType } from 'react';
 
 import type { RouteProp } from '../react-navigation';
 import type { AppNavigationProp } from '../nav/AppNavigator';
@@ -48,7 +49,7 @@ type State = {|
   isFetching: boolean,
 |};
 
-class SearchMessagesScreen extends PureComponent<Props, State> {
+class SearchMessagesScreenInner extends PureComponent<Props, State> {
   state = {
     query: '',
     messages: null,
@@ -148,6 +149,8 @@ class SearchMessagesScreen extends PureComponent<Props, State> {
   }
 }
 
-export default connect(state => ({
+const SearchMessagesScreen: ComponentType<OuterProps> = connect(state => ({
   auth: getAuth(state),
-}))(SearchMessagesScreen);
+}))(SearchMessagesScreenInner);
+
+export default SearchMessagesScreen;

--- a/src/search/SearchMessagesScreen.js
+++ b/src/search/SearchMessagesScreen.js
@@ -13,12 +13,21 @@ import { connect } from '../react-redux';
 import { getAuth } from '../account/accountsSelectors';
 import { fetchMessages } from '../message/fetchActions';
 
-type Props = $ReadOnly<{|
+type OuterProps = $ReadOnly<{|
+  // These should be passed from React Navigation
   navigation: AppNavigationProp<'search-messages'>,
   route: RouteProp<'search-messages', void>,
+|}>;
 
+type SelectorProps = $ReadOnly<{|
   auth: Auth,
+|}>;
+
+type Props = $ReadOnly<{|
+  ...OuterProps,
+
   dispatch: Dispatch,
+  ...SelectorProps,
   // Warning: do not add new props without considering their effect on the
   // behavior of this component's non-React internal state. See comment below.
 |}>;

--- a/src/sharing/ShareToStream.js
+++ b/src/sharing/ShareToStream.js
@@ -1,5 +1,6 @@
 /* @flow strict-local */
 import React from 'react';
+import type { ComponentType } from 'react';
 
 import type { SharingNavigationProp } from './SharingScreen';
 import type { RouteProp } from '../react-navigation';
@@ -42,7 +43,7 @@ type State = $ReadOnly<{|
   isTopicFocused: boolean,
 |}>;
 
-class ShareToStream extends React.Component<Props, State> {
+class ShareToStreamInner extends React.Component<Props, State> {
   static contextType = TranslationContext;
   context: GetText;
 
@@ -147,7 +148,9 @@ class ShareToStream extends React.Component<Props, State> {
   }
 }
 
-export default connect(state => ({
+const ShareToStream: ComponentType<OuterProps> = connect(state => ({
   subscriptions: getSubscriptionsById(state),
   auth: getAuth(state),
-}))(ShareToStream);
+}))(ShareToStreamInner);
+
+export default ShareToStream;

--- a/src/sharing/ShareToStream.js
+++ b/src/sharing/ShareToStream.js
@@ -17,13 +17,22 @@ import { getAuth } from '../selectors';
 import { fetchTopicsForStream } from '../topics/topicActions';
 import ShareWrapper from './ShareWrapper';
 
-type Props = $ReadOnly<{|
+type OuterProps = $ReadOnly<{|
+  // These should be passed from React Navigation
   navigation: SharingNavigationProp<'share-to-stream'>,
   route: RouteProp<'share-to-stream', {| sharedData: SharedData |}>,
+|}>;
 
-  dispatch: Dispatch,
+type SelectorProps = $ReadOnly<{|
   subscriptions: Map<number, Subscription>,
   auth: Auth,
+|}>;
+
+type Props = $ReadOnly<{|
+  ...OuterProps,
+
+  ...SelectorProps,
+  dispatch: Dispatch,
 |}>;
 
 type State = $ReadOnly<{|

--- a/src/sharing/ShareWrapper.js
+++ b/src/sharing/ShareWrapper.js
@@ -1,6 +1,6 @@
 /* @flow strict-local */
 import React from 'react';
-import type { Node } from 'react';
+import type { Node, ComponentType } from 'react';
 import { FlatList, ImageBackground, ScrollView, View, Text } from 'react-native';
 
 import type { Auth, Dispatch, GetText, UserId } from '../types';
@@ -85,7 +85,7 @@ type State = $ReadOnly<{|
  * Wraps Around different sharing screens,
  * for minimal duplication of code.
  */
-class ShareWrapper extends React.Component<Props, State> {
+class ShareWrapperInner extends React.Component<Props, State> {
   static contextType = TranslationContext;
   context: GetText;
 
@@ -260,7 +260,9 @@ class ShareWrapper extends React.Component<Props, State> {
   }
 }
 
-export default connect(state => ({
+const ShareWrapper: ComponentType<OuterProps> = connect(state => ({
   auth: getAuth(state),
   ownUserId: getOwnUserId(state),
-}))(ShareWrapper);
+}))(ShareWrapperInner);
+
+export default ShareWrapper;

--- a/src/sharing/ShareWrapper.js
+++ b/src/sharing/ShareWrapper.js
@@ -56,15 +56,23 @@ const styles = createStyleSheet({
   },
 });
 
-type Props = $ReadOnly<{|
+type OuterProps = $ReadOnly<{|
   children: Node,
   isSendButtonEnabled: (message: string) => boolean,
   sendTo: SendTo,
   sharedData: SharedData,
+|}>;
 
-  dispatch: Dispatch,
+type SelectorProps = $ReadOnly<{|
   auth: Auth,
   ownUserId: UserId,
+|}>;
+
+type Props = $ReadOnly<{|
+  ...OuterProps,
+
+  ...SelectorProps,
+  dispatch: Dispatch,
 |}>;
 
 type State = $ReadOnly<{|

--- a/src/start/AuthScreen.js
+++ b/src/start/AuthScreen.js
@@ -167,12 +167,21 @@ export const activeAuthentications = (
   return result;
 };
 
-type Props = $ReadOnly<{|
+type OuterProps = $ReadOnly<{|
+  // These should be passed from React Navigation
   navigation: AppNavigationProp<'auth'>,
   route: RouteProp<'auth', {| serverSettings: ApiResponseServerSettings |}>,
+|}>;
+
+type SelectorProps = $ReadOnly<{|
+  realm: URL,
+|}>;
+
+type Props = $ReadOnly<{|
+  ...OuterProps,
 
   dispatch: Dispatch,
-  realm: URL,
+  ...SelectorProps,
 |}>;
 
 let otp = '';

--- a/src/start/AuthScreen.js
+++ b/src/start/AuthScreen.js
@@ -1,6 +1,7 @@
 /* @flow strict-local */
 
 import React, { PureComponent } from 'react';
+import type { ComponentType } from 'react';
 import { Linking, Platform } from 'react-native';
 import type { AppleAuthenticationCredential } from 'expo-apple-authentication';
 import * as AppleAuthentication from 'expo-apple-authentication';
@@ -199,7 +200,7 @@ type LinkingEvent = {
   ...
 };
 
-class AuthScreen extends PureComponent<Props> {
+class AuthScreenInner extends PureComponent<Props> {
   componentDidMount = () => {
     Linking.addEventListener('url', this.endWebAuth);
     Linking.getInitialURL().then((initialUrl: ?string) => {
@@ -360,8 +361,10 @@ class AuthScreen extends PureComponent<Props> {
   }
 }
 
-export default connect((state, props) => ({
+const AuthScreen: ComponentType<OuterProps> = connect((state, props) => ({
   // Not from the Redux state, but it's convenient to validate the URL
   // in one central place, like here.
   realm: new URL(props.route.params.serverSettings.realm_uri),
-}))(AuthScreen);
+}))(AuthScreenInner);
+
+export default AuthScreen;

--- a/src/start/DevAuthScreen.js
+++ b/src/start/DevAuthScreen.js
@@ -1,6 +1,7 @@
 /* @flow strict-local */
 
 import React, { PureComponent } from 'react';
+import type { ComponentType } from 'react';
 import { ActivityIndicator, View, FlatList } from 'react-native';
 
 import type { RouteProp } from '../react-navigation';
@@ -49,7 +50,7 @@ type State = {|
   error: string,
 |};
 
-class DevAuthScreen extends PureComponent<Props, State> {
+class DevAuthScreenInner extends PureComponent<Props, State> {
   state = {
     progress: false,
     directAdmins: [],
@@ -133,4 +134,6 @@ class DevAuthScreen extends PureComponent<Props, State> {
   }
 }
 
-export default connect<{||}, _, _>()(DevAuthScreen);
+const DevAuthScreen: ComponentType<OuterProps> = connect<{||}, _, _>()(DevAuthScreenInner);
+
+export default DevAuthScreen;

--- a/src/start/DevAuthScreen.js
+++ b/src/start/DevAuthScreen.js
@@ -27,11 +27,19 @@ const componentStyles = createStyleSheet({
   },
 });
 
-type Props = $ReadOnly<{|
+type OuterProps = $ReadOnly<{|
+  // These should be passed from React Navigation
   navigation: AppNavigationProp<'dev-auth'>,
   route: RouteProp<'dev-auth', {| realm: URL |}>,
+|}>;
+
+type SelectorProps = $ReadOnly<{||}>;
+
+type Props = $ReadOnly<{|
+  ...OuterProps,
 
   dispatch: Dispatch,
+  ...SelectorProps,
 |}>;
 
 type State = {|

--- a/src/start/PasswordAuthScreen.js
+++ b/src/start/PasswordAuthScreen.js
@@ -31,11 +31,19 @@ const styles = createStyleSheet({
   },
 });
 
-type Props = $ReadOnly<{|
+type OuterProps = $ReadOnly<{|
+  // These should be passed from React Navigation
   navigation: AppNavigationProp<'password-auth'>,
   route: RouteProp<'password-auth', {| realm: URL, requireEmailFormat: boolean |}>,
+|}>;
+
+type SelectorProps = $ReadOnly<{||}>;
+
+type Props = $ReadOnly<{|
+  ...OuterProps,
 
   dispatch: Dispatch,
+  ...SelectorProps,
 |}>;
 
 type State = {|

--- a/src/start/PasswordAuthScreen.js
+++ b/src/start/PasswordAuthScreen.js
@@ -1,5 +1,6 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
+import type { ComponentType } from 'react';
 import { View } from 'react-native';
 
 import type { RouteProp } from '../react-navigation';
@@ -53,7 +54,7 @@ type State = {|
   progress: boolean,
 |};
 
-class PasswordAuthScreen extends PureComponent<Props, State> {
+class PasswordAuthScreenInner extends PureComponent<Props, State> {
   state = {
     progress: false,
     email: '',
@@ -150,4 +151,8 @@ class PasswordAuthScreen extends PureComponent<Props, State> {
   }
 }
 
-export default connect<{||}, _, _>()(PasswordAuthScreen);
+const PasswordAuthScreen: ComponentType<OuterProps> = connect<{||}, _, _>()(
+  PasswordAuthScreenInner,
+);
+
+export default PasswordAuthScreen;


### PR DESCRIPTION
With the exception of `MentionWarnings`, which I've opened #4942 for, and `ComposeMenu`, which we have #4796 for.

Related: #4907 