### PR TITLE
compose: Add full-screen compose box

### DIFF
--- a/src/common/Icons.js
+++ b/src/common/Icons.js
@@ -89,3 +89,5 @@ export const IconAttach: SpecificIconType = makeIcon(Feather, 'paperclip');
 export const IconAttachment: SpecificIconType = makeIcon(IoniconsIcon, 'document-attach-outline');
 export const IconGroup: SpecificIconType = makeIcon(FontAwesome, 'group');
 export const IconPublic: SpecificIconType = makeIcon(FontAwesome, 'globe');
+export const IconExpand: SpecificIconType = makeIcon(FontAwesome, 'expand');
+export const IconCompress: SpecificIconType = makeIcon(FontAwesome, 'compress');

--- a/src/compose/ComposeMenu.js
+++ b/src/compose/ComposeMenu.js
@@ -25,6 +25,7 @@ import { androidEnsureStoragePermission } from '../lightbox/download';
 
 type OuterProps = $ReadOnly<{|
   expanded: boolean,
+  iscomposeExpanded: boolean,
   destinationNarrow: Narrow,
   insertAttachment: ($ReadOnlyArray<DocumentPickerResponse>) => Promise<void>,
   insertVideoCallLink: (() => void) | null,
@@ -236,7 +237,7 @@ class ComposeMenuInner extends PureComponent<Props> {
   });
 
   render() {
-    const { expanded, insertVideoCallLink, onExpandContract } = this.props;
+    const { expanded, insertVideoCallLink, onExpandContract, iscomposeExpanded } = this.props;
     const numIcons =
       2 + (Platform.OS === 'android' ? 1 : 0) + (insertVideoCallLink !== null ? 1 : 0);
 
@@ -278,8 +279,13 @@ class ComposeMenuInner extends PureComponent<Props> {
         {!expanded && (
           <IconPlusCircle style={this.styles.expandButton} size={24} onPress={onExpandContract} />
         )}
-        {expanded && (
-          <IconLeft style={this.styles.expandButton} size={24} onPress={onExpandContract} />
+        {/* Hiding the left icon if it is opened by the expanded compose box */}
+        {!iscomposeExpanded ? (
+          expanded && (
+            <IconLeft style={this.styles.expandButton} size={24} onPress={onExpandContract} />
+          )
+        ) : (
+          <></>
         )}
       </View>
     );


### PR DESCRIPTION
Closes: #4873 

Changes:
- Main changes are in `src/compose/ComposeBox.js`, added an expand button in the right corner of the text input box.
- When pressed on the button a full screen compose box will pop up. Added a shrink button at the top right so the user can go back to the normal input.
- `src/compose/ComposeMenu.js`, in this added a condition to check where the menu is called from. The reason for adding this is because I reused the compose menu from the normal compose box and wanted to hide the collapse button if the compose box is in expanded mode.

Changes demo:

https://user-images.githubusercontent.com/73246484/139150667-b5d0f1ff-c9fc-4e50-8f14-b69c6d62da7a.mp4



