### PR TITLE
Use PmMessage, StreamMessage, PmOutbox, StreamOutbox more, replacing runtime checks.

### DIFF
--- a/src/pm-conversations/pmConversationsModel.js
+++ b/src/pm-conversations/pmConversationsModel.js
@@ -11,7 +11,7 @@ import {
 } from '../actionConstants';
 import { makeUserId } from '../api/idTypes';
 
-import type { Action, Message, Outbox, UserId } from '../types';
+import type { Action, PmMessage, PmOutbox, UserId } from '../types';
 import { recipientsOfPrivateMessage } from '../utils/recipient';
 import { ZulipVersion } from '../utils/zulipVersion';
 
@@ -47,7 +47,7 @@ function keyOfUsers(ids: UserId[], ownUserId: UserId): PmConversationKey {
 }
 
 // Input must indeed be a PM, else throws.
-function keyOfPrivateMessage(msg: Message | Outbox, ownUserId: UserId): PmConversationKey {
+function keyOfPrivateMessage(msg: PmMessage | PmOutbox, ownUserId: UserId): PmConversationKey {
   return keyOfUsers(
     recipientsOfPrivateMessage(msg).map(r => r.id),
     ownUserId,

--- a/src/pm-conversations/pmConversationsModel.js
+++ b/src/pm-conversations/pmConversationsModel.js
@@ -46,7 +46,6 @@ function keyOfUsers(ids: UserId[], ownUserId: UserId): PmConversationKey {
   return keyOfExactUsers(ids.filter(id => id !== ownUserId));
 }
 
-// Input must indeed be a PM, else throws.
 function keyOfPrivateMessage(msg: PmMessage | PmOutbox, ownUserId: UserId): PmConversationKey {
   return keyOfUsers(
     recipientsOfPrivateMessage(msg).map(r => r.id),

--- a/src/pm-conversations/pmConversationsSelectors.js
+++ b/src/pm-conversations/pmConversationsSelectors.js
@@ -2,7 +2,7 @@
 import invariant from 'invariant';
 import { createSelector } from 'reselect';
 
-import type { PerAccountState, Message, PmConversationData, Selector } from '../types';
+import type { PerAccountState, PmMessage, PmConversationData, Selector } from '../types';
 import { getPrivateMessages } from '../message/messageSelectors';
 import { getAllUsersById, getOwnUserId } from '../users/userSelectors';
 import { getUnreadByPms, getUnreadByHuddles } from '../unread/unreadSelectors';
@@ -37,7 +37,7 @@ export const getRecentConversationsLegacy: Selector<PmConversationData[]> = crea
   getAllUsersById,
   (
     ownUserId,
-    messages: Message[],
+    messages: PmMessage[],
     unreadPms: {| [number]: number |},
     unreadHuddles: {| [string]: number |},
     allUsersById,

--- a/src/unread/unreadHuddlesReducer.js
+++ b/src/unread/unreadHuddlesReducer.js
@@ -18,20 +18,22 @@ import { NULL_ARRAY } from '../nullObjects';
 const initialState: UnreadHuddlesState = NULL_ARRAY;
 
 const eventNewMessage = (state, action) => {
-  if (action.message.type !== 'private') {
+  const { message } = action;
+
+  if (message.type !== 'private') {
     return state;
   }
 
-  if (recipientsOfPrivateMessage(action.message).length < 3) {
+  if (recipientsOfPrivateMessage(message).length < 3) {
     return state;
   }
 
-  invariant(action.message.flags, 'message in EVENT_NEW_MESSAGE must have flags');
-  if (action.message.flags.includes('read')) {
+  invariant(message.flags, 'message in EVENT_NEW_MESSAGE must have flags');
+  if (message.flags.includes('read')) {
     return state;
   }
 
-  return addItemsToHuddleArray(state, [action.message.id], pmUnreadsKeyFromMessage(action.message));
+  return addItemsToHuddleArray(state, [message.id], pmUnreadsKeyFromMessage(message));
 };
 
 const eventUpdateMessageFlags = (state, action) => {

--- a/src/utils/recipient.js
+++ b/src/utils/recipient.js
@@ -4,15 +4,19 @@ import isEqual from 'lodash.isequal';
 
 import { mapOrNull } from '../collections';
 import * as logging from './logging';
-import type { PmRecipientUser, Message, Outbox, UserId, UserOrBot } from '../types';
+import type {
+  PmRecipientUser,
+  Message,
+  StreamMessage,
+  Outbox,
+  StreamOutbox,
+  UserId,
+  UserOrBot,
+} from '../types';
 
-/** The stream name a stream message was sent to.  Throws if a PM. */
-export const streamNameOfStreamMessage = (message: Message | Outbox): string => {
-  if (message.type !== 'stream') {
-    throw new Error('streamNameOfStreamMessage: got PM');
-  }
-  return message.display_recipient;
-};
+/** The stream name a stream message was sent to. */
+export const streamNameOfStreamMessage = (message: StreamMessage | StreamOutbox): string =>
+  message.display_recipient;
 
 /** The recipients of a PM, in the form found on Message.  Throws if a stream message. */
 export const recipientsOfPrivateMessage = (

--- a/src/utils/recipient.js
+++ b/src/utils/recipient.js
@@ -8,8 +8,10 @@ import type {
   PmRecipientUser,
   Message,
   StreamMessage,
+  PmMessage,
   Outbox,
   StreamOutbox,
+  PmOutbox,
   UserId,
   UserOrBot,
 } from '../types';
@@ -227,7 +229,7 @@ export const pmKeyRecipientUsersFromIds = (
  * Just like pmKeyRecipientsFromMessage, but in a slightly different format.
  */
 export const pmKeyRecipientUsersFromMessage = (
-  message: Message | Outbox,
+  message: PmMessage | PmOutbox,
   allUsersById: Map<UserId, UserOrBot>,
   ownUserId: UserId,
 ): PmKeyUsers | null => {

--- a/src/utils/recipient.js
+++ b/src/utils/recipient.js
@@ -20,15 +20,10 @@ import type {
 export const streamNameOfStreamMessage = (message: StreamMessage | StreamOutbox): string =>
   message.display_recipient;
 
-/** The recipients of a PM, in the form found on Message.  Throws if a stream message. */
+/** The recipients of a PM, in the form found on PmMessage. */
 export const recipientsOfPrivateMessage = (
-  message: Message | Outbox,
-): $ReadOnlyArray<PmRecipientUser> => {
-  if (message.type !== 'private') {
-    throw new Error('recipientsOfPrivateMessage: got stream message');
-  }
-  return message.display_recipient;
-};
+  message: PmMessage | PmOutbox,
+): $ReadOnlyArray<PmRecipientUser> => message.display_recipient;
 
 /**
  * A list of users identifying a PM conversation, as per pmKeyRecipientsFromMessage.

--- a/src/utils/recipient.js
+++ b/src/utils/recipient.js
@@ -349,12 +349,12 @@ export const isSameRecipient = (
   message1: Message | Outbox,
   message2: Message | Outbox,
 ): boolean => {
-  if (message1.type !== message2.type) {
-    return false;
-  }
-
   switch (message1.type) {
     case 'private':
+      if (message2.type !== 'private') {
+        return false;
+      }
+
       // We rely on the recipients being listed in a consistent order
       // between different messages in the same PM conversation.  The server
       // is indeed consistent to that degree; see comments on the Message
@@ -377,6 +377,10 @@ export const isSameRecipient = (
         recipientsOfPrivateMessage(message2).map(r => r.id),
       );
     case 'stream':
+      if (message2.type !== 'stream') {
+        return false;
+      }
+
       return (
         streamNameOfStreamMessage(message1).toLowerCase()
           === streamNameOfStreamMessage(message2).toLowerCase()

--- a/src/utils/recipient.js
+++ b/src/utils/recipient.js
@@ -252,10 +252,7 @@ export const pmKeyRecipientsFromUsers = (
 // and just the other user ID for non-self 1:1s; and in each case the list
 // is sorted numerically and encoded in ASCII-decimal, comma-separated.
 // See the `unread_msgs` data structure in `src/api/initialDataTypes.js`.
-export const pmUnreadsKeyFromMessage = (message: Message, ownUserId?: UserId): string => {
-  if (message.type !== 'private') {
-    throw new Error('pmUnreadsKeyFromMessage: expected PM, got stream message');
-  }
+export const pmUnreadsKeyFromMessage = (message: PmMessage, ownUserId?: UserId): string => {
   const recipients = recipientsOfPrivateMessage(message);
 
   // This includes all users in the thread; see `Message#display_recipient`.

--- a/src/utils/recipient.js
+++ b/src/utils/recipient.js
@@ -175,17 +175,13 @@ export const pmKeyRecipientsFromIds = (
 // But we also sort them ourselves, so as not to rely on that fact about
 // the server; it's easy enough to do.
 export const pmKeyRecipientsFromMessage = (
-  message: Message | Outbox,
+  message: PmMessage | PmOutbox,
   ownUserId: UserId,
-): PmKeyRecipients => {
-  if (message.type !== 'private') {
-    throw new Error('pmKeyRecipientsFromMessage: expected PM, got stream message');
-  }
-  return pmKeyRecipientsFromIds(
+): PmKeyRecipients =>
+  pmKeyRecipientsFromIds(
     recipientsOfPrivateMessage(message).map(r => r.id),
     ownUserId,
   );
-};
 
 /**
  * The list of users to identify a PM conversation by in our data structures.

--- a/src/utils/recipient.js
+++ b/src/utils/recipient.js
@@ -125,14 +125,10 @@ export const normalizeRecipientsAsUserIdsSansMe = (
  *    data structures.
  */
 export const pmUiRecipientsFromMessage = (
-  message: Message | Outbox,
+  message: PmMessage | PmOutbox,
   ownUserId: UserId,
-): $ReadOnlyArray<PmRecipientUser> => {
-  if (message.type !== 'private') {
-    throw new Error('pmUiRecipientsFromMessage: expected PM, got stream message');
-  }
-  return filterRecipients(recipientsOfPrivateMessage(message), ownUserId);
-};
+): $ReadOnlyArray<PmRecipientUser> =>
+  filterRecipients(recipientsOfPrivateMessage(message), ownUserId);
 
 /**
  * The list of users to identify a PM conversation by in our data structures.


### PR DESCRIPTION
This spun off of a draft I've been working on to resume message-list diffing. I've forgotten the specifics of why this cleanup is helpful or necessary for that work (and it would take some effort to go back and check), but I'm hoping it will still seem worthwhile without that context. 🙂 

Mainly, this PR takes a small handful of functions in `recipient.js` like this:

```js
/** The stream name a stream message was sent to.  Throws if a PM. */
export const streamNameOfStreamMessage = (message: Message | Outbox): string => {
  if (message.type !== 'stream') {
    throw new Error('streamNameOfStreamMessage: got PM');
  }
  return message.display_recipient;
};
```

And turns them into functions like this:

```js
/** The stream name a stream message was sent to. */
export const streamNameOfStreamMessage = (message: StreamMessage | StreamOutbox): string =>
  message.display_recipient;
```

(These improvements are now possible thanks to #4998! 🎉)

Callers have so far been really attentive in passing the appropriate kind of message or outbox. And I don't think we've seen any reports of those runtime errors in Sentry. But anyway, now we can enlist the type-checker to help these functions make sure their callers keep doing the right thing going forward.