### PR TITLE
sentry: Add `error.name` and `error.message` in apiCall error breadcrumb

### DIFF
--- a/jest/jestSetup.js
+++ b/jest/jestSetup.js
@@ -143,5 +143,6 @@ jest.mock('../src/utils/logging', () => {
     error: jest.fn().mockImplementation(logging.error),
     warn: jest.fn().mockImplementation(logging.warn),
     info: jest.fn().mockImplementation(logging.info),
+    ExtendableError: logging.ExtendableError,
   };
 });

--- a/src/api/apiErrors.js
+++ b/src/api/apiErrors.js
@@ -1,4 +1,5 @@
 /* @flow strict-local */
+import { ExtendableError } from '../utils/logging';
 import type { ApiErrorCode, ApiResponseErrorData } from './transportTypes';
 
 /**
@@ -6,7 +7,7 @@ import type { ApiErrorCode, ApiResponseErrorData } from './transportTypes';
  *
  * See subclasses: {@link ApiError}, {@link NetworkError}, {@link ServerError}.
  */
-export class RequestError extends Error {
+export class RequestError extends ExtendableError {
   /** The HTTP status code in the response, if any. */
   +httpStatus: number | void;
 

--- a/src/api/apiFetch.js
+++ b/src/api/apiFetch.js
@@ -74,6 +74,10 @@ export const apiCall = async (
   } catch (errorIllTyped) {
     const error: mixed = errorIllTyped; // https://github.com/facebook/flow/issues/2470
 
+    if (!(error instanceof Error)) {
+      throw new Error('Unexpected non-error thrown in apiCall');
+    }
+
     const { httpStatus, data } = error instanceof RequestError ? error : {};
 
     const response = data !== undefined ? data : '(none, or not valid JSON)';
@@ -81,7 +85,14 @@ export const apiCall = async (
     Sentry.addBreadcrumb({
       category: 'api',
       level: 'info',
-      data: { route, params, httpStatus, response },
+      data: {
+        route,
+        params,
+        httpStatus,
+        response,
+        errorName: error.name,
+        errorMessage: error.message,
+      },
     });
 
     if (error instanceof MalformedResponseError) {

--- a/src/notification/extract.js
+++ b/src/notification/extract.js
@@ -90,7 +90,7 @@ const asDict = (obj: JSONableInput | void): JSONableInputDict | void => {
 */
 
 /** Local error type. */
-class ApnsMsgValidationError extends Error {
+class ApnsMsgValidationError extends logging.ExtendableError {
   extras: JSONable;
   constructor(message, extras: JSONable) {
     super(message);

--- a/src/utils/async.js
+++ b/src/utils/async.js
@@ -1,8 +1,7 @@
 /* @flow strict-local */
+import { ExtendableError } from './logging';
 
-export class TimeoutError extends Error {
-  name: string = 'TimeoutError';
-}
+export class TimeoutError extends ExtendableError {}
 
 /**
  * Time-out a Promise after `timeLimitMs` has passed.


### PR DESCRIPTION
Prompted by noticing that we could be more informative here, after
seeing what looks like a failed API request in a Sentry breadcrumb,
but without an httpStatus:
  https://sentry.io/organizations/zulip/issues/2799655412/events/6664a7f3171749279ff724b4e805a132/?project=191284

(The breadcrumb was first noticed by Tim while debugging an issue
that turned out to be unrelated:
  https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/sentry.20IllegalArgumentException.3A.20Bitmap.20must.20not.20be.20null.2E/near/1283848.)