### PR TITLE
ios: Fix app-unusable bug with "Prefer Cross-Fade Transitions" setting

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -359,3 +359,23 @@ overrides:
       # a few variables already declared in upper scope; no bugs known
       # to result from this
       no-shadow: off
+
+  #
+  # ================================================================
+  # Third-party code: react-native.
+  #
+  # We leave this code in the style we received it in.
+  - files: ['src/third/react-native/**']
+    rules:
+      strict: off
+      import/order: off
+      import/first: off
+      object-curly-spacing: off
+      react/state-in-constructor: off
+      no-unused-vars: off
+      no-case-declarations: off
+      react/jsx-closing-bracket-location: off
+
+      # We'll fix these right away:
+      import/no-unresolved: off
+      import/extensions: off

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -375,7 +375,3 @@ overrides:
       no-unused-vars: off
       no-case-declarations: off
       react/jsx-closing-bracket-location: off
-
-      # We'll fix these right away:
-      import/no-unresolved: off
-      import/extensions: off

--- a/.flowconfig
+++ b/.flowconfig
@@ -22,9 +22,6 @@ node_modules/react-native/Libraries/polyfills/.*
 .*/node_modules/flow-coverage-report/.*
 .*/node_modules/@snyk/.*
 
-; We'll un-ignore this very soon.
-.*/third/react-native/KeyboardAvoidingView.js
-
 ; As of v4.1.1, this package only has TypeScript. That's fine as far as
 ; running the code goes -- Metro transpiles it -- but this line causes Flow
 ; to stop looking for types in that TypeScript, and then go and look in our

--- a/.flowconfig
+++ b/.flowconfig
@@ -22,6 +22,9 @@ node_modules/react-native/Libraries/polyfills/.*
 .*/node_modules/flow-coverage-report/.*
 .*/node_modules/@snyk/.*
 
+; We'll un-ignore this very soon.
+.*/third/react-native/KeyboardAvoidingView.js
+
 ; As of v4.1.1, this package only has TypeScript. That's fine as far as
 ; running the code goes -- Metro transpiles it -- but this line causes Flow
 ; to stop looking for types in that TypeScript, and then go and look in our

--- a/.prettierignore
+++ b/.prettierignore
@@ -9,3 +9,7 @@ flow-typed/@react-navigation
 # These are purely type definitions, no runtime code.  Most of them
 # are third-party code, too, so naturally don't match our style.
 **/flow-typed/**
+
+# Third-party code: react-native. We leave this code in the style we
+# received it in.
+src/third/react-native

--- a/docs/THIRDPARTY
+++ b/docs/THIRDPARTY
@@ -27,6 +27,13 @@ License: Apache-2
 Comment:
  Upstream is licensed as MIT.
 
+Files: src/third/react-native/*
+Copyright: Facebook, Inc., and its affiliates
+License: MIT
+Comment:
+ Changes we make here are designed to be sent upstream.  So even when making
+ changes, we keep our versions on the MIT license, the same as upstream.
+
 Files: src/third/redux-persist/*
 Copyright: 2015-2017 Zack Story, 2020-2021 Kandra Labs, Inc., and contributors
 License: Apache-2

--- a/docs/THIRDPARTY
+++ b/docs/THIRDPARTY
@@ -17,16 +17,22 @@ Comment:
  Kandra Labs of any inaccurate information or errors found in these notices.
 
 Files: *
-Copyright: 2016-2018 Kandra Labs, Inc., and contributors
+Copyright: 2016-2021 Kandra Labs, Inc., and contributors
 License: Apache-2
 
 Files: src/redux-persist-migrate/index.js
-Copyright: 2016-2017 Zack Story and contributors
-License: MIT
+Copyright: 2016-2017 Zack Story and contributors, 2018-2021 Kandra Labs, Inc.,
+ and contributors
+License: Apache-2
+Comment:
+ Upstream is licensed as MIT.
 
-Files: vendor/intl/*
-Copyright: 2013 Andy Earnshaw
-License: MIT
+Files: src/third/redux-persist/*
+Copyright: 2015-2017 Zack Story, 2020-2021 Kandra Labs, Inc., and contributors
+License: Apache-2
+Comment:
+ Upstream is licensed as MIT.  Forked from v4.10.2, at
+ https://github.com/rt2zz/redux-persist/tree/f4a6e86c666 .
 
 Files: static/img/app-store-badge.*
 Copyright: 2018 Apple Inc.

--- a/src/common/KeyboardAvoider.js
+++ b/src/common/KeyboardAvoider.js
@@ -1,8 +1,10 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
 import type { Node } from 'react';
-import { KeyboardAvoidingView, Platform, View } from 'react-native';
+import { Platform, View } from 'react-native';
 import type { ViewStyleProp } from 'react-native/Libraries/StyleSheet/StyleSheet';
+
+import KeyboardAvoidingView from '../third/react-native/KeyboardAvoidingView';
 
 type Props = $ReadOnly<{|
   behavior?: ?('height' | 'position' | 'padding'),

--- a/src/third/react-native/KeyboardAvoidingView.js
+++ b/src/third/react-native/KeyboardAvoidingView.js
@@ -1,0 +1,232 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * docs/THIRDPARTY file from the root directory of this source tree.
+ *
+ * @format
+ * @flow
+ */
+
+'use strict';
+
+const Keyboard = require('./Keyboard');
+const LayoutAnimation = require('../../LayoutAnimation/LayoutAnimation');
+const Platform = require('../../Utilities/Platform');
+const React = require('react');
+const StyleSheet = require('../../StyleSheet/StyleSheet');
+const View = require('../View/View');
+
+import type {ViewStyleProp} from '../../StyleSheet/StyleSheet';
+import {type EventSubscription} from '../../vendor/emitter/EventEmitter';
+import type {
+  ViewProps,
+  ViewLayout,
+  ViewLayoutEvent,
+} from '../View/ViewPropTypes';
+import type {KeyboardEvent} from './Keyboard';
+
+type Props = $ReadOnly<{|
+  ...ViewProps,
+
+  /**
+   * Specify how to react to the presence of the keyboard.
+   */
+  behavior?: ?('height' | 'position' | 'padding'),
+
+  /**
+   * Style of the content container when `behavior` is 'position'.
+   */
+  contentContainerStyle?: ?ViewStyleProp,
+
+  /**
+   * Controls whether this `KeyboardAvoidingView` instance should take effect.
+   * This is useful when more than one is on the screen. Defaults to true.
+   */
+  enabled: ?boolean,
+
+  /**
+   * Distance between the top of the user screen and the React Native view. This
+   * may be non-zero in some cases. Defaults to 0.
+   */
+  keyboardVerticalOffset: number,
+|}>;
+
+type State = {|
+  bottom: number,
+|};
+
+/**
+ * View that moves out of the way when the keyboard appears by automatically
+ * adjusting its height, position, or bottom padding.
+ */
+class KeyboardAvoidingView extends React.Component<Props, State> {
+  static defaultProps: {|enabled: boolean, keyboardVerticalOffset: number|} = {
+    enabled: true,
+    keyboardVerticalOffset: 0,
+  };
+
+  _frame: ?ViewLayout = null;
+  _keyboardEvent: ?KeyboardEvent = null;
+  _subscriptions: Array<EventSubscription> = [];
+  viewRef: {current: React.ElementRef<any> | null, ...};
+  _initialFrameHeight: number = 0;
+
+  constructor(props: Props) {
+    super(props);
+    this.state = {bottom: 0};
+    this.viewRef = React.createRef();
+  }
+
+  _relativeKeyboardHeight(keyboardFrame): number {
+    const frame = this._frame;
+    if (!frame || !keyboardFrame) {
+      return 0;
+    }
+
+    const keyboardY = keyboardFrame.screenY - this.props.keyboardVerticalOffset;
+
+    // Calculate the displacement needed for the view such that it
+    // no longer overlaps with the keyboard
+    return Math.max(frame.y + frame.height - keyboardY, 0);
+  }
+
+  _onKeyboardChange = (event: ?KeyboardEvent) => {
+    this._keyboardEvent = event;
+    this._updateBottomIfNecesarry();
+  };
+
+  _onLayout = (event: ViewLayoutEvent) => {
+    const wasFrameNull = this._frame == null;
+    this._frame = event.nativeEvent.layout;
+    if (!this._initialFrameHeight) {
+      // save the initial frame height, before the keyboard is visible
+      this._initialFrameHeight = this._frame.height;
+    }
+
+    if (wasFrameNull) {
+      this._updateBottomIfNecesarry();
+    }
+  };
+
+  _updateBottomIfNecesarry = () => {
+    if (this._keyboardEvent == null) {
+      this.setState({bottom: 0});
+      return;
+    }
+
+    const {duration, easing, endCoordinates} = this._keyboardEvent;
+    const height = this._relativeKeyboardHeight(endCoordinates);
+
+    if (this.state.bottom === height) {
+      return;
+    }
+
+    if (duration && easing) {
+      LayoutAnimation.configureNext({
+        // We have to pass the duration equal to minimal accepted duration defined here: RCTLayoutAnimation.m
+        duration: duration > 10 ? duration : 10,
+        update: {
+          duration: duration > 10 ? duration : 10,
+          type: LayoutAnimation.Types[easing] || 'keyboard',
+        },
+      });
+    }
+    this.setState({bottom: height});
+  };
+
+  componentDidMount(): void {
+    if (Platform.OS === 'ios') {
+      this._subscriptions = [
+        Keyboard.addListener('keyboardWillChangeFrame', this._onKeyboardChange),
+      ];
+    } else {
+      this._subscriptions = [
+        Keyboard.addListener('keyboardDidHide', this._onKeyboardChange),
+        Keyboard.addListener('keyboardDidShow', this._onKeyboardChange),
+      ];
+    }
+  }
+
+  componentWillUnmount(): void {
+    this._subscriptions.forEach(subscription => {
+      subscription.remove();
+    });
+  }
+
+  render(): React.Node {
+    const {
+      behavior,
+      children,
+      contentContainerStyle,
+      enabled,
+      keyboardVerticalOffset,
+      style,
+      ...props
+    } = this.props;
+    const bottomHeight = enabled ? this.state.bottom : 0;
+    switch (behavior) {
+      case 'height':
+        let heightStyle;
+        if (this._frame != null && this.state.bottom > 0) {
+          // Note that we only apply a height change when there is keyboard present,
+          // i.e. this.state.bottom is greater than 0. If we remove that condition,
+          // this.frame.height will never go back to its original value.
+          // When height changes, we need to disable flex.
+          heightStyle = {
+            height: this._initialFrameHeight - bottomHeight,
+            flex: 0,
+          };
+        }
+        return (
+          <View
+            ref={this.viewRef}
+            style={StyleSheet.compose(style, heightStyle)}
+            onLayout={this._onLayout}
+            {...props}>
+            {children}
+          </View>
+        );
+
+      case 'position':
+        return (
+          <View
+            ref={this.viewRef}
+            style={style}
+            onLayout={this._onLayout}
+            {...props}>
+            <View
+              style={StyleSheet.compose(contentContainerStyle, {
+                bottom: bottomHeight,
+              })}>
+              {children}
+            </View>
+          </View>
+        );
+
+      case 'padding':
+        return (
+          <View
+            ref={this.viewRef}
+            style={StyleSheet.compose(style, {paddingBottom: bottomHeight})}
+            onLayout={this._onLayout}
+            {...props}>
+            {children}
+          </View>
+        );
+
+      default:
+        return (
+          <View
+            ref={this.viewRef}
+            onLayout={this._onLayout}
+            style={style}
+            {...props}>
+            {children}
+          </View>
+        );
+    }
+  }
+}
+
+module.exports = KeyboardAvoidingView;

--- a/src/third/react-native/KeyboardAvoidingView.js
+++ b/src/third/react-native/KeyboardAvoidingView.js
@@ -5,26 +5,22 @@
  * docs/THIRDPARTY file from the root directory of this source tree.
  *
  * @format
- * @flow
+ * @flow strict-local
  */
 
 'use strict';
 
-const Keyboard = require('./Keyboard');
-const LayoutAnimation = require('../../LayoutAnimation/LayoutAnimation');
-const Platform = require('../../Utilities/Platform');
-const React = require('react');
-const StyleSheet = require('../../StyleSheet/StyleSheet');
-const View = require('../View/View');
-
-import type {ViewStyleProp} from '../../StyleSheet/StyleSheet';
-import {type EventSubscription} from '../../vendor/emitter/EventEmitter';
+import React from 'react';
+import type { ElementRef, Node } from 'react';
+import { Keyboard, LayoutAnimation, Platform, StyleSheet, View } from 'react-native';
+import type { ViewStyleProp } from 'react-native/Libraries/StyleSheet/StyleSheet';
+import type { EventSubscription } from 'react-native/Libraries/vendor/emitter/EventEmitter';
+import type { KeyboardEvent } from 'react-native/Libraries/Components/Keyboard/Keyboard';
 import type {
   ViewProps,
   ViewLayout,
   ViewLayoutEvent,
-} from '../View/ViewPropTypes';
-import type {KeyboardEvent} from './Keyboard';
+} from 'react-native/Libraries/Components/View/ViewPropTypes';
 
 type Props = $ReadOnly<{|
   ...ViewProps,
@@ -69,7 +65,8 @@ class KeyboardAvoidingView extends React.Component<Props, State> {
   _frame: ?ViewLayout = null;
   _keyboardEvent: ?KeyboardEvent = null;
   _subscriptions: Array<EventSubscription> = [];
-  viewRef: {current: React.ElementRef<any> | null, ...};
+  // $FlowFixMe[unclear-type]
+  viewRef: {current: ElementRef<any> | null, ...};
   _initialFrameHeight: number = 0;
 
   constructor(props: Props) {
@@ -122,6 +119,7 @@ class KeyboardAvoidingView extends React.Component<Props, State> {
       return;
     }
 
+    // $FlowFixMe[sketchy-number-and]
     if (duration && easing) {
       LayoutAnimation.configureNext({
         // We have to pass the duration equal to minimal accepted duration defined here: RCTLayoutAnimation.m
@@ -154,7 +152,7 @@ class KeyboardAvoidingView extends React.Component<Props, State> {
     });
   }
 
-  render(): React.Node {
+  render(): Node {
     const {
       behavior,
       children,
@@ -164,6 +162,7 @@ class KeyboardAvoidingView extends React.Component<Props, State> {
       style,
       ...props
     } = this.props;
+    // $FlowFixMe[sketchy-null-bool]
     const bottomHeight = enabled ? this.state.bottom : 0;
     switch (behavior) {
       case 'height':

--- a/src/third/react-native/KeyboardAvoidingView.js
+++ b/src/third/react-native/KeyboardAvoidingView.js
@@ -81,6 +81,20 @@ class KeyboardAvoidingView extends React.Component<Props, State> {
       return 0;
     }
 
+    if (keyboardFrame.height === 0) {
+      // The keyboard is hidden, and occupies no height.
+      //
+      // This condition is needed because in some circumstances when the
+      // keyboard is hidden we get both `screenY` and `height` (as well as
+      // `screenX` and `width`) of zero.  In particular, this happens on iOS
+      // when the UIAccessibilityPrefersCrossFadeTransitions setting is
+      // true, i.e. when the user has enabled both "Reduce Motion" and
+      // "Prefer Cross-Fade Transitions" under Settings > Accessibility >
+      // Motion. See zulip/zulip-mobile#5162 and
+      // facebook/react-native#29974.
+      return 0;
+    }
+
     const keyboardY = keyboardFrame.screenY - this.props.keyboardVerticalOffset;
 
     // Calculate the displacement needed for the view such that it


### PR DESCRIPTION
Fork React Native's `KeyboardAvoidingView` and apply a fix.

Fixes: #5162