### PR TITLE
flow: Enable Types-First mode, on the path to RN v0.64 upgrade.

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -113,5 +113,8 @@ module.file_ext=.js
 module.file_ext=.json
 module.file_ext=.ios.js
 
+; We can remove this on Flow v0.134 or later, when it's on by default.
+types_first=true
+
 [version]
 ^0.128.0

--- a/flow-typed/@react-navigation/stack_v5.x.x.js
+++ b/flow-typed/@react-navigation/stack_v5.x.x.js
@@ -840,11 +840,15 @@ declare module '@react-navigation/stack' {
     >>,
     +setOptions: (options: $Shape<ScreenOptions>) => void,
     +setParams: (
-      params: $If<
-        $IsUndefined<$ElementType<ParamList, RouteName>>,
-        empty,
-        $Shape<$NonMaybeType<$ElementType<ParamList, RouteName>>>,
-      >,
+      // We've edited this to be less complicated, so Flow in types-first
+      // mode can handle it.
+      //
+      // A slight downside of the edit is that the more complicated thing
+      // used to error when you tried to use `setParams` on a screen whose
+      // type says it has no params. Now we don't get those errors.
+      // Hopefully that kind of error is easy enough to avoid without help
+      // from the type-checker though.
+      params: $Shape<$NonMaybeType<$ElementType<ParamList, RouteName>>>,
     ) => void,
     ...
   };


### PR DESCRIPTION
From Flow's perspective, we're fine to delay types-first until we're
on v0.143, which we'd normally take along with the RN v0.65 upgrade.

But, from experimentation, React Native v0.64's internal code seems
to have been written with Types-First, such that a few Flow errors
would show up if we tried to use RN v0.64 without Types-First
enabled. So, enable it, now that we can, and now that the RN v0.64
upgrade is on the horizon (#4426).

Fixes: #4907