### PR TITLE
typeahead:Open typeahead immediately the '@' character is entered

### DIFF
--- a/src/autocomplete/AutocompleteView.js
+++ b/src/autocomplete/AutocompleteView.js
@@ -46,7 +46,16 @@ export default function AutocompleteView(props: Props): Node {
 
   const { lastWordPrefix, filter } = getAutocompleteFilter(text, selection);
   const AutocompleteComponent = prefixToComponent[lastWordPrefix];
-  const shouldShow = isFocused && !!AutocompleteComponent && filter.length > 0;
+  const shouldShow =
+    isFocused
+    && !!AutocompleteComponent
+    // For most autocompletes, wait until the user has typed at least one
+    // character of their search term…
+    && (filter.length > 0
+      // …but for the people autocomplete, just show it without waiting
+      // (i.e., just after the user has typed '@'). See
+      //   https://github.com/zulip/zulip-mobile/issues/4872#issuecomment-942612417.
+      || AutocompleteComponent === PeopleAutocomplete);
 
   return (
     <AnimatedScaleComponent visible={shouldShow}>


### PR DESCRIPTION
Typeahead opens immediately the **@** character is entered to reflect that in the web app.
Screenshot:
![typeahead](https://user-images.githubusercontent.com/38510556/137847831-38c3479f-b06f-4ac5-9e56-3e6a248143a7.jpeg)

Short gif to better explain:
https://user-images.githubusercontent.com/38510556/137847909-d10ec8ca-21c4-458d-9a9f-fccdeb80be5e.mp4



Fixes #4872 
