### PR TITLE
compose: Drop TextInput workaround on clearing contents

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
     "react-native-screens": "^2.10.1",
     "react-native-simple-toast": "^1.0.0",
     "react-native-tab-view": "^2.15.2",
-    "react-native-text-input-reset": "^1.0.2",
     "react-native-unimodules": "^0.14.6",
     "react-native-url-polyfill": "^1.3.0",
     "react-native-vector-icons": ">=7.0.0 <7.1.0",

--- a/src/compose/ComposeBox.js
+++ b/src/compose/ComposeBox.js
@@ -1,11 +1,9 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
 import type { ComponentType } from 'react';
-import { Platform, View, findNodeHandle } from 'react-native';
+import { Platform, View } from 'react-native';
 import type { DocumentPickerResponse } from 'react-native-document-picker';
 import type { LayoutEvent } from 'react-native/Libraries/Types/CoreEventTypes';
-// $FlowFixMe[untyped-import]
-import TextInputReset from 'react-native-text-input-reset';
 import { type EdgeInsets } from 'react-native-safe-area-context';
 import { compose } from 'redux';
 import invariant from 'invariant';
@@ -146,12 +144,6 @@ const updateTextInput = (textInput, text) => {
 
   // `textInput` is untyped; see definition.
   textInput.setNativeProps({ text });
-
-  if (text.length === 0 && TextInputReset) {
-    // React Native has problems with some custom keyboards when clearing
-    // the input's contents.  Force reset to make sure it works.
-    TextInputReset.resetKeyboardInput(findNodeHandle(textInput));
-  }
 };
 
 class ComposeBoxInner extends PureComponent<Props, State> {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9099,11 +9099,6 @@ react-native-tab-view@^2.15.2:
   resolved "https://registry.yarnpkg.com/react-native-tab-view/-/react-native-tab-view-2.16.0.tgz#cae72c7084394bd328fac5fefb86cd966df37a86"
   integrity sha512-ac2DmT7+l13wzIFqtbfXn4wwfgtPoKzWjjZyrK1t+T8sdemuUvD4zIt+UImg03fu3s3VD8Wh/fBrIdcqQyZJWg==
 
-react-native-text-input-reset@^1.0.2:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/react-native-text-input-reset/-/react-native-text-input-reset-1.0.4.tgz#d2c73b83f15ae9d9d3bab39b72261e26fec43c48"
-  integrity sha512-xIzh9jE5o3jLnxCQoYBR460pPPrD5N79gcD98urgeKEZsFuwSDQke2dVxqsfbI2IcWs1T9b3mb4NSuew15yc0A==
-
 react-native-unimodules@^0.14.6:
   version "0.14.8"
   resolved "https://registry.yarnpkg.com/react-native-unimodules/-/react-native-unimodules-0.14.8.tgz#8bf859ac1a4e06122e0331ddf9dec62019884432"


### PR DESCRIPTION
This library was a workaround for a bug in React Native's TextInput
component: it doesn't tell the keyboard to refresh its state after
the app changes the text contents programmatically.

The workaround only operates in the case where we're clearing the
contents entirely.  When we update it in any other way, such as for
autocomplete, we're still exposed to this RN bug; that's #5072.

And then it turns out that since RN v0.60.0, this workaround has been
superseded by one in RN which also operates only in the case of
completely clearing the contents:
  https://github.com/zulip/zulip-mobile/issues/4239#issuecomment-950039743

So we can happily drop it.

I tested this manually on a device which I know is affected by the
underlying RN bug, because it reproduces #5072: a Samsung J5 (model
SM-J510FN) running Android 6.0.1 and Samsung Keyboard 1.5.46.  (From
other reports I believe these issues appear on recent Samsung devices
too; that's just the one I have on hand.)  I sent a message, causing
us to clear the input.  The keyboard state refreshed as it should:
typing a new letter inserted only that letter, not also the last word
typed in the previous message.

Fixes: #4239