### PR TITLE
Check active account, too, in getHaveServerData

### DIFF
--- a/src/account/AccountItem.js
+++ b/src/account/AccountItem.js
@@ -51,7 +51,12 @@ type Props = $ReadOnly<{|
 export default function AccountItem(props: Props): Node {
   const { email, realm, isLoggedIn } = props.account;
 
+  // Don't show the "remove account" button (the "trash" icon) for the
+  // active account when it's logged in.  This prevents removing it when the
+  // main app UI, relying on that account's data, may be on the nav stack.
+  // See `getHaveServerData`.
   const showDoneIcon = props.index === 0 && isLoggedIn;
+
   const backgroundItemColor = isLoggedIn ? 'hsla(177, 70%, 47%, 0.1)' : 'hsla(0,0%,50%,0.1)';
   const textColor = isLoggedIn ? BRAND_COLOR : 'gray';
 

--- a/src/users/userSelectors.js
+++ b/src/users/userSelectors.js
@@ -306,6 +306,13 @@ export const getHaveServerData = (state: GlobalState): boolean => {
     return false;
   }
 
+  // TODO: A nice bonus would be to check that the account matches the
+  // server data, given any of:
+  //  * user ID in `Account` (#4951)
+  //  * realm URL in `RealmState`
+  //  * delivery email in `RealmState` and/or `User` (though not sure this
+  //    is available from server, even for self, in all configurations)
+
   // Any other subtree could also have been emptied while others weren't,
   // or otherwise be out of sync.
   //

--- a/src/users/userSelectors.js
+++ b/src/users/userSelectors.js
@@ -3,7 +3,7 @@ import { createSelector } from 'reselect';
 
 import type { GlobalState, UserOrBot, Selector, User, UserId } from '../types';
 import { getUsers, getCrossRealmBots, getNonActiveUsers } from '../directSelectors';
-import { tryGetActiveAccount } from '../account/accountsSelectors';
+import { getHasAuth, tryGetActiveAccount } from '../account/accountsSelectors';
 
 /**
  * All users in this Zulip org (aka realm).
@@ -287,6 +287,22 @@ export const getHaveServerData = (state: GlobalState): boolean => {
     // the main UI), and moreover is available for the active account only
     // when not logged in, in which case the main UI can't be on the
     // navigation stack either.
+    return false;
+  }
+
+  // Similarly, any valid server data comes from the active account being
+  // logged in.
+  if (!getHasAuth(state)) {
+    // From `accountsReducer`:
+    //  * This condition is resolved by LOGIN_SUCCESS.
+    //  * It's created only by ACCOUNT_REMOVE, by LOGOUT, and by (a
+    //    hypothetical) ACCOUNT_SWITCH for a logged-out account.
+    //
+    // When this condition applies, LOGIN_SUCCESS is the only way we might
+    // navigate to the main UI.
+    //
+    // For ACCOUNT_REMOVE, see the previous condition.
+    // ACCOUNT_SWITCH we only do for logged-in accounts.
     return false;
   }
 


### PR DESCRIPTION
This isn't itself server data -- it's what we use for acquiring server data -- which is why we didn't cover it when expanding these checks in 916dc4b28 / #4588.

But like the server data, it's something we assume is present when rendering the main UI of the app.  And because of the same issue #4841, the same lack of consistency in our data-storage model with redux-persist that caused #4587 and made that fix necessary, it's possible for it to be lacking data when the existing checks in this function all pass.

So, add a check for this too.

Also expand the comments in this function, particularly on the tricky balance it has to maintain. Some care is needed when adding checks here -- too much care, really, and I'd love to find a way to arrange things to make these delicate properties be more automatically true. Pending that, add some comments to make the needed reasoning more explicit, so that at least it's easier to re-confirm without reasoning back through everything from scratch.
