### PR TITLE
compose: Explain validation errors on press of disabled submit button

### DIFF
--- a/src/common/FloatingActionButton.js
+++ b/src/common/FloatingActionButton.js
@@ -13,6 +13,11 @@ const styles = createStyleSheet({
     justifyContent: 'center',
     alignItems: 'center',
     backgroundColor: BRAND_COLOR,
+
+    // This looks like it could clip the left/right of an icon if it's wider
+    //   than it is tall? (This can happen: see
+    //   https://github.com/zulip/zulip-mobile/pull/4730#discussion_r631342348.)
+    //   See note on the Icon prop in the jsdoc.
     overflow: 'hidden',
   },
 });
@@ -35,7 +40,8 @@ type Props = $ReadOnly<{|
  * @prop disabled - If 'true' component can't be pressed and
  *   becomes visibly inactive.
  * @prop size - Diameter of the component in pixels.
- * @prop Icon - Icon component to render.
+ * @prop Icon - Icon component to render. Should be a square (?) - see note
+ *   where we set overflow: 'hidden'
  * @prop onPress - Event called on component press.
  */
 export default function FloatingActionButton(props: Props): Node {

--- a/src/common/FloatingActionButton.js
+++ b/src/common/FloatingActionButton.js
@@ -1,5 +1,5 @@
 /* @flow strict-local */
-import React, { PureComponent } from 'react';
+import React from 'react';
 import type { Node } from 'react';
 import { View } from 'react-native';
 import type { ViewStyleProp } from 'react-native/Libraries/StyleSheet/StyleSheet';
@@ -38,30 +38,28 @@ type Props = $ReadOnly<{|
  * @prop Icon - Icon component to render.
  * @prop onPress - Event called on component press.
  */
-export default class FloatingActionButton extends PureComponent<Props> {
-  render(): Node {
-    const { style, size, disabled, onPress, Icon, accessibilityLabel } = this.props;
-    const iconSize = Math.trunc(size / 2);
-    const customWrapperStyle = {
-      width: size,
-      height: size,
-      borderRadius: size,
-      opacity: disabled ? 0.25 : 1,
-    };
-    const iconStyle = {
-      margin: Math.trunc(size / 4),
-    };
+export default function FloatingActionButton(props: Props): Node {
+  const { style, size, disabled, onPress, Icon, accessibilityLabel } = props;
+  const iconSize = Math.trunc(size / 2);
+  const customWrapperStyle = {
+    width: size,
+    height: size,
+    borderRadius: size,
+    opacity: disabled ? 0.25 : 1,
+  };
+  const iconStyle = {
+    margin: Math.trunc(size / 4),
+  };
 
-    return (
-      <Touchable
-        style={style}
-        onPress={disabled ? undefined : onPress}
-        accessibilityLabel={accessibilityLabel}
-      >
-        <View style={[styles.wrapper, customWrapperStyle]}>
-          <Icon style={iconStyle} size={iconSize} color="white" />
-        </View>
-      </Touchable>
-    );
-  }
+  return (
+    <Touchable
+      style={style}
+      onPress={disabled ? undefined : onPress}
+      accessibilityLabel={accessibilityLabel}
+    >
+      <View style={[styles.wrapper, customWrapperStyle]}>
+        <Icon style={iconStyle} size={iconSize} color="white" />
+      </View>
+    </Touchable>
+  );
 }

--- a/src/common/Touchable.js
+++ b/src/common/Touchable.js
@@ -1,6 +1,6 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
-import type { Node } from 'react';
+import type { Node, ElementConfig } from 'react';
 import { TouchableHighlight, TouchableNativeFeedback, Platform, View } from 'react-native';
 import type { ViewStyleProp } from 'react-native/Libraries/StyleSheet/StyleSheet';
 
@@ -9,6 +9,7 @@ import { HIGHLIGHT_COLOR } from '../styles';
 type Props = $ReadOnly<{|
   accessibilityLabel?: string,
   style?: ViewStyleProp,
+  hitSlop?: $PropertyType<ElementConfig<typeof View>, 'hitSlop'>,
   children: Node,
   onPress?: () => void | Promise<void>,
   onLongPress?: () => void,
@@ -46,10 +47,13 @@ type Props = $ReadOnly<{|
  * @prop [children] - A single component (not zero, or more than one.)
  * @prop [onPress] - Passed through; see upstream docs.
  * @prop [onLongPress] - Passed through; see upstream docs.
+ * @prop [accessibilityLabel] - Passed through; see upstream docs.
+ * @prop [hitSlop] - Passed through; see upstream docs.
  */
+// TODO(?): Use Pressable API: https://reactnative.dev/docs/pressable
 export default class Touchable extends PureComponent<Props> {
   render(): Node {
-    const { accessibilityLabel, style, onPress, onLongPress } = this.props;
+    const { accessibilityLabel, style, onPress, onLongPress, hitSlop } = this.props;
     const child: Node = React.Children.only(this.props.children);
 
     if (!onPress && !onLongPress) {
@@ -58,6 +62,7 @@ export default class Touchable extends PureComponent<Props> {
           accessible={!!accessibilityLabel}
           accessibilityLabel={accessibilityLabel}
           style={style}
+          hitSlop={hitSlop}
         >
           {child}
         </View>
@@ -74,6 +79,7 @@ export default class Touchable extends PureComponent<Props> {
           style={style}
           onPress={onPress}
           onLongPress={onLongPress}
+          hitSlop={hitSlop}
         >
           {child}
         </TouchableHighlight>
@@ -94,6 +100,7 @@ export default class Touchable extends PureComponent<Props> {
         }
         onPress={onPress}
         onLongPress={onLongPress}
+        hitSlop={hitSlop}
       >
         <View style={style}>{child}</View>
       </TouchableNativeFeedback>

--- a/src/common/Touchable.js
+++ b/src/common/Touchable.js
@@ -93,11 +93,7 @@ export default class Touchable extends PureComponent<Props> {
     return (
       <TouchableNativeFeedback
         accessibilityLabel={accessibilityLabel}
-        background={
-          Platform.Version >= 21
-            ? TouchableNativeFeedback.Ripple(HIGHLIGHT_COLOR, false)
-            : TouchableNativeFeedback.SelectableBackground()
-        }
+        background={TouchableNativeFeedback.Ripple(HIGHLIGHT_COLOR, false)}
         onPress={onPress}
         onLongPress={onLongPress}
         hitSlop={hitSlop}

--- a/src/compose/ComposeBox.js
+++ b/src/compose/ComposeBox.js
@@ -594,7 +594,7 @@ class ComposeBoxInner extends PureComponent<Props, State> {
           {(props => {
             // TODO: Integrate this into the surrounding code.
 
-            const { size, disabled, onPress, Icon } = props;
+            const { size, disabled, Icon } = props;
             const iconSize = Math.trunc(size / 2);
             const customWrapperStyle = {
               width: size,
@@ -609,7 +609,7 @@ class ComposeBoxInner extends PureComponent<Props, State> {
             return (
               <Touchable
                 style={this.styles.composeSendButton}
-                onPress={disabled ? undefined : onPress}
+                onPress={disabled ? undefined : this.handleSend}
                 accessibilityLabel="Send message"
               >
                 <View style={[fabStyles.wrapper, customWrapperStyle]}>
@@ -621,7 +621,6 @@ class ComposeBoxInner extends PureComponent<Props, State> {
             Icon: isEditing ? IconDone : IconSend,
             size: 32,
             disabled: message.trim().length === 0 || this.state.numUploading > 0,
-            onPress: this.handleSend,
           })}
         </View>
       </View>

--- a/src/compose/ComposeBox.js
+++ b/src/compose/ComposeBox.js
@@ -484,6 +484,8 @@ class ComposeBoxInner extends PureComponent<Props, State> {
     },
   };
 
+  submitButtonHitSlop = { top: 8, right: 8, bottom: 8, left: 8 };
+
   render() {
     const { isTopicFocused, isMenuExpanded, height, message, topic, selection } = this.state;
     const {
@@ -592,14 +594,27 @@ class ComposeBoxInner extends PureComponent<Props, State> {
             />
           </View>
           <View style={this.styles.submitButtonContainer}>
-            <Touchable
-              style={[this.styles.submitButton, { opacity: submitButtonDisabled ? 0.25 : 1 }]}
-              onPress={submitButtonDisabled ? undefined : this.handleSend}
-              accessibilityLabel="Send message"
-              hitSlop={{ top: 8, right: 8, bottom: 8, left: 8 }}
+            <View
+              // Mask the Android ripple-on-touch so it doesn't extend
+              //   outside the circle…
+              // TODO: `Touchable` should do this, and the `hitSlop`
+              //   workaround below.
+              style={{
+                borderRadius: this.styles.submitButton.borderRadius,
+                overflow: 'hidden',
+              }}
+              // …and don't defeat the `Touchable`'s `hitSlop`.
+              hitSlop={this.submitButtonHitSlop}
             >
-              <SubmitButtonIcon size={16} color="white" />
-            </Touchable>
+              <Touchable
+                style={[this.styles.submitButton, { opacity: submitButtonDisabled ? 0.25 : 1 }]}
+                onPress={submitButtonDisabled ? undefined : this.handleSend}
+                accessibilityLabel="Send message"
+                hitSlop={this.submitButtonHitSlop}
+              >
+                <SubmitButtonIcon size={16} color="white" />
+              </Touchable>
+            </View>
           </View>
         </View>
       </View>

--- a/src/compose/ComposeBox.js
+++ b/src/compose/ComposeBox.js
@@ -597,7 +597,6 @@ class ComposeBoxInner extends PureComponent<Props, State> {
           {(() => {
             // TODO: Integrate this into the surrounding code.
 
-            const iconSize = Math.trunc(32 / 2);
             const customWrapperStyle = {
               width: 32,
               height: 32,
@@ -605,7 +604,7 @@ class ComposeBoxInner extends PureComponent<Props, State> {
               opacity: submitButtonDisabled ? 0.25 : 1,
             };
             const iconStyle = {
-              margin: Math.trunc(32 / 4),
+              margin: 8,
             };
 
             return (
@@ -615,7 +614,7 @@ class ComposeBoxInner extends PureComponent<Props, State> {
                 accessibilityLabel="Send message"
               >
                 <View style={[fabStyles.wrapper, customWrapperStyle]}>
-                  <SubmitButtonIcon style={iconStyle} size={iconSize} color="white" />
+                  <SubmitButtonIcon style={iconStyle} size={16} color="white" />
                 </View>
               </Touchable>
             );

--- a/src/compose/ComposeBox.js
+++ b/src/compose/ComposeBox.js
@@ -409,15 +409,12 @@ class ComposeBoxInner extends PureComponent<Props, State> {
   };
 
   handleSend = () => {
-    const { dispatch, mandatoryTopics, _ } = this.props;
+    const { dispatch, _ } = this.props;
     const { message } = this.state;
     const destinationNarrow = this.getDestinationNarrow();
+    const validationErrors = this.getValidationErrors();
 
-    if (
-      isTopicNarrow(destinationNarrow)
-      && topicOfNarrow(destinationNarrow) === apiConstants.NO_TOPIC_TOPIC
-      && mandatoryTopics
-    ) {
+    if (validationErrors.includes('mandatory-topic-empty')) {
       // TODO how should this behave in the isEditing case? See
       //   https://github.com/zulip/zulip-mobile/pull/4798#discussion_r731341400.
       showErrorAlert(_('Message not sent'), _('Please specify a topic.'));

--- a/src/compose/ComposeBox.js
+++ b/src/compose/ComposeBox.js
@@ -595,9 +595,6 @@ class ComposeBoxInner extends PureComponent<Props, State> {
                 justifyContent: 'center',
                 alignItems: 'center',
                 backgroundColor: BRAND_COLOR,
-                overflow: 'hidden',
-                width: 32,
-                height: 32,
                 borderRadius: 32,
                 opacity: submitButtonDisabled ? 0.25 : 1,
               }}

--- a/src/compose/ComposeBox.js
+++ b/src/compose/ComposeBox.js
@@ -462,6 +462,13 @@ class ComposeBoxInner extends PureComponent<Props, State> {
     submitButtonContainer: {
       padding: 8,
     },
+    submitButton: {
+      justifyContent: 'center',
+      alignItems: 'center',
+      backgroundColor: BRAND_COLOR,
+      borderRadius: 32,
+      padding: 8,
+    },
     topicInput: {
       borderWidth: 0,
       borderRadius: 5,
@@ -584,17 +591,9 @@ class ComposeBoxInner extends PureComponent<Props, State> {
               onTouchStart={this.handleInputTouchStart}
             />
           </View>
-          {/* TODO: Integrate this more into the surrounding code. */}
           <View style={this.styles.submitButtonContainer}>
             <Touchable
-              style={{
-                justifyContent: 'center',
-                alignItems: 'center',
-                backgroundColor: BRAND_COLOR,
-                borderRadius: 32,
-                padding: 8,
-                opacity: submitButtonDisabled ? 0.25 : 1,
-              }}
+              style={[this.styles.submitButton, { opacity: submitButtonDisabled ? 0.25 : 1 }]}
               onPress={submitButtonDisabled ? undefined : this.handleSend}
               accessibilityLabel="Send message"
               hitSlop={{ top: 8, right: 8, bottom: 8, left: 8 }}

--- a/src/compose/ComposeBox.js
+++ b/src/compose/ComposeBox.js
@@ -594,35 +594,32 @@ class ComposeBoxInner extends PureComponent<Props, State> {
               onTouchStart={this.handleInputTouchStart}
             />
           </View>
-          {(() => (
-            // TODO: Integrate this into the surrounding code.
-
-            <Touchable
-              style={this.styles.composeSendButton}
-              onPress={submitButtonDisabled ? undefined : this.handleSend}
-              accessibilityLabel="Send message"
+          {/* TODO: Integrate this more into the surrounding code. */}
+          <Touchable
+            style={this.styles.composeSendButton}
+            onPress={submitButtonDisabled ? undefined : this.handleSend}
+            accessibilityLabel="Send message"
+          >
+            <View
+              style={[
+                fabStyles.wrapper,
+                {
+                  width: 32,
+                  height: 32,
+                  borderRadius: 32,
+                  opacity: submitButtonDisabled ? 0.25 : 1,
+                },
+              ]}
             >
-              <View
-                style={[
-                  fabStyles.wrapper,
-                  {
-                    width: 32,
-                    height: 32,
-                    borderRadius: 32,
-                    opacity: submitButtonDisabled ? 0.25 : 1,
-                  },
-                ]}
-              >
-                <SubmitButtonIcon
-                  style={{
-                    margin: 8,
-                  }}
-                  size={16}
-                  color="white"
-                />
-              </View>
-            </Touchable>
-          ))()}
+              <SubmitButtonIcon
+                style={{
+                  margin: 8,
+                }}
+                size={16}
+                color="white"
+              />
+            </View>
+          </Touchable>
         </View>
       </View>
     );

--- a/src/compose/ComposeBox.js
+++ b/src/compose/ComposeBox.js
@@ -409,14 +409,12 @@ class ComposeBoxInner extends PureComponent<Props, State> {
     return narrow;
   };
 
-  handleSend = () => {
-    const { dispatch, _ } = this.props;
+  handleSubmit = () => {
+    const { dispatch, _, isEditing } = this.props;
     const { message } = this.state;
     const destinationNarrow = this.getDestinationNarrow();
     const validationErrors = this.getValidationErrors();
 
-    // TODO how should this behave in the isEditing case? See
-    //   https://github.com/zulip/zulip-mobile/pull/4798#discussion_r731341400.
     if (validationErrors.length > 0) {
       const msg = validationErrors
         .map(error => {
@@ -435,7 +433,9 @@ class ComposeBoxInner extends PureComponent<Props, State> {
         })
         .join('\n\n');
 
-      showErrorAlert(_('Message not sent'), msg);
+      // TODO is this enough to handle the `isEditing` case? See
+      //   https://github.com/zulip/zulip-mobile/pull/4798#discussion_r731341400.
+      showErrorAlert(isEditing ? _('Message not saved') : _('Message not sent'), msg);
       return;
     }
 
@@ -653,8 +653,8 @@ class ComposeBoxInner extends PureComponent<Props, State> {
             >
               <Touchable
                 style={[this.styles.submitButton, { opacity: submitButtonDisabled ? 0.25 : 1 }]}
-                onPress={this.handleSend}
-                accessibilityLabel={_('Send message')}
+                onPress={this.handleSubmit}
+                accessibilityLabel={isEditing ? _('Save message') : _('Send message')}
                 hitSlop={this.submitButtonHitSlop}
               >
                 <SubmitButtonIcon size={16} color="white" />

--- a/src/compose/ComposeBox.js
+++ b/src/compose/ComposeBox.js
@@ -591,20 +591,16 @@ class ComposeBoxInner extends PureComponent<Props, State> {
             accessibilityLabel="Send message"
           >
             <View
-              style={[
-                {
-                  justifyContent: 'center',
-                  alignItems: 'center',
-                  backgroundColor: BRAND_COLOR,
-                  overflow: 'hidden',
-                },
-                {
-                  width: 32,
-                  height: 32,
-                  borderRadius: 32,
-                  opacity: submitButtonDisabled ? 0.25 : 1,
-                },
-              ]}
+              style={{
+                justifyContent: 'center',
+                alignItems: 'center',
+                backgroundColor: BRAND_COLOR,
+                overflow: 'hidden',
+                width: 32,
+                height: 32,
+                borderRadius: 32,
+                opacity: submitButtonDisabled ? 0.25 : 1,
+              }}
             >
               <SubmitButtonIcon
                 style={{

--- a/src/compose/ComposeBox.js
+++ b/src/compose/ComposeBox.js
@@ -11,7 +11,7 @@ import invariant from 'invariant';
 import * as apiConstants from '../api/constants';
 import { withSafeAreaInsets } from '../react-native-safe-area-context';
 import type { ThemeData } from '../styles';
-import { ThemeContext, BRAND_COLOR, createStyleSheet } from '../styles';
+import { ThemeContext, BRAND_COLOR } from '../styles';
 import type {
   Auth,
   Narrow,
@@ -145,16 +145,6 @@ const updateTextInput = (textInput, text) => {
   // `textInput` is untyped; see definition.
   textInput.setNativeProps({ text });
 };
-
-// TODO: Integrate this into the surrounding code.
-const fabStyles = createStyleSheet({
-  wrapper: {
-    justifyContent: 'center',
-    alignItems: 'center',
-    backgroundColor: BRAND_COLOR,
-    overflow: 'hidden',
-  },
-});
 
 class ComposeBoxInner extends PureComponent<Props, State> {
   static contextType = ThemeContext;
@@ -602,7 +592,12 @@ class ComposeBoxInner extends PureComponent<Props, State> {
           >
             <View
               style={[
-                fabStyles.wrapper,
+                {
+                  justifyContent: 'center',
+                  alignItems: 'center',
+                  backgroundColor: BRAND_COLOR,
+                  overflow: 'hidden',
+                },
                 {
                   width: 32,
                   height: 32,

--- a/src/compose/ComposeBox.js
+++ b/src/compose/ComposeBox.js
@@ -130,7 +130,8 @@ type State = {|
 |};
 
 // TODO(?): Could deduplicate with this type in ShareWrapper.
-export type ValidationError = 'upload-in-progress' | 'message-empty';
+export type ValidationError = 'upload-in-progress' | 'message-empty' | 'mandatory-topic-empty';
+
 const FOCUS_DEBOUNCE_TIME_MS = 16;
 
 function randomInt(min, max) {
@@ -489,9 +490,19 @@ class ComposeBoxInner extends PureComponent<Props, State> {
   submitButtonHitSlop = { top: 8, right: 8, bottom: 8, left: 8 };
 
   getValidationErrors = (): $ReadOnlyArray<ValidationError> => {
+    const { mandatoryTopics } = this.props;
+    const destinationNarrow = this.getDestinationNarrow();
     const { message } = this.state;
 
     const result = [];
+
+    if (
+      isTopicNarrow(destinationNarrow)
+      && topicOfNarrow(destinationNarrow) === apiConstants.NO_TOPIC_TOPIC
+      && mandatoryTopics
+    ) {
+      result.push('mandatory-topic-empty');
+    }
 
     if (message.trim().length === 0) {
       result.push('message-empty');

--- a/src/compose/ComposeBox.js
+++ b/src/compose/ComposeBox.js
@@ -517,6 +517,8 @@ class ComposeBoxInner extends PureComponent<Props, State> {
       backgroundColor: 'hsla(0, 0%, 50%, 0.1)',
     };
 
+    const SubmitButtonIcon = isEditing ? IconDone : IconSend;
+
     return (
       <View style={this.styles.wrapper}>
         <MentionWarnings narrow={narrow} stream={stream} ref={this.mentionWarnings} />
@@ -594,7 +596,7 @@ class ComposeBoxInner extends PureComponent<Props, State> {
           {(props => {
             // TODO: Integrate this into the surrounding code.
 
-            const { size, disabled, Icon } = props;
+            const { size, disabled } = props;
             const iconSize = Math.trunc(size / 2);
             const customWrapperStyle = {
               width: size,
@@ -613,12 +615,11 @@ class ComposeBoxInner extends PureComponent<Props, State> {
                 accessibilityLabel="Send message"
               >
                 <View style={[fabStyles.wrapper, customWrapperStyle]}>
-                  <Icon style={iconStyle} size={iconSize} color="white" />
+                  <SubmitButtonIcon style={iconStyle} size={iconSize} color="white" />
                 </View>
               </Touchable>
             );
           })({
-            Icon: isEditing ? IconDone : IconSend,
             size: 32,
             disabled: message.trim().length === 0 || this.state.numUploading > 0,
           })}

--- a/src/compose/ComposeBox.js
+++ b/src/compose/ComposeBox.js
@@ -543,6 +543,7 @@ class ComposeBoxInner extends PureComponent<Props, State> {
       isSubscribed,
       stream,
       videoChatProvider,
+      _,
     } = this.props;
 
     const insertVideoCallLink =
@@ -653,7 +654,7 @@ class ComposeBoxInner extends PureComponent<Props, State> {
               <Touchable
                 style={[this.styles.submitButton, { opacity: submitButtonDisabled ? 0.25 : 1 }]}
                 onPress={this.handleSend}
-                accessibilityLabel="Send message"
+                accessibilityLabel={_('Send message')}
                 hitSlop={this.submitButtonHitSlop}
               >
                 <SubmitButtonIcon size={16} color="white" />

--- a/src/compose/ComposeBox.js
+++ b/src/compose/ComposeBox.js
@@ -594,31 +594,35 @@ class ComposeBoxInner extends PureComponent<Props, State> {
               onTouchStart={this.handleInputTouchStart}
             />
           </View>
-          {(() => {
+          {(() => (
             // TODO: Integrate this into the surrounding code.
 
-            const customWrapperStyle = {
-              width: 32,
-              height: 32,
-              borderRadius: 32,
-              opacity: submitButtonDisabled ? 0.25 : 1,
-            };
-            const iconStyle = {
-              margin: 8,
-            };
-
-            return (
-              <Touchable
-                style={this.styles.composeSendButton}
-                onPress={submitButtonDisabled ? undefined : this.handleSend}
-                accessibilityLabel="Send message"
+            <Touchable
+              style={this.styles.composeSendButton}
+              onPress={submitButtonDisabled ? undefined : this.handleSend}
+              accessibilityLabel="Send message"
+            >
+              <View
+                style={[
+                  fabStyles.wrapper,
+                  {
+                    width: 32,
+                    height: 32,
+                    borderRadius: 32,
+                    opacity: submitButtonDisabled ? 0.25 : 1,
+                  },
+                ]}
               >
-                <View style={[fabStyles.wrapper, customWrapperStyle]}>
-                  <SubmitButtonIcon style={iconStyle} size={16} color="white" />
-                </View>
-              </Touchable>
-            );
-          })()}
+                <SubmitButtonIcon
+                  style={{
+                    margin: 8,
+                  }}
+                  size={16}
+                  color="white"
+                />
+              </View>
+            </Touchable>
+          ))()}
         </View>
       </View>
     );

--- a/src/compose/ComposeBox.js
+++ b/src/compose/ComposeBox.js
@@ -596,16 +596,11 @@ class ComposeBoxInner extends PureComponent<Props, State> {
                 alignItems: 'center',
                 backgroundColor: BRAND_COLOR,
                 borderRadius: 32,
+                padding: 8,
                 opacity: submitButtonDisabled ? 0.25 : 1,
               }}
             >
-              <SubmitButtonIcon
-                style={{
-                  margin: 8,
-                }}
-                size={16}
-                color="white"
-              />
+              <SubmitButtonIcon size={16} color="white" />
             </View>
           </Touchable>
         </View>

--- a/src/compose/ComposeBox.js
+++ b/src/compose/ComposeBox.js
@@ -11,7 +11,7 @@ import invariant from 'invariant';
 import * as apiConstants from '../api/constants';
 import { withSafeAreaInsets } from '../react-native-safe-area-context';
 import type { ThemeData } from '../styles';
-import { ThemeContext } from '../styles';
+import { ThemeContext, BRAND_COLOR, createStyleSheet } from '../styles';
 import type {
   Auth,
   Narrow,
@@ -27,7 +27,7 @@ import type {
 import { connect } from '../react-redux';
 import { withGetText } from '../boot/TranslationProvider';
 import { draftUpdate, sendTypingStart, sendTypingStop } from '../actions';
-import { FloatingActionButton, Input } from '../common';
+import { Touchable, Input } from '../common';
 import { showToast, showErrorAlert } from '../utils/info';
 import { IconDone, IconSend } from '../common/Icons';
 import {
@@ -145,6 +145,16 @@ const updateTextInput = (textInput, text) => {
   // `textInput` is untyped; see definition.
   textInput.setNativeProps({ text });
 };
+
+// TODO: Integrate this into the surrounding code.
+const fabStyles = createStyleSheet({
+  wrapper: {
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: BRAND_COLOR,
+    overflow: 'hidden',
+  },
+});
 
 class ComposeBoxInner extends PureComponent<Props, State> {
   static contextType = ThemeContext;
@@ -581,14 +591,41 @@ class ComposeBoxInner extends PureComponent<Props, State> {
               onTouchStart={this.handleInputTouchStart}
             />
           </View>
-          <FloatingActionButton
-            accessibilityLabel="Send message"
-            style={this.styles.composeSendButton}
-            Icon={isEditing ? IconDone : IconSend}
-            size={32}
-            disabled={message.trim().length === 0 || this.state.numUploading > 0}
-            onPress={this.handleSend}
-          />
+          {(props => {
+            // TODO: Integrate this into the surrounding code.
+
+            // eslint-disable-next-line no-shadow
+            const { style, size, disabled, onPress, Icon, accessibilityLabel } = props;
+            const iconSize = Math.trunc(size / 2);
+            const customWrapperStyle = {
+              width: size,
+              height: size,
+              borderRadius: size,
+              opacity: disabled ? 0.25 : 1,
+            };
+            const iconStyle = {
+              margin: Math.trunc(size / 4),
+            };
+
+            return (
+              <Touchable
+                style={style}
+                onPress={disabled ? undefined : onPress}
+                accessibilityLabel={accessibilityLabel}
+              >
+                <View style={[fabStyles.wrapper, customWrapperStyle]}>
+                  <Icon style={iconStyle} size={iconSize} color="white" />
+                </View>
+              </Touchable>
+            );
+          })({
+            accessibilityLabel: 'Send message',
+            style: this.styles.composeSendButton,
+            Icon: isEditing ? IconDone : IconSend,
+            size: 32,
+            disabled: message.trim().length === 0 || this.state.numUploading > 0,
+            onPress: this.handleSend,
+          })}
         </View>
       </View>
     );

--- a/src/compose/ComposeBox.js
+++ b/src/compose/ComposeBox.js
@@ -129,6 +129,8 @@ type State = {|
   selection: InputSelection,
 |};
 
+// TODO(?): Could deduplicate with this type in ShareWrapper.
+export type ValidationError = 'upload-in-progress' | 'message-empty';
 const FOCUS_DEBOUNCE_TIME_MS = 16;
 
 function randomInt(min, max) {
@@ -486,6 +488,22 @@ class ComposeBoxInner extends PureComponent<Props, State> {
 
   submitButtonHitSlop = { top: 8, right: 8, bottom: 8, left: 8 };
 
+  getValidationErrors = (): $ReadOnlyArray<ValidationError> => {
+    const { message } = this.state;
+
+    const result = [];
+
+    if (message.trim().length === 0) {
+      result.push('message-empty');
+    }
+
+    if (this.state.numUploading > 0) {
+      result.push('upload-in-progress');
+    }
+
+    return result;
+  };
+
   render() {
     const { isTopicFocused, isMenuExpanded, height, message, topic, selection } = this.state;
     const {
@@ -517,7 +535,7 @@ class ComposeBoxInner extends PureComponent<Props, State> {
     };
 
     const SubmitButtonIcon = isEditing ? IconDone : IconSend;
-    const submitButtonDisabled = message.trim().length === 0 || this.state.numUploading > 0;
+    const submitButtonDisabled = this.getValidationErrors().length > 0;
 
     return (
       <View style={this.styles.wrapper}>

--- a/src/compose/ComposeBox.js
+++ b/src/compose/ComposeBox.js
@@ -518,6 +518,7 @@ class ComposeBoxInner extends PureComponent<Props, State> {
     };
 
     const SubmitButtonIcon = isEditing ? IconDone : IconSend;
+    const submitButtonDisabled = message.trim().length === 0 || this.state.numUploading > 0;
 
     return (
       <View style={this.styles.wrapper}>
@@ -593,16 +594,15 @@ class ComposeBoxInner extends PureComponent<Props, State> {
               onTouchStart={this.handleInputTouchStart}
             />
           </View>
-          {(props => {
+          {(() => {
             // TODO: Integrate this into the surrounding code.
 
-            const { disabled } = props;
             const iconSize = Math.trunc(32 / 2);
             const customWrapperStyle = {
               width: 32,
               height: 32,
               borderRadius: 32,
-              opacity: disabled ? 0.25 : 1,
+              opacity: submitButtonDisabled ? 0.25 : 1,
             };
             const iconStyle = {
               margin: Math.trunc(32 / 4),
@@ -611,7 +611,7 @@ class ComposeBoxInner extends PureComponent<Props, State> {
             return (
               <Touchable
                 style={this.styles.composeSendButton}
-                onPress={disabled ? undefined : this.handleSend}
+                onPress={submitButtonDisabled ? undefined : this.handleSend}
                 accessibilityLabel="Send message"
               >
                 <View style={[fabStyles.wrapper, customWrapperStyle]}>
@@ -619,9 +619,7 @@ class ComposeBoxInner extends PureComponent<Props, State> {
                 </View>
               </Touchable>
             );
-          })({
-            disabled: message.trim().length === 0 || this.state.numUploading > 0,
-          })}
+          })()}
         </View>
       </View>
     );

--- a/src/compose/ComposeBox.js
+++ b/src/compose/ComposeBox.js
@@ -459,7 +459,7 @@ class ComposeBoxInner extends PureComponent<Props, State> {
       flex: 1,
       paddingVertical: 8,
     },
-    composeSendButton: {
+    submitButtonContainer: {
       padding: 8,
     },
     topicInput: {
@@ -585,12 +585,8 @@ class ComposeBoxInner extends PureComponent<Props, State> {
             />
           </View>
           {/* TODO: Integrate this more into the surrounding code. */}
-          <Touchable
-            style={this.styles.composeSendButton}
-            onPress={submitButtonDisabled ? undefined : this.handleSend}
-            accessibilityLabel="Send message"
-          >
-            <View
+          <View style={this.styles.submitButtonContainer}>
+            <Touchable
               style={{
                 justifyContent: 'center',
                 alignItems: 'center',
@@ -599,10 +595,13 @@ class ComposeBoxInner extends PureComponent<Props, State> {
                 padding: 8,
                 opacity: submitButtonDisabled ? 0.25 : 1,
               }}
+              onPress={submitButtonDisabled ? undefined : this.handleSend}
+              accessibilityLabel="Send message"
+              hitSlop={{ top: 8, right: 8, bottom: 8, left: 8 }}
             >
               <SubmitButtonIcon size={16} color="white" />
-            </View>
-          </Touchable>
+            </Touchable>
+          </View>
         </View>
       </View>
     );

--- a/src/compose/ComposeBox.js
+++ b/src/compose/ComposeBox.js
@@ -594,8 +594,7 @@ class ComposeBoxInner extends PureComponent<Props, State> {
           {(props => {
             // TODO: Integrate this into the surrounding code.
 
-            // eslint-disable-next-line no-shadow
-            const { style, size, disabled, onPress, Icon } = props;
+            const { size, disabled, onPress, Icon } = props;
             const iconSize = Math.trunc(size / 2);
             const customWrapperStyle = {
               width: size,
@@ -609,7 +608,7 @@ class ComposeBoxInner extends PureComponent<Props, State> {
 
             return (
               <Touchable
-                style={style}
+                style={this.styles.composeSendButton}
                 onPress={disabled ? undefined : onPress}
                 accessibilityLabel="Send message"
               >
@@ -619,7 +618,6 @@ class ComposeBoxInner extends PureComponent<Props, State> {
               </Touchable>
             );
           })({
-            style: this.styles.composeSendButton,
             Icon: isEditing ? IconDone : IconSend,
             size: 32,
             disabled: message.trim().length === 0 || this.state.numUploading > 0,

--- a/src/compose/ComposeBox.js
+++ b/src/compose/ComposeBox.js
@@ -595,7 +595,7 @@ class ComposeBoxInner extends PureComponent<Props, State> {
             // TODO: Integrate this into the surrounding code.
 
             // eslint-disable-next-line no-shadow
-            const { style, size, disabled, onPress, Icon, accessibilityLabel } = props;
+            const { style, size, disabled, onPress, Icon } = props;
             const iconSize = Math.trunc(size / 2);
             const customWrapperStyle = {
               width: size,
@@ -611,7 +611,7 @@ class ComposeBoxInner extends PureComponent<Props, State> {
               <Touchable
                 style={style}
                 onPress={disabled ? undefined : onPress}
-                accessibilityLabel={accessibilityLabel}
+                accessibilityLabel="Send message"
               >
                 <View style={[fabStyles.wrapper, customWrapperStyle]}>
                   <Icon style={iconStyle} size={iconSize} color="white" />
@@ -619,7 +619,6 @@ class ComposeBoxInner extends PureComponent<Props, State> {
               </Touchable>
             );
           })({
-            accessibilityLabel: 'Send message',
             style: this.styles.composeSendButton,
             Icon: isEditing ? IconDone : IconSend,
             size: 32,

--- a/src/compose/ComposeBox.js
+++ b/src/compose/ComposeBox.js
@@ -596,16 +596,16 @@ class ComposeBoxInner extends PureComponent<Props, State> {
           {(props => {
             // TODO: Integrate this into the surrounding code.
 
-            const { size, disabled } = props;
-            const iconSize = Math.trunc(size / 2);
+            const { disabled } = props;
+            const iconSize = Math.trunc(32 / 2);
             const customWrapperStyle = {
-              width: size,
-              height: size,
-              borderRadius: size,
+              width: 32,
+              height: 32,
+              borderRadius: 32,
               opacity: disabled ? 0.25 : 1,
             };
             const iconStyle = {
-              margin: Math.trunc(size / 4),
+              margin: Math.trunc(32 / 4),
             };
 
             return (
@@ -620,7 +620,6 @@ class ComposeBoxInner extends PureComponent<Props, State> {
               </Touchable>
             );
           })({
-            size: 32,
             disabled: message.trim().length === 0 || this.state.numUploading > 0,
           })}
         </View>

--- a/src/sharing/ShareWrapper.js
+++ b/src/sharing/ShareWrapper.js
@@ -58,6 +58,7 @@ const styles = createStyleSheet({
   },
 });
 
+// TODO(?): Could deduplicate with this type in ComposeBox.
 export type ValidationError =
   | 'mandatory-topic-empty'
   | 'stream-empty'

--- a/static/translations/messages_en.json
+++ b/static/translations/messages_en.json
@@ -7,6 +7,8 @@
   "Remind me later": "Remind me later",
   "The Zulip server at {realm} is not set up to deliver push notifications.": "The Zulip server at {realm} is not set up to deliver push notifications.",
   "The Zulip server at {realm} is not set up to deliver push notifications. Please contact your administrator.": "The Zulip server at {realm} is not set up to deliver push notifications. Please contact your administrator.",
+  "Message not saved": "Message not saved",
+  "Save message": "Save message",
   "Send message": "Send message",
   "Please wait for the upload to complete.": "Please wait for the upload to complete.",
   "To upload an image, please grant Zulip additional permissions in Settings.": "To upload an image, please grant Zulip additional permissions in Settings.",

--- a/static/translations/messages_en.json
+++ b/static/translations/messages_en.json
@@ -7,6 +7,7 @@
   "Remind me later": "Remind me later",
   "The Zulip server at {realm} is not set up to deliver push notifications.": "The Zulip server at {realm} is not set up to deliver push notifications.",
   "The Zulip server at {realm} is not set up to deliver push notifications. Please contact your administrator.": "The Zulip server at {realm} is not set up to deliver push notifications. Please contact your administrator.",
+  "Send message": "Send message",
   "Please wait for the upload to complete.": "Please wait for the upload to complete.",
   "To upload an image, please grant Zulip additional permissions in Settings.": "To upload an image, please grant Zulip additional permissions in Settings.",
   "Permissions needed": "Permissions needed",

--- a/static/translations/messages_en.json
+++ b/static/translations/messages_en.json
@@ -7,6 +7,7 @@
   "Remind me later": "Remind me later",
   "The Zulip server at {realm} is not set up to deliver push notifications.": "The Zulip server at {realm} is not set up to deliver push notifications.",
   "The Zulip server at {realm} is not set up to deliver push notifications. Please contact your administrator.": "The Zulip server at {realm} is not set up to deliver push notifications. Please contact your administrator.",
+  "Please wait for the upload to complete.": "Please wait for the upload to complete.",
   "To upload an image, please grant Zulip additional permissions in Settings.": "To upload an image, please grant Zulip additional permissions in Settings.",
   "Permissions needed": "Permissions needed",
   "Open settings": "Open settings",


### PR DESCRIPTION
Like 630a543de87355dcae67f5eeffd9051738cde1a6, but for the compose box instead of the share-to interface.

We could have done something like bb90a7e48f89881fbfd6c6fed64ccc050f10ea9a to the `FloatingActionButton`, where we add an `isPressHandledWhenDisabled` prop. But we already know that we don't want to keep using that component here, because the button isn't a FAB at all. So, stop using it.