### PR TITLE
webview: Have 'content' event only replace what's in msglistElementsDiv

### DIFF
--- a/src/webview/generateInboundEvents.js
+++ b/src/webview/generateInboundEvents.js
@@ -5,7 +5,6 @@ import isEqual from 'lodash.isequal';
 import type { Auth, FlagsState } from '../types';
 import type { Props } from './MessageList';
 import type { UpdateStrategy } from '../message/messageUpdates';
-import htmlBody from './html/htmlBody';
 import messageListElementHtml from './html/messageListElementHtml';
 import messageTypingAsHtml from './html/messageTypingAsHtml';
 import { getMessageUpdateStrategy } from '../message/messageUpdates';
@@ -47,22 +46,18 @@ export type WebViewInboundEvent =
   | WebViewInboundEventMessagesRead;
 
 const updateContent = (prevProps: Props, nextProps: Props): WebViewInboundEventContent => {
-  const content = htmlBody(
-    messageListElementHtml({
-      backgroundData: nextProps.backgroundData,
-      narrow: nextProps.narrow,
-      messageListElements: nextProps.messageListElementsForShownMessages,
-      _: nextProps._,
-    }),
-    nextProps.showMessagePlaceholders,
-  );
   const updateStrategy = getMessageUpdateStrategy(prevProps, nextProps);
 
   return {
     type: 'content',
     scrollMessageId: nextProps.initialScrollMessageId,
     auth: nextProps.backgroundData.auth,
-    content,
+    content: messageListElementHtml({
+      backgroundData: nextProps.backgroundData,
+      narrow: nextProps.narrow,
+      messageListElements: nextProps.messageListElementsForShownMessages,
+      _: nextProps._,
+    }),
     updateStrategy,
   };
 };

--- a/src/webview/js/generatedEs3.js
+++ b/src/webview/js/generatedEs3.js
@@ -759,7 +759,7 @@ var compiledWebviewJs = (function (exports) {
         break;
     }
 
-    documentBody.innerHTML = uevent.content;
+    msglistElementsDiv.innerHTML = uevent.content;
     rewriteHtml(uevent.auth);
     runAfterLayout(function () {
       if (target.type === 'bottom') {

--- a/src/webview/js/js.js
+++ b/src/webview/js/js.js
@@ -628,7 +628,7 @@ const handleInboundEventContent = (uevent: WebViewInboundEventContent) => {
       break;
   }
 
-  documentBody.innerHTML = uevent.content;
+  msglistElementsDiv.innerHTML = uevent.content;
 
   rewriteHtml(uevent.auth);
 


### PR DESCRIPTION
Instead of replacing all of what's in htmlBody.

This is a step we're doing on its own, on the way to message-list
diffing, for #3851. When this is released, we can get some empirical
confirmation that there's not some state being tracked somewhere in
the DOM that's under htmlBody but not under msglistElementsDiv, that
we're no longer resetting, since that could be a buggy experience.

We don't think there is any state like that, from brief testing and
reading the code.

The most likely-looking bit is whether the div#message-loading has
the "hidden" class or not, IOW, whether or not we're covering the
view with our "fetching messages" indicator. After all, before this
change, this event was setting that state based on a
`showMessagePlaceholders` boolean.

It should be OK that we're not doing that anymore. That's the job of
the `updateFetching` inbound event. Before e26a59d5d, we were
failing to send that event along with this 'content' event, because
of an ill-considered early return. But that's gone now, and testing
suggests that that state is being set as it should be.