### PR TITLE
api [nfc]: Explain InitialData more; simplify register-queue interface

### DIFF
--- a/src/__tests__/lib/exampleData.js
+++ b/src/__tests__/lib/exampleData.js
@@ -376,8 +376,8 @@ export const pmMessage = (args?: {|
     ...messagePropertiesBase,
     ...messagePropertiesFromSender(sender),
 
-    content: 'This is an example PM message.',
-    content_type: 'text/markdown',
+    content: '<p>This is an example PM message.</p>',
+    content_type: 'text/html',
     // We don't sort the recipients, because they're inconsistently sorted
     // in real messages.  (See comments on the Message type.)
     display_recipient: recipients.map(displayRecipientFromUser),
@@ -431,8 +431,8 @@ export const streamMessage = (args?: {|
     ...messagePropertiesFromSender(sender),
     ...messagePropertiesFromStream(streamInner),
 
-    content: 'This is an example stream message.',
-    content_type: 'text/markdown',
+    content: '<p>This is an example stream message.</p>',
+    content_type: 'text/html',
     id: randMessageId(),
     subject: 'example topic',
     subject_links: [],

--- a/src/api/initialDataTypes.js
+++ b/src/api/initialDataTypes.js
@@ -16,6 +16,18 @@ import type {
   UserStatusMapObject,
 } from './apiTypes';
 
+/*
+   The types in this file are organized by which `fetch_event_types` values
+   cause the server to send them to us.
+
+   See comments at `InitialData`, at the bottom, for details.
+ */
+
+/**
+ * The parts of the `/register` response sent regardless of `fetch_event_types`.
+ *
+ * See `InitialData` for more discussion.
+ */
 export type InitialDataBase = $ReadOnly<{|
   last_event_id: number,
   msg: string,
@@ -509,16 +521,29 @@ export type InitialDataUserStatus = $ReadOnly<{|
   user_status?: UserStatusMapObject,
 |}>;
 
-// Initial data snapshot sent in response to a `/register` request,
-// after validation and transformation.
+/**
+ * The initial data snapshot sent on `/register`.
+ *
+ * See API docs:
+ *   https://zulip.com/api/register-queue#response
+ *
+ * Most properties are sent only if the client includes a particular item in
+ * the `fetch_event_types` list.  This type is meant to reflect the
+ * properties that appear when sending the `fetch_event_types` that this
+ * client sends, which is more or less all of them.
+ *
+ * This is the version after some processing.  See `RawInitialData` for the
+ * raw form sent by the server.
+ */
 export type InitialData = $ReadOnly<{|
-  // The server sends different subsets of the full available data,
-  // depending on what event types the client subscribes to with the
-  // `fetch_event_types` field of the `/register` request. We name these
-  // subsets after the event types that cause them to be included.
+  // To give a bit of organization to this very large object type, we group
+  // the properties by which event type in `fetch_event_types` causes the
+  // server to send them.  The properties elicited by `realm_user` are
+  // grouped together as a type called `InitialDataRealmUser`, and so on.
   //
-  // See zerver/lib/events.py in fetch_initial_state_data for the
-  // server-side implementation.
+  // For the server-side implementation, see zerver/lib/events.py at
+  // fetch_initial_state_data.  (But see the API docs first; if you need to
+  // consult the server implementation, that's a bug in the API docs.)
   ...InitialDataBase,
   ...InitialDataAlertWords,
   ...InitialDataMessage,
@@ -540,8 +565,15 @@ export type InitialData = $ReadOnly<{|
   ...InitialDataUserStatus,
 |}>;
 
-// Initial data snapshot sent in response to a `/register` request,
-// before validation and transformation.
+/**
+ * Raw form of the initial data snapshot sent on `/register`.
+ *
+ * See API docs:
+ *   https://zulip.com/api/register-queue#response
+ *
+ * This represents the raw JSON-decoding of the response from the server.
+ * See `InitialData` for a slightly processed form.
+ */
 export type RawInitialData = $ReadOnly<{|
   ...InitialData,
   ...RawInitialDataRealmUser,

--- a/src/api/modelTypes.js
+++ b/src/api/modelTypes.js
@@ -569,7 +569,7 @@ type MessageBase = $ReadOnly<{|
 
   client: string,
   content: string,
-  content_type: 'text/html' | 'text/markdown',
+  content_type: 'text/html',
   edit_history: $ReadOnlyArray<MessageEdit>,
   gravatar_hash: string,
   id: number,

--- a/src/api/registerForEvents.js
+++ b/src/api/registerForEvents.js
@@ -6,22 +6,6 @@ import type { CrossRealmBot, User } from './modelTypes';
 import { apiPost } from './apiFetch';
 import { AvatarURL } from '../utils/avatar';
 
-type RegisterForEventsParams = {|
-  apply_markdown?: boolean,
-  client_gravatar?: boolean,
-  all_public_streams?: boolean,
-  event_types?: string[],
-  fetch_event_types?: string[],
-  include_subscribers?: boolean,
-  narrow?: ApiNarrow,
-  queue_lifespan_secs?: number,
-  client_capabilities?: {|
-    notification_settings_null: boolean,
-    bulk_message_deletion: boolean,
-    user_avatar_url_field_optional: boolean,
-  |},
-|};
-
 const transformUser = (rawUser: {| ...User, avatar_url?: string | null |}, realm: URL): User => {
   const { avatar_url: rawAvatarUrl, email } = rawUser;
 
@@ -91,7 +75,24 @@ const transform = (rawInitialData: RawInitialData, auth: Auth): InitialData => (
 });
 
 /** See https://zulip.com/api/register-queue */
-export default async (auth: Auth, params: RegisterForEventsParams): Promise<InitialData> => {
+export default async (
+  auth: Auth,
+  params: {|
+    apply_markdown?: boolean,
+    client_gravatar?: boolean,
+    all_public_streams?: boolean,
+    event_types?: string[],
+    fetch_event_types?: string[],
+    include_subscribers?: boolean,
+    narrow?: ApiNarrow,
+    queue_lifespan_secs?: number,
+    client_capabilities?: {|
+      notification_settings_null: boolean,
+      bulk_message_deletion: boolean,
+      user_avatar_url_field_optional: boolean,
+    |},
+  |},
+): Promise<InitialData> => {
   const { narrow, event_types, fetch_event_types, client_capabilities } = params;
   const rawInitialData = await apiPost(auth, 'register', {
     ...params,

--- a/src/api/registerForEvents.js
+++ b/src/api/registerForEvents.js
@@ -76,8 +76,7 @@ const transform = (rawInitialData: RawInitialData, auth: Auth): InitialData => (
 /** See https://zulip.com/api/register-queue */
 export default async (
   auth: Auth,
-  params: {|
-    apply_markdown?: boolean,
+  params?: {|
     queue_lifespan_secs?: number,
   |},
 ): Promise<InitialData> => {
@@ -96,6 +95,7 @@ export default async (
     // it's OK that it isn't.  This is where we set up the event queue that
     // would keep us up to date on that, so it's much easier for it to be
     // stale here than for most other API endpoints.
+    apply_markdown: true,
     client_gravatar: true,
     client_capabilities: JSON.stringify({
       notification_settings_null: true,

--- a/src/config.js
+++ b/src/config.js
@@ -9,7 +9,6 @@ type Config = {|
   enableReduxSlowReducerWarnings: boolean,
   slowReducersThreshold: number,
   enableErrorConsoleLogging: boolean,
-  serverDataOnStartup: string[],
   appOwnDomains: string[],
 |};
 
@@ -25,27 +24,6 @@ const config: Config = {
   enableReduxSlowReducerWarnings: isDevelopment && !!global.btoa,
   slowReducersThreshold: 5,
   enableErrorConsoleLogging: true,
-  serverDataOnStartup: [
-    'alert_words',
-    'message',
-    'muted_topics',
-    'muted_users',
-    'presence',
-    'realm',
-    'realm_emoji',
-    'realm_filters',
-    'realm_linkifiers',
-    'realm_user',
-    'realm_user_groups',
-    'recent_private_conversations',
-    'stream',
-    'subscription',
-    'update_display_settings',
-    'update_global_notifications',
-    'update_message_flags',
-    'user_status',
-    'zulip_version',
-  ],
   appOwnDomains: ['zulip.com', 'zulipchat.com', 'chat.zulip.org'],
 };
 

--- a/src/message/fetchActions.js
+++ b/src/message/fetchActions.js
@@ -449,18 +449,7 @@ export const doInitialFetch = (): ThunkAction<Promise<void>> => async (dispatch,
         // be from the *last* time it was run. That could be a long
         // time ago, like from the previous app startup.
         api.registerForEvents(auth, {
-          // Event types not supported by the server are ignored; see
-          //   https://zulip.com/api/register-queue#parameter-fetch_event_types.
-          fetch_event_types: config.serverDataOnStartup,
-
           apply_markdown: true,
-          include_subscribers: false,
-          client_gravatar: true,
-          client_capabilities: {
-            notification_settings_null: true,
-            bulk_message_deletion: true,
-            user_avatar_url_field_optional: true,
-          },
         }),
       // We might have (potentially stale) server data already. If
       // we do, we'll be showing some UI that lets the user see that

--- a/src/message/fetchActions.js
+++ b/src/message/fetchActions.js
@@ -440,17 +440,14 @@ export const doInitialFetch = (): ThunkAction<Promise<void>> => async (dispatch,
 
   try {
     initData = await tryFetch(
-      () =>
-        // Currently, no input we're giving `registerForEvents` is
-        // conditional on the server version / feature level. If we
-        // need to do that, make sure that data is up-to-date -- we've
-        // been using this `registerForEvents` call to update the
-        // feature level in Redux, which means the value in Redux will
-        // be from the *last* time it was run. That could be a long
-        // time ago, like from the previous app startup.
-        api.registerForEvents(auth, {
-          apply_markdown: true,
-        }),
+      // Currently, no input we're giving `registerForEvents` is
+      // conditional on the server version / feature level. If we
+      // need to do that, make sure that data is up-to-date -- we've
+      // been using this `registerForEvents` call to update the
+      // feature level in Redux, which means the value in Redux will
+      // be from the *last* time it was run. That could be a long
+      // time ago, like from the previous app startup.
+      () => api.registerForEvents(auth),
       // We might have (potentially stale) server data already. If
       // we do, we'll be showing some UI that lets the user see that
       // data. If we don't, we'll be showing a full-screen loading

--- a/src/webview/html/__tests__/__snapshots__/messageListElementHtml-test.js.snap.android
+++ b/src/webview/html/__tests__/__snapshots__/messageListElementHtml-test.js.snap.android
@@ -42,7 +42,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
 </div>
 
     
-This is an example stream message.
+<p>This is an example stream message.</p>
 
 
 
@@ -68,7 +68,7 @@ This is an example stream message.
 </div>
 
     
-This is an example stream message.
+<p>This is an example stream message.</p>
 
 
 
@@ -120,7 +120,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
 </div>
 
     
-This is an example stream message.
+<p>This is an example stream message.</p>
 
 
 
@@ -150,7 +150,7 @@ This is an example stream message.
 </div>
 
     
-This is an example stream message.
+<p>This is an example stream message.</p>
 
 
 
@@ -203,7 +203,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
 </div>
 
     
-This is an example stream message.
+<p>This is an example stream message.</p>
 
 
 
@@ -246,7 +246,7 @@ This is an example stream message.
 </div>
 
     
-This is an example stream message.
+<p>This is an example stream message.</p>
 
 
 
@@ -299,7 +299,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
 </div>
 
     
-This is an example stream message.
+<p>This is an example stream message.</p>
 
 
 
@@ -342,7 +342,7 @@ This is an example stream message.
 </div>
 
     
-This is an example stream message.
+<p>This is an example stream message.</p>
 
 
 
@@ -395,7 +395,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
 </div>
 
     
-This is an example stream message.
+<p>This is an example stream message.</p>
 
 
 
@@ -431,7 +431,7 @@ This is an example stream message.
 </div>
 
     
-This is an example stream message.
+<p>This is an example stream message.</p>
 
 
 
@@ -477,7 +477,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -503,7 +503,7 @@ This is an example PM message.
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -548,7 +548,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -578,7 +578,7 @@ This is an example PM message.
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -624,7 +624,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -660,7 +660,7 @@ This is an example PM message.
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -706,7 +706,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -732,7 +732,7 @@ This is an example PM message.
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -777,7 +777,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -807,7 +807,7 @@ This is an example PM message.
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -853,7 +853,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -889,7 +889,7 @@ This is an example PM message.
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -942,7 +942,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
 </div>
 
     
-This is an example stream message.
+<p>This is an example stream message.</p>
 
 
 
@@ -968,7 +968,7 @@ This is an example stream message.
 </div>
 
     
-This is an example stream message.
+<p>This is an example stream message.</p>
 
 
 
@@ -1003,7 +1003,7 @@ This is an example stream message.
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -1039,7 +1039,7 @@ This is an example PM message.
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -1088,7 +1088,7 @@ This is an example PM message.
 </div>
 
     
-This is an example stream message.
+<p>This is an example stream message.</p>
 
 
 
@@ -1131,7 +1131,7 @@ This is an example stream message.
 </div>
 
     
-This is an example stream message.
+<p>This is an example stream message.</p>
 
 
 
@@ -1167,7 +1167,7 @@ This is an example stream message.
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -1197,7 +1197,7 @@ This is an example PM message.
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -1233,7 +1233,7 @@ This is an example PM message.
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -1259,7 +1259,7 @@ This is an example PM message.
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -1284,7 +1284,7 @@ This is an example PM message.
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -1313,7 +1313,7 @@ This is an example PM message.
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -1349,7 +1349,7 @@ This is an example PM message.
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -1385,7 +1385,7 @@ This is an example PM message.
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -1434,7 +1434,7 @@ This is an example PM message.
 </div>
 
     
-This is an example stream message.
+<p>This is an example stream message.</p>
 
 
 
@@ -1477,7 +1477,7 @@ This is an example stream message.
 </div>
 
     
-This is an example stream message.
+<p>This is an example stream message.</p>
 
 
 
@@ -1520,7 +1520,7 @@ This is an example stream message.
 </div>
 
     
-This is an example stream message.
+<p>This is an example stream message.</p>
 
 
 
@@ -1550,7 +1550,7 @@ This is an example stream message.
 </div>
 
     
-This is an example stream message.
+<p>This is an example stream message.</p>
 
 
 
@@ -1586,7 +1586,7 @@ This is an example stream message.
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -1612,7 +1612,7 @@ This is an example PM message.
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -1654,7 +1654,7 @@ This is an example PM message.
 </div>
 
     
-This is an example stream message.
+<p>This is an example stream message.</p>
 
 
 
@@ -1690,7 +1690,7 @@ This is an example stream message.
 </div>
 
     
-This is an example stream message.
+<p>This is an example stream message.</p>
 
 
 
@@ -1736,7 +1736,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -1762,7 +1762,7 @@ This is an example PM message.
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -1807,7 +1807,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -1837,7 +1837,7 @@ This is an example PM message.
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -1883,7 +1883,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -1919,7 +1919,7 @@ This is an example PM message.
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -1965,7 +1965,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -1991,7 +1991,7 @@ This is an example PM message.
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -2036,7 +2036,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -2066,7 +2066,7 @@ This is an example PM message.
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -2112,7 +2112,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -2148,7 +2148,7 @@ This is an example PM message.
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -2194,7 +2194,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -2230,7 +2230,7 @@ This is an example PM message.
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -2272,7 +2272,7 @@ This is an example PM message.
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -2302,7 +2302,7 @@ This is an example PM message.
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -2338,7 +2338,7 @@ This is an example PM message.
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -2364,7 +2364,7 @@ This is an example PM message.
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -2389,7 +2389,7 @@ This is an example PM message.
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -2418,7 +2418,7 @@ This is an example PM message.
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -2454,7 +2454,7 @@ This is an example PM message.
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -2490,7 +2490,7 @@ This is an example PM message.
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -2526,7 +2526,7 @@ This is an example PM message.
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -2552,7 +2552,7 @@ This is an example PM message.
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -2591,7 +2591,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -2617,7 +2617,7 @@ This is an example PM message.
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -2656,7 +2656,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -2686,7 +2686,7 @@ This is an example PM message.
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -2726,7 +2726,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -2762,7 +2762,7 @@ This is an example PM message.
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -2802,7 +2802,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -2832,7 +2832,7 @@ This is an example PM message.
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -2862,7 +2862,7 @@ This is an example PM message.
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -2898,7 +2898,7 @@ This is an example PM message.
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -2934,7 +2934,7 @@ This is an example PM message.
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -2960,7 +2960,7 @@ This is an example PM message.
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -2999,7 +2999,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -3025,7 +3025,7 @@ This is an example PM message.
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -3064,7 +3064,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -3094,7 +3094,7 @@ This is an example PM message.
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -3134,7 +3134,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -3170,7 +3170,7 @@ This is an example PM message.
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -3210,7 +3210,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -3246,7 +3246,7 @@ This is an example PM message.
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -3282,7 +3282,7 @@ This is an example PM message.
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -3308,7 +3308,7 @@ This is an example PM message.
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -3333,7 +3333,7 @@ This is an example PM message.
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -3362,7 +3362,7 @@ This is an example PM message.
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -3411,7 +3411,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible stream
 </div>
 
     
-This is an example stream message.
+<p>This is an example stream message.</p>
 
 
 
@@ -3437,7 +3437,7 @@ This is an example stream message.
 </div>
 
     
-This is an example stream message.
+<p>This is an example stream message.</p>
 
 
 
@@ -3485,7 +3485,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible stream
 </div>
 
     
-This is an example stream message.
+<p>This is an example stream message.</p>
 
 
 
@@ -3515,7 +3515,7 @@ This is an example stream message.
 </div>
 
     
-This is an example stream message.
+<p>This is an example stream message.</p>
 
 
 
@@ -3564,7 +3564,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible stream
 </div>
 
     
-This is an example stream message.
+<p>This is an example stream message.</p>
 
 
 
@@ -3603,7 +3603,7 @@ This is an example stream message.
 </div>
 
     
-This is an example stream message.
+<p>This is an example stream message.</p>
 
 
 
@@ -3652,7 +3652,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible stream
 </div>
 
     
-This is an example stream message.
+<p>This is an example stream message.</p>
 
 
 
@@ -3688,7 +3688,7 @@ This is an example stream message.
 </div>
 
     
-This is an example stream message.
+<p>This is an example stream message.</p>
 
 
 
@@ -3737,7 +3737,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible stream
 </div>
 
     
-This is an example stream message.
+<p>This is an example stream message.</p>
 
 
 
@@ -3763,7 +3763,7 @@ This is an example stream message.
 </div>
 
     
-This is an example stream message.
+<p>This is an example stream message.</p>
 
 
 
@@ -3798,7 +3798,7 @@ This is an example stream message.
 </div>
 
     
-This is an example stream message.
+<p>This is an example stream message.</p>
 
 
 
@@ -3837,7 +3837,7 @@ This is an example stream message.
 </div>
 
     
-This is an example stream message.
+<p>This is an example stream message.</p>
 
 
 
@@ -3882,7 +3882,7 @@ This is an example stream message.
 </div>
 
     
-This is an example stream message.
+<p>This is an example stream message.</p>
 
 
 
@@ -3912,7 +3912,7 @@ This is an example stream message.
 </div>
 
     
-This is an example stream message.
+<p>This is an example stream message.</p>
 
 
 
@@ -3942,7 +3942,7 @@ This is an example stream message.
 </div>
 
     
-This is an example stream message.
+<p>This is an example stream message.</p>
 
 
 
@@ -3978,7 +3978,7 @@ This is an example stream message.
 </div>
 
     
-This is an example stream message.
+<p>This is an example stream message.</p>
 
 
 
@@ -4018,7 +4018,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible topic:
 </div>
 
     
-This is an example stream message.
+<p>This is an example stream message.</p>
 
 
 
@@ -4044,7 +4044,7 @@ This is an example stream message.
 </div>
 
     
-This is an example stream message.
+<p>This is an example stream message.</p>
 
 
 
@@ -4083,7 +4083,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible topic:
 </div>
 
     
-This is an example stream message.
+<p>This is an example stream message.</p>
 
 
 
@@ -4113,7 +4113,7 @@ This is an example stream message.
 </div>
 
     
-This is an example stream message.
+<p>This is an example stream message.</p>
 
 
 
@@ -4153,7 +4153,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible topic:
 </div>
 
     
-This is an example stream message.
+<p>This is an example stream message.</p>
 
 
 
@@ -4189,7 +4189,7 @@ This is an example stream message.
 </div>
 
     
-This is an example stream message.
+<p>This is an example stream message.</p>
 
 
 
@@ -4229,7 +4229,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible topic:
 </div>
 
     
-This is an example stream message.
+<p>This is an example stream message.</p>
 
 
 
@@ -4255,7 +4255,7 @@ This is an example stream message.
 </div>
 
     
-This is an example stream message.
+<p>This is an example stream message.</p>
 
 
 
@@ -4290,7 +4290,7 @@ This is an example stream message.
 </div>
 
     
-This is an example stream message.
+<p>This is an example stream message.</p>
 
 
 
@@ -4320,7 +4320,7 @@ This is an example stream message.
 </div>
 
     
-This is an example stream message.
+<p>This is an example stream message.</p>
 
 
 
@@ -4350,7 +4350,7 @@ This is an example stream message.
 </div>
 
     
-This is an example stream message.
+<p>This is an example stream message.</p>
 
 
 
@@ -4386,7 +4386,7 @@ This is an example stream message.
 </div>
 
     
-This is an example stream message.
+<p>This is an example stream message.</p>
 
 
 

--- a/src/webview/html/__tests__/__snapshots__/messageListElementHtml-test.js.snap.ios
+++ b/src/webview/html/__tests__/__snapshots__/messageListElementHtml-test.js.snap.ios
@@ -42,7 +42,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
 </div>
 
     
-This is an example stream message.
+<p>This is an example stream message.</p>
 
 
 
@@ -68,7 +68,7 @@ This is an example stream message.
 </div>
 
     
-This is an example stream message.
+<p>This is an example stream message.</p>
 
 
 
@@ -120,7 +120,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
 </div>
 
     
-This is an example stream message.
+<p>This is an example stream message.</p>
 
 
 
@@ -150,7 +150,7 @@ This is an example stream message.
 </div>
 
     
-This is an example stream message.
+<p>This is an example stream message.</p>
 
 
 
@@ -203,7 +203,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
 </div>
 
     
-This is an example stream message.
+<p>This is an example stream message.</p>
 
 
 
@@ -246,7 +246,7 @@ This is an example stream message.
 </div>
 
     
-This is an example stream message.
+<p>This is an example stream message.</p>
 
 
 
@@ -299,7 +299,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
 </div>
 
     
-This is an example stream message.
+<p>This is an example stream message.</p>
 
 
 
@@ -342,7 +342,7 @@ This is an example stream message.
 </div>
 
     
-This is an example stream message.
+<p>This is an example stream message.</p>
 
 
 
@@ -395,7 +395,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
 </div>
 
     
-This is an example stream message.
+<p>This is an example stream message.</p>
 
 
 
@@ -431,7 +431,7 @@ This is an example stream message.
 </div>
 
     
-This is an example stream message.
+<p>This is an example stream message.</p>
 
 
 
@@ -477,7 +477,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -503,7 +503,7 @@ This is an example PM message.
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -548,7 +548,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -578,7 +578,7 @@ This is an example PM message.
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -624,7 +624,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -660,7 +660,7 @@ This is an example PM message.
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -706,7 +706,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -732,7 +732,7 @@ This is an example PM message.
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -777,7 +777,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -807,7 +807,7 @@ This is an example PM message.
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -853,7 +853,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -889,7 +889,7 @@ This is an example PM message.
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -942,7 +942,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
 </div>
 
     
-This is an example stream message.
+<p>This is an example stream message.</p>
 
 
 
@@ -968,7 +968,7 @@ This is an example stream message.
 </div>
 
     
-This is an example stream message.
+<p>This is an example stream message.</p>
 
 
 
@@ -1003,7 +1003,7 @@ This is an example stream message.
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -1039,7 +1039,7 @@ This is an example PM message.
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -1088,7 +1088,7 @@ This is an example PM message.
 </div>
 
     
-This is an example stream message.
+<p>This is an example stream message.</p>
 
 
 
@@ -1131,7 +1131,7 @@ This is an example stream message.
 </div>
 
     
-This is an example stream message.
+<p>This is an example stream message.</p>
 
 
 
@@ -1167,7 +1167,7 @@ This is an example stream message.
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -1197,7 +1197,7 @@ This is an example PM message.
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -1233,7 +1233,7 @@ This is an example PM message.
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -1259,7 +1259,7 @@ This is an example PM message.
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -1284,7 +1284,7 @@ This is an example PM message.
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -1313,7 +1313,7 @@ This is an example PM message.
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -1349,7 +1349,7 @@ This is an example PM message.
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -1385,7 +1385,7 @@ This is an example PM message.
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -1434,7 +1434,7 @@ This is an example PM message.
 </div>
 
     
-This is an example stream message.
+<p>This is an example stream message.</p>
 
 
 
@@ -1477,7 +1477,7 @@ This is an example stream message.
 </div>
 
     
-This is an example stream message.
+<p>This is an example stream message.</p>
 
 
 
@@ -1520,7 +1520,7 @@ This is an example stream message.
 </div>
 
     
-This is an example stream message.
+<p>This is an example stream message.</p>
 
 
 
@@ -1550,7 +1550,7 @@ This is an example stream message.
 </div>
 
     
-This is an example stream message.
+<p>This is an example stream message.</p>
 
 
 
@@ -1586,7 +1586,7 @@ This is an example stream message.
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -1612,7 +1612,7 @@ This is an example PM message.
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -1654,7 +1654,7 @@ This is an example PM message.
 </div>
 
     
-This is an example stream message.
+<p>This is an example stream message.</p>
 
 
 
@@ -1690,7 +1690,7 @@ This is an example stream message.
 </div>
 
     
-This is an example stream message.
+<p>This is an example stream message.</p>
 
 
 
@@ -1736,7 +1736,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -1762,7 +1762,7 @@ This is an example PM message.
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -1807,7 +1807,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -1837,7 +1837,7 @@ This is an example PM message.
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -1883,7 +1883,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -1919,7 +1919,7 @@ This is an example PM message.
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -1965,7 +1965,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -1991,7 +1991,7 @@ This is an example PM message.
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -2036,7 +2036,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -2066,7 +2066,7 @@ This is an example PM message.
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -2112,7 +2112,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -2148,7 +2148,7 @@ This is an example PM message.
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -2194,7 +2194,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -2230,7 +2230,7 @@ This is an example PM message.
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -2272,7 +2272,7 @@ This is an example PM message.
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -2302,7 +2302,7 @@ This is an example PM message.
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -2338,7 +2338,7 @@ This is an example PM message.
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -2364,7 +2364,7 @@ This is an example PM message.
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -2389,7 +2389,7 @@ This is an example PM message.
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -2418,7 +2418,7 @@ This is an example PM message.
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -2454,7 +2454,7 @@ This is an example PM message.
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -2490,7 +2490,7 @@ This is an example PM message.
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -2526,7 +2526,7 @@ This is an example PM message.
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -2552,7 +2552,7 @@ This is an example PM message.
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -2591,7 +2591,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -2617,7 +2617,7 @@ This is an example PM message.
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -2656,7 +2656,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -2686,7 +2686,7 @@ This is an example PM message.
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -2726,7 +2726,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -2762,7 +2762,7 @@ This is an example PM message.
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -2802,7 +2802,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -2832,7 +2832,7 @@ This is an example PM message.
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -2862,7 +2862,7 @@ This is an example PM message.
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -2898,7 +2898,7 @@ This is an example PM message.
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -2934,7 +2934,7 @@ This is an example PM message.
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -2960,7 +2960,7 @@ This is an example PM message.
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -2999,7 +2999,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -3025,7 +3025,7 @@ This is an example PM message.
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -3064,7 +3064,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -3094,7 +3094,7 @@ This is an example PM message.
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -3134,7 +3134,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -3170,7 +3170,7 @@ This is an example PM message.
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -3210,7 +3210,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -3246,7 +3246,7 @@ This is an example PM message.
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -3282,7 +3282,7 @@ This is an example PM message.
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -3308,7 +3308,7 @@ This is an example PM message.
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -3333,7 +3333,7 @@ This is an example PM message.
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -3362,7 +3362,7 @@ This is an example PM message.
 </div>
 
     
-This is an example PM message.
+<p>This is an example PM message.</p>
 
 
 
@@ -3411,7 +3411,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible stream
 </div>
 
     
-This is an example stream message.
+<p>This is an example stream message.</p>
 
 
 
@@ -3437,7 +3437,7 @@ This is an example stream message.
 </div>
 
     
-This is an example stream message.
+<p>This is an example stream message.</p>
 
 
 
@@ -3485,7 +3485,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible stream
 </div>
 
     
-This is an example stream message.
+<p>This is an example stream message.</p>
 
 
 
@@ -3515,7 +3515,7 @@ This is an example stream message.
 </div>
 
     
-This is an example stream message.
+<p>This is an example stream message.</p>
 
 
 
@@ -3564,7 +3564,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible stream
 </div>
 
     
-This is an example stream message.
+<p>This is an example stream message.</p>
 
 
 
@@ -3603,7 +3603,7 @@ This is an example stream message.
 </div>
 
     
-This is an example stream message.
+<p>This is an example stream message.</p>
 
 
 
@@ -3652,7 +3652,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible stream
 </div>
 
     
-This is an example stream message.
+<p>This is an example stream message.</p>
 
 
 
@@ -3688,7 +3688,7 @@ This is an example stream message.
 </div>
 
     
-This is an example stream message.
+<p>This is an example stream message.</p>
 
 
 
@@ -3737,7 +3737,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible stream
 </div>
 
     
-This is an example stream message.
+<p>This is an example stream message.</p>
 
 
 
@@ -3763,7 +3763,7 @@ This is an example stream message.
 </div>
 
     
-This is an example stream message.
+<p>This is an example stream message.</p>
 
 
 
@@ -3798,7 +3798,7 @@ This is an example stream message.
 </div>
 
     
-This is an example stream message.
+<p>This is an example stream message.</p>
 
 
 
@@ -3837,7 +3837,7 @@ This is an example stream message.
 </div>
 
     
-This is an example stream message.
+<p>This is an example stream message.</p>
 
 
 
@@ -3882,7 +3882,7 @@ This is an example stream message.
 </div>
 
     
-This is an example stream message.
+<p>This is an example stream message.</p>
 
 
 
@@ -3912,7 +3912,7 @@ This is an example stream message.
 </div>
 
     
-This is an example stream message.
+<p>This is an example stream message.</p>
 
 
 
@@ -3942,7 +3942,7 @@ This is an example stream message.
 </div>
 
     
-This is an example stream message.
+<p>This is an example stream message.</p>
 
 
 
@@ -3978,7 +3978,7 @@ This is an example stream message.
 </div>
 
     
-This is an example stream message.
+<p>This is an example stream message.</p>
 
 
 
@@ -4018,7 +4018,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible topic:
 </div>
 
     
-This is an example stream message.
+<p>This is an example stream message.</p>
 
 
 
@@ -4044,7 +4044,7 @@ This is an example stream message.
 </div>
 
     
-This is an example stream message.
+<p>This is an example stream message.</p>
 
 
 
@@ -4083,7 +4083,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible topic:
 </div>
 
     
-This is an example stream message.
+<p>This is an example stream message.</p>
 
 
 
@@ -4113,7 +4113,7 @@ This is an example stream message.
 </div>
 
     
-This is an example stream message.
+<p>This is an example stream message.</p>
 
 
 
@@ -4153,7 +4153,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible topic:
 </div>
 
     
-This is an example stream message.
+<p>This is an example stream message.</p>
 
 
 
@@ -4189,7 +4189,7 @@ This is an example stream message.
 </div>
 
     
-This is an example stream message.
+<p>This is an example stream message.</p>
 
 
 
@@ -4229,7 +4229,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible topic:
 </div>
 
     
-This is an example stream message.
+<p>This is an example stream message.</p>
 
 
 
@@ -4255,7 +4255,7 @@ This is an example stream message.
 </div>
 
     
-This is an example stream message.
+<p>This is an example stream message.</p>
 
 
 
@@ -4290,7 +4290,7 @@ This is an example stream message.
 </div>
 
     
-This is an example stream message.
+<p>This is an example stream message.</p>
 
 
 
@@ -4320,7 +4320,7 @@ This is an example stream message.
 </div>
 
     
-This is an example stream message.
+<p>This is an example stream message.</p>
 
 
 
@@ -4350,7 +4350,7 @@ This is an example stream message.
 </div>
 
     
-This is an example stream message.
+<p>This is an example stream message.</p>
 
 
 
@@ -4386,7 +4386,7 @@ This is an example stream message.
 </div>
 
     
-This is an example stream message.
+<p>This is an example stream message.</p>
 
 
 


### PR DESCRIPTION
This started from the note here:
https://github.com/zulip/zulip-mobile/pull/4968#discussion_r696943253
to better explain how `initialDataTypes.js` is organized, and expanded as I noticed that the register-queue binding could be 
cleaned up to make its interface better reflect how it actually behaves.
