### PR TITLE
Extract and improve reusable banner component; fix eventQueueId type; get feature level from /register

### DIFF
--- a/docs/architecture/realtime.md
+++ b/docs/architecture/realtime.md
@@ -383,12 +383,10 @@ In the current Zulip mobile app, the structure looks like
   The code is in `eventActions.js` as `startEventPolling`, an action
   creator which takes the events finger as parameters.
 * That action creator is in turn invoked within the thunk action
-  created by the nullary action creator `fetchInitialData`
+  created by the nullary action creator `doInitialFetch`
   (in `fetchActions.js`), which does a number of other things but in
   particular first invokes `registerForEvents`, which is `/register`
   in the API binding.
-* That in turn is invoked by the thunk action created by
-  `doInitialFetch`, in the same file.
 * Which is invoked by `AppDataFetcher`.  This is a Redux-`connect`ed
   component that appears near the very top of the hierarchy in
   `ZulipMobile.js`.  The component's one job is to listen for changes
@@ -405,7 +403,7 @@ In the current Zulip mobile app, the structure looks like
     exclusively by the long-poll loop in `startEventPolling`, when it
     finds the event queue has expired.
   * It's set to false on an `INITIAL_FETCH_COMPLETE` action -- which
-    is dispatched exclusively by `fetchInitialData`, just
+    is dispatched exclusively by `doInitialFetch`, just
     before it dispatches a `startEventPolling` action.
 
 Essentially, the `AppDataFetcher` React component is used as a way of

--- a/src/__tests__/lib/exampleData.js
+++ b/src/__tests__/lib/exampleData.js
@@ -694,7 +694,6 @@ export const action = Object.freeze({
       },
       user_status: {},
     },
-    zulipVersion,
   }): RealmInitAction),
   message_fetch_start: (deepFreeze({
     type: MESSAGE_FETCH_START,

--- a/src/__tests__/lib/exampleData.js
+++ b/src/__tests__/lib/exampleData.js
@@ -593,7 +593,7 @@ export const action = Object.freeze({
     data: {
       last_event_id: 34,
       msg: '',
-      queue_id: 1,
+      queue_id: '1',
       alert_words: [],
       max_message_id: 100,
       muted_topics: [],

--- a/src/__tests__/lib/exampleData.js
+++ b/src/__tests__/lib/exampleData.js
@@ -641,6 +641,7 @@ export const action = Object.freeze({
       realm_video_chat_provider: 1,
       realm_waiting_period_threshold: 3,
       zulip_feature_level: 1,
+      zulip_version: zulipVersion.raw(),
       realm_emoji: {},
       realm_filters: [],
       avatar_source: 'G',

--- a/src/account/__tests__/accountsReducer-test.js
+++ b/src/account/__tests__/accountsReducer-test.js
@@ -25,7 +25,10 @@ describe('accountsReducer', () => {
       expect(
         accountsReducer(
           deepFreeze([account1, account2, account3]),
-          deepFreeze({ ...eg.action.realm_init, zulipVersion: newZulipVersion }),
+          deepFreeze({
+            ...eg.action.realm_init,
+            data: { ...eg.action.realm_init.data, zulip_version: newZulipVersion.raw() },
+          }),
         ),
       ).toEqual([{ ...account1, zulipVersion: newZulipVersion }, account2, account3]);
     });

--- a/src/account/accountsReducer.js
+++ b/src/account/accountsReducer.js
@@ -21,7 +21,7 @@ const realmInit = (state, action) => [
     ...state[0],
     userId: action.data.user_id,
     zulipFeatureLevel: action.data.zulip_feature_level ?? 0,
-    zulipVersion: action.zulipVersion,
+    zulipVersion: new ZulipVersion(action.data.zulip_version),
   },
   ...state.slice(1),
 ];

--- a/src/actionTypes.js
+++ b/src/actionTypes.js
@@ -92,7 +92,6 @@ import type {
   UserId,
   UserStatusEvent,
 } from './types';
-import type { ZulipVersion } from './utils/zulipVersion';
 
 /**
  * Dispatched by redux-persist when the stored state is loaded.
@@ -163,7 +162,6 @@ type LogoutAction = {|
 export type RealmInitAction = {|
   type: typeof REALM_INIT,
   data: InitialData,
-  zulipVersion: ZulipVersion,
 |};
 
 /** We learned the device token from the system.  See `SessionState`. */

--- a/src/api/initialDataTypes.js
+++ b/src/api/initialDataTypes.js
@@ -19,7 +19,7 @@ import type {
 export type InitialDataBase = $ReadOnly<{|
   last_event_id: number,
   msg: string,
-  queue_id: number,
+  queue_id: string,
 |}>;
 
 export type InitialDataAlertWords = $ReadOnly<{|

--- a/src/api/initialDataTypes.js
+++ b/src/api/initialDataTypes.js
@@ -21,10 +21,10 @@ export type InitialDataBase = $ReadOnly<{|
   msg: string,
   queue_id: string,
 
-  // The feature level (below) is included unconditionally as of 3.0
-  // (zulip/zulip@2c6313019), which is why we put it in `InitialDataBase`.
-  // To get it from servers older than that, we have to pass `zulip_version`
-  // in `fetch_event_types`, which we do.
+  // The feature level and server version, below, are included
+  // unconditionally as of 3.0 (zulip/zulip@2c6313019), which is why we put
+  // them in `InitialDataBase`. To get them from servers older than that, we
+  // have to pass `zulip_version` in `fetch_event_types`, which we do.
   //
   // TODO(server-3.0): We can stop passing `zulip_version` in
   // `fetch_event_types` and remove this comment.
@@ -35,6 +35,14 @@ export type InitialDataBase = $ReadOnly<{|
    * https://zulip.com/api/get-server-settings. See also the comment above.
    */
   zulip_feature_level?: number,
+
+  /**
+   * Should be present as far back as 1.6.0 (zulip/zulip@d9b10727f). Same
+   * meaning as in the server_settings response:
+   * https://zulip.com/api/get-server-settings. See also the comment above
+   * `zulip_feature_level`, above.
+   */
+  zulip_version: string,
 |}>;
 
 export type InitialDataAlertWords = $ReadOnly<{|

--- a/src/api/initialDataTypes.js
+++ b/src/api/initialDataTypes.js
@@ -20,6 +20,21 @@ export type InitialDataBase = $ReadOnly<{|
   last_event_id: number,
   msg: string,
   queue_id: string,
+
+  // The feature level (below) is included unconditionally as of 3.0
+  // (zulip/zulip@2c6313019), which is why we put it in `InitialDataBase`.
+  // To get it from servers older than that, we have to pass `zulip_version`
+  // in `fetch_event_types`, which we do.
+  //
+  // TODO(server-3.0): We can stop passing `zulip_version` in
+  // `fetch_event_types` and remove this comment.
+
+  /**
+   * Added in server version 2.2, feature level 1.
+   * Same meaning as in the server_settings response:
+   * https://zulip.com/api/get-server-settings. See also the comment above.
+   */
+  zulip_feature_level?: number,
 |}>;
 
 export type InitialDataAlertWords = $ReadOnly<{|
@@ -92,13 +107,6 @@ export type InitialDataRealm = $ReadOnly<{|
   realm_uri: string,
   realm_video_chat_provider: number,
   realm_waiting_period_threshold: number,
-
-  /**
-   * Added in server version 2.2, feature level 1.
-   * Same meaning as in the server_settings response:
-   * https://zulip.com/api/get-server-settings
-   */
-  zulip_feature_level?: number,
 |}>;
 
 export type InitialDataRealmEmoji = $ReadOnly<{|

--- a/src/api/messages/sendMessage.js
+++ b/src/api/messages/sendMessage.js
@@ -12,7 +12,7 @@ export default async (
     subject?: string,
     content: string,
     localId?: number,
-    eventQueueId?: number,
+    eventQueueId?: string,
   |},
 ): Promise<ApiResponse> =>
   apiPost(auth, 'messages', {

--- a/src/api/pollForEvents.js
+++ b/src/api/pollForEvents.js
@@ -9,7 +9,7 @@ type ApiResponsePollEvents = {|
 |};
 
 /** See https://zulip.com/api/get-events */
-export default (auth: Auth, queueId: number, lastEventId: number): Promise<ApiResponsePollEvents> =>
+export default (auth: Auth, queueId: string, lastEventId: number): Promise<ApiResponsePollEvents> =>
   apiGet(
     auth,
     'events',

--- a/src/chat/ChatScreen.js
+++ b/src/chat/ChatScreen.js
@@ -81,7 +81,10 @@ const useMessagesWithFetch = args => {
     }
   }, [dispatch, narrow]);
 
-  // When the event queue changes, schedule a fetch.
+  // When the event queue changes, schedule a fetch. (Currently, we never
+  // set this to null from a non-null value, so this really does mean the
+  // event queue has changed; it can't mean that we had a queue ID and
+  // dropped it.)
   React.useEffect(() => {
     shouldFetchWhenNextFocused.current = true;
   }, [eventQueueId]);

--- a/src/common/ServerCompatBanner.js
+++ b/src/common/ServerCompatBanner.js
@@ -2,52 +2,23 @@
 
 import React from 'react';
 import type { Node } from 'react';
-import { View } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
 
-import { createStyleSheet, HALF_COLOR } from '../styles';
+import ZulipBanner from './ZulipBanner';
 import { useSelector, useDispatch } from '../react-redux';
-import Label from './Label';
 import { getIdentity, getServerVersion } from '../account/accountsSelectors';
 import { getIsAdmin, getSession, getSettings } from '../directSelectors';
 import { dismissCompatNotice } from '../session/sessionActions';
-import ZulipTextButton from './ZulipTextButton';
 import { openLinkWithUserPreference } from '../utils/openLink';
 
 // The oldest version we currently support. Should match what we say at
 //   https://zulip.readthedocs.io/en/stable/overview/release-lifecycle.html#compatibility-and-upgrading.
 const minSupportedVersion = '2.1.0';
 
-const styles = createStyleSheet({
-  wrapper: {
-    backgroundColor: HALF_COLOR,
-    paddingLeft: 16,
-    paddingRight: 8,
-    paddingBottom: 8,
-  },
-  textRow: {
-    flexDirection: 'row',
-  },
-  text: {
-    marginTop: 16,
-    lineHeight: 20,
-  },
-  buttonsRow: {
-    marginTop: 12,
-    flexDirection: 'row',
-    justifyContent: 'flex-end',
-  },
-});
-
 type Props = $ReadOnly<{||}>;
 
 /**
  * A "nag banner" saying the server version is unsupported, if so.
  */
-// Made with somewhat careful attention to
-// https://material.io/components/banners. Please consult that before making
-// layout changes, and try to make them in a direction that brings us closer
-// to those guidelines.
 export default function ServerCompatBanner(props: Props): Node {
   const dispatch = useDispatch();
   const hasDismissedServerCompatNotice = useSelector(
@@ -58,50 +29,50 @@ export default function ServerCompatBanner(props: Props): Node {
   const isAdmin = useSelector(getIsAdmin);
   const settings = useSelector(getSettings);
 
+  let visible = false;
+  let text = '';
   if (!zulipVersion || zulipVersion.isAtLeast(minSupportedVersion)) {
-    return null;
+    // don't show
   } else if (hasDismissedServerCompatNotice) {
-    return null;
+    // don't show
+  } else {
+    visible = true;
+    text = isAdmin
+      ? {
+          text:
+            '{realm} is running Zulip Server {serverVersion}, which is unsupported. Please upgrade your server as soon as possible.',
+          values: { realm: realm.toString(), serverVersion: zulipVersion.raw() },
+        }
+      : {
+          text:
+            '{realm} is running Zulip Server {serverVersion}, which is unsupported. Please contact your administrator about upgrading.',
+          values: { realm: realm.toString(), serverVersion: zulipVersion.raw() },
+        };
   }
 
   return (
-    <SafeAreaView mode="padding" edges={['right', 'left']} style={styles.wrapper}>
-      <View style={styles.textRow}>
-        <Label
-          style={styles.text}
-          text={
-            isAdmin
-              ? {
-                  text:
-                    '{realm} is running Zulip Server {serverVersion}, which is unsupported. Please upgrade your server as soon as possible.',
-                  values: { realm: realm.toString(), serverVersion: zulipVersion.raw() },
-                }
-              : {
-                  text:
-                    '{realm} is running Zulip Server {serverVersion}, which is unsupported. Please contact your administrator about upgrading.',
-                  values: { realm: realm.toString(), serverVersion: zulipVersion.raw() },
-                }
-          }
-        />
-      </View>
-      <View style={styles.buttonsRow}>
-        <ZulipTextButton
-          label="Dismiss"
-          onPress={() => {
+    <ZulipBanner
+      visible={visible}
+      text={text}
+      buttons={[
+        {
+          id: 'dismiss',
+          label: 'Dismiss',
+          onPress: () => {
             dispatch(dismissCompatNotice());
-          }}
-        />
-        <ZulipTextButton
-          leftMargin
-          label={isAdmin ? 'Fix now' : 'Learn more'}
-          onPress={() => {
+          },
+        },
+        {
+          id: 'resolve',
+          label: isAdmin ? 'Fix now' : 'Learn more',
+          onPress: () => {
             openLinkWithUserPreference(
               'https://zulip.readthedocs.io/en/stable/overview/release-lifecycle.html#compatibility-and-upgrading',
               settings,
             );
-          }}
-        />
-      </View>
-    </SafeAreaView>
+          },
+        },
+      ]}
+    />
   );
 }

--- a/src/common/ZulipBanner.js
+++ b/src/common/ZulipBanner.js
@@ -1,0 +1,77 @@
+/* @flow strict-local */
+
+import React from 'react';
+import type { Node } from 'react';
+import { View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+
+import { createStyleSheet, HALF_COLOR } from '../styles';
+import type { LocalizableText } from '../types';
+import Label from './Label';
+import ZulipTextButton from './ZulipTextButton';
+
+const styles = createStyleSheet({
+  wrapper: {
+    backgroundColor: HALF_COLOR,
+    paddingLeft: 16,
+    paddingRight: 8,
+    paddingBottom: 8,
+  },
+  textRow: {
+    flexDirection: 'row',
+  },
+  text: {
+    marginTop: 16,
+    lineHeight: 20,
+  },
+  buttonsRow: {
+    marginTop: 12,
+    flexDirection: 'row',
+    justifyContent: 'flex-end',
+  },
+});
+
+type Button = $ReadOnly<{|
+  id: string,
+  label: LocalizableText,
+  onPress: () => void,
+|}>;
+
+type Props = $ReadOnly<{|
+  visible: boolean,
+  text: LocalizableText,
+  buttons: $ReadOnlyArray<Button>,
+|}>;
+
+/**
+ * A banner that follows Material Design specifications as much as possible.
+ *
+ * See https://material.io/components/banners.
+ */
+// Please consult the Material Design doc before making layout changes, and
+// try to make them in a direction that brings us closer to the guidelines.
+export default function ZulipBanner(props: Props): Node {
+  const { visible, text, buttons } = props;
+
+  if (!visible) {
+    return null;
+  }
+
+  return (
+    <SafeAreaView mode="padding" edges={['right', 'left']} style={styles.wrapper}>
+      <View style={styles.textRow}>
+        <Label style={styles.text} text={text} />
+      </View>
+      <View style={styles.buttonsRow}>
+        {buttons.map(({ id, label, onPress }, index) => (
+          <ZulipTextButton
+            key={id}
+            leftMargin={index !== 0 || undefined}
+            label={label}
+            onPress={onPress}
+          />
+        ))}
+      </View>
+    </SafeAreaView>
+  );
+}

--- a/src/common/ZulipBanner.js
+++ b/src/common/ZulipBanner.js
@@ -16,12 +16,13 @@ const styles = createStyleSheet({
     paddingLeft: 16,
     paddingRight: 8,
     paddingBottom: 8,
+    paddingTop: 10,
   },
   textRow: {
     flexDirection: 'row',
   },
   text: {
-    marginTop: 16,
+    marginTop: 6,
     lineHeight: 20,
   },
   buttonsRow: {

--- a/src/common/ZulipBanner.js
+++ b/src/common/ZulipBanner.js
@@ -10,8 +10,24 @@ import type { LocalizableText } from '../types';
 import Label from './Label';
 import ZulipTextButton from './ZulipTextButton';
 
+// `textRow` and `buttonsRow` are named for the more common case where
+// there's not enough room for the text and the button(s) to share a single
+// row.
+//
+// But we do support having the text and button(s) share a row if there's
+// room, i.e., if the entities' combined widths are less than or equal to
+// one row width. The spec gives an example of this in an illustration where
+// the text just takes one line and there's only one action button.
+//
+// TODO(?): The vertical centering logic for when the text and buttons share
+//   a row isn't pixel-perfect; it depends on explicit padding/margin values
+//   instead of declaring "center" somewhere. This is an intentional
+//   compromise to reduce complexity while still supporting the two-row
+//   layout. If we find an elegant solution, we should use it.
 const styles = createStyleSheet({
   wrapper: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
     backgroundColor: HALF_COLOR,
     paddingLeft: 16,
     paddingRight: 8,
@@ -19,6 +35,7 @@ const styles = createStyleSheet({
     paddingTop: 10,
   },
   textRow: {
+    flexGrow: 1,
     flexDirection: 'row',
     marginBottom: 12,
   },
@@ -27,6 +44,7 @@ const styles = createStyleSheet({
     lineHeight: 20,
   },
   buttonsRow: {
+    flexGrow: 1,
     flexDirection: 'row',
     justifyContent: 'flex-end',
   },

--- a/src/common/ZulipBanner.js
+++ b/src/common/ZulipBanner.js
@@ -20,13 +20,13 @@ const styles = createStyleSheet({
   },
   textRow: {
     flexDirection: 'row',
+    marginBottom: 12,
   },
   text: {
     marginTop: 6,
     lineHeight: 20,
   },
   buttonsRow: {
-    marginTop: 12,
     flexDirection: 'row',
     justifyContent: 'flex-end',
   },

--- a/src/config.js
+++ b/src/config.js
@@ -46,6 +46,7 @@ const config: Config = {
     'update_global_notifications',
     'update_message_flags',
     'user_status',
+    'zulip_version',
   ],
   appOwnDomains: ['zulip.com', 'zulipchat.com', 'chat.zulip.org'],
 };

--- a/src/events/eventActions.js
+++ b/src/events/eventActions.js
@@ -43,7 +43,7 @@ const handleEvent = (event: GeneralEvent, dispatch, getState) => {
  * for discussion.
  */
 export const startEventPolling = (
-  queueId: number,
+  queueId: string,
   eventId: number,
 ): ThunkAction<Promise<void>> => async (dispatch, getState) => {
   let lastEventId = eventId;

--- a/src/message/__tests__/fetchActions-test.js
+++ b/src/message/__tests__/fetchActions-test.js
@@ -566,12 +566,12 @@ describe('fetchActions', () => {
       expect(actions).toHaveLength(0);
     });
 
-    test('when needsInitialFetch is true, no action is dispatched', async () => {
+    test('when loading is true, no action is dispatched', async () => {
       const store = mockStore<GlobalState, Action>({
         ...baseState,
         session: {
           ...baseState.session,
-          needsInitialFetch: true,
+          loading: true,
         },
       });
 
@@ -658,12 +658,12 @@ describe('fetchActions', () => {
       expect(actions).toHaveLength(0);
     });
 
-    test('when needsInitialFetch is true, no action is dispatched', async () => {
+    test('when loading is true, no action is dispatched', async () => {
       const store = mockStore<GlobalState, Action>({
         ...baseState,
         session: {
           ...baseState.session,
-          needsInitialFetch: true,
+          loading: true,
         },
       });
 

--- a/src/message/fetchActions.js
+++ b/src/message/fetchActions.js
@@ -4,7 +4,6 @@ import * as NavigationService from '../nav/NavigationService';
 import type { Narrow, GlobalState, Message, Action, ThunkAction, UserId } from '../types';
 import { ensureUnreachable } from '../types';
 import type { InitialFetchAbortReason } from '../actionTypes';
-import type { ApiResponseServerSettings } from '../api/settings/getServerSettings';
 import type { InitialData } from '../api/initialDataTypes';
 import * as api from '../api';
 import { ApiError, Server5xxError, NetworkError } from '../api/apiErrors';
@@ -424,46 +423,42 @@ export const doInitialFetch = (): ThunkAction<Promise<void>> => async (dispatch,
   const auth = getAuth(getState());
 
   let initData: InitialData;
-  let serverSettings: ApiResponseServerSettings;
 
   const haveServerData = getHaveServerData(getState());
 
   try {
-    [initData, serverSettings] = await Promise.all([
-      tryFetch(
-        () =>
-          // Currently, no input we're giving `registerForEvents` is
-          // conditional on the server version / feature level. If we
-          // need to do that, make sure that data is up-to-date -- we've
-          // been using this `registerForEvents` call to update the
-          // feature level in Redux, which means the value in Redux will
-          // be from the *last* time it was run. That could be a long
-          // time ago, like from the previous app startup.
-          api.registerForEvents(auth, {
-            // Event types not supported by the server are ignored; see
-            //   https://zulip.com/api/register-queue#parameter-fetch_event_types.
-            fetch_event_types: config.serverDataOnStartup,
+    initData = await tryFetch(
+      () =>
+        // Currently, no input we're giving `registerForEvents` is
+        // conditional on the server version / feature level. If we
+        // need to do that, make sure that data is up-to-date -- we've
+        // been using this `registerForEvents` call to update the
+        // feature level in Redux, which means the value in Redux will
+        // be from the *last* time it was run. That could be a long
+        // time ago, like from the previous app startup.
+        api.registerForEvents(auth, {
+          // Event types not supported by the server are ignored; see
+          //   https://zulip.com/api/register-queue#parameter-fetch_event_types.
+          fetch_event_types: config.serverDataOnStartup,
 
-            apply_markdown: true,
-            include_subscribers: false,
-            client_gravatar: true,
-            client_capabilities: {
-              notification_settings_null: true,
-              bulk_message_deletion: true,
-              user_avatar_url_field_optional: true,
-            },
-          }),
-        // We might have (potentially stale) server data already. If
-        // we do, we'll be showing some UI that lets the user see that
-        // data. If we don't, we'll be showing a full-screen loading
-        // indicator that prevents the user from doing anything useful
-        // -- if that's the case, don't bother retrying on 5xx errors,
-        // to save the user's time and patience. They can retry
-        // manually if they want.
-        haveServerData,
-      ),
-      tryFetch(() => api.getServerSettings(auth.realm), haveServerData),
-    ]);
+          apply_markdown: true,
+          include_subscribers: false,
+          client_gravatar: true,
+          client_capabilities: {
+            notification_settings_null: true,
+            bulk_message_deletion: true,
+            user_avatar_url_field_optional: true,
+          },
+        }),
+      // We might have (potentially stale) server data already. If
+      // we do, we'll be showing some UI that lets the user see that
+      // data. If we don't, we'll be showing a full-screen loading
+      // indicator that prevents the user from doing anything useful
+      // -- if that's the case, don't bother retrying on 5xx errors,
+      // to save the user's time and patience. They can retry
+      // manually if they want.
+      haveServerData,
+    );
   } catch (e) {
     if (e instanceof ApiError) {
       // This should only happen when `auth` is no longer valid. No
@@ -480,17 +475,17 @@ export const doInitialFetch = (): ThunkAction<Promise<void>> => async (dispatch,
     } else {
       dispatch(initialFetchAbort('unexpected'));
       logging.warn(e, {
-        message: 'Unexpected error during initial fetch and serverSettings fetch.',
+        message: 'Unexpected error during /register.',
       });
     }
     return;
   }
 
-  const serverVersion = new ZulipVersion(serverSettings.zulip_version);
-  dispatch(realmInit(initData, serverVersion));
+  dispatch(realmInit(initData));
   dispatch(initialFetchComplete());
   dispatch(startEventPolling(initData.queue_id, initData.last_event_id));
 
+  const serverVersion = new ZulipVersion(initData.zulip_version);
   if (!serverVersion.isAtLeast(MIN_RECENTPMS_SERVER_VERSION)) {
     dispatch(fetchPrivateMessages());
   }

--- a/src/message/fetchActions.js
+++ b/src/message/fetchActions.js
@@ -160,9 +160,9 @@ export const fetchOlder = (narrow: Narrow): ThunkAction<void> => (dispatch, getS
   const firstMessageId = getFirstMessageId(state, narrow);
   const caughtUp = getCaughtUpForNarrow(state, narrow);
   const fetching = getFetchingForNarrow(state, narrow);
-  const { needsInitialFetch } = getSession(state);
+  const { loading } = getSession(state);
 
-  if (!needsInitialFetch && !fetching.older && !caughtUp.older && firstMessageId !== undefined) {
+  if (!loading && !fetching.older && !caughtUp.older && firstMessageId !== undefined) {
     dispatch(
       fetchMessages({
         narrow,
@@ -179,9 +179,9 @@ export const fetchNewer = (narrow: Narrow): ThunkAction<void> => (dispatch, getS
   const lastMessageId = getLastMessageId(state, narrow);
   const caughtUp = getCaughtUpForNarrow(state, narrow);
   const fetching = getFetchingForNarrow(state, narrow);
-  const { needsInitialFetch } = getSession(state);
+  const { loading } = getSession(state);
 
-  if (!needsInitialFetch && !fetching.newer && !caughtUp.newer && lastMessageId !== undefined) {
+  if (!loading && !fetching.newer && !caughtUp.newer && lastMessageId !== undefined) {
     dispatch(
       fetchMessages({
         narrow,

--- a/src/outbox/outboxActions.js
+++ b/src/outbox/outboxActions.js
@@ -86,7 +86,7 @@ const trySendMessages = (dispatch, getState): boolean => {
         subject: item.subject,
         content: item.markdownContent,
         localId: item.timestamp,
-        eventQueueId: state.session.eventQueueId,
+        eventQueueId: state.session.eventQueueId ?? undefined,
       });
       dispatch(messageSendComplete(item.timestamp));
     });

--- a/src/realm/realmActions.js
+++ b/src/realm/realmActions.js
@@ -1,10 +1,8 @@
 /* @flow strict-local */
 import type { InitialData, Action } from '../types';
-import type { ZulipVersion } from '../utils/zulipVersion';
 import { REALM_INIT } from '../actionConstants';
 
-export const realmInit = (data: InitialData, zulipVersion: ZulipVersion): Action => ({
+export const realmInit = (data: InitialData): Action => ({
   type: REALM_INIT,
   data,
-  zulipVersion,
 });

--- a/src/session/__tests__/sessionReducer-test.js
+++ b/src/session/__tests__/sessionReducer-test.js
@@ -62,10 +62,10 @@ describe('sessionReducer', () => {
   test('REALM_INIT', () => {
     const action = deepFreeze({
       ...eg.action.realm_init,
-      data: { ...eg.action.realm_init.data, queue_id: 100 },
+      data: { ...eg.action.realm_init.data, queue_id: '100' },
     });
     const newState = sessionReducer(baseState, action);
-    expect(newState).toEqual({ ...baseState, eventQueueId: 100 });
+    expect(newState).toEqual({ ...baseState, eventQueueId: '100' });
   });
 
   test('APP_ONLINE', () => {

--- a/src/session/sessionReducer.js
+++ b/src/session/sessionReducer.js
@@ -25,7 +25,7 @@ import { getHasAuth } from '../account/accountsSelectors';
  * See {@link SessionState} for discussion of what "non-persistent" means.
  */
 export type PerAccountSessionState = $ReadOnly<{
-  eventQueueId: number,
+  eventQueueId: string | null,
 
   /**
    * Whether the /register request is in progress.
@@ -104,7 +104,7 @@ export type SessionState = $ReadOnly<{|
 (s: SessionState): PerAccountSessionState => s; // eslint-disable-line no-unused-expressions
 
 const initialState: SessionState = {
-  eventQueueId: -1,
+  eventQueueId: null,
 
   // This will be `null` on startup, while we wait to hear `true` or `false`
   // from the native module over the RN bridge; so, have it start as `null`.


### PR DESCRIPTION
I'd like to make these improvements on the path to a better alternative to 6d2647f2730665215c68e3c0e98a7d8666e2314a. I think they're also good to do independently of my plan for that.

See discussion: https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/connection.20failed/near/1248170

(screenshots coming soon)