### PR TITLE
Annotate more exports.

### DIFF
--- a/src/api/initialDataTypes.js
+++ b/src/api/initialDataTypes.js
@@ -242,7 +242,7 @@ export type HuddlesUnreadItem = {|
   user_ids_string: string,
 
   // Sorted.
-  unread_message_ids: number[],
+  unread_message_ids: $ReadOnlyArray<number>,
 |};
 
 /** The unreads in a 1:1 PM thread, as represented in `unread_msgs`. */
@@ -259,7 +259,7 @@ export type PmsUnreadItem = {|
   sender_id: UserId,
 
   // Sorted.
-  unread_message_ids: number[],
+  unread_message_ids: $ReadOnlyArray<number>,
 |};
 
 /** Initial data for `update_message_flags` events. */

--- a/src/api/initialDataTypes.js
+++ b/src/api/initialDataTypes.js
@@ -16,40 +16,40 @@ import type {
   UserStatusMapObject,
 } from './apiTypes';
 
-export type InitialDataBase = {|
+export type InitialDataBase = $ReadOnly<{|
   last_event_id: number,
   msg: string,
   queue_id: number,
-|};
+|}>;
 
-export type InitialDataAlertWords = {|
+export type InitialDataAlertWords = $ReadOnly<{|
   alert_words: string[],
-|};
+|}>;
 
-export type InitialDataMessage = {|
+export type InitialDataMessage = $ReadOnly<{|
   max_message_id: number,
-|};
+|}>;
 
 export type MuteTuple = [string, string];
 
-export type InitialDataMutedTopics = {|
+export type InitialDataMutedTopics = $ReadOnly<{|
   muted_topics: MuteTuple[],
-|};
+|}>;
 
 /** Added in server version 4.0, feature level 48 */
-export type InitialDataMutedUsers = {|
+export type InitialDataMutedUsers = $ReadOnly<{|
   muted_users?: MutedUser[],
-|};
+|}>;
 
-export type InitialDataPresence = {|
+export type InitialDataPresence = $ReadOnly<{|
   presences: {| [email: string]: UserPresence |},
-|};
+|}>;
 
-export type AvailableVideoChatProviders = {|
-  [providerName: string]: {| name: string, id: number |},
-|};
+export type AvailableVideoChatProviders = $ReadOnly<{|
+  [providerName: string]: $ReadOnly<{| name: string, id: number |}>,
+|}>;
 
-export type InitialDataRealm = {|
+export type InitialDataRealm = $ReadOnly<{|
   jitsi_server_url?: string,
   max_icon_file_size: number,
   realm_add_emoji_by_admins_only: boolean,
@@ -57,7 +57,7 @@ export type InitialDataRealm = {|
   realm_allow_edit_history: boolean,
   realm_allow_message_deleting: boolean,
   realm_allow_message_editing: boolean,
-  realm_authentication_methods: { GitHub: true, Email: true, Google: true, ... },
+  realm_authentication_methods: $ReadOnly<{ GitHub: true, Email: true, Google: true, ... }>,
   realm_available_video_chat_providers: AvailableVideoChatProviders,
   realm_bot_creation_policy: number,
   realm_bot_domain: string,
@@ -99,17 +99,17 @@ export type InitialDataRealm = {|
    * https://zulip.com/api/get-server-settings
    */
   zulip_feature_level?: number,
-|};
+|}>;
 
-export type InitialDataRealmEmoji = {|
+export type InitialDataRealmEmoji = $ReadOnly<{|
   realm_emoji: RealmEmojiById,
-|};
+|}>;
 
-export type RawInitialDataRealmFilters = {|
+export type RawInitialDataRealmFilters = $ReadOnly<{|
   // We still request this, since not all servers can provide the
   // newer `realm_linkifiers` format.
-  realm_filters?: RealmFilter[],
-|};
+  realm_filters?: $ReadOnlyArray<RealmFilter>,
+|}>;
 
 /**
  * The realm_filters/realm_linkifiers data, post-transformation.
@@ -121,67 +121,67 @@ export type RawInitialDataRealmFilters = {|
  *
  * See notes on `RealmFilter` and `RealmLinkifier`.
  */
-export type InitialDataRealmFilters = {|
-  realm_filters: RealmFilter[],
-|};
+export type InitialDataRealmFilters = $ReadOnly<{|
+  realm_filters: $ReadOnlyArray<RealmFilter>,
+|}>;
 
-export type InitialDataRealmLinkifiers = {|
+export type InitialDataRealmLinkifiers = $ReadOnly<{|
   // Possibly absent: Not all servers can provide this. See
   // `InitialDataRealmFilters`.
-  realm_linkifiers?: RealmLinkifier[],
-|};
+  realm_linkifiers?: $ReadOnlyArray<RealmLinkifier>,
+|}>;
 
-export type RawInitialDataRealmUser = {|
+export type RawInitialDataRealmUser = $ReadOnly<{|
   avatar_source: 'G',
   avatar_url: string | null,
   avatar_url_medium: string,
   can_create_streams: boolean,
-  cross_realm_bots: Array<{| ...CrossRealmBot, avatar_url?: string | null |}>,
+  cross_realm_bots: $ReadOnlyArray<{| ...CrossRealmBot, +avatar_url?: string | null |}>,
   email: string,
   enter_sends: boolean,
   full_name: string,
   is_admin: boolean,
-  realm_users: Array<{| ...User, avatar_url?: string | null |}>,
-  realm_non_active_users: Array<{| ...User, avatar_url?: string | null |}>,
+  realm_users: $ReadOnlyArray<{| ...User, avatar_url?: string | null |}>,
+  realm_non_active_users: $ReadOnlyArray<{| ...User, avatar_url?: string | null |}>,
   user_id: UserId,
-|};
+|}>;
 
-export type InitialDataRealmUser = {|
+export type InitialDataRealmUser = $ReadOnly<{|
   ...RawInitialDataRealmUser,
-  cross_realm_bots: CrossRealmBot[],
-  realm_non_active_users: User[],
-  realm_users: User[],
-|};
+  cross_realm_bots: $ReadOnlyArray<CrossRealmBot>,
+  realm_non_active_users: $ReadOnlyArray<User>,
+  realm_users: $ReadOnlyArray<User>,
+|}>;
 
-export type InitialDataRealmUserGroups = {|
+export type InitialDataRealmUserGroups = $ReadOnly<{|
   /**
    * Absent in servers prior to v1.8.0-rc1~2711 (or thereabouts).
    */
-  realm_user_groups?: UserGroup[],
-|};
+  realm_user_groups?: $ReadOnlyArray<UserGroup>,
+|}>;
 
-export type InitialDataRecentPmConversations = {|
+export type InitialDataRecentPmConversations = $ReadOnly<{|
   // * Added in server commit 2.1-dev-384-g4c3c669b41.
   // * `user_id` fields are sorted as of commit 2.2-dev-53-g405a529340, which
   //    was backported to 2.1.1-50-gd452ad31e0 -- meaning that they are _not_
   //    sorted in either v2.1.0 or v2.1.1.
-  recent_private_conversations?: RecentPrivateConversation[],
-|};
+  recent_private_conversations?: $ReadOnlyArray<RecentPrivateConversation>,
+|}>;
 
-type NeverSubscribedStream = {|
+type NeverSubscribedStream = $ReadOnly<{|
   description: string,
   invite_only: boolean,
   is_old_stream: boolean,
   name: string,
   stream_id: number,
-|};
+|}>;
 
-export type InitialDataStream = {|
-  streams: Stream[],
-|};
+export type InitialDataStream = $ReadOnly<{|
+  streams: $ReadOnlyArray<Stream>,
+|}>;
 
-export type InitialDataSubscription = {|
-  never_subscribed: NeverSubscribedStream[],
+export type InitialDataSubscription = $ReadOnly<{|
+  never_subscribed: $ReadOnlyArray<NeverSubscribedStream>,
 
   /**
    * All servers, at least as far back as zulip/zulip@7a930af, in
@@ -192,24 +192,24 @@ export type InitialDataSubscription = {|
    * This investigation is reported at
    * https://github.com/zulip/zulip-mobile/pull/4046#discussion_r414901766.
    */
-  subscriptions: Subscription[],
+  subscriptions: $ReadOnlyArray<Subscription>,
 
-  unsubscribed: Subscription[],
-|};
+  unsubscribed: $ReadOnlyArray<Subscription>,
+|}>;
 
-export type InitialDataUpdateDisplaySettings = {|
+export type InitialDataUpdateDisplaySettings = $ReadOnly<{|
   default_language: string,
   emojiset: string,
-  emojiset_choices: {| [string]: string |},
+  emojiset_choices: $ReadOnly<{| [string]: string |}>,
   high_contrast_mode: boolean,
   left_side_userlist: boolean,
   night_mode: boolean,
   timezone: string,
   translate_emoticons: boolean,
   twenty_four_hour_time: boolean,
-|};
+|}>;
 
-export type InitialDataUpdateGlobalNotifications = {|
+export type InitialDataUpdateGlobalNotifications = $ReadOnly<{|
   default_desktop_notifications: boolean,
   enable_desktop_notifications: boolean,
   enable_digest_emails: boolean,
@@ -224,29 +224,29 @@ export type InitialDataUpdateGlobalNotifications = {|
   message_content_in_email_notifications: boolean,
   pm_content_in_desktop_notifications: boolean,
   realm_name_in_notifications: boolean,
-|};
+|}>;
 
-export type StreamUnreadItem = {|
+export type StreamUnreadItem = $ReadOnly<{|
   stream_id: number,
   topic: string,
 
   // Sorted.
-  unread_message_ids: number[],
+  unread_message_ids: $ReadOnlyArray<number>,
 
   /** All distinct senders of these messages; sorted. */
   // sender_ids: UserId[],
-|};
+|}>;
 
-export type HuddlesUnreadItem = {|
+export type HuddlesUnreadItem = $ReadOnly<{|
   /** All users, including self; numerically sorted, comma-separated. */
   user_ids_string: string,
 
   // Sorted.
   unread_message_ids: $ReadOnlyArray<number>,
-|};
+|}>;
 
 /** The unreads in a 1:1 PM thread, as represented in `unread_msgs`. */
-export type PmsUnreadItem = {|
+export type PmsUnreadItem = $ReadOnly<{|
   /**
    * Misnamed; really the *other* user, or self for a self-PM.
    *
@@ -260,7 +260,7 @@ export type PmsUnreadItem = {|
 
   // Sorted.
   unread_message_ids: $ReadOnlyArray<number>,
-|};
+|}>;
 
 /** Initial data for `update_message_flags` events. */
 export type InitialDataUpdateMessageFlags = {|

--- a/src/api/modelTypes.js
+++ b/src/api/modelTypes.js
@@ -54,11 +54,11 @@ export type RealmFilter = [string, string, number];
 //   `realm_linkifiers`.)
 // - When we drop support for servers older than 54, we can remove all
 //   our code that knows about the `realm_filters` format.
-export type RealmLinkifier = {|
+export type RealmLinkifier = $ReadOnly<{|
   id: number,
   pattern: string,
   url_format: string,
-|};
+|}>;
 
 //
 //
@@ -68,10 +68,10 @@ export type RealmLinkifier = {|
 //
 //
 
-export type DevUser = {|
+export type DevUser = $ReadOnly<{|
   realm_uri: string,
   email: string,
-|};
+|}>;
 
 /**
  * A Zulip user, which might be a human or a bot, as found in one realm.
@@ -101,7 +101,7 @@ export type DevUser = {|
  *    different part of a `/register` response
  *  * `UserOrBot` for a convenience union of the two
  */
-export type User = {|
+export type User = $ReadOnly<{|
   user_id: UserId,
   email: string,
 
@@ -156,7 +156,7 @@ export type User = {|
   // see also e3aed0f7b (in 2.0.0)
   // (This one doesn't appear in `/users` responses.)
   profile_data?: empty, // TODO describe actual type
-|};
+|}>;
 
 /**
  * A "cross-realm bot", a bot user shared across the realms on a Zulip server.
@@ -170,7 +170,7 @@ export type User = {|
  *    realm are, like human users, represented by a `User` value.
  *  * `UserOrBot`, a convenience union
  */
-export type CrossRealmBot = {|
+export type CrossRealmBot = $ReadOnly<{|
   /**
    * See note for this property on User.
    */
@@ -192,7 +192,7 @@ export type CrossRealmBot = {|
   // omitted later to reduce payload sizes. So, we're future-proofing this field
   // by making it optional. See comment on the same field in User.
   timezone?: string,
-|};
+|}>;
 
 /**
  * A Zulip user/account, which might be a cross-realm bot.
@@ -208,12 +208,12 @@ export type UserOrBot = User | CrossRealmBot;
  *
  * This feature is not related to group PMs.
  */
-export type UserGroup = {|
+export type UserGroup = $ReadOnly<{|
   description: string,
   id: number,
-  members: UserId[],
+  members: $ReadOnlyArray<UserId>,
   name: string,
-|};
+|}>;
 
 /**
  * Specifies user status related properties
@@ -223,19 +223,19 @@ export type UserGroup = {|
  * @prop status_text - a string representing information the user decided to
  *   manually set as their 'current status'
  */
-export type UserStatus = {|
+export type UserStatus = $ReadOnly<{|
   away?: true,
   status_text?: string,
-|};
+|}>;
 
-export type UserStatusMapObject = {|
+export type UserStatusMapObject = $ReadOnly<{|
   // TODO(flow): The key here is really UserId, not just any number; but
   //   this Flow bug:
   //     https://github.com/facebook/flow/issues/5407
   //   means that doesn't work right, and the best workaround is to
   //   leave it as `number`.
   [userId: number]: UserStatus,
-|};
+|}>;
 
 /** See ClientPresence, and the doc linked there. */
 export type PresenceStatus = 'active' | 'idle' | 'offline';
@@ -252,7 +252,7 @@ export type PresenceStatus = 'active' | 'idle' | 'offline';
  * @prop client
  * @prop pushable - Legacy; unused.
  */
-export type ClientPresence = {|
+export type ClientPresence = $ReadOnly<{|
   status: PresenceStatus,
   timestamp: number,
   client: string,
@@ -269,7 +269,7 @@ export type ClientPresence = {|
    * `aggregated`.  By writing `empty` we make it an error to actually use it.
    */
   pushable?: empty,
-|};
+|}>;
 
 /**
  * A user's presence status, including all information from all their clients.
@@ -280,18 +280,18 @@ export type ClientPresence = {|
  * See also the app's `getAggregatedPresence`, which reimplements a version
  * of the logic to compute `aggregated`.
  */
-export type UserPresence = {|
+export type UserPresence = $ReadOnly<{|
   aggregated: ClientPresence,
   [client: string]: ClientPresence,
-|};
+|}>;
 
 /** This is what appears in the `muted_users` server event.
  * See https://chat.zulip.org/api/get-events#muted_users for details.
  */
-export type MutedUser = {|
+export type MutedUser = $ReadOnly<{|
   id: UserId,
   timestamp: number,
-|};
+|}>;
 
 //
 //
@@ -301,16 +301,16 @@ export type MutedUser = {|
 //
 //
 
-export type Stream = {|
+export type Stream = $ReadOnly<{|
   stream_id: number,
   description: string,
   name: string,
   invite_only: boolean,
   is_announcement_only: boolean,
   history_public_to_subscribers: boolean,
-|};
+|}>;
 
-export type Subscription = {|
+export type Subscription = $ReadOnly<{|
   ...$Exact<Stream>,
   color: string,
   in_home_view: boolean,
@@ -321,12 +321,12 @@ export type Subscription = {|
   is_old_stream: boolean,
   push_notifications: null | boolean,
   stream_weekly_traffic: number,
-|};
+|}>;
 
-export type Topic = {|
+export type Topic = $ReadOnly<{|
   name: string,
   max_id: number,
-|};
+|}>;
 
 //
 //
@@ -716,9 +716,9 @@ export type Message = PmMessage | StreamMessage;
  * as [], which is unlike the behaviour found in some other parts of the
  * codebase.
  */
-export type RecentPrivateConversation = {|
+export type RecentPrivateConversation = $ReadOnly<{|
   max_message_id: number,
   // When received from the server, these are guaranteed to be sorted only after
   // 2.2-dev-53-g405a529340. To be safe, we always sort them on receipt.
-  user_ids: UserId[],
-|};
+  user_ids: $ReadOnlyArray<UserId>,
+|}>;

--- a/src/boot/reducers.js
+++ b/src/boot/reducers.js
@@ -1,6 +1,5 @@
 /* @flow strict-local */
 import config from '../config';
-import { NULL_OBJECT } from '../nullObjects';
 import type { Action, GlobalState, MigrationsState } from '../types';
 
 import accounts from '../account/accountsReducer';
@@ -29,7 +28,9 @@ import userStatus from '../user-status/userStatusReducer';
 import users from '../users/usersReducer';
 import timing from '../utils/timing';
 
-const migrations = (state: MigrationsState = NULL_OBJECT): MigrationsState => state;
+// The `Object.freeze` is to work around a Flow issue:
+//   https://github.com/facebook/flow/issues/2386#issuecomment-695064325
+const migrations = (state: MigrationsState = Object.freeze({})): MigrationsState => state;
 
 const { enableReduxSlowReducerWarnings, slowReducersThreshold } = config;
 

--- a/src/chat/narrowsSelectors.js
+++ b/src/chat/narrowsSelectors.js
@@ -33,7 +33,7 @@ import { shouldBeMuted } from '../utils/message';
 import { NULL_ARRAY, NULL_SUBSCRIPTION } from '../nullObjects';
 import * as logging from '../utils/logging';
 
-export const outboxMessagesForNarrow: Selector<Outbox[], Narrow> = createSelector(
+export const outboxMessagesForNarrow: Selector<$ReadOnlyArray<Outbox>, Narrow> = createSelector(
   (state, narrow) => narrow,
   getCaughtUpForNarrow,
   state => getOutbox(state),
@@ -57,8 +57,10 @@ export const outboxMessagesForNarrow: Selector<Outbox[], Narrow> = createSelecto
   },
 );
 
-export const getFetchedMessageIdsForNarrow = (state: GlobalState, narrow: Narrow): number[] =>
-  getAllNarrows(state).get(keyFromNarrow(narrow)) || NULL_ARRAY;
+export const getFetchedMessageIdsForNarrow = (
+  state: GlobalState,
+  narrow: Narrow,
+): $ReadOnlyArray<number> => getAllNarrows(state).get(keyFromNarrow(narrow)) || NULL_ARRAY;
 
 const getFetchedMessagesForNarrow: Selector<Message[], Narrow> = createSelector(
   getFetchedMessageIdsForNarrow,

--- a/src/common/RawLabel.js
+++ b/src/common/RawLabel.js
@@ -1,6 +1,7 @@
 /* @flow strict-local */
 import invariant from 'invariant';
 import React, { PureComponent } from 'react';
+import type { Node, Context } from 'react';
 import { Text } from 'react-native';
 
 import type { ThemeData } from '../styles';
@@ -24,10 +25,10 @@ type Props = $ReadOnly<{|
  *   See upstream: https://reactnative.dev/docs/text
  */
 export default class RawLabel extends PureComponent<Props> {
-  static contextType = ThemeContext;
+  static contextType: Context<ThemeData> = ThemeContext;
   context: ThemeData;
 
-  render() {
+  render(): Node {
     const { text, children, style, ...restProps } = this.props;
 
     invariant((text != null) !== (children != null), 'pass either `text` or `children`');

--- a/src/common/SectionHeader.js
+++ b/src/common/SectionHeader.js
@@ -1,5 +1,6 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
+import type { Node, Context } from 'react';
 import { View } from 'react-native';
 
 import type { ThemeData } from '../styles';
@@ -18,10 +19,10 @@ type Props = $ReadOnly<{|
 |}>;
 
 export default class SectionHeader extends PureComponent<Props> {
-  static contextType = ThemeContext;
+  static contextType: Context<ThemeData> = ThemeContext;
   context: ThemeData;
 
-  render() {
+  render(): Node {
     const { text } = this.props;
     return (
       <View style={[styles.header, { backgroundColor: this.context.backgroundColor }]}>

--- a/src/directSelectors.js
+++ b/src/directSelectors.js
@@ -1,6 +1,12 @@
 /* @flow strict-local */
 import type {
   GlobalState,
+  AccountsState,
+  SubscriptionsState,
+  StreamsState,
+  OutboxState,
+  UsersState,
+  UserGroupsState,
   DraftsState,
   FetchingState,
   FlagsState,
@@ -15,19 +21,14 @@ import type {
   RealmState,
   SettingsState,
   TypingState,
-  Account,
   Debug,
-  Subscription,
   VideoChatProvider,
-  Stream,
-  Outbox,
   User,
-  UserGroup,
   UserStatusState,
 } from './types';
 import type { SessionState } from './session/sessionReducer';
 
-export const getAccounts = (state: GlobalState): Account[] => state.accounts;
+export const getAccounts = (state: GlobalState): AccountsState => state.accounts;
 
 export const getSession = (state: GlobalState): SessionState => state.session;
 
@@ -51,7 +52,7 @@ export const getTyping = (state: GlobalState): TypingState => state.typing;
 
 export const getTopics = (state: GlobalState): TopicsState => state.topics;
 
-export const getUserGroups = (state: GlobalState): UserGroup[] => state.userGroups;
+export const getUserGroups = (state: GlobalState): UserGroupsState => state.userGroups;
 
 export const getUserStatus = (state: GlobalState): UserStatusState => state.userStatus;
 
@@ -60,7 +61,7 @@ export const getUserStatus = (state: GlobalState): UserStatusState => state.user
  *
  * See `getAllUsers`.
  */
-export const getUsers = (state: GlobalState): User[] => state.users;
+export const getUsers = (state: GlobalState): UsersState => state.users;
 
 export const getFetching = (state: GlobalState): FetchingState => state.fetching;
 
@@ -70,7 +71,7 @@ export const getAllNarrows = (state: GlobalState): NarrowsState => state.narrows
 
 export const getSettings = (state: GlobalState): SettingsState => state.settings;
 
-export const getSubscriptions = (state: GlobalState): Subscription[] => state.subscriptions;
+export const getSubscriptions = (state: GlobalState): SubscriptionsState => state.subscriptions;
 
 /**
  * All streams in the current realm.
@@ -78,11 +79,11 @@ export const getSubscriptions = (state: GlobalState): Subscription[] => state.su
  * This is rarely the right selector to use: consider `getStreamForId`
  * or `getStreamsById` instead.
  */
-export const getStreams = (state: GlobalState): Stream[] => state.streams;
+export const getStreams = (state: GlobalState): StreamsState => state.streams;
 
 export const getPresence = (state: GlobalState): PresenceState => state.presence;
 
-export const getOutbox = (state: GlobalState): Outbox[] => state.outbox;
+export const getOutbox = (state: GlobalState): OutboxState => state.outbox;
 
 export const getRealm = (state: GlobalState): RealmState => state.realm;
 

--- a/src/directSelectors.js
+++ b/src/directSelectors.js
@@ -87,12 +87,13 @@ export const getOutbox = (state: GlobalState): OutboxState => state.outbox;
 
 export const getRealm = (state: GlobalState): RealmState => state.realm;
 
-export const getCrossRealmBots = (state: GlobalState): CrossRealmBot[] =>
+export const getCrossRealmBots = (state: GlobalState): $ReadOnlyArray<CrossRealmBot> =>
   state.realm.crossRealmBots;
 
 export const getRawRealmEmoji = (state: GlobalState): RealmEmojiById => state.realm.emoji;
 
-export const getNonActiveUsers = (state: GlobalState): User[] => state.realm.nonActiveUsers;
+export const getNonActiveUsers = (state: GlobalState): $ReadOnlyArray<User> =>
+  state.realm.nonActiveUsers;
 
 export const getIsAdmin = (state: GlobalState): boolean => state.realm.isAdmin;
 

--- a/src/message/NotSubscribed.js
+++ b/src/message/NotSubscribed.js
@@ -12,7 +12,7 @@ import styles from '../styles';
 
 type SelectorProps = $ReadOnly<{|
   auth: Auth,
-  stream: { ...Stream, ... },
+  stream: $ReadOnly<{ ...Stream, ... }>,
 |}>;
 
 type Props = $ReadOnly<{|

--- a/src/message/getHtmlPieceDescriptors.js
+++ b/src/message/getHtmlPieceDescriptors.js
@@ -4,6 +4,7 @@ import { isTopicNarrow, isPmNarrow } from '../utils/narrow';
 import { isSameRecipient } from '../utils/recipient';
 import { isSameDay } from '../utils/date';
 
+// Prefer getHtmlPieceDescriptorsMemoized.
 export default (
   messages: $ReadOnlyArray<Message | Outbox>,
   narrow: Narrow,

--- a/src/message/messageActionSheet.js
+++ b/src/message/messageActionSheet.js
@@ -43,7 +43,7 @@ type TopicArgs = {
   auth: Auth,
   streamId: number,
   topic: string,
-  subscriptions: Subscription[],
+  subscriptions: $ReadOnlyArray<Subscription>,
   streams: Map<number, Stream>,
   dispatch: Dispatch,
   _: GetText,
@@ -240,7 +240,7 @@ export const constructTopicActionButtons = ({
   backgroundData: $ReadOnly<{
     mute: MuteState,
     streams: Map<number, Stream>,
-    subscriptions: Subscription[],
+    subscriptions: $ReadOnlyArray<Subscription>,
     unread: UnreadState,
     ownUser: User,
     ...
@@ -380,7 +380,7 @@ export const showMessageActionSheet = ({
   |},
   backgroundData: $ReadOnly<{
     auth: Auth,
-    subscriptions: Subscription[],
+    subscriptions: $ReadOnlyArray<Subscription>,
     ownUser: User,
     flags: FlagsState,
     ...
@@ -419,7 +419,7 @@ export const showTopicActionSheet = ({
     auth: Auth,
     mute: MuteState,
     streams: Map<number, Stream>,
-    subscriptions: Subscription[],
+    subscriptions: $ReadOnlyArray<Subscription>,
     unread: UnreadState,
     ownUser: User,
     flags: FlagsState,

--- a/src/message/messageSelectors.js
+++ b/src/message/messageSelectors.js
@@ -21,7 +21,7 @@ import { NULL_ARRAY } from '../nullObjects';
  * Returns something which may or may not be an array, but is at least JSONable
  * and human-readable.
  */
-function truncateForLogging<T: JSONable>(arr: Array<T>, len = 10): JSONable {
+function truncateForLogging<T: JSONable>(arr: $ReadOnlyArray<T>, len = 10): JSONable {
   if (arr.length <= 2 * len) {
     return arr;
   }

--- a/src/message/messageSelectors.js
+++ b/src/message/messageSelectors.js
@@ -61,7 +61,7 @@ export const getPrivateMessages: Selector<Message[]> = createSelector(
   },
 );
 
-export const getHtmlPieceDescriptorsForMessages: (
+export const getHtmlPieceDescriptorsMemoized: (
   $ReadOnlyArray<Message | Outbox>,
   Narrow,
 ) => $ReadOnlyArray<HtmlPieceDescriptor> = defaultMemoize(getHtmlPieceDescriptors);

--- a/src/message/messageSelectors.js
+++ b/src/message/messageSelectors.js
@@ -1,7 +1,7 @@
 /* @flow strict-local */
 import { createSelector, defaultMemoize } from 'reselect';
 
-import type { Message, Outbox, Narrow, Selector } from '../types';
+import type { Message, Outbox, Narrow, Selector, HtmlPieceDescriptor } from '../types';
 import {
   getAllNarrows,
   getFlags,
@@ -61,10 +61,10 @@ export const getPrivateMessages: Selector<Message[]> = createSelector(
   },
 );
 
-export const getHtmlPieceDescriptorsForMessages = defaultMemoize(
-  (messages: $ReadOnlyArray<Message | Outbox>, narrow: Narrow) =>
-    getHtmlPieceDescriptors(messages, narrow),
-);
+export const getHtmlPieceDescriptorsForMessages: (
+  $ReadOnlyArray<Message | Outbox>,
+  Narrow,
+) => $ReadOnlyArray<HtmlPieceDescriptor> = defaultMemoize(getHtmlPieceDescriptors);
 
 export const getFirstUnreadIdInNarrow: Selector<number | null, Narrow> = createSelector(
   (state, narrow) => getShownMessagesForNarrow(state, narrow),

--- a/src/nav/BackNavigationHandler.js
+++ b/src/nav/BackNavigationHandler.js
@@ -19,7 +19,7 @@ export default class BackNavigationHandler extends PureComponent<Props> {
     BackHandler.removeEventListener('hardwareBackPress', this.handleBackButtonPress);
   }
 
-  handleBackButtonPress = () => {
+  handleBackButtonPress: () => boolean = () => {
     const canGoBack = NavigationService.getState().index > 0;
     if (canGoBack) {
       NavigationService.dispatch(
@@ -32,7 +32,7 @@ export default class BackNavigationHandler extends PureComponent<Props> {
     return canGoBack;
   };
 
-  render() {
+  render(): Node {
     return this.props.children;
   }
 }

--- a/src/nav/NavButton.js
+++ b/src/nav/NavButton.js
@@ -1,5 +1,5 @@
 /* @flow strict-local */
-import React, { PureComponent } from 'react';
+import React from 'react';
 import type { TextStyleProp } from 'react-native/Libraries/StyleSheet/StyleSheet';
 
 import { BRAND_COLOR, createStyleSheet } from '../styles';
@@ -8,7 +8,7 @@ import type { IconNames } from '../common/Icons';
 import NavButtonGeneral from './NavButtonGeneral';
 
 type Props = $ReadOnly<{|
-  color: string,
+  color?: string,
   style?: TextStyleProp,
   name: IconNames,
   onPress: () => void,
@@ -21,18 +21,12 @@ const componentStyles = createStyleSheet({
   },
 });
 
-export default class NavButton extends PureComponent<Props> {
-  static defaultProps = {
-    color: BRAND_COLOR,
-  };
+export default function NavButton(props: Props) {
+  const { name, style, color = BRAND_COLOR, onPress, accessibilityLabel } = props;
 
-  render() {
-    const { name, style, color, onPress, accessibilityLabel } = this.props;
-
-    return (
-      <NavButtonGeneral onPress={onPress} accessibilityLabel={accessibilityLabel}>
-        <Icon size={24} style={[componentStyles.navButtonIcon, style]} color={color} name={name} />
-      </NavButtonGeneral>
-    );
-  }
+  return (
+    <NavButtonGeneral onPress={onPress} accessibilityLabel={accessibilityLabel}>
+      <Icon size={24} style={[componentStyles.navButtonIcon, style]} color={color} name={name} />
+    </NavButtonGeneral>
+  );
 }

--- a/src/nav/NavButton.js
+++ b/src/nav/NavButton.js
@@ -1,5 +1,6 @@
 /* @flow strict-local */
 import React from 'react';
+import type { Node } from 'react';
 import type { TextStyleProp } from 'react-native/Libraries/StyleSheet/StyleSheet';
 
 import { BRAND_COLOR, createStyleSheet } from '../styles';
@@ -21,7 +22,7 @@ const componentStyles = createStyleSheet({
   },
 });
 
-export default function NavButton(props: Props) {
+export default function NavButton(props: Props): Node {
   const { name, style, color = BRAND_COLOR, onPress, accessibilityLabel } = props;
 
   return (

--- a/src/nav/NavButton.js
+++ b/src/nav/NavButton.js
@@ -15,23 +15,23 @@ type Props = $ReadOnly<{|
   accessibilityLabel?: string,
 |}>;
 
+const componentStyles = createStyleSheet({
+  navButtonIcon: {
+    textAlign: 'center',
+  },
+});
+
 export default class NavButton extends PureComponent<Props> {
   static defaultProps = {
     color: BRAND_COLOR,
   };
-
-  styles = createStyleSheet({
-    navButtonIcon: {
-      textAlign: 'center',
-    },
-  });
 
   render() {
     const { name, style, color, onPress, accessibilityLabel } = this.props;
 
     return (
       <NavButtonGeneral onPress={onPress} accessibilityLabel={accessibilityLabel}>
-        <Icon size={24} style={[this.styles.navButtonIcon, style]} color={color} name={name} />
+        <Icon size={24} style={[componentStyles.navButtonIcon, style]} color={color} name={name} />
       </NavButtonGeneral>
     );
   }

--- a/src/nav/NavigationService.js
+++ b/src/nav/NavigationService.js
@@ -6,8 +6,10 @@ import type {
   NavigationContainerType,
 } from '@react-navigation/native';
 
-export const isReadyRef = React.createRef<boolean>();
-export const navigationContainerRef = React.createRef<React$ElementRef<NavigationContainerType>>();
+export const isReadyRef: {| current: null | boolean |} = React.createRef();
+export const navigationContainerRef: {|
+  current: null | React$ElementRef<NavigationContainerType>,
+|} = React.createRef();
 
 const getContainer = () => {
   if (navigationContainerRef.current === null) {

--- a/src/nav/getInitialRouteInfo.js
+++ b/src/nav/getInitialRouteInfo.js
@@ -6,7 +6,7 @@ import type { Account } from '../types';
 
 export default (args: {|
   hasAuth: boolean,
-  accounts: Account[],
+  accounts: $ReadOnlyArray<Account>,
 |}): {| initialRouteName: string, initialRouteParams?: ScreenParams |} => {
   const { hasAuth, accounts } = args;
 

--- a/src/notification/index.js
+++ b/src/notification/index.js
@@ -207,7 +207,7 @@ export class NotificationListener {
   }
 
   /** Private. */
-  handleNotificationOpen = (notification: Notification) => {
+  handleNotificationOpen: Notification => void = notification => {
     this.dispatch(narrowToNotification(notification));
   };
 
@@ -218,7 +218,7 @@ export class NotificationListener {
    *   at the registration site to allow us to ensure it. As we've been burned
    *   by unexpected types here before, we do the validation explicitly.
    */
-  handleDeviceToken = async (deviceToken: mixed) => {
+  handleDeviceToken: mixed => Promise<void> = async deviceToken => {
     // Null device tokens are known to occur (at least) on Android emulators
     // without Google Play services, and have been reported in other scenarios.
     // See https://stackoverflow.com/q/37517860 for relevant discussion.
@@ -239,7 +239,7 @@ export class NotificationListener {
   };
 
   /** Private. */
-  handleIOSRegistrationFailure = (err: NotificationRegistrationFailedEvent) => {
+  handleIOSRegistrationFailure: NotificationRegistrationFailedEvent => void = err => {
     logging.warn(`Failed to register iOS push token: ${err.code}`, {
       raw_error: err,
     });

--- a/src/nullObjects.js
+++ b/src/nullObjects.js
@@ -1,7 +1,7 @@
 /* @flow strict-local */
 import type { Subscription } from './types';
 
-export const NULL_OBJECT = Object.freeze({});
+export const NULL_OBJECT: {||} = Object.freeze({});
 
 export const NULL_ARRAY = Object.freeze([]);
 

--- a/src/nullObjects.js
+++ b/src/nullObjects.js
@@ -3,7 +3,7 @@ import type { Subscription } from './types';
 
 export const NULL_OBJECT: {||} = Object.freeze({});
 
-export const NULL_ARRAY = Object.freeze([]);
+export const NULL_ARRAY: $ReadOnlyArray<empty> = Object.freeze([]);
 
 /*
  * All the below objects are DEPRECATED; rather than using one, choose the

--- a/src/pm-conversations/pmConversationsModel.js
+++ b/src/pm-conversations/pmConversationsModel.js
@@ -31,7 +31,11 @@ export const MIN_RECENTPMS_SERVER_VERSION: ZulipVersion = new ZulipVersion('2.1'
 // User IDs, excluding self, sorted numerically, joined with commas.
 export opaque type PmConversationKey = string;
 
-/** PRIVATE.  Exported only for tests. */
+/**
+ * PRIVATE.  Exported only for tests.
+ *
+ * Sorts `ids` in-place.
+ */
 // Input must have the exact right (multi-)set of users.  Needn't be sorted.
 export function keyOfExactUsers(ids: UserId[]): PmConversationKey {
   return ids.sort((a, b) => a - b).join(',');
@@ -190,7 +194,8 @@ export function reducer(
       // TODO optimize; this is quadratic (but so is the webapp's version?!)
       let st = initialState;
       for (const r of action.data.recent_private_conversations ?? []) {
-        st = insert(st, keyOfExactUsers(r.user_ids), r.max_message_id);
+        const key = keyOfExactUsers([...r.user_ids]);
+        st = insert(st, key, r.max_message_id);
       }
       return st;
     }

--- a/src/pm-conversations/pmConversationsModel.js
+++ b/src/pm-conversations/pmConversationsModel.js
@@ -72,13 +72,13 @@ export function usersOfKey(key: PmConversationKey): UserId[] {
  * kept up to date as we learn about new or newly-fetched messages.
  */
 // (Compare the webapp's implementation, in static/js/pm_conversations.js.)
-export type PmConversationsState = {|
+export type PmConversationsState = $ReadOnly<{|
   // The latest message ID in each conversation.
   map: Immutable.Map<PmConversationKey, number>,
 
   // The keys of the map, sorted by latest message descending.
   sorted: Immutable.List<PmConversationKey>,
-|};
+|}>;
 
 const initialState: PmConversationsState = { map: Immutable.Map(), sorted: Immutable.List() };
 

--- a/src/presence/heartbeat.js
+++ b/src/presence/heartbeat.js
@@ -47,7 +47,7 @@ class Heartbeat {
     this._milliseconds = milliseconds;
   }
 
-  doCallback = () => {
+  doCallback: () => void = () => {
     if (!this._active) {
       clearInterval(this._intervalId);
       this._intervalId = null;
@@ -58,7 +58,7 @@ class Heartbeat {
   };
 
   /** PRIVATE. Exposed only for tests. */
-  isActive() {
+  isActive(): boolean {
     return this._active;
   }
 

--- a/src/reduxTypes.js
+++ b/src/reduxTypes.js
@@ -47,9 +47,9 @@ export type * from './actionTypes';
  *    the app.
  *  * `Account` for details on the properties of each account object.
  */
-export type AccountsState = Account[];
+export type AccountsState = $ReadOnlyArray<Account>;
 
-export type AlertWordsState = string[];
+export type AlertWordsState = $ReadOnlyArray<string>;
 
 /**
  * Info about how complete our knowledge is of the messages in some narrow.
@@ -174,7 +174,7 @@ export type MigrationsState = {|
   version?: string,
 |};
 
-export type MuteState = MuteTuple[];
+export type MuteState = $ReadOnlyArray<MuteTuple>;
 
 /** A map from user IDs to the Unix timestamp in seconds when they were muted. */
 export type MutedUsersState = Immutable.Map<UserId, number>;
@@ -199,7 +199,7 @@ export type MutedUsersState = Immutable.Map<UserId, number>;
  */
 export type NarrowsState = Immutable.Map<string, number[]>;
 
-export type OutboxState = Outbox[];
+export type OutboxState = $ReadOnlyArray<Outbox>;
 
 /**
  * The `presence` subtree of our Redux state.
@@ -300,9 +300,9 @@ export type SettingsState = {|
   doNotMarkMessagesAsRead: boolean,
 |};
 
-export type StreamsState = Stream[];
+export type StreamsState = $ReadOnlyArray<Stream>;
 
-export type SubscriptionsState = Subscription[];
+export type SubscriptionsState = $ReadOnlyArray<Subscription>;
 
 export type TopicsState = {|
   [number]: Topic[],
@@ -315,7 +315,7 @@ export type TypingState = {|
   |},
 |};
 
-export type UserGroupsState = UserGroup[];
+export type UserGroupsState = $ReadOnlyArray<UserGroup>;
 
 export type UserStatusState = UserStatusMapObject;
 
@@ -325,7 +325,7 @@ export type UserStatusState = UserStatusMapObject;
  * This contains all users except deactivated users and cross-realm bots.
  * For those, see RealmState.
  */
-export type UsersState = User[];
+export type UsersState = $ReadOnlyArray<User>;
 
 /**
  * Our complete Redux state tree.

--- a/src/reduxTypes.js
+++ b/src/reduxTypes.js
@@ -60,10 +60,10 @@ export type AlertWordsState = $ReadOnlyArray<string>;
  *   the narrow.  Of course their may always be new messages, but we should
  *   learn about them through events; so again, no need to fetch more.
  */
-export type CaughtUp = {|
+export type CaughtUp = $ReadOnly<{|
   older: boolean,
   newer: boolean,
-|};
+|}>;
 
 /**
  * Info about how completely we know the messages in each narrow.
@@ -72,23 +72,23 @@ export type CaughtUp = {|
  *
  * See `CaughtUp` for details on what each value means.
  */
-export type CaughtUpState = {|
+export type CaughtUpState = $ReadOnly<{|
   [narrow: string]: CaughtUp,
-|};
+|}>;
 
 /**
  * The user's draft message, if any, in each conversation.
  *
  * The keys correspond to the keys in `NarrowsState`.
  */
-export type DraftsState = {|
+export type DraftsState = $ReadOnly<{|
   [narrow: string]: string,
-|};
+|}>;
 
-export type Fetching = {|
+export type Fetching = $ReadOnly<{|
   older: boolean,
   newer: boolean,
-|};
+|}>;
 
 /**
  * Info about which narrows we're actively fetching more messages from.
@@ -97,9 +97,9 @@ export type Fetching = {|
  *
  * See also: `CaughtUpState`, `NarrowsState`.
  */
-export type FetchingState = {|
+export type FetchingState = $ReadOnly<{|
   [narrow: string]: Fetching,
-|};
+|}>;
 
 /**
  * The message flags corresponding to all the messages in `MessagesState`.
@@ -117,20 +117,20 @@ export type FetchingState = {|
  * "message without flag", we can look up the message ID in
  * `state.messages`.
  */
-export type FlagsState = {|
-  read: {| [messageId: number]: true |},
-  starred: {| [messageId: number]: true |},
-  collapsed: {| [messageId: number]: true |},
-  mentioned: {| [messageId: number]: true |},
-  wildcard_mentioned: {| [messageId: number]: true |},
-  summarize_in_home: {| [messageId: number]: true |},
-  summarize_in_stream: {| [messageId: number]: true |},
-  force_expand: {| [messageId: number]: true |},
-  force_collapse: {| [messageId: number]: true |},
-  has_alert_word: {| [messageId: number]: true |},
-  historical: {| [messageId: number]: true |},
-  is_me_message: {| [messageId: number]: true |},
-|};
+export type FlagsState = $ReadOnly<{|
+  read: {| +[messageId: number]: true |},
+  starred: {| +[messageId: number]: true |},
+  collapsed: {| +[messageId: number]: true |},
+  mentioned: {| +[messageId: number]: true |},
+  wildcard_mentioned: {| +[messageId: number]: true |},
+  summarize_in_home: {| +[messageId: number]: true |},
+  summarize_in_stream: {| +[messageId: number]: true |},
+  force_expand: {| +[messageId: number]: true |},
+  force_collapse: {| +[messageId: number]: true |},
+  has_alert_word: {| +[messageId: number]: true |},
+  historical: {| +[messageId: number]: true |},
+  is_me_message: {| +[messageId: number]: true |},
+|}>;
 
 export type FlagName = $Keys<FlagsState>;
 
@@ -170,9 +170,9 @@ export type FlagName = $Keys<FlagsState>;
  */
 export type MessagesState = Immutable.Map<number, Message>;
 
-export type MigrationsState = {|
+export type MigrationsState = $ReadOnly<{|
   version?: string,
-|};
+|}>;
 
 export type MuteState = $ReadOnlyArray<MuteTuple>;
 
@@ -207,9 +207,9 @@ export type OutboxState = $ReadOnlyArray<Outbox>;
  * @prop (email) - Indexes over all users for which the app has received a
  *   presence status.
  */
-export type PresenceState = {|
+export type PresenceState = $ReadOnly<{|
   [email: string]: UserPresence,
-|};
+|}>;
 
 /**
  * Configuration for a video chat provider, as specified by the server.
@@ -223,7 +223,7 @@ export type PresenceState = {|
  */
 // Right now there's just one branch here; if we add another provider, this
 // should become a disjoint union on `name`.
-export type VideoChatProvider = {| name: 'jitsi_meet', jitsiServerUrl: string |};
+export type VideoChatProvider = $ReadOnly<{| name: 'jitsi_meet', jitsiServerUrl: string |}>;
 
 /**
  * State with miscellaneous data from the server; our state subtree `realm`.
@@ -253,11 +253,11 @@ export type VideoChatProvider = {| name: 'jitsi_meet', jitsiServerUrl: string |}
  * @prop canCreateStreams
  * @prop isAdmin
  */
-export type RealmState = {|
-  crossRealmBots: CrossRealmBot[],
+export type RealmState = $ReadOnly<{|
+  crossRealmBots: $ReadOnlyArray<CrossRealmBot>,
 
-  nonActiveUsers: User[],
-  filters: RealmFilter[],
+  nonActiveUsers: $ReadOnlyArray<User>,
+  filters: $ReadOnlyArray<RealmFilter>,
   emoji: RealmEmojiById,
   videoChatProvider: VideoChatProvider | null,
 
@@ -266,7 +266,7 @@ export type RealmState = {|
   twentyFourHourTime: boolean,
   canCreateStreams: boolean,
   isAdmin: boolean,
-|};
+|}>;
 
 // TODO: Stop using the 'default' name. Any 'default' semantics should
 // only apply the device level, not within the app. See
@@ -287,7 +287,7 @@ export type ThemeName = 'default' | 'night';
  */
 export type BrowserPreference = 'embedded' | 'external' | 'default';
 
-export type SettingsState = {|
+export type SettingsState = $ReadOnly<{|
   // The user's chosen language, as an IETF BCP 47 language tag.
   language: string,
 
@@ -298,22 +298,22 @@ export type SettingsState = {|
   streamNotification: boolean,
   browser: BrowserPreference,
   doNotMarkMessagesAsRead: boolean,
-|};
+|}>;
 
 export type StreamsState = $ReadOnlyArray<Stream>;
 
 export type SubscriptionsState = $ReadOnlyArray<Subscription>;
 
-export type TopicsState = {|
-  [number]: Topic[],
-|};
+export type TopicsState = $ReadOnly<{|
+  [number]: $ReadOnlyArray<Topic>,
+|}>;
 
-export type TypingState = {|
-  [normalizedRecipients: string]: {|
+export type TypingState = $ReadOnly<{|
+  [normalizedRecipients: string]: $ReadOnly<{|
     time: number,
-    userIds: UserId[],
-  |},
-|};
+    userIds: $ReadOnlyArray<UserId>,
+  |}>,
+|}>;
 
 export type UserGroupsState = $ReadOnlyArray<UserGroup>;
 

--- a/src/session/sessionReducer.js
+++ b/src/session/sessionReducer.js
@@ -27,7 +27,7 @@ import { getHasAuth } from '../account/accountsSelectors';
  * won't be persisted between sessions; on startup, they'll all be
  * initialized to their default values.
  */
-export type SessionState = {|
+export type SessionState = $ReadOnly<{|
   eventQueueId: number,
   isOnline: boolean,
   isHydrated: boolean,
@@ -75,7 +75,7 @@ export type SessionState = {|
    * doesn't act on the notice.
    */
   hasDismissedServerCompatNotice: boolean,
-|};
+|}>;
 
 const initialState: SessionState = {
   eventQueueId: -1,

--- a/src/settings/LanguagePicker.js
+++ b/src/settings/LanguagePicker.js
@@ -1,5 +1,6 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
+import type { Node, Context } from 'react';
 import { FlatList } from 'react-native';
 
 import type { GetText } from '../types';
@@ -15,10 +16,10 @@ type Props = $ReadOnly<{|
 |}>;
 
 export default class LanguagePicker extends PureComponent<Props> {
-  static contextType = TranslationContext;
+  static contextType: Context<GetText> = TranslationContext;
   context: GetText;
 
-  getTranslatedLanguages = (): Language[] =>
+  getTranslatedLanguages: () => Language[] = () =>
     languages.map((language: Language) => {
       const _ = this.context;
       const translatedName = _(language.name);
@@ -28,7 +29,7 @@ export default class LanguagePicker extends PureComponent<Props> {
       };
     });
 
-  getFilteredLanguageList = (filter: string): Language[] => {
+  getFilteredLanguageList: string => Language[] = filter => {
     const list = this.getTranslatedLanguages();
 
     if (!filter) {
@@ -43,7 +44,7 @@ export default class LanguagePicker extends PureComponent<Props> {
     });
   };
 
-  render() {
+  render(): Node {
     const { value, onValueChange, filter } = this.props;
     const data = this.getFilteredLanguageList(filter);
 

--- a/src/sharing/ShareToPm.js
+++ b/src/sharing/ShareToPm.js
@@ -1,5 +1,6 @@
 /* @flow strict-local */
 import React from 'react';
+import type { Node, Context } from 'react';
 import { View, Modal } from 'react-native';
 
 import type { RouteProp } from '../react-navigation';
@@ -36,24 +37,24 @@ type State = $ReadOnly<{|
 |}>;
 
 export default class ShareToPm extends React.Component<Props, State> {
-  static contextType = TranslationContext;
+  static contextType: Context<GetText> = TranslationContext;
   context: GetText;
 
-  state = {
+  state: State = {
     selectedRecipients: [],
     choosingRecipients: false,
   };
 
-  handleModalClose = () => {
+  handleModalClose: () => void = () => {
     this.setState({ choosingRecipients: false });
   };
 
-  handleChooseRecipients = (selectedRecipients: $ReadOnlyArray<UserId>) => {
+  handleChooseRecipients: ($ReadOnlyArray<UserId>) => void = selectedRecipients => {
     this.setState({ selectedRecipients });
     this.setState({ choosingRecipients: false });
   };
 
-  isSendButtonEnabled = (message: string) => {
+  isSendButtonEnabled: string => boolean = message => {
     const { selectedRecipients } = this.state;
     const { sharedData } = this.props.route.params;
 
@@ -64,7 +65,7 @@ export default class ShareToPm extends React.Component<Props, State> {
     return selectedRecipients.length > 0;
   };
 
-  renderUsersPreview = () => {
+  renderUsersPreview: () => Node = () => {
     const { selectedRecipients } = this.state;
 
     if (selectedRecipients.length === 0) {
@@ -77,7 +78,7 @@ export default class ShareToPm extends React.Component<Props, State> {
     return preview;
   };
 
-  render() {
+  render(): Node {
     const { selectedRecipients, choosingRecipients } = this.state;
     const { sharedData } = this.props.route.params;
     const sendTo = { selectedRecipients, type: 'pm' };

--- a/src/sharing/index.js
+++ b/src/sharing/index.js
@@ -46,7 +46,7 @@ export class ShareReceivedListener {
     }
   }
 
-  handleShareReceived = (data: SharedData) => {
+  handleShareReceived: SharedData => void = data => {
     this.dispatch(goToSharing(data));
   };
 

--- a/src/start/CompatibilityScreen.js
+++ b/src/start/CompatibilityScreen.js
@@ -1,5 +1,6 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
+import type { Node } from 'react';
 import { Image, Text, View, Platform } from 'react-native';
 
 import { openLinkExternal } from '../utils/openLink';
@@ -46,16 +47,16 @@ const GooglePlayBadge = () => (
 );
 
 export default class CompatibilityScreen extends PureComponent<{||}> {
-  storeURL =
+  storeURL: string =
     Platform.OS === 'ios'
       ? 'https://itunes.apple.com/app/zulip/id1203036395'
       : 'https://play.google.com/store/apps/details?id=com.zulipmobile';
 
-  openStoreURL = () => {
+  openStoreURL: () => void = () => {
     openLinkExternal(this.storeURL);
   };
 
-  render() {
+  render(): Node {
     return (
       <View style={styles.screen}>
         <Text style={styles.text}>This app is too old!</Text>

--- a/src/start/RealmInputScreen.js
+++ b/src/start/RealmInputScreen.js
@@ -1,5 +1,6 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
+import type { Node } from 'react';
 import { Keyboard } from 'react-native';
 
 import type { RouteProp } from '../react-navigation';
@@ -23,13 +24,13 @@ type State = {|
 |};
 
 export default class RealmInputScreen extends PureComponent<Props, State> {
-  state = {
+  state: State = {
     progress: false,
     realmInputValue: '',
     error: null,
   };
 
-  tryRealm = async () => {
+  tryRealm: () => Promise<void> = async () => {
     const { realmInputValue } = this.state;
 
     const parsedRealm = tryParseUrl(realmInputValue);
@@ -60,9 +61,9 @@ export default class RealmInputScreen extends PureComponent<Props, State> {
     }
   };
 
-  handleRealmChange = (value: string) => this.setState({ realmInputValue: value });
+  handleRealmChange: string => void = value => this.setState({ realmInputValue: value });
 
-  render() {
+  render(): Node {
     const { navigation } = this.props;
     const { progress, error, realmInputValue } = this.state;
 

--- a/src/streams/EditStreamCard.js
+++ b/src/streams/EditStreamCard.js
@@ -1,5 +1,6 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
+import type { Node } from 'react';
 import { View } from 'react-native';
 
 import { Input, Label, SwitchRow, ZulipButton } from '../common';
@@ -30,31 +31,31 @@ type State = {|
 |};
 
 export default class EditStreamCard extends PureComponent<Props, State> {
-  state = {
+  state: State = {
     name: this.props.initialValues.name,
     description: this.props.initialValues.description,
     isPrivate: this.props.initialValues.invite_only,
   };
 
-  handlePerformAction = () => {
+  handlePerformAction: () => void = () => {
     const { onComplete } = this.props;
     const { name, description, isPrivate } = this.state;
     onComplete(name, description, isPrivate);
   };
 
-  handleNameChange = (name: string) => {
+  handleNameChange: string => void = name => {
     this.setState({ name });
   };
 
-  handleDescriptionChange = (description: string) => {
+  handleDescriptionChange: string => void = description => {
     this.setState({ description });
   };
 
-  handleIsPrivateChange = (isPrivate: boolean) => {
+  handleIsPrivateChange: boolean => void = isPrivate => {
     this.setState({ isPrivate });
   };
 
-  render() {
+  render(): Node {
     const { initialValues, isNewStream } = this.props;
     const { name } = this.state;
 

--- a/src/subscriptions/StreamListCard.js
+++ b/src/subscriptions/StreamListCard.js
@@ -33,8 +33,8 @@ type Props = $ReadOnly<{|
   dispatch: Dispatch,
   auth: Auth,
   canCreateStreams: boolean,
-  streams: Stream[],
-  subscriptions: Subscription[],
+  streams: $ReadOnlyArray<Stream>,
+  subscriptions: $ReadOnlyArray<Subscription>,
 |}>;
 
 class StreamListCard extends PureComponent<Props> {

--- a/src/topics/topicSelectors.js
+++ b/src/topics/topicSelectors.js
@@ -16,7 +16,7 @@ import { getStreamsById } from '../subscriptions/subscriptionSelectors';
 import { NULL_ARRAY } from '../nullObjects';
 import { isStreamNarrow, streamNameOfNarrow } from '../utils/narrow';
 
-export const getTopicsForNarrow: Selector<string[], Narrow> = createSelector(
+export const getTopicsForNarrow: Selector<$ReadOnlyArray<string>, Narrow> = createSelector(
   (state, narrow) => narrow,
   state => getTopics(state),
   state => getStreams(state),

--- a/src/typing/typingSelectors.js
+++ b/src/typing/typingSelectors.js
@@ -12,7 +12,7 @@ export const getCurrentTypingUsers: Selector<$ReadOnlyArray<UserOrBot>, Narrow> 
   (state, narrow) => narrow,
   state => getTyping(state),
   state => getAllUsersById(state),
-  (narrow, typing, allUsersById): UserOrBot[] => {
+  (narrow, typing, allUsersById): $ReadOnlyArray<UserOrBot> => {
     if (!isPmNarrow(narrow)) {
       return NULL_ARRAY;
     }

--- a/src/unread/unreadHelpers.js
+++ b/src/unread/unreadHelpers.js
@@ -2,7 +2,7 @@
 import type { HuddlesUnreadItem, PmsUnreadItem, UserId } from '../types';
 import { addItemsToArray, removeItemsFromArray, filterArray } from '../utils/immutability';
 
-type SomeUnreadItem = { unread_message_ids: $ReadOnlyArray<number>, ... };
+type SomeUnreadItem = $ReadOnly<{ unread_message_ids: $ReadOnlyArray<number>, ... }>;
 
 export function removeItemsDeeply<T: SomeUnreadItem>(
   objArray: $ReadOnlyArray<T>,

--- a/src/unread/unreadHelpers.js
+++ b/src/unread/unreadHelpers.js
@@ -2,9 +2,12 @@
 import type { HuddlesUnreadItem, PmsUnreadItem, UserId } from '../types';
 import { addItemsToArray, removeItemsFromArray, filterArray } from '../utils/immutability';
 
-type SomeUnreadItem = { unread_message_ids: number[], ... };
+type SomeUnreadItem = { unread_message_ids: $ReadOnlyArray<number>, ... };
 
-export function removeItemsDeeply<T: SomeUnreadItem>(objArray: T[], messageIds: number[]): T[] {
+export function removeItemsDeeply<T: SomeUnreadItem>(
+  objArray: $ReadOnlyArray<T>,
+  messageIds: number[],
+): $ReadOnlyArray<T> {
   let changed = false;
   const objWithAddedUnreadIds = objArray.map(obj => {
     const filteredIds = removeItemsFromArray(obj.unread_message_ids, messageIds);
@@ -29,7 +32,11 @@ export function removeItemsDeeply<T: SomeUnreadItem>(objArray: T[], messageIds: 
   );
 }
 
-function addItemsDeeply<T: SomeUnreadItem>(input: T[], itemsToAdd: number[], index: number): T[] {
+function addItemsDeeply<T: SomeUnreadItem>(
+  input: $ReadOnlyArray<T>,
+  itemsToAdd: number[],
+  index: number,
+): $ReadOnlyArray<T> {
   const item = input[index];
 
   const unreadMessageIds = addItemsToArray(item.unread_message_ids, itemsToAdd);
@@ -48,10 +55,10 @@ function addItemsDeeply<T: SomeUnreadItem>(input: T[], itemsToAdd: number[], ind
 }
 
 export const addItemsToPmArray = (
-  input: PmsUnreadItem[],
+  input: $ReadOnlyArray<PmsUnreadItem>,
   itemsToAdd: number[],
   senderId: UserId,
-): PmsUnreadItem[] => {
+): $ReadOnlyArray<PmsUnreadItem> => {
   const index = input.findIndex(sender => sender.sender_id === senderId);
 
   if (index !== -1) {
@@ -68,10 +75,10 @@ export const addItemsToPmArray = (
 };
 
 export const addItemsToHuddleArray = (
-  input: HuddlesUnreadItem[],
+  input: $ReadOnlyArray<HuddlesUnreadItem>,
   itemsToAdd: number[],
   userIds: string,
-): HuddlesUnreadItem[] => {
+): $ReadOnlyArray<HuddlesUnreadItem> => {
   const index = input.findIndex(recipients => recipients.user_ids_string === userIds);
 
   if (index !== -1) {

--- a/src/unread/unreadModelTypes.js
+++ b/src/unread/unreadModelTypes.js
@@ -66,9 +66,9 @@ export type UnreadMentionsState = $ReadOnlyArray<number>;
  * Starting from that initial version, we keep this data structure up to
  * date as new messages arrive, as messages are marked as read, etc.
  */
-export type UnreadState = {|
+export type UnreadState = $ReadOnly<{|
   streams: UnreadStreamsState,
   huddles: UnreadHuddlesState,
   pms: UnreadPmsState,
   mentions: UnreadMentionsState,
-|};
+|}>;

--- a/src/unread/unreadModelTypes.js
+++ b/src/unread/unreadModelTypes.js
@@ -29,7 +29,7 @@ export type UnreadStreamsState =
  *
  * Part of `UnreadState`; see there for more.
  */
-export type UnreadHuddlesState = HuddlesUnreadItem[];
+export type UnreadHuddlesState = $ReadOnlyArray<HuddlesUnreadItem>;
 
 /**
  * A summary of (almost) all unread 1:1 PMs.
@@ -41,7 +41,7 @@ export type UnreadHuddlesState = HuddlesUnreadItem[];
  * Part of `UnreadState`; see there for more.
  * See in particular `UnreadHuddlesState` for group PMs.
  */
-export type UnreadPmsState = PmsUnreadItem[];
+export type UnreadPmsState = $ReadOnlyArray<PmsUnreadItem>;
 
 /**
  * A summary of (almost) all unread messages with @-mentions.
@@ -54,7 +54,7 @@ export type UnreadPmsState = PmsUnreadItem[];
  *
  * Part of `UnreadState`; see there for more.
  */
-export type UnreadMentionsState = number[];
+export type UnreadMentionsState = $ReadOnlyArray<number>;
 
 /**
  * A summary of (almost) all unread messages, even those we don't have.

--- a/src/user-picker/AvatarItem.js
+++ b/src/user-picker/AvatarItem.js
@@ -48,7 +48,7 @@ export default class AvatarItem extends PureComponent<Props> {
     }).start();
   }
 
-  handlePress = () => {
+  handlePress: () => void = () => {
     const { user, onPress } = this.props;
     Animated.timing(this.animatedValue, {
       toValue: 0,

--- a/src/users/UserItem.js
+++ b/src/users/UserItem.js
@@ -49,9 +49,9 @@ type Props<UserT> = $ReadOnly<{|
  * user, one that doesn't exist in the database.  (But anywhere we're doing
  * that, there's probably a better UI anyway than showing a fake user.)
  */
-export function UserItemRaw<UserT: { user_id: UserId, email: string, full_name: string, ... }>(
-  props: Props<UserT>,
-): Node {
+export function UserItemRaw<
+  UserT: $ReadOnly<{ user_id: UserId, email: string, full_name: string, ... }>,
+>(props: Props<UserT>): Node {
   const { user, isSelected = false, onPress, unreadCount, showEmail = false } = props;
   const _ = useContext(TranslationContext);
   const isMuted = useSelector(getMutedUsers).has(user.user_id);

--- a/src/users/userHelpers.js
+++ b/src/users/userHelpers.js
@@ -145,7 +145,7 @@ export const getAutocompleteSuggestion = (
 };
 
 export const getAutocompleteUserGroupSuggestions = (
-  userGroups: UserGroup[],
+  userGroups: $ReadOnlyArray<UserGroup>,
   filter: string = '',
 ): UserGroup[] =>
   userGroups.filter(

--- a/src/users/userHelpers.js
+++ b/src/users/userHelpers.js
@@ -53,7 +53,12 @@ export const sortUserList = (users: UserOrBot[], presences: PresenceState): User
       || x1.full_name.toLowerCase().localeCompare(x2.full_name.toLowerCase()),
   );
 
-export type AutocompleteOption = { user_id: UserId, email: string, full_name: string, ... };
+export type AutocompleteOption = $ReadOnly<{
+  user_id: UserId,
+  email: string,
+  full_name: string,
+  ...
+}>;
 
 export const filterUserList = (
   users: $ReadOnlyArray<UserOrBot>,

--- a/src/utils/immutability.js
+++ b/src/utils/immutability.js
@@ -1,16 +1,22 @@
 /* @flow strict-local */
 
-export const removeItemsFromArray = (input: number[], itemsToRemove: number[]): number[] => {
+export const removeItemsFromArray = (
+  input: $ReadOnlyArray<number>,
+  itemsToRemove: number[],
+): $ReadOnlyArray<number> => {
   const output = input.filter((item: number) => !itemsToRemove.includes(item));
   return input.length === output.length ? input : output;
 };
 
-export function addItemsToArray<T>(input: T[], itemsToAdd: T[]): T[] {
+export function addItemsToArray<T>(input: $ReadOnlyArray<T>, itemsToAdd: T[]): $ReadOnlyArray<T> {
   const newItems = itemsToAdd.filter(item => !input.includes(item));
   return newItems.length > 0 ? [...input, ...itemsToAdd] : input;
 }
 
-export function filterArray<T>(input: T[], predicate: T => boolean): T[] {
+export function filterArray<T>(
+  input: $ReadOnlyArray<T>,
+  predicate: T => boolean,
+): $ReadOnlyArray<T> {
   const filteredList = input.filter(predicate);
   return filteredList.length === input.length ? input : filteredList;
 }

--- a/src/utils/immutability.js
+++ b/src/utils/immutability.js
@@ -22,7 +22,7 @@ export function filterArray<T>(
 }
 
 export function replaceItemInArray<T>(
-  input: T[],
+  input: $ReadOnlyArray<T>,
   predicate: (item: T) => boolean,
   replaceFunc: (item?: T) => T,
 ): T[] {

--- a/src/utils/message.js
+++ b/src/utils/message.js
@@ -9,7 +9,7 @@ export const isTopicMuted = (stream: string, topic: string, mute: MuteState = []
 export const shouldBeMuted = (
   message: Message | Outbox,
   narrow: Narrow,
-  subscriptions: Subscription[] = [],
+  subscriptions: $ReadOnlyArray<Subscription> = [],
   mutes: MuteState = [],
 ): boolean => {
   if (message.type === 'private') {

--- a/src/utils/misc.js
+++ b/src/utils/misc.js
@@ -8,7 +8,10 @@ export const caseInsensitiveCompareFunc = (a: string, b: string): number =>
 export const numberWithSeparators = (value: number | string): string =>
   value.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
 
-export function deeperMerge<K, V>(obj1: {| [K]: V |}, obj2: {| [K]: V |}): {| [K]: V |} {
+export function deeperMerge<K, V>(
+  obj1: $ReadOnly<{| [K]: V |}>,
+  obj2: $ReadOnly<{| [K]: V |}>,
+): {| [K]: V |} {
   const mergedKeys = Array.from(new Set([...Object.keys(obj1), ...Object.keys(obj2)]));
   return objectFromEntries(
     mergedKeys.map(key =>

--- a/src/webview/MessageList.js
+++ b/src/webview/MessageList.js
@@ -88,7 +88,7 @@ export type BackgroundData = $ReadOnly<{|
   ownUser: User,
   streams: Map<number, Stream>,
   streamsByName: Map<string, Stream>,
-  subscriptions: Subscription[],
+  subscriptions: $ReadOnlyArray<Subscription>,
   unread: UnreadState,
   theme: ThemeName,
   twentyFourHourTime: boolean,

--- a/src/webview/MessageList.js
+++ b/src/webview/MessageList.js
@@ -48,7 +48,7 @@ import {
 } from '../selectors';
 import { withGetText } from '../boot/TranslationProvider';
 import type { ShowActionSheetWithOptions } from '../message/messageActionSheet';
-import { getHtmlPieceDescriptorsForMessages } from '../message/messageSelectors';
+import { getHtmlPieceDescriptorsMemoized } from '../message/messageSelectors';
 import type { WebViewInboundEvent } from './generateInboundEvents';
 import type { WebViewOutboundEvent } from './handleOutboundEvents';
 import getHtml from './html/html';
@@ -360,7 +360,7 @@ const MessageList: ComponentType<OuterProps> = connect<SelectorProps, _, _>(
     return {
       backgroundData,
       fetching: getFetchingForNarrow(state, props.narrow),
-      htmlPieceDescriptorsForShownMessages: getHtmlPieceDescriptorsForMessages(
+      htmlPieceDescriptorsForShownMessages: getHtmlPieceDescriptorsMemoized(
         props.messages,
         props.narrow,
       ),

--- a/src/webview/html/processAlertWords.js
+++ b/src/webview/html/processAlertWords.js
@@ -21,7 +21,7 @@ function escape_user_regex(value) {
 
 /* Helper borrowed near-verbatim from webapp; see comment above. */
 // prettier-ignore
-const process_message = function (words: string[],
+const process_message = function (words: $ReadOnlyArray<string>,
                                   message: {| alerted: boolean, content: string |}) {
     // Parsing for alert words is expensive, so we rely on the host
     // to tell us there any alert words to even look for.
@@ -58,7 +58,12 @@ const process_message = function (words: string[],
 };
 
 /** Mark any alert words in `content` with an appropriate span. */
-export default (content: string, id: number, alertWords: string[], flags: FlagsState): string => {
+export default (
+  content: string,
+  id: number,
+  alertWords: $ReadOnlyArray<string>,
+  flags: FlagsState,
+): string => {
   // This is kind of funny style, but lets us borrow the webapp's code near
   // verbatim, inside `process_message`.
   let message = { content, alerted: flags.has_alert_word[id] };


### PR DESCRIPTION
I promise we're getting nearer to done with these! 🙂

After this, and after the currently open PRs #4943, #4942, #4926, and after we do something about `ZulipAsyncStorage` (see [discussion](https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/ZulipAsyncStorage.20extends.20AsyncStorage.20.28.3F.29/near/1244517) and #4947), there will be just a few small things that I expect will basically disappear naturally with #4898 and #4868 (and maybe a third PR that's not occurring to me right now—if so, it's tiny).

This also adds a lot of read-only annotations that aren't strictly necessary for our work on annotating things for #4907. But I figured it's a good thing to do, and I'd happily split that off to a different PR if you'd like.

Related: #4907