### PR TITLE
checkout-keystore [nfc]: Use less-fancy Bash for filtering stderr

### DIFF
--- a/tools/checkout-keystore
+++ b/tools/checkout-keystore
@@ -51,25 +51,15 @@ sq_user_dir="${XDG_CONFIG_HOME:-${HOME}/.config}"/sq
 recipient_key="${sq_user_dir}"/"${key_name}".key.pgp
 
 # `sq decrypt` prints obnoxious, confusing output about the key file
-# to stderr.  Filter that out.
-#
-# This `coproc`, the `2>&…` below, and the `exec …>&-` and `wait` after,
-# combine to do the same thing as `sq decrypt … | grep -v …` would do,
-# except that the `grep` is inserted into the flow of file descriptor 2
-# (aka standard error) rather than file descriptor 1 (aka standard output.)
-#
-# The `coproc` feature was new in Bash 4.0 (released in 2009), so the
-# ancient /bin/bash on macOS doesn't support it; macOS users will need
-# to install a modern Bash with e.g. `brew install bash`.  This is a
-# maintainer script, so we don't worry about that.
-coproc grep -vE '^(Compressed|Encrypted) ' >&2
+# to stderr.  Filter that out (as a normal pipe-style filter, from
+# stdin to stdout.)
+filter_sq_stderr() {
+    grep -vE '^(Compressed|Encrypted) '
+}
 
 sq decrypt --recipient-key "${recipient_key}" \
   -o "${cleartext}" "${cryptotext}" \
-  2>&"${COPROC[1]}"
-
-exec {COPROC[1]}>&-
-wait $COPROC_PID || :
+  2> >(filter_sq_stderr >&2)
 
 wait_min=15
 (


### PR DESCRIPTION
Thanks to Anders for the suggestion:
  https://github.com/zulip/zulip-mobile/pull/5144#issuecomment-985778181

I wasn't sure if /dev/fd/N was available on macOS, but indeed it
seems to be, and this `>(…)` Bash syntax works just fine there.
(Even in the ancient /bin/bash that Apple ships.)

This sure is simpler to read!  Really not much different from
the usual case of applying a grep to a command's stdout.  More
shell-style, in the spirit of shell pipelines, while the `coproc`
approach feels lower-level.

I kept the grep command pulled out separate from the main `sq`
command, as a tiny shell function, in order to have a place to put
the comment explaining what it's there for.

Suggested-by: Anders Kaseorg <anders@zulip.com>

/cc @andersk 