### PR TITLE
compose: Don't try to save photos to device camera roll

### DIFF
--- a/src/compose/ComposeMenu.js
+++ b/src/compose/ComposeMenu.js
@@ -134,12 +134,6 @@ class ComposeMenuInner extends PureComponent<Props> {
     launchCamera(
       {
         mediaType: 'photo',
-
-        // TODO: Do we actually need this? If not, also check if we can remove
-        // the relevant WRITE_EXTERNAL_STORAGE permission in our Android
-        // manifest.
-        saveToPhotos: true,
-
         includeBase64: false,
       },
       this.handleImagePickerResponse,


### PR DESCRIPTION
When you're composing a Zulip message and you take a fresh photo to
send, our behavior has been that we also go and save that photo to
the set of photos stored on your device.

As a product choice, this is an unconventional one: in other chat and
messaging apps, my experience is typically that if you take a photo
there it goes only into the app, and not into the general store of
photos on your device.

And it has a side effect that in order to take a photo to send to
Zulip, we have to ask the user (at least on Android before Android 10,
which introduced "scoped storage" to fix this kind of thing) for
permission to manage photos, videos, and media on their device.
That's a potentially intrusive-feeling permission for a user to see us
ask for, and it's not obvious why it has anything to do with just
taking a photo to send in Zulip.  Better not to.

With the old react-native-image-picker, I believe that's just how the
library worked, because its design wasn't great, and we lived with it.
The library also took care of requesting the permission.  But with the
new react-native-image-picker we recently upgraded to, the library
doesn't have to save the photo locally, and indeed doesn't by default.
And if you do ask it to do so, it doesn't handle asking permission:
  https://github.com/react-native-image-picker/react-native-image-picker#note-on-file-storage

With the upgrade, we'd set the option to have the library keep saving
photos locally.  That preserved behavior on Android 10+ (and iOS?), but
broke taking photos on Android ≤9: when you touch the camera icon, we
now just show an error modal reading "Error":
  https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/camera.2Fstorage.20permissions/near/1271358

We could fix this by requesting the permission as needed.  Instead,
fix it by just not trying to locally save the photos.

The deleted comment asked if this means we can drop this permission
from our Android manifest.  We still need it for downloading from
the lightbox, though; see androidEnsureStoragePermission in
src/lightbox/download.js.