### PR TITLE
android sharing [nfc]: Rename and javadoc the shim activity

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -91,7 +91,7 @@
         </activity>
 
         <activity
-            android:name=".HandleSendIntent"
+            android:name=".ShareToZulipActivity"
             android:label="@string/app_name"
             android:launchMode="standard"
         >

--- a/android/app/src/main/java/com/zulipmobile/ShareToZulipActivity.kt
+++ b/android/app/src/main/java/com/zulipmobile/ShareToZulipActivity.kt
@@ -6,7 +6,11 @@ import android.content.Intent;
 import android.content.ComponentName;
 import android.os.Bundle;
 
-class HandleSendIntent : AppCompatActivity() {
+/// The activity for when a user shares to Zulip from another app.
+///
+/// This is a tiny shim activity, which forwards the user on to our
+/// [MainActivity] to get the actual UI for sharing to Zulip.
+class ShareToZulipActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         intent.component = ComponentName(applicationContext.packageName, "com.zulipmobile.MainActivity")


### PR DESCRIPTION
This is an activity, not an intent, so its name should end with
"Activity" and not with "Intent".

We can also name it a bit more for what its purpose is at a
product level; the fact that it gets intents whose action is
SEND (and SEND_MULTIPLE) is expressed more clearly in the
relevant code in the manifest anyway.  Also add a bit of javadoc
to explain what's going on and why it doesn't look like it's
doing much.