### PR TITLE
typeaheads:Make typeaheads more visible by changing the background color

### DIFF
--- a/src/common/Popup.js
+++ b/src/common/Popup.js
@@ -9,23 +9,27 @@ import { getGlobalSettings } from '../directSelectors';
 
 const styles = createStyleSheet({
   popup: {
+    maxHeight: 250,
     marginHorizontal: 16,
     marginVertical: 8,
     borderRadius: 5,
+    overflow: 'hidden', // Keep the overlay inside the rounded corners.
+
+    // Elevation of 8 agrees with menus and bottom sheets, which seem like
+    // the best matches in this table:
+    //   https://material.io/design/environment/elevation.html#default-elevations
+    elevation: 8,
+    // TODO(material): Is this the right shadow for that elevation?
     shadowOpacity: 0.5,
     shadowRadius: 16,
-    elevation: 8,
-    maxHeight: 250,
-    overflow: 'hidden',
   },
 
+  // In a dark theme, we signal elevation by overlaying the background with
+  // white at low opacity, following the Material spec:
+  //   https://material.io/design/color/dark-theme.html#properties
+  // (In a light theme, the shadow does that job.)
   overlay: {
-    /*
-     * Adding background color white with 12% overlay as specified in Material.io
-     * Reference https://material.io/design/color/dark-theme.html#properties.
-     * For more information
-     */
-    backgroundColor: 'hsla(0,0%,100%, 0.12)',
+    backgroundColor: 'hsla(0, 0%, 100%, 0.12)', // elevation 8 -> alpha 0.12
   },
 });
 
@@ -33,13 +37,19 @@ type Props = $ReadOnly<{|
   children: Node,
 |}>;
 
+/**
+ * An elevated surface, good for autocomplete popups.
+ *
+ * If using this for something else, consider parametrizing its height, or
+ * other constants in its styles.
+ */
 export default function Popup(props: Props): Node {
   const themeContext = useContext(ThemeContext);
-  // Getting the active theme to set, the overlay only to the night mode.
-  const theme = useSelector(state => getGlobalSettings(state).theme);
+  // TODO(color/theme): find a cleaner way to express this
+  const isDarkTheme = useSelector(state => getGlobalSettings(state).theme !== 'default');
   return (
     <View style={[{ backgroundColor: themeContext.backgroundColor }, styles.popup]}>
-      <View style={theme !== 'default' && styles.overlay}>{props.children}</View>
+      <View style={isDarkTheme && styles.overlay}>{props.children}</View>
     </View>
   );
 }


### PR DESCRIPTION
Makes typeahead boxes more visible
Screenshots:
![darkmode](https://user-images.githubusercontent.com/38510556/137014851-2ec7b69d-a172-4858-ae74-045b88a62522.jpeg)
![lightmode](https://user-images.githubusercontent.com/38510556/137014894-e8e8f0a4-86ea-44e9-a8ff-cdd54e490f84.jpeg)

Fixes: #5018

