### PR TITLE
message: Handle server stealth-edits a bit more broadly

### DIFF
--- a/src/actionTypes.js
+++ b/src/actionTypes.js
@@ -344,7 +344,11 @@ type EventMessageDeleteAction = $ReadOnly<{|
 type EventUpdateMessageAction = $ReadOnly<{|
   ...ServerEvent,
   type: typeof EVENT_UPDATE_MESSAGE,
-  user_id?: UserId,
+
+  // Future servers might send `null` here:
+  //   https://chat.zulip.org/#narrow/stream/378-api-design/topic/.60update_message.60.20event/near/1309241
+  // TODO(server-5.0): Update this and/or simplify.
+  user_id?: UserId | null,
 
   // Any content changes apply to just message_id.
   message_id: number,

--- a/src/message/messagesReducer.js
+++ b/src/message/messagesReducer.js
@@ -142,7 +142,7 @@ export default (
         }
 
         const historyEntry = (() => {
-          if (action.edit_timestamp === undefined || action.user_id === undefined) {
+          if (action.edit_timestamp == null || action.user_id == null) {
             // The update isn't a real edit; rather it's just filling in an
             // inline URL preview (which can require the server to make an
             // external request, so we don't let it block delivering the


### PR DESCRIPTION
Future server versions may start sending `user_id: null` for these,
rather than omitting it:
  https://chat.zulip.org/#narrow/stream/378-api-design/topic/.60update_message.60.20event/near/1309241

To future-proof this code for that case, have it treat the update
as a stealth-edit if one of these fields is null, as well as if it's
omitted.