### PR TITLE
RawLabel: Make `invariant` slightly more helpful in Sentry.

### DIFF
--- a/src/common/RawLabel.js
+++ b/src/common/RawLabel.js
@@ -31,7 +31,11 @@ export default class RawLabel extends PureComponent<Props> {
   render(): Node {
     const { text, children, style, ...restProps } = this.props;
 
-    invariant((text != null) !== (children != null), 'pass either `text` or `children`');
+    invariant(
+      text != null || children != null,
+      'RawLabel: `text` or `children` should be non-nullish',
+    );
+    invariant(text == null || children == null, 'RawLabel: `text` or `children` should be nullish');
 
     // These attributes will be applied unless specifically overridden
     // with the `style` prop -- even if this `<RawLabel />` is nested


### PR DESCRIPTION
Since we've seen a violation:
  https://sentry.io/organizations/zulip/issues/2645242607/?project=191284&query=is%3Aunresolved+%22pass+either+%60text%60+or+%60children%60%22&statsPeriod=14d