### PR TITLE
ios [nfc]: Finish cleaning up unused `AppIdentifierPrefix` logic

### DIFF
--- a/ios/ZulipMobile/Info.plist
+++ b/ios/ZulipMobile/Info.plist
@@ -2,8 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>AppIdentifierPrefix</key>
-	<string>$(AppIdentifierPrefix)</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>


### PR DESCRIPTION
Looks like we missed this in eb37e6c78.