### PR TITLE
lint: Drop unhelpful rule flowtype/space-after-type-colon

### DIFF
--- a/src/__flow-tests__/generics-tests.js
+++ b/src/__flow-tests__/generics-tests.js
@@ -2,8 +2,6 @@
 import { type BoundedDiff, typesEquivalent } from '../generics';
 import type { IsSupertype } from '../types';
 
-/* eslint-disable flowtype/space-after-type-colon */
-
 /** General tip on writing tests for fancy generic types like these. */
 // prettier-ignore
 function demo_need_value_flow() {

--- a/src/actionTypes.js
+++ b/src/actionTypes.js
@@ -265,7 +265,8 @@ type EventRealmFiltersAction = {|
 type EventUpdateGlobalNotificationsSettingsAction = {|
   ...ServerEvent,
   type: typeof EVENT_UPDATE_GLOBAL_NOTIFICATIONS_SETTINGS,
-  notification_name: | 'enable_offline_push_notifications'
+  notification_name:
+    | 'enable_offline_push_notifications'
     | 'enable_online_push_notifications'
     | 'enable_stream_push_notifications',
   setting: boolean,

--- a/tools/formatting.eslintrc.yaml
+++ b/tools/formatting.eslintrc.yaml
@@ -31,16 +31,3 @@ rules:
   # This *would* overrule Prettier, and in particular run roughshod over
   # line-length limits.  Let Prettier take care of it.
   implicit-arrow-linebreak: off
-
-  # Not sure this rule is quite *right* -- in a type fragment like
-  #   foo:
-  #     | 'have_a_long_name_number_the_first'
-  #     | 'have_a_long_name_number_the_second'
-  #     | 'have_a_long_name_number_the_third'
-  # Prettier would format that code like above, while this rule
-  # causes the first item to get stuffed on the previous line,
-  # like `foo: | 'have_a_...'`.  But it's what we've had, so make
-  # prettier and lint runs agree.
-  #
-  # TODO: try fixing this to follow what Prettier does.
-  flowtype/space-after-type-colon: [error, always]


### PR DESCRIPTION
From the comment, it doesn't seem I thought this rule was a good idea
even in 2018, when I moved it from our top-level ESLint config to this
file that also applies in our prettier-eslint runs.

But mostly it just hasn't come up much.  It did again in a recent PR,
though:
  https://github.com/zulip/zulip-mobile/pull/5084#discussion_r740514987

And it turns out it's quite easy to remove!  Just one place changes.
(Even the one place we've explicitly disabled the rule, it seems to
have no effect; must have applied to an earlier version or draft.)
So do so.