### PR TITLE
Add stream_id to Outbox values

### DIFF
--- a/src/chat/ChatScreen.js
+++ b/src/chat/ChatScreen.js
@@ -17,7 +17,7 @@ import InvalidNarrow from './InvalidNarrow';
 import { fetchMessagesInNarrow } from '../message/fetchActions';
 import ComposeBox from '../compose/ComposeBox';
 import UnreadNotice from './UnreadNotice';
-import { canSendToNarrow, caseNarrowDefault, keyFromNarrow } from '../utils/narrow';
+import { showComposeBoxOnNarrow, caseNarrowDefault, keyFromNarrow } from '../utils/narrow';
 import { getLoading, getSession } from '../directSelectors';
 import { getFetchingForNarrow } from './fetchingSelectors';
 import { getShownMessagesForNarrow, isNarrowValid as getIsNarrowValid } from './narrowsSelectors';
@@ -127,7 +127,7 @@ export default function ChatScreen(props: Props): Node {
 
   const showMessagePlaceholders = haveNoMessages && isFetching;
   const sayNoMessages = haveNoMessages && !isFetching;
-  const showComposeBox = canSendToNarrow(narrow) && !showMessagePlaceholders;
+  const showComposeBox = showComposeBoxOnNarrow(narrow) && !showMessagePlaceholders;
 
   const auth = useSelector(getAuth);
   const dispatch = useDispatch();

--- a/src/compose/ComposeBox.js
+++ b/src/compose/ComposeBox.js
@@ -72,7 +72,7 @@ type OuterProps = $ReadOnly<{|
   // (and other code might too.)
   narrow: Narrow,
 
-  onSend: (string, Narrow) => void,
+  onSend: (message: string, destinationNarrow: Narrow) => void,
 
   isEditing: boolean,
 
@@ -402,9 +402,9 @@ class ComposeBoxInner extends PureComponent<Props, State> {
   handleSend = () => {
     const { dispatch } = this.props;
     const { message } = this.state;
-    const narrow = this.getDestinationNarrow();
+    const destinationNarrow = this.getDestinationNarrow();
 
-    this.props.onSend(message, narrow);
+    this.props.onSend(message, destinationNarrow);
 
     this.setMessageInputValue('');
 
@@ -412,7 +412,7 @@ class ComposeBoxInner extends PureComponent<Props, State> {
       this.mentionWarnings.current.clearMentionWarnings();
     }
 
-    dispatch(sendTypingStop(narrow));
+    dispatch(sendTypingStop(destinationNarrow));
   };
 
   inputMarginPadding = {

--- a/src/compose/ComposeBox.js
+++ b/src/compose/ComposeBox.js
@@ -8,6 +8,7 @@ import type { LayoutEvent } from 'react-native/Libraries/Types/CoreEventTypes';
 import TextInputReset from 'react-native-text-input-reset';
 import { type EdgeInsets } from 'react-native-safe-area-context';
 import { compose } from 'redux';
+import invariant from 'invariant';
 
 import { withSafeAreaInsets } from '../react-native-safe-area-context';
 import type { ThemeData } from '../styles';
@@ -31,6 +32,7 @@ import { FloatingActionButton, Input } from '../common';
 import { showToast } from '../utils/info';
 import { IconDone, IconSend } from '../common/Icons';
 import {
+  isConversationNarrow,
   isStreamNarrow,
   isStreamOrTopicNarrow,
   isTopicNarrow,
@@ -43,7 +45,6 @@ import getComposeInputPlaceholder from './getComposeInputPlaceholder';
 import NotSubscribed from '../message/NotSubscribed';
 import AnnouncementOnly from '../message/AnnouncementOnly';
 import MentionWarnings from './MentionWarnings';
-
 import { getAuth, getIsAdmin, getStreamInNarrow, getVideoChatProvider } from '../selectors';
 import {
   getIsActiveStreamSubscribed,
@@ -66,6 +67,9 @@ type SelectorProps = {|
 |};
 
 type OuterProps = $ReadOnly<{|
+  /** The narrow shown in the message list.  Must be a conversation or stream. */
+  // In particular `getDestinationNarrow` makes assumptions about the narrow
+  // (and other code might too.)
   narrow: Narrow,
 
   onSend: (string, Narrow) => void,
@@ -391,6 +395,7 @@ class ComposeBoxInner extends PureComponent<Props, State> {
       const topic = this.state.topic.trim();
       return topicNarrow(streamName, topic || '(no topic)');
     }
+    invariant(isConversationNarrow(narrow), 'destination narrow must be conversation');
     return narrow;
   };
 

--- a/src/message/NoMessages.js
+++ b/src/message/NoMessages.js
@@ -16,7 +16,7 @@ import {
   isStreamNarrow,
   isTopicNarrow,
   isSearchNarrow,
-  canSendToNarrow,
+  showComposeBoxOnNarrow,
 } from '../utils/narrow';
 
 const styles = createStyleSheet({
@@ -60,7 +60,7 @@ export default class NoMessages extends PureComponent<Props> {
     return (
       <View style={styles.container}>
         <Label style={styles.text} text={message.text} />
-        {canSendToNarrow(narrow) ? <Label text="Why not start the conversation?" /> : null}
+        {showComposeBoxOnNarrow(narrow) ? <Label text="Why not start the conversation?" /> : null}
       </View>
     );
   }

--- a/src/message/fetchActions.js
+++ b/src/message/fetchActions.js
@@ -509,7 +509,7 @@ export const doInitialFetch = (): ThunkAction<Promise<void>> => async (dispatch,
 };
 
 export const uploadFile = (
-  narrow: Narrow,
+  destinationNarrow: Narrow,
   uri: string,
   name: string,
 ): ThunkAction<Promise<void>> => async (dispatch, getState) => {
@@ -517,5 +517,5 @@ export const uploadFile = (
   const response = await api.uploadFile(auth, uri, name);
   const messageToSend = `[${name}](${response.uri})`;
 
-  dispatch(addToOutbox(narrow, messageToSend));
+  dispatch(addToOutbox(destinationNarrow, messageToSend));
 };

--- a/src/outbox/outboxActions.js
+++ b/src/outbox/outboxActions.js
@@ -131,7 +131,7 @@ type DataFromNarrow =
   | SubsetProperties<PmOutbox, {| type: mixed, display_recipient: mixed, subject: mixed |}>
   | SubsetProperties<StreamOutbox, {| type: mixed, display_recipient: mixed, subject: mixed |}>;
 
-const extractTypeToAndSubjectFromNarrow = (
+const outboxPropertiesForNarrow = (
   destinationNarrow: Narrow,
   allUsersById: Map<UserId, UserOrBot>,
   ownUser: UserOrBot,
@@ -177,7 +177,7 @@ export const addToOutbox = (
   dispatch(
     messageSendStart({
       isSent: false,
-      ...extractTypeToAndSubjectFromNarrow(destinationNarrow, getAllUsersById(state), ownUser),
+      ...outboxPropertiesForNarrow(destinationNarrow, getAllUsersById(state), ownUser),
       markdownContent: content,
       content: getContentPreview(content, state),
       timestamp: localTime,

--- a/src/outbox/outboxActions.js
+++ b/src/outbox/outboxActions.js
@@ -131,11 +131,11 @@ type DataFromNarrow =
   | SubsetProperties<StreamOutbox, {| type: mixed, display_recipient: mixed, subject: mixed |}>;
 
 const extractTypeToAndSubjectFromNarrow = (
-  narrow: Narrow,
+  destinationNarrow: Narrow,
   allUsersById: Map<UserId, UserOrBot>,
   ownUser: UserOrBot,
 ): DataFromNarrow =>
-  caseNarrowPartial(narrow, {
+  caseNarrowPartial(destinationNarrow, {
     pm: ids => ({
       type: 'private',
       display_recipient: recipientsFromIds(ids, allUsersById, ownUser),
@@ -168,10 +168,10 @@ const getContentPreview = (content: string, state: GlobalState): string => {
   }
 };
 
-export const addToOutbox = (narrow: Narrow, content: string): ThunkAction<Promise<void>> => async (
-  dispatch,
-  getState,
-) => {
+export const addToOutbox = (
+  destinationNarrow: Narrow,
+  content: string,
+): ThunkAction<Promise<void>> => async (dispatch, getState) => {
   const state = getState();
   const ownUser = getOwnUser(state);
 
@@ -179,7 +179,7 @@ export const addToOutbox = (narrow: Narrow, content: string): ThunkAction<Promis
   dispatch(
     messageSendStart({
       isSent: false,
-      ...extractTypeToAndSubjectFromNarrow(narrow, getAllUsersById(state), ownUser),
+      ...extractTypeToAndSubjectFromNarrow(destinationNarrow, getAllUsersById(state), ownUser),
       markdownContent: content,
       content: getContentPreview(content, state),
       timestamp: localTime,

--- a/src/types.js
+++ b/src/types.js
@@ -223,7 +223,8 @@ export type StreamOutbox = $ReadOnly<{|
   //   in the Outbox values we create; compare a1fad7ca9, for sender_id.
   //
   //   Once it is required, it should move from here to the second type
-  //   argument passed to `SubsetProperties` of `StreamMessage`, below.
+  //   argument passed to `SubsetProperties` of `StreamMessage`, below;
+  //   and we can also drop the hack line about it in `MessageLike`.
   stream_id?: number,
 
   ...SubsetProperties<

--- a/src/utils/narrow.js
+++ b/src/utils/narrow.js
@@ -467,7 +467,14 @@ export const isMessageInNarrow = (
     // Adding a case here?  Be sure to add to getNarrowsForMessage, too.
   });
 
-export const canSendToNarrow = (narrow: Narrow): boolean =>
+/**
+ * Whether we show the compose box on this narrow's message list.
+ *
+ * This is really a UI choice that belongs to a specific part of the UI.
+ * It's here for now because several files refer to it.
+ */
+// TODO make this appropriately part of the UI code.
+export const showComposeBoxOnNarrow = (narrow: Narrow): boolean =>
   caseNarrow(narrow, {
     pm: () => true,
     stream: () => true,

--- a/src/utils/narrow.js
+++ b/src/utils/narrow.js
@@ -391,6 +391,17 @@ export const isMentionedNarrow = (narrow?: Narrow): boolean =>
   !!narrow && caseNarrowDefault(narrow, { mentioned: () => true }, () => false);
 
 /**
+ * Whether the narrow represents a single whole conversation.
+ *
+ * A conversation is the smallest unit that discussions are threaded into:
+ * either a specific topic in a stream, or a PM thread (either 1:1 or group).
+ *
+ * When sending a message, its destination is identified by a conversation.
+ */
+export const isConversationNarrow = (narrow: Narrow): boolean =>
+  caseNarrowDefault(narrow, { topic: () => true, pm: () => true }, () => false);
+
+/**
  * Convert the narrow into the form used in the Zulip API at get-messages.
  */
 export const apiNarrowOfNarrow = (


### PR DESCRIPTION
This makes #3998 mostly complete: the remaining steps will be to get a release with this change out, wait a few weeks, then make `stream_id` required with a migration to drop Outbox values that lack it, just as we did for `sender_id` before.

Along the way, we pin down some invariants about the different narrows involved in the compose code. I remember having to work through some of this same reasoning in order to verify some of the refactoring in #4773 (around the `onSend` callback, IIRC); hopefully the added jsdoc and asserts here will help memoize that work for the future, and also ensure the logic gets revised appropriately when we make changes that would affect its assumptions (like showing the compose box on a wider variety of narrows.)
