### PR TITLE
android: Update target SDK version to 30, i.e. Android 11

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -47,6 +47,21 @@
         android:name="android.hardware.wifi"
         android:required="false" />
 
+    <queries>
+        <intent>
+            <!-- Find Chrome Custom Tabs, with this query and a
+                 "com.android.chrome" package check, so we can use
+                 it to open external links. -->
+            <action android:name="android.support.customtabs.action.CustomTabsService" />
+        </intent>
+        <intent>
+            <!-- Find other apps that can open URLs, in case Chrome
+                 Custom Tabs is unavailable, so we can open external links. -->
+            <action android:name="android.intent.action.VIEW" />
+            <category android:name="android.intent.category.BROWSABLE" />
+        </intent>
+    </queries>
+
     <application
         android:name=".MainApplication"
         android:allowBackup="true"

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -18,7 +18,22 @@
         android:name="android.permission.CAMERA"
         tools:node="remove" />
 
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <!-- We shouldn't need these two elements in our merged manifest when we
+         stop supporting Android 9 (SDK version 28); see
+         https://developer.android.com/training/data-storage/shared/media#storage-permission.
+         At that time, check that none of our dependencies (such as
+         expo-file-system) are trying to request these permissions; if they
+         are, use tools:node="remove"
+         (https://developer.android.com/studio/build/manage-manifests#node_markers).
+         If this reasoning changes, adjust `androidEnsureStoragePermission`
+         in src/lightbox/download.js accordingly.
+         -->
+    <uses-permission
+        android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+        android:maxSdkVersion="28" />
+    <uses-permission
+        android:name="android.permission.READ_EXTERNAL_STORAGE"
+        android:maxSdkVersion="28" />
 
     <uses-feature
         android:name="android.hardware.touchscreen"
@@ -37,7 +52,6 @@
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
-        android:requestLegacyExternalStorage="true"
         android:theme="@style/AppTheme">
         <activity
             android:name=".MainActivity"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -19,8 +19,7 @@ buildscript {
         //   https://medium.com/androiddevelopers/picking-your-compilesdkversion-minsdkversion-targetsdkversion-a098a0341ebd
         // What's the latest?  Consult this list:
         //   https://developer.android.com/studio/releases/platforms
-        // Do edit .travis.yml when updating this.
-        compileSdkVersion = 29
+        compileSdkVersion = 30
     }
     repositories {
         google()

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -13,7 +13,7 @@ buildscript {
         // but some testing is required and code changes are often required.
         // See upstream for background and more discussion:
         //   https://medium.com/androiddevelopers/picking-your-compilesdkversion-minsdkversion-targetsdkversion-a098a0341ebd
-        targetSdkVersion = 29
+        targetSdkVersion = 30
 
         // Should be the latest SDK version available.  See upstream recommendation:
         //   https://medium.com/androiddevelopers/picking-your-compilesdkversion-minsdkversion-targetsdkversion-a098a0341ebd


### PR DESCRIPTION
Along with moving us over to "scoped storage", which will be newly enforced on Android 11.

Fixes: #4283
Fixes: #4284