### PR TITLE
action-sheets types: Simplify BackgroundData uses slightly

### DIFF
--- a/src/action-sheets/index.js
+++ b/src/action-sheets/index.js
@@ -514,7 +514,6 @@ export const showMessageActionSheet = ({
   |},
   backgroundData: $ReadOnly<{
     auth: Auth,
-    subscriptions: Map<number, Subscription>,
     ownUser: User,
     flags: FlagsState,
     ...
@@ -556,7 +555,6 @@ export const showTopicActionSheet = ({
     subscriptions: Map<number, Subscription>,
     unread: UnreadState,
     ownUser: User,
-    flags: FlagsState,
     ...
   }>,
   streamId: number,


### PR DESCRIPTION
Spotted these while looking at where `flags` is used from
BackgroundData.

We use both these properties in other places, even in this file,
so these don't let us do anything like remove things from the
background data outright.