### PR TITLE
types [nfc]: Remove some redundant read-only-property annotations.

### DIFF
--- a/src/api/transportTypes.js
+++ b/src/api/transportTypes.js
@@ -31,8 +31,8 @@ export type Auth = $ReadOnly<{|
  *  * {@link ApiResponseErrorData}
  */
 export type ApiResponse = $ReadOnly<{
-  +result: string,
-  +msg: string,
+  result: string,
+  msg: string,
   ...
 }>;
 
@@ -46,8 +46,8 @@ export type ApiResponse = $ReadOnly<{
  *  * {@link ApiResponseErrorData}
  */
 export type ApiResponseSuccess = $ReadOnly<{
-  +result: 'success',
-  +msg: '',
+  result: 'success',
+  msg: '',
   ...
 }>;
 
@@ -93,8 +93,8 @@ export type ApiErrorCode = string;
  * This type is not exact: some error responses may contain additional data.
  */
 export type ApiResponseErrorData = $ReadOnly<{
-  +code: ApiErrorCode,
-  +msg: string,
-  +result: 'error',
+  code: ApiErrorCode,
+  msg: string,
+  result: 'error',
   ...
 }>;

--- a/src/common/Screen.js
+++ b/src/common/Screen.js
@@ -36,7 +36,7 @@ const componentStyles = createStyleSheet({
 
 type Props = $ReadOnly<{|
   centerContent?: boolean,
-  +children: Node,
+  children: Node,
   keyboardShouldPersistTaps?: 'never' | 'always' | 'handled',
   padding?: boolean,
   scrollEnabled?: boolean,
@@ -49,7 +49,7 @@ type Props = $ReadOnly<{|
   shouldShowLoadingBanner?: boolean,
 
   canGoBack?: boolean,
-  +title?: LocalizableText,
+  title?: LocalizableText,
 |}>;
 
 /**


### PR DESCRIPTION
Each of these `+` marks means the property is read-only:
  https://flow.org/en/docs/types/interfaces/#toc-interface-property-variance-read-only-and-write-only

In each case that's the behavior we want.  But in each case we
already have a `$ReadOnly<…>` around the whole object type, which
applies a `+` to each property:
  https://flow.org/en/docs/types/utilities/#toc-readonly

So putting `+` on an individual property is redundant.  Take it out,
to avoid confusing people reading the codebase and trying to
understand what the various type annotations mean:
  https://github.com/zulip/zulip-mobile/pull/5039#discussion_r724636461

(In each of these cases, we added the `+` marks at a time when there
wasn't a `$ReadOnly` there, and then added the latter as part of a
broad automated refactoring.)