### PR TITLE
per-account 6/n: Stop letting GlobalState cast to PerAccountState

### DIFF
--- a/src/__tests__/lib/exampleData.js
+++ b/src/__tests__/lib/exampleData.js
@@ -582,6 +582,7 @@ export const plusReduxState: GlobalState & PerAccountState = reduxState({
  */
 export const reduxStatePlus = (
   extra?: $Rest<GlobalState, { ... }>,
+  // $FlowFixMe[not-an-object]
 ): GlobalState & PerAccountState =>
   dubJointState(deepFreeze({ ...(plusReduxState: GlobalState), ...extra }));
 

--- a/src/account/accountsSelectors.js
+++ b/src/account/accountsSelectors.js
@@ -11,7 +11,7 @@ import type {
   Selector,
   GlobalSelector,
 } from '../types';
-import { assumeSecretlyGlobalState } from '../reduxTypes';
+import { dubPerAccountState, assumeSecretlyGlobalState } from '../reduxTypes';
 import { getAccounts } from '../directSelectors';
 import { identityOfAccount, keyOfIdentity, identityOfAuth, authOfAccount } from './accountMisc';
 import { ZulipVersion } from '../utils/zulipVersion';
@@ -67,7 +67,9 @@ export const getAccountsByIdentity: GlobalSelector<(Identity) => Account | void>
  */
 export const tryGetActiveAccountState = (state: GlobalState): PerAccountState | void => {
   const accounts = getAccounts(state);
-  return accounts && accounts.length > 0 ? state : undefined;
+  // TODO(#5006): This is the inverse of where getAccount uses the same
+  //   assumption that the two state types are really the same objects.
+  return accounts && accounts.length > 0 ? dubPerAccountState(state) : undefined;
 };
 
 /**

--- a/src/boot/AppEventHandlers.js
+++ b/src/boot/AppEventHandlers.js
@@ -7,6 +7,7 @@ import NetInfo from '@react-native-community/netinfo';
 import * as ScreenOrientation from 'expo-screen-orientation';
 
 import type { GlobalDispatch, Orientation as OrientationT } from '../types';
+import { dubPerAccountState } from '../reduxTypes';
 import { createStyleSheet } from '../styles';
 import { connectGlobal } from '../react-redux';
 import { getUnreadByHuddlesMentionsAndPMs } from '../selectors';
@@ -168,7 +169,11 @@ class AppEventHandlersInner extends PureComponent<Props> {
 }
 
 const AppEventHandlers: ComponentType<OuterProps> = connectGlobal(state => ({
-  unreadCount: getUnreadByHuddlesMentionsAndPMs(state),
+  // TODO(#5006): The use of this per-account state in this global component
+  //   highlights how this feature (a badge count based on unreads, on
+  //   Android only) is pretty broken if you use multiple accounts -- it
+  //   reflects only the one last account you used.  Maybe just cut it?
+  unreadCount: getUnreadByHuddlesMentionsAndPMs(dubPerAccountState(state)),
 }))(AppEventHandlersInner);
 
 export default AppEventHandlers;

--- a/src/boot/reducers.js
+++ b/src/boot/reducers.js
@@ -102,6 +102,7 @@ export default (state: void | GlobalState, action: Action): GlobalState => {
     subscriptions: applyReducer('subscriptions', subscriptions, state?.subscriptions, action, state),
     topics: applyReducer('topics', topics, state?.topics, action, state),
     typing: applyReducer('typing', typing, state?.typing, action, state),
+    // $FlowFixMe[incompatible-call] TODO(#5006)
     unread: applyReducer('unread', unread, state?.unread, action, state),
     userGroups: applyReducer('userGroups', userGroups, state?.userGroups, action, state),
     userStatus: applyReducer('userStatus', userStatus, state?.userStatus, action, state),

--- a/src/events/eventActions.js
+++ b/src/events/eventActions.js
@@ -55,7 +55,7 @@ export const startEventPolling = (
   while (true) {
     const globalState = assumeSecretlyGlobalState(getState());
     const state = tryGetActiveAccountState(globalState);
-    const auth = state && tryGetAuth(state);
+    const auth = state ? tryGetAuth(state) : undefined;
     if (!auth) {
       // There is no logged-in active account.
       break;

--- a/src/notification/index.js
+++ b/src/notification/index.js
@@ -26,6 +26,7 @@ import { getAccounts } from '../directSelectors';
  * Identify the account the notification is for, if possible.
  *
  * Returns an index into `identities`, or `null` if we can't tell.
+ * In the latter case, logs a warning.
  *
  * @param identities Identities corresponding to the accounts state in Redux.
  */

--- a/src/reduxTypes.js
+++ b/src/reduxTypes.js
@@ -405,7 +405,7 @@ export type UsersState = $ReadOnlyArray<User>;
  * parts of our code will in that future operate on a particular account and
  * which parts will operate on all accounts' data or none.
  */
-export type PerAccountState = $ReadOnly<{
+type PerAccountStateImpl = $ReadOnly<{
   // TODO(#5006): Secretly we assume these objects also have `Account` data,
   //   like so:
   // accounts: [Account, ...mixed],
@@ -445,6 +445,8 @@ export type PerAccountState = $ReadOnly<{
   ...
 }>;
 
+export opaque type PerAccountState: PerAccountStateImpl = PerAccountStateImpl;
+
 /**
  * Our complete Redux state tree.
  *
@@ -474,10 +476,6 @@ export type GlobalState = $ReadOnly<{|
   accounts: AccountsState,
 |}>;
 
-// For now, under our single-active-account model, we want a GlobalState
-// to be seamlessly usable as a PerAccountState.
-(s: GlobalState): PerAccountState => s; // eslint-disable-line no-unused-expressions
-
 /**
  * Assume the given per-account state object is secretly a GlobalState.
  *
@@ -499,6 +497,10 @@ export function assumeSecretlyGlobalState(state: PerAccountState): GlobalState {
  * TODO(#5006): We'll have to fix and eliminate each call to this.
  */
 export function dubPerAccountState(state: GlobalState): PerAccountState {
+  // Here in this file, we can make this cast with no fixmes (for now, under
+  // our single-active-account model.)  But from anywhere outside this file,
+  // that's forbidden because PerAccountState is opaque, so the way to do it
+  // is by calling this function.
   return state;
 }
 

--- a/src/reduxTypes.js
+++ b/src/reduxTypes.js
@@ -493,6 +493,24 @@ export function assumeSecretlyGlobalState(state: PerAccountState): GlobalState {
   return state;
 }
 
+/**
+ * Use the given state object as a per-account state.
+ *
+ * TODO(#5006): We'll have to fix and eliminate each call to this.
+ */
+export function dubPerAccountState(state: GlobalState): PerAccountState {
+  return state;
+}
+
+/**
+ * For tests only.  Use the given state object as *both* kinds of state.
+ *
+ * TODO(#5006): We'll have to fix and eliminate each call to this.
+ */
+export function dubJointState(state: GlobalState): GlobalState & PerAccountState {
+  return state;
+}
+
 // No substate should allow `undefined`; our use of AsyncStorage
 // depends on it. (This check will also complain on `null`, which I
 // don't think we'd have a problem with. We could try to write this


### PR DESCRIPTION
This is the next PR in the series after #5083, #5066, #5030, #5016, #5017, and #5023, produced from the branch described at [#5006 (comment)](https://github.com/zulip/zulip-mobile/issues/5006#issuecomment-924341909).

From the foreshadowing last time:

> Coming next, we'll tighten the distinction between `GlobalState` and `PerAccountState` in the same way as we did for `GlobalDispatch` and `Dispatch`.

That's this PR.

Then, continuing as described last time:

> After that, we'll start distinguishing plain actions: just like other areas of our code before the start of this PR series, most of them implicitly refer to the active account while others don't, and we'll start tracking which is which so that we can later reinterpret the former group as referring to whichever specific account their caller had in mind.
