### PR TITLE
@react-navigation/stack libdef: Fix setParams by dropping $Shape.

### DIFF
--- a/__libdef-tests__/stack_v5.x.x-test.js
+++ b/__libdef-tests__/stack_v5.x.x-test.js
@@ -1,0 +1,36 @@
+/* @flow strict-local */
+import { type NavigationProp } from '@react-navigation/stack';
+
+/* eslint-disable no-unused-vars */
+
+function test_setParams() {
+    type NavProp<P> = NavigationProp<{| r: P |}, 'r'>;
+
+    function test_happy(navigation: NavProp<{| a: number |}>) {
+        navigation.setParams({ a: 1 });
+    }
+
+    function test_accepts_missing(navigation: NavProp<{| a: number, b: number |}>) {
+        navigation.setParams({ a: 1 });
+    }
+
+    function test_rejects_extra(navigation: NavProp<{| a: number |}>) {
+        // $FlowExpectedError[prop-missing]
+        navigation.setParams({ b: 1 });
+    }
+
+    function test_rejects_mismatch(navigation: NavProp<{| a: number |}>) {
+        // $FlowExpectedError[incompatible-call]
+        navigation.setParams({ a: 'a' });
+    }
+
+    function test_rejects_object_to_void(navigation: NavProp<void>) {
+        // $FlowExpectedError[incompatible-call]
+        navigation.setParams({ a: 1 });
+    }
+
+    function test_rejects_void_to_object(navigation: NavProp<{| a: number |}>) {
+        // $FlowExpectedError[incompatible-call]
+        navigation.setParams();
+    }
+}

--- a/flow-typed/@react-navigation/stack_v5.x.x.js
+++ b/flow-typed/@react-navigation/stack_v5.x.x.js
@@ -843,12 +843,10 @@ declare module '@react-navigation/stack' {
       // We've edited this to be less complicated, so Flow in types-first
       // mode can handle it.
       //
-      // A slight downside of the edit is that the more complicated thing
-      // used to error when you tried to use `setParams` on a screen whose
-      // type says it has no params. Now we don't get those errors.
-      // Hopefully that kind of error is easy enough to avoid without help
-      // from the type-checker though.
-      params: $Shape<$NonMaybeType<$ElementType<ParamList, RouteName>>>,
+      // The complicated version appears to have been a workaround for the
+      // brokenness of $Shape: `$Shape<empty>` is `{ ... }`.  `$Partial` is
+      // basically the fixed `$Shape`, and makes the complexity unneeded.
+      params: $Partial<$NonMaybeType<$ElementType<ParamList, RouteName>>>,
     ) => void,
     ...
   };


### PR DESCRIPTION
This is a followup to the small type-safety regression in #4987.

See comment.  The underlying Flow bug is that $Shape doesn't
really work:
  https://github.com/facebook/flow/issues/5702

Happily there is a workaround, namely `$Rest<T, {...}>`.
One might give that a handy alias, like `$Partial<T>` -- and
that's exactly what this libdef already does.  So just use it here.

Also add a type-test.  The most natural place for this might be a
folder like `flow-typed/__tests__/`, next to the libdefs themselves…
but if we do that, then every time we touch the file, Flow restarts
from scratch, just as it does for actual libdefs in `flow-typed/`.
Seems like something odd there.  But we can work around it by just
using a separate folder.
