### PR TITLE
message action sheet: Prep work for showing/hiding edit/delete buttons better.

### DIFF
--- a/src/action-sheets/index.js
+++ b/src/action-sheets/index.js
@@ -406,6 +406,7 @@ export const constructMessageActionButtons = ({
     buttons.push(shareMessage);
   }
   if (
+    // TODO(#2792): Don't show if message isn't editable.
     message.sender_id === ownUser.user_id
     // Our "edit message" UI only works in certain kinds of narrows.
     && (isStreamOrTopicNarrow(narrow) || isPmNarrow(narrow))
@@ -413,6 +414,7 @@ export const constructMessageActionButtons = ({
     buttons.push(editMessage);
   }
   if (message.sender_id === ownUser.user_id && messageNotDeleted(message)) {
+    // TODO(#2793): Don't show if message isn't deletable.
     buttons.push(deleteMessage);
   }
   if (message.id in flags.starred) {

--- a/src/api/initialDataTypes.js
+++ b/src/api/initialDataTypes.js
@@ -101,7 +101,12 @@ export type InitialDataRealm = $ReadOnly<{|
   realm_invite_required: boolean,
   realm_is_zephyr_mirror_realm: boolean,
   realm_mandatory_topics: boolean,
-  realm_message_content_delete_limit_seconds: number,
+
+  // In 5.0 (feature level 100), the representation the server sends for "no
+  // limit" changed from 0 to `null`, and 0 became an invalid value. (For
+  // the invalid-value part, see zulip/zulip#20131.)
+  realm_message_content_delete_limit_seconds: number | null,
+
   realm_message_content_edit_limit_seconds: number,
   realm_message_retention_days: ?number,
   realm_name: string,

--- a/src/api/messages/deleteMessage.js
+++ b/src/api/messages/deleteMessage.js
@@ -2,6 +2,12 @@
 import type { ApiResponse, Auth } from '../transportTypes';
 import { apiPatch } from '../apiFetch';
 
+// TODO(#4701): Make an API method for DELETE /messages/{id}. Use it to
+// implement the permanent message deletion capability:
+//   https://zulip.com/help/configure-message-editing-and-deletion
+// To do so, we'll need input from realm_delete_own_message_policy,
+// realm_message_content_delete_limit_seconds, the user's role, the current
+// time, and maybe more; we'll want #3898 if we can.
 export default async (auth: Auth, id: number): Promise<ApiResponse> =>
   apiPatch(auth, `messages/${id}`, {
     content: '',

--- a/src/api/registerForEvents.js
+++ b/src/api/registerForEvents.js
@@ -64,6 +64,23 @@ const transform = (rawInitialData: RawInitialData, auth: Auth): InitialData => (
       ])
     : rawInitialData.realm_filters,
 
+  // In 5.0 (feature level 100), the representation the server sends for "no
+  // limit" changed from 0 to `null`.
+  //
+  // It's convenient to emulate Server 5.0's representation in our own data
+  // structures. To get a correct initial value, it's sufficient to coerce
+  // `0` to null here, without even looking at the server feature level.
+  // That's because, in addition to the documented change in 5.0, there was
+  // another: 0 became an invalid value, which means we don't have to
+  // anticipate servers 5.0+ using it to mean anything, such as "0 seconds":
+  //   https://github.com/zulip/zulip/blob/b13bfa09c/zerver/lib/message.py#L1482.
+  //
+  // TODO(server-5.0) Remove this conditional.
+  realm_message_content_delete_limit_seconds:
+    rawInitialData.realm_message_content_delete_limit_seconds === 0
+      ? null
+      : rawInitialData.realm_message_content_delete_limit_seconds,
+
   realm_users: rawInitialData.realm_users.map(rawUser => transformUser(rawUser, auth.realm)),
   realm_non_active_users: rawInitialData.realm_non_active_users.map(rawNonActiveUser =>
     transformUser(rawNonActiveUser, auth.realm),

--- a/src/boot/store.js
+++ b/src/boot/store.js
@@ -366,6 +366,9 @@ const migrations: {| [string]: (GlobalState) => GlobalState |} = {
     outbox: state.outbox.filter(o => o.type === 'private' || o.stream_id !== undefined),
   }),
 
+  // Add messageContentDeleteLimitSeconds to RealmState. No migration;
+  // handled automatically by merging with the new initial state.
+
   // TIP: When adding a migration, consider just using `dropCache`.
 };
 

--- a/src/boot/store.js
+++ b/src/boot/store.js
@@ -366,8 +366,9 @@ const migrations: {| [string]: (GlobalState) => GlobalState |} = {
     outbox: state.outbox.filter(o => o.type === 'private' || o.stream_id !== undefined),
   }),
 
-  // Add messageContentDeleteLimitSeconds to RealmState. No migration;
-  // handled automatically by merging with the new initial state.
+  // Add messageContentDeleteLimitSeconds and messageContentEditLimitSeconds
+  // to RealmState. No migration; handled automatically by merging with the
+  // new initial state.
 
   // TIP: When adding a migration, consider just using `dropCache`.
 };

--- a/src/realm/__tests__/realmReducer-test.js
+++ b/src/realm/__tests__/realmReducer-test.js
@@ -22,6 +22,7 @@ describe('realmReducer', () => {
         emoji: {}, // update as necessary if example data changes
         videoChatProvider: null, // update as necessary if example data changes
         mandatoryTopics: action.data.realm_mandatory_topics,
+        messageContentDeleteLimitSeconds: action.data.realm_message_content_delete_limit_seconds,
 
         email: action.data.email,
         user_id: action.data.user_id,

--- a/src/realm/__tests__/realmReducer-test.js
+++ b/src/realm/__tests__/realmReducer-test.js
@@ -23,6 +23,7 @@ describe('realmReducer', () => {
         videoChatProvider: null, // update as necessary if example data changes
         mandatoryTopics: action.data.realm_mandatory_topics,
         messageContentDeleteLimitSeconds: action.data.realm_message_content_delete_limit_seconds,
+        messageContentEditLimitSeconds: action.data.realm_message_content_edit_limit_seconds,
 
         email: action.data.email,
         user_id: action.data.user_id,

--- a/src/realm/realmReducer.js
+++ b/src/realm/realmReducer.js
@@ -19,6 +19,7 @@ const initialState = {
   emoji: {},
   videoChatProvider: null,
   mandatoryTopics: false,
+  messageContentDeleteLimitSeconds: null,
 
   email: undefined,
   user_id: undefined,
@@ -68,6 +69,7 @@ export default (state: RealmState = initialState, action: Action): RealmState =>
           providerId: action.data.realm_video_chat_provider,
         }),
         mandatoryTopics: action.data.realm_mandatory_topics,
+        messageContentDeleteLimitSeconds: action.data.realm_message_content_delete_limit_seconds,
 
         email: action.data.email,
         user_id: action.data.user_id,

--- a/src/realm/realmReducer.js
+++ b/src/realm/realmReducer.js
@@ -20,6 +20,7 @@ const initialState = {
   videoChatProvider: null,
   mandatoryTopics: false,
   messageContentDeleteLimitSeconds: null,
+  messageContentEditLimitSeconds: 1,
 
   email: undefined,
   user_id: undefined,
@@ -70,6 +71,7 @@ export default (state: RealmState = initialState, action: Action): RealmState =>
         }),
         mandatoryTopics: action.data.realm_mandatory_topics,
         messageContentDeleteLimitSeconds: action.data.realm_message_content_delete_limit_seconds,
+        messageContentEditLimitSeconds: action.data.realm_message_content_edit_limit_seconds,
 
         email: action.data.email,
         user_id: action.data.user_id,

--- a/src/reduxTypes.js
+++ b/src/reduxTypes.js
@@ -255,6 +255,8 @@ export type VideoChatProvider = $ReadOnly<{| name: 'jitsi_meet', jitsiServerUrl:
  *   realm_message_content_delete_limit_seconds in initial data. We use the
  *   Zulip Server 5.0+ convention that `null` means no limit, and 0 is
  *   invalid.
+ * @prop messageContentEditLimitSeconds - Corresponds to
+ *   realm_message_content_edit_limit_seconds in initial data.
  *
  * About the user:
  * @prop email
@@ -272,6 +274,7 @@ export type RealmState = $ReadOnly<{|
   videoChatProvider: VideoChatProvider | null,
   mandatoryTopics: boolean,
   messageContentDeleteLimitSeconds: number | null,
+  messageContentEditLimitSeconds: number,
 
   email: string | void,
   user_id: UserId | void,

--- a/src/reduxTypes.js
+++ b/src/reduxTypes.js
@@ -251,6 +251,10 @@ export type VideoChatProvider = $ReadOnly<{| name: 'jitsi_meet', jitsiServerUrl:
  *   support.
  * @prop mandatoryTopics - Whether topics are required in stream messages
  *   (see https://zulip.com/help/require-topics)
+ * @prop messageContentDeleteLimitSeconds - Corresponds to
+ *   realm_message_content_delete_limit_seconds in initial data. We use the
+ *   Zulip Server 5.0+ convention that `null` means no limit, and 0 is
+ *   invalid.
  *
  * About the user:
  * @prop email
@@ -267,6 +271,7 @@ export type RealmState = $ReadOnly<{|
   emoji: RealmEmojiById,
   videoChatProvider: VideoChatProvider | null,
   mandatoryTopics: boolean,
+  messageContentDeleteLimitSeconds: number | null,
 
   email: string | void,
   user_id: UserId | void,

--- a/src/reduxTypes.js
+++ b/src/reduxTypes.js
@@ -232,25 +232,28 @@ export type VideoChatProvider = $ReadOnly<{| name: 'jitsi_meet', jitsiServerUrl:
 /**
  * State with miscellaneous data from the server; our state subtree `realm`.
  *
+ * "Initial data", below, refers to data in the register-queue response:
+ *   https://zulip.com/api/register-queue#response
+ *
  * Despite the name, this info doesn't necessarily have much to do with the
  * Zulip organization/realm; some properties do, but others are per-user,
  * and others are per-server.
  *
  * About the server:
- * @prop crossRealmBots - The server's cross-realm bots; e.g., Welcome Bot.
- *   Cross-realm bots should be treated like normal bots.
+ * @prop crossRealmBots - Corresponds to cross_realm_bots in initial data.
+ *   We use our `AvatarURL` class at `.avatar_url`.
  *
  * About the org/realm:
- * @prop nonActiveUsers - All users in the organization with `is_active`
- *   false; for normal users, this means they or an admin deactivated their
- *   account.  See `User` and the linked documentation.
- * @prop filters
- * @prop emoji
+ * @prop nonActiveUsers - Corresponds to realm_non_active_users in initial
+ *   data. We use our `AvatarURL` class at `.avatar_url`.
+ * @prop filters - Corresponds to realm_linkifiers/realm_filters in initial
+ *   data. For now, we use the legacy realm_filters form internally.
+ * @prop emoji - Corresponds to realm_emoji in initial data.
  * @prop videoChatProvider - The video chat provider configured by the
  *   server; null if none, or if the configured provider is one we don't
  *   support.
- * @prop mandatoryTopics - Whether topics are required in stream messages
- *   (see https://zulip.com/help/require-topics)
+ * @prop mandatoryTopics - Corresponds to realm_mandatory_topics in initial
+ *   data.
  * @prop messageContentDeleteLimitSeconds - Corresponds to
  *   realm_message_content_delete_limit_seconds in initial data. We use the
  *   Zulip Server 5.0+ convention that `null` means no limit, and 0 is


### PR DESCRIPTION
I set out to do a quick and easy fix for #2792 and #2793, but then I realized that it'd be best to have #3898 done for those. These are the commits that I did manage to make without that; I think changes like these are fine to make even if we don't get through all those issues right away.