### PR TITLE
api types: Mark most remaining types read-only

### DIFF
--- a/src/api/eventTypes.js
+++ b/src/api/eventTypes.js
@@ -38,24 +38,24 @@ export class EventTypes {
   static user_status: 'user_status' = 'user_status';
 }
 
-type EventCommon = {|
+type EventCommon = $ReadOnly<{|
   id: number,
-|};
+|}>;
 
 /** A common supertype of all events, known or unknown. */
-export type GeneralEvent = {
+export type GeneralEvent = $ReadOnly<{
   ...EventCommon,
   type: string,
   // Note this is an inexact object type!  There will be more properties.
   ...
-};
+}>;
 
-export type HeartbeatEvent = {|
+export type HeartbeatEvent = $ReadOnly<{|
   ...EventCommon,
   type: typeof EventTypes.heartbeat,
-|};
+|}>;
 
-export type MessageEvent = {|
+export type MessageEvent = $ReadOnly<{|
   ...EventCommon,
   type: typeof EventTypes.message,
   message: Message,
@@ -70,16 +70,16 @@ export type MessageEvent = {|
    * Otherwise absent.
    */
   local_message_id?: number,
-|};
+|}>;
 
-export type MutedUsersEvent = {|
+export type MutedUsersEvent = $ReadOnly<{|
   ...EventCommon,
   type: typeof EventTypes.muted_users,
   muted_users: MutedUser[],
-|};
+|}>;
 
 /** A new submessage.  See the `Submessage` type for details. */
-export type SubmessageEvent = {|
+export type SubmessageEvent = $ReadOnly<{|
   ...EventCommon,
   type: typeof EventTypes.submessage,
   submessage_id: number,
@@ -87,15 +87,15 @@ export type SubmessageEvent = {|
   sender_id: UserId,
   msg_type: 'widget',
   content: string,
-|};
+|}>;
 
-export type PresenceEvent = {|
+export type PresenceEvent = $ReadOnly<{|
   ...EventCommon,
   type: typeof EventTypes.presence,
   email: string,
   server_timestamp: number,
   presence: UserPresence,
-|};
+|}>;
 
 /**
  * Updates the user status for a user
@@ -109,19 +109,19 @@ export type PresenceEvent = {|
  *
  * Not providing a property means 'leave this value unchanged'
  */
-export type UserStatusEvent = {|
+export type UserStatusEvent = $ReadOnly<{|
   ...EventCommon,
   type: typeof EventTypes.user_status,
   user_id: UserId,
   away?: boolean,
   status_text?: string,
-|};
+|}>;
 
-type StreamListEvent = {|
+type StreamListEvent = $ReadOnly<{|
   ...EventCommon,
   type: typeof EventTypes.stream,
   streams: Stream[],
-|};
+|}>;
 
 // prettier-ignore
 export type StreamEvent =
@@ -139,7 +139,7 @@ export type StreamEvent =
       value: string,
     |};
 
-export type UpdateMessageFlagsEvent = {|
+export type UpdateMessageFlagsEvent = $ReadOnly<{|
   ...EventCommon,
   type: typeof EventTypes.update_message_flags,
 
@@ -151,10 +151,10 @@ export type UpdateMessageFlagsEvent = {|
   flag: empty, // TODO fill in
   all: boolean,
   messages: number[],
-|};
+|}>;
 
 // https://zulip.com/api/get-events#restart
-export type RestartEvent = {|
+export type RestartEvent = $ReadOnly<{|
   ...EventCommon,
   type: typeof EventTypes.restart,
 
@@ -170,4 +170,4 @@ export type RestartEvent = {|
   // the /server_settings and /register responses.
   zulip_version?: string,
   zulip_feature_level?: number,
-|};
+|}>;

--- a/src/api/eventTypes.js
+++ b/src/api/eventTypes.js
@@ -75,7 +75,7 @@ export type MessageEvent = $ReadOnly<{|
 export type MutedUsersEvent = $ReadOnly<{|
   ...EventCommon,
   type: typeof EventTypes.muted_users,
-  muted_users: MutedUser[],
+  muted_users: $ReadOnlyArray<MutedUser>,
 |}>;
 
 /** A new submessage.  See the `Submessage` type for details. */
@@ -120,7 +120,7 @@ export type UserStatusEvent = $ReadOnly<{|
 type StreamListEvent = $ReadOnly<{|
   ...EventCommon,
   type: typeof EventTypes.stream,
-  streams: Stream[],
+  streams: $ReadOnlyArray<Stream>,
 |}>;
 
 // prettier-ignore
@@ -150,7 +150,7 @@ export type UpdateMessageFlagsEvent = $ReadOnly<{|
 
   flag: empty, // TODO fill in
   all: boolean,
-  messages: number[],
+  messages: $ReadOnlyArray<number>,
 |}>;
 
 // https://zulip.com/api/get-events#restart

--- a/src/api/eventTypes.js
+++ b/src/api/eventTypes.js
@@ -125,11 +125,11 @@ type StreamListEvent = $ReadOnly<{|
 
 // prettier-ignore
 export type StreamEvent =
-  | {| ...StreamListEvent, op: 'create', |}
-  | {| ...StreamListEvent, op: 'delete', |}
-  | {| ...StreamListEvent, op: 'occupy', |}
-  | {| ...StreamListEvent, op: 'vacate', |}
-  | {|
+  | {| ...StreamListEvent, +op: 'create', |}
+  | {| ...StreamListEvent, +op: 'delete', |}
+  | {| ...StreamListEvent, +op: 'occupy', |}
+  | {| ...StreamListEvent, +op: 'vacate', |}
+  | $ReadOnly<{|
       ...EventCommon,
       type: typeof EventTypes.stream,
       op: 'update',
@@ -137,7 +137,7 @@ export type StreamEvent =
       name: string,
       property: string,
       value: string,
-    |};
+    |}>;
 
 export type UpdateMessageFlagsEvent = $ReadOnly<{|
   ...EventCommon,

--- a/src/api/initialDataTypes.js
+++ b/src/api/initialDataTypes.js
@@ -263,7 +263,7 @@ export type PmsUnreadItem = $ReadOnly<{|
 |}>;
 
 /** Initial data for `update_message_flags` events. */
-export type InitialDataUpdateMessageFlags = {|
+export type InitialDataUpdateMessageFlags = $ReadOnly<{|
   /**
    * A summary of (almost) all unread messages, even those we don't have.
    *
@@ -316,19 +316,19 @@ export type InitialDataUpdateMessageFlags = {|
      */
     count: number,
   |},
-|};
+|}>;
 
-export type InitialDataUserStatus = {|
+export type InitialDataUserStatus = $ReadOnly<{|
   /**
    * Older servers (through at least 1.9.1) don't send this.
    * A missing value is equivalent to empty.
    */
   user_status?: UserStatusMapObject,
-|};
+|}>;
 
 // Initial data snapshot sent in response to a `/register` request,
 // after validation and transformation.
-export type InitialData = {|
+export type InitialData = $ReadOnly<{|
   // The server sends different subsets of the full available data,
   // depending on what event types the client subscribes to with the
   // `fetch_event_types` field of the `/register` request. We name these
@@ -355,12 +355,12 @@ export type InitialData = {|
   ...InitialDataUpdateGlobalNotifications,
   ...InitialDataUpdateMessageFlags,
   ...InitialDataUserStatus,
-|};
+|}>;
 
 // Initial data snapshot sent in response to a `/register` request,
 // before validation and transformation.
-export type RawInitialData = {|
+export type RawInitialData = $ReadOnly<{|
   ...InitialData,
   ...RawInitialDataRealmUser,
   ...RawInitialDataRealmFilters,
-|};
+|}>;

--- a/src/api/initialDataTypes.js
+++ b/src/api/initialDataTypes.js
@@ -42,7 +42,7 @@ export type InitialDataMutedUsers = $ReadOnly<{|
 |}>;
 
 export type InitialDataPresence = $ReadOnly<{|
-  presences: {| [email: string]: UserPresence |},
+  presences: {| +[email: string]: UserPresence |},
 |}>;
 
 export type AvailableVideoChatProviders = $ReadOnly<{|
@@ -288,7 +288,7 @@ export type InitialDataUpdateMessageFlags = $ReadOnly<{|
   // This is computed by `aggregate_unread_data` and its helper
   // `aggregate_message_dict`, consuming data supplied by
   // `get_raw_unread_data`, all found in `zerver/lib/message.py`.
-  unread_msgs: {|
+  unread_msgs: $ReadOnly<{|
     /**
      * Unread stream messages.
      *
@@ -315,7 +315,7 @@ export type InitialDataUpdateMessageFlags = $ReadOnly<{|
      * messages that are muted.
      */
     count: number,
-  |},
+  |}>,
 |}>;
 
 export type InitialDataUserStatus = $ReadOnly<{|

--- a/src/api/initialDataTypes.js
+++ b/src/api/initialDataTypes.js
@@ -23,7 +23,7 @@ export type InitialDataBase = $ReadOnly<{|
 |}>;
 
 export type InitialDataAlertWords = $ReadOnly<{|
-  alert_words: string[],
+  alert_words: $ReadOnlyArray<string>,
 |}>;
 
 export type InitialDataMessage = $ReadOnly<{|
@@ -33,12 +33,12 @@ export type InitialDataMessage = $ReadOnly<{|
 export type MuteTuple = [string, string];
 
 export type InitialDataMutedTopics = $ReadOnly<{|
-  muted_topics: MuteTuple[],
+  muted_topics: $ReadOnlyArray<MuteTuple>,
 |}>;
 
 /** Added in server version 4.0, feature level 48 */
 export type InitialDataMutedUsers = $ReadOnly<{|
-  muted_users?: MutedUser[],
+  muted_users?: $ReadOnlyArray<MutedUser>,
 |}>;
 
 export type InitialDataPresence = $ReadOnly<{|
@@ -234,7 +234,7 @@ export type StreamUnreadItem = $ReadOnly<{|
   unread_message_ids: $ReadOnlyArray<number>,
 
   /** All distinct senders of these messages; sorted. */
-  // sender_ids: UserId[],
+  // sender_ids: $ReadOnlyArray<UserId>,
 |}>;
 
 export type HuddlesUnreadItem = $ReadOnly<{|
@@ -294,18 +294,18 @@ export type InitialDataUpdateMessageFlags = $ReadOnly<{|
      *
      * NB this includes messages to muted streams and topics.
      */
-    streams: StreamUnreadItem[],
+    streams: $ReadOnlyArray<StreamUnreadItem>,
 
     /** Unread group PM messages, i.e. with >=3 participants. */
     // "huddle" is the server's internal term for a group PM conversation.
-    huddles: HuddlesUnreadItem[],
+    huddles: $ReadOnlyArray<HuddlesUnreadItem>,
 
     /** Unread 1:1 PM messages. */
-    pms: PmsUnreadItem[],
+    pms: $ReadOnlyArray<PmsUnreadItem>,
 
     /** Unread @-mentions. */
     // Unlike other lists of message IDs here, `mentions` is *not* sorted.
-    mentions: number[],
+    mentions: $ReadOnlyArray<number>,
 
     /**
      * Total *unmuted* unreads.

--- a/src/api/modelTypes.js
+++ b/src/api/modelTypes.js
@@ -671,7 +671,7 @@ export type StreamMessage = $ReadOnly<{|
  *    `EVENT_NEW_MESSAGE` Redux action for the event;
  *  * `messages: Message[]` in a `/messages` (our `getMessages`) response,
  *    and our resulting `MESSAGE_FETCH_COMPLETE` Redux action;
- *  * `messages: {| [id]: Message |}` in our global Redux state.
+ *  * `messages: Map<number, Message>` in our global Redux state.
  *
  * References include:
  *  * the two example events at https://zulip.com/api/get-events

--- a/src/api/transportTypes.js
+++ b/src/api/transportTypes.js
@@ -15,11 +15,11 @@
  * leaves out the secret API key; use `identityOfAuth` to extract one from
  * an `Auth`.
  */
-export type Auth = {|
+export type Auth = $ReadOnly<{|
   realm: URL,
   apiKey: string,
   email: string,
-|};
+|}>;
 
 /**
  * The type shared by all Zulip API responses.
@@ -30,11 +30,11 @@ export type Auth = {|
  *  * {@link ApiResponseSuccess}
  *  * {@link ApiResponseErrorData}
  */
-export type ApiResponse = {
+export type ApiResponse = $ReadOnly<{
   +result: string,
   +msg: string,
   ...
-};
+}>;
 
 /**
  * The type shared by all non-error Zulip API responses.
@@ -45,11 +45,11 @@ export type ApiResponse = {
  *  * {@link ApiResponse}
  *  * {@link ApiResponseErrorData}
  */
-export type ApiResponseSuccess = {
+export type ApiResponseSuccess = $ReadOnly<{
   +result: 'success',
   +msg: '',
   ...
-};
+}>;
 
 /**
  * A list of current error codes can be found at:
@@ -92,9 +92,9 @@ export type ApiErrorCode = string;
  *
  * This type is not exact: some error responses may contain additional data.
  */
-export type ApiResponseErrorData = {
+export type ApiResponseErrorData = $ReadOnly<{
   +code: ApiErrorCode,
   +msg: string,
   +result: 'error',
   ...
-};
+}>;

--- a/src/mute/mutedUsersReducer.js
+++ b/src/mute/mutedUsersReducer.js
@@ -13,7 +13,7 @@ import type { MutedUser } from '../api/apiTypes';
 
 const initialState: MutedUsersState = Immutable.Map();
 
-function mutedUsersToMap(muted_users: MutedUser[]): Immutable.Map<UserId, number> {
+function mutedUsersToMap(muted_users: $ReadOnlyArray<MutedUser>): Immutable.Map<UserId, number> {
   return Immutable.Map(muted_users.map(muted_user => [muted_user.id, muted_user.timestamp]));
 }
 


### PR DESCRIPTION
This largely covers the remaining types here, inspired by #4948, with the help of some Perl find-and-replace.

There isn't anything special about the API that means its objects and arrays should be read-only -- after all, the actual server itself can't possibly care. But we reuse a lot of these for Redux actions and for pieces of our Redux store, where we do want things to be read-only, so it's helpful to just consistently mark here too.