### PR TITLE
deps: Bring @rnc/react-native-netinfo back down to 6.0.0

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -284,7 +284,7 @@ PODS:
     - React-Core
   - react-native-image-picker (2.3.4):
     - React-Core
-  - react-native-netinfo (6.0.2):
+  - react-native-netinfo (6.0.0):
     - React-Core
   - react-native-photo-view (1.5.2):
     - React
@@ -668,7 +668,7 @@ SPEC CHECKSUMS:
   React-jsinspector: cc614ec18a9ca96fd275100c16d74d62ee11f0ae
   react-native-cameraroll: 88f4e62d9ecd0e1f253abe4f685474f2ea14bfa2
   react-native-image-picker: c6d75c4ab2cf46f9289f341242b219cb3c1180d3
-  react-native-netinfo: 92e6e4476eb8bf6fc2d7c0a6ca0a1406f663d73a
+  react-native-netinfo: e849fc21ca2f4128a5726c801a82fc6f4a6db50d
   react-native-photo-view: 63e9e61da873531f931008b545d8d10c5373ddf8
   react-native-safe-area-context: 584dc04881deb49474363f3be89e4ca0e854c057
   react-native-simple-toast: bf002828cf816775a6809f7a9ec3907509bce11f

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@react-native-async-storage/async-storage": "^1.13.0",
     "@react-native-community/cameraroll": "chrisbobbe/react-native-cameraroll#17fa5d8d2",
     "@react-native-community/masked-view": "^0.1.10",
-    "@react-native-community/netinfo": "^6.0.0",
+    "@react-native-community/netinfo": "6.0.0",
     "@react-native-community/push-notification-ios": "^1.5.0",
     "@react-navigation/bottom-tabs": "^5.10.6",
     "@react-navigation/drawer": "^5.9.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1917,10 +1917,10 @@
   resolved "https://registry.yarnpkg.com/@react-native-community/masked-view/-/masked-view-0.1.11.tgz#2f4c6e10bee0786abff4604e39a37ded6f3980ce"
   integrity sha512-rQfMIGSR/1r/SyN87+VD8xHHzDYeHaJq6elOSCAD+0iLagXkSI2pfA0LmSXP21uw5i3em7GkkRjfJ8wpqWXZNw==
 
-"@react-native-community/netinfo@^6.0.0":
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/@react-native-community/netinfo/-/netinfo-6.0.2.tgz#3b61757c46d0f387815d42b651bbee1eb998a385"
-  integrity sha512-HbVIv6p+VAzSqALkfKKNbtSy0TneL7EILIqxiOjt/5weVdTuZ88NRyPNQAZBh6W8QYirXJo3f00ryMk9iLs7gQ==
+"@react-native-community/netinfo@6.0.0":
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/@react-native-community/netinfo/-/netinfo-6.0.0.tgz#2a4d7190b508dd0c2293656c9c1aa068f6f60a71"
+  integrity sha512-Z9M8VGcF2IZVOo2x+oUStvpCW/8HjIRi4+iQCu5n+PhC7OqCQX58KYAzdBr///alIfRXiu6oMb+lK+rXQH1FvQ==
 
 "@react-native-community/push-notification-ios@^1.5.0":
   version "1.10.1"


### PR DESCRIPTION
6.0.1, which we took in 5cc9dfa4a, introduced a bug, in
  https://github.com/react-native-netinfo/react-native-netinfo/commit/7084771
, that was causing the "No Internet connection" message to wrongly
show up sometimes on Android.

See Greg's diagnosis and suggested solution (reversion) at
  https://github.com/react-native-netinfo/react-native-netinfo/issues/481#issuecomment-948143010
, and discussion on CZO at
  https://chat.zulip.org/#narrow/stream/48-mobile/topic/android.20.22No.20internet.20connection.22/near/1269190
.