### PR TITLE
js bundle: Try not to minify classnames that end in Error

### DIFF
--- a/metro.config.js
+++ b/metro.config.js
@@ -73,5 +73,23 @@ module.exports = {
         inlineRequires: true,
       },
     }),
+
+    // Use 'metro-minify-terser' (the default minifier at Metro v0.73.0+,
+    // but we're not there yet) to get the keep_classnames option in the
+    // minifierConfig, below.
+    // TODO(react-native-71): Remove "not there yet" comment, and maybe
+    //   leave this unspecified to accept the default.
+    minifierPath: 'metro-minify-terser',
+
+    minifierConfig: {
+      // Looking at the implementation, it seems that the "minifier config"
+      // is passed straight to the `terser` minifier (thanks to
+      // `minifierPath` being set to 'metro-minify-terser'), so we should
+      // use `terser`'s doc:
+      //   https://github.com/terser/terser#minify-options
+
+      // Don't minify our custom Error class names (for logging's sake)
+      keep_classnames: /Error$/,
+    },
   },
 };

--- a/package.json
+++ b/package.json
@@ -119,6 +119,7 @@
     "jest-extended": "^3.2.0",
     "jetifier": "^2.0.0",
     "metro-babel-register": "^0.67.0",
+    "metro-minify-terser": "^0.67.0",
     "metro-react-native-babel-preset": "^0.67.0",
     "prettier": "^2.6.2",
     "prettier-eslint": "^15.0.0",

--- a/src/utils/logging.js
+++ b/src/utils/logging.js
@@ -28,10 +28,11 @@ export type Extras = {| +[key: string]: JSONable |};
  */
 // TODO: Add linting to make sure all our custom errors extend this
 export class ExtendableError extends Error {
-  // Careful! Minification might make this differ from what we see in our
-  // source code, which would be kind of sad. (I guess we'll find out?)
-  // Don't use this for equality checks or user-facing text:
-  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/name#javascript_compressors_and_minifiers.
+  // Gotcha: Minification has been making this differ from what we see in
+  // our source code. Don't use in equality checks or user-facing text:
+  //   https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/name#javascript_compressors_and_minifiers
+  // However, we're trying Metro's `minifierConfig` to see if we can have it
+  // not minify classnames that end in Error.
   //
   // This will work even down a chain of subclasses, i.e.,
   // MyVerySpecificError extends MySpecificError extends ExtendableError. If

--- a/yarn.lock
+++ b/yarn.lock
@@ -1793,7 +1793,7 @@
     "@jridgewell/set-array" "^1.0.0"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
-"@jridgewell/gen-mapping@^0.3.2":
+"@jridgewell/gen-mapping@^0.3.0", "@jridgewell/gen-mapping@^0.3.2":
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz#c1aedc61e853f2bb9f5dfe6d4442d3b565b253b9"
   integrity sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==
@@ -1811,6 +1811,14 @@
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@jridgewell/set-array/-/set-array-1.1.2.tgz#7c6cf998d6d20b914c0a55a91ae928ff25965e72"
   integrity sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==
+
+"@jridgewell/source-map@^0.3.2":
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/@jridgewell/source-map/-/source-map-0.3.2.tgz#f45351aaed4527a298512ec72f81040c998580fb"
+  integrity sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==
+  dependencies:
+    "@jridgewell/gen-mapping" "^0.3.0"
+    "@jridgewell/trace-mapping" "^0.3.9"
 
 "@jridgewell/sourcemap-codec@1.4.14", "@jridgewell/sourcemap-codec@^1.4.10":
   version "1.4.14"
@@ -2898,10 +2906,10 @@ acorn@^7.1.1:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
   integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
 
-acorn@^8.2.4, acorn@^8.8.0:
-  version "8.8.1"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.8.1.tgz#0a3f9cbecc4ec3bea6f0a80b66ae8dd2da250b73"
-  integrity sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==
+acorn@^8.2.4, acorn@^8.5.0, acorn@^8.8.0:
+  version "8.8.2"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.8.2.tgz#1b2f25db02af965399b9776b0c2c391276d37c4a"
+  integrity sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==
 
 agent-base@6, agent-base@^6.0.2:
   version "6.0.2"
@@ -4162,7 +4170,7 @@ command-exists@^1.2.4, command-exists@^1.2.8:
   resolved "https://registry.yarnpkg.com/command-exists/-/command-exists-1.2.9.tgz#c50725af3808c8ab0260fd60b01fbfa25b954f69"
   integrity sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w==
 
-commander@^2.19.0:
+commander@^2.19.0, commander@^2.20.0:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
@@ -8665,6 +8673,13 @@ metro-inspector-proxy@0.67.0:
     ws "^7.5.1"
     yargs "^15.3.1"
 
+metro-minify-terser@^0.67.0:
+  version "0.67.0"
+  resolved "https://registry.yarnpkg.com/metro-minify-terser/-/metro-minify-terser-0.67.0.tgz#b056883db20d5818b0bf44b67920730768850156"
+  integrity sha512-twt08q2hS15cG0eR1pu6iYL5ckEdKR9iVENz096G3yl+YfPgK0xZtTXYQYQNOidqcord2ca4I6m/NVRxKhrxag==
+  dependencies:
+    terser "^5.10.0"
+
 metro-minify-uglify@0.67.0:
   version "0.67.0"
   resolved "https://registry.yarnpkg.com/metro-minify-uglify/-/metro-minify-uglify-0.67.0.tgz#28a77dbd78d9e558dba8c2f31c2b9c6f939df966"
@@ -11186,7 +11201,7 @@ source-map-resolve@^0.5.0:
     source-map-url "^0.4.0"
     urix "^0.1.0"
 
-source-map-support@^0.5.16, source-map-support@^0.5.6:
+source-map-support@^0.5.16, source-map-support@^0.5.6, source-map-support@~0.5.20:
   version "0.5.21"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.21.tgz#04fe7c7f9e1ed2d662233c28cb2b35b9f63f6e4f"
   integrity sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==
@@ -11718,6 +11733,16 @@ terminal-table@^0.0.12:
   dependencies:
     colors "^1.0.3"
     eastasianwidth "^0.1.0"
+
+terser@^5.10.0:
+  version "5.16.1"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-5.16.1.tgz#5af3bc3d0f24241c7fb2024199d5c461a1075880"
+  integrity sha512-xvQfyfA1ayT0qdK47zskQgRZeWLoOQ8JQ6mIgRGVNwZKdQMU+5FkCBjmv4QjcrTzyZquRw2FVtlJSRUmMKQslw==
+  dependencies:
+    "@jridgewell/source-map" "^0.3.2"
+    acorn "^8.5.0"
+    commander "^2.20.0"
+    source-map-support "~0.5.20"
 
 test-exclude@^6.0.0:
   version "6.0.0"


### PR DESCRIPTION
Note: I've so far only tested by running `yarn start` and observing that that doesn't crash.