### PR TITLE
stream IDs: StreamItem and TopicItem props and callbacks

### DIFF
--- a/src/autocomplete/StreamAutocomplete.js
+++ b/src/autocomplete/StreamAutocomplete.js
@@ -19,8 +19,8 @@ export default function StreamAutocomplete(props: Props): Node {
   const subscriptions = useSelector(getSubscribedStreams);
 
   const handleStreamItemAutocomplete = useCallback(
-    (name: string): void => {
-      onAutocomplete(`**${name}**`);
+    (streamId: number, streamName: string): void => {
+      onAutocomplete(`**${streamName}**`);
     },
     [onAutocomplete],
   );

--- a/src/autocomplete/StreamAutocomplete.js
+++ b/src/autocomplete/StreamAutocomplete.js
@@ -43,6 +43,7 @@ export default function StreamAutocomplete(props: Props): Node {
         keyExtractor={item => item.stream_id.toString()}
         renderItem={({ item }) => (
           <StreamItem
+            streamId={item.stream_id}
             name={item.name}
             isMuted={!item.in_home_view}
             isPrivate={item.invite_only}

--- a/src/streams/StreamItem.js
+++ b/src/streams/StreamItem.js
@@ -52,8 +52,8 @@ type Props = $ReadOnly<{|
   unreadCount?: number,
   iconSize: number,
   showSwitch?: boolean,
-  onPress: (name: string) => void,
-  onSwitch?: (name: string, newValue: boolean) => void,
+  onPress: (streamId: number, streamName: string) => void,
+  onSwitch?: (streamId: number, streamName: string, newValue: boolean) => void,
 |}>;
 
 /**
@@ -78,6 +78,7 @@ type Props = $ReadOnly<{|
  */
 export default function StreamItem(props: Props): Node {
   const {
+    streamId,
     name,
     description,
     color,
@@ -123,7 +124,7 @@ export default function StreamItem(props: Props): Node {
 
   return (
     <Touchable
-      onPress={() => onPress(name)}
+      onPress={() => onPress(streamId, name)}
       onLongPress={() => {
         showStreamActionSheet({
           showActionSheetWithOptions,
@@ -157,7 +158,7 @@ export default function StreamItem(props: Props): Node {
             value={!!isSubscribed}
             onValueChange={(newValue: boolean) => {
               if (onSwitch) {
-                onSwitch(name, newValue);
+                onSwitch(streamId, name, newValue);
               }
             }}
             disabled={!isSubscribed && isPrivate}

--- a/src/streams/StreamItem.js
+++ b/src/streams/StreamItem.js
@@ -41,6 +41,7 @@ const componentStyles = createStyleSheet({
 
 type Props = $ReadOnly<{|
   name: string,
+  streamId: number,
   description?: string,
   isMuted: boolean,
   isPrivate: boolean,

--- a/src/streams/StreamItem.js
+++ b/src/streams/StreamItem.js
@@ -4,7 +4,6 @@ import type { Node } from 'react';
 import { View } from 'react-native';
 // $FlowFixMe[untyped-import]
 import { useActionSheet } from '@expo/react-native-action-sheet';
-import invariant from 'invariant';
 
 import { showStreamActionSheet } from '../action-sheets';
 import type { ShowActionSheetWithOptions } from '../action-sheets';
@@ -15,7 +14,6 @@ import {
   getFlags,
   getSubscriptionsById,
   getStreamsById,
-  getStreamsByName,
   getOwnUser,
   getSettings,
 } from '../selectors';
@@ -105,8 +103,6 @@ export default function StreamItem(props: Props): Node {
     flags: getFlags(state),
     userSettingStreamNotification: getSettings(state).streamNotification,
   }));
-  const stream = useSelector(state => getStreamsByName(state).get(name));
-  invariant(stream !== undefined, 'No stream with provided stream name was found.');
 
   const { backgroundColor: themeBackgroundColor, color: themeColor } = useContext(ThemeContext);
 
@@ -130,7 +126,7 @@ export default function StreamItem(props: Props): Node {
           showActionSheetWithOptions,
           callbacks: { dispatch, _ },
           backgroundData,
-          streamId: stream.stream_id,
+          streamId,
         });
       }}
     >

--- a/src/streams/StreamList.js
+++ b/src/streams/StreamList.js
@@ -84,6 +84,7 @@ export default function StreamList(props: Props): Node {
       keyExtractor={item => item.stream_id}
       renderItem={({ item }: { item: PseudoSubscription, ... }) => (
         <StreamItem
+          streamId={item.stream_id}
           name={item.name}
           iconSize={16}
           isPrivate={item.invite_only}

--- a/src/streams/StreamList.js
+++ b/src/streams/StreamList.js
@@ -43,8 +43,8 @@ type Props = $ReadOnly<{|
   showSwitch?: boolean,
   streams?: $ReadOnlyArray<PseudoSubscription>,
   unreadByStream?: $ReadOnly<{| [number]: number |}>,
-  onPress: (streamName: string) => void,
-  onSwitch?: (streamName: string, newValue: boolean) => void,
+  onPress: (streamId: number, streamName: string) => void,
+  onSwitch?: (streamId: number, streamName: string, newValue: boolean) => void,
 |}>;
 
 export default function StreamList(props: Props): Node {

--- a/src/streams/SubscriptionsCard.js
+++ b/src/streams/SubscriptionsCard.js
@@ -33,7 +33,7 @@ export default function SubscriptionsCard(props: Props): Node {
   const unreadByStream = useSelector(getUnreadByStream);
 
   const handleNarrow = useCallback(
-    (streamName: string) => {
+    (streamId: number, streamName: string) => {
       dispatch(doNarrow(streamNarrow(streamName)));
     },
     [dispatch],

--- a/src/streams/TopicItem.js
+++ b/src/streams/TopicItem.js
@@ -45,11 +45,19 @@ type Props = $ReadOnly<{|
   isMuted?: boolean,
   isSelected?: boolean,
   unreadCount?: number,
-  onPress: (stream: string, topic: string) => void,
+  onPress: (streamId: number, streamName: string, topic: string) => void,
 |}>;
 
 export default function TopicItem(props: Props): Node {
-  const { name, streamName, isMuted = false, isSelected = false, unreadCount = 0, onPress } = props;
+  const {
+    streamId,
+    streamName,
+    name,
+    isMuted = false,
+    isSelected = false,
+    unreadCount = 0,
+    onPress,
+  } = props;
 
   const showActionSheetWithOptions: ShowActionSheetWithOptions = useActionSheet()
     .showActionSheetWithOptions;
@@ -71,7 +79,7 @@ export default function TopicItem(props: Props): Node {
 
   return (
     <Touchable
-      onPress={() => onPress(streamName, name)}
+      onPress={() => onPress(streamId, streamName, name)}
       onLongPress={() => {
         showTopicActionSheet({
           showActionSheetWithOptions,

--- a/src/streams/TopicItem.js
+++ b/src/streams/TopicItem.js
@@ -4,7 +4,6 @@ import type { Node } from 'react';
 import { View } from 'react-native';
 // $FlowFixMe[untyped-import]
 import { useActionSheet } from '@expo/react-native-action-sheet';
-import invariant from 'invariant';
 
 import styles, { BRAND_COLOR, createStyleSheet } from '../styles';
 import { RawLabel, Touchable, UnreadCount } from '../common';
@@ -74,9 +73,6 @@ export default function TopicItem(props: Props): Node {
     flags: getFlags(state),
   }));
 
-  const stream = backgroundData.streamsByName.get(streamName);
-  invariant(stream !== undefined, 'No stream with provided stream name was found.');
-
   return (
     <Touchable
       onPress={() => onPress(streamId, streamName, name)}
@@ -85,7 +81,7 @@ export default function TopicItem(props: Props): Node {
           showActionSheetWithOptions,
           callbacks: { dispatch, _ },
           backgroundData,
-          streamId: stream.stream_id,
+          streamId,
           topic: name,
         });
       }}

--- a/src/streams/TopicItem.js
+++ b/src/streams/TopicItem.js
@@ -39,6 +39,7 @@ const componentStyles = createStyleSheet({
 });
 
 type Props = $ReadOnly<{|
+  streamId: number,
   streamName: string,
   name: string,
   isMuted?: boolean,

--- a/src/subscriptions/StreamListCard.js
+++ b/src/subscriptions/StreamListCard.js
@@ -44,7 +44,7 @@ export default function StreamListCard(props: Props): Node {
   }));
 
   const handleSwitchChange = useCallback(
-    (streamName: string, switchValue: boolean) => {
+    (streamId: number, streamName: string, switchValue: boolean) => {
       if (switchValue) {
         api.subscriptionAdd(auth, [{ name: streamName }]);
       } else {
@@ -55,7 +55,7 @@ export default function StreamListCard(props: Props): Node {
   );
 
   const handleNarrow = useCallback(
-    (streamName: string) => {
+    (streamId: number, streamName: string) => {
       dispatch(doNarrow(streamNarrow(streamName)));
     },
     [dispatch],

--- a/src/topics/TopicList.js
+++ b/src/topics/TopicList.js
@@ -41,8 +41,9 @@ export default class TopicList extends PureComponent<Props> {
         keyExtractor={item => item.name}
         renderItem={({ item }) => (
           <TopicItem
-            name={item.name}
+            streamId={stream.stream_id}
             streamName={stream.name}
+            name={item.name}
             isMuted={item.isMuted}
             unreadCount={item.unreadCount}
             onPress={onPress}

--- a/src/topics/TopicList.js
+++ b/src/topics/TopicList.js
@@ -18,7 +18,7 @@ const styles = createStyleSheet({
 type Props = $ReadOnly<{|
   stream: Stream,
   topics: ?(TopicExtended[]),
-  onPress: (stream: string, topic: string) => void,
+  onPress: (streamId: number, streamName: string, topic: string) => void,
 |}>;
 
 export default class TopicList extends PureComponent<Props> {

--- a/src/topics/TopicListScreen.js
+++ b/src/topics/TopicListScreen.js
@@ -26,10 +26,10 @@ export default function TopicListScreen(props: Props): Node {
   const [filter, setFilter] = useState<string>('');
 
   const handlePress = useCallback(
-    (streamObj: string, topic: string) => {
-      dispatch(doNarrow(topicNarrow(stream.name, topic)));
+    (streamName: string, topic: string) => {
+      dispatch(doNarrow(topicNarrow(streamName, topic)));
     },
-    [dispatch, stream],
+    [dispatch],
   );
 
   useEffect(() => {

--- a/src/topics/TopicListScreen.js
+++ b/src/topics/TopicListScreen.js
@@ -26,7 +26,7 @@ export default function TopicListScreen(props: Props): Node {
   const [filter, setFilter] = useState<string>('');
 
   const handlePress = useCallback(
-    (streamName: string, topic: string) => {
+    (streamId: number, streamName: string, topic: string) => {
       dispatch(doNarrow(topicNarrow(streamName, topic)));
     },
     [dispatch],

--- a/src/types.js
+++ b/src/types.js
@@ -327,6 +327,7 @@ export type GetText = {|
 
 export type UnreadStreamItem = {|
   key: string,
+  streamId: number,
   streamName: string,
   unread: number,
   color: string,

--- a/src/unread/UnreadCards.js
+++ b/src/unread/UnreadCards.js
@@ -71,8 +71,8 @@ export default function UnreadCards(props: Props): Node {
             isMuted={section.isMuted || item.isMuted}
             isSelected={false}
             unreadCount={item.unread}
-            onPress={(stream: string, topic: string) => {
-              setTimeout(() => dispatch(doNarrow(topicNarrow(stream, topic))));
+            onPress={(streamId: number, streamName: string, topic: string) => {
+              setTimeout(() => dispatch(doNarrow(topicNarrow(streamName, topic))));
             }}
           />
         )

--- a/src/unread/UnreadCards.js
+++ b/src/unread/UnreadCards.js
@@ -54,8 +54,8 @@ export default function UnreadCards(props: Props): Node {
             isPrivate={section.isPrivate}
             backgroundColor={section.color}
             unreadCount={section.unread}
-            onPress={(stream: string) => {
-              setTimeout(() => dispatch(doNarrow(streamNarrow(stream))));
+            onPress={(streamId: number, streamName: string) => {
+              setTimeout(() => dispatch(doNarrow(streamNarrow(streamName))));
             }}
           />
         )

--- a/src/unread/UnreadCards.js
+++ b/src/unread/UnreadCards.js
@@ -47,6 +47,7 @@ export default function UnreadCards(props: Props): Node {
       renderSectionHeader={({ section }) =>
         section.key === 'private' ? null : (
           <StreamItem
+            streamId={section.streamId}
             name={section.streamName}
             iconSize={16}
             isMuted={section.isMuted}

--- a/src/unread/UnreadCards.js
+++ b/src/unread/UnreadCards.js
@@ -65,8 +65,9 @@ export default function UnreadCards(props: Props): Node {
           <PmConversationList {...item} />
         ) : (
           <TopicItem
-            name={item.topic}
+            streamId={section.streamId}
             streamName={section.streamName || ''}
+            name={item.topic}
             isMuted={section.isMuted || item.isMuted}
             isSelected={false}
             unreadCount={item.unread}

--- a/src/unread/__tests__/unreadSelectors-test.js
+++ b/src/unread/__tests__/unreadSelectors-test.js
@@ -286,6 +286,7 @@ describe('getUnreadStreamsAndTopics', () => {
         ],
         isMuted: true,
         key: 'stream:stream 0',
+        streamId: 0,
         streamName: 'stream 0',
         unread: 5,
       },
@@ -302,6 +303,7 @@ describe('getUnreadStreamsAndTopics', () => {
         ],
         isMuted: true,
         key: 'stream:stream 2',
+        streamId: 2,
         streamName: 'stream 2',
         unread: 2,
       },
@@ -352,6 +354,7 @@ describe('getUnreadStreamsAndTopics', () => {
         isMuted: false,
         isPrivate: undefined,
         key: 'stream:stream 0',
+        streamId: 0,
         streamName: 'stream 0',
         unread: 2,
       },
@@ -368,6 +371,7 @@ describe('getUnreadStreamsAndTopics', () => {
         ],
         isMuted: false,
         key: 'stream:stream 2',
+        streamId: 2,
         streamName: 'stream 2',
         unread: 2,
       },
@@ -399,6 +403,7 @@ describe('getUnreadStreamsAndTopics', () => {
     expect(unreadCount).toEqual([
       {
         key: 'stream:stream 0',
+        streamId: 0,
         streamName: 'stream 0',
         color: 'red',
         unread: 5,
@@ -416,6 +421,7 @@ describe('getUnreadStreamsAndTopics', () => {
       },
       {
         key: 'stream:stream 2',
+        streamId: 2,
         streamName: 'stream 2',
         color: 'blue',
         unread: 2,
@@ -485,6 +491,7 @@ describe('getUnreadStreamsAndTopics', () => {
     expect(unreadCount).toEqual([
       {
         key: 'stream:xyz stream',
+        streamId: 1,
         streamName: 'xyz stream',
         color: 'blue',
         isMuted: false,
@@ -498,6 +505,7 @@ describe('getUnreadStreamsAndTopics', () => {
       },
       {
         key: 'stream:abc stream',
+        streamId: 0,
         streamName: 'abc stream',
         color: 'red',
         isMuted: false,
@@ -511,6 +519,7 @@ describe('getUnreadStreamsAndTopics', () => {
       },
       {
         key: 'stream:def stream',
+        streamId: 2,
         streamName: 'def stream',
         color: 'green',
         isMuted: false,
@@ -583,6 +592,7 @@ describe('getUnreadStreamsAndTopicsSansMuted', () => {
         isMuted: false,
         isPrivate: undefined,
         key: 'stream:stream 0',
+        streamId: 0,
         streamName: 'stream 0',
         unread: 2,
       },

--- a/src/unread/unreadSelectors.js
+++ b/src/unread/unreadSelectors.js
@@ -143,6 +143,7 @@ export const getUnreadStreamsAndTopics: Selector<UnreadStreamItem[]> = createSel
 
       const total = {
         key: `stream:${name}`,
+        streamId,
         streamName: name,
         isMuted: !in_home_view,
         isPrivate: invite_only,


### PR DESCRIPTION
This is an installment on #3918, converting from stream names to stream IDs; I'd taken a look at it recently following #5056.

In this PR, we make those conversions for the two components StreamItem and TopicItem: they now take the stream ID as a prop along with the stream name and other details, and pass the stream ID to their callbacks as well as the stream name and in TopicItem's case the topic.

This allows a couple of simplifications, to skip looking up the ID from the name in a couple of places where this code was already calling something that demands an ID. It also makes stream IDs available in various places we currently use names, including several Narrow-constructor call sites.
