### PR TITLE
webview html: Skip expensive isSameRecipient where we can

### DIFF
--- a/src/message/getHtmlPieceDescriptors.js
+++ b/src/message/getHtmlPieceDescriptors.js
@@ -19,10 +19,10 @@ export default (
     const prevMessage: typeof message | void = messages[i - 1];
 
     // We show a date separator at the top, and whenever the day changes.
-    const diffDays =
-      !!prevMessage
-      && !isSameDay(new Date(prevMessage.timestamp * 1000), new Date(message.timestamp * 1000));
-    if (!prevMessage || diffDays) {
+    const showDateSeparator =
+      !prevMessage
+      || !isSameDay(new Date(prevMessage.timestamp * 1000), new Date(message.timestamp * 1000));
+    if (showDateSeparator) {
       pieces.push({
         key: `time${message.timestamp}`,
         type: 'time',
@@ -49,8 +49,7 @@ export default (
     const showSender =
       !prevMessage
       || prevMessage.sender_id !== message.sender_id
-      // TODO: nonobviously equivalent to "showed a date separator"
-      || diffDays
+      || showDateSeparator
       // TODO: this is *almost* the same as "showed a recipient header"
       || diffRecipient;
 

--- a/src/message/getHtmlPieceDescriptors.js
+++ b/src/message/getHtmlPieceDescriptors.js
@@ -34,7 +34,8 @@ export default (
     // If we show recipient headers here at all, we do so at the top and
     // whenever the recipient changes.
     const diffRecipient = !prevMessage || !isSameRecipient(prevMessage, message);
-    if (canShowRecipientHeaders && diffRecipient) {
+    const showRecipientHeader = canShowRecipientHeaders && diffRecipient;
+    if (showRecipientHeader) {
       pieces.push({
         type: 'header',
         key: `header${message.id}`,
@@ -50,8 +51,7 @@ export default (
       !prevMessage
       || prevMessage.sender_id !== message.sender_id
       || showDateSeparator
-      // TODO: this is *almost* the same as "showed a recipient header"
-      || diffRecipient;
+      || showRecipientHeader;
 
     pieces.push({
       key: message.id,

--- a/src/message/getHtmlPieceDescriptors.js
+++ b/src/message/getHtmlPieceDescriptors.js
@@ -28,7 +28,7 @@ export default (
       });
     }
 
-    const diffRecipient = !isSameRecipient(prevMessage, message);
+    const diffRecipient = !prevMessage || !isSameRecipient(prevMessage, message);
     if (showHeader && diffRecipient) {
       pieces.push({
         type: 'header',

--- a/src/message/getHtmlPieceDescriptors.js
+++ b/src/message/getHtmlPieceDescriptors.js
@@ -33,8 +33,8 @@ export default (
 
     // If we show recipient headers here at all, we do so at the top and
     // whenever the recipient changes.
-    const diffRecipient = !prevMessage || !isSameRecipient(prevMessage, message);
-    const showRecipientHeader = canShowRecipientHeaders && diffRecipient;
+    const showRecipientHeader =
+      canShowRecipientHeaders && (!prevMessage || !isSameRecipient(prevMessage, message));
     if (showRecipientHeader) {
       pieces.push({
         type: 'header',

--- a/src/message/getHtmlPieceDescriptors.js
+++ b/src/message/getHtmlPieceDescriptors.js
@@ -1,6 +1,6 @@
 /* @flow strict-local */
 import type { Message, Narrow, Outbox, HtmlPieceDescriptor } from '../types';
-import { isTopicNarrow, isPmNarrow } from '../utils/narrow';
+import { isConversationNarrow } from '../utils/narrow';
 import { isSameRecipient } from '../utils/recipient';
 import { isSameDay } from '../utils/date';
 
@@ -9,7 +9,9 @@ export default (
   messages: $ReadOnlyArray<Message | Outbox>,
   narrow: Narrow,
 ): $ReadOnlyArray<HtmlPieceDescriptor> => {
-  const showHeader = !isPmNarrow(narrow) && !isTopicNarrow(narrow);
+  // A recipient header identifies the conversation the messages after it
+  // are in.  We show them unless the narrow already contains that information.
+  const canShowRecipientHeaders = !isConversationNarrow(narrow);
 
   const pieces: HtmlPieceDescriptor[] = [];
   for (let i = 0; i < messages.length; i++) {
@@ -29,7 +31,7 @@ export default (
     }
 
     const diffRecipient = !prevMessage || !isSameRecipient(prevMessage, message);
-    if (showHeader && diffRecipient) {
+    if (canShowRecipientHeaders && diffRecipient) {
       pieces.push({
         type: 'header',
         key: `header${message.id}`,

--- a/src/message/getHtmlPieceDescriptors.js
+++ b/src/message/getHtmlPieceDescriptors.js
@@ -42,13 +42,22 @@ export default (
       });
     }
 
-    const shouldGroupWithPrev =
-      !diffRecipient && !diffDays && !!prevMessage && prevMessage.sender_id === message.sender_id;
+    // We show the sender at the top and whenever the sender changes.
+    // We also reaffirm the sender whenever we've shown a date separator or
+    // recipient header, because our visual design has it bind tighter than
+    // either of those.
+    const showSender =
+      !prevMessage
+      || prevMessage.sender_id !== message.sender_id
+      // TODO: nonobviously equivalent to "showed a date separator"
+      || diffDays
+      // TODO: this is *almost* the same as "showed a recipient header"
+      || diffRecipient;
 
     pieces.push({
       key: message.id,
       type: 'message',
-      isBrief: shouldGroupWithPrev,
+      isBrief: !showSender,
       message,
     });
   }

--- a/src/message/getHtmlPieceDescriptors.js
+++ b/src/message/getHtmlPieceDescriptors.js
@@ -18,6 +18,7 @@ export default (
     const message = messages[i];
     const prevMessage: typeof message | void = messages[i - 1];
 
+    // We show a date separator at the top, and whenever the day changes.
     const diffDays =
       !!prevMessage
       && !isSameDay(new Date(prevMessage.timestamp * 1000), new Date(message.timestamp * 1000));
@@ -30,6 +31,8 @@ export default (
       });
     }
 
+    // If we show recipient headers here at all, we do so at the top and
+    // whenever the recipient changes.
     const diffRecipient = !prevMessage || !isSameRecipient(prevMessage, message);
     if (canShowRecipientHeaders && diffRecipient) {
       pieces.push({

--- a/src/utils/__tests__/recipient-test.js
+++ b/src/utils/__tests__/recipient-test.js
@@ -53,12 +53,6 @@ describe('pmKeyRecipientUsersFromIds', () => {
 });
 
 describe('isSameRecipient', () => {
-  test('passing undefined as any of parameters means recipients are not the same', () => {
-    expect(isSameRecipient(undefined, eg.pmMessage())).toBe(false);
-    expect(isSameRecipient(eg.streamMessage(), undefined)).toBe(false);
-    expect(isSameRecipient(undefined, undefined)).toBe(false);
-  });
-
   test('recipient types are compared first, if they differ then recipients differ', () => {
     expect(isSameRecipient(eg.pmMessage(), eg.streamMessage())).toBe(false);
   });

--- a/src/utils/recipient.js
+++ b/src/utils/recipient.js
@@ -346,13 +346,9 @@ export const pmTypingKeyFromRecipients = (
 ): string => pmTypingKeyFromPmKeyIds(filterRecipientsAsUserIds(recipients, ownUserId));
 
 export const isSameRecipient = (
-  message1: Message | Outbox | void,
-  message2: Message | Outbox | void,
+  message1: Message | Outbox,
+  message2: Message | Outbox,
 ): boolean => {
-  if (message1 === undefined || message2 === undefined) {
-    return false;
-  }
-
   if (message1.type !== message2.type) {
     return false;
   }


### PR DESCRIPTION
When making the changes in #5011, I saw the comment in `isSameRecipient` mentioning that it's in a hot loop where we're already doing too much computation. There's a description there of how we can fix that for all cases; but in the meantime, for the case where the user is just looking at a single topic or PM conversation we can skip calling this function entirely.
