### PR TITLE
Don't immediately send & send multiple images.

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -644,7 +644,7 @@ SPEC CHECKSUMS:
   EXScreenOrientation: 09fe6b6b87899ae0c9320255bda7b7513cdfc8ec
   EXWebBrowser: 76783ba5dcb8699237746ecf41a9643d428a4cc5
   FBLazyVector: e686045572151edef46010a6f819ade377dfeb4b
-  FBReactNativeSpec: b96f20d2bcabd43e9acdeff6210208026a13633a
+  FBReactNativeSpec: 84bf0ee621e47a89282c2b1960e92dcb9d991b0c
   Flipper: d3da1aa199aad94455ae725e9f3aa43f3ec17021
   Flipper-DoubleConversion: 38631e41ef4f9b12861c67d17cb5518d06badc41
   Flipper-Folly: 755929a4f851b2fb2c347d533a23f191b008554c

--- a/ios/ZulipMobile.xcodeproj/project.pbxproj
+++ b/ios/ZulipMobile.xcodeproj/project.pbxproj
@@ -462,7 +462,7 @@
 				COPY_PHASE_STRIP = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "arm64 ";
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "";
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -524,7 +524,7 @@
 				COPY_PHASE_STRIP = YES;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "arm64 ";
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "";
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;


### PR DESCRIPTION
TODO:

- [ ] Choose better name for `toAttachmentResponse` method.
- [ ]  Break into multiple commits.
- [ ]  `FileName` isn't appropriate, `react-native-image-picker` modifies
  it. (it's along the line of `rn_image_picker_lib_temp_*`)


Fixes: #2366
Fixes: #4540