### PR TITLE
msglist-diffing: Add and use new '.msglist-element' class in WebView HTML

### DIFF
--- a/src/webview/html/__tests__/__snapshots__/messageListElementHtml-test.js.snap.android
+++ b/src/webview/html/__tests__/__snapshots__/messageListElementHtml-test.js.snap.android
@@ -2,13 +2,13 @@
 
 exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_NARROW 1`] = `
 "
-  <div class=\\"timerow\\" data-msg-id=\\"1024\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"1024\\">
     <div class=\\"timerow-left\\"></div>
     Feb 5, 1995
     <div class=\\"timerow-right\\"></div>
   </div>
 
-<div class=\\"header-wrapper header stream-header topic-header\\"
+<div class=\\"msglist-element header-wrapper header stream-header topic-header\\"
     data-msg-id=\\"1024\\"
     data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAx\\">
   <div class=\\"header stream-text\\"
@@ -23,7 +23,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
     
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-1024\\"
      data-msg-id=\\"1024\\"
      data-mute-state=\\"shown\\"
@@ -53,7 +53,7 @@ This is an example stream message.
 
 
     <div
-     class=\\"message message-brief\\"
+     class=\\"msglist-element message message-brief\\"
      id=\\"msg-1598\\"
      data-msg-id=\\"1598\\"
      data-mute-state=\\"shown\\"
@@ -80,13 +80,13 @@ This is an example stream message.
 
 exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_NARROW 2`] = `
 "
-  <div class=\\"timerow\\" data-msg-id=\\"7938\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"7938\\">
     <div class=\\"timerow-left\\"></div>
     Mar 5, 1995
     <div class=\\"timerow-right\\"></div>
   </div>
 
-<div class=\\"header-wrapper header stream-header topic-header\\"
+<div class=\\"msglist-element header-wrapper header stream-header topic-header\\"
     data-msg-id=\\"7938\\"
     data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAx\\">
   <div class=\\"header stream-text\\"
@@ -101,7 +101,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
     
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-7938\\"
      data-msg-id=\\"7938\\"
      data-mute-state=\\"shown\\"
@@ -131,7 +131,7 @@ This is an example stream message.
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-8060\\"
      data-msg-id=\\"8060\\"
      data-mute-state=\\"shown\\"
@@ -163,13 +163,13 @@ This is an example stream message.
 
 exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_NARROW 3`] = `
 "
-  <div class=\\"timerow\\" data-msg-id=\\"4948\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"4948\\">
     <div class=\\"timerow-left\\"></div>
     Feb 19, 1995
     <div class=\\"timerow-right\\"></div>
   </div>
 
-<div class=\\"header-wrapper header stream-header topic-header\\"
+<div class=\\"msglist-element header-wrapper header stream-header topic-header\\"
     data-msg-id=\\"4948\\"
     data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAx\\">
   <div class=\\"header stream-text\\"
@@ -184,7 +184,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
     
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-4948\\"
      data-msg-id=\\"4948\\"
      data-mute-state=\\"shown\\"
@@ -212,7 +212,7 @@ This is an example stream message.
   
 </div>
 
-<div class=\\"header-wrapper header stream-header topic-header\\"
+<div class=\\"msglist-element header-wrapper header stream-header topic-header\\"
     data-msg-id=\\"5083\\"
     data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAy\\">
   <div class=\\"header stream-text\\"
@@ -227,7 +227,7 @@ This is an example stream message.
     
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-5083\\"
      data-msg-id=\\"5083\\"
      data-mute-state=\\"shown\\"
@@ -259,13 +259,13 @@ This is an example stream message.
 
 exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_NARROW 4`] = `
 "
-  <div class=\\"timerow\\" data-msg-id=\\"6789\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"6789\\">
     <div class=\\"timerow-left\\"></div>
     Mar 5, 1995
     <div class=\\"timerow-right\\"></div>
   </div>
 
-<div class=\\"header-wrapper header stream-header topic-header\\"
+<div class=\\"msglist-element header-wrapper header stream-header topic-header\\"
     data-msg-id=\\"6789\\"
     data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAx\\">
   <div class=\\"header stream-text\\"
@@ -280,7 +280,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
     
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-6789\\"
      data-msg-id=\\"6789\\"
      data-mute-state=\\"shown\\"
@@ -308,7 +308,7 @@ This is an example stream message.
   
 </div>
 
-<div class=\\"header-wrapper header stream-header topic-header\\"
+<div class=\\"msglist-element header-wrapper header stream-header topic-header\\"
     data-msg-id=\\"7727\\"
     data-narrow=\\"dG9waWM6czpzdHJlYW0gMgB0b3BpYyAy\\">
   <div class=\\"header stream-text\\"
@@ -323,7 +323,7 @@ This is an example stream message.
     
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-7727\\"
      data-msg-id=\\"7727\\"
      data-mute-state=\\"shown\\"
@@ -355,13 +355,13 @@ This is an example stream message.
 
 exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_NARROW 5`] = `
 "
-  <div class=\\"timerow\\" data-msg-id=\\"9181\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"9181\\">
     <div class=\\"timerow-left\\"></div>
     Mar 5, 1995
     <div class=\\"timerow-right\\"></div>
   </div>
 
-<div class=\\"header-wrapper header stream-header topic-header\\"
+<div class=\\"msglist-element header-wrapper header stream-header topic-header\\"
     data-msg-id=\\"9181\\"
     data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAx\\">
   <div class=\\"header stream-text\\"
@@ -376,7 +376,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
     
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-9181\\"
      data-msg-id=\\"9181\\"
      data-mute-state=\\"shown\\"
@@ -404,7 +404,7 @@ This is an example stream message.
   
 </div>
 
-  <div class=\\"timerow\\" data-msg-id=\\"9815\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"9815\\">
     <div class=\\"timerow-left\\"></div>
     Mar 12, 1995
     <div class=\\"timerow-right\\"></div>
@@ -412,7 +412,7 @@ This is an example stream message.
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-9815\\"
      data-msg-id=\\"9815\\"
      data-mute-state=\\"shown\\"
@@ -444,13 +444,13 @@ This is an example stream message.
 
 exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_NARROW 6`] = `
 "
-  <div class=\\"timerow\\" data-msg-id=\\"8849\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"8849\\">
     <div class=\\"timerow-left\\"></div>
     Mar 5, 1995
     <div class=\\"timerow-right\\"></div>
   </div>
 
-<div class=\\"header-wrapper private-header header\\"
+<div class=\\"msglist-element header-wrapper private-header header\\"
      data-narrow=\\"cG06MSwy\\"
      data-msg-id=\\"8849\\">
   Nonrandom name one User, Nonrandom name two User
@@ -458,7 +458,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-8849\\"
      data-msg-id=\\"8849\\"
      data-mute-state=\\"shown\\"
@@ -488,7 +488,7 @@ This is an example PM message.
 
 
     <div
-     class=\\"message message-brief\\"
+     class=\\"msglist-element message message-brief\\"
      id=\\"msg-8917\\"
      data-msg-id=\\"8917\\"
      data-mute-state=\\"shown\\"
@@ -515,13 +515,13 @@ This is an example PM message.
 
 exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_NARROW 7`] = `
 "
-  <div class=\\"timerow\\" data-msg-id=\\"5287\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"5287\\">
     <div class=\\"timerow-left\\"></div>
     Feb 19, 1995
     <div class=\\"timerow-right\\"></div>
   </div>
 
-<div class=\\"header-wrapper private-header header\\"
+<div class=\\"msglist-element header-wrapper private-header header\\"
      data-narrow=\\"cG06MSwy\\"
      data-msg-id=\\"5287\\">
   Nonrandom name one User, Nonrandom name two User
@@ -529,7 +529,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-5287\\"
      data-msg-id=\\"5287\\"
      data-mute-state=\\"shown\\"
@@ -559,7 +559,7 @@ This is an example PM message.
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-5309\\"
      data-msg-id=\\"5309\\"
      data-mute-state=\\"shown\\"
@@ -591,13 +591,13 @@ This is an example PM message.
 
 exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_NARROW 8`] = `
 "
-  <div class=\\"timerow\\" data-msg-id=\\"5829\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"5829\\">
     <div class=\\"timerow-left\\"></div>
     Feb 19, 1995
     <div class=\\"timerow-right\\"></div>
   </div>
 
-<div class=\\"header-wrapper private-header header\\"
+<div class=\\"msglist-element header-wrapper private-header header\\"
      data-narrow=\\"cG06MSwy\\"
      data-msg-id=\\"5829\\">
   Nonrandom name one User, Nonrandom name two User
@@ -605,7 +605,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-5829\\"
      data-msg-id=\\"5829\\"
      data-mute-state=\\"shown\\"
@@ -633,7 +633,7 @@ This is an example PM message.
   
 </div>
 
-  <div class=\\"timerow\\" data-msg-id=\\"5963\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"5963\\">
     <div class=\\"timerow-left\\"></div>
     Feb 26, 1995
     <div class=\\"timerow-right\\"></div>
@@ -641,7 +641,7 @@ This is an example PM message.
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-5963\\"
      data-msg-id=\\"5963\\"
      data-mute-state=\\"shown\\"
@@ -673,13 +673,13 @@ This is an example PM message.
 
 exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_NARROW 9`] = `
 "
-  <div class=\\"timerow\\" data-msg-id=\\"5377\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"5377\\">
     <div class=\\"timerow-left\\"></div>
     Feb 19, 1995
     <div class=\\"timerow-right\\"></div>
   </div>
 
-<div class=\\"header-wrapper private-header header\\"
+<div class=\\"msglist-element header-wrapper private-header header\\"
      data-narrow=\\"cG06MSwyLDM=\\"
      data-msg-id=\\"5377\\">
   Nonrandom name one User, Nonrandom name three User, Nonrandom name two User
@@ -687,7 +687,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-5377\\"
      data-msg-id=\\"5377\\"
      data-mute-state=\\"shown\\"
@@ -717,7 +717,7 @@ This is an example PM message.
 
 
     <div
-     class=\\"message message-brief\\"
+     class=\\"msglist-element message message-brief\\"
      id=\\"msg-5620\\"
      data-msg-id=\\"5620\\"
      data-mute-state=\\"shown\\"
@@ -744,13 +744,13 @@ This is an example PM message.
 
 exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_NARROW 10`] = `
 "
-  <div class=\\"timerow\\" data-msg-id=\\"5637\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"5637\\">
     <div class=\\"timerow-left\\"></div>
     Feb 19, 1995
     <div class=\\"timerow-right\\"></div>
   </div>
 
-<div class=\\"header-wrapper private-header header\\"
+<div class=\\"msglist-element header-wrapper private-header header\\"
      data-narrow=\\"cG06MSwyLDM=\\"
      data-msg-id=\\"5637\\">
   Nonrandom name one User, Nonrandom name three User, Nonrandom name two User
@@ -758,7 +758,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-5637\\"
      data-msg-id=\\"5637\\"
      data-mute-state=\\"shown\\"
@@ -788,7 +788,7 @@ This is an example PM message.
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-5727\\"
      data-msg-id=\\"5727\\"
      data-mute-state=\\"shown\\"
@@ -820,13 +820,13 @@ This is an example PM message.
 
 exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_NARROW 11`] = `
 "
-  <div class=\\"timerow\\" data-msg-id=\\"2794\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"2794\\">
     <div class=\\"timerow-left\\"></div>
     Feb 5, 1995
     <div class=\\"timerow-right\\"></div>
   </div>
 
-<div class=\\"header-wrapper private-header header\\"
+<div class=\\"msglist-element header-wrapper private-header header\\"
      data-narrow=\\"cG06MSwyLDM=\\"
      data-msg-id=\\"2794\\">
   Nonrandom name one User, Nonrandom name three User, Nonrandom name two User
@@ -834,7 +834,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-2794\\"
      data-msg-id=\\"2794\\"
      data-mute-state=\\"shown\\"
@@ -862,7 +862,7 @@ This is an example PM message.
   
 </div>
 
-  <div class=\\"timerow\\" data-msg-id=\\"4581\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"4581\\">
     <div class=\\"timerow-left\\"></div>
     Feb 12, 1995
     <div class=\\"timerow-right\\"></div>
@@ -870,7 +870,7 @@ This is an example PM message.
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-4581\\"
      data-msg-id=\\"4581\\"
      data-mute-state=\\"shown\\"
@@ -902,13 +902,13 @@ This is an example PM message.
 
 exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_NARROW 12`] = `
 "
-  <div class=\\"timerow\\" data-msg-id=\\"1024\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"1024\\">
     <div class=\\"timerow-left\\"></div>
     Feb 5, 1995
     <div class=\\"timerow-right\\"></div>
   </div>
 
-<div class=\\"header-wrapper header stream-header topic-header\\"
+<div class=\\"msglist-element header-wrapper header stream-header topic-header\\"
     data-msg-id=\\"1024\\"
     data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAx\\">
   <div class=\\"header stream-text\\"
@@ -923,7 +923,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
     
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-1024\\"
      data-msg-id=\\"1024\\"
      data-mute-state=\\"shown\\"
@@ -953,7 +953,7 @@ This is an example stream message.
 
 
     <div
-     class=\\"message message-brief\\"
+     class=\\"msglist-element message message-brief\\"
      id=\\"msg-1598\\"
      data-msg-id=\\"1598\\"
      data-mute-state=\\"shown\\"
@@ -976,7 +976,7 @@ This is an example stream message.
   </div>
 </div>
 
-<div class=\\"header-wrapper private-header header\\"
+<div class=\\"msglist-element header-wrapper private-header header\\"
      data-narrow=\\"cG06MSwyLDM=\\"
      data-msg-id=\\"2794\\">
   Nonrandom name one User, Nonrandom name three User, Nonrandom name two User
@@ -984,7 +984,7 @@ This is an example stream message.
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-2794\\"
      data-msg-id=\\"2794\\"
      data-mute-state=\\"shown\\"
@@ -1012,7 +1012,7 @@ This is an example PM message.
   
 </div>
 
-  <div class=\\"timerow\\" data-msg-id=\\"4581\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"4581\\">
     <div class=\\"timerow-left\\"></div>
     Feb 12, 1995
     <div class=\\"timerow-right\\"></div>
@@ -1020,7 +1020,7 @@ This is an example PM message.
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-4581\\"
      data-msg-id=\\"4581\\"
      data-mute-state=\\"shown\\"
@@ -1048,13 +1048,13 @@ This is an example PM message.
   
 </div>
 
-  <div class=\\"timerow\\" data-msg-id=\\"4948\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"4948\\">
     <div class=\\"timerow-left\\"></div>
     Feb 19, 1995
     <div class=\\"timerow-right\\"></div>
   </div>
 
-<div class=\\"header-wrapper header stream-header topic-header\\"
+<div class=\\"msglist-element header-wrapper header stream-header topic-header\\"
     data-msg-id=\\"4948\\"
     data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAx\\">
   <div class=\\"header stream-text\\"
@@ -1069,7 +1069,7 @@ This is an example PM message.
     
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-4948\\"
      data-msg-id=\\"4948\\"
      data-mute-state=\\"shown\\"
@@ -1097,7 +1097,7 @@ This is an example stream message.
   
 </div>
 
-<div class=\\"header-wrapper header stream-header topic-header\\"
+<div class=\\"msglist-element header-wrapper header stream-header topic-header\\"
     data-msg-id=\\"5083\\"
     data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAy\\">
   <div class=\\"header stream-text\\"
@@ -1112,7 +1112,7 @@ This is an example stream message.
     
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-5083\\"
      data-msg-id=\\"5083\\"
      data-mute-state=\\"shown\\"
@@ -1140,7 +1140,7 @@ This is an example stream message.
   
 </div>
 
-<div class=\\"header-wrapper private-header header\\"
+<div class=\\"msglist-element header-wrapper private-header header\\"
      data-narrow=\\"cG06MSwy\\"
      data-msg-id=\\"5287\\">
   Nonrandom name one User, Nonrandom name two User
@@ -1148,7 +1148,7 @@ This is an example stream message.
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-5287\\"
      data-msg-id=\\"5287\\"
      data-mute-state=\\"shown\\"
@@ -1178,7 +1178,7 @@ This is an example PM message.
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-5309\\"
      data-msg-id=\\"5309\\"
      data-mute-state=\\"shown\\"
@@ -1206,7 +1206,7 @@ This is an example PM message.
   
 </div>
 
-<div class=\\"header-wrapper private-header header\\"
+<div class=\\"msglist-element header-wrapper private-header header\\"
      data-narrow=\\"cG06MSwyLDM=\\"
      data-msg-id=\\"5377\\">
   Nonrandom name one User, Nonrandom name three User, Nonrandom name two User
@@ -1214,7 +1214,7 @@ This is an example PM message.
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-5377\\"
      data-msg-id=\\"5377\\"
      data-mute-state=\\"shown\\"
@@ -1244,7 +1244,7 @@ This is an example PM message.
 
 
     <div
-     class=\\"message message-brief\\"
+     class=\\"msglist-element message message-brief\\"
      id=\\"msg-5620\\"
      data-msg-id=\\"5620\\"
      data-mute-state=\\"shown\\"
@@ -1269,7 +1269,7 @@ This is an example PM message.
 
 
     <div
-     class=\\"message message-brief\\"
+     class=\\"msglist-element message message-brief\\"
      id=\\"msg-5637\\"
      data-msg-id=\\"5637\\"
      data-mute-state=\\"shown\\"
@@ -1294,7 +1294,7 @@ This is an example PM message.
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-5727\\"
      data-msg-id=\\"5727\\"
      data-mute-state=\\"shown\\"
@@ -1322,7 +1322,7 @@ This is an example PM message.
   
 </div>
 
-<div class=\\"header-wrapper private-header header\\"
+<div class=\\"msglist-element header-wrapper private-header header\\"
      data-narrow=\\"cG06MSwy\\"
      data-msg-id=\\"5829\\">
   Nonrandom name one User, Nonrandom name two User
@@ -1330,7 +1330,7 @@ This is an example PM message.
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-5829\\"
      data-msg-id=\\"5829\\"
      data-mute-state=\\"shown\\"
@@ -1358,7 +1358,7 @@ This is an example PM message.
   
 </div>
 
-  <div class=\\"timerow\\" data-msg-id=\\"5963\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"5963\\">
     <div class=\\"timerow-left\\"></div>
     Feb 26, 1995
     <div class=\\"timerow-right\\"></div>
@@ -1366,7 +1366,7 @@ This is an example PM message.
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-5963\\"
      data-msg-id=\\"5963\\"
      data-mute-state=\\"shown\\"
@@ -1394,13 +1394,13 @@ This is an example PM message.
   
 </div>
 
-  <div class=\\"timerow\\" data-msg-id=\\"6789\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"6789\\">
     <div class=\\"timerow-left\\"></div>
     Mar 5, 1995
     <div class=\\"timerow-right\\"></div>
   </div>
 
-<div class=\\"header-wrapper header stream-header topic-header\\"
+<div class=\\"msglist-element header-wrapper header stream-header topic-header\\"
     data-msg-id=\\"6789\\"
     data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAx\\">
   <div class=\\"header stream-text\\"
@@ -1415,7 +1415,7 @@ This is an example PM message.
     
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-6789\\"
      data-msg-id=\\"6789\\"
      data-mute-state=\\"shown\\"
@@ -1443,7 +1443,7 @@ This is an example stream message.
   
 </div>
 
-<div class=\\"header-wrapper header stream-header topic-header\\"
+<div class=\\"msglist-element header-wrapper header stream-header topic-header\\"
     data-msg-id=\\"7727\\"
     data-narrow=\\"dG9waWM6czpzdHJlYW0gMgB0b3BpYyAy\\">
   <div class=\\"header stream-text\\"
@@ -1458,7 +1458,7 @@ This is an example stream message.
     
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-7727\\"
      data-msg-id=\\"7727\\"
      data-mute-state=\\"shown\\"
@@ -1486,7 +1486,7 @@ This is an example stream message.
   
 </div>
 
-<div class=\\"header-wrapper header stream-header topic-header\\"
+<div class=\\"msglist-element header-wrapper header stream-header topic-header\\"
     data-msg-id=\\"7938\\"
     data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAx\\">
   <div class=\\"header stream-text\\"
@@ -1501,7 +1501,7 @@ This is an example stream message.
     
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-7938\\"
      data-msg-id=\\"7938\\"
      data-mute-state=\\"shown\\"
@@ -1531,7 +1531,7 @@ This is an example stream message.
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-8060\\"
      data-msg-id=\\"8060\\"
      data-mute-state=\\"shown\\"
@@ -1559,7 +1559,7 @@ This is an example stream message.
   
 </div>
 
-<div class=\\"header-wrapper private-header header\\"
+<div class=\\"msglist-element header-wrapper private-header header\\"
      data-narrow=\\"cG06MSwy\\"
      data-msg-id=\\"8849\\">
   Nonrandom name one User, Nonrandom name two User
@@ -1567,7 +1567,7 @@ This is an example stream message.
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-8849\\"
      data-msg-id=\\"8849\\"
      data-mute-state=\\"shown\\"
@@ -1597,7 +1597,7 @@ This is an example PM message.
 
 
     <div
-     class=\\"message message-brief\\"
+     class=\\"msglist-element message message-brief\\"
      id=\\"msg-8917\\"
      data-msg-id=\\"8917\\"
      data-mute-state=\\"shown\\"
@@ -1620,7 +1620,7 @@ This is an example PM message.
   </div>
 </div>
 
-<div class=\\"header-wrapper header stream-header topic-header\\"
+<div class=\\"msglist-element header-wrapper header stream-header topic-header\\"
     data-msg-id=\\"9181\\"
     data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAx\\">
   <div class=\\"header stream-text\\"
@@ -1635,7 +1635,7 @@ This is an example PM message.
     
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-9181\\"
      data-msg-id=\\"9181\\"
      data-mute-state=\\"shown\\"
@@ -1663,7 +1663,7 @@ This is an example stream message.
   
 </div>
 
-  <div class=\\"timerow\\" data-msg-id=\\"9815\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"9815\\">
     <div class=\\"timerow-left\\"></div>
     Mar 12, 1995
     <div class=\\"timerow-right\\"></div>
@@ -1671,7 +1671,7 @@ This is an example stream message.
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-9815\\"
      data-msg-id=\\"9815\\"
      data-mute-state=\\"shown\\"
@@ -1703,13 +1703,13 @@ This is an example stream message.
 
 exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm 1`] = `
 "
-  <div class=\\"timerow\\" data-msg-id=\\"8849\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"8849\\">
     <div class=\\"timerow-left\\"></div>
     Mar 5, 1995
     <div class=\\"timerow-right\\"></div>
   </div>
 
-<div class=\\"header-wrapper private-header header\\"
+<div class=\\"msglist-element header-wrapper private-header header\\"
      data-narrow=\\"cG06MSwy\\"
      data-msg-id=\\"8849\\">
   Nonrandom name one User, Nonrandom name two User
@@ -1717,7 +1717,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-8849\\"
      data-msg-id=\\"8849\\"
      data-mute-state=\\"shown\\"
@@ -1747,7 +1747,7 @@ This is an example PM message.
 
 
     <div
-     class=\\"message message-brief\\"
+     class=\\"msglist-element message message-brief\\"
      id=\\"msg-8917\\"
      data-msg-id=\\"8917\\"
      data-mute-state=\\"shown\\"
@@ -1774,13 +1774,13 @@ This is an example PM message.
 
 exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm 2`] = `
 "
-  <div class=\\"timerow\\" data-msg-id=\\"5287\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"5287\\">
     <div class=\\"timerow-left\\"></div>
     Feb 19, 1995
     <div class=\\"timerow-right\\"></div>
   </div>
 
-<div class=\\"header-wrapper private-header header\\"
+<div class=\\"msglist-element header-wrapper private-header header\\"
      data-narrow=\\"cG06MSwy\\"
      data-msg-id=\\"5287\\">
   Nonrandom name one User, Nonrandom name two User
@@ -1788,7 +1788,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-5287\\"
      data-msg-id=\\"5287\\"
      data-mute-state=\\"shown\\"
@@ -1818,7 +1818,7 @@ This is an example PM message.
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-5309\\"
      data-msg-id=\\"5309\\"
      data-mute-state=\\"shown\\"
@@ -1850,13 +1850,13 @@ This is an example PM message.
 
 exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm 3`] = `
 "
-  <div class=\\"timerow\\" data-msg-id=\\"5829\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"5829\\">
     <div class=\\"timerow-left\\"></div>
     Feb 19, 1995
     <div class=\\"timerow-right\\"></div>
   </div>
 
-<div class=\\"header-wrapper private-header header\\"
+<div class=\\"msglist-element header-wrapper private-header header\\"
      data-narrow=\\"cG06MSwy\\"
      data-msg-id=\\"5829\\">
   Nonrandom name one User, Nonrandom name two User
@@ -1864,7 +1864,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-5829\\"
      data-msg-id=\\"5829\\"
      data-mute-state=\\"shown\\"
@@ -1892,7 +1892,7 @@ This is an example PM message.
   
 </div>
 
-  <div class=\\"timerow\\" data-msg-id=\\"5963\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"5963\\">
     <div class=\\"timerow-left\\"></div>
     Feb 26, 1995
     <div class=\\"timerow-right\\"></div>
@@ -1900,7 +1900,7 @@ This is an example PM message.
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-5963\\"
      data-msg-id=\\"5963\\"
      data-mute-state=\\"shown\\"
@@ -1932,13 +1932,13 @@ This is an example PM message.
 
 exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm 4`] = `
 "
-  <div class=\\"timerow\\" data-msg-id=\\"5377\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"5377\\">
     <div class=\\"timerow-left\\"></div>
     Feb 19, 1995
     <div class=\\"timerow-right\\"></div>
   </div>
 
-<div class=\\"header-wrapper private-header header\\"
+<div class=\\"msglist-element header-wrapper private-header header\\"
      data-narrow=\\"cG06MSwyLDM=\\"
      data-msg-id=\\"5377\\">
   Nonrandom name one User, Nonrandom name three User, Nonrandom name two User
@@ -1946,7 +1946,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-5377\\"
      data-msg-id=\\"5377\\"
      data-mute-state=\\"shown\\"
@@ -1976,7 +1976,7 @@ This is an example PM message.
 
 
     <div
-     class=\\"message message-brief\\"
+     class=\\"msglist-element message message-brief\\"
      id=\\"msg-5620\\"
      data-msg-id=\\"5620\\"
      data-mute-state=\\"shown\\"
@@ -2003,13 +2003,13 @@ This is an example PM message.
 
 exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm 5`] = `
 "
-  <div class=\\"timerow\\" data-msg-id=\\"5637\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"5637\\">
     <div class=\\"timerow-left\\"></div>
     Feb 19, 1995
     <div class=\\"timerow-right\\"></div>
   </div>
 
-<div class=\\"header-wrapper private-header header\\"
+<div class=\\"msglist-element header-wrapper private-header header\\"
      data-narrow=\\"cG06MSwyLDM=\\"
      data-msg-id=\\"5637\\">
   Nonrandom name one User, Nonrandom name three User, Nonrandom name two User
@@ -2017,7 +2017,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-5637\\"
      data-msg-id=\\"5637\\"
      data-mute-state=\\"shown\\"
@@ -2047,7 +2047,7 @@ This is an example PM message.
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-5727\\"
      data-msg-id=\\"5727\\"
      data-mute-state=\\"shown\\"
@@ -2079,13 +2079,13 @@ This is an example PM message.
 
 exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm 6`] = `
 "
-  <div class=\\"timerow\\" data-msg-id=\\"2794\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"2794\\">
     <div class=\\"timerow-left\\"></div>
     Feb 5, 1995
     <div class=\\"timerow-right\\"></div>
   </div>
 
-<div class=\\"header-wrapper private-header header\\"
+<div class=\\"msglist-element header-wrapper private-header header\\"
      data-narrow=\\"cG06MSwyLDM=\\"
      data-msg-id=\\"2794\\">
   Nonrandom name one User, Nonrandom name three User, Nonrandom name two User
@@ -2093,7 +2093,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-2794\\"
      data-msg-id=\\"2794\\"
      data-mute-state=\\"shown\\"
@@ -2121,7 +2121,7 @@ This is an example PM message.
   
 </div>
 
-  <div class=\\"timerow\\" data-msg-id=\\"4581\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"4581\\">
     <div class=\\"timerow-left\\"></div>
     Feb 12, 1995
     <div class=\\"timerow-right\\"></div>
@@ -2129,7 +2129,7 @@ This is an example PM message.
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-4581\\"
      data-msg-id=\\"4581\\"
      data-mute-state=\\"shown\\"
@@ -2161,13 +2161,13 @@ This is an example PM message.
 
 exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm 7`] = `
 "
-  <div class=\\"timerow\\" data-msg-id=\\"2794\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"2794\\">
     <div class=\\"timerow-left\\"></div>
     Feb 5, 1995
     <div class=\\"timerow-right\\"></div>
   </div>
 
-<div class=\\"header-wrapper private-header header\\"
+<div class=\\"msglist-element header-wrapper private-header header\\"
      data-narrow=\\"cG06MSwyLDM=\\"
      data-msg-id=\\"2794\\">
   Nonrandom name one User, Nonrandom name three User, Nonrandom name two User
@@ -2175,7 +2175,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-2794\\"
      data-msg-id=\\"2794\\"
      data-mute-state=\\"shown\\"
@@ -2203,7 +2203,7 @@ This is an example PM message.
   
 </div>
 
-  <div class=\\"timerow\\" data-msg-id=\\"4581\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"4581\\">
     <div class=\\"timerow-left\\"></div>
     Feb 12, 1995
     <div class=\\"timerow-right\\"></div>
@@ -2211,7 +2211,7 @@ This is an example PM message.
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-4581\\"
      data-msg-id=\\"4581\\"
      data-mute-state=\\"shown\\"
@@ -2239,13 +2239,13 @@ This is an example PM message.
   
 </div>
 
-  <div class=\\"timerow\\" data-msg-id=\\"5287\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"5287\\">
     <div class=\\"timerow-left\\"></div>
     Feb 19, 1995
     <div class=\\"timerow-right\\"></div>
   </div>
 
-<div class=\\"header-wrapper private-header header\\"
+<div class=\\"msglist-element header-wrapper private-header header\\"
      data-narrow=\\"cG06MSwy\\"
      data-msg-id=\\"5287\\">
   Nonrandom name one User, Nonrandom name two User
@@ -2253,7 +2253,7 @@ This is an example PM message.
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-5287\\"
      data-msg-id=\\"5287\\"
      data-mute-state=\\"shown\\"
@@ -2283,7 +2283,7 @@ This is an example PM message.
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-5309\\"
      data-msg-id=\\"5309\\"
      data-mute-state=\\"shown\\"
@@ -2311,7 +2311,7 @@ This is an example PM message.
   
 </div>
 
-<div class=\\"header-wrapper private-header header\\"
+<div class=\\"msglist-element header-wrapper private-header header\\"
      data-narrow=\\"cG06MSwyLDM=\\"
      data-msg-id=\\"5377\\">
   Nonrandom name one User, Nonrandom name three User, Nonrandom name two User
@@ -2319,7 +2319,7 @@ This is an example PM message.
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-5377\\"
      data-msg-id=\\"5377\\"
      data-mute-state=\\"shown\\"
@@ -2349,7 +2349,7 @@ This is an example PM message.
 
 
     <div
-     class=\\"message message-brief\\"
+     class=\\"msglist-element message message-brief\\"
      id=\\"msg-5620\\"
      data-msg-id=\\"5620\\"
      data-mute-state=\\"shown\\"
@@ -2374,7 +2374,7 @@ This is an example PM message.
 
 
     <div
-     class=\\"message message-brief\\"
+     class=\\"msglist-element message message-brief\\"
      id=\\"msg-5637\\"
      data-msg-id=\\"5637\\"
      data-mute-state=\\"shown\\"
@@ -2399,7 +2399,7 @@ This is an example PM message.
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-5727\\"
      data-msg-id=\\"5727\\"
      data-mute-state=\\"shown\\"
@@ -2427,7 +2427,7 @@ This is an example PM message.
   
 </div>
 
-<div class=\\"header-wrapper private-header header\\"
+<div class=\\"msglist-element header-wrapper private-header header\\"
      data-narrow=\\"cG06MSwy\\"
      data-msg-id=\\"5829\\">
   Nonrandom name one User, Nonrandom name two User
@@ -2435,7 +2435,7 @@ This is an example PM message.
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-5829\\"
      data-msg-id=\\"5829\\"
      data-mute-state=\\"shown\\"
@@ -2463,7 +2463,7 @@ This is an example PM message.
   
 </div>
 
-  <div class=\\"timerow\\" data-msg-id=\\"5963\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"5963\\">
     <div class=\\"timerow-left\\"></div>
     Feb 26, 1995
     <div class=\\"timerow-right\\"></div>
@@ -2471,7 +2471,7 @@ This is an example PM message.
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-5963\\"
      data-msg-id=\\"5963\\"
      data-mute-state=\\"shown\\"
@@ -2499,7 +2499,7 @@ This is an example PM message.
   
 </div>
 
-  <div class=\\"timerow\\" data-msg-id=\\"8849\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"8849\\">
     <div class=\\"timerow-left\\"></div>
     Mar 5, 1995
     <div class=\\"timerow-right\\"></div>
@@ -2507,7 +2507,7 @@ This is an example PM message.
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-8849\\"
      data-msg-id=\\"8849\\"
      data-mute-state=\\"shown\\"
@@ -2537,7 +2537,7 @@ This is an example PM message.
 
 
     <div
-     class=\\"message message-brief\\"
+     class=\\"msglist-element message message-brief\\"
      id=\\"msg-8917\\"
      data-msg-id=\\"8917\\"
      data-mute-state=\\"shown\\"
@@ -2564,7 +2564,7 @@ This is an example PM message.
 
 exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2 1`] = `
 "
-  <div class=\\"timerow\\" data-msg-id=\\"8849\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"8849\\">
     <div class=\\"timerow-left\\"></div>
     Mar 5, 1995
     <div class=\\"timerow-right\\"></div>
@@ -2572,7 +2572,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-8849\\"
      data-msg-id=\\"8849\\"
      data-mute-state=\\"shown\\"
@@ -2602,7 +2602,7 @@ This is an example PM message.
 
 
     <div
-     class=\\"message message-brief\\"
+     class=\\"msglist-element message message-brief\\"
      id=\\"msg-8917\\"
      data-msg-id=\\"8917\\"
      data-mute-state=\\"shown\\"
@@ -2629,7 +2629,7 @@ This is an example PM message.
 
 exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2 2`] = `
 "
-  <div class=\\"timerow\\" data-msg-id=\\"5287\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"5287\\">
     <div class=\\"timerow-left\\"></div>
     Feb 19, 1995
     <div class=\\"timerow-right\\"></div>
@@ -2637,7 +2637,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-5287\\"
      data-msg-id=\\"5287\\"
      data-mute-state=\\"shown\\"
@@ -2667,7 +2667,7 @@ This is an example PM message.
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-5309\\"
      data-msg-id=\\"5309\\"
      data-mute-state=\\"shown\\"
@@ -2699,7 +2699,7 @@ This is an example PM message.
 
 exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2 3`] = `
 "
-  <div class=\\"timerow\\" data-msg-id=\\"5829\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"5829\\">
     <div class=\\"timerow-left\\"></div>
     Feb 19, 1995
     <div class=\\"timerow-right\\"></div>
@@ -2707,7 +2707,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-5829\\"
      data-msg-id=\\"5829\\"
      data-mute-state=\\"shown\\"
@@ -2735,7 +2735,7 @@ This is an example PM message.
   
 </div>
 
-  <div class=\\"timerow\\" data-msg-id=\\"5963\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"5963\\">
     <div class=\\"timerow-left\\"></div>
     Feb 26, 1995
     <div class=\\"timerow-right\\"></div>
@@ -2743,7 +2743,7 @@ This is an example PM message.
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-5963\\"
      data-msg-id=\\"5963\\"
      data-mute-state=\\"shown\\"
@@ -2775,7 +2775,7 @@ This is an example PM message.
 
 exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2 4`] = `
 "
-  <div class=\\"timerow\\" data-msg-id=\\"5287\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"5287\\">
     <div class=\\"timerow-left\\"></div>
     Feb 19, 1995
     <div class=\\"timerow-right\\"></div>
@@ -2783,7 +2783,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-5287\\"
      data-msg-id=\\"5287\\"
      data-mute-state=\\"shown\\"
@@ -2813,7 +2813,7 @@ This is an example PM message.
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-5309\\"
      data-msg-id=\\"5309\\"
      data-mute-state=\\"shown\\"
@@ -2843,7 +2843,7 @@ This is an example PM message.
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-5829\\"
      data-msg-id=\\"5829\\"
      data-mute-state=\\"shown\\"
@@ -2871,7 +2871,7 @@ This is an example PM message.
   
 </div>
 
-  <div class=\\"timerow\\" data-msg-id=\\"5963\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"5963\\">
     <div class=\\"timerow-left\\"></div>
     Feb 26, 1995
     <div class=\\"timerow-right\\"></div>
@@ -2879,7 +2879,7 @@ This is an example PM message.
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-5963\\"
      data-msg-id=\\"5963\\"
      data-mute-state=\\"shown\\"
@@ -2907,7 +2907,7 @@ This is an example PM message.
   
 </div>
 
-  <div class=\\"timerow\\" data-msg-id=\\"8849\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"8849\\">
     <div class=\\"timerow-left\\"></div>
     Mar 5, 1995
     <div class=\\"timerow-right\\"></div>
@@ -2915,7 +2915,7 @@ This is an example PM message.
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-8849\\"
      data-msg-id=\\"8849\\"
      data-mute-state=\\"shown\\"
@@ -2945,7 +2945,7 @@ This is an example PM message.
 
 
     <div
-     class=\\"message message-brief\\"
+     class=\\"msglist-element message message-brief\\"
      id=\\"msg-8917\\"
      data-msg-id=\\"8917\\"
      data-mute-state=\\"shown\\"
@@ -2972,7 +2972,7 @@ This is an example PM message.
 
 exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2,3 1`] = `
 "
-  <div class=\\"timerow\\" data-msg-id=\\"5377\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"5377\\">
     <div class=\\"timerow-left\\"></div>
     Feb 19, 1995
     <div class=\\"timerow-right\\"></div>
@@ -2980,7 +2980,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-5377\\"
      data-msg-id=\\"5377\\"
      data-mute-state=\\"shown\\"
@@ -3010,7 +3010,7 @@ This is an example PM message.
 
 
     <div
-     class=\\"message message-brief\\"
+     class=\\"msglist-element message message-brief\\"
      id=\\"msg-5620\\"
      data-msg-id=\\"5620\\"
      data-mute-state=\\"shown\\"
@@ -3037,7 +3037,7 @@ This is an example PM message.
 
 exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2,3 2`] = `
 "
-  <div class=\\"timerow\\" data-msg-id=\\"5637\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"5637\\">
     <div class=\\"timerow-left\\"></div>
     Feb 19, 1995
     <div class=\\"timerow-right\\"></div>
@@ -3045,7 +3045,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-5637\\"
      data-msg-id=\\"5637\\"
      data-mute-state=\\"shown\\"
@@ -3075,7 +3075,7 @@ This is an example PM message.
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-5727\\"
      data-msg-id=\\"5727\\"
      data-mute-state=\\"shown\\"
@@ -3107,7 +3107,7 @@ This is an example PM message.
 
 exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2,3 3`] = `
 "
-  <div class=\\"timerow\\" data-msg-id=\\"2794\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"2794\\">
     <div class=\\"timerow-left\\"></div>
     Feb 5, 1995
     <div class=\\"timerow-right\\"></div>
@@ -3115,7 +3115,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-2794\\"
      data-msg-id=\\"2794\\"
      data-mute-state=\\"shown\\"
@@ -3143,7 +3143,7 @@ This is an example PM message.
   
 </div>
 
-  <div class=\\"timerow\\" data-msg-id=\\"4581\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"4581\\">
     <div class=\\"timerow-left\\"></div>
     Feb 12, 1995
     <div class=\\"timerow-right\\"></div>
@@ -3151,7 +3151,7 @@ This is an example PM message.
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-4581\\"
      data-msg-id=\\"4581\\"
      data-mute-state=\\"shown\\"
@@ -3183,7 +3183,7 @@ This is an example PM message.
 
 exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2,3 4`] = `
 "
-  <div class=\\"timerow\\" data-msg-id=\\"2794\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"2794\\">
     <div class=\\"timerow-left\\"></div>
     Feb 5, 1995
     <div class=\\"timerow-right\\"></div>
@@ -3191,7 +3191,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-2794\\"
      data-msg-id=\\"2794\\"
      data-mute-state=\\"shown\\"
@@ -3219,7 +3219,7 @@ This is an example PM message.
   
 </div>
 
-  <div class=\\"timerow\\" data-msg-id=\\"4581\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"4581\\">
     <div class=\\"timerow-left\\"></div>
     Feb 12, 1995
     <div class=\\"timerow-right\\"></div>
@@ -3227,7 +3227,7 @@ This is an example PM message.
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-4581\\"
      data-msg-id=\\"4581\\"
      data-mute-state=\\"shown\\"
@@ -3255,7 +3255,7 @@ This is an example PM message.
   
 </div>
 
-  <div class=\\"timerow\\" data-msg-id=\\"5377\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"5377\\">
     <div class=\\"timerow-left\\"></div>
     Feb 19, 1995
     <div class=\\"timerow-right\\"></div>
@@ -3263,7 +3263,7 @@ This is an example PM message.
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-5377\\"
      data-msg-id=\\"5377\\"
      data-mute-state=\\"shown\\"
@@ -3293,7 +3293,7 @@ This is an example PM message.
 
 
     <div
-     class=\\"message message-brief\\"
+     class=\\"msglist-element message message-brief\\"
      id=\\"msg-5620\\"
      data-msg-id=\\"5620\\"
      data-mute-state=\\"shown\\"
@@ -3318,7 +3318,7 @@ This is an example PM message.
 
 
     <div
-     class=\\"message message-brief\\"
+     class=\\"msglist-element message message-brief\\"
      id=\\"msg-5637\\"
      data-msg-id=\\"5637\\"
      data-mute-state=\\"shown\\"
@@ -3343,7 +3343,7 @@ This is an example PM message.
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-5727\\"
      data-msg-id=\\"5727\\"
      data-mute-state=\\"shown\\"
@@ -3375,14 +3375,14 @@ This is an example PM message.
 
 exports[`messages -> piece descriptors -> content HTML is stable/sensible stream:s:stream 1 1`] = `
 "
-  <div class=\\"timerow\\" data-msg-id=\\"1024\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"1024\\">
     <div class=\\"timerow-left\\"></div>
     Feb 5, 1995
     <div class=\\"timerow-right\\"></div>
   </div>
 
 <div
-  class=\\"header-wrapper header topic-header\\"
+  class=\\"msglist-element header-wrapper header topic-header\\"
   data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAx\\"
   data-msg-id=\\"1024\\"
 >
@@ -3392,7 +3392,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible stream
     
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-1024\\"
      data-msg-id=\\"1024\\"
      data-mute-state=\\"shown\\"
@@ -3422,7 +3422,7 @@ This is an example stream message.
 
 
     <div
-     class=\\"message message-brief\\"
+     class=\\"msglist-element message message-brief\\"
      id=\\"msg-1598\\"
      data-msg-id=\\"1598\\"
      data-mute-state=\\"shown\\"
@@ -3449,14 +3449,14 @@ This is an example stream message.
 
 exports[`messages -> piece descriptors -> content HTML is stable/sensible stream:s:stream 1 2`] = `
 "
-  <div class=\\"timerow\\" data-msg-id=\\"7938\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"7938\\">
     <div class=\\"timerow-left\\"></div>
     Mar 5, 1995
     <div class=\\"timerow-right\\"></div>
   </div>
 
 <div
-  class=\\"header-wrapper header topic-header\\"
+  class=\\"msglist-element header-wrapper header topic-header\\"
   data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAx\\"
   data-msg-id=\\"7938\\"
 >
@@ -3466,7 +3466,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible stream
     
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-7938\\"
      data-msg-id=\\"7938\\"
      data-mute-state=\\"shown\\"
@@ -3496,7 +3496,7 @@ This is an example stream message.
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-8060\\"
      data-msg-id=\\"8060\\"
      data-mute-state=\\"shown\\"
@@ -3528,14 +3528,14 @@ This is an example stream message.
 
 exports[`messages -> piece descriptors -> content HTML is stable/sensible stream:s:stream 1 3`] = `
 "
-  <div class=\\"timerow\\" data-msg-id=\\"4948\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"4948\\">
     <div class=\\"timerow-left\\"></div>
     Feb 19, 1995
     <div class=\\"timerow-right\\"></div>
   </div>
 
 <div
-  class=\\"header-wrapper header topic-header\\"
+  class=\\"msglist-element header-wrapper header topic-header\\"
   data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAx\\"
   data-msg-id=\\"4948\\"
 >
@@ -3545,7 +3545,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible stream
     
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-4948\\"
      data-msg-id=\\"4948\\"
      data-mute-state=\\"shown\\"
@@ -3574,7 +3574,7 @@ This is an example stream message.
 </div>
 
 <div
-  class=\\"header-wrapper header topic-header\\"
+  class=\\"msglist-element header-wrapper header topic-header\\"
   data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAy\\"
   data-msg-id=\\"5083\\"
 >
@@ -3584,7 +3584,7 @@ This is an example stream message.
     
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-5083\\"
      data-msg-id=\\"5083\\"
      data-mute-state=\\"shown\\"
@@ -3616,14 +3616,14 @@ This is an example stream message.
 
 exports[`messages -> piece descriptors -> content HTML is stable/sensible stream:s:stream 1 4`] = `
 "
-  <div class=\\"timerow\\" data-msg-id=\\"9181\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"9181\\">
     <div class=\\"timerow-left\\"></div>
     Mar 5, 1995
     <div class=\\"timerow-right\\"></div>
   </div>
 
 <div
-  class=\\"header-wrapper header topic-header\\"
+  class=\\"msglist-element header-wrapper header topic-header\\"
   data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAx\\"
   data-msg-id=\\"9181\\"
 >
@@ -3633,7 +3633,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible stream
     
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-9181\\"
      data-msg-id=\\"9181\\"
      data-mute-state=\\"shown\\"
@@ -3661,7 +3661,7 @@ This is an example stream message.
   
 </div>
 
-  <div class=\\"timerow\\" data-msg-id=\\"9815\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"9815\\">
     <div class=\\"timerow-left\\"></div>
     Mar 12, 1995
     <div class=\\"timerow-right\\"></div>
@@ -3669,7 +3669,7 @@ This is an example stream message.
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-9815\\"
      data-msg-id=\\"9815\\"
      data-mute-state=\\"shown\\"
@@ -3701,14 +3701,14 @@ This is an example stream message.
 
 exports[`messages -> piece descriptors -> content HTML is stable/sensible stream:s:stream 1 5`] = `
 "
-  <div class=\\"timerow\\" data-msg-id=\\"1024\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"1024\\">
     <div class=\\"timerow-left\\"></div>
     Feb 5, 1995
     <div class=\\"timerow-right\\"></div>
   </div>
 
 <div
-  class=\\"header-wrapper header topic-header\\"
+  class=\\"msglist-element header-wrapper header topic-header\\"
   data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAx\\"
   data-msg-id=\\"1024\\"
 >
@@ -3718,7 +3718,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible stream
     
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-1024\\"
      data-msg-id=\\"1024\\"
      data-mute-state=\\"shown\\"
@@ -3748,7 +3748,7 @@ This is an example stream message.
 
 
     <div
-     class=\\"message message-brief\\"
+     class=\\"msglist-element message message-brief\\"
      id=\\"msg-1598\\"
      data-msg-id=\\"1598\\"
      data-mute-state=\\"shown\\"
@@ -3771,7 +3771,7 @@ This is an example stream message.
   </div>
 </div>
 
-  <div class=\\"timerow\\" data-msg-id=\\"4948\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"4948\\">
     <div class=\\"timerow-left\\"></div>
     Feb 19, 1995
     <div class=\\"timerow-right\\"></div>
@@ -3779,7 +3779,7 @@ This is an example stream message.
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-4948\\"
      data-msg-id=\\"4948\\"
      data-mute-state=\\"shown\\"
@@ -3808,7 +3808,7 @@ This is an example stream message.
 </div>
 
 <div
-  class=\\"header-wrapper header topic-header\\"
+  class=\\"msglist-element header-wrapper header topic-header\\"
   data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAy\\"
   data-msg-id=\\"5083\\"
 >
@@ -3818,7 +3818,7 @@ This is an example stream message.
     
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-5083\\"
      data-msg-id=\\"5083\\"
      data-mute-state=\\"shown\\"
@@ -3846,14 +3846,14 @@ This is an example stream message.
   
 </div>
 
-  <div class=\\"timerow\\" data-msg-id=\\"7938\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"7938\\">
     <div class=\\"timerow-left\\"></div>
     Mar 5, 1995
     <div class=\\"timerow-right\\"></div>
   </div>
 
 <div
-  class=\\"header-wrapper header topic-header\\"
+  class=\\"msglist-element header-wrapper header topic-header\\"
   data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAx\\"
   data-msg-id=\\"7938\\"
 >
@@ -3863,7 +3863,7 @@ This is an example stream message.
     
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-7938\\"
      data-msg-id=\\"7938\\"
      data-mute-state=\\"shown\\"
@@ -3893,7 +3893,7 @@ This is an example stream message.
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-8060\\"
      data-msg-id=\\"8060\\"
      data-mute-state=\\"shown\\"
@@ -3923,7 +3923,7 @@ This is an example stream message.
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-9181\\"
      data-msg-id=\\"9181\\"
      data-mute-state=\\"shown\\"
@@ -3951,7 +3951,7 @@ This is an example stream message.
   
 </div>
 
-  <div class=\\"timerow\\" data-msg-id=\\"9815\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"9815\\">
     <div class=\\"timerow-left\\"></div>
     Mar 12, 1995
     <div class=\\"timerow-right\\"></div>
@@ -3959,7 +3959,7 @@ This is an example stream message.
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-9815\\"
      data-msg-id=\\"9815\\"
      data-mute-state=\\"shown\\"
@@ -3991,7 +3991,7 @@ This is an example stream message.
 
 exports[`messages -> piece descriptors -> content HTML is stable/sensible topic:s:stream 1 topic 1 1`] = `
 "
-  <div class=\\"timerow\\" data-msg-id=\\"1024\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"1024\\">
     <div class=\\"timerow-left\\"></div>
     Feb 5, 1995
     <div class=\\"timerow-right\\"></div>
@@ -3999,7 +3999,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible topic:
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-1024\\"
      data-msg-id=\\"1024\\"
      data-mute-state=\\"shown\\"
@@ -4029,7 +4029,7 @@ This is an example stream message.
 
 
     <div
-     class=\\"message message-brief\\"
+     class=\\"msglist-element message message-brief\\"
      id=\\"msg-1598\\"
      data-msg-id=\\"1598\\"
      data-mute-state=\\"shown\\"
@@ -4056,7 +4056,7 @@ This is an example stream message.
 
 exports[`messages -> piece descriptors -> content HTML is stable/sensible topic:s:stream 1 topic 1 2`] = `
 "
-  <div class=\\"timerow\\" data-msg-id=\\"7938\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"7938\\">
     <div class=\\"timerow-left\\"></div>
     Mar 5, 1995
     <div class=\\"timerow-right\\"></div>
@@ -4064,7 +4064,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible topic:
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-7938\\"
      data-msg-id=\\"7938\\"
      data-mute-state=\\"shown\\"
@@ -4094,7 +4094,7 @@ This is an example stream message.
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-8060\\"
      data-msg-id=\\"8060\\"
      data-mute-state=\\"shown\\"
@@ -4126,7 +4126,7 @@ This is an example stream message.
 
 exports[`messages -> piece descriptors -> content HTML is stable/sensible topic:s:stream 1 topic 1 3`] = `
 "
-  <div class=\\"timerow\\" data-msg-id=\\"9181\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"9181\\">
     <div class=\\"timerow-left\\"></div>
     Mar 5, 1995
     <div class=\\"timerow-right\\"></div>
@@ -4134,7 +4134,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible topic:
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-9181\\"
      data-msg-id=\\"9181\\"
      data-mute-state=\\"shown\\"
@@ -4162,7 +4162,7 @@ This is an example stream message.
   
 </div>
 
-  <div class=\\"timerow\\" data-msg-id=\\"9815\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"9815\\">
     <div class=\\"timerow-left\\"></div>
     Mar 12, 1995
     <div class=\\"timerow-right\\"></div>
@@ -4170,7 +4170,7 @@ This is an example stream message.
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-9815\\"
      data-msg-id=\\"9815\\"
      data-mute-state=\\"shown\\"
@@ -4202,7 +4202,7 @@ This is an example stream message.
 
 exports[`messages -> piece descriptors -> content HTML is stable/sensible topic:s:stream 1 topic 1 4`] = `
 "
-  <div class=\\"timerow\\" data-msg-id=\\"1024\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"1024\\">
     <div class=\\"timerow-left\\"></div>
     Feb 5, 1995
     <div class=\\"timerow-right\\"></div>
@@ -4210,7 +4210,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible topic:
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-1024\\"
      data-msg-id=\\"1024\\"
      data-mute-state=\\"shown\\"
@@ -4240,7 +4240,7 @@ This is an example stream message.
 
 
     <div
-     class=\\"message message-brief\\"
+     class=\\"msglist-element message message-brief\\"
      id=\\"msg-1598\\"
      data-msg-id=\\"1598\\"
      data-mute-state=\\"shown\\"
@@ -4263,7 +4263,7 @@ This is an example stream message.
   </div>
 </div>
 
-  <div class=\\"timerow\\" data-msg-id=\\"7938\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"7938\\">
     <div class=\\"timerow-left\\"></div>
     Mar 5, 1995
     <div class=\\"timerow-right\\"></div>
@@ -4271,7 +4271,7 @@ This is an example stream message.
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-7938\\"
      data-msg-id=\\"7938\\"
      data-mute-state=\\"shown\\"
@@ -4301,7 +4301,7 @@ This is an example stream message.
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-8060\\"
      data-msg-id=\\"8060\\"
      data-mute-state=\\"shown\\"
@@ -4331,7 +4331,7 @@ This is an example stream message.
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-9181\\"
      data-msg-id=\\"9181\\"
      data-mute-state=\\"shown\\"
@@ -4359,7 +4359,7 @@ This is an example stream message.
   
 </div>
 
-  <div class=\\"timerow\\" data-msg-id=\\"9815\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"9815\\">
     <div class=\\"timerow-left\\"></div>
     Mar 12, 1995
     <div class=\\"timerow-right\\"></div>
@@ -4367,7 +4367,7 @@ This is an example stream message.
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-9815\\"
      data-msg-id=\\"9815\\"
      data-mute-state=\\"shown\\"

--- a/src/webview/html/__tests__/__snapshots__/messageListElementHtml-test.js.snap.ios
+++ b/src/webview/html/__tests__/__snapshots__/messageListElementHtml-test.js.snap.ios
@@ -2,13 +2,13 @@
 
 exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_NARROW 1`] = `
 "
-  <div class=\\"timerow\\" data-msg-id=\\"1024\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"1024\\">
     <div class=\\"timerow-left\\"></div>
     Feb 5, 1995
     <div class=\\"timerow-right\\"></div>
   </div>
 
-<div class=\\"header-wrapper header stream-header topic-header\\"
+<div class=\\"msglist-element header-wrapper header stream-header topic-header\\"
     data-msg-id=\\"1024\\"
     data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAx\\">
   <div class=\\"header stream-text\\"
@@ -23,7 +23,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
     
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-1024\\"
      data-msg-id=\\"1024\\"
      data-mute-state=\\"shown\\"
@@ -53,7 +53,7 @@ This is an example stream message.
 
 
     <div
-     class=\\"message message-brief\\"
+     class=\\"msglist-element message message-brief\\"
      id=\\"msg-1598\\"
      data-msg-id=\\"1598\\"
      data-mute-state=\\"shown\\"
@@ -80,13 +80,13 @@ This is an example stream message.
 
 exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_NARROW 2`] = `
 "
-  <div class=\\"timerow\\" data-msg-id=\\"7938\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"7938\\">
     <div class=\\"timerow-left\\"></div>
     Mar 5, 1995
     <div class=\\"timerow-right\\"></div>
   </div>
 
-<div class=\\"header-wrapper header stream-header topic-header\\"
+<div class=\\"msglist-element header-wrapper header stream-header topic-header\\"
     data-msg-id=\\"7938\\"
     data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAx\\">
   <div class=\\"header stream-text\\"
@@ -101,7 +101,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
     
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-7938\\"
      data-msg-id=\\"7938\\"
      data-mute-state=\\"shown\\"
@@ -131,7 +131,7 @@ This is an example stream message.
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-8060\\"
      data-msg-id=\\"8060\\"
      data-mute-state=\\"shown\\"
@@ -163,13 +163,13 @@ This is an example stream message.
 
 exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_NARROW 3`] = `
 "
-  <div class=\\"timerow\\" data-msg-id=\\"4948\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"4948\\">
     <div class=\\"timerow-left\\"></div>
     Feb 19, 1995
     <div class=\\"timerow-right\\"></div>
   </div>
 
-<div class=\\"header-wrapper header stream-header topic-header\\"
+<div class=\\"msglist-element header-wrapper header stream-header topic-header\\"
     data-msg-id=\\"4948\\"
     data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAx\\">
   <div class=\\"header stream-text\\"
@@ -184,7 +184,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
     
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-4948\\"
      data-msg-id=\\"4948\\"
      data-mute-state=\\"shown\\"
@@ -212,7 +212,7 @@ This is an example stream message.
   
 </div>
 
-<div class=\\"header-wrapper header stream-header topic-header\\"
+<div class=\\"msglist-element header-wrapper header stream-header topic-header\\"
     data-msg-id=\\"5083\\"
     data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAy\\">
   <div class=\\"header stream-text\\"
@@ -227,7 +227,7 @@ This is an example stream message.
     
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-5083\\"
      data-msg-id=\\"5083\\"
      data-mute-state=\\"shown\\"
@@ -259,13 +259,13 @@ This is an example stream message.
 
 exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_NARROW 4`] = `
 "
-  <div class=\\"timerow\\" data-msg-id=\\"6789\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"6789\\">
     <div class=\\"timerow-left\\"></div>
     Mar 5, 1995
     <div class=\\"timerow-right\\"></div>
   </div>
 
-<div class=\\"header-wrapper header stream-header topic-header\\"
+<div class=\\"msglist-element header-wrapper header stream-header topic-header\\"
     data-msg-id=\\"6789\\"
     data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAx\\">
   <div class=\\"header stream-text\\"
@@ -280,7 +280,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
     
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-6789\\"
      data-msg-id=\\"6789\\"
      data-mute-state=\\"shown\\"
@@ -308,7 +308,7 @@ This is an example stream message.
   
 </div>
 
-<div class=\\"header-wrapper header stream-header topic-header\\"
+<div class=\\"msglist-element header-wrapper header stream-header topic-header\\"
     data-msg-id=\\"7727\\"
     data-narrow=\\"dG9waWM6czpzdHJlYW0gMgB0b3BpYyAy\\">
   <div class=\\"header stream-text\\"
@@ -323,7 +323,7 @@ This is an example stream message.
     
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-7727\\"
      data-msg-id=\\"7727\\"
      data-mute-state=\\"shown\\"
@@ -355,13 +355,13 @@ This is an example stream message.
 
 exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_NARROW 5`] = `
 "
-  <div class=\\"timerow\\" data-msg-id=\\"9181\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"9181\\">
     <div class=\\"timerow-left\\"></div>
     Mar 5, 1995
     <div class=\\"timerow-right\\"></div>
   </div>
 
-<div class=\\"header-wrapper header stream-header topic-header\\"
+<div class=\\"msglist-element header-wrapper header stream-header topic-header\\"
     data-msg-id=\\"9181\\"
     data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAx\\">
   <div class=\\"header stream-text\\"
@@ -376,7 +376,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
     
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-9181\\"
      data-msg-id=\\"9181\\"
      data-mute-state=\\"shown\\"
@@ -404,7 +404,7 @@ This is an example stream message.
   
 </div>
 
-  <div class=\\"timerow\\" data-msg-id=\\"9815\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"9815\\">
     <div class=\\"timerow-left\\"></div>
     Mar 12, 1995
     <div class=\\"timerow-right\\"></div>
@@ -412,7 +412,7 @@ This is an example stream message.
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-9815\\"
      data-msg-id=\\"9815\\"
      data-mute-state=\\"shown\\"
@@ -444,13 +444,13 @@ This is an example stream message.
 
 exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_NARROW 6`] = `
 "
-  <div class=\\"timerow\\" data-msg-id=\\"8849\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"8849\\">
     <div class=\\"timerow-left\\"></div>
     Mar 5, 1995
     <div class=\\"timerow-right\\"></div>
   </div>
 
-<div class=\\"header-wrapper private-header header\\"
+<div class=\\"msglist-element header-wrapper private-header header\\"
      data-narrow=\\"cG06MSwy\\"
      data-msg-id=\\"8849\\">
   Nonrandom name one User, Nonrandom name two User
@@ -458,7 +458,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-8849\\"
      data-msg-id=\\"8849\\"
      data-mute-state=\\"shown\\"
@@ -488,7 +488,7 @@ This is an example PM message.
 
 
     <div
-     class=\\"message message-brief\\"
+     class=\\"msglist-element message message-brief\\"
      id=\\"msg-8917\\"
      data-msg-id=\\"8917\\"
      data-mute-state=\\"shown\\"
@@ -515,13 +515,13 @@ This is an example PM message.
 
 exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_NARROW 7`] = `
 "
-  <div class=\\"timerow\\" data-msg-id=\\"5287\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"5287\\">
     <div class=\\"timerow-left\\"></div>
     Feb 19, 1995
     <div class=\\"timerow-right\\"></div>
   </div>
 
-<div class=\\"header-wrapper private-header header\\"
+<div class=\\"msglist-element header-wrapper private-header header\\"
      data-narrow=\\"cG06MSwy\\"
      data-msg-id=\\"5287\\">
   Nonrandom name one User, Nonrandom name two User
@@ -529,7 +529,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-5287\\"
      data-msg-id=\\"5287\\"
      data-mute-state=\\"shown\\"
@@ -559,7 +559,7 @@ This is an example PM message.
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-5309\\"
      data-msg-id=\\"5309\\"
      data-mute-state=\\"shown\\"
@@ -591,13 +591,13 @@ This is an example PM message.
 
 exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_NARROW 8`] = `
 "
-  <div class=\\"timerow\\" data-msg-id=\\"5829\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"5829\\">
     <div class=\\"timerow-left\\"></div>
     Feb 19, 1995
     <div class=\\"timerow-right\\"></div>
   </div>
 
-<div class=\\"header-wrapper private-header header\\"
+<div class=\\"msglist-element header-wrapper private-header header\\"
      data-narrow=\\"cG06MSwy\\"
      data-msg-id=\\"5829\\">
   Nonrandom name one User, Nonrandom name two User
@@ -605,7 +605,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-5829\\"
      data-msg-id=\\"5829\\"
      data-mute-state=\\"shown\\"
@@ -633,7 +633,7 @@ This is an example PM message.
   
 </div>
 
-  <div class=\\"timerow\\" data-msg-id=\\"5963\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"5963\\">
     <div class=\\"timerow-left\\"></div>
     Feb 26, 1995
     <div class=\\"timerow-right\\"></div>
@@ -641,7 +641,7 @@ This is an example PM message.
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-5963\\"
      data-msg-id=\\"5963\\"
      data-mute-state=\\"shown\\"
@@ -673,13 +673,13 @@ This is an example PM message.
 
 exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_NARROW 9`] = `
 "
-  <div class=\\"timerow\\" data-msg-id=\\"5377\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"5377\\">
     <div class=\\"timerow-left\\"></div>
     Feb 19, 1995
     <div class=\\"timerow-right\\"></div>
   </div>
 
-<div class=\\"header-wrapper private-header header\\"
+<div class=\\"msglist-element header-wrapper private-header header\\"
      data-narrow=\\"cG06MSwyLDM=\\"
      data-msg-id=\\"5377\\">
   Nonrandom name one User, Nonrandom name three User, Nonrandom name two User
@@ -687,7 +687,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-5377\\"
      data-msg-id=\\"5377\\"
      data-mute-state=\\"shown\\"
@@ -717,7 +717,7 @@ This is an example PM message.
 
 
     <div
-     class=\\"message message-brief\\"
+     class=\\"msglist-element message message-brief\\"
      id=\\"msg-5620\\"
      data-msg-id=\\"5620\\"
      data-mute-state=\\"shown\\"
@@ -744,13 +744,13 @@ This is an example PM message.
 
 exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_NARROW 10`] = `
 "
-  <div class=\\"timerow\\" data-msg-id=\\"5637\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"5637\\">
     <div class=\\"timerow-left\\"></div>
     Feb 19, 1995
     <div class=\\"timerow-right\\"></div>
   </div>
 
-<div class=\\"header-wrapper private-header header\\"
+<div class=\\"msglist-element header-wrapper private-header header\\"
      data-narrow=\\"cG06MSwyLDM=\\"
      data-msg-id=\\"5637\\">
   Nonrandom name one User, Nonrandom name three User, Nonrandom name two User
@@ -758,7 +758,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-5637\\"
      data-msg-id=\\"5637\\"
      data-mute-state=\\"shown\\"
@@ -788,7 +788,7 @@ This is an example PM message.
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-5727\\"
      data-msg-id=\\"5727\\"
      data-mute-state=\\"shown\\"
@@ -820,13 +820,13 @@ This is an example PM message.
 
 exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_NARROW 11`] = `
 "
-  <div class=\\"timerow\\" data-msg-id=\\"2794\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"2794\\">
     <div class=\\"timerow-left\\"></div>
     Feb 5, 1995
     <div class=\\"timerow-right\\"></div>
   </div>
 
-<div class=\\"header-wrapper private-header header\\"
+<div class=\\"msglist-element header-wrapper private-header header\\"
      data-narrow=\\"cG06MSwyLDM=\\"
      data-msg-id=\\"2794\\">
   Nonrandom name one User, Nonrandom name three User, Nonrandom name two User
@@ -834,7 +834,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-2794\\"
      data-msg-id=\\"2794\\"
      data-mute-state=\\"shown\\"
@@ -862,7 +862,7 @@ This is an example PM message.
   
 </div>
 
-  <div class=\\"timerow\\" data-msg-id=\\"4581\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"4581\\">
     <div class=\\"timerow-left\\"></div>
     Feb 12, 1995
     <div class=\\"timerow-right\\"></div>
@@ -870,7 +870,7 @@ This is an example PM message.
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-4581\\"
      data-msg-id=\\"4581\\"
      data-mute-state=\\"shown\\"
@@ -902,13 +902,13 @@ This is an example PM message.
 
 exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_NARROW 12`] = `
 "
-  <div class=\\"timerow\\" data-msg-id=\\"1024\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"1024\\">
     <div class=\\"timerow-left\\"></div>
     Feb 5, 1995
     <div class=\\"timerow-right\\"></div>
   </div>
 
-<div class=\\"header-wrapper header stream-header topic-header\\"
+<div class=\\"msglist-element header-wrapper header stream-header topic-header\\"
     data-msg-id=\\"1024\\"
     data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAx\\">
   <div class=\\"header stream-text\\"
@@ -923,7 +923,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
     
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-1024\\"
      data-msg-id=\\"1024\\"
      data-mute-state=\\"shown\\"
@@ -953,7 +953,7 @@ This is an example stream message.
 
 
     <div
-     class=\\"message message-brief\\"
+     class=\\"msglist-element message message-brief\\"
      id=\\"msg-1598\\"
      data-msg-id=\\"1598\\"
      data-mute-state=\\"shown\\"
@@ -976,7 +976,7 @@ This is an example stream message.
   </div>
 </div>
 
-<div class=\\"header-wrapper private-header header\\"
+<div class=\\"msglist-element header-wrapper private-header header\\"
      data-narrow=\\"cG06MSwyLDM=\\"
      data-msg-id=\\"2794\\">
   Nonrandom name one User, Nonrandom name three User, Nonrandom name two User
@@ -984,7 +984,7 @@ This is an example stream message.
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-2794\\"
      data-msg-id=\\"2794\\"
      data-mute-state=\\"shown\\"
@@ -1012,7 +1012,7 @@ This is an example PM message.
   
 </div>
 
-  <div class=\\"timerow\\" data-msg-id=\\"4581\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"4581\\">
     <div class=\\"timerow-left\\"></div>
     Feb 12, 1995
     <div class=\\"timerow-right\\"></div>
@@ -1020,7 +1020,7 @@ This is an example PM message.
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-4581\\"
      data-msg-id=\\"4581\\"
      data-mute-state=\\"shown\\"
@@ -1048,13 +1048,13 @@ This is an example PM message.
   
 </div>
 
-  <div class=\\"timerow\\" data-msg-id=\\"4948\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"4948\\">
     <div class=\\"timerow-left\\"></div>
     Feb 19, 1995
     <div class=\\"timerow-right\\"></div>
   </div>
 
-<div class=\\"header-wrapper header stream-header topic-header\\"
+<div class=\\"msglist-element header-wrapper header stream-header topic-header\\"
     data-msg-id=\\"4948\\"
     data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAx\\">
   <div class=\\"header stream-text\\"
@@ -1069,7 +1069,7 @@ This is an example PM message.
     
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-4948\\"
      data-msg-id=\\"4948\\"
      data-mute-state=\\"shown\\"
@@ -1097,7 +1097,7 @@ This is an example stream message.
   
 </div>
 
-<div class=\\"header-wrapper header stream-header topic-header\\"
+<div class=\\"msglist-element header-wrapper header stream-header topic-header\\"
     data-msg-id=\\"5083\\"
     data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAy\\">
   <div class=\\"header stream-text\\"
@@ -1112,7 +1112,7 @@ This is an example stream message.
     
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-5083\\"
      data-msg-id=\\"5083\\"
      data-mute-state=\\"shown\\"
@@ -1140,7 +1140,7 @@ This is an example stream message.
   
 </div>
 
-<div class=\\"header-wrapper private-header header\\"
+<div class=\\"msglist-element header-wrapper private-header header\\"
      data-narrow=\\"cG06MSwy\\"
      data-msg-id=\\"5287\\">
   Nonrandom name one User, Nonrandom name two User
@@ -1148,7 +1148,7 @@ This is an example stream message.
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-5287\\"
      data-msg-id=\\"5287\\"
      data-mute-state=\\"shown\\"
@@ -1178,7 +1178,7 @@ This is an example PM message.
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-5309\\"
      data-msg-id=\\"5309\\"
      data-mute-state=\\"shown\\"
@@ -1206,7 +1206,7 @@ This is an example PM message.
   
 </div>
 
-<div class=\\"header-wrapper private-header header\\"
+<div class=\\"msglist-element header-wrapper private-header header\\"
      data-narrow=\\"cG06MSwyLDM=\\"
      data-msg-id=\\"5377\\">
   Nonrandom name one User, Nonrandom name three User, Nonrandom name two User
@@ -1214,7 +1214,7 @@ This is an example PM message.
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-5377\\"
      data-msg-id=\\"5377\\"
      data-mute-state=\\"shown\\"
@@ -1244,7 +1244,7 @@ This is an example PM message.
 
 
     <div
-     class=\\"message message-brief\\"
+     class=\\"msglist-element message message-brief\\"
      id=\\"msg-5620\\"
      data-msg-id=\\"5620\\"
      data-mute-state=\\"shown\\"
@@ -1269,7 +1269,7 @@ This is an example PM message.
 
 
     <div
-     class=\\"message message-brief\\"
+     class=\\"msglist-element message message-brief\\"
      id=\\"msg-5637\\"
      data-msg-id=\\"5637\\"
      data-mute-state=\\"shown\\"
@@ -1294,7 +1294,7 @@ This is an example PM message.
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-5727\\"
      data-msg-id=\\"5727\\"
      data-mute-state=\\"shown\\"
@@ -1322,7 +1322,7 @@ This is an example PM message.
   
 </div>
 
-<div class=\\"header-wrapper private-header header\\"
+<div class=\\"msglist-element header-wrapper private-header header\\"
      data-narrow=\\"cG06MSwy\\"
      data-msg-id=\\"5829\\">
   Nonrandom name one User, Nonrandom name two User
@@ -1330,7 +1330,7 @@ This is an example PM message.
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-5829\\"
      data-msg-id=\\"5829\\"
      data-mute-state=\\"shown\\"
@@ -1358,7 +1358,7 @@ This is an example PM message.
   
 </div>
 
-  <div class=\\"timerow\\" data-msg-id=\\"5963\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"5963\\">
     <div class=\\"timerow-left\\"></div>
     Feb 26, 1995
     <div class=\\"timerow-right\\"></div>
@@ -1366,7 +1366,7 @@ This is an example PM message.
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-5963\\"
      data-msg-id=\\"5963\\"
      data-mute-state=\\"shown\\"
@@ -1394,13 +1394,13 @@ This is an example PM message.
   
 </div>
 
-  <div class=\\"timerow\\" data-msg-id=\\"6789\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"6789\\">
     <div class=\\"timerow-left\\"></div>
     Mar 5, 1995
     <div class=\\"timerow-right\\"></div>
   </div>
 
-<div class=\\"header-wrapper header stream-header topic-header\\"
+<div class=\\"msglist-element header-wrapper header stream-header topic-header\\"
     data-msg-id=\\"6789\\"
     data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAx\\">
   <div class=\\"header stream-text\\"
@@ -1415,7 +1415,7 @@ This is an example PM message.
     
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-6789\\"
      data-msg-id=\\"6789\\"
      data-mute-state=\\"shown\\"
@@ -1443,7 +1443,7 @@ This is an example stream message.
   
 </div>
 
-<div class=\\"header-wrapper header stream-header topic-header\\"
+<div class=\\"msglist-element header-wrapper header stream-header topic-header\\"
     data-msg-id=\\"7727\\"
     data-narrow=\\"dG9waWM6czpzdHJlYW0gMgB0b3BpYyAy\\">
   <div class=\\"header stream-text\\"
@@ -1458,7 +1458,7 @@ This is an example stream message.
     
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-7727\\"
      data-msg-id=\\"7727\\"
      data-mute-state=\\"shown\\"
@@ -1486,7 +1486,7 @@ This is an example stream message.
   
 </div>
 
-<div class=\\"header-wrapper header stream-header topic-header\\"
+<div class=\\"msglist-element header-wrapper header stream-header topic-header\\"
     data-msg-id=\\"7938\\"
     data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAx\\">
   <div class=\\"header stream-text\\"
@@ -1501,7 +1501,7 @@ This is an example stream message.
     
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-7938\\"
      data-msg-id=\\"7938\\"
      data-mute-state=\\"shown\\"
@@ -1531,7 +1531,7 @@ This is an example stream message.
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-8060\\"
      data-msg-id=\\"8060\\"
      data-mute-state=\\"shown\\"
@@ -1559,7 +1559,7 @@ This is an example stream message.
   
 </div>
 
-<div class=\\"header-wrapper private-header header\\"
+<div class=\\"msglist-element header-wrapper private-header header\\"
      data-narrow=\\"cG06MSwy\\"
      data-msg-id=\\"8849\\">
   Nonrandom name one User, Nonrandom name two User
@@ -1567,7 +1567,7 @@ This is an example stream message.
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-8849\\"
      data-msg-id=\\"8849\\"
      data-mute-state=\\"shown\\"
@@ -1597,7 +1597,7 @@ This is an example PM message.
 
 
     <div
-     class=\\"message message-brief\\"
+     class=\\"msglist-element message message-brief\\"
      id=\\"msg-8917\\"
      data-msg-id=\\"8917\\"
      data-mute-state=\\"shown\\"
@@ -1620,7 +1620,7 @@ This is an example PM message.
   </div>
 </div>
 
-<div class=\\"header-wrapper header stream-header topic-header\\"
+<div class=\\"msglist-element header-wrapper header stream-header topic-header\\"
     data-msg-id=\\"9181\\"
     data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAx\\">
   <div class=\\"header stream-text\\"
@@ -1635,7 +1635,7 @@ This is an example PM message.
     
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-9181\\"
      data-msg-id=\\"9181\\"
      data-mute-state=\\"shown\\"
@@ -1663,7 +1663,7 @@ This is an example stream message.
   
 </div>
 
-  <div class=\\"timerow\\" data-msg-id=\\"9815\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"9815\\">
     <div class=\\"timerow-left\\"></div>
     Mar 12, 1995
     <div class=\\"timerow-right\\"></div>
@@ -1671,7 +1671,7 @@ This is an example stream message.
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-9815\\"
      data-msg-id=\\"9815\\"
      data-mute-state=\\"shown\\"
@@ -1703,13 +1703,13 @@ This is an example stream message.
 
 exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm 1`] = `
 "
-  <div class=\\"timerow\\" data-msg-id=\\"8849\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"8849\\">
     <div class=\\"timerow-left\\"></div>
     Mar 5, 1995
     <div class=\\"timerow-right\\"></div>
   </div>
 
-<div class=\\"header-wrapper private-header header\\"
+<div class=\\"msglist-element header-wrapper private-header header\\"
      data-narrow=\\"cG06MSwy\\"
      data-msg-id=\\"8849\\">
   Nonrandom name one User, Nonrandom name two User
@@ -1717,7 +1717,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-8849\\"
      data-msg-id=\\"8849\\"
      data-mute-state=\\"shown\\"
@@ -1747,7 +1747,7 @@ This is an example PM message.
 
 
     <div
-     class=\\"message message-brief\\"
+     class=\\"msglist-element message message-brief\\"
      id=\\"msg-8917\\"
      data-msg-id=\\"8917\\"
      data-mute-state=\\"shown\\"
@@ -1774,13 +1774,13 @@ This is an example PM message.
 
 exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm 2`] = `
 "
-  <div class=\\"timerow\\" data-msg-id=\\"5287\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"5287\\">
     <div class=\\"timerow-left\\"></div>
     Feb 19, 1995
     <div class=\\"timerow-right\\"></div>
   </div>
 
-<div class=\\"header-wrapper private-header header\\"
+<div class=\\"msglist-element header-wrapper private-header header\\"
      data-narrow=\\"cG06MSwy\\"
      data-msg-id=\\"5287\\">
   Nonrandom name one User, Nonrandom name two User
@@ -1788,7 +1788,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-5287\\"
      data-msg-id=\\"5287\\"
      data-mute-state=\\"shown\\"
@@ -1818,7 +1818,7 @@ This is an example PM message.
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-5309\\"
      data-msg-id=\\"5309\\"
      data-mute-state=\\"shown\\"
@@ -1850,13 +1850,13 @@ This is an example PM message.
 
 exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm 3`] = `
 "
-  <div class=\\"timerow\\" data-msg-id=\\"5829\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"5829\\">
     <div class=\\"timerow-left\\"></div>
     Feb 19, 1995
     <div class=\\"timerow-right\\"></div>
   </div>
 
-<div class=\\"header-wrapper private-header header\\"
+<div class=\\"msglist-element header-wrapper private-header header\\"
      data-narrow=\\"cG06MSwy\\"
      data-msg-id=\\"5829\\">
   Nonrandom name one User, Nonrandom name two User
@@ -1864,7 +1864,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-5829\\"
      data-msg-id=\\"5829\\"
      data-mute-state=\\"shown\\"
@@ -1892,7 +1892,7 @@ This is an example PM message.
   
 </div>
 
-  <div class=\\"timerow\\" data-msg-id=\\"5963\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"5963\\">
     <div class=\\"timerow-left\\"></div>
     Feb 26, 1995
     <div class=\\"timerow-right\\"></div>
@@ -1900,7 +1900,7 @@ This is an example PM message.
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-5963\\"
      data-msg-id=\\"5963\\"
      data-mute-state=\\"shown\\"
@@ -1932,13 +1932,13 @@ This is an example PM message.
 
 exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm 4`] = `
 "
-  <div class=\\"timerow\\" data-msg-id=\\"5377\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"5377\\">
     <div class=\\"timerow-left\\"></div>
     Feb 19, 1995
     <div class=\\"timerow-right\\"></div>
   </div>
 
-<div class=\\"header-wrapper private-header header\\"
+<div class=\\"msglist-element header-wrapper private-header header\\"
      data-narrow=\\"cG06MSwyLDM=\\"
      data-msg-id=\\"5377\\">
   Nonrandom name one User, Nonrandom name three User, Nonrandom name two User
@@ -1946,7 +1946,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-5377\\"
      data-msg-id=\\"5377\\"
      data-mute-state=\\"shown\\"
@@ -1976,7 +1976,7 @@ This is an example PM message.
 
 
     <div
-     class=\\"message message-brief\\"
+     class=\\"msglist-element message message-brief\\"
      id=\\"msg-5620\\"
      data-msg-id=\\"5620\\"
      data-mute-state=\\"shown\\"
@@ -2003,13 +2003,13 @@ This is an example PM message.
 
 exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm 5`] = `
 "
-  <div class=\\"timerow\\" data-msg-id=\\"5637\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"5637\\">
     <div class=\\"timerow-left\\"></div>
     Feb 19, 1995
     <div class=\\"timerow-right\\"></div>
   </div>
 
-<div class=\\"header-wrapper private-header header\\"
+<div class=\\"msglist-element header-wrapper private-header header\\"
      data-narrow=\\"cG06MSwyLDM=\\"
      data-msg-id=\\"5637\\">
   Nonrandom name one User, Nonrandom name three User, Nonrandom name two User
@@ -2017,7 +2017,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-5637\\"
      data-msg-id=\\"5637\\"
      data-mute-state=\\"shown\\"
@@ -2047,7 +2047,7 @@ This is an example PM message.
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-5727\\"
      data-msg-id=\\"5727\\"
      data-mute-state=\\"shown\\"
@@ -2079,13 +2079,13 @@ This is an example PM message.
 
 exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm 6`] = `
 "
-  <div class=\\"timerow\\" data-msg-id=\\"2794\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"2794\\">
     <div class=\\"timerow-left\\"></div>
     Feb 5, 1995
     <div class=\\"timerow-right\\"></div>
   </div>
 
-<div class=\\"header-wrapper private-header header\\"
+<div class=\\"msglist-element header-wrapper private-header header\\"
      data-narrow=\\"cG06MSwyLDM=\\"
      data-msg-id=\\"2794\\">
   Nonrandom name one User, Nonrandom name three User, Nonrandom name two User
@@ -2093,7 +2093,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-2794\\"
      data-msg-id=\\"2794\\"
      data-mute-state=\\"shown\\"
@@ -2121,7 +2121,7 @@ This is an example PM message.
   
 </div>
 
-  <div class=\\"timerow\\" data-msg-id=\\"4581\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"4581\\">
     <div class=\\"timerow-left\\"></div>
     Feb 12, 1995
     <div class=\\"timerow-right\\"></div>
@@ -2129,7 +2129,7 @@ This is an example PM message.
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-4581\\"
      data-msg-id=\\"4581\\"
      data-mute-state=\\"shown\\"
@@ -2161,13 +2161,13 @@ This is an example PM message.
 
 exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm 7`] = `
 "
-  <div class=\\"timerow\\" data-msg-id=\\"2794\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"2794\\">
     <div class=\\"timerow-left\\"></div>
     Feb 5, 1995
     <div class=\\"timerow-right\\"></div>
   </div>
 
-<div class=\\"header-wrapper private-header header\\"
+<div class=\\"msglist-element header-wrapper private-header header\\"
      data-narrow=\\"cG06MSwyLDM=\\"
      data-msg-id=\\"2794\\">
   Nonrandom name one User, Nonrandom name three User, Nonrandom name two User
@@ -2175,7 +2175,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-2794\\"
      data-msg-id=\\"2794\\"
      data-mute-state=\\"shown\\"
@@ -2203,7 +2203,7 @@ This is an example PM message.
   
 </div>
 
-  <div class=\\"timerow\\" data-msg-id=\\"4581\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"4581\\">
     <div class=\\"timerow-left\\"></div>
     Feb 12, 1995
     <div class=\\"timerow-right\\"></div>
@@ -2211,7 +2211,7 @@ This is an example PM message.
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-4581\\"
      data-msg-id=\\"4581\\"
      data-mute-state=\\"shown\\"
@@ -2239,13 +2239,13 @@ This is an example PM message.
   
 </div>
 
-  <div class=\\"timerow\\" data-msg-id=\\"5287\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"5287\\">
     <div class=\\"timerow-left\\"></div>
     Feb 19, 1995
     <div class=\\"timerow-right\\"></div>
   </div>
 
-<div class=\\"header-wrapper private-header header\\"
+<div class=\\"msglist-element header-wrapper private-header header\\"
      data-narrow=\\"cG06MSwy\\"
      data-msg-id=\\"5287\\">
   Nonrandom name one User, Nonrandom name two User
@@ -2253,7 +2253,7 @@ This is an example PM message.
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-5287\\"
      data-msg-id=\\"5287\\"
      data-mute-state=\\"shown\\"
@@ -2283,7 +2283,7 @@ This is an example PM message.
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-5309\\"
      data-msg-id=\\"5309\\"
      data-mute-state=\\"shown\\"
@@ -2311,7 +2311,7 @@ This is an example PM message.
   
 </div>
 
-<div class=\\"header-wrapper private-header header\\"
+<div class=\\"msglist-element header-wrapper private-header header\\"
      data-narrow=\\"cG06MSwyLDM=\\"
      data-msg-id=\\"5377\\">
   Nonrandom name one User, Nonrandom name three User, Nonrandom name two User
@@ -2319,7 +2319,7 @@ This is an example PM message.
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-5377\\"
      data-msg-id=\\"5377\\"
      data-mute-state=\\"shown\\"
@@ -2349,7 +2349,7 @@ This is an example PM message.
 
 
     <div
-     class=\\"message message-brief\\"
+     class=\\"msglist-element message message-brief\\"
      id=\\"msg-5620\\"
      data-msg-id=\\"5620\\"
      data-mute-state=\\"shown\\"
@@ -2374,7 +2374,7 @@ This is an example PM message.
 
 
     <div
-     class=\\"message message-brief\\"
+     class=\\"msglist-element message message-brief\\"
      id=\\"msg-5637\\"
      data-msg-id=\\"5637\\"
      data-mute-state=\\"shown\\"
@@ -2399,7 +2399,7 @@ This is an example PM message.
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-5727\\"
      data-msg-id=\\"5727\\"
      data-mute-state=\\"shown\\"
@@ -2427,7 +2427,7 @@ This is an example PM message.
   
 </div>
 
-<div class=\\"header-wrapper private-header header\\"
+<div class=\\"msglist-element header-wrapper private-header header\\"
      data-narrow=\\"cG06MSwy\\"
      data-msg-id=\\"5829\\">
   Nonrandom name one User, Nonrandom name two User
@@ -2435,7 +2435,7 @@ This is an example PM message.
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-5829\\"
      data-msg-id=\\"5829\\"
      data-mute-state=\\"shown\\"
@@ -2463,7 +2463,7 @@ This is an example PM message.
   
 </div>
 
-  <div class=\\"timerow\\" data-msg-id=\\"5963\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"5963\\">
     <div class=\\"timerow-left\\"></div>
     Feb 26, 1995
     <div class=\\"timerow-right\\"></div>
@@ -2471,7 +2471,7 @@ This is an example PM message.
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-5963\\"
      data-msg-id=\\"5963\\"
      data-mute-state=\\"shown\\"
@@ -2499,7 +2499,7 @@ This is an example PM message.
   
 </div>
 
-  <div class=\\"timerow\\" data-msg-id=\\"8849\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"8849\\">
     <div class=\\"timerow-left\\"></div>
     Mar 5, 1995
     <div class=\\"timerow-right\\"></div>
@@ -2507,7 +2507,7 @@ This is an example PM message.
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-8849\\"
      data-msg-id=\\"8849\\"
      data-mute-state=\\"shown\\"
@@ -2537,7 +2537,7 @@ This is an example PM message.
 
 
     <div
-     class=\\"message message-brief\\"
+     class=\\"msglist-element message message-brief\\"
      id=\\"msg-8917\\"
      data-msg-id=\\"8917\\"
      data-mute-state=\\"shown\\"
@@ -2564,7 +2564,7 @@ This is an example PM message.
 
 exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2 1`] = `
 "
-  <div class=\\"timerow\\" data-msg-id=\\"8849\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"8849\\">
     <div class=\\"timerow-left\\"></div>
     Mar 5, 1995
     <div class=\\"timerow-right\\"></div>
@@ -2572,7 +2572,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-8849\\"
      data-msg-id=\\"8849\\"
      data-mute-state=\\"shown\\"
@@ -2602,7 +2602,7 @@ This is an example PM message.
 
 
     <div
-     class=\\"message message-brief\\"
+     class=\\"msglist-element message message-brief\\"
      id=\\"msg-8917\\"
      data-msg-id=\\"8917\\"
      data-mute-state=\\"shown\\"
@@ -2629,7 +2629,7 @@ This is an example PM message.
 
 exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2 2`] = `
 "
-  <div class=\\"timerow\\" data-msg-id=\\"5287\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"5287\\">
     <div class=\\"timerow-left\\"></div>
     Feb 19, 1995
     <div class=\\"timerow-right\\"></div>
@@ -2637,7 +2637,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-5287\\"
      data-msg-id=\\"5287\\"
      data-mute-state=\\"shown\\"
@@ -2667,7 +2667,7 @@ This is an example PM message.
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-5309\\"
      data-msg-id=\\"5309\\"
      data-mute-state=\\"shown\\"
@@ -2699,7 +2699,7 @@ This is an example PM message.
 
 exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2 3`] = `
 "
-  <div class=\\"timerow\\" data-msg-id=\\"5829\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"5829\\">
     <div class=\\"timerow-left\\"></div>
     Feb 19, 1995
     <div class=\\"timerow-right\\"></div>
@@ -2707,7 +2707,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-5829\\"
      data-msg-id=\\"5829\\"
      data-mute-state=\\"shown\\"
@@ -2735,7 +2735,7 @@ This is an example PM message.
   
 </div>
 
-  <div class=\\"timerow\\" data-msg-id=\\"5963\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"5963\\">
     <div class=\\"timerow-left\\"></div>
     Feb 26, 1995
     <div class=\\"timerow-right\\"></div>
@@ -2743,7 +2743,7 @@ This is an example PM message.
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-5963\\"
      data-msg-id=\\"5963\\"
      data-mute-state=\\"shown\\"
@@ -2775,7 +2775,7 @@ This is an example PM message.
 
 exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2 4`] = `
 "
-  <div class=\\"timerow\\" data-msg-id=\\"5287\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"5287\\">
     <div class=\\"timerow-left\\"></div>
     Feb 19, 1995
     <div class=\\"timerow-right\\"></div>
@@ -2783,7 +2783,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-5287\\"
      data-msg-id=\\"5287\\"
      data-mute-state=\\"shown\\"
@@ -2813,7 +2813,7 @@ This is an example PM message.
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-5309\\"
      data-msg-id=\\"5309\\"
      data-mute-state=\\"shown\\"
@@ -2843,7 +2843,7 @@ This is an example PM message.
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-5829\\"
      data-msg-id=\\"5829\\"
      data-mute-state=\\"shown\\"
@@ -2871,7 +2871,7 @@ This is an example PM message.
   
 </div>
 
-  <div class=\\"timerow\\" data-msg-id=\\"5963\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"5963\\">
     <div class=\\"timerow-left\\"></div>
     Feb 26, 1995
     <div class=\\"timerow-right\\"></div>
@@ -2879,7 +2879,7 @@ This is an example PM message.
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-5963\\"
      data-msg-id=\\"5963\\"
      data-mute-state=\\"shown\\"
@@ -2907,7 +2907,7 @@ This is an example PM message.
   
 </div>
 
-  <div class=\\"timerow\\" data-msg-id=\\"8849\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"8849\\">
     <div class=\\"timerow-left\\"></div>
     Mar 5, 1995
     <div class=\\"timerow-right\\"></div>
@@ -2915,7 +2915,7 @@ This is an example PM message.
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-8849\\"
      data-msg-id=\\"8849\\"
      data-mute-state=\\"shown\\"
@@ -2945,7 +2945,7 @@ This is an example PM message.
 
 
     <div
-     class=\\"message message-brief\\"
+     class=\\"msglist-element message message-brief\\"
      id=\\"msg-8917\\"
      data-msg-id=\\"8917\\"
      data-mute-state=\\"shown\\"
@@ -2972,7 +2972,7 @@ This is an example PM message.
 
 exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2,3 1`] = `
 "
-  <div class=\\"timerow\\" data-msg-id=\\"5377\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"5377\\">
     <div class=\\"timerow-left\\"></div>
     Feb 19, 1995
     <div class=\\"timerow-right\\"></div>
@@ -2980,7 +2980,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-5377\\"
      data-msg-id=\\"5377\\"
      data-mute-state=\\"shown\\"
@@ -3010,7 +3010,7 @@ This is an example PM message.
 
 
     <div
-     class=\\"message message-brief\\"
+     class=\\"msglist-element message message-brief\\"
      id=\\"msg-5620\\"
      data-msg-id=\\"5620\\"
      data-mute-state=\\"shown\\"
@@ -3037,7 +3037,7 @@ This is an example PM message.
 
 exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2,3 2`] = `
 "
-  <div class=\\"timerow\\" data-msg-id=\\"5637\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"5637\\">
     <div class=\\"timerow-left\\"></div>
     Feb 19, 1995
     <div class=\\"timerow-right\\"></div>
@@ -3045,7 +3045,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-5637\\"
      data-msg-id=\\"5637\\"
      data-mute-state=\\"shown\\"
@@ -3075,7 +3075,7 @@ This is an example PM message.
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-5727\\"
      data-msg-id=\\"5727\\"
      data-mute-state=\\"shown\\"
@@ -3107,7 +3107,7 @@ This is an example PM message.
 
 exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2,3 3`] = `
 "
-  <div class=\\"timerow\\" data-msg-id=\\"2794\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"2794\\">
     <div class=\\"timerow-left\\"></div>
     Feb 5, 1995
     <div class=\\"timerow-right\\"></div>
@@ -3115,7 +3115,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-2794\\"
      data-msg-id=\\"2794\\"
      data-mute-state=\\"shown\\"
@@ -3143,7 +3143,7 @@ This is an example PM message.
   
 </div>
 
-  <div class=\\"timerow\\" data-msg-id=\\"4581\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"4581\\">
     <div class=\\"timerow-left\\"></div>
     Feb 12, 1995
     <div class=\\"timerow-right\\"></div>
@@ -3151,7 +3151,7 @@ This is an example PM message.
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-4581\\"
      data-msg-id=\\"4581\\"
      data-mute-state=\\"shown\\"
@@ -3183,7 +3183,7 @@ This is an example PM message.
 
 exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2,3 4`] = `
 "
-  <div class=\\"timerow\\" data-msg-id=\\"2794\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"2794\\">
     <div class=\\"timerow-left\\"></div>
     Feb 5, 1995
     <div class=\\"timerow-right\\"></div>
@@ -3191,7 +3191,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-2794\\"
      data-msg-id=\\"2794\\"
      data-mute-state=\\"shown\\"
@@ -3219,7 +3219,7 @@ This is an example PM message.
   
 </div>
 
-  <div class=\\"timerow\\" data-msg-id=\\"4581\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"4581\\">
     <div class=\\"timerow-left\\"></div>
     Feb 12, 1995
     <div class=\\"timerow-right\\"></div>
@@ -3227,7 +3227,7 @@ This is an example PM message.
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-4581\\"
      data-msg-id=\\"4581\\"
      data-mute-state=\\"shown\\"
@@ -3255,7 +3255,7 @@ This is an example PM message.
   
 </div>
 
-  <div class=\\"timerow\\" data-msg-id=\\"5377\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"5377\\">
     <div class=\\"timerow-left\\"></div>
     Feb 19, 1995
     <div class=\\"timerow-right\\"></div>
@@ -3263,7 +3263,7 @@ This is an example PM message.
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-5377\\"
      data-msg-id=\\"5377\\"
      data-mute-state=\\"shown\\"
@@ -3293,7 +3293,7 @@ This is an example PM message.
 
 
     <div
-     class=\\"message message-brief\\"
+     class=\\"msglist-element message message-brief\\"
      id=\\"msg-5620\\"
      data-msg-id=\\"5620\\"
      data-mute-state=\\"shown\\"
@@ -3318,7 +3318,7 @@ This is an example PM message.
 
 
     <div
-     class=\\"message message-brief\\"
+     class=\\"msglist-element message message-brief\\"
      id=\\"msg-5637\\"
      data-msg-id=\\"5637\\"
      data-mute-state=\\"shown\\"
@@ -3343,7 +3343,7 @@ This is an example PM message.
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-5727\\"
      data-msg-id=\\"5727\\"
      data-mute-state=\\"shown\\"
@@ -3375,14 +3375,14 @@ This is an example PM message.
 
 exports[`messages -> piece descriptors -> content HTML is stable/sensible stream:s:stream 1 1`] = `
 "
-  <div class=\\"timerow\\" data-msg-id=\\"1024\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"1024\\">
     <div class=\\"timerow-left\\"></div>
     Feb 5, 1995
     <div class=\\"timerow-right\\"></div>
   </div>
 
 <div
-  class=\\"header-wrapper header topic-header\\"
+  class=\\"msglist-element header-wrapper header topic-header\\"
   data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAx\\"
   data-msg-id=\\"1024\\"
 >
@@ -3392,7 +3392,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible stream
     
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-1024\\"
      data-msg-id=\\"1024\\"
      data-mute-state=\\"shown\\"
@@ -3422,7 +3422,7 @@ This is an example stream message.
 
 
     <div
-     class=\\"message message-brief\\"
+     class=\\"msglist-element message message-brief\\"
      id=\\"msg-1598\\"
      data-msg-id=\\"1598\\"
      data-mute-state=\\"shown\\"
@@ -3449,14 +3449,14 @@ This is an example stream message.
 
 exports[`messages -> piece descriptors -> content HTML is stable/sensible stream:s:stream 1 2`] = `
 "
-  <div class=\\"timerow\\" data-msg-id=\\"7938\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"7938\\">
     <div class=\\"timerow-left\\"></div>
     Mar 5, 1995
     <div class=\\"timerow-right\\"></div>
   </div>
 
 <div
-  class=\\"header-wrapper header topic-header\\"
+  class=\\"msglist-element header-wrapper header topic-header\\"
   data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAx\\"
   data-msg-id=\\"7938\\"
 >
@@ -3466,7 +3466,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible stream
     
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-7938\\"
      data-msg-id=\\"7938\\"
      data-mute-state=\\"shown\\"
@@ -3496,7 +3496,7 @@ This is an example stream message.
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-8060\\"
      data-msg-id=\\"8060\\"
      data-mute-state=\\"shown\\"
@@ -3528,14 +3528,14 @@ This is an example stream message.
 
 exports[`messages -> piece descriptors -> content HTML is stable/sensible stream:s:stream 1 3`] = `
 "
-  <div class=\\"timerow\\" data-msg-id=\\"4948\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"4948\\">
     <div class=\\"timerow-left\\"></div>
     Feb 19, 1995
     <div class=\\"timerow-right\\"></div>
   </div>
 
 <div
-  class=\\"header-wrapper header topic-header\\"
+  class=\\"msglist-element header-wrapper header topic-header\\"
   data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAx\\"
   data-msg-id=\\"4948\\"
 >
@@ -3545,7 +3545,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible stream
     
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-4948\\"
      data-msg-id=\\"4948\\"
      data-mute-state=\\"shown\\"
@@ -3574,7 +3574,7 @@ This is an example stream message.
 </div>
 
 <div
-  class=\\"header-wrapper header topic-header\\"
+  class=\\"msglist-element header-wrapper header topic-header\\"
   data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAy\\"
   data-msg-id=\\"5083\\"
 >
@@ -3584,7 +3584,7 @@ This is an example stream message.
     
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-5083\\"
      data-msg-id=\\"5083\\"
      data-mute-state=\\"shown\\"
@@ -3616,14 +3616,14 @@ This is an example stream message.
 
 exports[`messages -> piece descriptors -> content HTML is stable/sensible stream:s:stream 1 4`] = `
 "
-  <div class=\\"timerow\\" data-msg-id=\\"9181\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"9181\\">
     <div class=\\"timerow-left\\"></div>
     Mar 5, 1995
     <div class=\\"timerow-right\\"></div>
   </div>
 
 <div
-  class=\\"header-wrapper header topic-header\\"
+  class=\\"msglist-element header-wrapper header topic-header\\"
   data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAx\\"
   data-msg-id=\\"9181\\"
 >
@@ -3633,7 +3633,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible stream
     
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-9181\\"
      data-msg-id=\\"9181\\"
      data-mute-state=\\"shown\\"
@@ -3661,7 +3661,7 @@ This is an example stream message.
   
 </div>
 
-  <div class=\\"timerow\\" data-msg-id=\\"9815\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"9815\\">
     <div class=\\"timerow-left\\"></div>
     Mar 12, 1995
     <div class=\\"timerow-right\\"></div>
@@ -3669,7 +3669,7 @@ This is an example stream message.
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-9815\\"
      data-msg-id=\\"9815\\"
      data-mute-state=\\"shown\\"
@@ -3701,14 +3701,14 @@ This is an example stream message.
 
 exports[`messages -> piece descriptors -> content HTML is stable/sensible stream:s:stream 1 5`] = `
 "
-  <div class=\\"timerow\\" data-msg-id=\\"1024\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"1024\\">
     <div class=\\"timerow-left\\"></div>
     Feb 5, 1995
     <div class=\\"timerow-right\\"></div>
   </div>
 
 <div
-  class=\\"header-wrapper header topic-header\\"
+  class=\\"msglist-element header-wrapper header topic-header\\"
   data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAx\\"
   data-msg-id=\\"1024\\"
 >
@@ -3718,7 +3718,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible stream
     
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-1024\\"
      data-msg-id=\\"1024\\"
      data-mute-state=\\"shown\\"
@@ -3748,7 +3748,7 @@ This is an example stream message.
 
 
     <div
-     class=\\"message message-brief\\"
+     class=\\"msglist-element message message-brief\\"
      id=\\"msg-1598\\"
      data-msg-id=\\"1598\\"
      data-mute-state=\\"shown\\"
@@ -3771,7 +3771,7 @@ This is an example stream message.
   </div>
 </div>
 
-  <div class=\\"timerow\\" data-msg-id=\\"4948\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"4948\\">
     <div class=\\"timerow-left\\"></div>
     Feb 19, 1995
     <div class=\\"timerow-right\\"></div>
@@ -3779,7 +3779,7 @@ This is an example stream message.
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-4948\\"
      data-msg-id=\\"4948\\"
      data-mute-state=\\"shown\\"
@@ -3808,7 +3808,7 @@ This is an example stream message.
 </div>
 
 <div
-  class=\\"header-wrapper header topic-header\\"
+  class=\\"msglist-element header-wrapper header topic-header\\"
   data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAy\\"
   data-msg-id=\\"5083\\"
 >
@@ -3818,7 +3818,7 @@ This is an example stream message.
     
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-5083\\"
      data-msg-id=\\"5083\\"
      data-mute-state=\\"shown\\"
@@ -3846,14 +3846,14 @@ This is an example stream message.
   
 </div>
 
-  <div class=\\"timerow\\" data-msg-id=\\"7938\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"7938\\">
     <div class=\\"timerow-left\\"></div>
     Mar 5, 1995
     <div class=\\"timerow-right\\"></div>
   </div>
 
 <div
-  class=\\"header-wrapper header topic-header\\"
+  class=\\"msglist-element header-wrapper header topic-header\\"
   data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAx\\"
   data-msg-id=\\"7938\\"
 >
@@ -3863,7 +3863,7 @@ This is an example stream message.
     
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-7938\\"
      data-msg-id=\\"7938\\"
      data-mute-state=\\"shown\\"
@@ -3893,7 +3893,7 @@ This is an example stream message.
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-8060\\"
      data-msg-id=\\"8060\\"
      data-mute-state=\\"shown\\"
@@ -3923,7 +3923,7 @@ This is an example stream message.
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-9181\\"
      data-msg-id=\\"9181\\"
      data-mute-state=\\"shown\\"
@@ -3951,7 +3951,7 @@ This is an example stream message.
   
 </div>
 
-  <div class=\\"timerow\\" data-msg-id=\\"9815\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"9815\\">
     <div class=\\"timerow-left\\"></div>
     Mar 12, 1995
     <div class=\\"timerow-right\\"></div>
@@ -3959,7 +3959,7 @@ This is an example stream message.
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-9815\\"
      data-msg-id=\\"9815\\"
      data-mute-state=\\"shown\\"
@@ -3991,7 +3991,7 @@ This is an example stream message.
 
 exports[`messages -> piece descriptors -> content HTML is stable/sensible topic:s:stream 1 topic 1 1`] = `
 "
-  <div class=\\"timerow\\" data-msg-id=\\"1024\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"1024\\">
     <div class=\\"timerow-left\\"></div>
     Feb 5, 1995
     <div class=\\"timerow-right\\"></div>
@@ -3999,7 +3999,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible topic:
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-1024\\"
      data-msg-id=\\"1024\\"
      data-mute-state=\\"shown\\"
@@ -4029,7 +4029,7 @@ This is an example stream message.
 
 
     <div
-     class=\\"message message-brief\\"
+     class=\\"msglist-element message message-brief\\"
      id=\\"msg-1598\\"
      data-msg-id=\\"1598\\"
      data-mute-state=\\"shown\\"
@@ -4056,7 +4056,7 @@ This is an example stream message.
 
 exports[`messages -> piece descriptors -> content HTML is stable/sensible topic:s:stream 1 topic 1 2`] = `
 "
-  <div class=\\"timerow\\" data-msg-id=\\"7938\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"7938\\">
     <div class=\\"timerow-left\\"></div>
     Mar 5, 1995
     <div class=\\"timerow-right\\"></div>
@@ -4064,7 +4064,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible topic:
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-7938\\"
      data-msg-id=\\"7938\\"
      data-mute-state=\\"shown\\"
@@ -4094,7 +4094,7 @@ This is an example stream message.
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-8060\\"
      data-msg-id=\\"8060\\"
      data-mute-state=\\"shown\\"
@@ -4126,7 +4126,7 @@ This is an example stream message.
 
 exports[`messages -> piece descriptors -> content HTML is stable/sensible topic:s:stream 1 topic 1 3`] = `
 "
-  <div class=\\"timerow\\" data-msg-id=\\"9181\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"9181\\">
     <div class=\\"timerow-left\\"></div>
     Mar 5, 1995
     <div class=\\"timerow-right\\"></div>
@@ -4134,7 +4134,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible topic:
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-9181\\"
      data-msg-id=\\"9181\\"
      data-mute-state=\\"shown\\"
@@ -4162,7 +4162,7 @@ This is an example stream message.
   
 </div>
 
-  <div class=\\"timerow\\" data-msg-id=\\"9815\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"9815\\">
     <div class=\\"timerow-left\\"></div>
     Mar 12, 1995
     <div class=\\"timerow-right\\"></div>
@@ -4170,7 +4170,7 @@ This is an example stream message.
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-9815\\"
      data-msg-id=\\"9815\\"
      data-mute-state=\\"shown\\"
@@ -4202,7 +4202,7 @@ This is an example stream message.
 
 exports[`messages -> piece descriptors -> content HTML is stable/sensible topic:s:stream 1 topic 1 4`] = `
 "
-  <div class=\\"timerow\\" data-msg-id=\\"1024\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"1024\\">
     <div class=\\"timerow-left\\"></div>
     Feb 5, 1995
     <div class=\\"timerow-right\\"></div>
@@ -4210,7 +4210,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible topic:
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-1024\\"
      data-msg-id=\\"1024\\"
      data-mute-state=\\"shown\\"
@@ -4240,7 +4240,7 @@ This is an example stream message.
 
 
     <div
-     class=\\"message message-brief\\"
+     class=\\"msglist-element message message-brief\\"
      id=\\"msg-1598\\"
      data-msg-id=\\"1598\\"
      data-mute-state=\\"shown\\"
@@ -4263,7 +4263,7 @@ This is an example stream message.
   </div>
 </div>
 
-  <div class=\\"timerow\\" data-msg-id=\\"7938\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"7938\\">
     <div class=\\"timerow-left\\"></div>
     Mar 5, 1995
     <div class=\\"timerow-right\\"></div>
@@ -4271,7 +4271,7 @@ This is an example stream message.
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-7938\\"
      data-msg-id=\\"7938\\"
      data-mute-state=\\"shown\\"
@@ -4301,7 +4301,7 @@ This is an example stream message.
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-8060\\"
      data-msg-id=\\"8060\\"
      data-mute-state=\\"shown\\"
@@ -4331,7 +4331,7 @@ This is an example stream message.
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-9181\\"
      data-msg-id=\\"9181\\"
      data-mute-state=\\"shown\\"
@@ -4359,7 +4359,7 @@ This is an example stream message.
   
 </div>
 
-  <div class=\\"timerow\\" data-msg-id=\\"9815\\">
+  <div class=\\"msglist-element timerow\\" data-msg-id=\\"9815\\">
     <div class=\\"timerow-left\\"></div>
     Mar 12, 1995
     <div class=\\"timerow-right\\"></div>
@@ -4367,7 +4367,7 @@ This is an example stream message.
 
 
     <div
-     class=\\"message message-full\\"
+     class=\\"msglist-element message message-full\\"
      id=\\"msg-9815\\"
      data-msg-id=\\"9815\\"
      data-mute-state=\\"shown\\"

--- a/src/webview/html/header.js
+++ b/src/webview/html/header.js
@@ -45,7 +45,7 @@ export default (
 
       return template`
 <div
-  class="header-wrapper header topic-header"
+  class="msglist-element header-wrapper header topic-header"
   data-narrow="${base64Utf8Encode(topicNarrowStr)}"
   data-msg-id="${message.id}"
 >
@@ -64,7 +64,7 @@ export default (
       const topicHtml = renderSubject(message);
 
       return template`
-<div class="header-wrapper header stream-header topic-header"
+<div class="msglist-element header-wrapper header stream-header topic-header"
     data-msg-id="${message.id}"
     data-narrow="${base64Utf8Encode(topicNarrowStr)}">
   <div class="header stream-text"
@@ -93,7 +93,7 @@ export default (
 
     const uiRecipients = pmUiRecipientsFromMessage(message, ownUser.user_id);
     return template`
-<div class="header-wrapper private-header header"
+<div class="msglist-element header-wrapper private-header header"
      data-narrow="${base64Utf8Encode(narrowStr)}"
      data-msg-id="${message.id}">
   ${uiRecipients

--- a/src/webview/html/message.js
+++ b/src/webview/html/message.js
@@ -200,7 +200,7 @@ export default (
 
   const divOpenHtml = template`
     <div
-     class="message ${isBrief ? 'message-brief' : 'message-full'}"
+     class="msglist-element message ${isBrief ? 'message-brief' : 'message-full'}"
      id="msg-${id}"
      data-msg-id="${id}"
      data-mute-state="${isUserMuted ? 'hidden' : 'shown'}"

--- a/src/webview/html/time.js
+++ b/src/webview/html/time.js
@@ -9,7 +9,7 @@ import { humanDate } from '../../utils/date';
  * This is a private helper of messageListElementHtml.
  */
 export default (element: TimeMessageListElement): string => template`
-  <div class="timerow" data-msg-id="${element.subsequentMessage.id}">
+  <div class="msglist-element timerow" data-msg-id="${element.subsequentMessage.id}">
     <div class="timerow-left"></div>
     ${humanDate(new Date(element.timestamp * 1000))}
     <div class="timerow-right"></div>

--- a/src/webview/js/generatedEs3.js
+++ b/src/webview/js/generatedEs3.js
@@ -988,11 +988,13 @@ var compiledWebviewJs = (function (exports) {
       return;
     }
 
-    if (target.parentNode instanceof Element && target.parentNode.matches('a')) {
+    var parentNode = target.parentNode;
+
+    if (parentNode instanceof Element && parentNode.matches('a')) {
       sendMessage({
         type: 'url',
-        href: requireAttribute(target.parentNode, 'href'),
-        messageId: getMessageIdFromNode(target.parentNode)
+        href: requireAttribute(parentNode, 'href'),
+        messageId: getMessageIdFromNode(parentNode)
       });
       return;
     }

--- a/src/webview/js/generatedEs3.js
+++ b/src/webview/js/generatedEs3.js
@@ -969,22 +969,13 @@ var compiledWebviewJs = (function (exports) {
       return;
     }
 
-    if (target.matches('a')) {
+    var closestA = target.closest('a');
+
+    if (closestA && (closestA === target || closestA === target.parentNode)) {
       sendMessage({
         type: 'url',
-        href: requireAttribute(target, 'href'),
-        messageId: getMessageIdFromElement(target)
-      });
-      return;
-    }
-
-    var parentNode = target.parentNode;
-
-    if (parentNode instanceof Element && parentNode.matches('a')) {
-      sendMessage({
-        type: 'url',
-        href: requireAttribute(parentNode, 'href'),
-        messageId: getMessageIdFromElement(parentNode)
+        href: requireAttribute(closestA, 'href'),
+        messageId: getMessageIdFromElement(closestA)
       });
       return;
     }

--- a/src/webview/js/generatedEs3.js
+++ b/src/webview/js/generatedEs3.js
@@ -599,13 +599,7 @@ var compiledWebviewJs = (function (exports) {
   }
 
   var getMessageNode = function getMessageNode(element) {
-    var curNode = element;
-
-    while (curNode && curNode.parentNode && curNode.parentNode !== documentBody) {
-      curNode = curNode.parentNode;
-    }
-
-    return curNode;
+    return element.closest('.msglist-element');
   };
 
   var getMessageIdFromElement = function getMessageIdFromElement(element) {

--- a/src/webview/js/generatedEs3.js
+++ b/src/webview/js/generatedEs3.js
@@ -598,14 +598,14 @@ var compiledWebviewJs = (function (exports) {
     };
   }
 
-  var getMessageNode = function getMessageNode(element) {
+  var getMessageElement = function getMessageElement(element) {
     return element.closest('.msglist-element');
   };
 
   var getMessageIdFromElement = function getMessageIdFromElement(element) {
     var defaultValue = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : -1;
-    var msgNode = getMessageNode(element);
-    return msgNode && msgNode instanceof Element ? +msgNode.getAttribute('data-msg-id') : defaultValue;
+    var msgElement = getMessageElement(element);
+    return msgElement ? +msgElement.getAttribute('data-msg-id') : defaultValue;
   };
 
   var setMessagesReadAttributes = function setMessagesReadAttributes(rangeHull) {

--- a/src/webview/js/generatedEs3.js
+++ b/src/webview/js/generatedEs3.js
@@ -969,17 +969,6 @@ var compiledWebviewJs = (function (exports) {
       return;
     }
 
-    var closestA = target.closest('a');
-
-    if (closestA && (closestA === target || closestA === target.parentNode)) {
-      sendMessage({
-        type: 'url',
-        href: requireAttribute(closestA, 'href'),
-        messageId: getMessageIdFromElement(closestA)
-      });
-      return;
-    }
-
     if (target.matches('.reaction')) {
       sendMessage({
         type: 'reaction',
@@ -1018,6 +1007,17 @@ var compiledWebviewJs = (function (exports) {
         type: 'time',
         originalText
       });
+    }
+
+    var closestA = target.closest('a');
+
+    if (closestA) {
+      sendMessage({
+        type: 'url',
+        href: requireAttribute(closestA, 'href'),
+        messageId: getMessageIdFromElement(closestA)
+      });
+      return;
     }
 
     var spoilerHeader = target.closest('.spoiler-header');

--- a/src/webview/js/generatedEs3.js
+++ b/src/webview/js/generatedEs3.js
@@ -608,9 +608,9 @@ var compiledWebviewJs = (function (exports) {
     return curNode;
   };
 
-  var getMessageIdFromNode = function getMessageIdFromNode(node) {
+  var getMessageIdFromElement = function getMessageIdFromElement(element) {
     var defaultValue = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : -1;
-    var msgNode = getMessageNode(node);
+    var msgNode = getMessageNode(element);
     return msgNode && msgNode instanceof Element ? +msgNode.getAttribute('data-msg-id') : defaultValue;
   };
 
@@ -974,7 +974,7 @@ var compiledWebviewJs = (function (exports) {
       sendMessage({
         type: 'image',
         src: requireAttribute(inlineImageLink, 'href'),
-        messageId: getMessageIdFromNode(inlineImageLink)
+        messageId: getMessageIdFromElement(inlineImageLink)
       });
       return;
     }
@@ -983,7 +983,7 @@ var compiledWebviewJs = (function (exports) {
       sendMessage({
         type: 'url',
         href: requireAttribute(target, 'href'),
-        messageId: getMessageIdFromNode(target)
+        messageId: getMessageIdFromElement(target)
       });
       return;
     }
@@ -994,7 +994,7 @@ var compiledWebviewJs = (function (exports) {
       sendMessage({
         type: 'url',
         href: requireAttribute(parentNode, 'href'),
-        messageId: getMessageIdFromNode(parentNode)
+        messageId: getMessageIdFromElement(parentNode)
       });
       return;
     }
@@ -1005,7 +1005,7 @@ var compiledWebviewJs = (function (exports) {
         name: requireAttribute(target, 'data-name'),
         code: requireAttribute(target, 'data-code'),
         reactionType: requireAttribute(target, 'data-type'),
-        messageId: getMessageIdFromNode(target),
+        messageId: getMessageIdFromElement(target),
         voted: target.classList.contains('self-voted')
       });
       return;
@@ -1061,7 +1061,7 @@ var compiledWebviewJs = (function (exports) {
     if (reactionNode) {
       sendMessage({
         type: 'reactionDetails',
-        messageId: getMessageIdFromNode(target),
+        messageId: getMessageIdFromElement(target),
         reactionName: requireAttribute(reactionNode, 'data-name')
       });
       return;
@@ -1078,7 +1078,7 @@ var compiledWebviewJs = (function (exports) {
     sendMessage({
       type: 'longPress',
       target: targetType,
-      messageId: getMessageIdFromNode(target),
+      messageId: getMessageIdFromElement(target),
       href: target.matches('a') ? requireAttribute(target, 'href') : null
     });
   };

--- a/src/webview/js/generatedEs3.js
+++ b/src/webview/js/generatedEs3.js
@@ -598,13 +598,9 @@ var compiledWebviewJs = (function (exports) {
     };
   }
 
-  var getMessageElement = function getMessageElement(element) {
-    return element.closest('.msglist-element');
-  };
-
   var getMessageIdFromElement = function getMessageIdFromElement(element) {
     var defaultValue = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : -1;
-    var msgElement = getMessageElement(element);
+    var msgElement = element.closest('.msglist-element');
     return msgElement ? +msgElement.getAttribute('data-msg-id') : defaultValue;
   };
 

--- a/src/webview/js/generatedEs3.js
+++ b/src/webview/js/generatedEs3.js
@@ -598,8 +598,8 @@ var compiledWebviewJs = (function (exports) {
     };
   }
 
-  var getMessageNode = function getMessageNode(node) {
-    var curNode = node;
+  var getMessageNode = function getMessageNode(element) {
+    var curNode = element;
 
     while (curNode && curNode.parentNode && curNode.parentNode !== documentBody) {
       curNode = curNode.parentNode;

--- a/src/webview/js/js.js
+++ b/src/webview/js/js.js
@@ -455,8 +455,8 @@ function visibleReadMessageIds(): {| first: number, last: number |} {
 }
 
 /** DEPRECATED - consider using `node.closest('.message')` instead. */
-const getMessageNode = (node: ?Node): ?Node => {
-  let curNode = node;
+const getMessageNode = (element: Element): ?Node => {
+  let curNode = element;
   while (curNode && curNode.parentNode && curNode.parentNode !== documentBody) {
     curNode = curNode.parentNode;
   }

--- a/src/webview/js/js.js
+++ b/src/webview/js/js.js
@@ -897,21 +897,17 @@ documentBody.addEventListener('click', (e: MouseEvent) => {
     return;
   }
 
-  if (target.matches('a')) {
+  const closestA = target.closest('a');
+  if (
+    closestA
+    // TODO: Is this right, or can target be even more deeply nested under
+    //   an <a />? (Check server API.)
+    && (closestA === target || closestA === target.parentNode)
+  ) {
     sendMessage({
       type: 'url',
-      href: requireAttribute(target, 'href'),
-      messageId: getMessageIdFromElement(target),
-    });
-    return;
-  }
-
-  const { parentNode } = target;
-  if (parentNode instanceof Element && parentNode.matches('a')) {
-    sendMessage({
-      type: 'url',
-      href: requireAttribute(parentNode, 'href'),
-      messageId: getMessageIdFromElement(parentNode),
+      href: requireAttribute(closestA, 'href'),
+      messageId: getMessageIdFromElement(closestA),
     });
     return;
   }

--- a/src/webview/js/js.js
+++ b/src/webview/js/js.js
@@ -897,21 +897,6 @@ documentBody.addEventListener('click', (e: MouseEvent) => {
     return;
   }
 
-  const closestA = target.closest('a');
-  if (
-    closestA
-    // TODO: Is this right, or can target be even more deeply nested under
-    //   an <a />? (Check server API.)
-    && (closestA === target || closestA === target.parentNode)
-  ) {
-    sendMessage({
-      type: 'url',
-      href: requireAttribute(closestA, 'href'),
-      messageId: getMessageIdFromElement(closestA),
-    });
-    return;
-  }
-
   if (target.matches('.reaction')) {
     sendMessage({
       type: 'reaction',
@@ -951,6 +936,16 @@ documentBody.addEventListener('click', (e: MouseEvent) => {
       type: 'time',
       originalText,
     });
+  }
+
+  const closestA = target.closest('a');
+  if (closestA) {
+    sendMessage({
+      type: 'url',
+      href: requireAttribute(closestA, 'href'),
+      messageId: getMessageIdFromElement(closestA),
+    });
+    return;
   }
 
   const spoilerHeader = target.closest('.spoiler-header');

--- a/src/webview/js/js.js
+++ b/src/webview/js/js.js
@@ -455,11 +455,8 @@ function visibleReadMessageIds(): {| first: number, last: number |} {
 }
 
 /** DEPRECATED */
-const getMessageElement = (element: Element): ?Element => element.closest('.msglist-element');
-
-/** DEPRECATED */
 const getMessageIdFromElement = (element: Element, defaultValue: number = -1): number => {
-  const msgElement = getMessageElement(element);
+  const msgElement = element.closest('.msglist-element');
   return msgElement ? +msgElement.getAttribute('data-msg-id') : defaultValue;
 };
 

--- a/src/webview/js/js.js
+++ b/src/webview/js/js.js
@@ -464,8 +464,8 @@ const getMessageNode = (node: ?Node): ?Node => {
 };
 
 /** DEPRECATED */
-const getMessageIdFromNode = (node: ?Node, defaultValue: number = -1): number => {
-  const msgNode = getMessageNode(node);
+const getMessageIdFromElement = (element: Element, defaultValue: number = -1): number => {
+  const msgNode = getMessageNode(element);
   return msgNode && msgNode instanceof Element
     ? +msgNode.getAttribute('data-msg-id')
     : defaultValue;
@@ -903,7 +903,7 @@ documentBody.addEventListener('click', (e: MouseEvent) => {
     sendMessage({
       type: 'image',
       src: requireAttribute(inlineImageLink, 'href'), // TODO: should be `src` / `data-src-fullsize`.
-      messageId: getMessageIdFromNode(inlineImageLink),
+      messageId: getMessageIdFromElement(inlineImageLink),
     });
     return;
   }
@@ -912,7 +912,7 @@ documentBody.addEventListener('click', (e: MouseEvent) => {
     sendMessage({
       type: 'url',
       href: requireAttribute(target, 'href'),
-      messageId: getMessageIdFromNode(target),
+      messageId: getMessageIdFromElement(target),
     });
     return;
   }
@@ -922,7 +922,7 @@ documentBody.addEventListener('click', (e: MouseEvent) => {
     sendMessage({
       type: 'url',
       href: requireAttribute(parentNode, 'href'),
-      messageId: getMessageIdFromNode(parentNode),
+      messageId: getMessageIdFromElement(parentNode),
     });
     return;
   }
@@ -933,7 +933,7 @@ documentBody.addEventListener('click', (e: MouseEvent) => {
       name: requireAttribute(target, 'data-name'),
       code: requireAttribute(target, 'data-code'),
       reactionType: requireAttribute(target, 'data-type'),
-      messageId: getMessageIdFromNode(target),
+      messageId: getMessageIdFromElement(target),
       voted: target.classList.contains('self-voted'),
     });
     return;
@@ -993,7 +993,7 @@ const handleLongPress = (target: Element) => {
   if (reactionNode) {
     sendMessage({
       type: 'reactionDetails',
-      messageId: getMessageIdFromNode(target),
+      messageId: getMessageIdFromElement(target),
       reactionName: requireAttribute(reactionNode, 'data-name'),
     });
     return;
@@ -1020,7 +1020,7 @@ const handleLongPress = (target: Element) => {
   sendMessage({
     type: 'longPress',
     target: targetType,
-    messageId: getMessageIdFromNode(target),
+    messageId: getMessageIdFromElement(target),
     href: target.matches('a') ? requireAttribute(target, 'href') : null,
   });
 };

--- a/src/webview/js/js.js
+++ b/src/webview/js/js.js
@@ -917,11 +917,12 @@ documentBody.addEventListener('click', (e: MouseEvent) => {
     return;
   }
 
-  if (target.parentNode instanceof Element && target.parentNode.matches('a')) {
+  const { parentNode } = target;
+  if (parentNode instanceof Element && parentNode.matches('a')) {
     sendMessage({
       type: 'url',
-      href: requireAttribute(target.parentNode, 'href'),
-      messageId: getMessageIdFromNode(target.parentNode),
+      href: requireAttribute(parentNode, 'href'),
+      messageId: getMessageIdFromNode(parentNode),
     });
     return;
   }

--- a/src/webview/js/js.js
+++ b/src/webview/js/js.js
@@ -454,14 +454,8 @@ function visibleReadMessageIds(): {| first: number, last: number |} {
   return { first, last };
 }
 
-/** DEPRECATED - consider using `node.closest('.message')` instead. */
-const getMessageNode = (element: Element): ?Node => {
-  let curNode = element;
-  while (curNode && curNode.parentNode && curNode.parentNode !== documentBody) {
-    curNode = curNode.parentNode;
-  }
-  return curNode;
-};
+/** DEPRECATED */
+const getMessageNode = (element: Element): ?Node => element.closest('.msglist-element');
 
 /** DEPRECATED */
 const getMessageIdFromElement = (element: Element, defaultValue: number = -1): number => {

--- a/src/webview/js/js.js
+++ b/src/webview/js/js.js
@@ -455,14 +455,12 @@ function visibleReadMessageIds(): {| first: number, last: number |} {
 }
 
 /** DEPRECATED */
-const getMessageNode = (element: Element): ?Node => element.closest('.msglist-element');
+const getMessageElement = (element: Element): ?Element => element.closest('.msglist-element');
 
 /** DEPRECATED */
 const getMessageIdFromElement = (element: Element, defaultValue: number = -1): number => {
-  const msgNode = getMessageNode(element);
-  return msgNode && msgNode instanceof Element
-    ? +msgNode.getAttribute('data-msg-id')
-    : defaultValue;
+  const msgElement = getMessageElement(element);
+  return msgElement ? +msgElement.getAttribute('data-msg-id') : defaultValue;
 };
 
 /**


### PR DESCRIPTION
(And fix an unrelated bug where a _**[bold, italic link](https://www.chat.zulip.org/)**_ in a Zulip message failed to open when you tapped on it.)