### PR TITLE
UsersScreen: Fixed the keyboard pop up unwantedly.

### DIFF
--- a/src/users/UsersScreen.js
+++ b/src/users/UsersScreen.js
@@ -16,7 +16,7 @@ export default function UsersScreen(props: Props): Node {
   const [filter, setFilter] = useState<string>('');
 
   return (
-    <Screen search autoFocus scrollEnabled={false} searchBarOnChange={setFilter}>
+    <Screen search scrollEnabled={false} searchBarOnChange={setFilter}>
       <UsersCard filter={filter} />
     </Screen>
   );


### PR DESCRIPTION
Keyboard Pops up unwantedly when you press `New PM` button and move towards the `UsersScreen`. This commit fixes this issue.
[See Discussion](https://chat.zulip.org/#narrow/stream/48-mobile/topic/keyboard.20issues/near/1303350)
Fixes: #5185