### PR TITLE
lint: Redirect react-redux imports through our type-wrapper module

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -227,7 +227,10 @@ rules:
     - devDependencies: ['**/__tests__/**/*.js', tools/**]
   no-restricted-imports:
     - error
-    - patterns: ['**/__tests__/**']
+    - patterns:
+      - group: ['**/__tests__/**']
+      - group: ['/react-redux']
+        message: 'Use our own src/react-redux.js instead.'
 
   import/no-cycle: off  # This would be nice to fix; but isn't easy.
   import/export: off  # This is redundant with Flow, and buggy.

--- a/src/boot/StoreProvider.js
+++ b/src/boot/StoreProvider.js
@@ -1,9 +1,9 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
 import type { Node } from 'react';
-import { Provider } from 'react-redux';
 
 import { observeStore } from '../redux';
+import { Provider } from '../react-redux';
 import * as logging from '../utils/logging';
 import { getAccount, tryGetActiveAccountState } from '../selectors';
 import store, { restore } from './store';

--- a/src/react-redux.js
+++ b/src/react-redux.js
@@ -9,6 +9,11 @@ import {
 import type { PerAccountState, GlobalState, Dispatch, GlobalDispatch } from './types';
 import type { BoundedDiff } from './generics';
 
+// There's not a lot to say about the type of `Provider`, and it only has
+// one use-site anyway; so we don't wrap it.  But do re-export it from here,
+// so everything else can uniformly never import directly from react-redux.
+export { Provider } from 'react-redux';
+
 /* eslint-disable flowtype/generic-spacing */
 
 // We leave this as invariant in `C` (i.e., we don't write `-C` or `+C`)

--- a/src/react-redux.js
+++ b/src/react-redux.js
@@ -1,5 +1,8 @@
 /* @flow strict-local */
 import type { ComponentType, ElementConfig } from 'react';
+/* eslint-disable no-restricted-imports */
+// This file is where we type-wrap items from react-redux for use in the
+// rest of the codebase.
 import {
   connect as connectInner,
   useSelector as useSelectorInner,


### PR DESCRIPTION
This lets us catch bugs where, for example, a selector passed to
`useSelector` doesn't return the type that the caller wants it to.

Now that we have a distinction between `useSelector` and
`useGlobalSelector`, it also lets us catch bugs where `useSelector` is
mentioned but `useGlobalSelector` is what's actually wanted.  For the
moment these are both purely type-wrappers of the upstream
`useSelector`, so such a bug would have no effect at runtime... but in
the future a per-account state will be a different actual object from
a global state, so one or both of them will not pass its selector the
same state object as the upstream `useSelector` would, and then such a
bug would likely cause a crash.
