### PR TITLE
notif settings screen: Always show server-push-setup-banner if it applies

### DIFF
--- a/src/common/ServerCompatBanner.js
+++ b/src/common/ServerCompatBanner.js
@@ -62,14 +62,14 @@ export default function ServerCompatBanner(props: Props): Node {
       buttons={[
         {
           id: 'dismiss',
-          label: 'Dismiss',
+          label: 'Remind me later',
           onPress: () => {
             dispatch(dismissCompatNotice());
           },
         },
         {
-          id: 'resolve',
-          label: isAdmin ? 'Fix now' : 'Learn more',
+          id: 'learn-more',
+          label: 'Learn more',
           onPress: () => {
             openLinkWithUserPreference(
               'https://zulip.readthedocs.io/en/stable/overview/release-lifecycle.html#compatibility-and-upgrading',

--- a/src/common/ServerPushSetupBanner.js
+++ b/src/common/ServerPushSetupBanner.js
@@ -16,7 +16,11 @@ type Props = $ReadOnly<{||}>;
 /**
  * A "nag banner" saying the server hasn't enabled push notifications, if so
  *
- * When dismissed, reappears again in two weeks.
+ * If this notice is dismissed, it sleeps for two weeks, then reappears if
+ * the server hasn't gotten set up for push notifications in that time.
+ * ("This notice" means the currently applicable notice. If the server does
+ * get setup for push notifications, then gets un-setup, a new notice will
+ * apply.)
  */
 export default function PushNotifsSetupBanner(props: Props): Node {
   const dispatch = useDispatch();

--- a/src/settings/NotificationsScreen.js
+++ b/src/settings/NotificationsScreen.js
@@ -9,6 +9,7 @@ import { useSelector } from '../react-redux';
 import { getAuth, getSettings } from '../selectors';
 import { SwitchRow, Screen } from '../common';
 import * as api from '../api';
+import ServerPushSetupBanner from '../common/ServerPushSetupBanner';
 
 type Props = $ReadOnly<{|
   navigation: AppNavigationProp<'notifications'>,
@@ -51,6 +52,7 @@ export default function NotificationsScreen(props: Props): Node {
 
   return (
     <Screen title="Notifications">
+      <ServerPushSetupBanner isDismissable={false} />
       <SwitchRow
         label="Notifications when offline"
         value={offlineNotification}

--- a/static/translations/messages_en.json
+++ b/static/translations/messages_en.json
@@ -83,8 +83,6 @@
   "Please check your Internet connection": "Please check your Internet connection",
   "{realm} is running Zulip Server {serverVersion}, which is unsupported. Please upgrade your server as soon as possible.": "{realm} is running Zulip Server {serverVersion}, which is unsupported. Please upgrade your server as soon as possible.",
   "{realm} is running Zulip Server {serverVersion}, which is unsupported. Please contact your administrator about upgrading.": "{realm} is running Zulip Server {serverVersion}, which is unsupported. Please contact your administrator about upgrading.",
-  "Dismiss": "Dismiss",
-  "Fix now": "Fix now",
   "Learn more": "Learn more",
   "Settings": "Settings",
   "Night mode": "Night mode",


### PR DESCRIPTION
In addition to the dismissable banner on the home screen that we started showing in #5090.

Related: #1507