### PR TITLE
Screen: Use View instead of ScrollView when scrollEnabled is false.

### DIFF
--- a/src/common/Screen.js
+++ b/src/common/Screen.js
@@ -2,7 +2,7 @@
 
 import React, { useContext } from 'react';
 import type { Node } from 'react';
-import { ScrollView } from 'react-native';
+import { ScrollView, View } from 'react-native';
 import type { ViewStyleProp } from 'react-native/Libraries/StyleSheet/StyleSheet';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import type { EditingEvent } from 'react-native/Libraries/Components/TextInput/TextInput';
@@ -62,7 +62,7 @@ type Props = $ReadOnly<{|
  * @prop children - Components to render inside the screen.
  * @prop [keyboardShouldPersistTaps] - Passed through to ScrollView.
  * @prop [padding] - Should padding be added to the contents of the screen.
- * @prop [scrollEnabled] - Passed through to ScrollView.
+ * @prop [scrollEnabled] - Whether to use a ScrollView or a normal View.
  * @prop [style] - Additional style for the ScrollView.
  *
  * @prop [search] - If 'true' show a search box in place of the title.
@@ -115,24 +115,25 @@ export default function Screen(props: Props): Node {
         style={[componentStyles.wrapper, padding && styles.padding]}
         contentContainerStyle={[padding && styles.padding]}
       >
-        <ScrollView
-          contentContainerStyle={[
-            // If `Screen` is responsible for managing scrolling,
-            // keep its childrens' height unbounded. If not, set a
-            // bounded height on its children, e.g., as required for
-            // a child `FlatList` or `SectionList` to work (or even
-            // another `ScrollView`, but hopefully we don't nest too
-            // many of these!).
-            !scrollEnabled ? styles.flexed : null,
-            centerContent && componentStyles.content,
-            style,
-          ]}
-          style={componentStyles.childrenWrapper}
-          keyboardShouldPersistTaps={keyboardShouldPersistTaps}
-          scrollEnabled={scrollEnabled}
-        >
-          {children}
-        </ScrollView>
+        {scrollEnabled ? (
+          <ScrollView
+            contentContainerStyle={[centerContent && componentStyles.content, style]}
+            style={componentStyles.childrenWrapper}
+            keyboardShouldPersistTaps={keyboardShouldPersistTaps}
+          >
+            {children}
+          </ScrollView>
+        ) : (
+          <View
+            style={[
+              componentStyles.childrenWrapper,
+              centerContent && componentStyles.content,
+              style,
+            ]}
+          >
+            {children}
+          </View>
+        )}
       </KeyboardAvoider>
     </SafeAreaView>
   );


### PR DESCRIPTION
This will eliminate the large and noisy "VirtualizedLists should never
be nested inside plain ScrollViews" warning that we see somewhat
frequently.