### PR TITLE
flags reducer: Handle `all: true` events correctly.

### DIFF
--- a/src/chat/__tests__/flagsReducer-test.js
+++ b/src/chat/__tests__/flagsReducer-test.js
@@ -279,7 +279,7 @@ describe('flagsReducer', () => {
       expect(actualState).toEqual(expectedState);
     });
 
-    test('when "all" is true all messages become read', () => {
+    test('when all=true, flag=read, and op=add, all messages become read', () => {
       const prevState = deepFreeze({
         read: {
           1: true,

--- a/src/chat/flagsReducer.js
+++ b/src/chat/flagsReducer.js
@@ -88,7 +88,15 @@ const processFlagsForMessages = (state: FlagsState, messages: Message[]): FlagsS
 
 const eventUpdateMessageFlags = (state, action) => {
   if (action.all) {
-    return addFlagsForMessages(initialState, Object.keys(action.allMessages).map(Number), ['read']);
+    if (action.op === 'add') {
+      return addFlagsForMessages(initialState, Object.keys(action.allMessages).map(Number), [
+        action.flag,
+      ]);
+    }
+
+    if (action.op === 'remove') {
+      return { ...state, [action.flag]: {} };
+    }
   }
 
   if (action.op === 'add') {


### PR DESCRIPTION
See CZO discussion:
https://chat.zulip.org/#narrow/stream/378-api-design/topic/UPDATE_MESSAGE_FLAGS.20.60all.3A.20true.60/near/1222451