### PR TITLE
checkout-keystore: Allow continuing if noise-grep command fails

### DIFF
--- a/tools/checkout-keystore
+++ b/tools/checkout-keystore
@@ -69,7 +69,7 @@ sq decrypt --recipient-key "${recipient_key}" \
   2>&"${COPROC[1]}"
 
 exec {COPROC[1]}>&-
-wait $COPROC_PID
+wait $COPROC_PID || :
 
 wait_min=15
 (


### PR DESCRIPTION
We want to continue to the wait-then-delete commands.