### PR TITLE
initialFetchAbort: Don't kick user out if we have server data.

### DIFF
--- a/src/message/fetchActions.js
+++ b/src/message/fetchActions.js
@@ -219,6 +219,7 @@ const initialFetchAbortPlain = (reason: InitialFetchAbortReason): Action => ({
 export const initialFetchAbort = (
   reason: InitialFetchAbortReason,
 ): ThunkAction<Promise<void>> => async (dispatch, getState) => {
+  dispatch(initialFetchAbortPlain(reason));
   showErrorAlert(
     // TODO: Set up these user-facing strings for translation once
     // `initialFetchAbort`'s callers all have access to a `GetText`
@@ -246,7 +247,6 @@ export const initialFetchAbort = (
     })(),
   );
   NavigationService.dispatch(resetToAccountPicker());
-  dispatch(initialFetchAbortPlain(reason));
 };
 
 /** Private; exported only for tests. */


### PR DESCRIPTION
I have a draft in progress for a better solution to this; see
discussion at
  https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/connection.20failed/near/1248170.

But for now this should fix an annoying situation that's so far been
observed on Alya's Android device, where a "Gave up trying to
connect" alert appears immediately on startup. The theory is that
the app stops making progress on the network request when the app is
backgrounded, while of course it doesn't stop approaching the
timeout. Then, when the app is foregrounded again, the request
hasn't succeeded but the timeout has fired, and the alert is shown.