### PR TITLE
Update `update_message` event expectations

### DIFF
--- a/src/actionTypes.js
+++ b/src/actionTypes.js
@@ -359,7 +359,7 @@ type EventUpdateMessageAction = $ReadOnly<{|
   new_stream_id?: number,
   propagate_mode: 'change_one' | 'change_later' | 'change_all',
   orig_subject?: string,
-  subject: string,
+  subject?: string,
 
   // TODO(server-4.0): Changed in feat. 46 to array-of-objects shape, from $ReadOnlyArray<string>
   topic_links?: $ReadOnlyArray<{| +text: string, +url: string |}> | $ReadOnlyArray<string>,

--- a/src/actionTypes.js
+++ b/src/actionTypes.js
@@ -344,7 +344,7 @@ type EventMessageDeleteAction = $ReadOnly<{|
 type EventUpdateMessageAction = $ReadOnly<{|
   ...ServerEvent,
   type: typeof EVENT_UPDATE_MESSAGE,
-  user_id: UserId,
+  user_id?: UserId,
 
   // Any content changes apply to just message_id.
   message_id: number,
@@ -353,7 +353,7 @@ type EventUpdateMessageAction = $ReadOnly<{|
   //   guaranteed to include message_id.
   message_ids: $ReadOnlyArray<number>,
 
-  edit_timestamp: number,
+  edit_timestamp?: number,
   stream_name?: string,
   stream_id?: number,
   new_stream_id?: number,

--- a/src/actionTypes.js
+++ b/src/actionTypes.js
@@ -353,11 +353,12 @@ type EventUpdateMessageAction = $ReadOnly<{|
   //   guaranteed to include message_id.
   message_ids: $ReadOnlyArray<number>,
 
+  flags: $ReadOnlyArray<string>,
   edit_timestamp?: number,
   stream_name?: string,
   stream_id?: number,
   new_stream_id?: number,
-  propagate_mode: 'change_one' | 'change_later' | 'change_all',
+  propagate_mode?: 'change_one' | 'change_later' | 'change_all',
   orig_subject?: string,
   subject?: string,
 
@@ -367,13 +368,12 @@ type EventUpdateMessageAction = $ReadOnly<{|
   // TODO(server-3.0): Replaced in feat. 1 by topic_links
   subject_links?: $ReadOnlyArray<string>,
 
-  orig_content: string,
-  orig_rendered_content: string,
-  prev_rendered_content_version: number,
-  content: string,
-  rendered_content: string,
-  is_me_message: boolean,
-  flags: $ReadOnlyArray<string>,
+  orig_content?: string,
+  orig_rendered_content?: string,
+  prev_rendered_content_version?: number,
+  content?: string,
+  rendered_content?: string,
+  is_me_message?: boolean,
 |}>;
 
 type EventReactionCommon = $ReadOnly<{|

--- a/src/message/__tests__/messagesReducer-test.js
+++ b/src/message/__tests__/messagesReducer-test.js
@@ -164,29 +164,37 @@ describe('messagesReducer', () => {
   });
 
   describe('EVENT_UPDATE_MESSAGE', () => {
+    const mkAction = args => {
+      const { message, ...restArgs } = args;
+      return {
+        id: 1,
+        type: EVENT_UPDATE_MESSAGE,
+        user_id: message.sender_id,
+        message_id: message.id,
+        message_ids: [message.id],
+        flags: [],
+        propagate_mode: 'change_one',
+        is_me_message: false,
+        ...restArgs,
+      };
+    };
+
     test('if a message does not exist no changes are made', () => {
       const message1 = eg.streamMessage();
       const message2 = eg.streamMessage();
       const message3 = eg.streamMessage();
 
       const prevState = eg.makeMessagesState([message1, message2]);
-      const action = deepFreeze({
-        id: 1,
-        type: EVENT_UPDATE_MESSAGE,
+      const action = mkAction({
         edit_timestamp: Date.now() - 1000,
-        message_id: message3.id,
-        message_ids: [message3.id],
+        message: message3,
         orig_content: eg.randString(),
         orig_rendered_content: eg.randString(),
         prev_rendered_content_version: 0,
-        propagate_mode: 'change_one',
         rendered_content: eg.randString(),
         content: eg.randString(),
         subject_links: [],
         subject: eg.randString(),
-        user_id: message3.sender_id,
-        is_me_message: false,
-        flags: [],
       });
       const newState = messagesReducer(prevState, action);
       expect(newState).toBe(prevState);
@@ -211,23 +219,16 @@ describe('messagesReducer', () => {
       };
 
       const prevState = eg.makeMessagesState([message1, message2, message3Old]);
-      const action = deepFreeze({
-        id: 1,
-        type: EVENT_UPDATE_MESSAGE,
+      const action = mkAction({
         edit_timestamp: 123,
-        message_id: message3New.id,
-        message_ids: [message3New.id],
+        message: message3New,
         orig_content: '<p>Old content</p>',
         orig_rendered_content: '<p>Old content</p>',
         prev_rendered_content_version: 1,
-        propagate_mode: 'change_one',
         rendered_content: '<p>New content</p>',
         content: 'New content',
         subject_links: [],
         subject: message3New.subject,
-        user_id: message3New.sender_id,
-        is_me_message: false,
-        flags: [],
       });
       const expectedState = eg.makeMessagesState([message1, message2, message3New]);
       const newState = messagesReducer(prevState, action);
@@ -258,24 +259,17 @@ describe('messagesReducer', () => {
         ],
       };
       const prevState = eg.makeMessagesState([message1Old]);
-      const action = deepFreeze({
-        id: 1,
-        type: EVENT_UPDATE_MESSAGE,
+      const action = mkAction({
         edit_timestamp: 123,
-        message_id: message1New.id,
-        message_ids: [message1New.id],
+        message: message1New,
         orig_content: message1Old.content,
         orig_subject: message1Old.subject,
         orig_rendered_content: message1Old.content,
         prev_rendered_content_version: 1,
-        propagate_mode: 'change_one',
         rendered_content: message1New.content,
         content: message1New.content,
         subject_links: [],
         subject: message1New.subject,
-        user_id: message1Old.sender_id,
-        is_me_message: false,
-        flags: [],
       });
       const expectedState = eg.makeMessagesState([message1New]);
       const newState = messagesReducer(prevState, action);
@@ -315,24 +309,17 @@ describe('messagesReducer', () => {
       };
 
       const prevState = eg.makeMessagesState([message1Old]);
-      const action = deepFreeze({
-        id: 1,
-        type: EVENT_UPDATE_MESSAGE,
+      const action = mkAction({
         edit_timestamp: 456,
-        message_id: message1Old.id,
-        message_ids: [message1Old.id],
+        message: message1Old,
         orig_content: message1Old.content,
         orig_rendered_content: message1Old.content,
         rendered_content: message1New.content,
         content: message1New.content,
-        propagate_mode: 'change_one',
         subject: message1New.subject,
         orig_subject: message1Old.subject,
         prev_rendered_content_version: 1,
-        user_id: message1New.sender_id,
         subject_links: [],
-        is_me_message: false,
-        flags: [],
       });
       const expectedState = eg.makeMessagesState([message1New]);
       const newState = messagesReducer(prevState, action);

--- a/src/message/__tests__/messagesReducer-test.js
+++ b/src/message/__tests__/messagesReducer-test.js
@@ -19,9 +19,9 @@ import { makeUserId } from '../../api/idTypes';
 describe('messagesReducer', () => {
   describe('EVENT_NEW_MESSAGE', () => {
     test('appends message to state, if any narrow is caught up to newest', () => {
-      const message1 = eg.streamMessage({ id: 1 });
-      const message2 = eg.streamMessage({ id: 2 });
-      const message3 = eg.streamMessage({ id: 3 });
+      const message1 = eg.streamMessage();
+      const message2 = eg.streamMessage();
+      const message3 = eg.streamMessage();
 
       const prevState = eg.makeMessagesState([message1, message2]);
       const action = eg.mkActionEventNewMessage(message3, {
@@ -39,9 +39,9 @@ describe('messagesReducer', () => {
     });
 
     test('does nothing, if no narrow is caught up to newest', () => {
-      const message1 = eg.streamMessage({ id: 1 });
-      const message2 = eg.streamMessage({ id: 2 });
-      const message3 = eg.streamMessage({ id: 3 });
+      const message1 = eg.streamMessage();
+      const message2 = eg.streamMessage();
+      const message3 = eg.streamMessage();
       const prevState = eg.makeMessagesState([message1, message2]);
       const action = eg.mkActionEventNewMessage(message3, {
         caughtUp: {
@@ -76,7 +76,7 @@ describe('messagesReducer', () => {
     });
 
     test('if the message exists add the incoming data to `submessages`', () => {
-      const message1 = eg.streamMessage({ id: 1 });
+      const message1 = eg.streamMessage();
       const message2 = eg.streamMessage({
         id: 2,
         submessages: [
@@ -137,8 +137,8 @@ describe('messagesReducer', () => {
     });
 
     test('if a message exists it is deleted', () => {
-      const message1 = eg.streamMessage({ id: 1 });
-      const message2 = eg.streamMessage({ id: 2 });
+      const message1 = eg.streamMessage();
+      const message2 = eg.streamMessage();
 
       const prevState = eg.makeMessagesState([message1, message2]);
       const action = deepFreeze({ type: EVENT_MESSAGE_DELETE, messageIds: [message2.id] });
@@ -165,9 +165,9 @@ describe('messagesReducer', () => {
 
   describe('EVENT_UPDATE_MESSAGE', () => {
     test('if a message does not exist no changes are made', () => {
-      const message1 = eg.streamMessage({ id: 1 });
-      const message2 = eg.streamMessage({ id: 2 });
-      const message3 = eg.streamMessage({ id: 3 });
+      const message1 = eg.streamMessage();
+      const message2 = eg.streamMessage();
+      const message3 = eg.streamMessage();
 
       const prevState = eg.makeMessagesState([message1, message2]);
       const action = deepFreeze({
@@ -193,9 +193,9 @@ describe('messagesReducer', () => {
     });
 
     test('when a message exists in state, it is updated', () => {
-      const message1 = eg.streamMessage({ id: 1 });
-      const message2 = eg.streamMessage({ id: 2 });
-      const message3Old = eg.streamMessage({ id: 3, content: '<p>Old content</p>' });
+      const message1 = eg.streamMessage();
+      const message2 = eg.streamMessage();
+      const message3Old = eg.streamMessage({ content: '<p>Old content</p>' });
       const message3New = {
         ...message3Old,
         content: '<p>New content</p>',
@@ -236,7 +236,6 @@ describe('messagesReducer', () => {
 
     test('when event contains a new subject but no new content only subject is updated', () => {
       const message1Old = eg.streamMessage({
-        id: 1,
         content: 'Old content',
         subject: 'Old subject',
         last_edit_timestamp: 123,
@@ -285,7 +284,6 @@ describe('messagesReducer', () => {
 
     test('when event contains a new subject and a new content, update both and update edit history object', () => {
       const message1Old = eg.streamMessage({
-        id: 1,
         content: '<p>Old content</p>',
         subject: 'Old subject',
         last_edit_timestamp: 123,
@@ -344,8 +342,8 @@ describe('messagesReducer', () => {
 
   describe('EVENT_REACTION_ADD', () => {
     test('on event received, add reaction to message with given id', () => {
-      const message1 = eg.streamMessage({ id: 1, reactions: [] });
-      const message2 = eg.streamMessage({ id: 2, reactions: [] });
+      const message1 = eg.streamMessage({ reactions: [] });
+      const message2 = eg.streamMessage({ reactions: [] });
       const reaction = eg.unicodeEmojiReaction;
 
       const prevState = eg.makeMessagesState([message1, message2]);
@@ -369,14 +367,14 @@ describe('messagesReducer', () => {
 
   describe('EVENT_REACTION_REMOVE', () => {
     test('if message does not contain reaction, no change is made', () => {
-      const message1 = eg.streamMessage({ id: 1, reactions: [] });
+      const message1 = eg.streamMessage({ reactions: [] });
       const reaction = eg.unicodeEmojiReaction;
 
       const prevState = eg.makeMessagesState([message1]);
       const action = deepFreeze({
         id: 1,
         type: EVENT_REACTION_REMOVE,
-        message_id: 1,
+        message_id: message1.id,
         ...reaction,
       });
       const expectedState = eg.makeMessagesState([message1]);
@@ -404,7 +402,7 @@ describe('messagesReducer', () => {
         user_id: makeUserId(1),
       };
 
-      const message1 = eg.streamMessage({ id: 1, reactions: [reaction1, reaction2, reaction3] });
+      const message1 = eg.streamMessage({ reactions: [reaction1, reaction2, reaction3] });
       const prevState = eg.makeMessagesState([message1]);
       const action = deepFreeze({
         id: 1,

--- a/src/message/__tests__/messagesReducer-test.js
+++ b/src/message/__tests__/messagesReducer-test.js
@@ -198,8 +198,6 @@ describe('messagesReducer', () => {
         prev_rendered_content_version: 0,
         rendered_content: eg.randString(),
         content: eg.randString(),
-        subject_links: [],
-        subject: eg.randString(),
       });
       const newState = messagesReducer(prevState, action);
       expect(newState).toBe(prevState);
@@ -232,8 +230,6 @@ describe('messagesReducer', () => {
         prev_rendered_content_version: 1,
         rendered_content: '<p>New content</p>',
         content: 'New content',
-        subject_links: [],
-        subject: message3New.subject,
       });
       const expectedState = eg.makeMessagesState([message1, message2, message3New]);
       const newState = messagesReducer(prevState, action);
@@ -258,8 +254,6 @@ describe('messagesReducer', () => {
             timestamp: 123,
             user_id: message1Old.sender_id,
             prev_subject: message1Old.subject,
-            prev_rendered_content: message1Old.content,
-            prev_rendered_content_version: 1,
           },
         ],
       };
@@ -267,12 +261,8 @@ describe('messagesReducer', () => {
       const action = mkAction({
         edit_timestamp: 123,
         message: message1New,
-        orig_content: message1Old.content,
+        stream_id: message1Old.stream_id,
         orig_subject: message1Old.subject,
-        orig_rendered_content: message1Old.content,
-        prev_rendered_content_version: 1,
-        rendered_content: message1New.content,
-        content: message1New.content,
         subject_links: [],
         subject: message1New.subject,
       });

--- a/src/message/messagesReducer.js
+++ b/src/message/messagesReducer.js
@@ -176,9 +176,7 @@ export default (
               subject: action.subject ?? messageWithNewCommonFields.subject,
               subject_links: action.subject_links ?? messageWithNewCommonFields.subject_links,
             }
-          : {
-              ...messageWithNewCommonFields,
-            };
+          : messageWithNewCommonFields;
       });
 
     default:

--- a/src/message/messagesReducer.js
+++ b/src/message/messagesReducer.js
@@ -149,7 +149,7 @@ export default (
             // message to clients) and shouldn't appear in the edit history.
             return null;
           }
-          if (action.orig_rendered_content) {
+          if (action.orig_rendered_content !== undefined) {
             if (action.orig_subject !== undefined) {
               return {
                 prev_rendered_content: action.orig_rendered_content,

--- a/src/message/messagesReducer.js
+++ b/src/message/messagesReducer.js
@@ -121,7 +121,7 @@ export default (
           message && {
             ...(message: M),
             submessages: [
-              ...(message.submessages || []),
+              ...(message.submessages ?? []),
               {
                 id: action.submessage_id,
                 message_id: action.message_id,
@@ -143,7 +143,7 @@ export default (
         }
         const messageWithNewCommonFields: M = {
           ...(oldMessage: M),
-          content: action.rendered_content || oldMessage.content,
+          content: action.rendered_content ?? oldMessage.content,
           edit_history: [
             action.orig_rendered_content
               ? action.orig_subject !== undefined
@@ -165,7 +165,7 @@ export default (
                   timestamp: action.edit_timestamp,
                   user_id: action.user_id,
                 },
-            ...(oldMessage.edit_history || NULL_ARRAY),
+            ...(oldMessage.edit_history ?? NULL_ARRAY),
           ],
           last_edit_timestamp: action.edit_timestamp,
         };
@@ -173,8 +173,8 @@ export default (
         return messageWithNewCommonFields.type === 'stream'
           ? {
               ...messageWithNewCommonFields,
-              subject: action.subject || messageWithNewCommonFields.subject,
-              subject_links: action.subject_links || messageWithNewCommonFields.subject_links,
+              subject: action.subject ?? messageWithNewCommonFields.subject,
+              subject_links: action.subject_links ?? messageWithNewCommonFields.subject_links,
             }
           : {
               ...messageWithNewCommonFields,

--- a/src/unread/__tests__/unreadModel-test.js
+++ b/src/unread/__tests__/unreadModel-test.js
@@ -76,16 +76,8 @@ describe('stream substate', () => {
         user_id: eg.selfUser.user_id,
         message_id: message_ids[0],
         message_ids,
-        edit_timestamp: 10000,
-        propagate_mode: 'change_later',
-        subject_links: [],
-        orig_content: '',
-        orig_rendered_content: '',
-        prev_rendered_content_version: 0,
-        content: '',
-        rendered_content: '',
-        is_me_message: false,
         flags: [],
+        edit_timestamp: 10000,
         ...restArgs,
       };
     };

--- a/src/unread/__tests__/unreadModel-test.js
+++ b/src/unread/__tests__/unreadModel-test.js
@@ -150,7 +150,6 @@ describe('stream substate', () => {
         stream_id: 123,
         new_stream_id: 456,
         orig_subject: 'foo',
-        subject: 'foo',
       });
       const state = reducer(baseState, action, eg.plusReduxState);
       // prettier-ignore

--- a/src/unread/unreadModel.js
+++ b/src/unread/unreadModel.js
@@ -230,13 +230,8 @@ function streamsReducer(
       const { stream_id } = action;
       if (stream_id == null) {
         // Not stream messages, or else a pure content edit (no stream/topic change.)
-        //
-        // The docs actually promise this field for all updates to stream
-        // messages.  As of 2021-12 (circa feature level 111):
-        //   https://chat.zulip.org/#narrow/stream/378-api-design/topic/.60update_message.60.20event/near/1296823
-        // empirically it's present just on edits affecting either the
-        // stream or topic (so, absent on pure content edits), and the plan
-        // is to make it indeed present for all updates to stream messages.
+        // TODO(server-5.0): Simplify comment: since FL 112 this means it's
+        //   just not a stream message.
         return state;
       }
 

--- a/src/unread/unreadModel.js
+++ b/src/unread/unreadModel.js
@@ -27,6 +27,7 @@ import {
   MESSAGE_FETCH_COMPLETE,
   REGISTER_COMPLETE,
 } from '../actionConstants';
+import * as logging from '../utils/logging';
 
 //
 //
@@ -237,13 +238,21 @@ function streamsReducer(
         return state;
       }
       const newStreamId = action.new_stream_id ?? origStreamId;
-      const newTopic = action.subject;
-      const origTopic = action.orig_subject ?? newTopic;
+      const origTopic = action.orig_subject;
+      const newTopic = action.subject ?? origTopic;
 
       if (newTopic === origTopic && newStreamId === origStreamId) {
         // Stream and topic didn't change.
         return state;
       }
+
+      if (origTopic == null) {
+        // `orig_subject` is documented to be present when either the
+        // stream or topic changed.
+        logging.warn('Got update_message event with stream/topic change and no orig_subject');
+        return state;
+      }
+      invariant(newTopic != null, 'newTopic must be non-nullish when origTopic is, by `??`');
 
       const actionIds = new Set(action.message_ids);
       const matchingIds = state

--- a/src/unread/unreadModel.js
+++ b/src/unread/unreadModel.js
@@ -240,10 +240,7 @@ function streamsReducer(
       const newTopic = action.subject;
       const origTopic = action.orig_subject ?? newTopic;
 
-      if (
-        (action.subject === action.orig_subject || action.orig_subject == null)
-        && (action.new_stream_id === origStreamId || action.new_stream_id == null)
-      ) {
+      if (newTopic === origTopic && newStreamId === origStreamId) {
         // Stream and topic didn't change.
         return state;
       }


### PR DESCRIPTION
This updates our type for `update_message` events (or the Redux actions we make for them, type `EventUpdateMessageAction` with `type: EVENT_UPDATE_MESSAGE`) to reflect the fixes and clarifications in zulip/zulip#20693, and updates our actual logic to match.

In particular this fixes two small bugs:
* If messages are moved to a different stream but without editing the topic, no `subject` property is included in the event, only `orig_subject`. Previously this would confuse the unread-messages data structure -- we'd wind up with those message IDs under a topic of `undefined` (rather than a topic string). I don't know what the symptom of that would be: whether the unreads screen would just forget about those, or show them with a topic like "undefined" or "", or would crash.
* When a message has something that gets an inline preview, the server passes the message to clients immediately without waiting for the preview to be ready (because that can involve an HTTP request to a random, possibly-slow external service.) Then when the preview is ready, it comes as an `update_message` event. These events (a) are a bit funny-looking, and (b) shouldn't be included in the edit history. It turns out that handling (a) to the type-checker's satisfaction leads naturally to correctly implementing (b), so we just go ahead and do so.
  * This one is purely a latent bug, not a live one, because… we don't currently have a UI for showing the edit history at all. That's #4134. But the data this bit of code is maintaining is what that feature will rely on when it is implemented.

