### PR TITLE
android notifs: Fix regression where notifs dropped when avatar not fetched

### DIFF
--- a/android/app/src/main/java/com/zulipmobile/notifications/NotificationUiManager.kt
+++ b/android/app/src/main/java/com/zulipmobile/notifications/NotificationUiManager.kt
@@ -334,14 +334,12 @@ private fun updateNotification(
         is Recipient.Pm -> fcmMessage.sender.fullName
     })
 
-    val sender = Person.Builder()
-        .apply {
-            setName(fcmMessage.sender.fullName)
-            fetchBitmap(fcmMessage.sender.avatarURL)?.let {
-                setIcon(IconCompat.createWithBitmap(it))
-            }
+    val sender = Person.Builder().apply {
+        setName(fcmMessage.sender.fullName)
+        fetchBitmap(fcmMessage.sender.avatarURL)?.let {
+            setIcon(IconCompat.createWithBitmap(it))
         }
-        .build()
+    }.build()
     messagingStyle.addMessage(fcmMessage.content, fcmMessage.timeMs, sender)
 
     // See comment at `setContentIntent` below.

--- a/android/app/src/main/java/com/zulipmobile/notifications/NotificationUiManager.kt
+++ b/android/app/src/main/java/com/zulipmobile/notifications/NotificationUiManager.kt
@@ -335,8 +335,12 @@ private fun updateNotification(
     })
 
     val sender = Person.Builder()
-        .setName(fcmMessage.sender.fullName)
-        .setIcon(IconCompat.createWithBitmap(fetchBitmap(fcmMessage.sender.avatarURL)))
+        .apply {
+            setName(fcmMessage.sender.fullName)
+            fetchBitmap(fcmMessage.sender.avatarURL)?.let {
+                setIcon(IconCompat.createWithBitmap(it))
+            }
+        }
         .build()
     messagingStyle.addMessage(fcmMessage.content, fcmMessage.timeMs, sender)
 


### PR DESCRIPTION
`IconCompat.createWithBitmap` [1] expects a non-null Bitmap object.
Since abd605d0e, we've been directly passing the value returned from
our own `fetchBitmap` function, which sometimes returns null. It
seems like the symptom would be a failure to deliver a notification
when the value is null.

So, go back to not calling `IconCompat.createWithBitmap` unless we
get a non-null value from `fetchBitmap`.

See discussion at
  https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/sentry.20IllegalArgumentException.3A.20Bitmap.20must.20not.20be.20null.2E/near/1283842.

[1] https://developer.android.com/reference/androidx/core/graphics/drawable/IconCompat#createWithBitmap(android.graphics.Bitmap)