### PR TITLE
api [nfc]: Start relying on server 1.9+

### DIFF
--- a/src/api/initialDataTypes.js
+++ b/src/api/initialDataTypes.js
@@ -335,11 +335,8 @@ export type InitialDataRealmUser = $ReadOnly<{|
 |}>;
 
 export type InitialDataRealmUserGroups = $ReadOnly<{|
-  /**
-   * Absent in servers prior to v1.8.0-rc1~2711 (or thereabouts).
-   */
-  // TODO(server-1.8): Mark as required.
-  realm_user_groups?: $ReadOnlyArray<UserGroup>,
+  // New in Zulip 1.8.
+  realm_user_groups: $ReadOnlyArray<UserGroup>,
 |}>;
 
 export type InitialDataRecentPmConversations = $ReadOnly<{|

--- a/src/api/modelTypes.js
+++ b/src/api/modelTypes.js
@@ -130,9 +130,9 @@ export type User = $ReadOnly<{|
   bot_owner?: string,
 
   // The ? is for future-proofing. Greg explains in 2020-02, at
-  // https://github.com/zulip/zulip-mobile/pull/3789#discussion_r378554698, that
-  // both human and bot Users will likely end up having a missing timezone
-  // instead of an empty string.
+  // https://github.com/zulip/zulip-mobile/pull/3789#discussion_r378554698 ,
+  // that both human and bot Users will likely end up having a missing
+  // timezone instead of an empty string.
   timezone?: string,
 
   /**
@@ -183,12 +183,10 @@ export type CrossRealmBot = $ReadOnly<{|
   is_bot: true,
   user_id: UserId,
 
-  // The timezone field has been included since commit 58ee3fa8c (in 1.9.0). Tim
-  // mentions in 2020-02, at
-  // https://github.com/zulip/zulip-mobile/pull/3789#issuecomment-581218576,
-  // that, as of the time of writing, it is always '' for bots, but it may be
-  // omitted later to reduce payload sizes. So, we're future-proofing this field
-  // by making it optional. See comment on the same field in User.
+  // The ? is for future-proofing.  For bots it's always '':
+  //   https://github.com/zulip/zulip-mobile/pull/3789#issuecomment-581218576
+  // so a future version may omit it to reduce payload sizes.  See comment
+  // on the same field in User.
   timezone?: string,
 |}>;
 

--- a/src/api/modelTypes.js
+++ b/src/api/modelTypes.js
@@ -108,9 +108,7 @@ export type User = $ReadOnly<{|
 
   full_name: string,
 
-  // date_joined included since commit 372e9740a (in 1.9.0)
-  // TODO(server-1.9): mark this as required
-  date_joined?: string,
+  date_joined: string,
 
   // is_active doesn't appear in `/register` responses -- instead,
   // users where is_active is true go in `realm_users`, and where false
@@ -178,10 +176,7 @@ export type CrossRealmBot = $ReadOnly<{|
    */
   avatar_url: AvatarURL,
 
-  // date_joined included since commit 58ee3fa8c (in 1.9.0)
-  // TODO(server-1.9): mark this as required
-  date_joined?: string,
-
+  date_joined: string,
   email: string,
   full_name: string,
   is_admin: boolean,

--- a/src/api/notificationTypes.js
+++ b/src/api/notificationTypes.js
@@ -3,42 +3,74 @@
 import { type UserId } from './idTypes';
 
 // This format is as of 2020-02, commit 3.0~3347.
-type BaseData = $ReadOnly<{|
-  message_ids: [number], // single-element tuple!
-
-  realm_uri: string, // as in `/server_settings` response
+type BaseData = {|
+  /** The realm URL, same as in the `/server_settings` response. */
+  +realm_uri: string,
 
   // The server and realm_id are an obsolete substitute for realm_uri.
-  server: string, // settings.EXTERNAL_HOST
-  realm_id: number, // server-internal realm identifier
+  -server: string, // settings.EXTERNAL_HOST
+  -realm_id: number, // server-internal realm identifier
 
-  // The user this notification is addressed to; our self-user.
-  // (This lets us distinguish different accounts in the same realm.)
+  /**
+   * The user this notification is addressed to; our self-user.
+   *
+   * (This lets us distinguish different accounts in the same realm.)
+   */
   // added 2.1-dev-540-g447a517e6f, release 2.1.0+
   // TODO(server-2.1): Simplify comment.
-  user_id: UserId, // recipient id
+  +user_id: UserId,
 
-  sender_email: string,
-  sender_id: UserId,
-|}>;
+  // The rest of the data is about the Zulip message we're being notified
+  // about.
 
-type StreamData = $ReadOnly<{|
+  +message_ids: [number], // single-element tuple!
+
+  +sender_id: UserId,
+  +sender_email: string,
+
+  // (... And see StreamData and PmData below.)
+|};
+
+/** For a notification about a stream message. */
+type StreamData = {|
   ...BaseData,
-  recipient_type: 'stream',
-  stream: string,
-  topic: string,
-|}>;
+  +recipient_type: 'stream',
 
-type PmData = $ReadOnly<{|
+  /**
+   * The name of the message's stream.
+   *
+   * Sadly no stream ID: https://github.com/zulip/zulip/issues/18067
+   */
+  +stream: string,
+
+  +topic: string,
+|};
+
+/** For a notification about a PM. */
+type PmData = {|
   ...BaseData,
-  recipient_type: 'private',
+  +recipient_type: 'private',
 
-  // present only on group PMs
-  pm_users?: string, // CSV of int (user ids)
-|}>;
+  /**
+   * The recipient user IDs, if this is a group PM; absent for 1:1 PMs.
+   *
+   * The user IDs are comma-separated ASCII decimal.
+   *
+   * (Does it include the self-user?  Are they sorted?  Unknown.)
+   */
+  +pm_users?: string,
+|};
 
 /** An APNs message sent by the Zulip server. */
-export type ApnsPayload = $ReadOnly<{
-  zulip: StreamData | PmData,
-  ...
-}>;
+export type ApnsPayload = {|
+  /** Our own data. */
+  +zulip: StreamData | PmData,
+
+  /**
+   * Various Apple-specified fields.
+   *
+   * Upstream docs here:
+   *   https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/generating_a_remote_notification
+   */
+  +aps: { ... },
+|};

--- a/src/api/notificationTypes.js
+++ b/src/api/notificationTypes.js
@@ -1,0 +1,44 @@
+// @flow strict-local
+
+import { type UserId } from './idTypes';
+
+// This format is as of 2020-02, commit 3.0~3347.
+type BaseData = $ReadOnly<{|
+  message_ids: [number], // single-element tuple!
+
+  realm_uri: string, // as in `/server_settings` response
+
+  // The server and realm_id are an obsolete substitute for realm_uri.
+  server: string, // settings.EXTERNAL_HOST
+  realm_id: number, // server-internal realm identifier
+
+  // The user this notification is addressed to; our self-user.
+  // (This lets us distinguish different accounts in the same realm.)
+  // added 2.1-dev-540-g447a517e6f, release 2.1.0+
+  // TODO(server-2.1): Simplify comment.
+  user_id: UserId, // recipient id
+
+  sender_email: string,
+  sender_id: UserId,
+|}>;
+
+type StreamData = $ReadOnly<{|
+  ...BaseData,
+  recipient_type: 'stream',
+  stream: string,
+  topic: string,
+|}>;
+
+type PmData = $ReadOnly<{|
+  ...BaseData,
+  recipient_type: 'private',
+
+  // present only on group PMs
+  pm_users?: string, // CSV of int (user ids)
+|}>;
+
+/** An APNs message sent by the Zulip server. */
+export type ApnsPayload = $ReadOnly<{
+  zulip: StreamData | PmData,
+  ...
+}>;

--- a/src/api/transportTypes.js
+++ b/src/api/transportTypes.js
@@ -52,25 +52,23 @@ export type ApiResponseSuccess = $ReadOnly<{
 }>;
 
 /**
+ * An identifier-like string identifying a Zulip API error.
+ *
+ * See API docs on error handling:
+ *   https://zulip.com/api/rest-error-handling
+ *
+ * (And at present, 2022-01, those are rather buggy.  So see also:
+ *   https://chat.zulip.org/#narrow/stream/378-api-design/topic/error.20docs/near/1308989
+ * )
+ *
  * A list of current error codes can be found at:
  *   https://github.com/zulip/zulip/blob/main/zerver/lib/exceptions.py
  *
- * Unfortunately, the `code` property is a relatively late addition to the
- * Zulip API, introduced for version 1.7.0. [1]  The modern default, when no
- * other code has been defined, is 'BAD_REQUEST'; we therefore synthesize
- * that value when connecting to old servers that don't provide an error
- * code.
- *
- * TODO(server-1.7): Simplify this.
- *
- * [1] Specifically at 1.7.0~2354 and ancestors, aka 9faa44af6^..709c3b50fc .
- *     See: https://github.com/zulip/zulip/commit/709c3b50fc
- *
- * It's tempting to make ApiErrorCode an enumerated type, save for the dual
- * problem: when connecting to _newer_ Zulip servers, we may see values of
- * `code` not known to this version of the client! In particular, new error
- * codes are occasionally assigned to existing classes of error which previously
- * returned 'BAD_REQUEST'.
+ * It's tempting to make ApiErrorCode an enumerated type, but: when
+ * connecting to newer Zulip servers, we may see values of `code` not known
+ * to this version of the client!  In particular, new error codes are
+ * occasionally assigned to existing classes of error which previously
+ * returned the generic 'BAD_REQUEST'.
  *
  * (Note that "newer" here doesn't necessarily mean "newer than this client",
  * but "newer than the last time someone updated the error code list from the

--- a/src/api/transportTypes.js
+++ b/src/api/transportTypes.js
@@ -64,22 +64,21 @@ export type ApiResponseSuccess = $ReadOnly<{
  * A list of current error codes can be found at:
  *   https://github.com/zulip/zulip/blob/main/zerver/lib/exceptions.py
  *
- * It's tempting to make ApiErrorCode an enumerated type, but: when
- * connecting to newer Zulip servers, we may see values of `code` not known
- * to this version of the client!  In particular, new error codes are
- * occasionally assigned to existing classes of error which previously
- * returned the generic 'BAD_REQUEST'.
- *
- * (Note that "newer" here doesn't necessarily mean "newer than this client",
- * but "newer than the last time someone updated the error code list from the
- * server". We have no mechanism in place to share the set of error codes --
- * and, given the facts above, it's not clear that the existence of such a
- * mechanism would be helpful anyway.)
- *
- * Though unstable in the general case, `code` is still useful.  It _is_
- * guaranteed to be stable for certain known classes of errors.
- * Nonetheless: let its user beware.
+ * Note that most possible values of `code` are not documented in the API,
+ * and may change in future versions.  This is especially likely when an
+ * error gives the generic `code: 'BAD_REQUEST'`.  When writing logic to
+ * rely on a `code` value, it's best to make sure it gets written into the
+ * API documentation.
  */
+// It's tempting to make ApiErrorCode an enumerated type, but: when
+// connecting to newer Zulip servers, we may see values of `code` not known
+// to this version of the client!
+//
+// (Note that "newer" here doesn't necessarily mean "newer than this client",
+// but "newer than the last time someone updated the error code list from the
+// server". We have no mechanism in place to share the set of error codes --
+// and, given the facts above, it's not clear that the existence of such a
+// mechanism would be helpful anyway.)
 export type ApiErrorCode = string;
 
 /**

--- a/src/notification/extract.js
+++ b/src/notification/extract.js
@@ -18,47 +18,29 @@ const asDict = (obj: JSONableInput | void): JSONableInputDict | void => {
 };
 
 /*
-    The Zulip APNs message format, as far back as 2013-03-23 [0], has always
-    been some subtype of the following:
-
-        type Data = { zulip: { ... } }
-
-    (Comments in `zerver/lib/push_notifications.py` may appear to indicate
-    otherwise, but these refer only to the format of inter-server messages for
-    the Zulip-hosted push-notification bouncer service. Messages sent over APNs
-    itself have always had a `zulip` field.)
-
-    [0] GitHub commit 410ee44eb6e40bac4099d1851d949533026fe4b3.
-
-    The original payload was merely `{ message_ids: [number] }`, but this has
-    been expanded incrementally over the years. As of 2020-02, commit
-    2.2-dev-775-g10e7e15088 (released with 3.0, as "2.2" became 3.0), the
-    current form of APNs messages is as follows:
+    The Zulip APNs message format is as follows
+    (as of 2020-02, commit 3.0~3347):
 
     ```
     type StreamData = {
-        // added 1.7.0-1351-g98943a8333, release 1.8.0+
         recipient_type: 'stream',
         stream: string,
         topic: string,
     };
 
     type PmData = {
-        // added 1.7.0-1351-g98943a8333, release 1.8.0+
         recipient_type: 'private',
 
-        // added 1.7.0-2360-g693a9a5e70, release 1.8.0+
         // present only on group PMs
         pm_users?: string,  // CSV of int (user ids)
     };
 
     type Data = { zulip: {
-        // present since antiquity
         message_ids: [number],  // single-element tuple!
 
-        // added 1.7.0-1351-g98943a8333, release 1.8.0+
         sender_email: string,
         sender_id: UserId,
+
         server: string,     // settings.EXTERNAL_HOST
         realm_id: number,   // server-internal realm identifier
 
@@ -72,21 +54,20 @@ const asDict = (obj: JSONableInput | void): JSONableInputDict | void => {
     } };
     ```
 
-    Note that prior to 1.7.0-1351-g98943a8333, we only received the
-    `message_ids` field. Messages of this form are not useful.
+    Many of these fields were first introduced in Zulip 1.8; forms of data
+    from before that are not very useful.
 
-    The pair `(server, realm_id)`, added in the same commit, uniquely identifies
-    a Zulip realm, and was originally intended to permit the client to associate
-    a notification with its associated realm. Unfortunately, there is no way to
-    get either of these from a server via the API, so this would not be possible
-    until the addition of `realm_uri` in 1.8.0-2150-g5f8d193bb7...
+    The pair `(server, realm_id)` uniquely identifies a Zulip realm, and was
+    originally intended to permit the client to associate a notification
+    with its associated realm.  Unfortunately, there is no way to get either
+    of these from a server via the API, so this would not be possible until
+    the addition of `realm_uri` in 1.8.0-2150-g5f8d193bb7...
 
     ... which still didn't permit differentiating between multiple accounts on
     the same realm. This was only made possible by the addition of the `user_id`
     field, in 2.1-dev-540-g447a517e6f.
 
-    TODO(server-1.8): Simplify this comment a lot.
-    TODO(server-1.9): Simplify further.
+    TODO(server-1.9): Simplify the above comment.
     TODO(server-2.1): Simplify further.
 */
 

--- a/src/notification/extract.js
+++ b/src/notification/extract.js
@@ -38,37 +38,24 @@ const asDict = (obj: JSONableInput | void): JSONableInputDict | void => {
     type Data = { zulip: {
         message_ids: [number],  // single-element tuple!
 
-        sender_email: string,
-        sender_id: UserId,
-
+        realm_uri: string,  // as in `/server_settings` response
+        // The server and realm_id are an obsolete substitute for realm_uri.
         server: string,     // settings.EXTERNAL_HOST
         realm_id: number,   // server-internal realm identifier
 
-        // added 1.8.0-2150-g5f8d193bb7, release 1.9.0+
-        realm_uri: string,  // as in `/server_settings` response
-
+        // The user this notification is addressed to; our self-user.
+        // (This lets us distinguish different accounts in the same realm.)
         // added 2.1-dev-540-g447a517e6f, release 2.1.0+
         user_id: UserId,    // recipient id
+
+        sender_email: string,
+        sender_id: UserId,
 
         ...(StreamData | PmData),
     } };
     ```
 
-    Many of these fields were first introduced in Zulip 1.8; forms of data
-    from before that are not very useful.
-
-    The pair `(server, realm_id)` uniquely identifies a Zulip realm, and was
-    originally intended to permit the client to associate a notification
-    with its associated realm.  Unfortunately, there is no way to get either
-    of these from a server via the API, so this would not be possible until
-    the addition of `realm_uri` in 1.8.0-2150-g5f8d193bb7...
-
-    ... which still didn't permit differentiating between multiple accounts on
-    the same realm. This was only made possible by the addition of the `user_id`
-    field, in 2.1-dev-540-g447a517e6f.
-
-    TODO(server-1.9): Simplify the above comment.
-    TODO(server-2.1): Simplify further.
+    TODO(server-2.1): Simplify the above comment.
 */
 
 /** Local error type. */

--- a/src/notification/index.js
+++ b/src/notification/index.js
@@ -36,9 +36,8 @@ export const getAccountFromNotificationData = (
 ): number | null => {
   const { realm_uri, user_id } = data;
   if (realm_uri == null) {
-    // Old server, no realm info included.  If needed to cater to 1.8.x
-    // servers, could try to guess using serverHost; for now, don't.
-    // TODO(server-1.8): Simplify this comment.
+    // Old server, no realm info included.  This field appeared in
+    // Zulip 1.8, so we don't support these servers anyway.
     logging.warn('notification missing field: realm_uri');
     return null;
   }

--- a/src/utils/avatar.js
+++ b/src/utils/avatar.js
@@ -34,20 +34,12 @@ export class AvatarURL {
   |}): AvatarURL {
     const { rawAvatarUrl, userId, email, realm } = args;
     if (rawAvatarUrl === undefined) {
-      // New in Zulip 3.0, feature level 18, the field may be missing
-      // on user objects in the register response, at the server's
-      // discretion, if we announce the
-      // `user_avatar_url_field_optional` client capability, which we
-      // do. See the note about `user_avatar_url_field_optional` at
-      // https://zulip.com/api/register-queue.
+      // New in Zulip 3.0, feature level 18, the field may be missing on
+      // user objects in the register response, at the server's discretion,
+      // if we announce the `user_avatar_url_field_optional` client
+      // capability, which we do.  See `user_avatar_url_field_optional` at:
+      //   https://zulip.com/api/register-queue
       //
-      // It will also be absent on cross-realm bots from servers prior
-      // to 58ee3fa8c (1.9.0). The effect of using FallbackAvatarURL for
-      // this case isn't thoroughly considered, but at worst, it means a
-      // 404. We could plumb through the server version and
-      // conditionalize on that.
-      //
-      // TODO(server-1.9): Simplify this comment.
       // TODO(server-3.0): Simplify this comment.
       return FallbackAvatarURL.validateAndConstructInstance({ realm, userId });
     } else if (rawAvatarUrl === null) {


### PR DESCRIPTION
This follows up on #5100, eliminating the various wrinkles we had for accommodating servers older than 1.9. This comprises:
* 1 for before Zulip 1.7 (released 2017-10)
* 3 for before Zulip 1.8 (released 2018-04)
* 4 for before Zulip 1.9 (released 2018-11)

The changes turn out to be entirely to types and comments. In 401b3a2e339139b59c7415e0abbbba6bbbe13e63 (#5100) we removed a significant amount of actual runtime logic that was for pre-1.8 servers, but I guess for this range of server versions we've already taken care of everything like that.

Zulip Server 2.0 will be a bigger deal: in particular it introduced user IDs and stream IDs in a number of places, as alternatives to emails and stream names.
