### PR TITLE
notif: Require sender_id, server, and realm_uri, rejecting ancient servers' data

### DIFF
--- a/android/app/src/main/java/com/zulipmobile/notifications/FcmMessage.kt
+++ b/android/app/src/main/java/com/zulipmobile/notifications/FcmMessage.kt
@@ -199,8 +199,8 @@ private fun extractIdentity(data: Map<String, String>): Identity =
         // likely to affect more users than the bug it'd fix.  So just ignore.
         // (data["user"] ignored)
 
-        // As of 2019-03 (with 2.0.0 the latest release), the server
-        // is expected to start sending this soon.  See zulip/zulip#11961 .
+        // `user_id` was added in server version 2.1.0 (released 2019-12-12;
+        // commit 447a517e6, PR #12172.)
         userId = data["user_id"]?.parseInt("user_id")
     )
 

--- a/android/app/src/main/java/com/zulipmobile/notifications/FcmMessage.kt
+++ b/android/app/src/main/java/com/zulipmobile/notifications/FcmMessage.kt
@@ -32,7 +32,7 @@ data class Identity(
  * Data about the Zulip user that sent a message.
  */
 data class Sender(
-    val id: Int?,
+    val id: Int,
     val email: String,
     val avatarURL: URL,
     val fullName: String
@@ -149,10 +149,7 @@ data class MessageFcmMessage(
             return MessageFcmMessage(
                 identity = extractIdentity(data),
                 sender = Sender(
-                    // sender_id was added in server version 1.8.0
-                    // (released 2018-04-16; commit 014900c2e).
-                    id = data["sender_id"]?.parseInt("sender_id"),
-
+                    id = data.require("sender_id").parseInt("sender_id"),
                     email = data.require("sender_email"),
                     avatarURL = avatarURL,
                     fullName = data.require("sender_full_name")

--- a/android/app/src/main/java/com/zulipmobile/notifications/FcmMessage.kt
+++ b/android/app/src/main/java/com/zulipmobile/notifications/FcmMessage.kt
@@ -21,7 +21,7 @@ data class Identity(
     /// the base for all URLs a client uses with this realm.  It corresponds
     /// to `realm_uri` in the `server_settings` API response:
     ///   https://zulip.com/api/get-server-settings
-    val realmUri: URL?,
+    val realmUri: URL,
 
     /// This user's ID within the server.  Useful mainly in the case where
     /// the user has multiple accounts in the same org.
@@ -111,7 +111,7 @@ data class MessageFcmMessage(
      */
     fun dataForOpen(): Bundle = Bundle().apply {
         // NOTE: Keep the JS-side type definition in sync with this code.
-        identity.realmUri?.let { putString("realm_uri", it.toString()) }
+        identity.realmUri.let { putString("realm_uri", it.toString()) }
         when (recipient) {
             is Recipient.Stream -> {
                 putString("recipient_type", "stream")
@@ -190,10 +190,7 @@ private fun extractIdentity(data: Map<String, String>): Identity =
     Identity(
         serverHost = data.require("server"),
         realmId = data.require("realm_id").parseInt("realm_id"),
-
-        // `realm_uri` was added in server version 1.9.0
-        // (released 2018-11-06; commit 5f8d193bb).
-        realmUri = data["realm_uri"]?.parseUrl("realm_uri"),
+        realmUri = data.require("realm_uri").parseUrl("realm_uri"),
 
         // Server versions from 1.6.0 through 2.0.0 (and possibly earlier
         // and later) send the user's email address, as `user`.  We *could*

--- a/android/app/src/test/java/com/zulipmobile/notifications/FcmMessageTest.kt
+++ b/android/app/src/test/java/com/zulipmobile/notifications/FcmMessageTest.kt
@@ -144,9 +144,6 @@ class MessageFcmMessageTest : FcmMessageTestBase() {
 
     @Test
     fun `optional fields missing cause no error`() {
-        expect.that(parse(Example.pm.minus("realm_uri")).identity.serverHost)
-            .isEqualTo(Example.stream["server"]!!)
-        expect.that(parse(Example.pm.minus("realm_uri")).identity.realmUri).isNull()
         expect.that(parse(Example.pm.minus("user_id")).identity.userId).isNull()
     }
 
@@ -164,6 +161,7 @@ class MessageFcmMessageTest : FcmMessageTestBase() {
         assertParseFails(Example.pm.minus("realm_id"))
         assertParseFails(Example.pm.plus("realm_id" to "12,34"))
         assertParseFails(Example.pm.plus("realm_id" to "abc"))
+        assertParseFails(Example.pm.minus("realm_uri"))
         assertParseFails(Example.pm.plus("realm_uri" to "zulip.example.com"))
         assertParseFails(Example.pm.plus("realm_uri" to "/examplecorp"))
 
@@ -252,9 +250,6 @@ class RemoveFcmMessageTest : FcmMessageTestBase() {
 
     @Test
     fun `optional fields missing cause no error`() {
-        expect.that(parse(Example.hybrid.minus("realm_uri")).identity.serverHost)
-            .isEqualTo(Example.hybrid["server"]!!)
-        expect.that(parse(Example.hybrid.minus("realm_uri")).identity.realmUri).isNull()
         expect.that(parse(Example.hybrid.minus("user_id")).identity.userId).isNull()
     }
 
@@ -264,6 +259,7 @@ class RemoveFcmMessageTest : FcmMessageTestBase() {
         assertParseFails(Example.hybrid.minus("realm_id"))
         assertParseFails(Example.hybrid.plus("realm_id" to "abc"))
         assertParseFails(Example.hybrid.plus("realm_id" to "12,34"))
+        assertParseFails(Example.hybrid.minus("realm_uri"))
         assertParseFails(Example.hybrid.plus("realm_uri" to "zulip.example.com"))
         assertParseFails(Example.hybrid.plus("realm_uri" to "/examplecorp"))
 

--- a/android/app/src/test/java/com/zulipmobile/notifications/FcmMessageTest.kt
+++ b/android/app/src/test/java/com/zulipmobile/notifications/FcmMessageTest.kt
@@ -149,8 +149,6 @@ class MessageFcmMessageTest : FcmMessageTestBase() {
             .isEqualTo(Example.stream["server"]!!)
         expect.that(parse(Example.pm.minus("realm_uri")).identity?.realmUri).isNull()
         expect.that(parse(Example.pm.minus("user_id")).identity?.userId).isNull()
-
-        expect.that(parse(Example.pm.minus("sender_id")).sender.id).isNull()
     }
 
     @Test
@@ -183,6 +181,7 @@ class MessageFcmMessageTest : FcmMessageTestBase() {
         assertParseFails(Example.pm.plus("sender_avatar_url" to "/avatar/123.jpeg"))
         assertParseFails(Example.pm.plus("sender_avatar_url" to ""))
 
+        assertParseFails(Example.pm.minus("sender_id"))
         assertParseFails(Example.pm.minus("sender_email"))
         assertParseFails(Example.pm.minus("sender_full_name"))
         assertParseFails(Example.pm.minus("zulip_message_id"))

--- a/android/app/src/test/java/com/zulipmobile/notifications/FcmMessageTest.kt
+++ b/android/app/src/test/java/com/zulipmobile/notifications/FcmMessageTest.kt
@@ -144,11 +144,10 @@ class MessageFcmMessageTest : FcmMessageTestBase() {
 
     @Test
     fun `optional fields missing cause no error`() {
-        expect.that(parse(Example.pm.minus("server")).identity).isNull()
-        expect.that(parse(Example.pm.minus("realm_uri")).identity?.serverHost)
+        expect.that(parse(Example.pm.minus("realm_uri")).identity.serverHost)
             .isEqualTo(Example.stream["server"]!!)
-        expect.that(parse(Example.pm.minus("realm_uri")).identity?.realmUri).isNull()
-        expect.that(parse(Example.pm.minus("user_id")).identity?.userId).isNull()
+        expect.that(parse(Example.pm.minus("realm_uri")).identity.realmUri).isNull()
+        expect.that(parse(Example.pm.minus("user_id")).identity.userId).isNull()
     }
 
     @Test
@@ -161,6 +160,7 @@ class MessageFcmMessageTest : FcmMessageTestBase() {
 
     @Test
     fun `parse failures on malformed 'message'`() {
+        assertParseFails(Example.pm.minus("server"))
         assertParseFails(Example.pm.minus("realm_id"))
         assertParseFails(Example.pm.plus("realm_id" to "12,34"))
         assertParseFails(Example.pm.plus("realm_id" to "abc"))

--- a/src/notification/__tests__/notification-test.js
+++ b/src/notification/__tests__/notification-test.js
@@ -25,6 +25,7 @@ describe('getNarrowFromNotificationData', () => {
 
   test('recognizes stream notifications and returns topic narrow', () => {
     const notification = {
+      realm_uri,
       recipient_type: 'stream',
       stream: 'some stream',
       topic: 'some topic',
@@ -37,6 +38,7 @@ describe('getNarrowFromNotificationData', () => {
     const users = [eg.selfUser, eg.otherUser];
     const allUsersByEmail: Map<string, UserOrBot> = new Map(users.map(u => [u.email, u]));
     const notification = {
+      realm_uri,
       recipient_type: 'private',
       sender_email: eg.otherUser.email,
     };
@@ -49,6 +51,7 @@ describe('getNarrowFromNotificationData', () => {
     const allUsersByEmail: Map<string, UserOrBot> = new Map(users.map(u => [u.email, u]));
 
     const notification = {
+      realm_uri,
       recipient_type: 'private',
       pm_users: users.map(u => u.user_id).join(','),
     };

--- a/src/notification/__tests__/notification-test.js
+++ b/src/notification/__tests__/notification-test.js
@@ -104,7 +104,11 @@ describe('extract iOS notification data', () => {
     });
 
     test('very-old-style messages', () => {
-      expect(make({ message_ids: [123] })).toThrow(/archaic/);
+      const sender_email = 'nobody@example.com';
+      // baseline
+      expect(make({ recipient_type: 'private', sender_email })).toBeTruthy();
+      // missing recipient_type
+      expect(make({ sender_email })).toThrow(/archaic/);
     });
 
     test('broken or partial messages', () => {

--- a/src/notification/__tests__/notification-test.js
+++ b/src/notification/__tests__/notification-test.js
@@ -62,14 +62,8 @@ describe('getNarrowFromNotificationData', () => {
 describe('extract iOS notification data', () => {
   const barebones = deepFreeze({
     stream: { recipient_type: 'stream', stream: 'announce', topic: 'New channel' },
-    private: {
-      recipient_type: 'private',
-      sender_email: 'nobody@example.com',
-    },
-    'group PM': {
-      recipient_type: 'private',
-      sender_email: 'nobody@example.com',
-    },
+    '1:1 PM': { recipient_type: 'private', sender_email: 'nobody@example.com' },
+    'group PM': { recipient_type: 'private', pm_users: '54,321' },
   });
 
   describe('success', () => {

--- a/src/notification/extract.js
+++ b/src/notification/extract.js
@@ -168,10 +168,12 @@ export const fromAPNsImpl = (rawData: ?JSONableDict): Notification | void => {
   }
 
   const { realm_uri } = zulip;
-  if (realm_uri !== undefined && typeof realm_uri !== 'string') {
+  if (realm_uri === undefined) {
+    throw err('archaic (pre-1.9.x)');
+  }
+  if (typeof realm_uri !== 'string') {
     throw err('invalid');
   }
-  const realm_uri_obj = Object.freeze(realm_uri === undefined ? {} : { realm_uri });
 
   if (recipient_type === 'stream') {
     const { stream, topic } = zulip;
@@ -182,7 +184,7 @@ export const fromAPNsImpl = (rawData: ?JSONableDict): Notification | void => {
       recipient_type: 'stream',
       stream,
       topic,
-      ...realm_uri_obj,
+      realm_uri,
     };
   } else {
     /* recipient_type === 'private' */
@@ -199,14 +201,14 @@ export const fromAPNsImpl = (rawData: ?JSONableDict): Notification | void => {
       return {
         recipient_type: 'private',
         pm_users: ids.sort((a, b) => a - b).join(','),
-        ...realm_uri_obj,
+        realm_uri,
       };
     }
 
     if (typeof sender_email !== 'string') {
       throw err('invalid');
     }
-    return { recipient_type: 'private', sender_email, ...realm_uri_obj };
+    return { recipient_type: 'private', sender_email, realm_uri };
   }
 
   /* unreachable */

--- a/src/notification/types.js
+++ b/src/notification/types.js
@@ -13,8 +13,8 @@
  */
 // NOTE: Keep the Android-side code in sync with this type definition.
 export type Notification =
-  | {| recipient_type: 'stream', stream: string, topic: string, realm_uri?: string |}
+  | {| recipient_type: 'stream', stream: string, topic: string, realm_uri: string |}
   // Group PM messages have `pm_users`, which is sorted, comma-separated IDs.
-  | {| recipient_type: 'private', pm_users: string, realm_uri?: string |}
+  | {| recipient_type: 'private', pm_users: string, realm_uri: string |}
   // 1:1 PM messages lack `pm_users`.
-  | {| recipient_type: 'private', sender_email: string, realm_uri?: string |};
+  | {| recipient_type: 'private', sender_email: string, realm_uri: string |};


### PR DESCRIPTION
These fields are all present since Zulip Server 1.9, and two of them even since 1.8, so it's long past time we should be able to not worry about servers that don't send them. Having them always present will be helpful for the work @AkashDhiman is doing on our Android notification UI, as discussed here:
https://github.com/zulip/zulip-mobile/pull/4842#discussion_r685546372

---

~~This PR is a draft because before we start ignoring these notifications from old (pre-1.9) servers, I'd like to set things up so that we log warnings to Sentry when we do so. There's a couple of commits at the start of this branch aimed at doing that, but then I realized that they can't possibly work yet because the Sentry destination (aka "DSN" or "client key") lives only in the JS code, at `src/sentryConfig.js`, and without that there's no way that the native-Android Sentry SDK can know where a Sentry event should go. So I'll see about fixing that and getting Sentry reporting working from the native Android side, and then this can go atop that.~~

(Sentry reporting from the native iOS side would be great too -- not so much for our own code, because we don't have much there, but because hopefully it can let us know if there are crashes happening there. That's also another benefit of getting it set up on Android.)

~~In the meantime, I think all the commits reflect what I'd want to merge once that preparatory work is in.~~
