### PR TITLE
stream IDs: sharing, links, tests

### DIFF
--- a/src/autocomplete/TopicAutocomplete.js
+++ b/src/autocomplete/TopicAutocomplete.js
@@ -19,7 +19,9 @@ const styles = createStyleSheet({
 });
 
 type Props = $ReadOnly<{|
-  narrow: Narrow,
+  /** If null, this component won't do anything. */
+  narrow: Narrow | null,
+
   isFocused: boolean,
   text: string,
   onAutocomplete: (name: string) => void,
@@ -28,7 +30,7 @@ type Props = $ReadOnly<{|
 export default function TopicAutocomplete(props: Props): Node {
   const { narrow, isFocused, text, onAutocomplete } = props;
   const dispatch = useDispatch();
-  const topics = useSelector(state => getTopicsForNarrow(state, narrow));
+  const topics = useSelector(state => (narrow ? getTopicsForNarrow(state, narrow) : []));
 
   useEffect(() => {
     // The following should be sufficient to ensure we're up-to-date
@@ -43,10 +45,12 @@ export default function TopicAutocomplete(props: Props): Node {
     //
     // The latter is already taken care of (see handling of
     // EVENT_NEW_MESSAGE in topicsReducer). So, do the former here.
-    dispatch(fetchTopicsForStream(narrow));
+    if (narrow) {
+      dispatch(fetchTopicsForStream(narrow));
+    }
   }, [dispatch, narrow]);
 
-  if (!isFocused) {
+  if (!isFocused || !narrow) {
     return null;
   }
 

--- a/src/drafts/__tests__/draftsSelectors-test.js
+++ b/src/drafts/__tests__/draftsSelectors-test.js
@@ -6,7 +6,7 @@ import * as eg from '../../__tests__/lib/exampleData';
 
 describe('getDraftForNarrow', () => {
   test('return content of draft if exists', () => {
-    const narrow = topicNarrow('stream', 'topic');
+    const narrow = topicNarrow(eg.stream.name, 'topic');
     const state = eg.reduxState({
       drafts: {
         [keyFromNarrow(narrow)]: 'content',
@@ -19,14 +19,14 @@ describe('getDraftForNarrow', () => {
   });
 
   test('return empty string if not exists', () => {
-    const narrow = topicNarrow('stream', 'topic');
+    const narrow = topicNarrow(eg.stream.name, 'topic');
     const state = eg.reduxState({
       drafts: {
         [keyFromNarrow(narrow)]: 'content',
       },
     });
 
-    const draft = getDraftForNarrow(state, topicNarrow('stream', 'topic1'));
+    const draft = getDraftForNarrow(state, topicNarrow(eg.stream.name, 'topic1'));
 
     expect(draft).toEqual('');
   });

--- a/src/drafts/__tests__/draftsSelectors-test.js
+++ b/src/drafts/__tests__/draftsSelectors-test.js
@@ -1,12 +1,13 @@
-import deepFreeze from 'deep-freeze';
+/* @flow strict-local */
 
 import { getDraftForNarrow } from '../draftsSelectors';
 import { topicNarrow, keyFromNarrow } from '../../utils/narrow';
+import * as eg from '../../__tests__/lib/exampleData';
 
 describe('getDraftForNarrow', () => {
   test('return content of draft if exists', () => {
     const narrow = topicNarrow('stream', 'topic');
-    const state = deepFreeze({
+    const state = eg.reduxState({
       drafts: {
         [keyFromNarrow(narrow)]: 'content',
       },
@@ -19,7 +20,7 @@ describe('getDraftForNarrow', () => {
 
   test('return empty string if not exists', () => {
     const narrow = topicNarrow('stream', 'topic');
-    const state = deepFreeze({
+    const state = eg.reduxState({
       drafts: {
         [keyFromNarrow(narrow)]: 'content',
       },

--- a/src/message/__tests__/fetchActions-test.js
+++ b/src/message/__tests__/fetchActions-test.js
@@ -26,7 +26,7 @@ import * as logging from '../../utils/logging';
 
 const mockStore = configureStore([thunk]);
 
-const narrow = streamNarrow('some stream');
+const narrow = streamNarrow(eg.stream.name);
 const streamNarrowStr = keyFromNarrow(narrow);
 
 global.FormData = class FormData {};
@@ -54,7 +54,7 @@ describe('fetchActions', () => {
         narrows: Immutable.Map({
           [streamNarrowStr]: [],
         }),
-        streams: [eg.makeStream({ name: 'some stream' })],
+        streams: [eg.stream],
       });
 
       const result = isFetchNeededAtAnchor(state, narrow, FIRST_UNREAD_ANCHOR);
@@ -77,7 +77,7 @@ describe('fetchActions', () => {
           [streamNarrowStr]: [1],
         }),
         messages: eg.makeMessagesState([message1, message2]),
-        streams: [eg.makeStream({ name: 'some stream' })],
+        streams: [eg.stream],
       });
 
       const result = isFetchNeededAtAnchor(state, narrow, FIRST_UNREAD_ANCHOR);

--- a/src/message/__tests__/messageActions-test.js
+++ b/src/message/__tests__/messageActions-test.js
@@ -13,7 +13,7 @@ import type { Action } from '../../actionTypes';
 
 const mockStore = configureStore([thunk]);
 
-const streamNarrowObj = streamNarrow('some stream');
+const streamNarrowObj = streamNarrow(eg.stream.name);
 
 describe('messageActions', () => {
   describe('doNarrow', () => {
@@ -25,7 +25,7 @@ describe('messageActions', () => {
         eg.reduxState({
           accounts: [eg.selfAccount],
           session: { ...eg.baseReduxState.session, isHydrated: true },
-          streams: [eg.makeStream({ name: 'some stream' })],
+          streams: [eg.stream],
         }),
       );
 

--- a/src/message/messagesActions.js
+++ b/src/message/messagesActions.js
@@ -6,7 +6,7 @@ import { getMessageIdFromLink, getNarrowFromLink } from '../utils/internalLinks'
 import { openLinkWithUserPreference } from '../utils/openLink';
 import { navigateToChat } from '../nav/navActions';
 import { FIRST_UNREAD_ANCHOR } from '../anchor';
-import { getStreamsById } from '../subscriptions/subscriptionSelectors';
+import { getStreamsById, getStreamsByName } from '../subscriptions/subscriptionSelectors';
 import * as api from '../api';
 import { isUrlOnRealm } from '../utils/url';
 import { getOwnUserId } from '../users/userSelectors';
@@ -30,8 +30,14 @@ export const messageLinkPress = (href: string): ThunkAction<Promise<void>> => as
   const state = getState();
   const auth = getAuth(state);
   const streamsById = getStreamsById(state);
+  const streamsByName = getStreamsByName(state);
   const ownUserId = getOwnUserId(state);
-  const narrow = getNarrowFromLink(href, auth.realm, streamsById, ownUserId);
+  const narrow = getNarrowFromLink(href, auth.realm, streamsById, streamsByName, ownUserId);
+  // TODO: In some cases getNarrowFromLink successfully parses the link, but
+  //   finds it points somewhere we can't see: in particular, to a stream
+  //   that's hidden from our user (perhaps doesn't exist.)  For those,
+  //   perhaps give an error instead of falling back to opening in browser,
+  //   which should be futile.
   if (narrow) {
     const anchor = getMessageIdFromLink(href, auth.realm);
     dispatch(doNarrow(narrow, anchor));

--- a/src/sharing/ShareToStream.js
+++ b/src/sharing/ShareToStream.js
@@ -5,12 +5,11 @@ import type { ComponentType } from 'react';
 import type { ValidationError } from './ShareWrapper';
 import type { SharingNavigationProp } from './SharingScreen';
 import type { RouteProp } from '../react-navigation';
-import type { Dispatch, Subscription, Auth, GetText } from '../types';
+import type { Dispatch, Auth, GetText } from '../types';
 import type { SharedData } from './types';
 import { TranslationContext } from '../boot/TranslationProvider';
 import { connect } from '../react-redux';
 import { Input } from '../common';
-import { getSubscriptionsById } from '../subscriptions/subscriptionSelectors';
 import StreamAutocomplete from '../autocomplete/StreamAutocomplete';
 import TopicAutocomplete from '../autocomplete/TopicAutocomplete';
 import AnimatedScaleComponent from '../animation/AnimatedScaleComponent';
@@ -26,7 +25,6 @@ type OuterProps = $ReadOnly<{|
 |}>;
 
 type SelectorProps = $ReadOnly<{|
-  subscriptions: Map<number, Subscription>,
   auth: Auth,
   mandatoryTopics: boolean,
 |}>;
@@ -164,7 +162,6 @@ class ShareToStreamInner extends React.Component<Props, State> {
 }
 
 const ShareToStream: ComponentType<OuterProps> = connect(state => ({
-  subscriptions: getSubscriptionsById(state),
   auth: getAuth(state),
   mandatoryTopics: getRealm(state).mandatoryTopics,
 }))(ShareToStreamInner);

--- a/src/sharing/ShareToStream.js
+++ b/src/sharing/ShareToStream.js
@@ -74,11 +74,21 @@ class ShareToStreamInner extends React.Component<Props, State> {
   };
 
   focusTopic = () => {
-    const { streamName } = this.state;
+    const { streamName, streamId } = this.state;
     const { dispatch } = this.props;
-    const narrow = streamNarrow(streamName);
 
-    dispatch(fetchTopicsForStream(narrow));
+    if (streamId !== null) {
+      // We have an actual stream selected.  Fetch its recent topic names.
+      // TODO: why do we do this?  `TopicAutocomplete` does the same thing,
+      //   with an effect that reruns when the stream changes.
+      const narrow = streamNarrow(streamName);
+      dispatch(fetchTopicsForStream(narrow));
+    }
+    // If what's entered in the stream-name field isn't an actual stream,
+    // then there's no point fetching topics.
+    // … Maybe we shouldn't be allowing this interaction in that case in
+    // the first place?
+
     this.setState({ isTopicFocused: true });
   };
 
@@ -137,7 +147,7 @@ class ShareToStreamInner extends React.Component<Props, State> {
   render() {
     const { sharedData } = this.props.route.params;
     const { streamName, streamId, topic, isStreamFocused, isTopicFocused } = this.state;
-    const narrow = streamNarrow(streamName);
+    const narrow = streamId !== null ? streamNarrow(streamName) : null;
     const sendTo = {
       streamName,
       /* $FlowFixMe[incompatible-cast]: ShareWrapper will only look at this

--- a/src/sharing/ShareToStream.js
+++ b/src/sharing/ShareToStream.js
@@ -37,7 +37,7 @@ type Props = $ReadOnly<{|
 |}>;
 
 type State = $ReadOnly<{|
-  stream: string,
+  streamName: string,
   topic: string,
   isStreamFocused: boolean,
   isTopicFocused: boolean,
@@ -48,7 +48,7 @@ class ShareToStreamInner extends React.Component<Props, State> {
   context: GetText;
 
   state = {
-    stream: '',
+    streamName: '',
     topic: '',
     isStreamFocused: false,
     isTopicFocused: false,
@@ -67,16 +67,16 @@ class ShareToStreamInner extends React.Component<Props, State> {
   };
 
   focusTopic = () => {
-    const { stream } = this.state;
+    const { streamName } = this.state;
     const { dispatch } = this.props;
-    const narrow = streamNarrow(stream);
+    const narrow = streamNarrow(streamName);
 
     dispatch(fetchTopicsForStream(narrow));
     this.setState({ isTopicFocused: true });
   };
 
-  handleStreamChange = stream => {
-    this.setState({ stream });
+  handleStreamChange = streamName => {
+    this.setState({ streamName });
   };
 
   handleTopicChange = topic => {
@@ -85,8 +85,8 @@ class ShareToStreamInner extends React.Component<Props, State> {
 
   handleStreamAutoComplete = (rawStream: string) => {
     // TODO: What is this for? (write down our assumptions)
-    const stream = rawStream.split('**')[1];
-    this.setState({ stream, isStreamFocused: false });
+    const streamName = rawStream.split('**')[1];
+    this.setState({ streamName, isStreamFocused: false });
   };
 
   handleTopicAutoComplete = (topic: string) => {
@@ -95,12 +95,12 @@ class ShareToStreamInner extends React.Component<Props, State> {
 
   getValidationErrors: string => $ReadOnlyArray<ValidationError> = message => {
     const { mandatoryTopics } = this.props;
-    const { stream, topic } = this.state;
+    const { streamName, topic } = this.state;
     const { sharedData } = this.props.route.params;
 
     const result = [];
 
-    if (stream.trim() === '') {
+    if (streamName.trim() === '') {
       result.push('stream-empty');
     }
 
@@ -117,9 +117,9 @@ class ShareToStreamInner extends React.Component<Props, State> {
 
   render() {
     const { sharedData } = this.props.route.params;
-    const { stream, topic, isStreamFocused, isTopicFocused } = this.state;
-    const narrow = streamNarrow(stream);
-    const sendTo = { stream, topic, type: 'stream' };
+    const { streamName, topic, isStreamFocused, isTopicFocused } = this.state;
+    const narrow = streamNarrow(streamName);
+    const sendTo = { streamName, topic, type: 'stream' };
 
     return (
       <ShareWrapper
@@ -128,11 +128,11 @@ class ShareToStreamInner extends React.Component<Props, State> {
         sendTo={sendTo}
       >
         <AnimatedScaleComponent visible={isStreamFocused}>
-          <StreamAutocomplete filter={stream} onAutocomplete={this.handleStreamAutoComplete} />
+          <StreamAutocomplete filter={streamName} onAutocomplete={this.handleStreamAutoComplete} />
         </AnimatedScaleComponent>
         <Input
           placeholder="Stream"
-          value={stream}
+          value={streamName}
           onChangeText={this.handleStreamChange}
           onFocus={this.focusStream}
           onChange={this.focusStream}
@@ -153,7 +153,7 @@ class ShareToStreamInner extends React.Component<Props, State> {
           onFocus={this.focusTopic}
           onBlur={this.blurTopic}
           onChangeText={this.handleTopicChange}
-          editable={stream !== ''}
+          editable={streamName !== ''}
           autoCapitalize="none"
         />
       </ShareWrapper>

--- a/src/sharing/ShareWrapper.js
+++ b/src/sharing/ShareWrapper.js
@@ -23,7 +23,7 @@ import { IconAttachment, IconCancel } from '../common/Icons';
 
 type SendTo =
   | {| type: 'pm', selectedRecipients: $ReadOnlyArray<UserId> |}
-  | {| type: 'stream', stream: string, topic: string |};
+  | {| type: 'stream', streamName: string, topic: string |};
 
 const styles = createStyleSheet({
   wrapper: {
@@ -169,7 +169,7 @@ class ShareWrapperInner extends React.Component<Props, State> {
             content: messageToSend,
             type: 'stream',
             subject: sendTo.topic || apiConstants.NO_TOPIC_TOPIC,
-            to: sendTo.stream,
+            to: sendTo.streamName,
           };
 
     try {
@@ -204,8 +204,8 @@ class ShareWrapperInner extends React.Component<Props, State> {
       }
 
       case 'stream': {
-        const { stream } = sendTo;
-        const narrow = streamNarrow(stream);
+        const { streamName } = sendTo;
+        const narrow = streamNarrow(streamName);
         NavigationService.dispatch(replaceWithChat(narrow));
         break;
       }

--- a/src/sharing/ShareWrapper.js
+++ b/src/sharing/ShareWrapper.js
@@ -23,7 +23,8 @@ import { IconAttachment, IconCancel } from '../common/Icons';
 
 type SendTo =
   | {| type: 'pm', selectedRecipients: $ReadOnlyArray<UserId> |}
-  | {| type: 'stream', streamName: string, topic: string |};
+  // TODO(#3918): Drop streamName.  Used below for sending, and for narrow.
+  | {| type: 'stream', streamName: string, streamId: number, topic: string |};
 
 const styles = createStyleSheet({
   wrapper: {
@@ -60,6 +61,7 @@ const styles = createStyleSheet({
 export type ValidationError =
   | 'mandatory-topic-empty'
   | 'stream-empty'
+  | 'stream-invalid'
   | 'recipients-empty'
   | 'message-empty';
 
@@ -132,6 +134,8 @@ class ShareWrapperInner extends React.Component<Props, State> {
           switch (error) {
             case 'stream-empty':
               return _('Please specify a stream.');
+            case 'stream-invalid':
+              return _('Please specify a valid stream.');
             case 'mandatory-topic-empty':
               return _('Please specify a topic.');
             case 'recipients-empty':
@@ -169,6 +173,7 @@ class ShareWrapperInner extends React.Component<Props, State> {
             content: messageToSend,
             type: 'stream',
             subject: sendTo.topic || apiConstants.NO_TOPIC_TOPIC,
+            // TODO(server-2.0): switch to numeric stream ID, not name
             to: sendTo.streamName,
           };
 

--- a/src/sharing/ShareWrapper.js
+++ b/src/sharing/ShareWrapper.js
@@ -177,19 +177,22 @@ class ShareWrapperInner extends React.Component<Props, State> {
     } catch (err) {
       showToast(_('Failed to send message'));
       logging.error(err);
-      this.onShareCancelled();
+      this.onShareCancelled(sendTo);
       return;
     }
     showToast(_('Message sent'));
-    this.onShareSuccess();
+    this.onShareSuccess(sendTo);
   };
 
-  onShareCancelled = () => {
+  onShareCancelled = sendTo => {
+    // If in the future this callback uses the `sendTo` data, it should get
+    // it from its parameter (just like `onShareSuccess` does) and not from
+    // the props.  That's because the props may have changed since the
+    // actual send request we just made.
     NavigationService.dispatch(navigateBack());
   };
 
-  onShareSuccess = () => {
-    const { sendTo } = this.props;
+  onShareSuccess = sendTo => {
     switch (sendTo.type) {
       case 'pm': {
         const { selectedRecipients } = sendTo;

--- a/src/utils/__tests__/internalLinks-test.js
+++ b/src/utils/__tests__/internalLinks-test.js
@@ -261,6 +261,7 @@ describe('getNarrowFromLink', () => {
       url,
       new URL('https://example.com'),
       new Map(streams.map(s => [s.stream_id, s])),
+      new Map(streams.map(s => [s.name, s])),
       eg.selfUser.user_id,
     );
 
@@ -287,10 +288,9 @@ describe('getNarrowFromLink', () => {
       expectStream(`${streamGeneral.stream_id}-`, [streamGeneral], streamGeneral);
     });
 
-    test('on malformed stream link: treat as old format', () => {
-      const expectAsName = name => expectStream(name, [streamGeneral], eg.makeStream({ name }));
-      expectAsName(`-${streamGeneral.stream_id}`);
-      expectAsName(`${streamGeneral.stream_id}nonsense-general`);
+    test('on malformed stream link: reject', () => {
+      expectStream(`-${streamGeneral.stream_id}`, [streamGeneral], null);
+      expectStream(`${streamGeneral.stream_id}nonsense-general`, [streamGeneral], null);
     });
 
     {

--- a/src/utils/__tests__/narrow-test.js
+++ b/src/utils/__tests__/narrow-test.js
@@ -61,8 +61,8 @@ describe('isPmNarrow', () => {
 describe('isStreamOrTopicNarrow', () => {
   test('check for stream or topic narrow', () => {
     expect(isStreamOrTopicNarrow(undefined)).toBe(false);
-    expect(isStreamOrTopicNarrow(streamNarrow('some stream'))).toBe(true);
-    expect(isStreamOrTopicNarrow(topicNarrow('some stream', 'some topic'))).toBe(true);
+    expect(isStreamOrTopicNarrow(streamNarrow(eg.stream.name))).toBe(true);
+    expect(isStreamOrTopicNarrow(topicNarrow(eg.stream.name, 'some topic'))).toBe(true);
     expect(isStreamOrTopicNarrow(HOME_NARROW)).toBe(false);
     expect(isStreamOrTopicNarrow(pm1to1NarrowFromUser(eg.otherUser))).toBe(false);
     expect(isStreamOrTopicNarrow(pmNarrowFromUsersUnsafe([eg.otherUser, eg.thirdUser]))).toBe(
@@ -76,37 +76,37 @@ describe('specialNarrow', () => {
   test('only narrowing with the "is" operator is special narrow', () => {
     expect(isSpecialNarrow(undefined)).toBe(false);
     expect(isSpecialNarrow(HOME_NARROW)).toBe(false);
-    expect(isSpecialNarrow(streamNarrow('some stream'))).toBe(false);
+    expect(isSpecialNarrow(streamNarrow(eg.stream.name))).toBe(false);
     expect(isSpecialNarrow(STARRED_NARROW)).toBe(true);
   });
 });
 
 describe('streamNarrow', () => {
   test('narrows to messages from a specific stream', () => {
-    const narrow = streamNarrow('some stream');
+    const narrow = streamNarrow(eg.stream.name);
     expect(isStreamNarrow(narrow)).toBeTrue();
-    expect(streamNameOfNarrow(narrow)).toEqual('some stream');
+    expect(streamNameOfNarrow(narrow)).toEqual(eg.stream.name);
   });
 
   test('only narrow with operator of "stream" is a stream narrow', () => {
     expect(isStreamNarrow(undefined)).toBe(false);
     expect(isStreamNarrow(HOME_NARROW)).toBe(false);
-    expect(isStreamNarrow(streamNarrow('some stream'))).toBe(true);
+    expect(isStreamNarrow(streamNarrow(eg.stream.name))).toBe(true);
   });
 });
 
 describe('topicNarrow', () => {
   test('narrows to a specific topic within a specified stream', () => {
-    const narrow = topicNarrow('some stream', 'some topic');
+    const narrow = topicNarrow(eg.stream.name, 'some topic');
     expect(isTopicNarrow(narrow)).toBeTrue();
-    expect(streamNameOfNarrow(narrow)).toEqual('some stream');
+    expect(streamNameOfNarrow(narrow)).toEqual(eg.stream.name);
     expect(topicOfNarrow(narrow)).toEqual('some topic');
   });
 
   test('only narrow with two items, one for stream, one for topic is a topic narrow', () => {
     expect(isTopicNarrow(undefined)).toBe(false);
     expect(isTopicNarrow(HOME_NARROW)).toBe(false);
-    expect(isTopicNarrow(topicNarrow('some stream', 'some topic'))).toBe(true);
+    expect(isTopicNarrow(topicNarrow(eg.stream.name, 'some topic'))).toBe(true);
   });
 });
 
@@ -246,12 +246,16 @@ describe('getNarrowsForMessage', () => {
 
   const cases = [
     {
-      label: "Message in stream 'myStream' with topic 'myTopic'",
+      label: "Message in a stream with topic 'myTopic'",
       message: {
-        ...eg.streamMessage({ stream: eg.makeStream({ name: 'myStream' }) }),
+        ...eg.streamMessage({ stream: eg.stream }),
         subject: 'myTopic',
       },
-      expectedNarrows: [HOME_NARROW, streamNarrow('myStream'), topicNarrow('myStream', 'myTopic')],
+      expectedNarrows: [
+        HOME_NARROW,
+        streamNarrow(eg.stream.name),
+        topicNarrow(eg.stream.name, 'myTopic'),
+      ],
     },
     {
       // If we find that `subject` is sometimes the empty string and
@@ -264,12 +268,12 @@ describe('getNarrowsForMessage', () => {
       // We don't store outbox messages with the empty string for
       // `subject`; if the topic input is left blank, we put down
       // `apiConstants.NO_TOPIC_TOPIC` for `subject`.
-      label: "Message in stream 'myStream' with empty-string topic",
+      label: 'Message in a stream with empty-string topic',
       message: {
-        ...eg.streamMessage({ stream: eg.makeStream({ name: 'myStream' }) }),
+        ...eg.streamMessage({ stream: eg.stream }),
         subject: '',
       },
-      expectedNarrows: [HOME_NARROW, streamNarrow('myStream'), topicNarrow('myStream', '')],
+      expectedNarrows: [HOME_NARROW, streamNarrow(eg.stream.name), topicNarrow(eg.stream.name, '')],
     },
     {
       label: 'PM message with one person',

--- a/src/webview/html/__tests__/header-test.js
+++ b/src/webview/html/__tests__/header-test.js
@@ -7,6 +7,7 @@ import type { BackgroundData } from '../../MessageList';
 const backgroundData: BackgroundData = ({
   ownEmail: eg.selfUser.email,
   subscriptions: [eg.stream],
+  streams: new Map([[eg.stream.stream_id, eg.stream]]),
 }: $FlowFixMe);
 
 describe('header', () => {

--- a/src/webview/html/__tests__/messageListElementHtml-test.js
+++ b/src/webview/html/__tests__/messageListElementHtml-test.js
@@ -49,13 +49,26 @@ import getMessageListElements from '../../../message/getMessageListElements';
  * and `messageListElementHtml`.
  */
 describe('messages -> piece descriptors -> content HTML is stable/sensible', () => {
+  const user1 = eg.makeUser({ user_id: 1, name: 'nonrandom name one' });
+  const user2 = eg.makeUser({ user_id: 2, name: 'nonrandom name two' });
+  const user3 = eg.makeUser({ user_id: 3, name: 'nonrandom name three' });
+
+  const stream1 = { ...eg.makeStream({ name: 'stream 1' }), stream_id: 1 };
+  const stream2 = { ...eg.makeStream({ name: 'stream 2' }), stream_id: 2 };
+
+  const topic1 = 'topic 1';
+  const topic2 = 'topic 2';
+
   // Tell ESLint to recognize `check` as a helper function that runs
   // assertions.
   /* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["expect", "check"] }] */
   const check = ({
     // TODO: Test with a variety of different things in
     // `backgroundData`.
-    backgroundData = eg.backgroundData,
+    backgroundData = {
+      ...eg.backgroundData,
+      streams: new Map([stream1, stream2].map(s => [s.stream_id, s])),
+    },
     narrow,
     messages,
   }) => {
@@ -78,16 +91,6 @@ describe('messages -> piece descriptors -> content HTML is stable/sensible', () 
       }),
     ).toMatchSnapshot();
   };
-
-  const user1 = eg.makeUser({ user_id: 1, name: 'nonrandom name one' });
-  const user2 = eg.makeUser({ user_id: 2, name: 'nonrandom name two' });
-  const user3 = eg.makeUser({ user_id: 3, name: 'nonrandom name three' });
-
-  const stream1 = { ...eg.makeStream({ name: 'stream 1' }), stream_id: 1 };
-  const stream2 = { ...eg.makeStream({ name: 'stream 2' }), stream_id: 2 };
-
-  const topic1 = 'topic 1';
-  const topic2 = 'topic 2';
 
   // Same sender, stream, topic, day
   const streamMessages1 = [

--- a/src/webview/html/header.js
+++ b/src/webview/html/header.js
@@ -37,10 +37,10 @@ export default (
     const stream = streams.get(message.stream_id);
     invariant(stream, 'stream should exist for message');
 
-    if (headerStyle === 'topic+date') {
-      const topicNarrowStr = keyFromNarrow(topicNarrow(stream.name, message.subject));
-      const topicHtml = renderSubject(message);
+    const topicNarrowStr = keyFromNarrow(topicNarrow(stream.name, message.subject));
+    const topicHtml = renderSubject(message);
 
+    if (headerStyle === 'topic+date') {
       return template`
 <div
   class="msglist-element header-wrapper header topic-header"
@@ -56,8 +56,6 @@ export default (
       const backgroundColor = subscription ? subscription.color : 'hsl(0, 0%, 80%)';
       const textColor = foregroundColorFromBackground(backgroundColor);
       const streamNarrowStr = keyFromNarrow(streamNarrow(stream.name));
-      const topicNarrowStr = keyFromNarrow(topicNarrow(stream.name, message.subject));
-      const topicHtml = renderSubject(message);
 
       return template`
 <div class="msglist-element header-wrapper header stream-header topic-header"

--- a/static/translations/messages_en.json
+++ b/static/translations/messages_en.json
@@ -18,6 +18,7 @@
   "Message not sent": "Message not sent",
   "Please specify a topic.": "Please specify a topic.",
   "Please specify a stream.": "Please specify a stream.",
+  "Please specify a valid stream.": "Please specify a valid stream.",
   "Please choose recipients.": "Please choose recipients.",
   "Message is empty.": "Message is empty.",
   "Failed to connect to server: {realm}": "Failed to connect to server: {realm}",


### PR DESCRIPTION
This is the next installment after #5069 on #3918, converting from stream names to stream IDs.

In this PR, we take care of getting stream IDs available at most of the remaining Narrow-constructor call sites that will need them:
* in ShareToStream and related code;
* when parsing an internal link to find a narrow to navigate to;
* in lots of unit tests where we had constructed narrows using a string literal directly for the name, and now we take the name from some actual `Stream` object.

