### PR TITLE
notification: Use user_id to find account if multiple on same realm

### DIFF
--- a/android/app/src/main/java/com/zulipmobile/notifications/FcmMessage.kt
+++ b/android/app/src/main/java/com/zulipmobile/notifications/FcmMessage.kt
@@ -112,6 +112,7 @@ data class MessageFcmMessage(
     fun dataForOpen(): Bundle = Bundle().apply {
         // NOTE: Keep the JS-side type definition in sync with this code.
         putString("realm_uri", identity.realmUri.toString())
+        identity.userId?.let { putInt("user_id", it) }
         when (recipient) {
             is Recipient.Stream -> {
                 putString("recipient_type", "stream")

--- a/android/app/src/main/java/com/zulipmobile/notifications/FcmMessage.kt
+++ b/android/app/src/main/java/com/zulipmobile/notifications/FcmMessage.kt
@@ -111,7 +111,7 @@ data class MessageFcmMessage(
      */
     fun dataForOpen(): Bundle = Bundle().apply {
         // NOTE: Keep the JS-side type definition in sync with this code.
-        identity.realmUri.let { putString("realm_uri", it.toString()) }
+        putString("realm_uri", identity.realmUri.toString())
         when (recipient) {
             is Recipient.Stream -> {
                 putString("recipient_type", "stream")

--- a/android/app/src/main/java/com/zulipmobile/notifications/FcmMessage.kt
+++ b/android/app/src/main/java/com/zulipmobile/notifications/FcmMessage.kt
@@ -190,6 +190,8 @@ private fun extractIdentity(data: Map<String, String>): Identity =
     Identity(
         serverHost = data.require("server"),
         realmId = data.require("realm_id").parseInt("realm_id"),
+
+        // `realm_uri` was added in server version 1.9.0
         realmUri = data.require("realm_uri").parseUrl("realm_uri"),
 
         // Server versions from 1.6.0 through 2.0.0 (and possibly earlier

--- a/src/notification/__tests__/notification-test.js
+++ b/src/notification/__tests__/notification-test.js
@@ -107,7 +107,7 @@ describe('extract iOS notification data', () => {
     test('very-old-style messages', () => {
       const sender_email = 'nobody@example.com';
       // baseline
-      expect(make({ realm_uri, recipient_type: 'private', sender_email })).toBeTruthy();
+      expect(make({ realm_uri, recipient_type: 'private', sender_email })()).toBeTruthy();
       // missing recipient_type
       expect(make({ realm_uri, sender_email })).toThrow(/archaic/);
       // missing realm_uri

--- a/src/notification/__tests__/notification-test.js
+++ b/src/notification/__tests__/notification-test.js
@@ -82,12 +82,12 @@ describe('extract iOS notification data', () => {
         const msg = data;
         expect(verify(msg)).toEqual(msg);
 
-        // new(-ish) optional user_id is accepted
+        // new(-ish) optional user_id is accepted and copied
         const msg1 = { ...msg, user_id };
-        expect(() => verify(msg1)).not.toThrow();
+        expect(verify(msg1)).toEqual(msg1);
 
         // unused fields are not copied
-        const msg2 = { ...msg, realm_id: 8675309, user_id };
+        const msg2 = { ...msg, realm_id: 8675309 };
         expect(verify(msg2)).toEqual(msg);
 
         // unknown fields are ignored and not copied

--- a/src/notification/__tests__/notification-test.js
+++ b/src/notification/__tests__/notification-test.js
@@ -83,6 +83,10 @@ describe('extract iOS notification data', () => {
         expect(verify(msg)).toEqual(msg);
 
         // new(-ish) optional user_id is accepted and copied
+        // TODO: Rewrite so modern-style payloads are the baseline, e.g.,
+        //   with a `modern` variable instead of `barebones`. Write
+        //   individual tests for supporting older-style payloads, and mark
+        //   those for future deletion, like with `TODO(1.9.0)`.
         const msg1 = { ...msg, user_id };
         expect(verify(msg1)).toEqual(msg1);
 

--- a/src/notification/__tests__/notification-test.js
+++ b/src/notification/__tests__/notification-test.js
@@ -12,6 +12,7 @@ import { fromAPNsImpl as extractIosNotificationData } from '../extract';
 import objectEntries from '../../utils/objectEntries';
 
 const realm_uri = eg.realm.toString();
+const user_id = eg.selfUser.user_id;
 
 describe('getNarrowFromNotificationData', () => {
   const ownUserId = eg.selfUser.user_id;
@@ -81,8 +82,12 @@ describe('extract iOS notification data', () => {
         const msg = data;
         expect(verify(msg)).toEqual(msg);
 
+        // new(-ish) optional user_id is accepted
+        const msg1 = { ...msg, user_id };
+        expect(() => verify(msg1)).not.toThrow();
+
         // unused fields are not copied
-        const msg2 = { ...msg, realm_id: 8675309 };
+        const msg2 = { ...msg, realm_id: 8675309, user_id };
         expect(verify(msg2)).toEqual(msg);
 
         // unknown fields are ignored and not copied
@@ -153,6 +158,13 @@ describe('extract iOS notification data', () => {
         make({
           ...barebones['group PM'],
           realm_uri: ['array', 'of', 'string'],
+        }),
+      ).toThrow(/invalid/);
+
+      expect(
+        make({
+          ...barebones.stream,
+          user_id: 'abc',
         }),
       ).toThrow(/invalid/);
     });

--- a/src/notification/extract.js
+++ b/src/notification/extract.js
@@ -2,6 +2,7 @@
 import PushNotificationIOS from '@react-native-community/push-notification-ios';
 
 import type { Notification } from './types';
+import { makeUserId } from '../api/idTypes';
 import type { JSONable, JSONableDict, JSONableInput, JSONableInputDict } from '../utils/jsonable';
 import * as logging from '../utils/logging';
 
@@ -185,6 +186,7 @@ export const fromAPNsImpl = (rawData: ?JSONableDict): Notification | void => {
 
   const identity = {
     realm_uri,
+    ...(user_id === undefined ? Object.freeze({}) : { user_id: makeUserId(user_id) }),
   };
 
   if (recipient_type === 'stream') {

--- a/src/notification/extract.js
+++ b/src/notification/extract.js
@@ -172,11 +172,14 @@ export const fromAPNsImpl = (rawData: ?JSONableDict): Notification | void => {
     throw err('invalid');
   }
 
-  const { realm_uri } = zulip;
+  const { realm_uri, user_id } = zulip;
   if (realm_uri === undefined) {
     throw err('archaic (pre-1.9.x)');
   }
   if (typeof realm_uri !== 'string') {
+    throw err('invalid');
+  }
+  if (user_id !== undefined && typeof user_id !== 'number') {
     throw err('invalid');
   }
 

--- a/src/notification/extract.js
+++ b/src/notification/extract.js
@@ -183,16 +183,20 @@ export const fromAPNsImpl = (rawData: ?JSONableDict): Notification | void => {
     throw err('invalid');
   }
 
+  const identity = {
+    realm_uri,
+  };
+
   if (recipient_type === 'stream') {
     const { stream, topic } = zulip;
     if (typeof stream !== 'string' || typeof topic !== 'string') {
       throw err('invalid');
     }
     return {
+      ...identity,
       recipient_type: 'stream',
       stream,
       topic,
-      realm_uri,
     };
   } else {
     /* recipient_type === 'private' */
@@ -207,16 +211,16 @@ export const fromAPNsImpl = (rawData: ?JSONableDict): Notification | void => {
         throw err('invalid');
       }
       return {
+        ...identity,
         recipient_type: 'private',
         pm_users: ids.sort((a, b) => a - b).join(','),
-        realm_uri,
       };
     }
 
     if (typeof sender_email !== 'string') {
       throw err('invalid');
     }
-    return { recipient_type: 'private', sender_email, realm_uri };
+    return { ...identity, recipient_type: 'private', sender_email };
   }
 
   /* unreachable */

--- a/src/notification/index.js
+++ b/src/notification/index.js
@@ -4,7 +4,7 @@ import PushNotificationIOS from '@react-native-community/push-notification-ios';
 import type { PushNotificationEventName } from '@react-native-community/push-notification-ios';
 
 import type { Notification } from './types';
-import type { Auth, Dispatch, GlobalDispatch, Identity, Narrow, UserId, UserOrBot } from '../types';
+import type { Auth, Dispatch, GlobalDispatch, Account, Narrow, UserId, UserOrBot } from '../types';
 import { topicNarrow, pm1to1NarrowFromUser, pmNarrowFromRecipients } from '../utils/narrow';
 import type { JSONable, JSONableDict } from '../utils/jsonable';
 import * as api from '../api';
@@ -25,14 +25,14 @@ import { getAccounts } from '../directSelectors';
 /**
  * Identify the account the notification is for, if possible.
  *
- * Returns an index into `identities`, or `null` if we can't tell.
+ * Returns an index into `accounts`, or `null` if we can't tell.
  * In the latter case, logs a warning.
  *
- * @param identities Identities corresponding to the accounts state in Redux.
+ * @param accounts The accounts state in Redux.
  */
 export const getAccountFromNotificationData = (
   data: Notification,
-  identities: $ReadOnlyArray<Identity>,
+  accounts: $ReadOnlyArray<Account>,
 ): number | null => {
   const { realm_uri } = data;
   if (realm_uri == null) {
@@ -50,7 +50,7 @@ export const getAccountFromNotificationData = (
   }
 
   const urlMatches = [];
-  identities.forEach((account, i) => {
+  accounts.forEach((account, i) => {
     if (account.realm.origin === realmUrl.origin) {
       urlMatches.push(i);
     }
@@ -62,7 +62,7 @@ export const getAccountFromNotificationData = (
     // just a race -- this notification was sent before the logout); or
     // there's some confusion where the realm_uri we have is different from
     // the one the server sends in notifications.
-    const knownUrls = identities.map(({ realm }) => realm.href);
+    const knownUrls = accounts.map(({ realm }) => realm.href);
     logging.warn('notification realm_uri not found in accounts', {
       realm_uri,
       parsed_url: realmUrl,
@@ -80,7 +80,7 @@ export const getAccountFromNotificationData = (
       realm_uri,
       parsed_url: realmUrl,
       match_count: urlMatches.length,
-      unique_identities_count: new Set(urlMatches.map(matchIndex => identities[matchIndex].email))
+      unique_identities_count: new Set(urlMatches.map(matchIndex => accounts[matchIndex].email))
         .size,
     });
     // TODO get user_id into accounts data, and use that

--- a/src/notification/notificationActions.js
+++ b/src/notification/notificationActions.js
@@ -26,7 +26,7 @@ import { identityOfAccount, authOfAccount } from '../account/accountMisc';
 import { getAllUsersByEmail, getOwnUserId } from '../users/userSelectors';
 import { doNarrow } from '../message/messagesActions';
 import { accountSwitch } from '../account/accountActions';
-import { getIdentities, getAccount, tryGetActiveAccountState } from '../account/accountsSelectors';
+import { getAccount, tryGetActiveAccountState } from '../account/accountsSelectors';
 
 export const gotPushToken = (pushToken: string | null): AccountIndependentAction => ({
   type: GOT_PUSH_TOKEN,
@@ -53,7 +53,7 @@ export const narrowToNotification = (data: ?Notification): GlobalThunkAction<voi
   }
 
   const globalState = getState();
-  const accountIndex = getAccountFromNotificationData(data, getIdentities(globalState));
+  const accountIndex = getAccountFromNotificationData(data, getAccounts(globalState));
   if (accountIndex !== null && accountIndex > 0) {
     // Notification is for a non-active account.  Switch there.
     dispatch(accountSwitch(accountIndex));

--- a/src/notification/types.js
+++ b/src/notification/types.js
@@ -1,7 +1,9 @@
 // @flow strict-local
+import type { UserId } from '../types';
 
 type NotificationBase = {|
   realm_uri: string,
+  user_id?: UserId,
 |};
 
 /**

--- a/src/notification/types.js
+++ b/src/notification/types.js
@@ -1,5 +1,9 @@
 // @flow strict-local
 
+type NotificationBase = {|
+  realm_uri: string,
+|};
+
 /**
  * The data we need in JS/React code for acting on a notification.
  *
@@ -13,8 +17,8 @@
  */
 // NOTE: Keep the Android-side code in sync with this type definition.
 export type Notification =
-  | {| recipient_type: 'stream', stream: string, topic: string, realm_uri: string |}
+  | {| ...NotificationBase, recipient_type: 'stream', stream: string, topic: string |}
   // Group PM messages have `pm_users`, which is sorted, comma-separated IDs.
-  | {| recipient_type: 'private', pm_users: string, realm_uri: string |}
+  | {| ...NotificationBase, recipient_type: 'private', pm_users: string |}
   // 1:1 PM messages lack `pm_users`.
-  | {| recipient_type: 'private', sender_email: string, realm_uri: string |};
+  | {| ...NotificationBase, recipient_type: 'private', sender_email: string |};


### PR DESCRIPTION
Along with making the property required on APNs and FCM payloads.

I noticed the opportunity to do this after reviewing #5100 and #5105.

Fixes: #4631 