### PR TITLE
Mark a bunch more object and array types read-only

### DIFF
--- a/flow-typed/redux_v4.x.x.js
+++ b/flow-typed/redux_v4.x.x.js
@@ -17,7 +17,7 @@ declare module 'redux' {
 
   declare export type DispatchAPI<A> = (action: A) => A;
 
-  declare export type Dispatch<A: { type: *, ... }> = DispatchAPI<A>;
+  declare export type Dispatch<A: { +type: *, ... }> = DispatchAPI<A>;
 
   declare export type MiddlewareAPI<S, A, D = Dispatch<A>> = {|
     dispatch: D,

--- a/flow-typed/redux_v4.x.x.js
+++ b/flow-typed/redux_v4.x.x.js
@@ -17,7 +17,7 @@ declare module 'redux' {
 
   declare export type DispatchAPI<A> = (action: A) => A;
 
-  declare export type Dispatch<A: { +type: *, ... }> = DispatchAPI<A>;
+  declare export type Dispatch<A: { +type: mixed, ... }> = DispatchAPI<A>;
 
   declare export type MiddlewareAPI<S, A, D = Dispatch<A>> = {|
     dispatch: D,
@@ -32,7 +32,7 @@ declare module 'redux' {
     replaceReducer(nextReducer: Reducer<S, A>): void,
   |};
 
-  declare export type Reducer<S, A> = (state: S | void, action: A) => S;
+  declare export type Reducer<S, -A> = (state: S | void, action: A) => S;
 
   declare export type CombinedReducer<S, A> = (
     state: ($Shape<S> & { ... }) | void,
@@ -70,14 +70,14 @@ declare module 'redux' {
     ...middlewares: Array<Middleware<S, A, D>>
   ): StoreEnhancer<S, A, D>;
 
-  declare export type ActionCreator<A, B> = (...args: Array<B>) => A;
+  declare export type ActionCreator<A, -B> = (...args: $ReadOnlyArray<B>) => A;
   declare export type ActionCreators<K, A> = {|
-    [key: K]: ActionCreator<A, any>,
+    [key: K]: ActionCreator<A, empty>,
   |};
 
   declare export function bindActionCreators<
     A,
-    C: ActionCreator<A, any>,
+    C: ActionCreator<A, empty>,
     D: DispatchAPI<A>
   >(
     actionCreator: C,
@@ -95,7 +95,7 @@ declare module 'redux' {
 
   declare export function combineReducers<O: { ... }, A>(
     reducers: O
-  ): CombinedReducer<$ObjMap<O, <S>(r: Reducer<S, any>) => S>, A>;
+  ): CombinedReducer<$ObjMap<O, <S>(r: Reducer<S, A>) => S>, A>;
 
   declare export var compose: $Compose;
 }

--- a/src/__tests__/lib/exampleData.js
+++ b/src/__tests__/lib/exampleData.js
@@ -360,7 +360,7 @@ const randMessageId: () => number = makeUniqueRandInt('message ID', 10000000);
 export const pmMessage = (args?: {|
   ...$Rest<PmMessage, { ... }>,
   sender?: User,
-  recipients?: User[],
+  recipients?: $ReadOnlyArray<User>,
   sender_id?: number, // accept a plain number, for convenience in tests
 |}): PmMessage => {
   // The `Object.freeze` is to work around a Flow issue:
@@ -395,7 +395,7 @@ export const pmMessage = (args?: {|
 
 export const pmMessageFromTo = (
   from: User,
-  to: User[],
+  to: $ReadOnlyArray<User>,
   extra?: $Rest<PmMessage, { ... }>,
 ): PmMessage => pmMessage({ sender: from, recipients: [from, ...to], ...extra });
 
@@ -444,7 +444,7 @@ export const streamMessage = (args?: {|
 };
 
 /** Construct a MessagesState from a list of messages. */
-export const makeMessagesState = (messages: Message[]): MessagesState =>
+export const makeMessagesState = (messages: $ReadOnlyArray<Message>): MessagesState =>
   Immutable.Map(messages.map(m => [m.id, m]));
 
 /* ========================================================================

--- a/src/actionTypes.js
+++ b/src/actionTypes.js
@@ -672,7 +672,6 @@ export type PerAccountAction =
   | LoadingAction
   | MessageAction
   | OutboxAction
-  | RegisterCompleteAction
   | DraftUpdateAction
   | PresenceResponseAction
   | InitTopicsAction

--- a/src/actionTypes.js
+++ b/src/actionTypes.js
@@ -110,86 +110,86 @@ import type {
  *     key where an error was encountered in reading the persisted state.
  *     In any case it will only contain the keys we configure to be persisted.
  */
-type RehydrateAction = {|
+type RehydrateAction = $ReadOnly<{|
   type: typeof REHYDRATE,
   +payload: $ReadOnly<$ObjMap<$Rest<GlobalState, { ... }>, <V>(V) => V | null>> | void,
-|};
+|}>;
 
-type AppOnlineAction = {|
+type AppOnlineAction = $ReadOnly<{|
   type: typeof APP_ONLINE,
   isOnline: boolean | null,
-|};
+|}>;
 
-type DeadQueueAction = {|
+type DeadQueueAction = $ReadOnly<{|
   type: typeof DEAD_QUEUE,
-|};
+|}>;
 
-type AppOrientationAction = {|
+type AppOrientationAction = $ReadOnly<{|
   type: typeof APP_ORIENTATION,
   orientation: Orientation,
-|};
+|}>;
 
-type DebugFlagToggleAction = {|
+type DebugFlagToggleAction = $ReadOnly<{|
   type: typeof DEBUG_FLAG_TOGGLE,
   key: string,
   value: boolean,
-|};
+|}>;
 
-type DismissServerCompatNoticeAction = {|
+type DismissServerCompatNoticeAction = $ReadOnly<{|
   type: typeof DISMISS_SERVER_COMPAT_NOTICE,
-|};
+|}>;
 
-export type AccountSwitchAction = {|
+export type AccountSwitchAction = $ReadOnly<{|
   type: typeof ACCOUNT_SWITCH,
   index: number,
-|};
+|}>;
 
-type AccountRemoveAction = {|
+type AccountRemoveAction = $ReadOnly<{|
   type: typeof ACCOUNT_REMOVE,
   index: number,
-|};
+|}>;
 
-export type LoginSuccessAction = {|
+export type LoginSuccessAction = $ReadOnly<{|
   type: typeof LOGIN_SUCCESS,
   realm: URL,
   email: string,
   apiKey: string,
-|};
+|}>;
 
-type LogoutAction = {|
+type LogoutAction = $ReadOnly<{|
   type: typeof LOGOUT,
-|};
+|}>;
 
-type DismissServerPushSetupNoticeAction = {|
+type DismissServerPushSetupNoticeAction = $ReadOnly<{|
   type: typeof DISMISS_SERVER_PUSH_SETUP_NOTICE,
   date: Date,
-|};
+|}>;
 
 /** We learned the device token from the system.  See `SessionState`. */
-type GotPushTokenAction = {|
+type GotPushTokenAction = $ReadOnly<{|
   type: typeof GOT_PUSH_TOKEN,
   pushToken: null | string,
-|};
+|}>;
 
 /** We're about to tell the server to forget our device token. */
-type UnackPushTokenAction = {|
+type UnackPushTokenAction = $ReadOnly<{|
   type: typeof UNACK_PUSH_TOKEN,
   identity: Identity,
-|};
+|}>;
 
 /** The server acknowledged our device token. */
-type AckPushTokenAction = {|
+type AckPushTokenAction = $ReadOnly<{|
   type: typeof ACK_PUSH_TOKEN,
   identity: Identity,
   pushToken: string,
-|};
+|}>;
 
-export type MessageFetchStartAction = {|
+export type MessageFetchStartAction = $ReadOnly<{|
   type: typeof MESSAGE_FETCH_START,
   narrow: Narrow,
   numBefore: number,
   numAfter: number,
-|};
+|}>;
 
 /**
  * Any unexpected failure in a message fetch.
@@ -206,16 +206,16 @@ export type MessageFetchStartAction = {|
  * [1] https://github.com/zulip/zulip-mobile/blob/main/docs/architecture/crunchy-shell.md
  * [2] https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/.23M4156.20Message.20List.20placeholders/near/937480
  */
-type MessageFetchErrorAction = {|
+type MessageFetchErrorAction = $ReadOnly<{|
   type: typeof MESSAGE_FETCH_ERROR,
   narrow: Narrow,
   // Before storing this in state, be sure to replace/revive Error
   // instances so they aren't coerced into plain objects; see
   // bfe794955 for an example.
   error: Error,
-|};
+|}>;
 
-export type MessageFetchCompleteAction = {|
+export type MessageFetchCompleteAction = $ReadOnly<{|
   type: typeof MESSAGE_FETCH_COMPLETE,
   messages: Message[],
   narrow: Narrow,
@@ -225,11 +225,11 @@ export type MessageFetchCompleteAction = {|
   foundNewest: boolean,
   foundOldest: boolean,
   ownUserId: UserId,
-|};
+|}>;
 
-type RegisterStartAction = {|
+type RegisterStartAction = $ReadOnly<{|
   type: typeof REGISTER_START,
-|};
+|}>;
 
 export type RegisterAbortReason = 'server' | 'network' | 'timeout' | 'unexpected';
 
@@ -239,32 +239,32 @@ export type RegisterAbortReason = 'server' | 'network' | 'timeout' | 'unexpected
  * Not for unrecoverable errors, like ApiErrors, which indicate that we
  * tried and failed, not that we gave up trying.
  */
-type RegisterAbortAction = {|
+type RegisterAbortAction = $ReadOnly<{|
   type: typeof REGISTER_ABORT,
   reason: RegisterAbortReason,
-|};
+|}>;
 
-export type RegisterCompleteAction = {|
+export type RegisterCompleteAction = $ReadOnly<{|
   type: typeof REGISTER_COMPLETE,
   data: InitialData,
-|};
+|}>;
 
-type ServerEvent = {|
+type ServerEvent = $ReadOnly<{|
   id: number,
-|};
+|}>;
 
-type EventAlertWordsAction = {|
+type EventAlertWordsAction = $ReadOnly<{|
   type: typeof EVENT_ALERT_WORDS,
   alertWords: AlertWordsState,
-|};
+|}>;
 
-type EventRealmFiltersAction = {|
+type EventRealmFiltersAction = $ReadOnly<{|
   ...ServerEvent,
   type: typeof EVENT_REALM_FILTERS,
   realm_filters: RealmFilter[],
-|};
+|}>;
 
-type EventUpdateGlobalNotificationsSettingsAction = {|
+type EventUpdateGlobalNotificationsSettingsAction = $ReadOnly<{|
   ...ServerEvent,
   type: typeof EVENT_UPDATE_GLOBAL_NOTIFICATIONS_SETTINGS,
   notification_name:
@@ -272,16 +272,16 @@ type EventUpdateGlobalNotificationsSettingsAction = {|
     | 'enable_online_push_notifications'
     | 'enable_stream_push_notifications',
   setting: boolean,
-|};
+|}>;
 
-type EventSubscriptionAddAction = {|
+type EventSubscriptionAddAction = $ReadOnly<{|
   ...ServerEvent,
   type: typeof EVENT_SUBSCRIPTION,
   op: 'add',
   subscriptions: Subscription[],
-|};
+|}>;
 
-type EventSubscriptionRemoveAction = {|
+type EventSubscriptionRemoveAction = $ReadOnly<{|
   ...ServerEvent,
   type: typeof EVENT_SUBSCRIPTION,
   op: 'remove',
@@ -289,9 +289,9 @@ type EventSubscriptionRemoveAction = {|
     name: string,
     stream_id: number,
   |}>,
-|};
+|}>;
 
-type EventSubscriptionUpdateAction = {|
+type EventSubscriptionUpdateAction = $ReadOnly<{|
   ...ServerEvent,
   type: typeof EVENT_SUBSCRIPTION,
   op: 'update',
@@ -302,49 +302,49 @@ type EventSubscriptionUpdateAction = {|
   // TODO(server-4.0): Delete these commented-out properties.
   // name: string, // exists pre-4.0, but expected to be removed soon
   // email: string, // gone in 4.0; was the user's own email, so never useful
-|};
+|}>;
 
-type EventSubscriptionPeerAddAction = {|
+type EventSubscriptionPeerAddAction = $ReadOnly<{|
   ...ServerEvent,
   type: typeof EVENT_SUBSCRIPTION,
   op: 'peer_add',
   subscriptions: string[],
   user_id: UserId,
-|};
+|}>;
 
-type EventSubscriptionPeerRemoveAction = {|
+type EventSubscriptionPeerRemoveAction = $ReadOnly<{|
   ...ServerEvent,
   type: typeof EVENT_SUBSCRIPTION,
   op: 'peer_remove',
   subscriptions: string[],
   user_id: UserId,
-|};
+|}>;
 
-type GenericEventAction = {|
+type GenericEventAction = $ReadOnly<{|
   type: typeof EVENT,
   event: StreamEvent | RestartEvent | RealmUpdateEvent | RealmUpdateDictEvent,
-|};
+|}>;
 
-type EventNewMessageAction = {|
+type EventNewMessageAction = $ReadOnly<{|
   ...$Diff<MessageEvent, {| flags: mixed |}>,
   type: typeof EVENT_NEW_MESSAGE,
   caughtUp: CaughtUpState,
   ownUserId: UserId,
-|};
+|}>;
 
-type EventSubmessageAction = {|
+type EventSubmessageAction = $ReadOnly<{|
   ...SubmessageEvent,
   type: typeof EVENT_SUBMESSAGE,
-|};
+|}>;
 
-type EventMessageDeleteAction = {|
+type EventMessageDeleteAction = $ReadOnly<{|
   type: typeof EVENT_MESSAGE_DELETE,
   messageIds: number[],
-|};
+|}>;
 
 // This is current to feature level 109:
 //   https://zulip.com/api/get-events#update_message
-type EventUpdateMessageAction = {|
+type EventUpdateMessageAction = $ReadOnly<{|
   ...ServerEvent,
   type: typeof EVENT_UPDATE_MESSAGE,
   user_id: UserId,
@@ -377,32 +377,32 @@ type EventUpdateMessageAction = {|
   rendered_content: string,
   is_me_message: boolean,
   flags: $ReadOnlyArray<string>,
-|};
+|}>;
 
-type EventReactionCommon = {|
+type EventReactionCommon = $ReadOnly<{|
   ...ServerEvent,
   ...$Exact<Reaction>,
   message_id: number,
-|};
+|}>;
 
-type EventReactionAddAction = {|
+type EventReactionAddAction = $ReadOnly<{|
   ...ServerEvent,
   ...EventReactionCommon,
   type: typeof EVENT_REACTION_ADD,
-|};
+|}>;
 
-type EventReactionRemoveAction = {|
+type EventReactionRemoveAction = $ReadOnly<{|
   ...ServerEvent,
   ...EventReactionCommon,
   type: typeof EVENT_REACTION_REMOVE,
-|};
+|}>;
 
-type EventPresenceAction = {|
+type EventPresenceAction = $ReadOnly<{|
   ...PresenceEvent,
   type: typeof EVENT_PRESENCE,
-|};
+|}>;
 
-type EventTypingCommon = {|
+type EventTypingCommon = $ReadOnly<{|
   ...ServerEvent,
   ownUserId: UserId,
   recipients: $ReadOnlyArray<{|
@@ -414,21 +414,21 @@ type EventTypingCommon = {|
     email: string,
   |},
   time: number,
-|};
+|}>;
 
-type EventTypingStartAction = {|
+type EventTypingStartAction = $ReadOnly<{|
   ...EventTypingCommon,
   type: typeof EVENT_TYPING_START,
   op: 'start',
-|};
+|}>;
 
-type EventTypingStopAction = {|
+type EventTypingStopAction = $ReadOnly<{|
   ...EventTypingCommon,
   type: typeof EVENT_TYPING_STOP,
   op: 'stop',
-|};
+|}>;
 
-type EventUpdateMessageFlagsAction = {|
+type EventUpdateMessageFlagsAction = $ReadOnly<{|
   ...ServerEvent,
   type: typeof EVENT_UPDATE_MESSAGE_FLAGS,
   all: boolean,
@@ -436,84 +436,84 @@ type EventUpdateMessageFlagsAction = {|
   flag: string,
   messages: number[],
   op: 'add' | 'remove',
-|};
+|}>;
 
-type EventUserAddAction = {|
+type EventUserAddAction = $ReadOnly<{|
   ...ServerEvent,
   type: typeof EVENT_USER_ADD,
   person: User,
-|};
+|}>;
 
-type EventUserRemoveAction = {|
+type EventUserRemoveAction = $ReadOnly<{|
   type: typeof EVENT_USER_REMOVE,
   // In reality there's more -- but this will prevent accidentally using
   // the type before going and adding those other properties here properly.
-|};
+|}>;
 
-type EventUserUpdateAction = {|
+type EventUserUpdateAction = $ReadOnly<{|
   ...ServerEvent,
   type: typeof EVENT_USER_UPDATE,
   userId: UserId,
   // Include only the fields that should be overwritten.
   person: $Shape<User>,
-|};
+|}>;
 
-type EventMutedTopicsAction = {|
+type EventMutedTopicsAction = $ReadOnly<{|
   ...ServerEvent,
   type: typeof EVENT_MUTED_TOPICS,
   muted_topics: MuteState,
-|};
+|}>;
 
-type EventMutedUsersAction = {|
+type EventMutedUsersAction = $ReadOnly<{|
   ...MutedUsersEvent,
   type: typeof EVENT_MUTED_USERS,
-|};
+|}>;
 
-type EventUserGroupAddAction = {|
+type EventUserGroupAddAction = $ReadOnly<{|
   ...ServerEvent,
   type: typeof EVENT_USER_GROUP_ADD,
   op: 'add',
   group: UserGroup,
-|};
+|}>;
 
-type EventUserGroupRemoveAction = {|
+type EventUserGroupRemoveAction = $ReadOnly<{|
   ...ServerEvent,
   type: typeof EVENT_USER_GROUP_REMOVE,
   op: 'remove',
   group_id: number,
-|};
+|}>;
 
-type EventUserGroupUpdateAction = {|
+type EventUserGroupUpdateAction = $ReadOnly<{|
   ...ServerEvent,
   type: typeof EVENT_USER_GROUP_UPDATE,
   op: 'update',
   group_id: number,
   data: {| description?: string, name?: string |},
-|};
+|}>;
 
-type EventUserGroupAddMembersAction = {|
+type EventUserGroupAddMembersAction = $ReadOnly<{|
   ...ServerEvent,
   type: typeof EVENT_USER_GROUP_ADD_MEMBERS,
   op: 'add_members',
   group_id: number,
   user_ids: UserId[],
-|};
+|}>;
 
-type EventUserGroupRemoveMembersAction = {|
+type EventUserGroupRemoveMembersAction = $ReadOnly<{|
   ...ServerEvent,
   type: typeof EVENT_USER_GROUP_REMOVE_MEMBERS,
   op: 'remove_members',
   group_id: number,
   user_ids: UserId[],
-|};
+|}>;
 
-type EventRealmEmojiUpdateAction = {|
+type EventRealmEmojiUpdateAction = $ReadOnly<{|
   ...ServerEvent,
   type: typeof EVENT_REALM_EMOJI_UPDATE,
   realm_emoji: RealmEmojiById,
-|};
+|}>;
 
-type EventUpdateDisplaySettingsAction = {|
+type EventUpdateDisplaySettingsAction = $ReadOnly<{|
   ...ServerEvent,
   type: typeof EVENT_UPDATE_DISPLAY_SETTINGS,
   setting_name: string,
@@ -521,14 +521,14 @@ type EventUpdateDisplaySettingsAction = {|
    * `setting_name` of `twenty_four_hour_time`, which is the only case we
    * currently look at. */
   setting: boolean,
-|};
+|}>;
 
 type EventReactionAction = EventReactionAddAction | EventReactionRemoveAction;
 
-type EventUserStatusUpdateAction = {|
+type EventUserStatusUpdateAction = $ReadOnly<{|
   ...UserStatusEvent,
   type: typeof EVENT_USER_STATUS_UPDATE,
-|};
+|}>;
 
 type EventSubscriptionAction =
   | EventSubscriptionAddAction
@@ -573,53 +573,53 @@ export type EventAction =
   | EventUserGroupAction
   | EventUserStatusUpdateAction;
 
-type SetGlobalSettingsAction = {|
+type SetGlobalSettingsAction = $ReadOnly<{|
   type: typeof SET_GLOBAL_SETTINGS,
   update: $Shape<$Exact<GlobalSettingsState>>,
-|};
+|}>;
 
-type DraftUpdateAction = {|
+type DraftUpdateAction = $ReadOnly<{|
   type: typeof DRAFT_UPDATE,
   narrow: Narrow,
   content: string,
-|};
+|}>;
 
-type PresenceResponseAction = {|
+type PresenceResponseAction = $ReadOnly<{|
   type: typeof PRESENCE_RESPONSE,
   presence: PresenceState,
   serverTimestamp: number,
-|};
+|}>;
 
-type MessageSendStartAction = {|
+type MessageSendStartAction = $ReadOnly<{|
   type: typeof MESSAGE_SEND_START,
   outbox: Outbox,
-|};
+|}>;
 
-type MessageSendCompleteAction = {|
+type MessageSendCompleteAction = $ReadOnly<{|
   type: typeof MESSAGE_SEND_COMPLETE,
   local_message_id: number,
-|};
+|}>;
 
-type DeleteOutboxMessageAction = {|
+type DeleteOutboxMessageAction = $ReadOnly<{|
   type: typeof DELETE_OUTBOX_MESSAGE,
   local_message_id: number,
-|};
+|}>;
 
-type ToggleOutboxSendingAction = {|
+type ToggleOutboxSendingAction = $ReadOnly<{|
   type: typeof TOGGLE_OUTBOX_SENDING,
   sending: boolean,
-|};
+|}>;
 
-type ClearTypingAction = {|
+type ClearTypingAction = $ReadOnly<{|
   type: typeof CLEAR_TYPING,
   outdatedNotifications: string[],
-|};
+|}>;
 
-type InitTopicsAction = {|
+type InitTopicsAction = $ReadOnly<{|
   type: typeof INIT_TOPICS,
   topics: Topic[],
   streamId: number,
-|};
+|}>;
 
 /* eslint-disable spaced-comment */
 

--- a/src/actionTypes.js
+++ b/src/actionTypes.js
@@ -217,7 +217,7 @@ type MessageFetchErrorAction = $ReadOnly<{|
 
 export type MessageFetchCompleteAction = $ReadOnly<{|
   type: typeof MESSAGE_FETCH_COMPLETE,
-  messages: Message[],
+  messages: $ReadOnlyArray<Message>,
   narrow: Narrow,
   anchor: number,
   numBefore: number,
@@ -261,7 +261,7 @@ type EventAlertWordsAction = $ReadOnly<{|
 type EventRealmFiltersAction = $ReadOnly<{|
   ...ServerEvent,
   type: typeof EVENT_REALM_FILTERS,
-  realm_filters: RealmFilter[],
+  realm_filters: $ReadOnlyArray<RealmFilter>,
 |}>;
 
 type EventUpdateGlobalNotificationsSettingsAction = $ReadOnly<{|
@@ -278,14 +278,14 @@ type EventSubscriptionAddAction = $ReadOnly<{|
   ...ServerEvent,
   type: typeof EVENT_SUBSCRIPTION,
   op: 'add',
-  subscriptions: Subscription[],
+  subscriptions: $ReadOnlyArray<Subscription>,
 |}>;
 
 type EventSubscriptionRemoveAction = $ReadOnly<{|
   ...ServerEvent,
   type: typeof EVENT_SUBSCRIPTION,
   op: 'remove',
-  subscriptions: Array<{|
+  subscriptions: $ReadOnlyArray<{|
     name: string,
     stream_id: number,
   |}>,
@@ -308,7 +308,7 @@ type EventSubscriptionPeerAddAction = $ReadOnly<{|
   ...ServerEvent,
   type: typeof EVENT_SUBSCRIPTION,
   op: 'peer_add',
-  subscriptions: string[],
+  subscriptions: $ReadOnlyArray<string>,
   user_id: UserId,
 |}>;
 
@@ -316,7 +316,7 @@ type EventSubscriptionPeerRemoveAction = $ReadOnly<{|
   ...ServerEvent,
   type: typeof EVENT_SUBSCRIPTION,
   op: 'peer_remove',
-  subscriptions: string[],
+  subscriptions: $ReadOnlyArray<string>,
   user_id: UserId,
 |}>;
 
@@ -339,7 +339,7 @@ type EventSubmessageAction = $ReadOnly<{|
 
 type EventMessageDeleteAction = $ReadOnly<{|
   type: typeof EVENT_MESSAGE_DELETE,
-  messageIds: number[],
+  messageIds: $ReadOnlyArray<number>,
 |}>;
 
 // This is current to feature level 109:
@@ -364,11 +364,11 @@ type EventUpdateMessageAction = $ReadOnly<{|
   orig_subject?: string,
   subject: string,
 
-  // TODO(server-4.0): Changed in feat. 46 to array-of-objects shape, from string[]
+  // TODO(server-4.0): Changed in feat. 46 to array-of-objects shape, from $ReadOnlyArray<string>
   topic_links?: $ReadOnlyArray<{| +text: string, +url: string |}> | $ReadOnlyArray<string>,
 
   // TODO(server-3.0): Replaced in feat. 1 by topic_links
-  subject_links?: string[],
+  subject_links?: $ReadOnlyArray<string>,
 
   orig_content: string,
   orig_rendered_content: string,
@@ -434,7 +434,7 @@ type EventUpdateMessageFlagsAction = $ReadOnly<{|
   all: boolean,
   allMessages: MessagesState,
   flag: string,
-  messages: number[],
+  messages: $ReadOnlyArray<number>,
   op: 'add' | 'remove',
 |}>;
 
@@ -496,7 +496,7 @@ type EventUserGroupAddMembersAction = $ReadOnly<{|
   type: typeof EVENT_USER_GROUP_ADD_MEMBERS,
   op: 'add_members',
   group_id: number,
-  user_ids: UserId[],
+  user_ids: $ReadOnlyArray<UserId>,
 |}>;
 
 type EventUserGroupRemoveMembersAction = $ReadOnly<{|
@@ -504,7 +504,7 @@ type EventUserGroupRemoveMembersAction = $ReadOnly<{|
   type: typeof EVENT_USER_GROUP_REMOVE_MEMBERS,
   op: 'remove_members',
   group_id: number,
-  user_ids: UserId[],
+  user_ids: $ReadOnlyArray<UserId>,
 |}>;
 
 type EventRealmEmojiUpdateAction = $ReadOnly<{|
@@ -612,12 +612,12 @@ type ToggleOutboxSendingAction = $ReadOnly<{|
 
 type ClearTypingAction = $ReadOnly<{|
   type: typeof CLEAR_TYPING,
-  outdatedNotifications: string[],
+  outdatedNotifications: $ReadOnlyArray<string>,
 |}>;
 
 type InitTopicsAction = $ReadOnly<{|
   type: typeof INIT_TOPICS,
-  topics: Topic[],
+  topics: $ReadOnlyArray<Topic>,
   streamId: number,
 |}>;
 

--- a/src/actionTypes.js
+++ b/src/actionTypes.js
@@ -285,10 +285,7 @@ type EventSubscriptionRemoveAction = $ReadOnly<{|
   ...ServerEvent,
   type: typeof EVENT_SUBSCRIPTION,
   op: 'remove',
-  subscriptions: $ReadOnlyArray<{|
-    name: string,
-    stream_id: number,
-  |}>,
+  subscriptions: $ReadOnlyArray<{| +stream_id: number, +name: string |}>,
 |}>;
 
 type EventSubscriptionUpdateAction = $ReadOnly<{|
@@ -405,14 +402,8 @@ type EventPresenceAction = $ReadOnly<{|
 type EventTypingCommon = $ReadOnly<{|
   ...ServerEvent,
   ownUserId: UserId,
-  recipients: $ReadOnlyArray<{|
-    user_id: UserId,
-    email: string,
-  |}>,
-  sender: {|
-    user_id: UserId,
-    email: string,
-  |},
+  recipients: $ReadOnlyArray<{| +user_id: UserId, +email: string |}>,
+  sender: {| +user_id: UserId, +email: string |},
   time: number,
 |}>;
 
@@ -488,7 +479,7 @@ type EventUserGroupUpdateAction = $ReadOnly<{|
   type: typeof EVENT_USER_GROUP_UPDATE,
   op: 'update',
   group_id: number,
-  data: {| description?: string, name?: string |},
+  data: {| +description?: string, +name?: string |},
 |}>;
 
 type EventUserGroupAddMembersAction = $ReadOnly<{|

--- a/src/animation/AnimatedRotateComponent.js
+++ b/src/animation/AnimatedRotateComponent.js
@@ -28,7 +28,7 @@ export default class AnimatedRotateComponent extends PureComponent<Props> {
     const { children, style } = this.props;
     const rotation = this.rotation.interpolate({
       inputRange: [0, 360],
-      outputRange: (['0deg', '360deg']: string[]),
+      outputRange: (['0deg', '360deg']: $ReadOnlyArray<string>),
     });
     const animatedStyle = { transform: [{ rotate: rotation }] };
 

--- a/src/api/devListUsers.js
+++ b/src/api/devListUsers.js
@@ -5,8 +5,8 @@ import { apiGet } from './apiFetch';
 
 type ApiResponseDevListUsers = {|
   ...$Exact<ApiResponseSuccess>,
-  direct_admins: DevUser[],
-  direct_users: DevUser[],
+  direct_admins: $ReadOnlyArray<DevUser>,
+  direct_users: $ReadOnlyArray<DevUser>,
 |};
 
 export default (auth: Auth): Promise<ApiResponseDevListUsers> => apiGet(auth, 'dev_list_users');

--- a/src/api/eventTypes.js
+++ b/src/api/eventTypes.js
@@ -191,7 +191,7 @@ export type RealmUpdateEvent = $ReadOnly<{|
   property: $Keys<RealmDataForUpdate>,
   value: $ElementType<RealmDataForUpdate, $Keys<RealmDataForUpdate>>,
 
-  extra_data: { upload_quota?: number, ... },
+  extra_data: { +upload_quota?: number, ... },
 |}>;
 
 // https://zulip.com/api/get-events#realm-update-dict

--- a/src/api/getTopics.js
+++ b/src/api/getTopics.js
@@ -5,7 +5,7 @@ import { apiGet } from './apiFetch';
 
 type ApiResponseTopics = {|
   ...$Exact<ApiResponseSuccess>,
-  topics: Topic[],
+  topics: $ReadOnlyArray<Topic>,
 |};
 
 /** See https://zulip.com/api/get-stream-topics */

--- a/src/api/messages/__tests__/migrateMessages-test.js
+++ b/src/api/messages/__tests__/migrateMessages-test.js
@@ -26,9 +26,9 @@ describe('migrateMessages', () => {
     avatar_url: null,
   };
 
-  const input: ServerMessage[] = [serverMessage];
+  const input: $ReadOnlyArray<ServerMessage> = [serverMessage];
 
-  const expectedOutput: Message[] = [
+  const expectedOutput: $ReadOnlyArray<Message> = [
     {
       ...serverMessage,
       reactions: [
@@ -43,7 +43,7 @@ describe('migrateMessages', () => {
     },
   ];
 
-  const actualOutput: Message[] = migrateMessages(input, identityOfAuth(eg.selfAuth));
+  const actualOutput: $ReadOnlyArray<Message> = migrateMessages(input, identityOfAuth(eg.selfAuth));
 
   test('In reactions, replace user object with `user_id`', () => {
     expect(actualOutput.map(m => m.reactions)).toEqual(expectedOutput.map(m => m.reactions));

--- a/src/api/messages/getMessageHistory.js
+++ b/src/api/messages/getMessageHistory.js
@@ -5,7 +5,7 @@ import { apiGet } from '../apiFetch';
 
 type ApiResponseMessageHistory = {|
   ...$Exact<ApiResponseSuccess>,
-  message_history: MessageSnapshot[],
+  message_history: $ReadOnlyArray<MessageSnapshot>,
 |};
 
 /** See https://zulip.com/api/get-message-history */

--- a/src/api/messages/getMessages.js
+++ b/src/api/messages/getMessages.js
@@ -13,7 +13,7 @@ type ApiResponseMessages = {|
   found_anchor: boolean,
   found_newest: boolean,
   found_oldest: boolean,
-  messages: Message[],
+  messages: $ReadOnlyArray<Message>,
 |};
 
 /**
@@ -49,7 +49,7 @@ export type ServerMessage = ServerMessageOf<PmMessage> | ServerMessageOf<StreamM
 // `ApiResponseMessages` before returning it to application code.
 type ServerApiResponseMessages = {|
   ...ApiResponseMessages,
-  messages: ServerMessage[],
+  messages: $ReadOnlyArray<ServerMessage>,
 |};
 
 /** Exported for tests only. */

--- a/src/api/messages/messagesFlags.js
+++ b/src/api/messages/messagesFlags.js
@@ -4,7 +4,7 @@ import { apiPost } from '../apiFetch';
 
 export type ApiResponseMessagesFlags = {|
   ...$Exact<ApiResponseSuccess>,
-  messages: number[],
+  messages: $ReadOnlyArray<number>,
 |};
 
 export default (

--- a/src/api/messages/toggleMessageStarred.js
+++ b/src/api/messages/toggleMessageStarred.js
@@ -5,7 +5,7 @@ import type { ApiResponseMessagesFlags } from './messagesFlags';
 
 export default (
   auth: Auth,
-  messageIds: number[],
+  messageIds: $ReadOnlyArray<number>,
   starMessage: boolean,
 ): Promise<ApiResponseMessagesFlags> =>
   messagesFlags(auth, messageIds, starMessage ? 'add' : 'remove', 'starred');

--- a/src/api/pollForEvents.js
+++ b/src/api/pollForEvents.js
@@ -5,7 +5,7 @@ import { apiGet } from './apiFetch';
 
 type ApiResponsePollEvents = {|
   ...$Exact<ApiResponseSuccess>,
-  events: GeneralEvent[],
+  events: $ReadOnlyArray<GeneralEvent>,
 |};
 
 /** See https://zulip.com/api/get-events */

--- a/src/api/queueMarkAsRead.js
+++ b/src/api/queueMarkAsRead.js
@@ -36,7 +36,7 @@ const processQueue = async (auth: Auth) => {
   unackedMessageIds = unackedMessageIds.filter(id => !acked_messages.has(id));
 };
 
-export default (auth: Auth, messageIds: number[]): void => {
+export default (auth: Auth, messageIds: $ReadOnlyArray<number>): void => {
   unackedMessageIds.push(...messageIds);
   processQueue(auth);
 };

--- a/src/api/settings/getServerSettings.js
+++ b/src/api/settings/getServerSettings.js
@@ -27,7 +27,7 @@ export type ApiResponseServerSettings = {|
   authentication_methods: AuthenticationMethods,
   // external_authentication_methods added for server v2.1
   // TODO(server-2.1): Mark this as required; simplify downstream.
-  external_authentication_methods?: ExternalAuthenticationMethod[],
+  external_authentication_methods?: $ReadOnlyArray<ExternalAuthenticationMethod>,
   email_auth_enabled: boolean,
   push_notifications_enabled: boolean,
   realm_description: string,

--- a/src/api/streams/createStream.js
+++ b/src/api/streams/createStream.js
@@ -7,7 +7,7 @@ export default (
   auth: Auth,
   name: string,
   description?: string = '',
-  principals?: string[] = [],
+  principals?: $ReadOnlyArray<string> = [],
   inviteOnly?: boolean = false,
   announce?: boolean = false,
 ): Promise<ApiResponse> =>

--- a/src/api/streams/getStreams.js
+++ b/src/api/streams/getStreams.js
@@ -5,7 +5,7 @@ import { apiGet } from '../apiFetch';
 
 type ApiResponseStreams = {|
   ...$Exact<ApiResponseSuccess>,
-  streams: Stream[],
+  streams: $ReadOnlyArray<Stream>,
 |};
 
 /** See https://zulip.com/api/get-streams */

--- a/src/api/subscriptions/getSubscriptions.js
+++ b/src/api/subscriptions/getSubscriptions.js
@@ -5,7 +5,7 @@ import { apiGet } from '../apiFetch';
 
 type ApiResponseSubscriptions = {|
   ...$Exact<ApiResponseSuccess>,
-  subscriptions: Subscription[],
+  subscriptions: $ReadOnlyArray<Subscription>,
 |};
 
 /** See https://zulip.com/api/get-subscriptions */

--- a/src/api/subscriptions/subscriptionAdd.js
+++ b/src/api/subscriptions/subscriptionAdd.js
@@ -9,8 +9,8 @@ type SubscriptionObj = {|
 /** See https://zulip.com/api/subscribe */
 export default (
   auth: Auth,
-  subscriptions: SubscriptionObj[],
-  principals?: string[],
+  subscriptions: $ReadOnlyArray<SubscriptionObj>,
+  principals?: $ReadOnlyArray<string>,
 ): Promise<ApiResponse> =>
   apiPost(auth, 'users/me/subscriptions', {
     subscriptions: JSON.stringify(subscriptions),

--- a/src/api/subscriptions/subscriptionRemove.js
+++ b/src/api/subscriptions/subscriptionRemove.js
@@ -3,7 +3,11 @@ import type { ApiResponse, Auth } from '../transportTypes';
 import { apiDelete } from '../apiFetch';
 
 /** See https://zulip.com/api/unsubscribe */
-export default (auth: Auth, subscriptions: string[], principals?: string[]): Promise<ApiResponse> =>
+export default (
+  auth: Auth,
+  subscriptions: $ReadOnlyArray<string>,
+  principals?: $ReadOnlyArray<string>,
+): Promise<ApiResponse> =>
   apiDelete(auth, 'users/me/subscriptions', {
     subscriptions: JSON.stringify(subscriptions),
     principals: JSON.stringify(principals),

--- a/src/boot/store.js
+++ b/src/boot/store.js
@@ -44,7 +44,7 @@ if (process.env.NODE_ENV === 'development') {
  * the lists of properties we do persist, below.
  */
 // prettier-ignore
-export const discardKeys: Array<$Keys<GlobalState>> = [
+export const discardKeys: $ReadOnlyArray<$Keys<GlobalState>> = [
   'alertWords', 'caughtUp', 'fetching',
   'presence', 'session', 'topics', 'typing', 'userStatus',
 ];
@@ -57,7 +57,7 @@ export const discardKeys: Array<$Keys<GlobalState>> = [
  * persist them.
  */
 // prettier-ignore
-export const storeKeys: Array<$Keys<GlobalState>> = [
+export const storeKeys: $ReadOnlyArray<$Keys<GlobalState>> = [
   'migrations', 'accounts', 'drafts', 'outbox', 'settings',
 ];
 
@@ -69,7 +69,7 @@ export const storeKeys: Array<$Keys<GlobalState>> = [
  * don't have to re-download it.
  */
 // prettier-ignore
-export const cacheKeys: Array<$Keys<GlobalState>> = [
+export const cacheKeys: $ReadOnlyArray<$Keys<GlobalState>> = [
   'flags', 'messages', 'mute', 'mutedUsers', 'narrows', 'pmConversations',
   'realm', 'streams', 'subscriptions', 'unread', 'userGroups', 'users',
 ];

--- a/src/chat/flagsReducer.js
+++ b/src/chat/flagsReducer.js
@@ -54,7 +54,11 @@ const addFlagsForMessages = (
   };
 };
 
-const removeFlagForMessages = (state: FlagsState, messages: number[], flag: string): FlagsState => {
+const removeFlagForMessages = (
+  state: FlagsState,
+  messages: $ReadOnlyArray<number>,
+  flag: string,
+): FlagsState => {
   const newStateForFlag = { ...(state[flag] || {}) };
   messages.forEach(message => {
     delete newStateForFlag[message];
@@ -65,7 +69,10 @@ const removeFlagForMessages = (state: FlagsState, messages: number[], flag: stri
   };
 };
 
-const processFlagsForMessages = (state: FlagsState, messages: Message[]): FlagsState => {
+const processFlagsForMessages = (
+  state: FlagsState,
+  messages: $ReadOnlyArray<Message>,
+): FlagsState => {
   let stateChanged = false;
   // $FlowFixMe[incompatible-exact] - #4252
   const newState: FlagsState = {};

--- a/src/chat/narrowsSelectors.js
+++ b/src/chat/narrowsSelectors.js
@@ -65,7 +65,7 @@ export const getFetchedMessageIdsForNarrow = (
   narrow: Narrow,
 ): $ReadOnlyArray<number> => getAllNarrows(state).get(keyFromNarrow(narrow)) || NULL_ARRAY;
 
-const getFetchedMessagesForNarrow: Selector<Message[], Narrow> = createSelector(
+const getFetchedMessagesForNarrow: Selector<$ReadOnlyArray<Message>, Narrow> = createSelector(
   getFetchedMessageIdsForNarrow,
   state => getMessages(state),
   (messageIds, messages) =>

--- a/src/common/GroupAvatar.js
+++ b/src/common/GroupAvatar.js
@@ -18,7 +18,7 @@ const styles = createStyleSheet({
 });
 
 type Props = $ReadOnly<{|
-  names: string[],
+  names: $ReadOnlyArray<string>,
   size: number,
   children?: Node,
   onPress?: () => void,

--- a/src/compose/ComposeBox.js
+++ b/src/compose/ComposeBox.js
@@ -235,7 +235,7 @@ class ComposeBoxInner extends PureComponent<Props, State> {
     }
   };
 
-  insertAttachment = async (attachments: DocumentPickerResponse[]) => {
+  insertAttachment = async (attachments: $ReadOnlyArray<DocumentPickerResponse>) => {
     this.setState(({ numUploading }) => ({
       numUploading: numUploading + 1,
     }));

--- a/src/compose/ComposeMenu.js
+++ b/src/compose/ComposeMenu.js
@@ -26,7 +26,7 @@ import { androidEnsureStoragePermission } from '../lightbox/download';
 type OuterProps = $ReadOnly<{|
   expanded: boolean,
   destinationNarrow: Narrow,
-  insertAttachment: (DocumentPickerResponse[]) => Promise<void>,
+  insertAttachment: ($ReadOnlyArray<DocumentPickerResponse>) => Promise<void>,
   insertVideoCallLink: (() => void) | null,
   onExpandContract: () => void,
 |}>;
@@ -206,7 +206,7 @@ class ComposeMenuInner extends PureComponent<Props> {
     try {
       response = (await DocumentPicker.pickMultiple({
         type: [DocumentPicker.types.allFiles],
-      }): DocumentPickerResponse[]);
+      }): $ReadOnlyArray<DocumentPickerResponse>);
     } catch (e) {
       if (!DocumentPicker.isCancel(e)) {
         showErrorAlert(_('Error'), e);

--- a/src/compose/MentionWarnings.js
+++ b/src/compose/MentionWarnings.js
@@ -43,7 +43,7 @@ function MentionWarningsInner(props: Props, ref): Node {
   const auth = useSelector(getAuth);
   const allUsersById = useSelector(getAllUsersById);
 
-  const [unsubscribedMentions, setUnsubscribedMentions] = useState<UserId[]>([]);
+  const [unsubscribedMentions, setUnsubscribedMentions] = useState<$ReadOnlyArray<UserId>>([]);
 
   const _ = useContext(TranslationContext);
 

--- a/src/config.js
+++ b/src/config.js
@@ -9,7 +9,7 @@ type Config = {|
   enableReduxSlowReducerWarnings: boolean,
   slowReducersThreshold: number,
   enableErrorConsoleLogging: boolean,
-  appOwnDomains: string[],
+  appOwnDomains: $ReadOnlyArray<string>,
 |};
 
 const config: Config = {

--- a/src/lightbox/LightboxActionSheet.js
+++ b/src/lightbox/LightboxActionSheet.js
@@ -57,7 +57,7 @@ const shareImageDirectly = ({ src, auth }: DownloadImageType) => {
   shareImage(src, auth);
 };
 
-const actionSheetButtons: ButtonType[] = [
+const actionSheetButtons: $ReadOnlyArray<ButtonType> = [
   { title: 'Download image', onPress: tryToDownloadImage },
   { title: 'Share image', onPress: shareImageDirectly },
   { title: 'Share link to image', onPress: shareLink },

--- a/src/message/NoMessages.js
+++ b/src/message/NoMessages.js
@@ -37,7 +37,7 @@ type EmptyMessage = {|
   text: string,
 |};
 
-const messages: EmptyMessage[] = [
+const messages: $ReadOnlyArray<EmptyMessage> = [
   { isFunc: isHomeNarrow, text: 'No messages on server' },
   { isFunc: isSpecialNarrow, text: 'No messages' },
   { isFunc: isStreamNarrow, text: 'No messages in stream' },

--- a/src/message/fetchActions.js
+++ b/src/message/fetchActions.js
@@ -67,7 +67,7 @@ const messageFetchError = (args: {| narrow: Narrow, error: Error |}): PerAccount
 };
 
 const messageFetchComplete = (args: {|
-  messages: Message[],
+  messages: $ReadOnlyArray<Message>,
   narrow: Narrow,
   anchor: number,
   numBefore: number,
@@ -111,7 +111,7 @@ export const fetchMessages = (fetchArgs: {|
   anchor: number,
   numBefore: number,
   numAfter: number,
-|}): ThunkAction<Promise<Message[]>> => async (dispatch, getState) => {
+|}): ThunkAction<Promise<$ReadOnlyArray<Message>>> => async (dispatch, getState) => {
   dispatch(messageFetchStart(fetchArgs.narrow, fetchArgs.numBefore, fetchArgs.numAfter));
   try {
     const { messages, found_newest, found_oldest } =
@@ -308,7 +308,7 @@ export const isFetchNeededAtAnchor = (
 export const fetchMessagesInNarrow = (
   narrow: Narrow,
   anchor: number = FIRST_UNREAD_ANCHOR,
-): ThunkAction<Promise<Message[] | void>> => async (dispatch, getState) => {
+): ThunkAction<Promise<$ReadOnlyArray<Message> | void>> => async (dispatch, getState) => {
   if (!isFetchNeededAtAnchor(getState(), narrow, anchor)) {
     return undefined;
   }

--- a/src/message/messageSelectors.js
+++ b/src/message/messageSelectors.js
@@ -33,7 +33,7 @@ function truncateForLogging<T: JSONable>(arr: $ReadOnlyArray<T>, len = 10): JSON
   };
 }
 
-export const getPrivateMessages: Selector<PmMessage[]> = createSelector(
+export const getPrivateMessages: Selector<$ReadOnlyArray<PmMessage>> = createSelector(
   getAllNarrows,
   getMessages,
   (narrows, messages) => {

--- a/src/pm-conversations/PmConversationList.js
+++ b/src/pm-conversations/PmConversationList.js
@@ -21,7 +21,7 @@ const styles = createStyleSheet({
 });
 
 type Props = $ReadOnly<{|
-  conversations: PmConversationData[],
+  conversations: $ReadOnlyArray<PmConversationData>,
 |}>;
 
 /**

--- a/src/pm-conversations/pmConversationsModel.js
+++ b/src/pm-conversations/pmConversationsModel.js
@@ -42,7 +42,7 @@ export function keyOfExactUsers(ids: UserId[]): PmConversationKey {
 }
 
 // Input may contain self or not, and needn't be sorted.
-function keyOfUsers(ids: UserId[], ownUserId: UserId): PmConversationKey {
+function keyOfUsers(ids: $ReadOnlyArray<UserId>, ownUserId: UserId): PmConversationKey {
   return keyOfExactUsers(ids.filter(id => id !== ownUserId));
 }
 

--- a/src/pm-conversations/pmConversationsSelectors.js
+++ b/src/pm-conversations/pmConversationsSelectors.js
@@ -30,7 +30,9 @@ function unreadCount(unreadsKey, unreadPms, unreadHuddles): number {
 }
 
 // TODO(server-2.1): Delete this, and simplify logic around it.
-export const getRecentConversationsLegacy: Selector<PmConversationData[]> = createSelector(
+export const getRecentConversationsLegacy: Selector<
+  $ReadOnlyArray<PmConversationData>,
+> = createSelector(
   getOwnUserId,
   getPrivateMessages,
   getUnreadByPms,
@@ -38,11 +40,11 @@ export const getRecentConversationsLegacy: Selector<PmConversationData[]> = crea
   getAllUsersById,
   (
     ownUserId,
-    messages: PmMessage[],
+    messages: $ReadOnlyArray<PmMessage>,
     unreadPms: {| [number]: number |},
     unreadHuddles: {| [string]: number |},
     allUsersById,
-  ): PmConversationData[] => {
+  ): $ReadOnlyArray<PmConversationData> => {
     const items = messages
       .map(msg => {
         // Note this can be a different set of users from those in `keyRecipients`.
@@ -73,7 +75,9 @@ export const getRecentConversationsLegacy: Selector<PmConversationData[]> = crea
   },
 );
 
-export const getRecentConversationsModern: Selector<PmConversationData[]> = createSelector(
+export const getRecentConversationsModern: Selector<
+  $ReadOnlyArray<PmConversationData>,
+> = createSelector(
   state => state.pmConversations,
   getUnreadByPms,
   getUnreadByHuddles,
@@ -92,7 +96,7 @@ function getRecentConversationsModernImpl(
   unreadHuddles,
   allUsersById,
   ownUserId,
-): PmConversationData[] {
+): $ReadOnlyArray<PmConversationData> {
   return sorted
     .toSeq()
     .map(recentsKey => {
@@ -129,11 +133,13 @@ const getServerIsOld: Selector<boolean> = createSelector(
 /**
  * The most recent PM conversations, with unread count and latest message ID.
  */
-export const getRecentConversations = (state: PerAccountState): PmConversationData[] =>
+export const getRecentConversations = (
+  state: PerAccountState,
+): $ReadOnlyArray<PmConversationData> =>
   getServerIsOld(state) ? getRecentConversationsLegacy(state) : getRecentConversationsModern(state);
 
 export const getUnreadConversations: Selector<
-  PmConversationData[],
+  $ReadOnlyArray<PmConversationData>,
 > = createSelector(getRecentConversations, conversations =>
   conversations.filter(c => c.unread > 0),
 );

--- a/src/reduxTypes.js
+++ b/src/reduxTypes.js
@@ -201,7 +201,7 @@ export type MutedUsersState = Immutable.Map<UserId, number>;
  *  * `FetchingState` for information about which narrows we're actively
  *    fetching more messages from.
  */
-export type NarrowsState = Immutable.Map<string, number[]>;
+export type NarrowsState = Immutable.Map<string, $ReadOnlyArray<number>>;
 
 export type OutboxState = $ReadOnlyArray<Outbox>;
 
@@ -546,11 +546,11 @@ export type GlobalSelector<TResult, TParam = void> = InputSelector<GlobalState, 
  * PerAccountState, but which is perfectly legitimate for per-account code
  * to use.
  */
-export type ThunkExtras = {
+export type ThunkExtras = $ReadOnly<{
   getGlobalSession: () => GlobalSessionState,
   getGlobalSettings: () => GlobalSettingsState,
   ...
-};
+}>;
 
 /** The Redux `dispatch` for a per-account context. */
 export interface Dispatch {

--- a/src/search/SearchMessagesCard.js
+++ b/src/search/SearchMessagesCard.js
@@ -16,7 +16,7 @@ const styles = createStyleSheet({
 });
 
 type Props = $ReadOnly<{|
-  messages: Message[] | null,
+  messages: $ReadOnlyArray<Message> | null,
   narrow: Narrow,
   isFetching: boolean,
 |}>;

--- a/src/search/SearchMessagesScreen.js
+++ b/src/search/SearchMessagesScreen.js
@@ -44,7 +44,7 @@ type State = {|
    * This is `null` if `query` is empty, representing an empty search box
    * and so effectively not a query to have results from at all.
    */
-  messages: Message[] | null,
+  messages: $ReadOnlyArray<Message> | null,
 
   /** Whether there is currently an active valid network request. */
   isFetching: boolean,
@@ -63,7 +63,7 @@ class SearchMessagesScreenInner extends PureComponent<Props, State> {
    * Stores the fetched messages in the Redux store. Does not read any
    * of the component's data except `props.dispatch`.
    */
-  fetchSearchMessages = async (query: string): Promise<Message[]> => {
+  fetchSearchMessages = async (query: string): Promise<$ReadOnlyArray<Message>> => {
     const fetchArgs = {
       narrow: SEARCH_NARROW(query),
       anchor: LAST_MESSAGE_ANCHOR,

--- a/src/sharing/ChooseRecipientsScreen.js
+++ b/src/sharing/ChooseRecipientsScreen.js
@@ -14,7 +14,7 @@ export default function ChooseRecipientsScreen(props: Props): Node {
   const [filter, setFilter] = useState<string>('');
 
   const handleComplete = useCallback(
-    (selected: Array<UserOrBot>) => {
+    (selected: $ReadOnlyArray<UserOrBot>) => {
       onComplete(selected.map(u => u.user_id));
     },
     [onComplete],

--- a/src/sharing/ShareWrapper.js
+++ b/src/sharing/ShareWrapper.js
@@ -87,7 +87,7 @@ type Props = $ReadOnly<{|
 type State = $ReadOnly<{|
   message: string,
   sending: boolean,
-  files: SharedFile[],
+  files: $ReadOnlyArray<SharedFile>,
 |}>;
 
 /**

--- a/src/sharing/types.js
+++ b/src/sharing/types.js
@@ -19,4 +19,4 @@ export type SharedFile = {|
 export type SharedData =
   // Note: Keep these in sync with platform-native code.
   | {| type: 'text', sharedText: string |}
-  | {| type: 'file', files: SharedFile[] |};
+  | {| type: 'file', files: $ReadOnlyArray<SharedFile> |};

--- a/src/start/AuthScreen.js
+++ b/src/start/AuthScreen.js
@@ -54,7 +54,7 @@ type AuthenticationMethodDetails = {|
 |};
 
 // Methods that don't show up in external_authentication_methods.
-const availableDirectMethods: AuthenticationMethodDetails[] = [
+const availableDirectMethods: $ReadOnlyArray<AuthenticationMethodDetails> = [
   {
     name: 'dev',
     displayName: 'dev account',
@@ -86,7 +86,7 @@ const availableDirectMethods: AuthenticationMethodDetails[] = [
 // which have that key (Zulip Server v2.1+).  We refer to this array for
 // servers that don't.
 // TODO(server-2.1): Simplify this away.
-const availableExternalMethods: AuthenticationMethodDetails[] = [
+const availableExternalMethods: $ReadOnlyArray<AuthenticationMethodDetails> = [
   {
     name: 'google',
     displayName: 'Google',
@@ -120,8 +120,8 @@ const externalMethodIcons = new Map([
 /** Exported for tests only. */
 export const activeAuthentications = (
   authenticationMethods: AuthenticationMethods,
-  externalAuthenticationMethods: ExternalAuthenticationMethod[] | void,
-): AuthenticationMethodDetails[] => {
+  externalAuthenticationMethods: $ReadOnlyArray<ExternalAuthenticationMethod> | void,
+): $ReadOnlyArray<AuthenticationMethodDetails> => {
   const result = [];
 
   availableDirectMethods.forEach(auth => {

--- a/src/start/DevAuthScreen.js
+++ b/src/start/DevAuthScreen.js
@@ -45,8 +45,8 @@ type Props = $ReadOnly<{|
 
 type State = {|
   progress: boolean,
-  directAdmins: DevUser[],
-  directUsers: DevUser[],
+  directAdmins: $ReadOnlyArray<DevUser>,
+  directUsers: $ReadOnlyArray<DevUser>,
   error: string,
 |};
 

--- a/src/streams/InviteUsersScreen.js
+++ b/src/streams/InviteUsersScreen.js
@@ -25,7 +25,7 @@ export default function InviteUsersScreen(props: Props): Node {
   const [filter, setFilter] = useState<string>('');
 
   const handleInviteUsers = useCallback(
-    (selected: UserOrBot[]) => {
+    (selected: $ReadOnlyArray<UserOrBot>) => {
       const recipients = selected.map(user => user.email);
       api.subscriptionAdd(auth, [{ name: stream.name }], recipients);
       NavigationService.dispatch(navigateBack());

--- a/src/streams/StreamList.js
+++ b/src/streams/StreamList.js
@@ -61,7 +61,7 @@ export default function StreamList(props: Props): Node {
     return <SearchEmptyState text="No streams found" />;
   }
 
-  const sortedStreams: PseudoSubscription[] = streams
+  const sortedStreams: $ReadOnlyArray<PseudoSubscription> = streams
     .slice()
     .sort((a, b) => caseInsensitiveCompareFunc(a.name, b.name));
   const sections = [

--- a/src/subscriptions/subscriptionSelectors.js
+++ b/src/subscriptions/subscriptionSelectors.js
@@ -50,7 +50,7 @@ export const getIsActiveStreamSubscribed: Selector<boolean, Narrow> = createSele
   },
 );
 
-export const getSubscribedStreams: Selector<Subscription[]> = createSelector(
+export const getSubscribedStreams: Selector<$ReadOnlyArray<Subscription>> = createSelector(
   getStreams,
   getSubscriptions,
   (allStreams, allSubscriptions) =>

--- a/src/third/redux-persist/autoRehydrate.js
+++ b/src/third/redux-persist/autoRehydrate.js
@@ -54,7 +54,7 @@ export default function autoRehydrate<S: { ... }, A: { +type: string, ... }, D>(
   }
 }
 
-function logPreRehydrate<A: { +type: string, ... }>(preRehydrateActions: A[]) {
+function logPreRehydrate<A: { +type: string, ... }>(preRehydrateActions: $ReadOnlyArray<A>) {
   const concernedActions = preRehydrateActions.slice(1);
   if (concernedActions.length > 0) {
     logging.warn(

--- a/src/third/redux-persist/types.js
+++ b/src/third/redux-persist/types.js
@@ -11,7 +11,7 @@ export type Storage = {
 };
 
 export type Config = {|
-  +whitelist: string[],
+  +whitelist: $ReadOnlyArray<string>,
   +storage: Storage,
   +serialize: mixed => string,
   +deserialize: string => mixed,

--- a/src/topics/TopicList.js
+++ b/src/topics/TopicList.js
@@ -17,7 +17,7 @@ const styles = createStyleSheet({
 
 type Props = $ReadOnly<{|
   stream: Stream,
-  topics: ?(TopicExtended[]),
+  topics: ?$ReadOnlyArray<TopicExtended>,
   onPress: (streamId: number, streamName: string, topic: string) => void,
 |}>;
 

--- a/src/topics/topicActions.js
+++ b/src/topics/topicActions.js
@@ -7,7 +7,7 @@ import { getAuth, getStreams } from '../selectors';
 import { deleteOutboxMessage } from '../actions';
 import { getOutbox } from '../directSelectors';
 
-export const initTopics = (topics: Topic[], streamId: number): PerAccountAction => ({
+export const initTopics = (topics: $ReadOnlyArray<Topic>, streamId: number): PerAccountAction => ({
   type: INIT_TOPICS,
   topics,
   streamId,

--- a/src/topics/topicSelectors.js
+++ b/src/topics/topicSelectors.js
@@ -33,7 +33,7 @@ export const getTopicsForNarrow: Selector<$ReadOnlyArray<string>, Narrow> = crea
   },
 );
 
-export const getTopicsForStream: Selector<?(TopicExtended[]), number> = createSelector(
+export const getTopicsForStream: Selector<?$ReadOnlyArray<TopicExtended>, number> = createSelector(
   (state, streamId) => getTopics(state)[streamId],
   state => getMute(state),
   (state, streamId) => getStreamsById(state).get(streamId),

--- a/src/typing/typingActions.js
+++ b/src/typing/typingActions.js
@@ -4,7 +4,7 @@ import type { PerAccountAction, ThunkAction } from '../types';
 import { sleep } from '../utils/async';
 import { getTyping } from '../directSelectors';
 
-export const clearTyping = (outdatedNotifications: string[]): PerAccountAction => ({
+export const clearTyping = (outdatedNotifications: $ReadOnlyArray<string>): PerAccountAction => ({
   type: 'CLEAR_TYPING',
   outdatedNotifications,
 });

--- a/src/unread/UnreadCards.js
+++ b/src/unread/UnreadCards.js
@@ -22,8 +22,8 @@ export default function UnreadCards(props: Props): Node {
   const unreadStreamsAndTopics = useSelector(getUnreadStreamsAndTopicsSansMuted);
   type Card =
     | UnreadStreamItem
-    | {| key: 'private', data: Array<React$ElementConfig<typeof PmConversationList>> |};
-  const unreadCards: Array<Card> = [
+    | {| key: 'private', data: $ReadOnlyArray<React$ElementConfig<typeof PmConversationList>> |};
+  const unreadCards: $ReadOnlyArray<Card> = [
     {
       key: 'private',
       data: [{ conversations }],

--- a/src/unread/unreadHelpers.js
+++ b/src/unread/unreadHelpers.js
@@ -34,7 +34,7 @@ export function removeItemsDeeply<T: SomeUnreadItem>(
 
 function addItemsDeeply<T: SomeUnreadItem>(
   input: $ReadOnlyArray<T>,
-  itemsToAdd: number[],
+  itemsToAdd: $ReadOnlyArray<number>,
   index: number,
 ): $ReadOnlyArray<T> {
   const item = input[index];
@@ -56,7 +56,7 @@ function addItemsDeeply<T: SomeUnreadItem>(
 
 export const addItemsToPmArray = (
   input: $ReadOnlyArray<PmsUnreadItem>,
-  itemsToAdd: number[],
+  itemsToAdd: $ReadOnlyArray<number>,
   senderId: UserId,
 ): $ReadOnlyArray<PmsUnreadItem> => {
   const index = input.findIndex(sender => sender.sender_id === senderId);
@@ -76,7 +76,7 @@ export const addItemsToPmArray = (
 
 export const addItemsToHuddleArray = (
   input: $ReadOnlyArray<HuddlesUnreadItem>,
-  itemsToAdd: number[],
+  itemsToAdd: $ReadOnlyArray<number>,
   userIds: string,
 ): $ReadOnlyArray<HuddlesUnreadItem> => {
   const index = input.findIndex(recipients => recipients.user_ids_string === userIds);

--- a/src/unread/unreadHelpers.js
+++ b/src/unread/unreadHelpers.js
@@ -6,7 +6,7 @@ type SomeUnreadItem = $ReadOnly<{ unread_message_ids: $ReadOnlyArray<number>, ..
 
 export function removeItemsDeeply<T: SomeUnreadItem>(
   objArray: $ReadOnlyArray<T>,
-  messageIds: number[],
+  messageIds: $ReadOnlyArray<number>,
 ): $ReadOnlyArray<T> {
   let changed = false;
   const objWithAddedUnreadIds = objArray.map(obj => {

--- a/src/unread/unreadSelectors.js
+++ b/src/unread/unreadSelectors.js
@@ -131,7 +131,7 @@ export const getUnreadTotal: Selector<number> = createSelector(
 );
 
 /** Helper for getUnreadStreamsAndTopicsSansMuted; see there. */
-export const getUnreadStreamsAndTopics: Selector<UnreadStreamItem[]> = createSelector(
+export const getUnreadStreamsAndTopics: Selector<$ReadOnlyArray<UnreadStreamItem>> = createSelector(
   getSubscriptionsById,
   getUnreadStreams,
   getMute,
@@ -192,15 +192,15 @@ export const getUnreadStreamsAndTopics: Selector<UnreadStreamItem[]> = createSel
  * contains in `.data` an array with an element for each unmuted topic that
  * has unreads.
  */
-export const getUnreadStreamsAndTopicsSansMuted: Selector<UnreadStreamItem[]> = createSelector(
-  getUnreadStreamsAndTopics,
-  unreadStreamsAndTopics =>
-    unreadStreamsAndTopics
-      .map(stream => ({
-        ...stream,
-        data: stream.data.filter(topic => !topic.isMuted),
-      }))
-      .filter(stream => !stream.isMuted && stream.data.length > 0),
+export const getUnreadStreamsAndTopicsSansMuted: Selector<
+  $ReadOnlyArray<UnreadStreamItem>,
+> = createSelector(getUnreadStreamsAndTopics, unreadStreamsAndTopics =>
+  unreadStreamsAndTopics
+    .map(stream => ({
+      ...stream,
+      data: stream.data.filter(topic => !topic.isMuted),
+    }))
+    .filter(stream => !stream.isMuted && stream.data.length > 0),
 );
 
 /** Total number of a certain subset of unreads, plus ??? double-counting. */

--- a/src/user-groups/CreateGroupScreen.js
+++ b/src/user-groups/CreateGroupScreen.js
@@ -26,7 +26,7 @@ export default function CreateGroupScreen(props: Props): Node {
   const [filter, setFilter] = useState<string>('');
 
   const handleCreateGroup = useCallback(
-    (selected: UserOrBot[]) => {
+    (selected: $ReadOnlyArray<UserOrBot>) => {
       NavigationService.dispatch(navigateBack());
       dispatch(doNarrow(pmNarrowFromRecipients(pmKeyRecipientsFromUsers(selected, ownUserId))));
     },

--- a/src/user-picker/AvatarList.js
+++ b/src/user-picker/AvatarList.js
@@ -7,7 +7,7 @@ import type { UserId, UserOrBot } from '../types';
 import AvatarItem from './AvatarItem';
 
 type Props = $ReadOnly<{|
-  users: UserOrBot[],
+  users: $ReadOnlyArray<UserOrBot>,
   listRef: React$Ref<typeof FlatList>,
   onPress: UserId => void,
 |}>;

--- a/src/user-picker/UserPickerCard.js
+++ b/src/user-picker/UserPickerCard.js
@@ -29,11 +29,11 @@ const styles = createStyleSheet({
 
 type Props = $ReadOnly<{|
   filter: string,
-  onComplete: (selected: UserOrBot[]) => void,
+  onComplete: (selected: $ReadOnlyArray<UserOrBot>) => void,
   showOwnUser: boolean,
 |}>;
 
-const getUsersExceptSelf: Selector<User[]> = createSelector(
+const getUsersExceptSelf: Selector<$ReadOnlyArray<User>> = createSelector(
   getUsers,
   getOwnUserId,
   (users, ownUserId) => users.filter(user => user.user_id !== ownUserId),
@@ -52,7 +52,7 @@ export default function UserPickerCard(props: Props): Node {
   const users = useSelector(state => getUsersToShow(state, showOwnUser));
   const presences = useSelector(getPresence);
 
-  const [selectedState, setSelectedState] = useState<UserOrBot[]>([]);
+  const [selectedState, setSelectedState] = useState<$ReadOnlyArray<UserOrBot>>([]);
   const listRef = useRef<FlatList<UserOrBot> | null>(null);
 
   const prevSelectedState = usePrevious(selectedState);

--- a/src/users/userHelpers.js
+++ b/src/users/userHelpers.js
@@ -22,7 +22,10 @@ type UsersByStatus = {|
   unavailable: UserOrBot[],
 |};
 
-export const groupUsersByStatus = (users: UserOrBot[], presences: PresenceState): UsersByStatus => {
+export const groupUsersByStatus = (
+  users: $ReadOnlyArray<UserOrBot>,
+  presences: PresenceState,
+): UsersByStatus => {
   const groupedUsers = { active: [], idle: [], offline: [], unavailable: [] };
   users.forEach(user => {
     const status = statusFromPresence(presences[user.email]);
@@ -46,7 +49,10 @@ const statusOrder = (presence: UserPresence): number => {
   }
 };
 
-export const sortUserList = (users: UserOrBot[], presences: PresenceState): UserOrBot[] =>
+export const sortUserList = (
+  users: $ReadOnlyArray<UserOrBot>,
+  presences: PresenceState,
+): $ReadOnlyArray<UserOrBot> =>
   [...users].sort(
     (x1, x2) =>
       statusOrder(presences[x1.email]) - statusOrder(presences[x2.email])
@@ -64,7 +70,7 @@ export const filterUserList = (
   users: $ReadOnlyArray<UserOrBot>,
   filter: string = '',
   ownUserId: ?UserId,
-): UserOrBot[] =>
+): $ReadOnlyArray<UserOrBot> =>
   users.filter(
     user =>
       user.user_id !== ownUserId
@@ -73,7 +79,7 @@ export const filterUserList = (
         || user.email.toLowerCase().includes(filter.toLowerCase())),
   );
 
-export const sortAlphabetically = (users: User[]): User[] =>
+export const sortAlphabetically = (users: $ReadOnlyArray<User>): $ReadOnlyArray<User> =>
   [...users].sort((x1, x2) => x1.full_name.toLowerCase().localeCompare(x2.full_name.toLowerCase()));
 
 export const filterUserStartWith = (
@@ -154,7 +160,7 @@ export const getAutocompleteSuggestion = (
 export const getAutocompleteUserGroupSuggestions = (
   userGroups: $ReadOnlyArray<UserGroup>,
   filter: string = '',
-): UserGroup[] =>
+): $ReadOnlyArray<UserGroup> =>
   userGroups.filter(
     userGroup =>
       userGroup.name.toLowerCase().includes(filter.toLowerCase())

--- a/src/users/userSelectors.js
+++ b/src/users/userSelectors.js
@@ -24,7 +24,7 @@ import { tryGetAuth, tryGetActiveAccountState } from '../account/accountsSelecto
  *  * `getActiveUsersById` for leaving out deactivated users
  *  * `User` for details on properties, and links to docs.
  */
-const getAllUsers: Selector<UserOrBot[]> = createSelector(
+const getAllUsers: Selector<$ReadOnlyArray<UserOrBot>> = createSelector(
   getUsers,
   getNonActiveUsers,
   getCrossRealmBots,
@@ -69,7 +69,7 @@ export const getUsersById: Selector<Map<UserId, User>> = createSelector(
  *
  * See `getAllUsers`.
  */
-export const getSortedUsers: Selector<User[]> = createSelector(getUsers, users =>
+export const getSortedUsers: Selector<$ReadOnlyArray<User>> = createSelector(getUsers, users =>
   [...users].sort((x1, x2) => x1.full_name.toLowerCase().localeCompare(x2.full_name.toLowerCase())),
 );
 

--- a/src/utils/__tests__/async-test.js
+++ b/src/utils/__tests__/async-test.js
@@ -26,7 +26,7 @@ describe('BackoffMachine', () => {
     const NUM_TRIALS = 100;
     const expectedMaxDurations = [100, 200, 400, 800, 1600, 3200, 6400, 10000, 10000, 10000, 10000];
 
-    const trialResults: Array<number[]> = [];
+    const trialResults: Array<$ReadOnlyArray<number>> = [];
 
     for (let i = 0; i < NUM_TRIALS; i++) {
       const resultsForThisTrial = [];

--- a/src/utils/__tests__/zulipVersion-test.js
+++ b/src/utils/__tests__/zulipVersion-test.js
@@ -8,7 +8,7 @@ describe('ZulipVersion.prototype.isAtLeast(otherZulipVersion)', () => {
   // if i = j, versions[i][k] = versions[j][l] for all k, l
   // if i < j, versions[i][k] < versions[j][l] for all k, l
   // (where i, j, k, l are valid indexes)
-  const versions: Array<ZulipVersion[]> = [
+  const versions: $ReadOnlyArray<$ReadOnlyArray<ZulipVersion>> = [
     ['0.0.0', '', '-dev', '-devasdfjkl;', '-123-g01ab', 'asdfjkl;-dev'],
     ['0.0.1-dev'],
     ['0.0.1-rc1'],

--- a/src/utils/immutability.js
+++ b/src/utils/immutability.js
@@ -8,7 +8,10 @@ export const removeItemsFromArray = (
   return input.length === output.length ? input : output;
 };
 
-export function addItemsToArray<T>(input: $ReadOnlyArray<T>, itemsToAdd: T[]): $ReadOnlyArray<T> {
+export function addItemsToArray<T>(
+  input: $ReadOnlyArray<T>,
+  itemsToAdd: $ReadOnlyArray<T>,
+): $ReadOnlyArray<T> {
   const newItems = itemsToAdd.filter(item => !input.includes(item));
   return newItems.length > 0 ? [...input, ...itemsToAdd] : input;
 }
@@ -25,7 +28,7 @@ export function replaceItemInArray<T>(
   input: $ReadOnlyArray<T>,
   predicate: (item: T) => boolean,
   replaceFunc: (item?: T) => T,
-): T[] {
+): $ReadOnlyArray<T> {
   let replacementHappened = false;
 
   const newArray = input.map(x => {

--- a/src/utils/immutability.js
+++ b/src/utils/immutability.js
@@ -2,7 +2,7 @@
 
 export const removeItemsFromArray = (
   input: $ReadOnlyArray<number>,
-  itemsToRemove: number[],
+  itemsToRemove: $ReadOnlyArray<number>,
 ): $ReadOnlyArray<number> => {
   const output = input.filter((item: number) => !itemsToRemove.includes(item));
   return input.length === output.length ? input : output;

--- a/src/utils/narrow.js
+++ b/src/utils/narrow.js
@@ -107,7 +107,7 @@ export const pmNarrowFromUsers = (recipients: PmKeyUsers): Narrow =>
  */
 // It'd be fine for test data to go through the usual filtering logic; the
 // annoying thing is just that that requires an ownUserId value.
-export const pmNarrowFromUsersUnsafe = (recipients: UserOrBot[]): Narrow => {
+export const pmNarrowFromUsersUnsafe = (recipients: $ReadOnlyArray<UserOrBot>): Narrow => {
   const userIds = recipients.map(u => u.user_id).sort((a, b) => a - b);
   // This call is unsafe, but that's why this function is too.
   return pmNarrowInternal(makePmKeyRecipients_UNSAFE(userIds));
@@ -522,7 +522,7 @@ export const getNarrowsForMessage = (
   message: Message | Outbox,
   ownUserId: UserId,
   flags: $ReadOnlyArray<string>,
-): Narrow[] => {
+): $ReadOnlyArray<Narrow> => {
   const result = [];
 
   // All messages are in the home narrow.

--- a/src/utils/objectEntries.js
+++ b/src/utils/objectEntries.js
@@ -6,7 +6,7 @@
 //    static entries(object: mixed): Array<[string, mixed]>;
 // .... which is almost useless.
 
-const objectEntries = <K: string, V>(obj: {| +[K]: V |}): $ReadOnlyArray<[K, V]> =>
+const objectEntries = <K: string, V>(obj: {| +[K]: V |}): Array<[K, V]> =>
   (Object.entries(obj): $FlowFixMe);
 
 export default objectEntries;

--- a/src/utils/unread.js
+++ b/src/utils/unread.js
@@ -1,8 +1,10 @@
 /* @flow strict-local */
 import type { FlagsState, Message, Outbox } from '../types';
 
-export const filterUnreadMessageIds = (messageIds: number[], flags: FlagsState): number[] =>
-  messageIds.filter((msgId: number) => !flags || !flags.read || !flags.read[msgId]);
+export const filterUnreadMessageIds = (
+  messageIds: $ReadOnlyArray<number>,
+  flags: FlagsState,
+): number[] => messageIds.filter((msgId: number) => !flags || !flags.read || !flags.read[msgId]);
 
 export const filterUnreadMessagesInRange = (
   messages: $ReadOnlyArray<Message | Outbox>,

--- a/src/utils/url.js
+++ b/src/utils/url.js
@@ -176,7 +176,7 @@ export type AutocompletionPieces = [Protocol | null, string, string | null];
 /**
  * A short list of some characters not permitted in subdomain name elements.
  */
-const disallowedCharacters: Array<string> = [...'.:/'];
+const disallowedCharacters: $ReadOnlyArray<string> = [...'.:/'];
 
 /**
  * Given user input purporting to identify a Zulip realm, provide a prefix,

--- a/src/utils/zulipVersion.js
+++ b/src/utils/zulipVersion.js
@@ -26,7 +26,7 @@ type VersionElements = {|
  */
 export class ZulipVersion {
   _raw: string;
-  _comparisonArray: number[];
+  _comparisonArray: $ReadOnlyArray<number>;
   _elements: VersionElements;
 
   constructor(raw: string) {
@@ -117,9 +117,9 @@ export class ZulipVersion {
   }
 
   /**
-   * Compute a number[] to be used in .isAtLeast comparisons.
+   * Compute a $ReadOnlyArray<number> to be used in .isAtLeast comparisons.
    */
-  static _getComparisonArray(elements: VersionElements): number[] {
+  static _getComparisonArray(elements: VersionElements): $ReadOnlyArray<number> {
     const { major, minor, patch, flag, numCommits } = elements;
     const result: number[] = [];
 

--- a/src/webview/MessageList.js
+++ b/src/webview/MessageList.js
@@ -174,7 +174,7 @@ class MessageListInner extends Component<Props> {
     console.error(event); // eslint-disable-line
   };
 
-  sendInboundEvents = (uevents: WebViewInboundEvent[]): void => {
+  sendInboundEvents = (uevents: $ReadOnlyArray<WebViewInboundEvent>): void => {
     if (this.webviewRef.current !== null && uevents.length > 0) {
       /* $FlowFixMe[incompatible-type]: This `postMessage` is undocumented;
          tracking as #3572. */

--- a/src/webview/generateInboundEvents.js
+++ b/src/webview/generateInboundEvents.js
@@ -35,7 +35,7 @@ export type WebViewInboundEventReady = {|
 
 export type WebViewInboundEventMessagesRead = {|
   type: 'read',
-  messageIds: number[],
+  messageIds: $ReadOnlyArray<number>,
 |};
 
 export type WebViewInboundEvent =

--- a/src/webview/html/message.js
+++ b/src/webview/html/message.js
@@ -180,7 +180,7 @@ $!${message.content}
   `;
 };
 
-export const flagsStateToStringList = (flags: FlagsState, id: number): string[] =>
+export const flagsStateToStringList = (flags: FlagsState, id: number): $ReadOnlyArray<string> =>
   Object.keys(flags).filter(key => flags[key][id]);
 
 /**

--- a/src/webview/html/template.js
+++ b/src/webview/html/template.js
@@ -14,9 +14,12 @@ import escape from 'lodash.escape';
  * To include a literal '$!' before a value, write '$\!':
  *   template`Hello $\!${&<world}` -> 'Hello $!&amp;&lt;world'
  */
-export default (strings: string[], ...values: Array<string | number>): string => {
+export default (
+  strings: $ReadOnlyArray<string>,
+  ...values: $ReadOnlyArray<string | number>
+): string => {
   // $FlowIssue[prop-missing] #2616 github.com/facebook/flow/issues/2616
-  const raw: string[] = strings.raw; // eslint-disable-line prefer-destructuring
+  const raw: $ReadOnlyArray<string> = strings.raw; // eslint-disable-line prefer-destructuring
   const result = [];
   values.forEach((value, i) => {
     if (raw[i].endsWith('$!')) {

--- a/src/webview/js/js.js
+++ b/src/webview/js/js.js
@@ -716,7 +716,7 @@ const handleMessageEvent: MessageEventListener = e => {
   // This decoding inverts `base64Utf8Encode`.
   const decodedData = decodeURIComponent(escape(window.atob(e.data)));
   const rawInboundEvents = JSON.parse(decodedData);
-  const inboundEvents: WebViewInboundEvent[] = rawInboundEvents.map(inboundEvent => ({
+  const inboundEvents: $ReadOnlyArray<WebViewInboundEvent> = rawInboundEvents.map(inboundEvent => ({
     ...inboundEvent,
     // A URL object doesn't round-trip through JSON; we get the string
     // representation. So, "revive" it back into a URL object.

--- a/src/webview/js/js.js
+++ b/src/webview/js/js.js
@@ -219,7 +219,7 @@ function midMessageListElement(top: number, bottom: number): ?Element {
 
   const midY = (bottom + top) / 2;
 
-  const midElements: Array<HTMLElement> = document.elementsFromPoint(0, midY);
+  const midElements = document.elementsFromPoint(0, midY);
   if (midElements.length < 4) {
     // Just [div#msglist-elements, body, html].
     return null;

--- a/src/webview/js/rewriteHtml.js
+++ b/src/webview/js/rewriteHtml.js
@@ -3,9 +3,11 @@
 import type { Auth } from '../../types';
 
 /** List of routes which accept the API key appended as a GET parameter. */
-const inlineApiRoutes: RegExp[] = ['^/user_uploads/', '^/thumbnail$', '^/avatar/'].map(
-  r => new RegExp(r),
-);
+const inlineApiRoutes: $ReadOnlyArray<RegExp> = [
+  '^/user_uploads/',
+  '^/thumbnail$',
+  '^/avatar/',
+].map(r => new RegExp(r));
 
 /**
  * Rewrite the source URLs of <img> elements under the given root, inclusive.


### PR DESCRIPTION
Including all the object and array types in our actions and other Redux-related types, and a bunch of miscellaneous others.

The lack of read-only markings on the type for (Redux actions for) `update_message` events, `EventUpdateMessageAction`, produced some very confusing Flow errors in tests when I started changing those, sending me down a path of at least a half-hour of debugging. (It was a real type error, it turned out -- a missing `subject` property, which for now our types believe is required there.)

And it turns out I had a draft branch from last summer with that and the other action types, and a few more changes. So, here's that branch finished up, along with some further changes in the same direction.
