### PR TITLE
flow: Add missing error codes in some new suppressions.

### DIFF
--- a/src/__flow-tests__/reactUtils-test.js
+++ b/src/__flow-tests__/reactUtils-test.js
@@ -11,26 +11,26 @@ function test_usePrevious() {
     // In particular, make sure the type knows the return value can be void.
     // (This is the case that would break with one natural-but-wrong way to
     // write the definition.)
-    // $FlowExpectedError
+    // $FlowExpectedError[incompatible-cast]
     (usePrevious(b): boolean);
 
-    // $FlowExpectedError
+    // $FlowExpectedError[incompatible-cast]
     (usePrevious(b): void);
   }
 
   // With initial value, returns union type:
   {
     (usePrevious(b, null): boolean | null);
-    // $FlowExpectedError
+    // $FlowExpectedError[incompatible-cast]
     (usePrevious(b, null): boolean);
-    // $FlowExpectedError
+    // $FlowExpectedError[incompatible-cast]
     (usePrevious(b, null): null);
   }
 
   // With initial value of type T, returns T:
   {
     (usePrevious(b, false): boolean);
-    // $FlowExpectedError
+    // $FlowExpectedError[incompatible-cast]
     (usePrevious(b, false): false);
   }
 }


### PR DESCRIPTION
When we bump the Flow version along with the RN v0.64 upgrade (#4426), Flow will enforce having all of our Flow error suppressions indicate which specific error code they're meant to suppress. These few snuck in after we'd gone through the whole codebase and added those indications.

Inheriting priority from #4426.