### PR TITLE
transport: Accept international email address when making auth headers

### DIFF
--- a/src/api/transport.js
+++ b/src/api/transport.js
@@ -1,11 +1,10 @@
 /* @flow strict-local */
-import base64 from 'base-64';
-
 import type { Auth } from './transportTypes';
+import { base64Utf8Encode } from '../utils/encoding';
 
 export const getAuthHeaders = (auth: Auth): {| Authorization?: string |} =>
   // The `Object.freeze`` in the `:` case avoids a Flow issue:
   // https://github.com/facebook/flow/issues/2386#issuecomment-695064325
   auth.apiKey
-    ? { Authorization: `Basic ${base64.encode(`${auth.email}:${auth.apiKey}`)}` }
+    ? { Authorization: `Basic ${base64Utf8Encode(`${auth.email}:${auth.apiKey}`)}` }
     : Object.freeze({});


### PR DESCRIPTION
Anders points out on CZO [1] that non-ASCII UTF-8 characters are now
allowed in email addresses:

> From [RFC 6532 §3.2](https://www.rfc-editor.org/rfc/rfc6532#section-3.2):
> “The preceding changes mean that the following constructs now
> allow UTF-8: … 4. Domains.”

So, we need to accept those characters. Otherwise, you could have a
valid email address and be unable to make any authenticated API
requests in the app.

Use our handy helper function for base64 encoding that accepts UTF-8
as input.

[1] https://chat.zulip.org/#narrow/stream/378-api-design/topic/Non-ASCII.20email.2Fapi_key.3F/near/1300579