### PR TITLE
TopicList: Don't nest VirtualList in scrollable ScrollView.

### DIFF
--- a/src/topics/TopicListScreen.js
+++ b/src/topics/TopicListScreen.js
@@ -54,7 +54,13 @@ class TopicListScreen extends PureComponent<Props, State> {
       topics && topics.filter(topic => topic.name.toLowerCase().includes(filter.toLowerCase()));
 
     return (
-      <Screen title="Topics" centerContent search searchBarOnChange={this.handleFilterChange}>
+      <Screen
+        title="Topics"
+        centerContent
+        search
+        searchBarOnChange={this.handleFilterChange}
+        scrollEnabled={false}
+      >
         <TopicList stream={stream} topics={filteredTopics} onPress={this.handlePress} />
       </Screen>
     );


### PR DESCRIPTION
Doing so causes the entire list to be rendered, which causes performance
problems, and pops up a warning every time we open the TopicListScreen.

This is a problem because the ScrollView will render the entire
TopicList, and then just show the parts that are scrolled into view,
which prevents most of the VirtualList optimizations from working.
Instead, we let the VirtualList that TopicList is built on manage the
scrolling, which lets it apply optimizations. This also unblocks making
other optimizations, like using getItemLayout.

This commit doesn't get rid of the warning (since we still have a
ScrollView, it's just not one that... scrolls), but it makes it safe to
ignore in this specific case.