### PR TITLE
ZulipAsyncStorage: Document and assert JSON requirement

### DIFF
--- a/src/boot/__tests__/ZulipAsyncStorage-test.js
+++ b/src/boot/__tests__/ZulipAsyncStorage-test.js
@@ -58,8 +58,8 @@ describe('setItem', () => {
 
 describe('multiSet', () => {
   const keyValuePairs = [
-    ['foo', 'bar'],
-    ['food', 'bard'],
+    ['foo', JSON.stringify('bar')],
+    ['food', JSON.stringify('bard')],
   ];
 
   // For checking that AsyncStorage.multiSet is called in ways we expect.
@@ -196,15 +196,15 @@ describe('set/get together', () => {
 
   test('round-tripping of single key-value pair works', async () => {
     const key = eg.randString();
-    const value = eg.randString();
+    const value = JSON.stringify(eg.randString());
     await ZulipAsyncStorage.setItem(key, value);
     expect(await ZulipAsyncStorage.getItem(key)).toEqual(value);
   });
 
   test('round-tripping of multiple key-value pairs works', async () => {
     const keyValuePairs = [
-      [eg.randString(), eg.randString()],
-      [eg.randString(), eg.randString()],
+      [eg.randString(), JSON.stringify(eg.randString())],
+      [eg.randString(), JSON.stringify(eg.randString())],
     ];
     await ZulipAsyncStorage.multiSet(keyValuePairs);
     expect(


### PR DESCRIPTION
We've always passed JSON-encoded data in the one place we actually
use this storage, inside the redux-persist code; and our `getItem`
has relied on that assumption for a long time.

But our tests for this module have been passing random strings
instead.  When those happen to start with a `z`, that collides
with our compression header, and the test flakes.

Document that requirement on this module's actual interface, and
add some debug asserts to enforce it.  That then makes the flakes
much easier to reproduce; fix those tests to conform to the
interface's requirements.

Fixes: #4994