### PR TITLE
redux-persist: Improve logging of errors.

### DIFF
--- a/src/third/redux-persist/createPersistor.js
+++ b/src/third/redux-persist/createPersistor.js
@@ -84,7 +84,7 @@ export default function createPersistor (store, config) {
           let value = data
           state[key] = value
         } catch (err) {
-          logging.warn('Error rehydrating data for a key', { key, err })
+          logging.warn(err, { message: 'Error rehydrating data for a key', key })
         }
       })
     } else state = incoming
@@ -113,7 +113,7 @@ export default function createPersistor (store, config) {
 
 function warnIfSetError (key) {
   return function setError (err) {
-    if (err) { logging.warn('Error storing data for key:', key, err) }
+    if (err) { logging.warn(err, { message: 'Error storing data for key:', key }) }
   }
 }
 

--- a/src/third/redux-persist/getStoredState.js
+++ b/src/third/redux-persist/getStoredState.js
@@ -29,7 +29,7 @@ export default function getStoredState (config, onComplete) {
     }
 
     if (err) {
-      logging.warn('redux-persist/getStoredState: Error in storage.getAllKeys')
+      logging.warn(err, { message: 'redux-persist/getStoredState: Error in storage.getAllKeys' })
       complete(err)
       return
     }
@@ -48,7 +48,7 @@ export default function getStoredState (config, onComplete) {
         } catch (e) {
           err = e
         }
-        if (err) logging.warn('redux-persist/getStoredState: Error restoring data for a key.', { key, err })
+        if (err) logging.warn(err, { message: 'redux-persist/getStoredState: Error restoring data for a key.', key})
         else restoredState[key] = rehydrate(key, serialized)
         completionCount += 1
         if (completionCount === restoreCount) complete(null, restoredState)
@@ -63,7 +63,7 @@ export default function getStoredState (config, onComplete) {
       let data = deserializer(serialized)
       state = data
     } catch (err) {
-      logging.warn('redux-persist/getStoredState: Error restoring data for a key.', { key, err })
+      logging.warn(err, { message: 'redux-persist/getStoredState: Error restoring data for a key.', key })
     }
 
     return state

--- a/src/third/redux-persist/purgeStoredState.js
+++ b/src/third/redux-persist/purgeStoredState.js
@@ -21,7 +21,7 @@ export default function purgeStoredState (config, keys) {
           err = e
         }
         if (err) {
-          logging.warn('redux-persist: error during purgeStoredState in storage.getAllKeys')
+          logging.warn(err, { message: 'redux-persist: error during purgeStoredState in storage.getAllKeys' })
           reject(err)
         } else {
           resolve(purgeStoredState(config, allKeys.filter((key) => key.indexOf(keyPrefix) === 0).map((key) => key.slice(keyPrefix.length))))
@@ -42,6 +42,6 @@ export default function purgeStoredState (config, keys) {
 
 function warnIfRemoveError (key) {
   return function removeError (err) {
-    if (err) { logging.warn('Error storing data for a key.', { key, err }) }
+    if (err) { logging.warn(err, { message: 'Error storing data for a key.', key }) }
   }
 }


### PR DESCRIPTION
`logging.warn` has the best chance of helpfully reporting an Error
object if we pass it as the first argument. In some of these cases,
we weren't even passing an Error at all, when we had one available
-- so, do so, and have it be the first argument.

The second argument should be a plain, JSONable object. So, make
that happen, too, so we don't get Sentry events with things like

  "extra": {
    "0": "u",
    "1": "s",
    "2": "e",
    "3": "r",
    "4": "G",
    "5": "r",
    "6": "o",
    "7": "u",
    "8": "p",
    "9": "s"
  }