### PR TITLE
ComposeMenu: Change a `logging.info` to `logging.warn`, to send to Sentry

### DIFF
--- a/src/compose/ComposeMenu.js
+++ b/src/compose/ComposeMenu.js
@@ -76,7 +76,7 @@ export const chooseUploadImageFilename = (uri: string, fileName: string): string
   if (/\.jpe?g$/i.test(uri)) {
     const result = nameWithoutPrefix.replace(/\.heic$/i, '.jpeg');
     if (result !== nameWithoutPrefix) {
-      logging.info('OK, so .HEIC to .jpeg replacement still seems like a good idea.');
+      logging.warn('OK, so .HEIC to .jpeg replacement still seems like a good idea.');
     }
     return result;
   }

--- a/src/compose/__tests__/ComposeMenu-test.js
+++ b/src/compose/__tests__/ComposeMenu-test.js
@@ -11,9 +11,9 @@ describe('chooseUploadImageFilename', () => {
     'Replaces any extension for the HEIC format with an extension for the JPEG format '
       + 'if the file name does end with an extension for the JPEG format',
     () => {
-      // suppress `logging.info` output
+      // suppress `logging.warn` output
       // $FlowFixMe[prop-missing]: Jest mock
-      logging.info.mockReturnValue();
+      logging.warn.mockReturnValue();
 
       const fileNameWithoutExtension = 'foo';
       expect(


### PR DESCRIPTION
Checking the jsdoc on logging.info, it explicitly says it's not
meant for sending things to Sentry. So, use logging.warn, which is.