### PR TITLE
Set up Sentry for Android-native code

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -87,5 +87,12 @@
                 <action android:name="com.google.firebase.MESSAGING_EVENT" />
             </intent-filter>
         </service>
+
+        <!-- To make a build that reports errors to Sentry, fill in the Sentry DSN below
+             and uncomment.  See src/sentryConfig.js for another site and more discussion. -->
+        <!--
+        <meta-data android:name="io.sentry.auto-init" android:value="true" tools:node="replace" />
+        <meta-data android:name="io.sentry.dsn" android:value="https://123@sentry.example/45" />
+        -->
     </application>
 </manifest>

--- a/android/app/src/main/java/com/zulipmobile/SentryUtils.kt
+++ b/android/app/src/main/java/com/zulipmobile/SentryUtils.kt
@@ -1,0 +1,26 @@
+package com.zulipmobile
+
+import io.sentry.Sentry
+import io.sentry.SentryLevel
+
+/**
+ * A home for things that ought to be static extensions of `Sentry`.
+ *
+ * Extending Java classes with static members isn't currently a feature
+ * available in Kotlin:
+ *   https://youtrack.jetbrains.com/issue/KT-11968
+ * so this is our substitute.
+ */
+class SentryX {
+    companion object {
+        /**
+         * Like `Sentry.captureException`, but at level `SentryLevel.WARNING`.
+         */
+        public fun warnException(e: Throwable) {
+            Sentry.withScope { scope ->
+                scope.level = SentryLevel.WARNING
+                Sentry.captureException(e)
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/zulipmobile/ZLog.kt
+++ b/android/app/src/main/java/com/zulipmobile/ZLog.kt
@@ -1,0 +1,31 @@
+package com.zulipmobile
+
+import android.util.Log
+import io.sentry.Sentry
+
+/**
+ * Zulip-specific logging helpers.
+ *
+ * These mirror part of the interface of `android.util.Log`, but they log
+ * to Sentry as well as to the device console.
+ *
+ * We basically always want to use these instead of plain `Log.e` or `Log.w`.
+ */
+class ZLog {
+    companion object {
+        /** Log an error to both Sentry and the device log. */
+        public fun e(tag: String, e: Throwable) {
+            // Oddly there is no `Log.e` taking just a throwable, like there is for `Log.w`.
+            // Have a message that just repeats the first line of how the throwable prints.
+            val msg = "${e.javaClass.name}: ${e.message}"
+            Log.e(tag, msg, e)
+            Sentry.captureException(e)
+        }
+
+        /** Log a warning to both Sentry and the device log. */
+        public fun w(tag: String, e: Throwable) {
+            Log.w(tag, e)
+            SentryX.warnException(e)
+        }
+    }
+}

--- a/android/app/src/main/java/com/zulipmobile/notifications/FCMPushNotifications.kt
+++ b/android/app/src/main/java/com/zulipmobile/notifications/FCMPushNotifications.kt
@@ -21,6 +21,7 @@ import me.leolin.shortcutbadger.ShortcutBadger
 
 import com.zulipmobile.BuildConfig
 import com.zulipmobile.R
+import com.zulipmobile.ZLog
 
 private val CHANNEL_ID = "default"
 private val NOTIFICATION_ID = 435
@@ -64,7 +65,7 @@ internal fun onReceived(context: Context, conversations: ConversationMap, mapDat
     try {
         fcmMessage = FcmMessage.fromFcmData(mapData)
     } catch (e: FcmMessageParseException) {
-        Log.w(TAG, "Ignoring malformed FCM message: ${e.message}")
+        ZLog.w(TAG, e)
         return
     }
 
@@ -149,7 +150,7 @@ private fun getNotificationBuilder(
     try {
         ShortcutBadger.applyCount(context, totalMessagesCount)
     } catch (e: Exception) {
-        Log.e(TAG, "BADGE ERROR: $e")
+        ZLog.e(TAG, e)
     }
 
     builder.setWhen(fcmMessage.timeMs)
@@ -181,7 +182,7 @@ internal fun onOpened(application: ReactApplication, conversations: Conversation
     try {
         ShortcutBadger.removeCount(application as Context)
     } catch (e: Exception) {
-        Log.e(TAG, "BADGE ERROR: $e")
+        ZLog.e(TAG, e)
     }
 
 }

--- a/android/app/src/main/java/com/zulipmobile/notifications/NotificationHelper.kt
+++ b/android/app/src/main/java/com/zulipmobile/notifications/NotificationHelper.kt
@@ -9,9 +9,9 @@ import android.text.Spannable
 import android.text.SpannableStringBuilder
 import android.text.TextUtils
 import android.text.style.StyleSpan
-import android.util.Log
 import android.util.TypedValue
 import androidx.core.app.NotificationCompat
+import com.zulipmobile.ZLog
 import java.io.IOException
 import java.io.InputStream
 import java.net.URL
@@ -37,7 +37,7 @@ fun fetchBitmap(url: URL): Bitmap? {
         (connection.content as? InputStream)
             ?.let { BitmapFactory.decodeStream(it) }
     } catch (e: IOException) {
-        Log.e(TAG, "ERROR: $e")
+        ZLog.e(TAG, e)
         null
     }
 }

--- a/android/app/src/main/java/com/zulipmobile/sharing/SharingHelper.kt
+++ b/android/app/src/main/java/com/zulipmobile/sharing/SharingHelper.kt
@@ -10,6 +10,7 @@ import android.util.Log
 import com.facebook.react.ReactApplication
 import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.WritableMap
+import com.zulipmobile.ZLog
 import com.zulipmobile.notifications.ReactAppStatus
 import com.zulipmobile.notifications.appStatus
 import com.zulipmobile.notifications.emit
@@ -40,7 +41,7 @@ private fun handleSend(intent: Intent, application: ReactApplication, contentRes
     val params: WritableMap = try {
         getParamsFromIntent(intent, contentResolver)
     } catch (e: ShareParamsParseException) {
-        Log.w(TAG, "Ignoring malformed share Intent: ${e.message}")
+        ZLog.w(TAG, e)
         return
     }
 

--- a/docs/howto/release.md
+++ b/docs/howto/release.md
@@ -519,6 +519,9 @@ script Sentry supplies.)
    `sentryKey`.  See the jsdoc and comment there for more about this
    value.
 
+   Edit `android/app/src/main/AndroidManifest.xml` similarly,
+   following the comment around `io.sentry.dsn`.
+
    You won't want to push that change, or to make builds with it
    except when you're making a release build you intend to publish.
    But you will want to have it handy to apply whenever you are making

--- a/src/sentryConfig.js
+++ b/src/sentryConfig.js
@@ -23,4 +23,5 @@
 //
 // If you're making your own builds and want to use Sentry with them, please
 // create your own Sentry client key / DSN, and fill it in here.
+// See also the comment in AndroidManifest.xml about `io.sentry.dsn`.
 export const sentryKey: string | null = null;


### PR DESCRIPTION
This means we'll start seeing reports in Sentry of both uncaught exceptions, and error or warning cases we explicitly catch, in our Kotlin code just as we do already in our RN-based JS code.
