### PR TITLE
per-account 3/n: Sort out remaining selectors

### DIFF
--- a/src/account/__tests__/accountsSelectors-test.js
+++ b/src/account/__tests__/accountsSelectors-test.js
@@ -1,43 +1,6 @@
 import deepFreeze from 'deep-freeze';
 
-import { getAuth, tryGetAuth } from '../accountsSelectors';
-
-describe('tryGetAuth', () => {
-  test('returns undefined when no accounts', () => {
-    const state = deepFreeze({
-      accounts: [],
-    });
-
-    const auth = tryGetAuth(state);
-
-    expect(auth).toBe(undefined);
-  });
-
-  test('returns undefined when no API key on active account', () => {
-    const state = deepFreeze({
-      accounts: [
-        { apiKey: '', realm: 'https://realm1.com' },
-        { apiKey: 'asdf', realm: 'https://realm2.com' },
-      ],
-    });
-
-    expect(tryGetAuth(state)).toBe(undefined);
-  });
-
-  test('returns the auth information from the first account, if valid', () => {
-    const state = deepFreeze({
-      accounts: [
-        { apiKey: 'asdf', realm: 'https://realm1.com' },
-        { apiKey: 'aoeu', realm: 'https://realm2.com' },
-      ],
-    });
-
-    expect(tryGetAuth(state)).toEqual({
-      realm: 'https://realm1.com',
-      apiKey: 'asdf',
-    });
-  });
-});
+import { getAuth } from '../accountsSelectors';
 
 describe('getAuth', () => {
   test('throws when no accounts', () => {
@@ -61,5 +24,19 @@ describe('getAuth', () => {
     expect(() => {
       getAuth(state);
     }).toThrow();
+  });
+
+  test('returns the auth information from the first account, if valid', () => {
+    const state = deepFreeze({
+      accounts: [
+        { apiKey: 'asdf', realm: 'https://realm1.com' },
+        { apiKey: 'aoeu', realm: 'https://realm2.com' },
+      ],
+    });
+
+    expect(getAuth(state)).toEqual({
+      realm: 'https://realm1.com',
+      apiKey: 'asdf',
+    });
   });
 });

--- a/src/account/accountsSelectors.js
+++ b/src/account/accountsSelectors.js
@@ -100,7 +100,7 @@ export const getRealmUrl = (state: PerAccountState): URL => getAccount(state).re
  *
  * See:
  *  * `getAuth` for use in the bulk of the app, operating on a logged-in
- *    active account.
+ *    account.
  */
 // TODO(#5006): Should be called just tryGetAuth, after the old one is gone.
 export const tryGetThisAuth: Selector<Auth | void> = createSelector(getAccount, account => {
@@ -136,17 +136,17 @@ export const getHasAuth = (globalState: GlobalState): boolean => {
 };
 
 /**
- * The auth object for the active, logged-in account; throws if none.
+ * The auth object for this account, if logged in; else throws.
  *
  * For use in all the normal-use screens and codepaths of the app, which
- * assume there is an active, logged-in account.
+ * assume the specified account is logged in.
  *
  * See:
- *  * `tryGetAuth` for the meaning of "active, logged-in".
- *  * `tryGetAuth` again, for use where there might not be such an account.
+ *  * `tryGetAuth` for the meaning of "logged in".
+ *  * `tryGetAuth` again, for use where the account might not be logged in.
  */
-export const getAuth = (state: GlobalState): Auth => {
-  const auth = tryGetAuth(state);
+export const getAuth = (state: PerAccountState): Auth => {
+  const auth = tryGetThisAuth(state);
   if (auth === undefined) {
     throw new Error('Active account not logged in');
   }
@@ -159,9 +159,8 @@ export const getAuth = (state: GlobalState): Auth => {
  * See `getAuth` and `tryGetAuth` for discussion.
  */
 // TODO why should this care if the account is logged in?
-export const getIdentity: Selector<Identity> = createSelector(
-  state => getAuth(assumeSecretlyGlobalState(state)),
-  auth => identityOfAuth(auth),
+export const getIdentity: Selector<Identity> = createSelector(getAuth, auth =>
+  identityOfAuth(auth),
 );
 
 /**

--- a/src/account/accountsSelectors.js
+++ b/src/account/accountsSelectors.js
@@ -110,25 +110,16 @@ export const tryGetThisAuth: Selector<Auth | void> = createSelector(getAccount, 
   return authOfAccount(account);
 });
 
-/**
- * DEPRECATED on road to #5006.
- *
- * Calls to this can be translated to calls to `tryGetActiveAccountState`
- * followed by `tryGetThisAuth`.  They should become that, if the caller is
- * indeed global, or just `tryGetThisAuth` if the caller is per-account.
- */
-export const tryGetAuth = (globalState: GlobalState): Auth | void => {
-  const state = tryGetActiveAccountState(globalState);
-  if (!state) {
-    return undefined;
-  }
-  return tryGetThisAuth(state);
-};
+// Some see-also comments refer to `tryGetAuth`.  They really mean the
+// function that for now is called `tryGetThisAuth`, which we'll rename
+// shortly.
 
 /**
  * True just if there is an active, logged-in account.
  *
- * See `tryGetAuth` for the meaning of "active, logged-in".
+ * See:
+ *  * `tryGetActiveAccountState` for the meaning of "active".
+ *  * `tryGetAuth` for the meaning of "logged in".
  */
 export const getHasAuth = (globalState: GlobalState): boolean => {
   const state = tryGetActiveAccountState(globalState);

--- a/src/account/accountsSelectors.js
+++ b/src/account/accountsSelectors.js
@@ -102,17 +102,12 @@ export const getRealmUrl = (state: PerAccountState): URL => getAccount(state).re
  *  * `getAuth` for use in the bulk of the app, operating on a logged-in
  *    account.
  */
-// TODO(#5006): Should be called just tryGetAuth, after the old one is gone.
-export const tryGetThisAuth: Selector<Auth | void> = createSelector(getAccount, account => {
+export const tryGetAuth: Selector<Auth | void> = createSelector(getAccount, account => {
   if (account.apiKey === '') {
     return undefined;
   }
   return authOfAccount(account);
 });
-
-// Some see-also comments refer to `tryGetAuth`.  They really mean the
-// function that for now is called `tryGetThisAuth`, which we'll rename
-// shortly.
 
 /**
  * True just if there is an active, logged-in account.
@@ -123,7 +118,7 @@ export const tryGetThisAuth: Selector<Auth | void> = createSelector(getAccount, 
  */
 export const getHasAuth = (globalState: GlobalState): boolean => {
   const state = tryGetActiveAccountState(globalState);
-  return !!state && !!tryGetThisAuth(state);
+  return !!state && !!tryGetAuth(state);
 };
 
 /**
@@ -137,7 +132,7 @@ export const getHasAuth = (globalState: GlobalState): boolean => {
  *  * `tryGetAuth` again, for use where the account might not be logged in.
  */
 export const getAuth = (state: PerAccountState): Auth => {
-  const auth = tryGetThisAuth(state);
+  const auth = tryGetAuth(state);
   if (auth === undefined) {
     throw new Error('Active account not logged in');
   }

--- a/src/boot/ThemeProvider.js
+++ b/src/boot/ThemeProvider.js
@@ -4,7 +4,7 @@ import React from 'react';
 import type { Node } from 'react';
 
 import { useSelector } from '../react-redux';
-import { getSettings } from '../directSelectors';
+import { getGlobalSettings } from '../directSelectors';
 import { themeData, ThemeContext } from '../styles/theme';
 import { ZulipStatusBar } from '../common';
 
@@ -14,7 +14,7 @@ type Props = $ReadOnly<{|
 
 export default function ThemeProvider(props: Props): Node {
   const { children } = props;
-  const theme = useSelector(state => getSettings(state).theme);
+  const theme = useSelector(state => getGlobalSettings(state).theme);
   return (
     <ThemeContext.Provider value={themeData[theme]}>
       <ZulipStatusBar />

--- a/src/boot/TranslationProvider.js
+++ b/src/boot/TranslationProvider.js
@@ -7,7 +7,7 @@ import type { IntlShape } from 'react-intl';
 
 import type { GetText } from '../types';
 import { useSelector } from '../react-redux';
-import { getSettings } from '../selectors';
+import { getGlobalSettings } from '../selectors';
 import messages from '../i18n/messages';
 
 // $FlowFixMe[incompatible-type] could put a well-typed mock value here, to help write tests
@@ -78,7 +78,7 @@ type Props = $ReadOnly<{|
 
 export default function TranslationProvider(props: Props): Node {
   const { children } = props;
-  const language = useSelector(state => getSettings(state).language);
+  const language = useSelector(state => getGlobalSettings(state).language);
 
   return (
     <IntlProvider locale={language} textComponent={Text} messages={messages[language]}>

--- a/src/common/OfflineNotice.js
+++ b/src/common/OfflineNotice.js
@@ -9,7 +9,7 @@ import * as logging from '../utils/logging';
 import { createStyleSheet, HALF_COLOR } from '../styles';
 import { useHasStayedTrueForMs } from '../reactUtils';
 import { useSelector } from '../react-redux';
-import { getSession } from '../selectors';
+import { getGlobalSession } from '../selectors';
 import Label from './Label';
 
 const styles = createStyleSheet({
@@ -37,7 +37,7 @@ type Props = $ReadOnly<{||}>;
  * Shows nothing if the Internet is reachable.
  */
 export default function OfflineNotice(props: Props): Node {
-  const isOnline = useSelector(state => getSession(state).isOnline);
+  const isOnline = useSelector(state => getGlobalSession(state).isOnline);
 
   const shouldShowUncertaintyNotice = useHasStayedTrueForMs(
     // See note in `SessionState` for what this means.

--- a/src/common/ServerCompatBanner.js
+++ b/src/common/ServerCompatBanner.js
@@ -6,7 +6,7 @@ import type { Node } from 'react';
 import ZulipBanner from './ZulipBanner';
 import { useSelector, useDispatch } from '../react-redux';
 import { getIdentity, getServerVersion } from '../account/accountsSelectors';
-import { getIsAdmin, getSession, getSettings } from '../directSelectors';
+import { getIsAdmin, getSession, getGlobalSettings } from '../directSelectors';
 import { dismissCompatNotice } from '../session/sessionActions';
 import { openLinkWithUserPreference } from '../utils/openLink';
 
@@ -27,7 +27,7 @@ export default function ServerCompatBanner(props: Props): Node {
   const zulipVersion = useSelector(getServerVersion);
   const realm = useSelector(state => getIdentity(state).realm);
   const isAdmin = useSelector(getIsAdmin);
-  const settings = useSelector(getSettings);
+  const settings = useSelector(getGlobalSettings);
 
   let visible = false;
   let text = '';

--- a/src/common/UserAvatar.js
+++ b/src/common/UserAvatar.js
@@ -5,7 +5,7 @@ import { Image, View, PixelRatio } from 'react-native';
 
 import { useSelector } from '../react-redux';
 import { getAuthHeaders } from '../api/transport';
-import { tryGetAuth } from '../account/accountsSelectors';
+import { getAuth } from '../account/accountsSelectors';
 import Touchable from './Touchable';
 import { AvatarURL, FallbackAvatarURL } from '../utils/avatar';
 import { IconUserMuted } from './Icons';
@@ -43,17 +43,7 @@ function UserAvatar(props: Props): Node {
 
   const { color } = useContext(ThemeContext);
 
-  const auth = useSelector(state => tryGetAuth(state));
-  if (!auth) {
-    // TODO: This should be impossible (and then the selector should be
-    //   `getAuth` to say so.)  There's a bug where this component (probably
-    //   as part of the whole main nav-tabs UI?) apparently stays mounted,
-    //   and keeps getting updates, after the active account changes on
-    //   choosing "Add new account", or an existing logged-out account, from
-    //   the pick-accounts screen after Profile > Switch account.  See:
-    //     https://github.com/zulip/zulip-mobile/issues/4388
-    return null;
-  }
+  const auth = useSelector(state => getAuth(state));
 
   return (
     <Touchable onPress={onPress}>

--- a/src/common/ZulipStatusBar.js
+++ b/src/common/ZulipStatusBar.js
@@ -9,7 +9,7 @@ import Color from 'color';
 import type { ThemeName } from '../types';
 import { useSelector } from '../react-redux';
 import { foregroundColorFromBackground } from '../utils/color';
-import { getSession, getSettings } from '../selectors';
+import { getSession, getGlobalSettings } from '../selectors';
 
 type BarStyle = $PropertyType<React$ElementConfig<typeof StatusBar>, 'barStyle'>;
 
@@ -45,7 +45,7 @@ type Props = $ReadOnly<{|
  */
 export default function ZulipStatusBar(props: Props): Node {
   const { hidden = false } = props;
-  const theme = useSelector(state => getSettings(state).theme);
+  const theme = useSelector(state => getGlobalSettings(state).theme);
   const orientation = useSelector(state => getSession(state).orientation);
   const backgroundColor = props.backgroundColor;
   const statusBarColor = getStatusBarColor(backgroundColor, theme);

--- a/src/common/ZulipStatusBar.js
+++ b/src/common/ZulipStatusBar.js
@@ -9,7 +9,7 @@ import Color from 'color';
 import type { ThemeName } from '../types';
 import { useSelector } from '../react-redux';
 import { foregroundColorFromBackground } from '../utils/color';
-import { getSession, getGlobalSettings } from '../selectors';
+import { getGlobalSession, getGlobalSettings } from '../selectors';
 
 type BarStyle = $PropertyType<React$ElementConfig<typeof StatusBar>, 'barStyle'>;
 
@@ -46,7 +46,7 @@ type Props = $ReadOnly<{|
 export default function ZulipStatusBar(props: Props): Node {
   const { hidden = false } = props;
   const theme = useSelector(state => getGlobalSettings(state).theme);
-  const orientation = useSelector(state => getSession(state).orientation);
+  const orientation = useSelector(state => getGlobalSession(state).orientation);
   const backgroundColor = props.backgroundColor;
   const statusBarColor = getStatusBarColor(backgroundColor, theme);
   return (

--- a/src/directSelectors.js
+++ b/src/directSelectors.js
@@ -28,11 +28,12 @@ import type {
   User,
   UserStatusState,
 } from './types';
-import type { SessionState } from './session/sessionReducer';
+import type { PerAccountSessionState, GlobalSessionState } from './session/sessionReducer';
 
 export const getAccounts = (state: GlobalState): AccountsState => state.accounts;
 
-export const getSession = (state: GlobalState): SessionState => state.session;
+export const getSession = (state: PerAccountState): PerAccountSessionState => state.session;
+export const getGlobalSession = (state: GlobalState): GlobalSessionState => state.session;
 
 export const getIsOnline = (state: GlobalState): boolean | null => state.session.isOnline;
 export const getDebug = (state: GlobalState): Debug => state.session.debug;

--- a/src/directSelectors.js
+++ b/src/directSelectors.js
@@ -20,7 +20,8 @@ import type {
   CrossRealmBot,
   RealmEmojiById,
   RealmState,
-  SettingsState,
+  PerAccountSettingsState,
+  GlobalSettingsState,
   TypingState,
   Debug,
   VideoChatProvider,
@@ -71,7 +72,8 @@ export const getFlags = (state: PerAccountState): FlagsState => state.flags;
 
 export const getAllNarrows = (state: PerAccountState): NarrowsState => state.narrows;
 
-export const getSettings = (state: GlobalState): SettingsState => state.settings;
+export const getSettings = (state: PerAccountState): PerAccountSettingsState => state.settings;
+export const getGlobalSettings = (state: GlobalState): GlobalSettingsState => state.settings;
 
 export const getSubscriptions = (state: PerAccountState): SubscriptionsState => state.subscriptions;
 

--- a/src/events/eventActions.js
+++ b/src/events/eventActions.js
@@ -5,7 +5,7 @@ import { logout } from '../account/accountActions';
 import { deadQueue } from '../session/sessionActions';
 import eventToAction from './eventToAction';
 import doEventActionSideEffects from './doEventActionSideEffects';
-import { tryGetActiveAccountState, tryGetThisAuth } from '../selectors';
+import { tryGetActiveAccountState, tryGetAuth } from '../selectors';
 import { BackoffMachine } from '../utils/async';
 import { ApiError } from '../api/apiErrors';
 import * as logging from '../utils/logging';
@@ -53,7 +53,7 @@ export const startEventPolling = (
   // eslint-disable-next-line no-constant-condition
   while (true) {
     const state = tryGetActiveAccountState(getState());
-    const auth = state && tryGetThisAuth(state);
+    const auth = state && tryGetAuth(state);
     if (!auth) {
       // There is no logged-in active account.
       break;

--- a/src/lightbox/Lightbox.js
+++ b/src/lightbox/Lightbox.js
@@ -12,7 +12,7 @@ import * as NavigationService from '../nav/NavigationService';
 import type { Message } from '../types';
 import { useSelector } from '../react-redux';
 import type { ShowActionSheetWithOptions } from '../message/messageActionSheet';
-import { getAuth, getSession } from '../selectors';
+import { getAuth, getGlobalSession } from '../selectors';
 import { getResource } from '../utils/url';
 import LightboxHeader from './LightboxHeader';
 import LightboxFooter from './LightboxFooter';
@@ -69,7 +69,7 @@ export default function Lightbox(props: Props): Node {
 
   // Since we're using `Dimensions.get` (below), we'll want a rerender
   // when the orientation changes. No need to store the value.
-  useSelector(state => getSession(state).orientation);
+  useSelector(state => getGlobalSession(state).orientation);
 
   const { width: windowWidth, height: windowHeight } = Dimensions.get('window');
 

--- a/src/message/__tests__/fetchActions-test.js
+++ b/src/message/__tests__/fetchActions-test.js
@@ -332,7 +332,7 @@ describe('fetchActions', () => {
           ),
         ).rejects.toThrow(
           // Update this with changes to the message string or error type.
-          new Error('Active account not logged in'),
+          new Error('getAccount: must have account'),
         );
 
         const actions = store.getActions();
@@ -340,7 +340,7 @@ describe('fetchActions', () => {
         expect(actions[actions.length - 1]).toMatchObject({
           type: 'MESSAGE_FETCH_ERROR',
           // Update this with changes to the message string or error type.
-          error: new Error('Active account not logged in'),
+          error: new Error('getAccount: must have account'),
         });
       });
 

--- a/src/nav/ZulipNavigationContainer.js
+++ b/src/nav/ZulipNavigationContainer.js
@@ -6,7 +6,7 @@ import { NavigationContainer, DefaultTheme, DarkTheme } from '@react-navigation/
 import { useSelector } from '../react-redux';
 import { ThemeContext } from '../styles';
 import * as NavigationService from './NavigationService';
-import { getSettings } from '../selectors';
+import { getGlobalSettings } from '../selectors';
 import AppNavigator from './AppNavigator';
 
 type Props = $ReadOnly<{||}>;
@@ -22,7 +22,7 @@ type Props = $ReadOnly<{||}>;
  *   and `initialRouteParams` which we get from data in Redux.
  */
 export default function ZulipAppContainer(props: Props): Node {
-  const themeName = useSelector(state => getSettings(state).theme);
+  const themeName = useSelector(state => getGlobalSettings(state).theme);
 
   useEffect(
     () =>

--- a/src/notification/notificationActions.js
+++ b/src/notification/notificationActions.js
@@ -11,7 +11,7 @@ import {
 } from '.';
 import type { Notification } from './types';
 import { getAuth } from '../selectors';
-import { getSession, getAccounts } from '../directSelectors';
+import { getGlobalSession, getAccounts } from '../directSelectors';
 import { GOT_PUSH_TOKEN, ACK_PUSH_TOKEN, UNACK_PUSH_TOKEN } from '../actionConstants';
 import { identityOfAccount, authOfAccount } from '../account/accountMisc';
 import { getAllUsersByEmail, getOwnUserId } from '../users/userSelectors';
@@ -79,7 +79,7 @@ const sendPushToken = async (dispatch: Dispatch, account: Account | void, pushTo
 
 /** Tell all logged-in accounts' servers about our device token, as needed. */
 export const sendAllPushToken = (): ThunkAction<Promise<void>> => async (dispatch, getState) => {
-  const { pushToken } = getSession(getState());
+  const { pushToken } = getGlobalSession(getState());
   if (pushToken === null) {
     return;
   }
@@ -89,7 +89,7 @@ export const sendAllPushToken = (): ThunkAction<Promise<void>> => async (dispatc
 
 /** Tell this account's server about our device token, if needed. */
 export const initNotifications = (): ThunkAction<Promise<void>> => async (dispatch, getState) => {
-  const { pushToken } = getSession(getState());
+  const { pushToken } = getGlobalSession(getState());
   if (pushToken === null) {
     // Probably, we just don't have the token yet.  When we learn it,
     // the listener will update this and all other logged-in servers.

--- a/src/outbox/outboxActions.js
+++ b/src/outbox/outboxActions.js
@@ -97,6 +97,7 @@ const trySendMessages = (dispatch, getState): boolean => {
   }
 };
 
+/** Try sending any pending outbox messages for this account, with retries. */
 export const sendOutbox = (): ThunkAction<Promise<void>> => async (dispatch, getState) => {
   const state = getState();
   if (state.outbox.length === 0 || state.session.outboxSending) {

--- a/src/reduxTypes.js
+++ b/src/reduxTypes.js
@@ -298,20 +298,16 @@ export type PerAccountSettingsState = $ReadOnly<{
 }>;
 
 /**
- * The user's chosen settings.
+ * The user's chosen settings independent of account, on this client.
  *
- * This is a mix of server data representing the active account (see
- * {@link PerAccountSettingsState}), and client-only data that applies
- * across all the user's accounts on this client (i.e. on this install of
- * the app on this device.)
+ * These apply across all the user's accounts on this client (i.e. on this
+ * install of the app on this device).
+ *
+ * See also {@link PerAccountSettingsState}.
  */
-export type SettingsState = $ReadOnly<{|
-  ...$Exact<PerAccountSettingsState>,
-
-  // The properties below apply independent of account.  That also means
-  // they can't come from the server.  For per-account settings, see
-  // PerAccountSettingsState.
-
+// Because these apply independent of account, they necessarily can't come
+// from the server.
+export type GlobalSettingsState = $ReadOnly<{
   // The user's chosen language, as an IETF BCP 47 language tag.
   language: string,
 
@@ -324,6 +320,21 @@ export type SettingsState = $ReadOnly<{|
   // Possibly this should be per-account.  If so it should probably be put
   // on the server, so it can also be cross-device for the account.
   doNotMarkMessagesAsRead: boolean,
+
+  ...
+}>;
+
+/**
+ * The user's chosen settings.
+ *
+ * This is a mix of server data representing the active account (see
+ * {@link PerAccountSettingsState}), and client-only data that applies
+ * across all the user's accounts on this client (see
+ * {@link GlobalSettingsState}).
+ */
+export type SettingsState = $ReadOnly<{|
+  ...$Exact<GlobalSettingsState>,
+  ...$Exact<PerAccountSettingsState>,
 |}>;
 
 // As part of letting GlobalState freely convert to PerAccountState,

--- a/src/session/sessionReducer.js
+++ b/src/session/sessionReducer.js
@@ -55,20 +55,14 @@ export type PerAccountSessionState = $ReadOnly<{
 }>;
 
 /**
- * Miscellaneous non-persistent state about this run of the app.
+ * Miscellaneous non-persistent state independent of account.
  *
- * These state items are stored in `session.state`, and 'session' is
- * in `discardKeys` in src/boot/store.js. That means these values
- * won't be persisted between sessions; on startup, they'll all be
- * initialized to their default values.
+ * This contains data about the device and the app as a whole, independent
+ * of any particular Zulip server or account.
+ *
+ * See {@link SessionState} for discussion of what "non-persistent" means.
  */
-export type SessionState = $ReadOnly<{|
-  ...$Exact<PerAccountSessionState>,
-
-  // The properties below are data about the device and the app as a whole,
-  // independent of any particular Zulip server or account.
-  // For per-account data, see PerAccountSessionState.
-
+export type GlobalSessionState = $ReadOnly<{
   // `null` if we don't know. See the place where we set this, for what that
   // means.
   isOnline: boolean | null,
@@ -96,6 +90,21 @@ export type SessionState = $ReadOnly<{|
   pushToken: string | null,
 
   debug: Debug,
+
+  ...
+}>;
+
+/**
+ * Miscellaneous non-persistent state about this run of the app.
+ *
+ * These state items are stored in `session.state`, and 'session' is
+ * in `discardKeys` in src/boot/store.js. That means these values
+ * won't be persisted between sessions; on startup, they'll all be
+ * initialized to their default values.
+ */
+export type SessionState = $ReadOnly<{|
+  ...$Exact<GlobalSessionState>,
+  ...$Exact<PerAccountSessionState>,
 |}>;
 
 // As part of letting GlobalState freely convert to PerAccountState,

--- a/src/settings/LanguageScreen.js
+++ b/src/settings/LanguageScreen.js
@@ -8,7 +8,7 @@ import type { AppNavigationProp } from '../nav/AppNavigator';
 import { useSelector, useDispatch } from '../react-redux';
 import { Screen } from '../common';
 import LanguagePicker from './LanguagePicker';
-import { getSettings } from '../selectors';
+import { getGlobalSettings } from '../selectors';
 import { settingsChange } from '../actions';
 
 type Props = $ReadOnly<{|
@@ -18,7 +18,7 @@ type Props = $ReadOnly<{|
 
 export default function LanguageScreen(props: Props): Node {
   const dispatch = useDispatch();
-  const language = useSelector(state => getSettings(state).language);
+  const language = useSelector(state => getGlobalSettings(state).language);
 
   const [filter, setFilter] = useState<string>('');
 

--- a/src/settings/NotificationsScreen.js
+++ b/src/settings/NotificationsScreen.js
@@ -16,6 +16,7 @@ type Props = $ReadOnly<{|
   route: RouteProp<'notifications', void>,
 |}>;
 
+/** (NB this is a per-account screen -- these are per-account settings.) */
 export default function NotificationsScreen(props: Props): Node {
   const auth = useSelector(getAuth);
   const offlineNotification = useSelector(state => getSettings(state).offlineNotification);

--- a/src/settings/SettingsScreen.js
+++ b/src/settings/SettingsScreen.js
@@ -9,7 +9,7 @@ import type { MainTabsNavigationProp } from '../main/MainTabsScreen';
 import * as NavigationService from '../nav/NavigationService';
 import { createStyleSheet } from '../styles';
 import { useSelector, useDispatch } from '../react-redux';
-import { getSettings } from '../selectors';
+import { getGlobalSettings } from '../selectors';
 import { NestedNavRow, SwitchRow } from '../common';
 import {
   IconDiagnostics,
@@ -38,9 +38,11 @@ type Props = $ReadOnly<{|
 |}>;
 
 export default function SettingsScreen(props: Props): Node {
-  const theme = useSelector(state => getSettings(state).theme);
-  const browser = useSelector(state => getSettings(state).browser);
-  const doNotMarkMessagesAsRead = useSelector(state => getSettings(state).doNotMarkMessagesAsRead);
+  const theme = useSelector(state => getGlobalSettings(state).theme);
+  const browser = useSelector(state => getGlobalSettings(state).browser);
+  const doNotMarkMessagesAsRead = useSelector(
+    state => getGlobalSettings(state).doNotMarkMessagesAsRead,
+  );
   const dispatch = useDispatch();
 
   const handleThemeChange = useCallback(() => {

--- a/src/start/IosCompliantAppleAuthButton/index.js
+++ b/src/start/IosCompliantAppleAuthButton/index.js
@@ -8,7 +8,7 @@ import { useSelector } from '../../react-redux';
 
 import type { SubsetProperties } from '../../generics';
 import Custom from './Custom';
-import { getSettings } from '../../selectors';
+import { getGlobalSettings } from '../../selectors';
 
 type Props = $ReadOnly<{|
   // See `ZulipButton`'s `style` prop, where a comment discusses this
@@ -35,7 +35,7 @@ type Props = $ReadOnly<{|
  */
 export default function IosCompliantAppleAuthButton(props: Props): Node {
   const { style, onPress } = props;
-  const theme = useSelector(state => getSettings(state).theme);
+  const theme = useSelector(state => getGlobalSettings(state).theme);
   const [isNativeButtonAvailable, setIsNativeButtonAvailable] = useState<boolean | void>(undefined);
 
   useEffect(() => {

--- a/src/users/userSelectors.js
+++ b/src/users/userSelectors.js
@@ -3,7 +3,7 @@ import { createSelector } from 'reselect';
 
 import type { GlobalState, PerAccountState, UserOrBot, Selector, User, UserId } from '../types';
 import { getUsers, getCrossRealmBots, getNonActiveUsers } from '../directSelectors';
-import { tryGetThisAuth, tryGetActiveAccountState } from '../account/accountsSelectors';
+import { tryGetAuth, tryGetActiveAccountState } from '../account/accountsSelectors';
 
 /**
  * All users in this Zulip org (aka realm).
@@ -262,7 +262,7 @@ export const getHaveServerData = (globalState: GlobalState): boolean => {
 
   // Similarly, any valid server data comes from the active account being
   // logged in.
-  if (!tryGetThisAuth(state)) {
+  if (!tryGetAuth(state)) {
     // From `accountsReducer`:
     //  * This condition is resolved by LOGIN_SUCCESS.
     //  * It's created only by ACCOUNT_REMOVE, by LOGOUT, and by (a

--- a/src/utils/openLink.js
+++ b/src/utils/openLink.js
@@ -2,7 +2,7 @@
 import { NativeModules, Platform, Linking } from 'react-native';
 import * as WebBrowser from 'expo-web-browser';
 
-import type { BrowserPreference, SettingsState } from '../types';
+import type { BrowserPreference, GlobalSettingsState } from '../types';
 
 /** Open a URL in the in-app browser. */
 export function openLinkEmbedded(url: string): void {
@@ -27,7 +27,7 @@ export function shouldUseInAppBrowser(browser: BrowserPreference): boolean {
 }
 
 /** Open a URL using whichever browser the user has configured in the Zulip settings. */
-export function openLinkWithUserPreference(url: string, settings: SettingsState): void {
+export function openLinkWithUserPreference(url: string, settings: GlobalSettingsState): void {
   if (shouldUseInAppBrowser(settings.browser)) {
     openLinkEmbedded(url);
   } else {

--- a/src/webview/MessageList.js
+++ b/src/webview/MessageList.js
@@ -40,7 +40,7 @@ import {
   getMute,
   getMutedUsers,
   getOwnUser,
-  getSettings,
+  getGlobalSettings,
   getSubscriptions,
   getStreamsById,
   getStreamsByName,
@@ -344,7 +344,7 @@ const MessageList: ComponentType<OuterProps> = connect<SelectorProps, _, _>(
       auth: getAuth(state),
       debug: getDebug(state),
       doNotMarkMessagesAsRead:
-        !marksMessagesAsRead(props.narrow) || getSettings(state).doNotMarkMessagesAsRead,
+        !marksMessagesAsRead(props.narrow) || getGlobalSettings(state).doNotMarkMessagesAsRead,
       flags: getFlags(state),
       mute: getMute(state),
       mutedUsers: getMutedUsers(state),
@@ -353,7 +353,7 @@ const MessageList: ComponentType<OuterProps> = connect<SelectorProps, _, _>(
       streamsByName: getStreamsByName(state),
       subscriptions: getSubscriptions(state),
       unread: getUnread(state),
-      theme: getSettings(state).theme,
+      theme: getGlobalSettings(state).theme,
       twentyFourHourTime: getRealm(state).twentyFourHourTime,
     };
 


### PR DESCRIPTION
This is the next PR in the series after #5016, #5017, and #5023, produced from the branch described at [#5006 (comment)](https://github.com/zulip/zulip-mobile/issues/5006#issuecomment-924341909).

From the foreshadowing last time:

> After this PR, the conversion of `tryGetAuth` is still incomplete, so that's next up. Then we handle a few remaining selectors elsewhere, in particular those for `state.settings` and `state.session`.

That's this PR.

Next, continuing what we mentioned last time:

> After that, we'll convert thunk actions and React components so that they get a PerAccountState rather than a GlobalState.
