### PR TITLE
narrow: Store stream IDs instead of names!

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -75,12 +75,13 @@ rules:
   # of Airbnb's settings where we don't want a full repeal.
   #
 
-  # Tricky code.
+  # Tricky-looking code.  These are all sometimes perfectly legitimate.
   no-bitwise: off
   no-confusing-arrow: off
   no-continue: off
   no-plusplus: off
   no-nested-ternary: off
+  no-control-regex: off
 
   # We prefer `let foo = undefined;` over `let foo;`, not vice versa.
   #

--- a/android/app/src/main/java/com/zulipmobile/notifications/FcmMessage.kt
+++ b/android/app/src/main/java/com/zulipmobile/notifications/FcmMessage.kt
@@ -55,7 +55,7 @@ sealed class Recipient {
     }
 
     /** A stream message. */
-    data class Stream(val stream: String, val topic: String) : Recipient()
+    data class Stream(val streamName: String, val topic: String) : Recipient()
 }
 
 /**
@@ -116,7 +116,7 @@ data class MessageFcmMessage(
         when (recipient) {
             is Recipient.Stream -> {
                 putString("recipient_type", "stream")
-                putString("stream", recipient.stream)
+                putString("stream_name", recipient.streamName)
                 putString("topic", recipient.topic)
             }
             is Recipient.GroupPm -> {

--- a/android/app/src/main/java/com/zulipmobile/notifications/NotificationUiManager.kt
+++ b/android/app/src/main/java/com/zulipmobile/notifications/NotificationUiManager.kt
@@ -259,7 +259,7 @@ private fun extractConversationKey(fcmMessage: MessageFcmMessage): String {
         // So long as this does use the stream name, we use `\u0000` as the delimiter because
         // it's the one character not allowed in Zulip stream names.
         // (See `check_stream_name` in zulip.git:zerver/lib/streams.py.)
-        is Recipient.Stream -> "stream:${fcmMessage.recipient.stream}\u0000${fcmMessage.recipient.topic}"
+        is Recipient.Stream -> "stream:${fcmMessage.recipient.streamName}\u0000${fcmMessage.recipient.topic}"
         is Recipient.GroupPm -> "groupPM:${fcmMessage.recipient.pmUsers.toString()}"
         is Recipient.Pm -> "private:${fcmMessage.sender.id}"
     }
@@ -321,7 +321,7 @@ private fun updateNotification(
     // group-PM threads (pending #5116) get titled with the latest sender, rather than
     // the first.
     messagingStyle.setConversationTitle(when (fcmMessage.recipient) {
-        is Recipient.Stream -> "#${fcmMessage.recipient.stream} > ${fcmMessage.recipient.topic}"
+        is Recipient.Stream -> "#${fcmMessage.recipient.streamName} > ${fcmMessage.recipient.topic}"
         // TODO(#5116): use proper title for GroupPM, for which we will need
         //   to have a way to get names of PM users here.
         is Recipient.GroupPm -> context.resources.getQuantityString(

--- a/android/app/src/test/java/com/zulipmobile/notifications/FcmMessageTest.kt
+++ b/android/app/src/test/java/com/zulipmobile/notifications/FcmMessageTest.kt
@@ -127,7 +127,7 @@ class MessageFcmMessageTest : FcmMessageTestBase() {
                 ),
                 zulipMessageId = 12345,
                 recipient = Recipient.Stream(
-                    stream = Example.stream["stream"]!!,
+                    streamName = Example.stream["stream"]!!,
                     topic = Example.stream["topic"]!!
                 ),
                 content = Example.stream["content"]!!,

--- a/src/__tests__/lib/exampleData.js
+++ b/src/__tests__/lib/exampleData.js
@@ -269,6 +269,10 @@ export const stream: Stream = makeStream({
   name: 'a stream',
   description: 'An example stream.',
 });
+export const otherStream: Stream = makeStream({
+  name: 'another stream',
+  description: 'Another example stream.',
+});
 
 /** A subscription, by default to eg.stream. */
 export const makeSubscription = (
@@ -291,6 +295,9 @@ export const makeSubscription = (
 
 /** A subscription to eg.stream. */
 export const subscription: Subscription = makeSubscription();
+
+/** A subscription to eg.otherStream. */
+export const otherSubscription: Subscription = makeSubscription({ stream: otherStream });
 
 /* ========================================================================
  * Messages
@@ -572,8 +579,8 @@ export const plusReduxState: GlobalState & PerAccountState = reduxState({
   realm: { ...baseReduxState.realm, user_id: selfUser.user_id, email: selfUser.email },
   // TODO add crossRealmBot
   users: [selfUser, otherUser, thirdUser],
-  streams: [stream],
-  subscriptions: [subscription],
+  streams: [stream, otherStream],
+  subscriptions: [subscription, otherSubscription],
 });
 
 /**

--- a/src/__tests__/lib/exampleData.js
+++ b/src/__tests__/lib/exampleData.js
@@ -47,12 +47,7 @@ import rootReducer from '../../boot/reducers';
 import { authOfAccount } from '../../account/accountMisc';
 import { HOME_NARROW } from '../../utils/narrow';
 import type { BackgroundData } from '../../webview/MessageList';
-import {
-  getSettings,
-  getStreamsById,
-  getStreamsByName,
-  getSubscriptionsById,
-} from '../../selectors';
+import { getSettings, getStreamsById, getSubscriptionsById } from '../../selectors';
 
 /* ========================================================================
  * Utilities
@@ -852,7 +847,6 @@ export const backgroundData: BackgroundData = deepFreeze({
   mutedUsers: Immutable.Map(),
   ownUser: selfUser,
   streams: getStreamsById(baseReduxState),
-  streamsByName: getStreamsByName(baseReduxState),
   subscriptions: getSubscriptionsById(baseReduxState),
   unread: baseReduxState.unread,
   theme: 'default',

--- a/src/autocomplete/StreamAutocomplete.js
+++ b/src/autocomplete/StreamAutocomplete.js
@@ -6,7 +6,7 @@ import { FlatList } from 'react-native';
 
 import { useSelector } from '../react-redux';
 import { Popup } from '../common';
-import { getSubscribedStreams } from '../subscriptions/subscriptionSelectors';
+import { getSubscriptions } from '../directSelectors';
 import StreamItem from '../streams/StreamItem';
 
 type Props = $ReadOnly<{|
@@ -16,7 +16,7 @@ type Props = $ReadOnly<{|
 
 export default function StreamAutocomplete(props: Props): Node {
   const { filter, onAutocomplete } = props;
-  const subscriptions = useSelector(getSubscribedStreams);
+  const subscriptions = useSelector(getSubscriptions);
 
   const handleStreamItemAutocomplete = useCallback(
     (streamId: number, streamName: string): void => {

--- a/src/chat/ChatScreen.js
+++ b/src/chat/ChatScreen.js
@@ -138,9 +138,7 @@ export default function ChatScreen(props: Props): Node {
         const content = editMessage.content !== message ? message : undefined;
         const subject = caseNarrowDefault(
           destinationNarrow,
-          {
-            topic: (_1, topic, streamId) => (topic !== editMessage.topic ? topic : undefined),
-          },
+          { topic: (streamId, topic) => (topic !== editMessage.topic ? topic : undefined) },
           () => undefined,
         );
 

--- a/src/chat/ChatScreen.js
+++ b/src/chat/ChatScreen.js
@@ -138,7 +138,9 @@ export default function ChatScreen(props: Props): Node {
         const content = editMessage.content !== message ? message : undefined;
         const subject = caseNarrowDefault(
           destinationNarrow,
-          { topic: (stream, topic) => (topic !== editMessage.topic ? topic : undefined) },
+          {
+            topic: (_1, topic, streamId) => (topic !== editMessage.topic ? topic : undefined),
+          },
           () => undefined,
         );
 

--- a/src/chat/MarkAsReadButton.js
+++ b/src/chat/MarkAsReadButton.js
@@ -8,14 +8,14 @@ import { createStyleSheet } from '../styles';
 import { useSelector } from '../react-redux';
 import { ZulipButton } from '../common';
 import * as api from '../api';
-import { getAuth, getStreams, getOwnUserId } from '../selectors';
+import { getAuth, getOwnUserId } from '../selectors';
 import { getUnread, getUnreadIdsForPmNarrow } from '../unread/unreadModel';
 import {
   isHomeNarrow,
   isStreamNarrow,
   isTopicNarrow,
   isPmNarrow,
-  streamNameOfNarrow,
+  streamIdOfNarrow,
   topicOfNarrow,
 } from '../utils/narrow';
 
@@ -35,7 +35,6 @@ type Props = $ReadOnly<{|
 export default function MarkAsReadButton(props: Props): Node {
   const { narrow } = props;
   const auth = useSelector(getAuth);
-  const streams = useSelector(getStreams);
   const unread = useSelector(getUnread);
   const ownUserId = useSelector(getOwnUserId);
 
@@ -44,20 +43,12 @@ export default function MarkAsReadButton(props: Props): Node {
   }, [auth]);
 
   const markStreamAsRead = useCallback(() => {
-    const streamName = streamNameOfNarrow(narrow);
-    const stream = streams.find(s => s.name === streamName);
-    if (stream) {
-      api.markStreamAsRead(auth, stream.stream_id);
-    }
-  }, [auth, narrow, streams]);
+    api.markStreamAsRead(auth, streamIdOfNarrow(narrow));
+  }, [auth, narrow]);
 
   const markTopicAsRead = useCallback(() => {
-    const streamName = streamNameOfNarrow(narrow);
-    const stream = streams.find(s => s.name === streamName);
-    if (stream) {
-      api.markTopicAsRead(auth, stream.stream_id, topicOfNarrow(narrow));
-    }
-  }, [auth, narrow, streams]);
+    api.markTopicAsRead(auth, streamIdOfNarrow(narrow), topicOfNarrow(narrow));
+  }, [auth, narrow]);
 
   const markPmAsRead = useCallback(() => {
     // The message IDs come from our unread-messages data, which is

--- a/src/chat/__tests__/fetchingReducer-test.js
+++ b/src/chat/__tests__/fetchingReducer-test.js
@@ -41,7 +41,7 @@ describe('fetchingReducer', () => {
         [HOME_NARROW_STR]: { older: false, newer: false },
       });
 
-      const narrow = streamNarrow(eg.stream.name, eg.stream.stream_id);
+      const narrow = streamNarrow(eg.stream.stream_id);
       const action = deepFreeze({
         type: MESSAGE_FETCH_START,
         narrow,

--- a/src/chat/__tests__/fetchingReducer-test.js
+++ b/src/chat/__tests__/fetchingReducer-test.js
@@ -41,16 +41,17 @@ describe('fetchingReducer', () => {
         [HOME_NARROW_STR]: { older: false, newer: false },
       });
 
+      const narrow = streamNarrow(eg.stream.name);
       const action = deepFreeze({
         type: MESSAGE_FETCH_START,
-        narrow: streamNarrow('some stream'),
+        narrow,
         numBefore: 10,
         numAfter: 0,
       });
 
       const expectedState = {
         [HOME_NARROW_STR]: { older: false, newer: false },
-        [keyFromNarrow(streamNarrow('some stream'))]: { older: true, newer: false },
+        [keyFromNarrow(narrow)]: { older: true, newer: false },
       };
 
       const newState = fetchingReducer(initialState, action);

--- a/src/chat/__tests__/fetchingReducer-test.js
+++ b/src/chat/__tests__/fetchingReducer-test.js
@@ -41,7 +41,7 @@ describe('fetchingReducer', () => {
         [HOME_NARROW_STR]: { older: false, newer: false },
       });
 
-      const narrow = streamNarrow(eg.stream.name);
+      const narrow = streamNarrow(eg.stream.name, eg.stream.stream_id);
       const action = deepFreeze({
         type: MESSAGE_FETCH_START,
         narrow,

--- a/src/chat/__tests__/narrowsReducer-test.js
+++ b/src/chat/__tests__/narrowsReducer-test.js
@@ -27,9 +27,9 @@ import * as eg from '../../__tests__/lib/exampleData';
 describe('narrowsReducer', () => {
   const privateNarrowStr = keyFromNarrow(pm1to1NarrowFromUser(eg.otherUser));
   const groupNarrowStr = keyFromNarrow(pmNarrowFromUsersUnsafe([eg.otherUser, eg.thirdUser]));
-  const streamNarrowStr = keyFromNarrow(streamNarrow(eg.stream.name, eg.stream.stream_id));
+  const streamNarrowStr = keyFromNarrow(streamNarrow(eg.stream.stream_id));
   const egTopic = eg.streamMessage().subject;
-  const topicNarrowStr = keyFromNarrow(topicNarrow(eg.stream.name, eg.stream.stream_id, egTopic));
+  const topicNarrowStr = keyFromNarrow(topicNarrow(eg.stream.stream_id, egTopic));
 
   describe('EVENT_NEW_MESSAGE', () => {
     test('if not caught up in narrow, do not add message in home narrow', () => {

--- a/src/chat/__tests__/narrowsReducer-test.js
+++ b/src/chat/__tests__/narrowsReducer-test.js
@@ -27,9 +27,9 @@ import * as eg from '../../__tests__/lib/exampleData';
 describe('narrowsReducer', () => {
   const privateNarrowStr = keyFromNarrow(pm1to1NarrowFromUser(eg.otherUser));
   const groupNarrowStr = keyFromNarrow(pmNarrowFromUsersUnsafe([eg.otherUser, eg.thirdUser]));
-  const streamNarrowStr = keyFromNarrow(streamNarrow(eg.stream.name));
+  const streamNarrowStr = keyFromNarrow(streamNarrow(eg.stream.name, eg.stream.stream_id));
   const egTopic = eg.streamMessage().subject;
-  const topicNarrowStr = keyFromNarrow(topicNarrow(eg.stream.name, egTopic));
+  const topicNarrowStr = keyFromNarrow(topicNarrow(eg.stream.name, eg.stream.stream_id, egTopic));
 
   describe('EVENT_NEW_MESSAGE', () => {
     test('if not caught up in narrow, do not add message in home narrow', () => {

--- a/src/chat/__tests__/narrowsSelectors-test.js
+++ b/src/chat/__tests__/narrowsSelectors-test.js
@@ -356,7 +356,7 @@ describe('isNarrowValid', () => {
     const state = eg.reduxState({
       streams: [],
     });
-    const narrow = streamNarrow('nonexisting');
+    const narrow = streamNarrow(eg.stream.name);
 
     const result = isNarrowValid(state, narrow);
 

--- a/src/chat/__tests__/narrowsSelectors-test.js
+++ b/src/chat/__tests__/narrowsSelectors-test.js
@@ -146,7 +146,7 @@ describe('getShownMessagesForNarrow', () => {
   });
 
   describe('stream narrow', () => {
-    const narrow = streamNarrow(stream.name, stream.stream_id);
+    const narrow = streamNarrow(stream.stream_id);
     const makeState = extra => makeStateGeneral(message, narrow, extra);
     const shown = state => shownGeneral(state, narrow);
 
@@ -171,7 +171,7 @@ describe('getShownMessagesForNarrow', () => {
   });
 
   describe('topic narrow', () => {
-    const narrow = topicNarrow(stream.name, stream.stream_id, message.subject);
+    const narrow = topicNarrow(stream.stream_id, message.subject);
     const makeState = extra => makeStateGeneral(message, narrow, extra);
     const shown = state => shownGeneral(state, narrow);
 
@@ -306,26 +306,26 @@ describe('getStreamInNarrow', () => {
   });
 
   test('return subscription if stream in narrow is subscribed', () => {
-    const narrow = streamNarrow(stream1.name, stream1.stream_id);
+    const narrow = streamNarrow(stream1.stream_id);
 
     expect(getStreamInNarrow(state, narrow)).toEqual(sub1);
   });
 
   test('return stream if stream in narrow is not subscribed', () => {
-    const narrow = streamNarrow(stream3.name, stream3.stream_id);
+    const narrow = streamNarrow(stream3.stream_id);
 
     expect(getStreamInNarrow(state, narrow)).toEqual({ ...stream3, in_home_view: true });
   });
 
   test('return NULL_SUBSCRIPTION if stream in narrow is not valid', () => {
-    const narrow = streamNarrow(stream4.name, stream4.stream_id);
+    const narrow = streamNarrow(stream4.stream_id);
 
     expect(getStreamInNarrow(state, narrow)).toEqual(NULL_SUBSCRIPTION);
   });
 
   test('return NULL_SUBSCRIPTION is narrow is not topic or stream', () => {
     expect(getStreamInNarrow(state, pm1to1NarrowFromUser(eg.otherUser))).toEqual(NULL_SUBSCRIPTION);
-    expect(getStreamInNarrow(state, topicNarrow(stream4.name, stream4.stream_id, 'topic'))).toEqual(
+    expect(getStreamInNarrow(state, topicNarrow(stream4.stream_id, 'topic'))).toEqual(
       NULL_SUBSCRIPTION,
     );
   });
@@ -347,7 +347,7 @@ describe('isNarrowValid', () => {
     const state = eg.reduxState({
       streams: [stream],
     });
-    const narrow = streamNarrow(stream.name, stream.stream_id);
+    const narrow = streamNarrow(stream.stream_id);
 
     const result = isNarrowValid(state, narrow);
 
@@ -358,7 +358,7 @@ describe('isNarrowValid', () => {
     const state = eg.reduxState({
       streams: [],
     });
-    const narrow = streamNarrow(eg.stream.name, eg.stream.stream_id);
+    const narrow = streamNarrow(eg.stream.stream_id);
 
     const result = isNarrowValid(state, narrow);
 
@@ -371,7 +371,7 @@ describe('isNarrowValid', () => {
     const state = eg.reduxState({
       streams: [stream],
     });
-    const narrow = topicNarrow(stream.name, stream.stream_id, 'topic does not matter');
+    const narrow = topicNarrow(stream.stream_id, 'topic does not matter');
 
     const result = isNarrowValid(state, narrow);
 

--- a/src/chat/__tests__/narrowsSelectors-test.js
+++ b/src/chat/__tests__/narrowsSelectors-test.js
@@ -146,7 +146,7 @@ describe('getShownMessagesForNarrow', () => {
   });
 
   describe('stream narrow', () => {
-    const narrow = streamNarrow(stream.name);
+    const narrow = streamNarrow(stream.name, stream.stream_id);
     const makeState = extra => makeStateGeneral(message, narrow, extra);
     const shown = state => shownGeneral(state, narrow);
 
@@ -171,7 +171,7 @@ describe('getShownMessagesForNarrow', () => {
   });
 
   describe('topic narrow', () => {
-    const narrow = topicNarrow(stream.name, message.subject);
+    const narrow = topicNarrow(stream.name, stream.stream_id, message.subject);
     const makeState = extra => makeStateGeneral(message, narrow, extra);
     const shown = state => shownGeneral(state, narrow);
 
@@ -306,26 +306,28 @@ describe('getStreamInNarrow', () => {
   });
 
   test('return subscription if stream in narrow is subscribed', () => {
-    const narrow = streamNarrow(stream1.name);
+    const narrow = streamNarrow(stream1.name, stream1.stream_id);
 
     expect(getStreamInNarrow(state, narrow)).toEqual(sub1);
   });
 
   test('return stream if stream in narrow is not subscribed', () => {
-    const narrow = streamNarrow(stream3.name);
+    const narrow = streamNarrow(stream3.name, stream3.stream_id);
 
     expect(getStreamInNarrow(state, narrow)).toEqual({ ...stream3, in_home_view: true });
   });
 
   test('return NULL_SUBSCRIPTION if stream in narrow is not valid', () => {
-    const narrow = streamNarrow(stream4.name);
+    const narrow = streamNarrow(stream4.name, stream4.stream_id);
 
     expect(getStreamInNarrow(state, narrow)).toEqual(NULL_SUBSCRIPTION);
   });
 
   test('return NULL_SUBSCRIPTION is narrow is not topic or stream', () => {
     expect(getStreamInNarrow(state, pm1to1NarrowFromUser(eg.otherUser))).toEqual(NULL_SUBSCRIPTION);
-    expect(getStreamInNarrow(state, topicNarrow(stream4.name, 'topic'))).toEqual(NULL_SUBSCRIPTION);
+    expect(getStreamInNarrow(state, topicNarrow(stream4.name, stream4.stream_id, 'topic'))).toEqual(
+      NULL_SUBSCRIPTION,
+    );
   });
 });
 
@@ -345,7 +347,7 @@ describe('isNarrowValid', () => {
     const state = eg.reduxState({
       streams: [stream],
     });
-    const narrow = streamNarrow(stream.name);
+    const narrow = streamNarrow(stream.name, stream.stream_id);
 
     const result = isNarrowValid(state, narrow);
 
@@ -356,7 +358,7 @@ describe('isNarrowValid', () => {
     const state = eg.reduxState({
       streams: [],
     });
-    const narrow = streamNarrow(eg.stream.name);
+    const narrow = streamNarrow(eg.stream.name, eg.stream.stream_id);
 
     const result = isNarrowValid(state, narrow);
 
@@ -369,7 +371,7 @@ describe('isNarrowValid', () => {
     const state = eg.reduxState({
       streams: [stream],
     });
-    const narrow = topicNarrow(stream.name, 'topic does not matter');
+    const narrow = topicNarrow(stream.name, stream.stream_id, 'topic does not matter');
 
     const result = isNarrowValid(state, narrow);
 

--- a/src/chat/narrowsSelectors.js
+++ b/src/chat/narrowsSelectors.js
@@ -17,7 +17,6 @@ import {
   getSubscriptions,
   getMessages,
   getMute,
-  getStreams,
   getOutbox,
   getFlags,
 } from '../directSelectors';
@@ -224,14 +223,14 @@ export const getStreamInNarrow: Selector<Subscription | {| ...Stream, in_home_vi
 
 export const isNarrowValid: Selector<boolean, Narrow> = createSelector(
   (state, narrow) => narrow,
-  state => getStreams(state),
+  state => getStreamsById(state),
   state => getAllUsersById(state),
   (narrow, streams, allUsersById) =>
     caseNarrowDefault(
       narrow,
       {
-        stream: streamName => streams.find(s => s.name === streamName) !== undefined,
-        topic: streamName => streams.find(s => s.name === streamName) !== undefined,
+        stream: (_, streamId) => streams.get(streamId) !== undefined,
+        topic: (_, t, streamId) => streams.get(streamId) !== undefined,
         pm: ids => ids.every(id => allUsersById.get(id) !== undefined),
       },
       () => true,

--- a/src/chat/narrowsSelectors.js
+++ b/src/chat/narrowsSelectors.js
@@ -229,8 +229,8 @@ export const isNarrowValid: Selector<boolean, Narrow> = createSelector(
     caseNarrowDefault(
       narrow,
       {
-        stream: (_, streamId) => streams.get(streamId) !== undefined,
-        topic: (_, t, streamId) => streams.get(streamId) !== undefined,
+        stream: streamId => streams.get(streamId) !== undefined,
+        topic: streamId => streams.get(streamId) !== undefined,
         pm: ids => ids.every(id => allUsersById.get(id) !== undefined),
       },
       () => true,

--- a/src/chat/narrowsSelectors.js
+++ b/src/chat/narrowsSelectors.js
@@ -28,13 +28,14 @@ import {
   isMessageInNarrow,
   caseNarrowDefault,
   keyFromNarrow,
-  streamNameOfNarrow,
   caseNarrow,
+  streamIdOfNarrow,
 } from '../utils/narrow';
 import { isTopicMuted } from '../mute/muteModel';
 import { streamNameOfStreamMessage } from '../utils/recipient';
 import { NULL_ARRAY, NULL_SUBSCRIPTION } from '../nullObjects';
 import * as logging from '../utils/logging';
+import { getStreamsById, getSubscriptionsById } from '../selectors';
 
 export const outboxMessagesForNarrow: Selector<$ReadOnlyArray<Outbox>, Narrow> = createSelector(
   (state, narrow) => narrow,
@@ -196,20 +197,20 @@ export const getLastMessageId = (state: PerAccountState, narrow: Narrow): number
 // TODO: clean up what this returns; possibly to just `Stream`
 export const getStreamInNarrow: Selector<Subscription | {| ...Stream, in_home_view: boolean |}, Narrow> = createSelector(
   (state, narrow) => narrow,
-  state => getSubscriptions(state),
-  state => getStreams(state),
+  state => getSubscriptionsById(state),
+  state => getStreamsById(state),
   (narrow, subscriptions, streams) => {
     if (!isStreamOrTopicNarrow(narrow)) {
       return NULL_SUBSCRIPTION;
     }
-    const streamName = streamNameOfNarrow(narrow);
+    const streamId = streamIdOfNarrow(narrow);
 
-    const subscription = subscriptions.find(x => x.name === streamName);
+    const subscription = subscriptions.get(streamId);
     if (subscription) {
       return subscription;
     }
 
-    const stream = streams.find(x => x.name === streamName);
+    const stream = streams.get(streamId);
     if (stream) {
       return {
         ...stream,

--- a/src/compose/ComposeBox.js
+++ b/src/compose/ComposeBox.js
@@ -35,6 +35,7 @@ import {
   isStreamNarrow,
   isStreamOrTopicNarrow,
   isTopicNarrow,
+  streamIdOfNarrow,
   streamNameOfNarrow,
   topicNarrow,
   topicOfNarrow,
@@ -402,8 +403,9 @@ class ComposeBoxInner extends PureComponent<Props, State> {
     const { narrow, isEditing } = this.props;
     if (isStreamNarrow(narrow) || (isTopicNarrow(narrow) && isEditing)) {
       const streamName = streamNameOfNarrow(narrow);
+      const streamId = streamIdOfNarrow(narrow);
       const topic = this.state.topic.trim();
-      return topicNarrow(streamName, topic || apiConstants.NO_TOPIC_TOPIC);
+      return topicNarrow(streamName, streamId, topic || apiConstants.NO_TOPIC_TOPIC);
     }
     invariant(isConversationNarrow(narrow), 'destination narrow must be conversation');
     return narrow;

--- a/src/compose/ComposeBox.js
+++ b/src/compose/ComposeBox.js
@@ -405,7 +405,7 @@ class ComposeBoxInner extends PureComponent<Props, State> {
     if (isStreamNarrow(narrow) || (isTopicNarrow(narrow) && isEditing)) {
       const streamId = streamIdOfNarrow(narrow);
       const topic = this.state.topic.trim() || apiConstants.NO_TOPIC_TOPIC;
-      return topicNarrow(undefined, streamId, topic);
+      return topicNarrow(streamId, topic);
     }
     invariant(isConversationNarrow(narrow), 'destination narrow must be conversation');
     return narrow;

--- a/src/compose/ComposeBox.js
+++ b/src/compose/ComposeBox.js
@@ -36,7 +36,6 @@ import {
   isStreamOrTopicNarrow,
   isTopicNarrow,
   streamIdOfNarrow,
-  streamNameOfNarrow,
   topicNarrow,
   topicOfNarrow,
 } from '../utils/narrow';
@@ -406,7 +405,7 @@ class ComposeBoxInner extends PureComponent<Props, State> {
     if (isStreamNarrow(narrow) || (isTopicNarrow(narrow) && isEditing)) {
       const streamId = streamIdOfNarrow(narrow);
       const topic = this.state.topic.trim() || apiConstants.NO_TOPIC_TOPIC;
-      return topicNarrow(streamNameOfNarrow(narrow), streamId, topic);
+      return topicNarrow(undefined, streamId, topic);
     }
     invariant(isConversationNarrow(narrow), 'destination narrow must be conversation');
     return narrow;

--- a/src/compose/ComposeBox.js
+++ b/src/compose/ComposeBox.js
@@ -402,10 +402,9 @@ class ComposeBoxInner extends PureComponent<Props, State> {
   getDestinationNarrow = (): Narrow => {
     const { narrow, isEditing } = this.props;
     if (isStreamNarrow(narrow) || (isTopicNarrow(narrow) && isEditing)) {
-      const streamName = streamNameOfNarrow(narrow);
       const streamId = streamIdOfNarrow(narrow);
-      const topic = this.state.topic.trim();
-      return topicNarrow(streamName, streamId, topic || apiConstants.NO_TOPIC_TOPIC);
+      const topic = this.state.topic.trim() || apiConstants.NO_TOPIC_TOPIC;
+      return topicNarrow(streamNameOfNarrow(narrow), streamId, topic);
     }
     invariant(isConversationNarrow(narrow), 'destination narrow must be conversation');
     return narrow;

--- a/src/compose/ComposeBox.js
+++ b/src/compose/ComposeBox.js
@@ -49,6 +49,7 @@ import {
   getAuth,
   getIsAdmin,
   getStreamInNarrow,
+  getStreamsById,
   getVideoChatProvider,
   getRealm,
 } from '../selectors';
@@ -72,6 +73,7 @@ type SelectorProps = {|
   videoChatProvider: VideoChatProvider | null,
   mandatoryTopics: boolean,
   stream: Subscription | {| ...Stream, in_home_view: boolean |},
+  streamsById: Map<number, Stream>,
 |};
 
 type OuterProps = $ReadOnly<{|
@@ -543,6 +545,7 @@ class ComposeBoxInner extends PureComponent<Props, State> {
       isAnnouncementOnly,
       isSubscribed,
       stream,
+      streamsById,
       videoChatProvider,
       _,
     } = this.props;
@@ -556,7 +559,7 @@ class ComposeBoxInner extends PureComponent<Props, State> {
       return <AnnouncementOnly />;
     }
 
-    const placeholder = getComposeInputPlaceholder(narrow, ownUserId, allUsersById);
+    const placeholder = getComposeInputPlaceholder(narrow, ownUserId, allUsersById, streamsById);
     const style = {
       paddingBottom: insets.bottom,
       backgroundColor: 'hsla(0, 0%, 50%, 0.1)',
@@ -677,6 +680,7 @@ const ComposeBox: ComponentType<OuterProps> = compose(
     isAnnouncementOnly: getIsActiveStreamAnnouncementOnly(state, props.narrow),
     isSubscribed: getIsActiveStreamSubscribed(state, props.narrow),
     stream: getStreamInNarrow(state, props.narrow),
+    streamsById: getStreamsById(state),
     videoChatProvider: getVideoChatProvider(state),
     mandatoryTopics: getRealm(state).mandatoryTopics,
   })),

--- a/src/compose/__tests__/getComposeInputPlaceholder-test.js
+++ b/src/compose/__tests__/getComposeInputPlaceholder-test.js
@@ -30,13 +30,16 @@ describe('getComposeInputPlaceholder', () => {
   });
 
   test('returns "Message #streamName" for stream narrow', () => {
-    const narrow = deepFreeze(streamNarrow('Denmark'));
+    const narrow = deepFreeze(streamNarrow(eg.stream.name));
     const placeholder = getComposeInputPlaceholder(narrow, ownUserId, usersById);
-    expect(placeholder).toEqual({ text: 'Message {recipient}', values: { recipient: '#Denmark' } });
+    expect(placeholder).toEqual({
+      text: 'Message {recipient}',
+      values: { recipient: `#${eg.stream.name}` },
+    });
   });
 
   test('returns properly for topic narrow', () => {
-    const narrow = deepFreeze(topicNarrow('Denmark', 'Copenhagen'));
+    const narrow = deepFreeze(topicNarrow(eg.stream.name, 'Copenhagen'));
     const placeholder = getComposeInputPlaceholder(narrow, ownUserId, usersById);
     expect(placeholder).toEqual({ text: 'Reply' });
   });

--- a/src/compose/__tests__/getComposeInputPlaceholder-test.js
+++ b/src/compose/__tests__/getComposeInputPlaceholder-test.js
@@ -32,7 +32,7 @@ describe('getComposeInputPlaceholder', () => {
   });
 
   test('returns "Message #streamName" for stream narrow', () => {
-    const narrow = deepFreeze(streamNarrow(eg.stream.name, eg.stream.stream_id));
+    const narrow = deepFreeze(streamNarrow(eg.stream.stream_id));
     const placeholder = getComposeInputPlaceholder(narrow, ownUserId, usersById, streamsById);
     expect(placeholder).toEqual({
       text: 'Message {recipient}',
@@ -41,7 +41,7 @@ describe('getComposeInputPlaceholder', () => {
   });
 
   test('returns properly for topic narrow', () => {
-    const narrow = deepFreeze(topicNarrow(eg.stream.name, eg.stream.stream_id, 'Copenhagen'));
+    const narrow = deepFreeze(topicNarrow(eg.stream.stream_id, 'Copenhagen'));
     const placeholder = getComposeInputPlaceholder(narrow, ownUserId, usersById, streamsById);
     expect(placeholder).toEqual({ text: 'Reply' });
   });

--- a/src/compose/__tests__/getComposeInputPlaceholder-test.js
+++ b/src/compose/__tests__/getComposeInputPlaceholder-test.js
@@ -9,14 +9,16 @@ import {
   pmNarrowFromUsersUnsafe,
 } from '../../utils/narrow';
 import * as eg from '../../__tests__/lib/exampleData';
+import { getStreamsById } from '../../selectors';
 
 describe('getComposeInputPlaceholder', () => {
   const usersById = new Map([eg.selfUser, eg.otherUser, eg.thirdUser].map(u => [u.user_id, u]));
   const ownUserId = eg.selfUser.user_id;
+  const streamsById = getStreamsById(eg.plusReduxState);
 
   test('returns "Message @ThisPerson" object for person narrow', () => {
     const narrow = deepFreeze(pm1to1NarrowFromUser(eg.otherUser));
-    const placeholder = getComposeInputPlaceholder(narrow, ownUserId, usersById);
+    const placeholder = getComposeInputPlaceholder(narrow, ownUserId, usersById, streamsById);
     expect(placeholder).toEqual({
       text: 'Message {recipient}',
       values: { recipient: `@${eg.otherUser.full_name}` },
@@ -25,13 +27,13 @@ describe('getComposeInputPlaceholder', () => {
 
   test('returns "Jot down something" object for self narrow', () => {
     const narrow = deepFreeze(pm1to1NarrowFromUser(eg.selfUser));
-    const placeholder = getComposeInputPlaceholder(narrow, ownUserId, usersById);
+    const placeholder = getComposeInputPlaceholder(narrow, ownUserId, usersById, streamsById);
     expect(placeholder).toEqual({ text: 'Jot down something' });
   });
 
   test('returns "Message #streamName" for stream narrow', () => {
     const narrow = deepFreeze(streamNarrow(eg.stream.name, eg.stream.stream_id));
-    const placeholder = getComposeInputPlaceholder(narrow, ownUserId, usersById);
+    const placeholder = getComposeInputPlaceholder(narrow, ownUserId, usersById, streamsById);
     expect(placeholder).toEqual({
       text: 'Message {recipient}',
       values: { recipient: `#${eg.stream.name}` },
@@ -40,13 +42,13 @@ describe('getComposeInputPlaceholder', () => {
 
   test('returns properly for topic narrow', () => {
     const narrow = deepFreeze(topicNarrow(eg.stream.name, eg.stream.stream_id, 'Copenhagen'));
-    const placeholder = getComposeInputPlaceholder(narrow, ownUserId, usersById);
+    const placeholder = getComposeInputPlaceholder(narrow, ownUserId, usersById, streamsById);
     expect(placeholder).toEqual({ text: 'Reply' });
   });
 
   test('returns "Message group" object for group narrow', () => {
     const narrow = deepFreeze(pmNarrowFromUsersUnsafe([eg.otherUser, eg.thirdUser]));
-    const placeholder = getComposeInputPlaceholder(narrow, ownUserId, usersById);
+    const placeholder = getComposeInputPlaceholder(narrow, ownUserId, usersById, streamsById);
     expect(placeholder).toEqual({ text: 'Message group' });
   });
 });

--- a/src/compose/__tests__/getComposeInputPlaceholder-test.js
+++ b/src/compose/__tests__/getComposeInputPlaceholder-test.js
@@ -30,7 +30,7 @@ describe('getComposeInputPlaceholder', () => {
   });
 
   test('returns "Message #streamName" for stream narrow', () => {
-    const narrow = deepFreeze(streamNarrow(eg.stream.name));
+    const narrow = deepFreeze(streamNarrow(eg.stream.name, eg.stream.stream_id));
     const placeholder = getComposeInputPlaceholder(narrow, ownUserId, usersById);
     expect(placeholder).toEqual({
       text: 'Message {recipient}',
@@ -39,7 +39,7 @@ describe('getComposeInputPlaceholder', () => {
   });
 
   test('returns properly for topic narrow', () => {
-    const narrow = deepFreeze(topicNarrow(eg.stream.name, 'Copenhagen'));
+    const narrow = deepFreeze(topicNarrow(eg.stream.name, eg.stream.stream_id, 'Copenhagen'));
     const placeholder = getComposeInputPlaceholder(narrow, ownUserId, usersById);
     expect(placeholder).toEqual({ text: 'Reply' });
   });

--- a/src/compose/getComposeInputPlaceholder.js
+++ b/src/compose/getComposeInputPlaceholder.js
@@ -31,7 +31,7 @@ export default (
           values: { recipient: `@${user.full_name}` },
         };
       },
-      stream: (_, streamId) => {
+      stream: streamId => {
         const stream = streamsById.get(streamId);
         if (!stream) {
           return { text: 'Type a message' };

--- a/src/compose/getComposeInputPlaceholder.js
+++ b/src/compose/getComposeInputPlaceholder.js
@@ -1,11 +1,12 @@
 /* @flow strict-local */
-import type { Narrow, UserId, UserOrBot, LocalizableText } from '../types';
+import type { Narrow, Stream, UserId, UserOrBot, LocalizableText } from '../types';
 import { caseNarrowDefault } from '../utils/narrow';
 
 export default (
   narrow: Narrow,
   ownUserId: UserId,
   allUsersById: Map<UserId, UserOrBot>,
+  streamsById: Map<number, Stream>,
 ): LocalizableText =>
   caseNarrowDefault(
     narrow,
@@ -30,10 +31,13 @@ export default (
           values: { recipient: `@${user.full_name}` },
         };
       },
-      stream: name => ({
-        text: 'Message {recipient}',
-        values: { recipient: `#${name}` },
-      }),
+      stream: (_, streamId) => {
+        const stream = streamsById.get(streamId);
+        if (!stream) {
+          return { text: 'Type a message' };
+        }
+        return { text: 'Message {recipient}', values: { recipient: `#${stream.name}` } };
+      },
       topic: () => ({ text: 'Reply' }),
     },
     () => ({ text: 'Type a message' }),

--- a/src/drafts/__tests__/draftsReducer-test.js
+++ b/src/drafts/__tests__/draftsReducer-test.js
@@ -8,7 +8,7 @@ import { topicNarrow, keyFromNarrow } from '../../utils/narrow';
 import * as eg from '../../__tests__/lib/exampleData';
 
 describe('draftsReducer', () => {
-  const testNarrow = topicNarrow(eg.stream.name, 'denmark2');
+  const testNarrow = topicNarrow(eg.stream.name, eg.stream.stream_id, 'denmark2');
   const testNarrowStr = keyFromNarrow(testNarrow);
 
   describe('DRAFT_UPDATE', () => {

--- a/src/drafts/__tests__/draftsReducer-test.js
+++ b/src/drafts/__tests__/draftsReducer-test.js
@@ -8,7 +8,7 @@ import { topicNarrow, keyFromNarrow } from '../../utils/narrow';
 import * as eg from '../../__tests__/lib/exampleData';
 
 describe('draftsReducer', () => {
-  const testNarrow = topicNarrow(eg.stream.name, eg.stream.stream_id, 'denmark2');
+  const testNarrow = topicNarrow(eg.stream.stream_id, 'denmark2');
   const testNarrowStr = keyFromNarrow(testNarrow);
 
   describe('DRAFT_UPDATE', () => {

--- a/src/drafts/__tests__/draftsReducer-test.js
+++ b/src/drafts/__tests__/draftsReducer-test.js
@@ -5,9 +5,10 @@ import { NULL_OBJECT } from '../../nullObjects';
 import draftsReducer from '../draftsReducer';
 import { DRAFT_UPDATE } from '../../actionConstants';
 import { topicNarrow, keyFromNarrow } from '../../utils/narrow';
+import * as eg from '../../__tests__/lib/exampleData';
 
 describe('draftsReducer', () => {
-  const testNarrow = topicNarrow('denmark', 'denmark2');
+  const testNarrow = topicNarrow(eg.stream.name, 'denmark2');
   const testNarrowStr = keyFromNarrow(testNarrow);
 
   describe('DRAFT_UPDATE', () => {
@@ -71,7 +72,7 @@ describe('draftsReducer', () => {
       const action = {
         type: DRAFT_UPDATE,
         content: '   ',
-        narrow: topicNarrow('denmark', 'denmark2'),
+        narrow: testNarrow,
       };
 
       const expectedState = {};

--- a/src/drafts/__tests__/draftsReducer-test.js
+++ b/src/drafts/__tests__/draftsReducer-test.js
@@ -1,3 +1,4 @@
+// @flow strict-local
 import deepFreeze from 'deep-freeze';
 
 import { NULL_OBJECT } from '../../nullObjects';

--- a/src/drafts/__tests__/draftsSelectors-test.js
+++ b/src/drafts/__tests__/draftsSelectors-test.js
@@ -6,7 +6,7 @@ import * as eg from '../../__tests__/lib/exampleData';
 
 describe('getDraftForNarrow', () => {
   test('return content of draft if exists', () => {
-    const narrow = topicNarrow(eg.stream.name, eg.stream.stream_id, 'topic');
+    const narrow = topicNarrow(eg.stream.stream_id, 'topic');
     const state = eg.reduxState({
       drafts: {
         [keyFromNarrow(narrow)]: 'content',
@@ -19,17 +19,14 @@ describe('getDraftForNarrow', () => {
   });
 
   test('return empty string if not exists', () => {
-    const narrow = topicNarrow(eg.stream.name, eg.stream.stream_id, 'topic');
+    const narrow = topicNarrow(eg.stream.stream_id, 'topic');
     const state = eg.reduxState({
       drafts: {
         [keyFromNarrow(narrow)]: 'content',
       },
     });
 
-    const draft = getDraftForNarrow(
-      state,
-      topicNarrow(eg.stream.name, eg.stream.stream_id, 'topic1'),
-    );
+    const draft = getDraftForNarrow(state, topicNarrow(eg.stream.stream_id, 'topic1'));
 
     expect(draft).toEqual('');
   });

--- a/src/drafts/__tests__/draftsSelectors-test.js
+++ b/src/drafts/__tests__/draftsSelectors-test.js
@@ -6,7 +6,7 @@ import * as eg from '../../__tests__/lib/exampleData';
 
 describe('getDraftForNarrow', () => {
   test('return content of draft if exists', () => {
-    const narrow = topicNarrow(eg.stream.name, 'topic');
+    const narrow = topicNarrow(eg.stream.name, eg.stream.stream_id, 'topic');
     const state = eg.reduxState({
       drafts: {
         [keyFromNarrow(narrow)]: 'content',
@@ -19,14 +19,17 @@ describe('getDraftForNarrow', () => {
   });
 
   test('return empty string if not exists', () => {
-    const narrow = topicNarrow(eg.stream.name, 'topic');
+    const narrow = topicNarrow(eg.stream.name, eg.stream.stream_id, 'topic');
     const state = eg.reduxState({
       drafts: {
         [keyFromNarrow(narrow)]: 'content',
       },
     });
 
-    const draft = getDraftForNarrow(state, topicNarrow(eg.stream.name, 'topic1'));
+    const draft = getDraftForNarrow(
+      state,
+      topicNarrow(eg.stream.name, eg.stream.stream_id, 'topic1'),
+    );
 
     expect(draft).toEqual('');
   });

--- a/src/message/__tests__/fetchActions-test.js
+++ b/src/message/__tests__/fetchActions-test.js
@@ -26,7 +26,7 @@ import * as logging from '../../utils/logging';
 
 const mockStore = configureStore([thunk]);
 
-const narrow = streamNarrow(eg.stream.name, eg.stream.stream_id);
+const narrow = streamNarrow(eg.stream.stream_id);
 const streamNarrowStr = keyFromNarrow(narrow);
 
 global.FormData = class FormData {};

--- a/src/message/__tests__/fetchActions-test.js
+++ b/src/message/__tests__/fetchActions-test.js
@@ -26,7 +26,7 @@ import * as logging from '../../utils/logging';
 
 const mockStore = configureStore([thunk]);
 
-const narrow = streamNarrow(eg.stream.name);
+const narrow = streamNarrow(eg.stream.name, eg.stream.stream_id);
 const streamNarrowStr = keyFromNarrow(narrow);
 
 global.FormData = class FormData {};

--- a/src/message/__tests__/messageActions-test.js
+++ b/src/message/__tests__/messageActions-test.js
@@ -13,7 +13,7 @@ import type { Action } from '../../actionTypes';
 
 const mockStore = configureStore([thunk]);
 
-const streamNarrowObj = streamNarrow(eg.stream.name);
+const streamNarrowObj = streamNarrow(eg.stream.name, eg.stream.stream_id);
 
 describe('messageActions', () => {
   describe('doNarrow', () => {

--- a/src/message/__tests__/messageActions-test.js
+++ b/src/message/__tests__/messageActions-test.js
@@ -13,7 +13,7 @@ import type { Action } from '../../actionTypes';
 
 const mockStore = configureStore([thunk]);
 
-const streamNarrowObj = streamNarrow(eg.stream.name, eg.stream.stream_id);
+const streamNarrowObj = streamNarrow(eg.stream.stream_id);
 
 describe('messageActions', () => {
   describe('doNarrow', () => {

--- a/src/message/__tests__/scrollStrategy-test.js
+++ b/src/message/__tests__/scrollStrategy-test.js
@@ -5,7 +5,8 @@ import { getScrollStrategy } from '../scrollStrategy';
 import * as eg from '../../__tests__/lib/exampleData';
 
 const someNarrow = streamNarrow(eg.stream.name);
-const anotherNarrow = streamNarrow(eg.makeStream().name);
+const anotherStream = eg.makeStream();
+const anotherNarrow = streamNarrow(anotherStream.name);
 
 describe('getScrollStrategy', () => {
   test('initial load positions at anchor (first unread)', () => {

--- a/src/message/__tests__/scrollStrategy-test.js
+++ b/src/message/__tests__/scrollStrategy-test.js
@@ -4,9 +4,9 @@ import { getScrollStrategy } from '../scrollStrategy';
 
 import * as eg from '../../__tests__/lib/exampleData';
 
-const someNarrow = streamNarrow(eg.stream.name, eg.stream.stream_id);
+const someNarrow = streamNarrow(eg.stream.stream_id);
 const anotherStream = eg.makeStream();
-const anotherNarrow = streamNarrow(anotherStream.name, anotherStream.stream_id);
+const anotherNarrow = streamNarrow(anotherStream.stream_id);
 
 describe('getScrollStrategy', () => {
   test('initial load positions at anchor (first unread)', () => {

--- a/src/message/__tests__/scrollStrategy-test.js
+++ b/src/message/__tests__/scrollStrategy-test.js
@@ -4,9 +4,9 @@ import { getScrollStrategy } from '../scrollStrategy';
 
 import * as eg from '../../__tests__/lib/exampleData';
 
-const someNarrow = streamNarrow(eg.stream.name);
+const someNarrow = streamNarrow(eg.stream.name, eg.stream.stream_id);
 const anotherStream = eg.makeStream();
-const anotherNarrow = streamNarrow(anotherStream.name);
+const anotherNarrow = streamNarrow(anotherStream.name, anotherStream.stream_id);
 
 describe('getScrollStrategy', () => {
   test('initial load positions at anchor (first unread)', () => {

--- a/src/message/fetchActions.js
+++ b/src/message/fetchActions.js
@@ -147,14 +147,14 @@ export const fetchMessages = (fetchArgs: {|
 
       // Describe the narrow without sending sensitive data to Sentry.
       narrow: caseNarrow(fetchArgs.narrow, {
-        stream: name => 'stream',
-        topic: (streamName, topic) => 'topic',
+        stream: () => 'stream',
+        topic: () => 'topic',
         pm: ids => (ids.length > 1 ? 'pm (group)' : 'pm (1:1)'),
         home: () => 'all',
         starred: () => 'starred',
         mentioned: () => 'mentioned',
         allPrivate: () => 'all-pm',
-        search: query => 'search',
+        search: () => 'search',
       }),
 
       anchor: fetchArgs.anchor,

--- a/src/message/fetchActions.js
+++ b/src/message/fetchActions.js
@@ -24,6 +24,7 @@ import {
   getFetchingForNarrow,
   getIsAdmin,
   getIdentity,
+  getStreamsById,
 } from '../selectors';
 import config from '../config';
 import {
@@ -121,7 +122,11 @@ export const fetchMessages = (fetchArgs: {|
       await tryFetch(() =>
         api.getMessages(getAuth(getState()), {
           ...fetchArgs,
-          narrow: apiNarrowOfNarrow(fetchArgs.narrow, getAllUsersById(getState())),
+          narrow: apiNarrowOfNarrow(
+            fetchArgs.narrow,
+            getAllUsersById(getState()),
+            getStreamsById(getState()),
+          ),
           useFirstUnread: fetchArgs.anchor === FIRST_UNREAD_ANCHOR, // TODO: don't use this; see #4203
         }),
       );
@@ -336,7 +341,11 @@ export const fetchMessagesInNarrow = (
 const fetchPrivateMessages = () => async (dispatch, getState) => {
   const auth = getAuth(getState());
   const { messages, found_newest, found_oldest } = await api.getMessages(auth, {
-    narrow: apiNarrowOfNarrow(ALL_PRIVATE_NARROW, getAllUsersById(getState())),
+    narrow: apiNarrowOfNarrow(
+      ALL_PRIVATE_NARROW,
+      getAllUsersById(getState()),
+      getStreamsById(getState()),
+    ),
     anchor: LAST_MESSAGE_ANCHOR,
     numBefore: 100,
     numAfter: 0,

--- a/src/nav/ChatNavBar.js
+++ b/src/nav/ChatNavBar.js
@@ -23,12 +23,18 @@ import {
   doNarrow,
 } from '../actions';
 import * as NavigationService from './NavigationService';
-import { getStreams } from '../selectors';
+import { getStreams, isNarrowValid as getIsNarrowValid } from '../selectors';
 import NavButton from './NavButton';
 
 function ExtraNavButtonStream(props): Node {
   const { color, narrow } = props;
   const streams = useSelector(getStreams);
+
+  const isNarrowValid = useSelector(state => getIsNarrowValid(state, narrow));
+  if (!isNarrowValid) {
+    return null;
+  }
+
   return (
     <NavButton
       name="list"
@@ -63,6 +69,12 @@ function ExtraNavButtonTopic(props): Node {
 function InfoNavButtonStream(props): Node {
   const { color, narrow } = props;
   const streams = useSelector(getStreams);
+
+  const isNarrowValid = useSelector(state => getIsNarrowValid(state, narrow));
+  if (!isNarrowValid) {
+    return null;
+  }
+
   return (
     <NavButton
       name="info"

--- a/src/nav/ChatNavBar.js
+++ b/src/nav/ChatNavBar.js
@@ -14,7 +14,12 @@ import Title from '../title/Title';
 import NavBarBackButton from './NavBarBackButton';
 import { getStreamColorForNarrow } from '../subscriptions/subscriptionSelectors';
 import { foregroundColorFromBackground } from '../utils/color';
-import { caseNarrowDefault, streamNameOfNarrow, streamNarrow } from '../utils/narrow';
+import {
+  caseNarrowDefault,
+  streamIdOfNarrow,
+  streamNameOfNarrow,
+  streamNarrow,
+} from '../utils/narrow';
 import {
   navigateToStream,
   navigateToAccountDetails,
@@ -23,12 +28,11 @@ import {
   doNarrow,
 } from '../actions';
 import * as NavigationService from './NavigationService';
-import { getStreams, isNarrowValid as getIsNarrowValid } from '../selectors';
+import { isNarrowValid as getIsNarrowValid } from '../selectors';
 import NavButton from './NavButton';
 
 function ExtraNavButtonStream(props): Node {
   const { color, narrow } = props;
-  const streams = useSelector(getStreams);
 
   const isNarrowValid = useSelector(state => getIsNarrowValid(state, narrow));
   if (!isNarrowValid) {
@@ -40,11 +44,7 @@ function ExtraNavButtonStream(props): Node {
       name="list"
       color={color}
       onPress={() => {
-        const streamName = streamNameOfNarrow(narrow);
-        const stream = streams.find(x => x.name === streamName);
-        if (stream) {
-          NavigationService.dispatch(navigateToTopicList(stream.stream_id));
-        }
+        NavigationService.dispatch(navigateToTopicList(streamIdOfNarrow(narrow)));
       }}
     />
   );
@@ -53,22 +53,16 @@ function ExtraNavButtonStream(props): Node {
 function ExtraNavButtonTopic(props): Node {
   const { narrow, color } = props;
   const dispatch = useDispatch();
-  const streams = useSelector(getStreams);
 
   const handlePress = useCallback(() => {
-    const streamName = streamNameOfNarrow(narrow);
-    const stream = streams.find(x => x.name === streamName);
-    if (stream) {
-      dispatch(doNarrow(streamNarrow(stream.name, stream.stream_id)));
-    }
-  }, [dispatch, narrow, streams]);
+    dispatch(doNarrow(streamNarrow(streamNameOfNarrow(narrow), streamIdOfNarrow(narrow))));
+  }, [dispatch, narrow]);
 
   return <NavButton name="arrow-up" color={color} onPress={handlePress} />;
 }
 
 function InfoNavButtonStream(props): Node {
   const { color, narrow } = props;
-  const streams = useSelector(getStreams);
 
   const isNarrowValid = useSelector(state => getIsNarrowValid(state, narrow));
   if (!isNarrowValid) {
@@ -80,11 +74,7 @@ function InfoNavButtonStream(props): Node {
       name="info"
       color={color}
       onPress={() => {
-        const streamName = streamNameOfNarrow(narrow);
-        const stream = streams.find(x => x.name === streamName);
-        if (stream) {
-          NavigationService.dispatch(navigateToStream(stream.stream_id));
-        }
+        NavigationService.dispatch(navigateToStream(streamIdOfNarrow(narrow)));
       }}
     />
   );

--- a/src/nav/ChatNavBar.js
+++ b/src/nav/ChatNavBar.js
@@ -14,12 +14,7 @@ import Title from '../title/Title';
 import NavBarBackButton from './NavBarBackButton';
 import { getStreamColorForNarrow } from '../subscriptions/subscriptionSelectors';
 import { foregroundColorFromBackground } from '../utils/color';
-import {
-  caseNarrowDefault,
-  streamIdOfNarrow,
-  streamNameOfNarrow,
-  streamNarrow,
-} from '../utils/narrow';
+import { caseNarrowDefault, streamIdOfNarrow, streamNarrow } from '../utils/narrow';
 import {
   navigateToStream,
   navigateToAccountDetails,
@@ -55,7 +50,7 @@ function ExtraNavButtonTopic(props): Node {
   const dispatch = useDispatch();
 
   const handlePress = useCallback(() => {
-    dispatch(doNarrow(streamNarrow(streamNameOfNarrow(narrow), streamIdOfNarrow(narrow))));
+    dispatch(doNarrow(streamNarrow(undefined, streamIdOfNarrow(narrow))));
   }, [dispatch, narrow]);
 
   return <NavButton name="arrow-up" color={color} onPress={handlePress} />;

--- a/src/nav/ChatNavBar.js
+++ b/src/nav/ChatNavBar.js
@@ -50,7 +50,7 @@ function ExtraNavButtonTopic(props): Node {
   const dispatch = useDispatch();
 
   const handlePress = useCallback(() => {
-    dispatch(doNarrow(streamNarrow(undefined, streamIdOfNarrow(narrow))));
+    dispatch(doNarrow(streamNarrow(streamIdOfNarrow(narrow))));
   }, [dispatch, narrow]);
 
   return <NavButton name="arrow-up" color={color} onPress={handlePress} />;

--- a/src/nav/ChatNavBar.js
+++ b/src/nav/ChatNavBar.js
@@ -53,7 +53,7 @@ function ExtraNavButtonTopic(props): Node {
     const streamName = streamNameOfNarrow(narrow);
     const stream = streams.find(x => x.name === streamName);
     if (stream) {
-      dispatch(doNarrow(streamNarrow(stream.name)));
+      dispatch(doNarrow(streamNarrow(stream.name, stream.stream_id)));
     }
   }, [dispatch, narrow, streams]);
 

--- a/src/nav/ChatNavBar.js
+++ b/src/nav/ChatNavBar.js
@@ -117,13 +117,13 @@ const ActionItems: ComponentType<{| +color: string, +narrow: Narrow |}> = props 
   caseNarrowDefault(
     props.narrow,
     {
-      stream: streamName => (
+      stream: () => (
         <>
           <ExtraNavButtonStream {...props} />
           <InfoNavButtonStream {...props} />
         </>
       ),
-      topic: (streamName, topic) => (
+      topic: () => (
         <>
           <ExtraNavButtonTopic {...props} />
           <InfoNavButtonStream {...props} />

--- a/src/notification/__tests__/notification-test.js
+++ b/src/notification/__tests__/notification-test.js
@@ -34,7 +34,7 @@ describe('getNarrowFromNotificationData', () => {
       topic: 'some topic',
     };
     const narrow = getNarrowFromNotificationData(notification, new Map(), streamsByName, ownUserId);
-    expect(narrow).toEqual(topicNarrow(stream.name, stream.stream_id, 'some topic'));
+    expect(narrow).toEqual(topicNarrow(stream.stream_id, 'some topic'));
   });
 
   test('on notification for a private message returns a PM narrow', () => {

--- a/src/notification/__tests__/notification-test.js
+++ b/src/notification/__tests__/notification-test.js
@@ -20,19 +20,21 @@ describe('getNarrowFromNotificationData', () => {
   test('unknown notification data returns null', () => {
     // $FlowFixMe[incompatible-type]: actually validate APNs messages
     const notification: Notification = {};
-    const narrow = getNarrowFromNotificationData(notification, new Map(), ownUserId);
+    const narrow = getNarrowFromNotificationData(notification, new Map(), new Map(), ownUserId);
     expect(narrow).toBe(null);
   });
 
   test('recognizes stream notifications and returns topic narrow', () => {
+    const stream = eg.makeStream({ name: 'some stream' });
+    const streamsByName = new Map([[stream.name, stream]]);
     const notification = {
       realm_uri,
       recipient_type: 'stream',
       stream_name: 'some stream',
       topic: 'some topic',
     };
-    const narrow = getNarrowFromNotificationData(notification, new Map(), ownUserId);
-    expect(narrow).toEqual(topicNarrow('some stream', 'some topic'));
+    const narrow = getNarrowFromNotificationData(notification, new Map(), streamsByName, ownUserId);
+    expect(narrow).toEqual(topicNarrow(stream.name, 'some topic'));
   });
 
   test('on notification for a private message returns a PM narrow', () => {
@@ -43,7 +45,12 @@ describe('getNarrowFromNotificationData', () => {
       recipient_type: 'private',
       sender_email: eg.otherUser.email,
     };
-    const narrow = getNarrowFromNotificationData(notification, allUsersByEmail, ownUserId);
+    const narrow = getNarrowFromNotificationData(
+      notification,
+      allUsersByEmail,
+      new Map(),
+      ownUserId,
+    );
     expect(narrow).toEqual(pm1to1NarrowFromUser(eg.otherUser));
   });
 
@@ -59,7 +66,12 @@ describe('getNarrowFromNotificationData', () => {
 
     const expectedNarrow = pmNarrowFromUsersUnsafe(users.slice(1));
 
-    const narrow = getNarrowFromNotificationData(notification, allUsersByEmail, ownUserId);
+    const narrow = getNarrowFromNotificationData(
+      notification,
+      allUsersByEmail,
+      new Map(),
+      ownUserId,
+    );
 
     expect(narrow).toEqual(expectedNarrow);
   });

--- a/src/notification/__tests__/notification-test.js
+++ b/src/notification/__tests__/notification-test.js
@@ -34,7 +34,7 @@ describe('getNarrowFromNotificationData', () => {
       topic: 'some topic',
     };
     const narrow = getNarrowFromNotificationData(notification, new Map(), streamsByName, ownUserId);
-    expect(narrow).toEqual(topicNarrow(stream.name, 'some topic'));
+    expect(narrow).toEqual(topicNarrow(stream.name, stream.stream_id, 'some topic'));
   });
 
   test('on notification for a private message returns a PM narrow', () => {

--- a/src/notification/extract.js
+++ b/src/notification/extract.js
@@ -125,14 +125,14 @@ export const fromAPNsImpl = (rawData: ?JSONableDict): Notification | void => {
   };
 
   if (recipient_type === 'stream') {
-    const { stream, topic } = zulip;
-    if (typeof stream !== 'string' || typeof topic !== 'string') {
+    const { stream: stream_name, topic } = zulip;
+    if (typeof stream_name !== 'string' || typeof topic !== 'string') {
       throw err('invalid');
     }
     return {
       ...identity,
       recipient_type: 'stream',
-      stream,
+      stream_name,
       topic,
     };
   } else {

--- a/src/notification/index.js
+++ b/src/notification/index.js
@@ -131,7 +131,7 @@ export const getNarrowFromNotificationData = (
   }
 
   if (data.recipient_type === 'stream') {
-    return topicNarrow(data.stream, data.topic);
+    return topicNarrow(data.stream_name, data.topic);
   }
 
   if (data.pm_users === undefined) {

--- a/src/notification/index.js
+++ b/src/notification/index.js
@@ -154,10 +154,10 @@ export const getNarrowFromNotificationData = (
   //   message) and whatever the notification did tell us about the
   //   stream/user: in particular, the stream name.
   //
-  //   But once Narrow objects stop relying on stream names (coming soon),
-  //   doing that will require some alternate plumbing to pass the stream
-  //   name through.  For now, we skip dealing with that; this should be an
-  //   uncommon case, so we settle for not crashing.
+  //   But because Narrow objects don't carry stream names, doing that will
+  //   require some alternate plumbing to pass the stream name through.  For
+  //   now, we skip dealing with that; this should be an uncommon case, so
+  //   we settle for not crashing.
 
   if (data.recipient_type === 'stream') {
     const stream = streamsByName.get(data.stream_name);

--- a/src/notification/index.js
+++ b/src/notification/index.js
@@ -161,7 +161,7 @@ export const getNarrowFromNotificationData = (
 
   if (data.recipient_type === 'stream') {
     const stream = streamsByName.get(data.stream_name);
-    return (stream && topicNarrow(stream.name, data.topic)) ?? null;
+    return (stream && topicNarrow(stream.name, stream.stream_id, data.topic)) ?? null;
   }
 
   if (data.pm_users === undefined) {

--- a/src/notification/index.js
+++ b/src/notification/index.js
@@ -161,7 +161,7 @@ export const getNarrowFromNotificationData = (
 
   if (data.recipient_type === 'stream') {
     const stream = streamsByName.get(data.stream_name);
-    return (stream && topicNarrow(stream.name, stream.stream_id, data.topic)) ?? null;
+    return (stream && topicNarrow(stream.stream_id, data.topic)) ?? null;
   }
 
   if (data.pm_users === undefined) {

--- a/src/notification/notificationActions.js
+++ b/src/notification/notificationActions.js
@@ -19,7 +19,7 @@ import {
   getAccountFromNotificationData,
 } from '.';
 import type { Notification } from './types';
-import { getAuth } from '../selectors';
+import { getAuth, getStreamsByName } from '../selectors';
 import { getGlobalSession, getAccounts } from '../directSelectors';
 import { GOT_PUSH_TOKEN, ACK_PUSH_TOKEN, UNACK_PUSH_TOKEN } from '../actionConstants';
 import { identityOfAccount, authOfAccount } from '../account/accountMisc';
@@ -76,6 +76,7 @@ export const narrowToNotification = (data: ?Notification): GlobalThunkAction<voi
   const narrow = getNarrowFromNotificationData(
     data,
     getAllUsersByEmail(state),
+    getStreamsByName(state),
     getOwnUserId(state),
   );
   if (narrow) {

--- a/src/notification/types.js
+++ b/src/notification/types.js
@@ -19,7 +19,7 @@ type NotificationBase = {|
  */
 // NOTE: Keep the Android-side code in sync with this type definition.
 export type Notification =
-  | {| ...NotificationBase, recipient_type: 'stream', stream: string, topic: string |}
+  | {| ...NotificationBase, recipient_type: 'stream', stream_name: string, topic: string |}
   // Group PM messages have `pm_users`, which is sorted, comma-separated IDs.
   | {| ...NotificationBase, recipient_type: 'private', pm_users: string |}
   // 1:1 PM messages lack `pm_users`.

--- a/src/outbox/outboxActions.js
+++ b/src/outbox/outboxActions.js
@@ -23,7 +23,7 @@ import {
   DELETE_OUTBOX_MESSAGE,
   MESSAGE_SEND_COMPLETE,
 } from '../actionConstants';
-import { getAuth, getStreamsByName } from '../selectors';
+import { getAuth, getStreamsById } from '../selectors';
 import * as api from '../api';
 import { getAllUsersById, getOwnUser } from '../users/userSelectors';
 import { getUsersAndWildcards } from '../users/userHelpers';
@@ -133,7 +133,7 @@ type DataFromNarrow =
 
 const outboxPropertiesForNarrow = (
   destinationNarrow: Narrow,
-  streamsByName: Map<string, Stream>,
+  streamsById: Map<number, Stream>,
   allUsersById: Map<UserId, UserOrBot>,
   ownUser: UserOrBot,
 ): DataFromNarrow =>
@@ -144,8 +144,8 @@ const outboxPropertiesForNarrow = (
       subject: '',
     }),
 
-    topic: (streamName, topic) => {
-      const stream = streamsByName.get(streamName);
+    topic: (_, topic, streamId) => {
+      const stream = streamsById.get(streamId);
       invariant(stream, 'narrow must be known stream');
       return {
         type: 'stream',
@@ -185,7 +185,7 @@ export const addToOutbox = (
       isSent: false,
       ...outboxPropertiesForNarrow(
         destinationNarrow,
-        getStreamsByName(state),
+        getStreamsById(state),
         getAllUsersById(state),
         ownUser,
       ),

--- a/src/outbox/outboxActions.js
+++ b/src/outbox/outboxActions.js
@@ -144,7 +144,7 @@ const outboxPropertiesForNarrow = (
       subject: '',
     }),
 
-    topic: (_, topic, streamId) => {
+    topic: (streamId, topic) => {
       const stream = streamsById.get(streamId);
       invariant(stream, 'narrow must be known stream');
       return {

--- a/src/sharing/ShareToStream.js
+++ b/src/sharing/ShareToStream.js
@@ -74,14 +74,14 @@ class ShareToStreamInner extends React.Component<Props, State> {
   };
 
   focusTopic = () => {
-    const { streamName, streamId } = this.state;
+    const { streamId } = this.state;
     const { dispatch } = this.props;
 
     if (streamId !== null) {
       // We have an actual stream selected.  Fetch its recent topic names.
       // TODO: why do we do this?  `TopicAutocomplete` does the same thing,
       //   with an effect that reruns when the stream changes.
-      const narrow = streamNarrow(streamName, streamId);
+      const narrow = streamNarrow(streamId);
       dispatch(fetchTopicsForStream(narrow));
     }
     // If what's entered in the stream-name field isn't an actual stream,
@@ -147,7 +147,7 @@ class ShareToStreamInner extends React.Component<Props, State> {
   render() {
     const { sharedData } = this.props.route.params;
     const { streamName, streamId, topic, isStreamFocused, isTopicFocused } = this.state;
-    const narrow = streamId !== null ? streamNarrow(streamName, streamId) : null;
+    const narrow = streamId !== null ? streamNarrow(streamId) : null;
     const sendTo = {
       streamName,
       /* $FlowFixMe[incompatible-cast]: ShareWrapper will only look at this

--- a/src/sharing/ShareToStream.js
+++ b/src/sharing/ShareToStream.js
@@ -81,7 +81,7 @@ class ShareToStreamInner extends React.Component<Props, State> {
       // We have an actual stream selected.  Fetch its recent topic names.
       // TODO: why do we do this?  `TopicAutocomplete` does the same thing,
       //   with an effect that reruns when the stream changes.
-      const narrow = streamNarrow(streamName);
+      const narrow = streamNarrow(streamName, streamId);
       dispatch(fetchTopicsForStream(narrow));
     }
     // If what's entered in the stream-name field isn't an actual stream,
@@ -147,7 +147,7 @@ class ShareToStreamInner extends React.Component<Props, State> {
   render() {
     const { sharedData } = this.props.route.params;
     const { streamName, streamId, topic, isStreamFocused, isTopicFocused } = this.state;
-    const narrow = streamId !== null ? streamNarrow(streamName) : null;
+    const narrow = streamId !== null ? streamNarrow(streamName, streamId) : null;
     const sendTo = {
       streamName,
       /* $FlowFixMe[incompatible-cast]: ShareWrapper will only look at this

--- a/src/sharing/ShareWrapper.js
+++ b/src/sharing/ShareWrapper.js
@@ -210,8 +210,8 @@ class ShareWrapperInner extends React.Component<Props, State> {
       }
 
       case 'stream': {
-        const { streamName } = sendTo;
-        const narrow = streamNarrow(streamName);
+        const { streamName, streamId } = sendTo;
+        const narrow = streamNarrow(streamName, streamId);
         NavigationService.dispatch(replaceWithChat(narrow));
         break;
       }

--- a/src/sharing/ShareWrapper.js
+++ b/src/sharing/ShareWrapper.js
@@ -210,8 +210,8 @@ class ShareWrapperInner extends React.Component<Props, State> {
       }
 
       case 'stream': {
-        const { streamName, streamId } = sendTo;
-        const narrow = streamNarrow(streamName, streamId);
+        const { streamId } = sendTo;
+        const narrow = streamNarrow(streamId);
         NavigationService.dispatch(replaceWithChat(narrow));
         break;
       }

--- a/src/storage/__tests__/migrations-test.js
+++ b/src/storage/__tests__/migrations-test.js
@@ -87,7 +87,7 @@ describe('migrations', () => {
   // What `base` becomes after all migrations.
   const endBase = {
     ...base37,
-    migrations: { version: 38 },
+    migrations: { version: 39 },
   };
 
   for (const [desc, before, after] of [
@@ -224,6 +224,22 @@ describe('migrations', () => {
         },
       },
       { ...endBase, drafts: { 'pm:12': 'pm text' } },
+    ],
+    [
+      'check 39',
+      {
+        ...base37,
+        migrations: { version: 38 },
+        drafts: {
+          'topic:d:8:general\x00stuff': 'text',
+          'stream:d:8:general': 'more text',
+          'pm:12': 'pm text',
+        },
+      },
+      {
+        ...endBase,
+        drafts: { 'topic:8:stuff': 'text', 'stream:8': 'more text', 'pm:12': 'pm text' },
+      },
     ],
   ]) {
     /* eslint-disable no-loop-func */

--- a/src/storage/migrations.js
+++ b/src/storage/migrations.js
@@ -362,6 +362,19 @@ const migrationsInner: {| [string]: (LessPartialState) => LessPartialState |} = 
     ),
   }),
 
+  // Change format of keys representing stream/topic narrows, dropping names.
+  '39': state => ({
+    ...state,
+    drafts: objectFromEntries(
+      Object.keys(state.drafts).map(key => [
+        key
+          .replace(/^stream:d:(\d+):.*/s, 'stream:$1')
+          .replace(/^topic:d:(\d+):.*?\x00(.*)/s, 'topic:$1:$2'),
+        state.drafts[key],
+      ]),
+    ),
+  }),
+
   // TIP: When adding a migration, consider just using `dropCache`.
 };
 

--- a/src/storage/migrations.js
+++ b/src/storage/migrations.js
@@ -350,6 +350,18 @@ const migrationsInner: {| [string]: (LessPartialState) => LessPartialState |} = 
     },
   }),
 
+  // Change format of keys representing stream and topic narrows, adding IDs.
+  '38': state => ({
+    ...state,
+    drafts: objectFromEntries(
+      // Just drop drafts for stream and topic narrows, for the same reasons
+      // as for PM narrows in migration 21 above.
+      Object.keys(state.drafts)
+        .filter(key => !key.startsWith('stream:') && !key.startsWith('topic:'))
+        .map(key => [key, state.drafts[key]]),
+    ),
+  }),
+
   // TIP: When adding a migration, consider just using `dropCache`.
 };
 

--- a/src/streams/SubscriptionsCard.js
+++ b/src/streams/SubscriptionsCard.js
@@ -12,7 +12,7 @@ import StreamList from './StreamList';
 import { LoadingBanner } from '../common';
 import { streamNarrow } from '../utils/narrow';
 import { getUnreadByStream } from '../selectors';
-import { getSubscribedStreams } from '../subscriptions/subscriptionSelectors';
+import { getSubscriptions } from '../directSelectors';
 import { doNarrow } from '../actions';
 
 const styles = createStyleSheet({
@@ -29,7 +29,7 @@ type Props = $ReadOnly<{|
 
 export default function SubscriptionsCard(props: Props): Node {
   const dispatch = useDispatch();
-  const subscriptions = useSelector(getSubscribedStreams);
+  const subscriptions = useSelector(getSubscriptions);
   const unreadByStream = useSelector(getUnreadByStream);
 
   const handleNarrow = useCallback(

--- a/src/streams/SubscriptionsCard.js
+++ b/src/streams/SubscriptionsCard.js
@@ -33,9 +33,7 @@ export default function SubscriptionsCard(props: Props): Node {
   const unreadByStream = useSelector(getUnreadByStream);
 
   const handleNarrow = useCallback(
-    (streamId: number, streamName: string) => {
-      dispatch(doNarrow(streamNarrow(streamId)));
-    },
+    (streamId: number) => dispatch(doNarrow(streamNarrow(streamId))),
     [dispatch],
   );
 

--- a/src/streams/SubscriptionsCard.js
+++ b/src/streams/SubscriptionsCard.js
@@ -34,7 +34,7 @@ export default function SubscriptionsCard(props: Props): Node {
 
   const handleNarrow = useCallback(
     (streamId: number, streamName: string) => {
-      dispatch(doNarrow(streamNarrow(streamName, streamId)));
+      dispatch(doNarrow(streamNarrow(streamId)));
     },
     [dispatch],
   );

--- a/src/streams/SubscriptionsCard.js
+++ b/src/streams/SubscriptionsCard.js
@@ -34,7 +34,7 @@ export default function SubscriptionsCard(props: Props): Node {
 
   const handleNarrow = useCallback(
     (streamId: number, streamName: string) => {
-      dispatch(doNarrow(streamNarrow(streamName)));
+      dispatch(doNarrow(streamNarrow(streamName, streamId)));
     },
     [dispatch],
   );

--- a/src/streams/TopicItem.js
+++ b/src/streams/TopicItem.js
@@ -17,7 +17,6 @@ import {
   getFlags,
   getSubscriptionsById,
   getStreamsById,
-  getStreamsByName,
   getOwnUser,
 } from '../selectors';
 import { getUnread } from '../unread/unreadModel';
@@ -66,7 +65,6 @@ export default function TopicItem(props: Props): Node {
     auth: getAuth(state),
     mute: getMute(state),
     streams: getStreamsById(state),
-    streamsByName: getStreamsByName(state),
     subscriptions: getSubscriptionsById(state),
     unread: getUnread(state),
     ownUser: getOwnUser(state),

--- a/src/subscriptions/StreamListCard.js
+++ b/src/subscriptions/StreamListCard.js
@@ -56,7 +56,7 @@ export default function StreamListCard(props: Props): Node {
 
   const handleNarrow = useCallback(
     (streamId: number, streamName: string) => {
-      dispatch(doNarrow(streamNarrow(streamName)));
+      dispatch(doNarrow(streamNarrow(streamName, streamId)));
     },
     [dispatch],
   );

--- a/src/subscriptions/StreamListCard.js
+++ b/src/subscriptions/StreamListCard.js
@@ -55,9 +55,7 @@ export default function StreamListCard(props: Props): Node {
   );
 
   const handleNarrow = useCallback(
-    (streamId: number, streamName: string) => {
-      dispatch(doNarrow(streamNarrow(streamId)));
-    },
+    (streamId: number) => dispatch(doNarrow(streamNarrow(streamId))),
     [dispatch],
   );
 

--- a/src/subscriptions/StreamListCard.js
+++ b/src/subscriptions/StreamListCard.js
@@ -56,7 +56,7 @@ export default function StreamListCard(props: Props): Node {
 
   const handleNarrow = useCallback(
     (streamId: number, streamName: string) => {
-      dispatch(doNarrow(streamNarrow(streamName, streamId)));
+      dispatch(doNarrow(streamNarrow(streamId)));
     },
     [dispatch],
   );

--- a/src/subscriptions/__tests__/subscriptionSelectors-test.js
+++ b/src/subscriptions/__tests__/subscriptionSelectors-test.js
@@ -1,4 +1,4 @@
-import deepFreeze from 'deep-freeze';
+// @flow strict-local
 
 import {
   getStreamsById,
@@ -16,86 +16,64 @@ import {
 import * as eg from '../../__tests__/lib/exampleData';
 
 describe('getStreamsById', () => {
-  test('returns empty object for an empty input', () => {
-    const state = deepFreeze({
-      streams: [],
-    });
+  test('returns empty map for an empty input', () => {
+    const state = eg.reduxState({ streams: [] });
     expect(getStreamsById(state)).toEqual(new Map());
   });
 
-  test('returns an object with stream id as keys', () => {
-    const state = deepFreeze({
-      streams: [{ stream_id: 1 }, { stream_id: 2 }],
-    });
-
-    // prettier-ignore
-    const expectedState = new Map([[1, { stream_id: 1 }], [2, { stream_id: 2 }]]);
-
-    const streamsById = getStreamsById(state);
-
-    expect(streamsById).toEqual(expectedState);
+  test('returns a map with stream id as keys', () => {
+    const state = eg.reduxState({ streams: [eg.stream, eg.otherStream] });
+    expect(getStreamsById(state)).toEqual(
+      new Map([
+        [eg.stream.stream_id, eg.stream],
+        [eg.otherStream.stream_id, eg.otherStream],
+      ]),
+    );
   });
 });
 
 describe('getSubscriptionsById', () => {
-  test('returns empty object for an empty input', () => {
-    const state = deepFreeze({
-      subscriptions: [],
-    });
+  test('returns empty map for an empty input', () => {
+    const state = eg.reduxState({ subscriptions: [] });
     expect(getSubscriptionsById(state)).toEqual(new Map());
   });
 
-  test('returns an object with stream id as keys', () => {
-    const state = deepFreeze({
-      subscriptions: [{ stream_id: 1 }, { stream_id: 2 }],
-    });
-
-    // prettier-ignore
-    const expectedState = new Map([[1, { stream_id: 1 }], [2, { stream_id: 2 }]]);
-
-    const subscriptionsById = getSubscriptionsById(state);
-
-    expect(subscriptionsById).toEqual(expectedState);
+  test('returns a map with stream id as keys', () => {
+    const state = eg.reduxState({ subscriptions: [eg.subscription, eg.otherSubscription] });
+    expect(getSubscriptionsById(state)).toEqual(
+      new Map([
+        [eg.subscription.stream_id, eg.subscription],
+        [eg.otherSubscription.stream_id, eg.otherSubscription],
+      ]),
+    );
   });
 });
 
 describe('getIsActiveStreamSubscribed', () => {
-  test('return true for narrows other than stream and topic', () => {
-    const state = deepFreeze({});
+  const state = eg.reduxStatePlus({ subscriptions: [eg.subscription] });
 
+  test('return true for narrows other than stream and topic', () => {
     expect(getIsActiveStreamSubscribed(state, HOME_NARROW)).toBe(true);
   });
 
   test('return true if current narrowed stream is subscribed', () => {
-    const state = deepFreeze({
-      subscriptions: [{ name: 'announce' }],
-    });
-
-    expect(getIsActiveStreamSubscribed(state, streamNarrow('announce'))).toBe(true);
+    const narrow = streamNarrow(eg.stream.name);
+    expect(getIsActiveStreamSubscribed(state, narrow)).toBe(true);
   });
 
   test('return false if current narrowed stream is not subscribed', () => {
-    const state = deepFreeze({
-      subscriptions: [{ name: 'announce' }],
-    });
-
-    expect(getIsActiveStreamSubscribed(state, streamNarrow('all'))).toBe(false);
+    const narrow = streamNarrow(eg.otherStream.name);
+    expect(getIsActiveStreamSubscribed(state, narrow)).toBe(false);
   });
 
   test('return true if stream of current narrowed topic is subscribed', () => {
-    const state = deepFreeze({
-      subscriptions: [{ name: 'announce' }],
-    });
-
-    expect(getIsActiveStreamSubscribed(state, topicNarrow('announce', 'news'))).toBe(true);
+    const narrow = topicNarrow(eg.stream.name, 'news');
+    expect(getIsActiveStreamSubscribed(state, narrow)).toBe(true);
   });
 
   test('return false if stream of current narrowed topic is not subscribed', () => {
-    const state = deepFreeze({
-      subscriptions: [{ name: 'announce' }],
-    });
-
-    expect(getIsActiveStreamSubscribed(state, topicNarrow('all', 'news'))).toBe(false);
+    const narrow = topicNarrow(eg.otherStream.name, 'news');
+    expect(getIsActiveStreamSubscribed(state, narrow)).toBe(false);
   });
 });
 
@@ -106,18 +84,19 @@ describe('getStreamColorForNarrow', () => {
   });
 
   test('return stream color for stream and topic narrow', () => {
-    expect(getStreamColorForNarrow(state, streamNarrow(eg.stream.name))).toEqual(exampleColor);
+    const narrow = streamNarrow(eg.stream.name);
+    expect(getStreamColorForNarrow(state, narrow)).toEqual(exampleColor);
   });
 
   test('return null stream color for invalid stream or unknown subscriptions', () => {
     const unknownStream = eg.makeStream();
-    expect(getStreamColorForNarrow(state, streamNarrow(unknownStream.name))).toEqual('gray');
+    const narrow = streamNarrow(unknownStream.name);
+    expect(getStreamColorForNarrow(state, narrow)).toEqual('gray');
   });
 
   test('return undefined for non topic/stream narrow', () => {
     expect(getStreamColorForNarrow(state, pm1to1NarrowFromUser(eg.otherUser))).toEqual(undefined);
-    expect(
-      getStreamColorForNarrow(state, pmNarrowFromUsersUnsafe([eg.otherUser, eg.thirdUser])),
-    ).toEqual(undefined);
+    const narrow = pmNarrowFromUsersUnsafe([eg.otherUser, eg.thirdUser]);
+    expect(getStreamColorForNarrow(state, narrow)).toEqual(undefined);
   });
 });

--- a/src/subscriptions/__tests__/subscriptionSelectors-test.js
+++ b/src/subscriptions/__tests__/subscriptionSelectors-test.js
@@ -57,22 +57,22 @@ describe('getIsActiveStreamSubscribed', () => {
   });
 
   test('return true if current narrowed stream is subscribed', () => {
-    const narrow = streamNarrow(eg.stream.name);
+    const narrow = streamNarrow(eg.stream.name, eg.stream.stream_id);
     expect(getIsActiveStreamSubscribed(state, narrow)).toBe(true);
   });
 
   test('return false if current narrowed stream is not subscribed', () => {
-    const narrow = streamNarrow(eg.otherStream.name);
+    const narrow = streamNarrow(eg.otherStream.name, eg.otherStream.stream_id);
     expect(getIsActiveStreamSubscribed(state, narrow)).toBe(false);
   });
 
   test('return true if stream of current narrowed topic is subscribed', () => {
-    const narrow = topicNarrow(eg.stream.name, 'news');
+    const narrow = topicNarrow(eg.stream.name, eg.stream.stream_id, 'news');
     expect(getIsActiveStreamSubscribed(state, narrow)).toBe(true);
   });
 
   test('return false if stream of current narrowed topic is not subscribed', () => {
-    const narrow = topicNarrow(eg.otherStream.name, 'news');
+    const narrow = topicNarrow(eg.otherStream.name, eg.otherStream.stream_id, 'news');
     expect(getIsActiveStreamSubscribed(state, narrow)).toBe(false);
   });
 });
@@ -84,13 +84,13 @@ describe('getStreamColorForNarrow', () => {
   });
 
   test('return stream color for stream and topic narrow', () => {
-    const narrow = streamNarrow(eg.stream.name);
+    const narrow = streamNarrow(eg.stream.name, eg.stream.stream_id);
     expect(getStreamColorForNarrow(state, narrow)).toEqual(exampleColor);
   });
 
   test('return null stream color for invalid stream or unknown subscriptions', () => {
     const unknownStream = eg.makeStream();
-    const narrow = streamNarrow(unknownStream.name);
+    const narrow = streamNarrow(unknownStream.name, unknownStream.stream_id);
     expect(getStreamColorForNarrow(state, narrow)).toEqual('gray');
   });
 

--- a/src/subscriptions/__tests__/subscriptionSelectors-test.js
+++ b/src/subscriptions/__tests__/subscriptionSelectors-test.js
@@ -57,22 +57,22 @@ describe('getIsActiveStreamSubscribed', () => {
   });
 
   test('return true if current narrowed stream is subscribed', () => {
-    const narrow = streamNarrow(eg.stream.name, eg.stream.stream_id);
+    const narrow = streamNarrow(eg.stream.stream_id);
     expect(getIsActiveStreamSubscribed(state, narrow)).toBe(true);
   });
 
   test('return false if current narrowed stream is not subscribed', () => {
-    const narrow = streamNarrow(eg.otherStream.name, eg.otherStream.stream_id);
+    const narrow = streamNarrow(eg.otherStream.stream_id);
     expect(getIsActiveStreamSubscribed(state, narrow)).toBe(false);
   });
 
   test('return true if stream of current narrowed topic is subscribed', () => {
-    const narrow = topicNarrow(eg.stream.name, eg.stream.stream_id, 'news');
+    const narrow = topicNarrow(eg.stream.stream_id, 'news');
     expect(getIsActiveStreamSubscribed(state, narrow)).toBe(true);
   });
 
   test('return false if stream of current narrowed topic is not subscribed', () => {
-    const narrow = topicNarrow(eg.otherStream.name, eg.otherStream.stream_id, 'news');
+    const narrow = topicNarrow(eg.otherStream.stream_id, 'news');
     expect(getIsActiveStreamSubscribed(state, narrow)).toBe(false);
   });
 });
@@ -84,13 +84,13 @@ describe('getStreamColorForNarrow', () => {
   });
 
   test('return stream color for stream and topic narrow', () => {
-    const narrow = streamNarrow(eg.stream.name, eg.stream.stream_id);
+    const narrow = streamNarrow(eg.stream.stream_id);
     expect(getStreamColorForNarrow(state, narrow)).toEqual(exampleColor);
   });
 
   test('return null stream color for invalid stream or unknown subscriptions', () => {
     const unknownStream = eg.makeStream();
-    const narrow = streamNarrow(unknownStream.name, unknownStream.stream_id);
+    const narrow = streamNarrow(unknownStream.stream_id);
     expect(getStreamColorForNarrow(state, narrow)).toEqual('gray');
   });
 

--- a/src/subscriptions/__tests__/subscriptionSelectors-test.js
+++ b/src/subscriptions/__tests__/subscriptionSelectors-test.js
@@ -4,7 +4,6 @@ import {
   getStreamsById,
   getSubscriptionsById,
   getIsActiveStreamSubscribed,
-  getSubscribedStreams,
   getStreamColorForNarrow,
 } from '../subscriptionSelectors';
 import {
@@ -97,33 +96,6 @@ describe('getIsActiveStreamSubscribed', () => {
     });
 
     expect(getIsActiveStreamSubscribed(state, topicNarrow('all', 'news'))).toBe(false);
-  });
-});
-
-describe('getSubscribedStreams', () => {
-  test('get all subscribed streams', () => {
-    const state = deepFreeze({
-      streams: [
-        { stream_id: 1, name: 'all', description: 'stream for all' },
-        { stream_id: 2, name: 'new announce', description: 'stream for announce' },
-        { stream_id: 3, name: 'Denmark', description: 'Denmark is awesome' },
-        { stream_id: 4, name: 'general', description: 'stream for general' },
-      ],
-      subscriptions: [
-        { stream_id: 1, name: 'all', color: '#001' },
-        { stream_id: 2, name: 'announce', color: '#002' },
-        { stream_id: 4, name: 'general', color: '#003' },
-      ],
-    });
-
-    const expectedResult = [
-      { stream_id: 1, name: 'all', color: '#001', description: 'stream for all' },
-      { stream_id: 2, name: 'new announce', color: '#002', description: 'stream for announce' },
-      { stream_id: 4, name: 'general', color: '#003', description: 'stream for general' },
-    ];
-
-    const actualResult = getSubscribedStreams(state);
-    expect(actualResult).toEqual(expectedResult);
   });
 });
 

--- a/src/subscriptions/subscriptionSelectors.js
+++ b/src/subscriptions/subscriptionSelectors.js
@@ -32,11 +32,6 @@ export const getSubscriptionsById: Selector<Map<number, Subscription>> = createS
     new Map(subscriptions.map(subscription => [subscription.stream_id, subscription])),
 );
 
-export const getSubscriptionsByName: Selector<Map<string, Subscription>> = createSelector(
-  getSubscriptions,
-  subscriptions => new Map(subscriptions.map(subscription => [subscription.name, subscription])),
-);
-
 export const getIsActiveStreamSubscribed: Selector<boolean, Narrow> = createSelector(
   (state, narrow) => narrow,
   state => getSubscriptionsById(state),

--- a/src/subscriptions/subscriptionSelectors.js
+++ b/src/subscriptions/subscriptionSelectors.js
@@ -2,7 +2,7 @@
 import { createSelector } from 'reselect';
 
 import type { PerAccountState, Narrow, Selector, Stream, Subscription } from '../types';
-import { isStreamOrTopicNarrow, streamNameOfNarrow } from '../utils/narrow';
+import { isStreamOrTopicNarrow, streamIdOfNarrow } from '../utils/narrow';
 import { getSubscriptions, getStreams } from '../directSelectors';
 
 /**
@@ -39,14 +39,12 @@ export const getSubscriptionsByName: Selector<Map<string, Subscription>> = creat
 
 export const getIsActiveStreamSubscribed: Selector<boolean, Narrow> = createSelector(
   (state, narrow) => narrow,
-  state => getSubscriptions(state),
+  state => getSubscriptionsById(state),
   (narrow, subscriptions) => {
     if (!isStreamOrTopicNarrow(narrow)) {
       return true;
     }
-    const streamName = streamNameOfNarrow(narrow);
-
-    return subscriptions.find(sub => streamName === sub.name) !== undefined;
+    return subscriptions.get(streamIdOfNarrow(narrow)) !== undefined;
   },
 );
 
@@ -70,14 +68,12 @@ export const getStreamForId = (state: PerAccountState, streamId: number): Stream
 
 export const getIsActiveStreamAnnouncementOnly: Selector<boolean, Narrow> = createSelector(
   (state, narrow) => narrow,
-  state => getStreams(state),
+  state => getStreamsById(state),
   (narrow, streams) => {
     if (!isStreamOrTopicNarrow(narrow)) {
       return false;
     }
-    const streamName = streamNameOfNarrow(narrow);
-
-    const stream = streams.find(stream_ => streamName === stream_.name);
+    const stream = streams.get(streamIdOfNarrow(narrow));
     return stream ? stream.is_announcement_only : false;
   },
 );
@@ -92,7 +88,7 @@ export const getStreamColorForNarrow = (state: PerAccountState, narrow: Narrow):
     return undefined;
   }
 
-  const subscriptionsByName = getSubscriptionsByName(state);
-  const streamName = streamNameOfNarrow(narrow);
-  return subscriptionsByName.get(streamName)?.color ?? 'gray';
+  const subscriptionsById = getSubscriptionsById(state);
+  const streamId = streamIdOfNarrow(narrow);
+  return subscriptionsById.get(streamId)?.color ?? 'gray';
 };

--- a/src/subscriptions/subscriptionSelectors.js
+++ b/src/subscriptions/subscriptionSelectors.js
@@ -50,16 +50,6 @@ export const getIsActiveStreamSubscribed: Selector<boolean, Narrow> = createSele
   },
 );
 
-export const getSubscribedStreams: Selector<$ReadOnlyArray<Subscription>> = createSelector(
-  getStreams,
-  getSubscriptions,
-  (allStreams, allSubscriptions) =>
-    allSubscriptions.map(subscription => ({
-      ...subscription,
-      ...allStreams.find(stream => stream.stream_id === subscription.stream_id),
-    })),
-);
-
 /**
  * The stream with the given ID; throws if none.
  *

--- a/src/topics/TopicListScreen.js
+++ b/src/topics/TopicListScreen.js
@@ -27,7 +27,7 @@ export default function TopicListScreen(props: Props): Node {
 
   const handlePress = useCallback(
     (streamId: number, streamName: string, topic: string) => {
-      dispatch(doNarrow(topicNarrow(streamName, streamId, topic)));
+      dispatch(doNarrow(topicNarrow(streamId, topic)));
     },
     [dispatch],
   );

--- a/src/topics/TopicListScreen.js
+++ b/src/topics/TopicListScreen.js
@@ -26,7 +26,7 @@ export default function TopicListScreen(props: Props): Node {
   const [filter, setFilter] = useState<string>('');
 
   const handlePress = useCallback(
-    (streamId: number, streamName: string, topic: string) => {
+    (streamId: number, _ignored_streamName: string, topic: string) => {
       dispatch(doNarrow(topicNarrow(streamId, topic)));
     },
     [dispatch],

--- a/src/topics/TopicListScreen.js
+++ b/src/topics/TopicListScreen.js
@@ -27,7 +27,7 @@ export default function TopicListScreen(props: Props): Node {
 
   const handlePress = useCallback(
     (streamId: number, streamName: string, topic: string) => {
-      dispatch(doNarrow(topicNarrow(streamName, topic)));
+      dispatch(doNarrow(topicNarrow(streamName, streamId, topic)));
     },
     [dispatch],
   );

--- a/src/topics/__tests__/topicsSelectors-test.js
+++ b/src/topics/__tests__/topicsSelectors-test.js
@@ -23,7 +23,7 @@ describe('getTopicsForNarrow', () => {
       },
     });
 
-    const topics = getTopicsForNarrow(state, streamNarrow(stream.name, stream.stream_id));
+    const topics = getTopicsForNarrow(state, streamNarrow(stream.stream_id));
 
     expect(topics).toEqual(['hi', 'wow']);
   });

--- a/src/topics/__tests__/topicsSelectors-test.js
+++ b/src/topics/__tests__/topicsSelectors-test.js
@@ -23,7 +23,7 @@ describe('getTopicsForNarrow', () => {
       },
     });
 
-    const topics = getTopicsForNarrow(state, streamNarrow(stream.name));
+    const topics = getTopicsForNarrow(state, streamNarrow(stream.name, stream.stream_id));
 
     expect(topics).toEqual(['hi', 'wow']);
   });

--- a/src/topics/topicActions.js
+++ b/src/topics/topicActions.js
@@ -2,8 +2,8 @@
 import type { Narrow, Topic, PerAccountAction, ThunkAction, Outbox } from '../types';
 import * as api from '../api';
 import { INIT_TOPICS } from '../actionConstants';
-import { isStreamNarrow, streamNameOfNarrow } from '../utils/narrow';
-import { getAuth, getStreams } from '../selectors';
+import { isStreamNarrow, streamIdOfNarrow } from '../utils/narrow';
+import { getAuth } from '../selectors';
 import { deleteOutboxMessage } from '../actions';
 import { getOutbox } from '../directSelectors';
 
@@ -26,20 +26,10 @@ export const fetchTopicsForStream = (narrow: Narrow): ThunkAction<Promise<void>>
   dispatch,
   getState,
 ) => {
-  const state = getState();
-
   if (!isStreamNarrow(narrow)) {
     return;
   }
-  const streamName = streamNameOfNarrow(narrow);
-
-  const streams = getStreams(state);
-  // TODO (#4333): Look for the stream by its ID, not its name.
-  const stream = streams.find(sub => streamName === sub.name);
-  if (!stream) {
-    return;
-  }
-  dispatch(fetchTopics(stream.stream_id));
+  dispatch(fetchTopics(streamIdOfNarrow(narrow)));
 };
 
 export const deleteMessagesForTopic = (

--- a/src/topics/topicSelectors.js
+++ b/src/topics/topicSelectors.js
@@ -1,35 +1,27 @@
 /* @flow strict-local */
 import { createSelector } from 'reselect';
 
-import type { Narrow, Selector, StreamsState, TopicExtended, TopicsState } from '../types';
-import { getMute, getStreams, getTopics } from '../directSelectors';
+import type { Narrow, Selector, TopicExtended, TopicsState } from '../types';
+import { getMute, getTopics } from '../directSelectors';
 import { getUnread, getUnreadCountForTopic } from '../unread/unreadModel';
 import { getStreamsById } from '../subscriptions/subscriptionSelectors';
 import { NULL_ARRAY } from '../nullObjects';
-import { isStreamNarrow, streamNameOfNarrow } from '../utils/narrow';
+import { isStreamNarrow, streamIdOfNarrow } from '../utils/narrow';
 import { isTopicMuted } from '../mute/muteModel';
 
 export const getTopicsForNarrow: Selector<$ReadOnlyArray<string>, Narrow> = createSelector(
   (state, narrow) => narrow,
   state => getTopics(state),
-  state => getStreams(state),
-  (narrow: Narrow, topics: TopicsState, streams: StreamsState) => {
+  (narrow: Narrow, topics: TopicsState) => {
     if (!isStreamNarrow(narrow)) {
       return NULL_ARRAY;
     }
-    const streamName = streamNameOfNarrow(narrow);
+    const streamId = streamIdOfNarrow(narrow);
 
-    // TODO (#4333): Look for the stream by its ID, not its name. One
-    // expected consequence of the current code is that
-    // `TopicAutocomplete` would stop showing any topics, if someone
-    // changed the stream name while you were looking at
-    // `TopicAutocomplete`.
-    const stream = streams.find(x => x.name === streamName);
-    if (!stream || !topics[stream.stream_id]) {
+    if (!topics[streamId]) {
       return NULL_ARRAY;
     }
-
-    return topics[stream.stream_id].map(x => x.name);
+    return topics[streamId].map(x => x.name);
   },
 );
 

--- a/src/unread/UnreadCards.js
+++ b/src/unread/UnreadCards.js
@@ -54,7 +54,7 @@ export default function UnreadCards(props: Props): Node {
             isPrivate={section.isPrivate}
             backgroundColor={section.color}
             unreadCount={section.unread}
-            onPress={(streamId: number, streamName: string) => {
+            onPress={(streamId: number) => {
               setTimeout(() => dispatch(doNarrow(streamNarrow(streamId))));
             }}
           />
@@ -71,7 +71,7 @@ export default function UnreadCards(props: Props): Node {
             isMuted={section.isMuted || item.isMuted}
             isSelected={false}
             unreadCount={item.unread}
-            onPress={(streamId: number, streamName: string, topic: string) => {
+            onPress={(streamId: number, _ignored_streamName: string, topic: string) => {
               setTimeout(() => dispatch(doNarrow(topicNarrow(streamId, topic))));
             }}
           />

--- a/src/unread/UnreadCards.js
+++ b/src/unread/UnreadCards.js
@@ -55,7 +55,7 @@ export default function UnreadCards(props: Props): Node {
             backgroundColor={section.color}
             unreadCount={section.unread}
             onPress={(streamId: number, streamName: string) => {
-              setTimeout(() => dispatch(doNarrow(streamNarrow(streamName))));
+              setTimeout(() => dispatch(doNarrow(streamNarrow(streamName, streamId))));
             }}
           />
         )
@@ -72,7 +72,7 @@ export default function UnreadCards(props: Props): Node {
             isSelected={false}
             unreadCount={item.unread}
             onPress={(streamId: number, streamName: string, topic: string) => {
-              setTimeout(() => dispatch(doNarrow(topicNarrow(streamName, topic))));
+              setTimeout(() => dispatch(doNarrow(topicNarrow(streamName, streamId, topic))));
             }}
           />
         )

--- a/src/unread/UnreadCards.js
+++ b/src/unread/UnreadCards.js
@@ -55,7 +55,7 @@ export default function UnreadCards(props: Props): Node {
             backgroundColor={section.color}
             unreadCount={section.unread}
             onPress={(streamId: number, streamName: string) => {
-              setTimeout(() => dispatch(doNarrow(streamNarrow(streamName, streamId))));
+              setTimeout(() => dispatch(doNarrow(streamNarrow(streamId))));
             }}
           />
         )
@@ -72,7 +72,7 @@ export default function UnreadCards(props: Props): Node {
             isSelected={false}
             unreadCount={item.unread}
             onPress={(streamId: number, streamName: string, topic: string) => {
-              setTimeout(() => dispatch(doNarrow(topicNarrow(streamName, streamId, topic))));
+              setTimeout(() => dispatch(doNarrow(topicNarrow(streamId, topic))));
             }}
           />
         )

--- a/src/unread/unreadSelectors.js
+++ b/src/unread/unreadSelectors.js
@@ -231,7 +231,7 @@ export const getUnreadCountForNarrow: Selector<number, Narrow> = createSelector(
     caseNarrow(narrow, {
       home: () => unreadTotal,
 
-      stream: (_1, streamId) => {
+      stream: streamId => {
         const stream = streams.get(streamId);
         if (!stream) {
           return 0;
@@ -248,7 +248,7 @@ export const getUnreadCountForNarrow: Selector<number, Narrow> = createSelector(
         );
       },
 
-      topic: (_, topic, streamId) => getUnreadCountForTopic(unread, streamId, topic),
+      topic: (streamId, topic) => getUnreadCountForTopic(unread, streamId, topic),
 
       pm: _ => getUnreadIdsForPmNarrow(unread, narrow, ownUserId).length,
 

--- a/src/utils/__tests__/internalLinks-test.js
+++ b/src/utils/__tests__/internalLinks-test.js
@@ -275,9 +275,7 @@ describe('getNarrowFromLink', () => {
     /* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["expect", "expectStream"] }] */
     const expectStream = (operand, streams, expectedStream: null | Stream) => {
       expect(get(`#narrow/stream/${operand}`, streams)).toEqual(
-        expectedStream === null
-          ? null
-          : streamNarrow(expectedStream.name, expectedStream.stream_id),
+        expectedStream === null ? null : streamNarrow(expectedStream.stream_id),
       );
     };
 
@@ -322,7 +320,7 @@ describe('getNarrowFromLink', () => {
       const expectNameMatch = (operand, streamName) => {
         const stream = eg.makeStream({ name: streamName });
         expect(get(`https://example.com/#narrow/stream/${operand}`, [stream])).toEqual(
-          streamNarrow(stream.name, stream.stream_id),
+          streamNarrow(stream.stream_id),
         );
       };
       expectNameMatch('jest', 'jest');
@@ -336,10 +334,10 @@ describe('getNarrowFromLink', () => {
 
     test('on old stream link, without realm info', () => {
       expect(get(`/#narrow/stream/${eg.stream.name}`, [eg.stream])).toEqual(
-        streamNarrow(eg.stream.name, eg.stream.stream_id),
+        streamNarrow(eg.stream.stream_id),
       );
       expect(get(`#narrow/stream/${eg.stream.name}`, [eg.stream])).toEqual(
-        streamNarrow(eg.stream.name, eg.stream.stream_id),
+        streamNarrow(eg.stream.stream_id),
       );
     });
   });
@@ -349,7 +347,7 @@ describe('getNarrowFromLink', () => {
       const expectBasic = (operand, expectedTopic) => {
         const url = `#narrow/stream/${streamGeneral.stream_id}-general/topic/${operand}`;
         expect(get(url, [streamGeneral])).toEqual(
-          topicNarrow(streamGeneral.name, streamGeneral.stream_id, expectedTopic),
+          topicNarrow(streamGeneral.stream_id, expectedTopic),
         );
       };
 
@@ -360,11 +358,11 @@ describe('getNarrowFromLink', () => {
     test('on old topic link, with dot-encoding', () => {
       expect(
         get(`https://example.com/#narrow/stream/${eg.stream.name}/topic/(no.20topic)`, [eg.stream]),
-      ).toEqual(topicNarrow(eg.stream.name, eg.stream.stream_id, '(no topic)'));
+      ).toEqual(topicNarrow(eg.stream.stream_id, '(no topic)'));
 
       expect(
         get(`https://example.com/#narrow/stream/${eg.stream.name}/topic/google.2Ecom`, [eg.stream]),
-      ).toEqual(topicNarrow(eg.stream.name, eg.stream.stream_id, 'google.com'));
+      ).toEqual(topicNarrow(eg.stream.stream_id, 'google.com'));
 
       expect(() =>
         get(`https://example.com/#narrow/stream/${eg.stream.name}/topic/google.com`, [eg.stream]),
@@ -372,23 +370,23 @@ describe('getNarrowFromLink', () => {
 
       expect(
         get(`https://example.com/#narrow/stream/${eg.stream.name}/topic/topic.20name`, [eg.stream]),
-      ).toEqual(topicNarrow(eg.stream.name, eg.stream.stream_id, 'topic name'));
+      ).toEqual(topicNarrow(eg.stream.stream_id, 'topic name'));
 
       expect(
         get(`https://example.com/#narrow/stream/${eg.stream.name}/topic/stream`, [eg.stream]),
-      ).toEqual(topicNarrow(eg.stream.name, eg.stream.stream_id, 'stream'));
+      ).toEqual(topicNarrow(eg.stream.stream_id, 'stream'));
 
       expect(
         get(`https://example.com/#narrow/stream/${eg.stream.name}/topic/topic`, [eg.stream]),
-      ).toEqual(topicNarrow(eg.stream.name, eg.stream.stream_id, 'topic'));
+      ).toEqual(topicNarrow(eg.stream.stream_id, 'topic'));
     });
 
     test('on old topic link, without realm info', () => {
       expect(get(`/#narrow/stream/${eg.stream.name}/topic/topic`, [eg.stream])).toEqual(
-        topicNarrow(eg.stream.name, eg.stream.stream_id, 'topic'),
+        topicNarrow(eg.stream.stream_id, 'topic'),
       );
       expect(get(`#narrow/stream/${eg.stream.name}/topic/topic`, [eg.stream])).toEqual(
-        topicNarrow(eg.stream.name, eg.stream.stream_id, 'topic'),
+        topicNarrow(eg.stream.stream_id, 'topic'),
       );
     });
   });
@@ -420,11 +418,11 @@ describe('getNarrowFromLink', () => {
 
     expect(
       get(`https://example.com/#narrow/stream/${eg.stream.name}/topic/test/near/1`, [eg.stream]),
-    ).toEqual(topicNarrow(eg.stream.name, eg.stream.stream_id, 'test'));
+    ).toEqual(topicNarrow(eg.stream.stream_id, 'test'));
 
     expect(
       get(`https://example.com/#narrow/stream/${eg.stream.name}/subject/test/near/1`, [eg.stream]),
-    ).toEqual(topicNarrow(eg.stream.name, eg.stream.stream_id, 'test'));
+    ).toEqual(topicNarrow(eg.stream.stream_id, 'test'));
   });
 });
 

--- a/src/utils/__tests__/internalLinks-test.js
+++ b/src/utils/__tests__/internalLinks-test.js
@@ -275,7 +275,9 @@ describe('getNarrowFromLink', () => {
     /* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["expect", "expectStream"] }] */
     const expectStream = (operand, streams, expectedStream: null | Stream) => {
       expect(get(`#narrow/stream/${operand}`, streams)).toEqual(
-        expectedStream === null ? null : streamNarrow(expectedStream.name),
+        expectedStream === null
+          ? null
+          : streamNarrow(expectedStream.name, expectedStream.stream_id),
       );
     };
 
@@ -320,7 +322,7 @@ describe('getNarrowFromLink', () => {
       const expectNameMatch = (operand, streamName) => {
         const stream = eg.makeStream({ name: streamName });
         expect(get(`https://example.com/#narrow/stream/${operand}`, [stream])).toEqual(
-          streamNarrow(stream.name),
+          streamNarrow(stream.name, stream.stream_id),
         );
       };
       expectNameMatch('jest', 'jest');
@@ -334,10 +336,10 @@ describe('getNarrowFromLink', () => {
 
     test('on old stream link, without realm info', () => {
       expect(get(`/#narrow/stream/${eg.stream.name}`, [eg.stream])).toEqual(
-        streamNarrow(eg.stream.name),
+        streamNarrow(eg.stream.name, eg.stream.stream_id),
       );
       expect(get(`#narrow/stream/${eg.stream.name}`, [eg.stream])).toEqual(
-        streamNarrow(eg.stream.name),
+        streamNarrow(eg.stream.name, eg.stream.stream_id),
       );
     });
   });
@@ -346,7 +348,9 @@ describe('getNarrowFromLink', () => {
     test('basic', () => {
       const expectBasic = (operand, expectedTopic) => {
         const url = `#narrow/stream/${streamGeneral.stream_id}-general/topic/${operand}`;
-        expect(get(url, [streamGeneral])).toEqual(topicNarrow(streamGeneral.name, expectedTopic));
+        expect(get(url, [streamGeneral])).toEqual(
+          topicNarrow(streamGeneral.name, streamGeneral.stream_id, expectedTopic),
+        );
       };
 
       expectBasic('(no.20topic)', '(no topic)');
@@ -356,11 +360,11 @@ describe('getNarrowFromLink', () => {
     test('on old topic link, with dot-encoding', () => {
       expect(
         get(`https://example.com/#narrow/stream/${eg.stream.name}/topic/(no.20topic)`, [eg.stream]),
-      ).toEqual(topicNarrow(eg.stream.name, '(no topic)'));
+      ).toEqual(topicNarrow(eg.stream.name, eg.stream.stream_id, '(no topic)'));
 
       expect(
         get(`https://example.com/#narrow/stream/${eg.stream.name}/topic/google.2Ecom`, [eg.stream]),
-      ).toEqual(topicNarrow(eg.stream.name, 'google.com'));
+      ).toEqual(topicNarrow(eg.stream.name, eg.stream.stream_id, 'google.com'));
 
       expect(() =>
         get(`https://example.com/#narrow/stream/${eg.stream.name}/topic/google.com`, [eg.stream]),
@@ -368,23 +372,23 @@ describe('getNarrowFromLink', () => {
 
       expect(
         get(`https://example.com/#narrow/stream/${eg.stream.name}/topic/topic.20name`, [eg.stream]),
-      ).toEqual(topicNarrow(eg.stream.name, 'topic name'));
+      ).toEqual(topicNarrow(eg.stream.name, eg.stream.stream_id, 'topic name'));
 
       expect(
         get(`https://example.com/#narrow/stream/${eg.stream.name}/topic/stream`, [eg.stream]),
-      ).toEqual(topicNarrow(eg.stream.name, 'stream'));
+      ).toEqual(topicNarrow(eg.stream.name, eg.stream.stream_id, 'stream'));
 
       expect(
         get(`https://example.com/#narrow/stream/${eg.stream.name}/topic/topic`, [eg.stream]),
-      ).toEqual(topicNarrow(eg.stream.name, 'topic'));
+      ).toEqual(topicNarrow(eg.stream.name, eg.stream.stream_id, 'topic'));
     });
 
     test('on old topic link, without realm info', () => {
       expect(get(`/#narrow/stream/${eg.stream.name}/topic/topic`, [eg.stream])).toEqual(
-        topicNarrow(eg.stream.name, 'topic'),
+        topicNarrow(eg.stream.name, eg.stream.stream_id, 'topic'),
       );
       expect(get(`#narrow/stream/${eg.stream.name}/topic/topic`, [eg.stream])).toEqual(
-        topicNarrow(eg.stream.name, 'topic'),
+        topicNarrow(eg.stream.name, eg.stream.stream_id, 'topic'),
       );
     });
   });
@@ -416,11 +420,11 @@ describe('getNarrowFromLink', () => {
 
     expect(
       get(`https://example.com/#narrow/stream/${eg.stream.name}/topic/test/near/1`, [eg.stream]),
-    ).toEqual(topicNarrow(eg.stream.name, 'test'));
+    ).toEqual(topicNarrow(eg.stream.name, eg.stream.stream_id, 'test'));
 
     expect(
       get(`https://example.com/#narrow/stream/${eg.stream.name}/subject/test/near/1`, [eg.stream]),
-    ).toEqual(topicNarrow(eg.stream.name, 'test'));
+    ).toEqual(topicNarrow(eg.stream.name, eg.stream.stream_id, 'test'));
   });
 });
 

--- a/src/utils/__tests__/narrow-test.js
+++ b/src/utils/__tests__/narrow-test.js
@@ -26,6 +26,7 @@ import {
   streamNameOfNarrow,
   topicOfNarrow,
   caseNarrowPartial,
+  streamIdOfNarrow,
 } from '../narrow';
 import type { Narrow, Message } from '../../types';
 import * as eg from '../../__tests__/lib/exampleData';
@@ -87,6 +88,7 @@ describe('streamNarrow', () => {
   test('narrows to messages from a specific stream', () => {
     const narrow = streamNarrow(eg.stream.name, eg.stream.stream_id);
     expect(isStreamNarrow(narrow)).toBeTrue();
+    expect(streamIdOfNarrow(narrow)).toEqual(eg.stream.stream_id);
     expect(streamNameOfNarrow(narrow)).toEqual(eg.stream.name);
   });
 
@@ -101,6 +103,7 @@ describe('topicNarrow', () => {
   test('narrows to a specific topic within a specified stream', () => {
     const narrow = topicNarrow(eg.stream.name, eg.stream.stream_id, 'some topic');
     expect(isTopicNarrow(narrow)).toBeTrue();
+    expect(streamIdOfNarrow(narrow)).toEqual(eg.stream.stream_id);
     expect(streamNameOfNarrow(narrow)).toEqual(eg.stream.name);
     expect(topicOfNarrow(narrow)).toEqual('some topic');
   });

--- a/src/utils/__tests__/narrow-test.js
+++ b/src/utils/__tests__/narrow-test.js
@@ -61,8 +61,10 @@ describe('isPmNarrow', () => {
 describe('isStreamOrTopicNarrow', () => {
   test('check for stream or topic narrow', () => {
     expect(isStreamOrTopicNarrow(undefined)).toBe(false);
-    expect(isStreamOrTopicNarrow(streamNarrow(eg.stream.name))).toBe(true);
-    expect(isStreamOrTopicNarrow(topicNarrow(eg.stream.name, 'some topic'))).toBe(true);
+    expect(isStreamOrTopicNarrow(streamNarrow(eg.stream.name, eg.stream.stream_id))).toBe(true);
+    expect(
+      isStreamOrTopicNarrow(topicNarrow(eg.stream.name, eg.stream.stream_id, 'some topic')),
+    ).toBe(true);
     expect(isStreamOrTopicNarrow(HOME_NARROW)).toBe(false);
     expect(isStreamOrTopicNarrow(pm1to1NarrowFromUser(eg.otherUser))).toBe(false);
     expect(isStreamOrTopicNarrow(pmNarrowFromUsersUnsafe([eg.otherUser, eg.thirdUser]))).toBe(
@@ -76,14 +78,14 @@ describe('specialNarrow', () => {
   test('only narrowing with the "is" operator is special narrow', () => {
     expect(isSpecialNarrow(undefined)).toBe(false);
     expect(isSpecialNarrow(HOME_NARROW)).toBe(false);
-    expect(isSpecialNarrow(streamNarrow(eg.stream.name))).toBe(false);
+    expect(isSpecialNarrow(streamNarrow(eg.stream.name, eg.stream.stream_id))).toBe(false);
     expect(isSpecialNarrow(STARRED_NARROW)).toBe(true);
   });
 });
 
 describe('streamNarrow', () => {
   test('narrows to messages from a specific stream', () => {
-    const narrow = streamNarrow(eg.stream.name);
+    const narrow = streamNarrow(eg.stream.name, eg.stream.stream_id);
     expect(isStreamNarrow(narrow)).toBeTrue();
     expect(streamNameOfNarrow(narrow)).toEqual(eg.stream.name);
   });
@@ -91,13 +93,13 @@ describe('streamNarrow', () => {
   test('only narrow with operator of "stream" is a stream narrow', () => {
     expect(isStreamNarrow(undefined)).toBe(false);
     expect(isStreamNarrow(HOME_NARROW)).toBe(false);
-    expect(isStreamNarrow(streamNarrow(eg.stream.name))).toBe(true);
+    expect(isStreamNarrow(streamNarrow(eg.stream.name, eg.stream.stream_id))).toBe(true);
   });
 });
 
 describe('topicNarrow', () => {
   test('narrows to a specific topic within a specified stream', () => {
-    const narrow = topicNarrow(eg.stream.name, 'some topic');
+    const narrow = topicNarrow(eg.stream.name, eg.stream.stream_id, 'some topic');
     expect(isTopicNarrow(narrow)).toBeTrue();
     expect(streamNameOfNarrow(narrow)).toEqual(eg.stream.name);
     expect(topicOfNarrow(narrow)).toEqual('some topic');
@@ -106,7 +108,9 @@ describe('topicNarrow', () => {
   test('only narrow with two items, one for stream, one for topic is a topic narrow', () => {
     expect(isTopicNarrow(undefined)).toBe(false);
     expect(isTopicNarrow(HOME_NARROW)).toBe(false);
-    expect(isTopicNarrow(topicNarrow(eg.stream.name, 'some topic'))).toBe(true);
+    expect(isTopicNarrow(topicNarrow(eg.stream.name, eg.stream.stream_id, 'some topic'))).toBe(
+      true,
+    );
   });
 });
 
@@ -127,12 +131,12 @@ describe('isMessageInNarrow', () => {
       ['a message', true, eg.streamMessage()],
     ]],
 
-    ['whole-stream narrow', streamNarrow(eg.stream.name), [
+    ['whole-stream narrow', streamNarrow(eg.stream.name, eg.stream.stream_id), [
       ['matching stream message', true, eg.streamMessage()],
       ['other-stream message', false, eg.streamMessage({ stream: otherStream })],
       ['PM', false, eg.pmMessage()],
     ]],
-    ['stream conversation', topicNarrow(eg.stream.name, 'cabbages'), [
+    ['stream conversation', topicNarrow(eg.stream.name, eg.stream.stream_id, 'cabbages'), [
       ['matching message', true, eg.streamMessage({ subject: 'cabbages' })],
       ['message in same stream but other topic', false, eg.streamMessage({ subject: 'kings' })],
       ['other-stream message', false, eg.streamMessage({ stream: otherStream })],
@@ -253,8 +257,8 @@ describe('getNarrowsForMessage', () => {
       },
       expectedNarrows: [
         HOME_NARROW,
-        streamNarrow(eg.stream.name),
-        topicNarrow(eg.stream.name, 'myTopic'),
+        streamNarrow(eg.stream.name, eg.stream.stream_id),
+        topicNarrow(eg.stream.name, eg.stream.stream_id, 'myTopic'),
       ],
     },
     {
@@ -273,7 +277,11 @@ describe('getNarrowsForMessage', () => {
         ...eg.streamMessage({ stream: eg.stream }),
         subject: '',
       },
-      expectedNarrows: [HOME_NARROW, streamNarrow(eg.stream.name), topicNarrow(eg.stream.name, '')],
+      expectedNarrows: [
+        HOME_NARROW,
+        streamNarrow(eg.stream.name, eg.stream.stream_id),
+        topicNarrow(eg.stream.name, eg.stream.stream_id, ''),
+      ],
     },
     {
       label: 'PM message with one person',
@@ -323,7 +331,7 @@ describe('getNarrowForReply', () => {
 
   test('for stream message with nonempty topic, returns a topic narrow', () => {
     const message = eg.streamMessage();
-    const expectedNarrow = topicNarrow(eg.stream.name, message.subject);
+    const expectedNarrow = topicNarrow(eg.stream.name, eg.stream.stream_id, message.subject);
 
     const actualNarrow = getNarrowForReply(message, eg.selfUser.user_id);
 
@@ -333,8 +341,8 @@ describe('getNarrowForReply', () => {
 
 describe('keyFromNarrow+parseNarrow', () => {
   const baseNarrows = [
-    ['whole stream', streamNarrow(eg.stream.name)],
-    ['stream conversation', topicNarrow(eg.stream.name, 'a topic')],
+    ['whole stream', streamNarrow(eg.stream.name, eg.stream.stream_id)],
+    ['stream conversation', topicNarrow(eg.stream.name, eg.stream.stream_id, 'a topic')],
     ['1:1 PM conversation, non-self', pm1to1NarrowFromUser(eg.otherUser)],
     ['self-1:1 conversation', pm1to1NarrowFromUser(eg.selfUser)],
     ['group-PM conversation', pmNarrowFromUsersUnsafe([eg.otherUser, eg.thirdUser])],
@@ -353,15 +361,29 @@ describe('keyFromNarrow+parseNarrow', () => {
   const diverseCharactersStream = eg.makeStream({ name: diverseCharacters });
   const htmlEntitiesStream = eg.makeStream({ name: htmlEntities });
   const awkwardNarrows = [
-    ['whole stream about awkward characters', streamNarrow(diverseCharactersStream.name)],
-    ['whole stream about HTML entities', streamNarrow(htmlEntitiesStream.name)],
+    [
+      'whole stream about awkward characters',
+      streamNarrow(diverseCharactersStream.name, diverseCharactersStream.stream_id),
+    ],
+    [
+      'whole stream about HTML entities',
+      streamNarrow(htmlEntitiesStream.name, htmlEntitiesStream.stream_id),
+    ],
     [
       'stream conversation about awkward characters',
-      topicNarrow(diverseCharactersStream.name, `regarding ${diverseCharacters}`),
+      topicNarrow(
+        diverseCharactersStream.name,
+        diverseCharactersStream.stream_id,
+        `regarding ${diverseCharacters}`,
+      ),
     ],
     [
       'stream conversation about HTML entities',
-      topicNarrow(htmlEntitiesStream.name, `regarding ${htmlEntities}`),
+      topicNarrow(
+        htmlEntitiesStream.name,
+        htmlEntitiesStream.stream_id,
+        `regarding ${htmlEntities}`,
+      ),
     ],
     ['search narrow for awkward characters', SEARCH_NARROW(diverseCharacters)],
     ['search narrow for HTML entities', SEARCH_NARROW(htmlEntities)],

--- a/src/utils/__tests__/narrow-test.js
+++ b/src/utils/__tests__/narrow-test.js
@@ -350,16 +350,18 @@ describe('keyFromNarrow+parseNarrow', () => {
   // Try approximately everything else.
   const diverseCharacters = eg.diverseCharacters.replace(/\x00/g, '');
   const htmlEntities = 'h & t &amp; &lquo;ml&quot;';
+  const diverseCharactersStream = eg.makeStream({ name: diverseCharacters });
+  const htmlEntitiesStream = eg.makeStream({ name: htmlEntities });
   const awkwardNarrows = [
-    ['whole stream about awkward characters', streamNarrow(diverseCharacters)],
-    ['whole stream about HTML entities', streamNarrow(htmlEntities)],
+    ['whole stream about awkward characters', streamNarrow(diverseCharactersStream.name)],
+    ['whole stream about HTML entities', streamNarrow(htmlEntitiesStream.name)],
     [
       'stream conversation about awkward characters',
-      topicNarrow(diverseCharacters, `regarding ${diverseCharacters}`),
+      topicNarrow(diverseCharactersStream.name, `regarding ${diverseCharacters}`),
     ],
     [
       'stream conversation about HTML entities',
-      topicNarrow(htmlEntities, `regarding ${htmlEntities}`),
+      topicNarrow(htmlEntitiesStream.name, `regarding ${htmlEntities}`),
     ],
     ['search narrow for awkward characters', SEARCH_NARROW(diverseCharacters)],
     ['search narrow for HTML entities', SEARCH_NARROW(htmlEntities)],

--- a/src/utils/__tests__/narrow-test.js
+++ b/src/utils/__tests__/narrow-test.js
@@ -348,7 +348,6 @@ describe('keyFromNarrow+parseNarrow', () => {
   // The only character not allowed in Zulip stream names is '\x00'.
   // (See `check_stream_name` in zulip.git:zerver/lib/streams.py.)
   // Try approximately everything else.
-  /* eslint-disable no-control-regex */
   const diverseCharacters = eg.diverseCharacters.replace(/\x00/g, '');
   const htmlEntities = 'h & t &amp; &lquo;ml&quot;';
   const awkwardNarrows = [

--- a/src/utils/__tests__/narrow-test.js
+++ b/src/utils/__tests__/narrow-test.js
@@ -23,7 +23,6 @@ import {
   STARRED_NARROW,
   MENTIONED_NARROW,
   keyFromNarrow,
-  streamNameOfNarrow,
   topicOfNarrow,
   caseNarrowPartial,
   streamIdOfNarrow,
@@ -89,7 +88,6 @@ describe('streamNarrow', () => {
     const narrow = streamNarrow(eg.stream.name, eg.stream.stream_id);
     expect(isStreamNarrow(narrow)).toBeTrue();
     expect(streamIdOfNarrow(narrow)).toEqual(eg.stream.stream_id);
-    expect(streamNameOfNarrow(narrow)).toEqual(eg.stream.name);
   });
 
   test('only narrow with operator of "stream" is a stream narrow', () => {
@@ -104,7 +102,6 @@ describe('topicNarrow', () => {
     const narrow = topicNarrow(eg.stream.name, eg.stream.stream_id, 'some topic');
     expect(isTopicNarrow(narrow)).toBeTrue();
     expect(streamIdOfNarrow(narrow)).toEqual(eg.stream.stream_id);
-    expect(streamNameOfNarrow(narrow)).toEqual(eg.stream.name);
     expect(topicOfNarrow(narrow)).toEqual('some topic');
   });
 

--- a/src/utils/internalLinks.js
+++ b/src/utils/internalLinks.js
@@ -119,19 +119,18 @@ export const decodeHashComponent = (string: string): string => {
 };
 
 /**
- * Parse the operand of a `stream` operator, returning a stream ID and name.
+ * Parse the operand of a `stream` operator.
  *
  * Return null if the operand doesn't match any known stream.
  */
-// TODO simplify: return only stream ID, not name
-const parseStreamOperand = (operand, streamsById, streamsByName): null | [string, number] => {
+const parseStreamOperand = (operand, streamsById, streamsByName): null | Stream => {
   // "New" (2018) format: ${stream_id}-${stream_name} .
   const match = /^([\d]+)(?:-.*)?$/.exec(operand);
   if (match) {
     const streamId = parseInt(match[1], 10);
     const stream = streamsById.get(streamId);
     if (stream) {
-      return [stream.name, streamId];
+      return stream;
     }
   }
 
@@ -140,7 +139,7 @@ const parseStreamOperand = (operand, streamsById, streamsByName): null | [string
   const streamName = decodeHashComponent(operand);
   const stream = streamsByName.get(streamName);
   if (stream) {
-    return [streamName, stream.stream_id];
+    return stream;
   }
 
   // Not any stream we know.  (Most likely this means a stream the user
@@ -189,12 +188,12 @@ export const getNarrowFromLink = (
       return pmNarrowFromRecipients(pmKeyRecipientsFromIds(ids, ownUserId));
     }
     case 'topic': {
-      const streamNameAndId = parseStreamOperand(paths[1], streamsById, streamsByName);
-      return streamNameAndId && topicNarrow(streamNameAndId[1], parseTopicOperand(paths[3]));
+      const stream = parseStreamOperand(paths[1], streamsById, streamsByName);
+      return stream && topicNarrow(stream.stream_id, parseTopicOperand(paths[3]));
     }
     case 'stream': {
-      const streamNameAndId = parseStreamOperand(paths[1], streamsById, streamsByName);
-      return streamNameAndId && streamNarrow(streamNameAndId[1]);
+      const stream = parseStreamOperand(paths[1], streamsById, streamsByName);
+      return stream && streamNarrow(stream.stream_id);
     }
     case 'special':
       try {

--- a/src/utils/internalLinks.js
+++ b/src/utils/internalLinks.js
@@ -123,6 +123,7 @@ export const decodeHashComponent = (string: string): string => {
  *
  * Return null if the operand doesn't match any known stream.
  */
+// TODO simplify: return only stream ID, not name
 const parseStreamOperand = (operand, streamsById, streamsByName): null | [string, number] => {
   // "New" (2018) format: ${stream_id}-${stream_name} .
   const match = /^([\d]+)(?:-.*)?$/.exec(operand);
@@ -189,11 +190,11 @@ export const getNarrowFromLink = (
     }
     case 'topic': {
       const streamNameAndId = parseStreamOperand(paths[1], streamsById, streamsByName);
-      return streamNameAndId && topicNarrow(...streamNameAndId, parseTopicOperand(paths[3]));
+      return streamNameAndId && topicNarrow(streamNameAndId[1], parseTopicOperand(paths[3]));
     }
     case 'stream': {
       const streamNameAndId = parseStreamOperand(paths[1], streamsById, streamsByName);
-      return streamNameAndId && streamNarrow(...streamNameAndId);
+      return streamNameAndId && streamNarrow(streamNameAndId[1]);
     }
     case 'special':
       try {

--- a/src/utils/internalLinks.js
+++ b/src/utils/internalLinks.js
@@ -189,11 +189,11 @@ export const getNarrowFromLink = (
     }
     case 'topic': {
       const streamNameAndId = parseStreamOperand(paths[1], streamsById, streamsByName);
-      return streamNameAndId && topicNarrow(streamNameAndId[0], parseTopicOperand(paths[3]));
+      return streamNameAndId && topicNarrow(...streamNameAndId, parseTopicOperand(paths[3]));
     }
     case 'stream': {
       const streamNameAndId = parseStreamOperand(paths[1], streamsById, streamsByName);
-      return streamNameAndId && streamNarrow(streamNameAndId[0]);
+      return streamNameAndId && streamNarrow(...streamNameAndId);
     }
     case 'special':
       try {

--- a/src/utils/narrow.js
+++ b/src/utils/narrow.js
@@ -477,11 +477,9 @@ export const isMessageInNarrow = (
 ): boolean =>
   caseNarrow(narrow, {
     home: () => true,
-    stream: name => message.type === 'stream' && name === streamNameOfStreamMessage(message),
-    topic: (streamName, topic) =>
-      message.type === 'stream'
-      && streamName === streamNameOfStreamMessage(message)
-      && topic === message.subject,
+    stream: (_, streamId) => message.type === 'stream' && streamId === message.stream_id,
+    topic: (_, topic, streamId) =>
+      message.type === 'stream' && streamId === message.stream_id && topic === message.subject,
     pm: ids => {
       if (message.type !== 'private') {
         return false;

--- a/src/utils/narrow.js
+++ b/src/utils/narrow.js
@@ -148,11 +148,12 @@ export const ALL_PRIVATE_NARROW: Narrow = specialNarrow('private');
 
 export const ALL_PRIVATE_NARROW_STR: string = keyFromNarrow(ALL_PRIVATE_NARROW);
 
-export const streamNarrow = (stream: string): Narrow =>
-  Object.freeze({ type: 'stream', streamName: stream });
+export const streamNarrow = (streamName: string, streamId?: number): Narrow =>
+  Object.freeze({ type: 'stream', streamName });
 
-export const topicNarrow = (stream: string, topic: string): Narrow =>
-  Object.freeze({ type: 'topic', streamName: stream, topic });
+export const topicNarrow = (streamName: string, ...args: [string] | [number, string]): Narrow =>
+  // $FlowFixMe[incompatible-cast]
+  Object.freeze({ type: 'topic', streamName, topic: (args[args.length - 1]: string) });
 
 export const SEARCH_NARROW = (query: string): Narrow => Object.freeze({ type: 'search', query });
 

--- a/src/utils/narrow.js
+++ b/src/utils/narrow.js
@@ -533,8 +533,8 @@ export const getNarrowsForMessage = (
     result.push(pmNarrowFromRecipients(pmKeyRecipientsFromMessage(message, ownUserId)));
   } else {
     const streamName = streamNameOfStreamMessage(message);
-    result.push(topicNarrow(streamName, message.subject));
-    result.push(streamNarrow(streamName));
+    result.push(topicNarrow(streamName, message.stream_id, message.subject));
+    result.push(streamNarrow(streamName, message.stream_id));
   }
 
   if (flags.includes('mentioned') || flags.includes('wildcard_mentioned')) {
@@ -562,6 +562,6 @@ export const getNarrowForReply = (message: Message | Outbox, ownUserId: UserId):
     return pmNarrowFromRecipients(pmKeyRecipientsFromMessage(message, ownUserId));
   } else {
     const streamName = streamNameOfStreamMessage(message);
-    return topicNarrow(streamName, message.subject);
+    return topicNarrow(streamName, message.stream_id, message.subject);
   }
 };

--- a/src/utils/narrow.js
+++ b/src/utils/narrow.js
@@ -351,17 +351,6 @@ export const userIdsOfPmNarrow = (narrow: Narrow): PmKeyRecipients =>
   caseNarrowPartial(narrow, { pm: ids => ids });
 
 /**
- * The stream name for a stream or topic narrow; else error.
- *
- * Most callers of this should probably be getting passed a stream name
- * instead of a Narrow in the first place; or if they do handle other kinds
- * of narrows, should be using `caseNarrow`.
- */
-// TODO delete
-export const streamNameOfNarrow = (narrow: Narrow): void =>
-  caseNarrowPartial(narrow, { stream: () => undefined, topic: () => undefined });
-
-/**
  * The stream ID for a stream or topic narrow; else error.
  *
  * Most callers of this should probably be getting passed a stream ID

--- a/src/utils/narrow.js
+++ b/src/utils/narrow.js
@@ -291,7 +291,6 @@ export const parseNarrow = (narrowStr: string): Narrow => {
       // The `/s` regexp flag means the `.` patterns match absolutely
       // anything.  By default they reject certain "newline" characters,
       // which in principle could appear in stream names or topics.
-      // eslint-disable-next-line no-control-regex
       const match = /^s:(.*?)\x00(.*)/s.exec(rest);
       if (!match) {
         throw makeError();

--- a/src/webview/MessageList.js
+++ b/src/webview/MessageList.js
@@ -47,7 +47,6 @@ import {
   getGlobalSettings,
   getSubscriptionsById,
   getStreamsById,
-  getStreamsByName,
   getRealm,
 } from '../selectors';
 import { withGetText } from '../boot/TranslationProvider';
@@ -92,7 +91,6 @@ export type BackgroundData = $ReadOnly<{|
   mutedUsers: MutedUsersState,
   ownUser: User,
   streams: Map<number, Stream>,
-  streamsByName: Map<string, Stream>,
   subscriptions: Map<number, Subscription>,
   unread: UnreadState,
   theme: ThemeName,
@@ -364,7 +362,6 @@ const MessageList: ComponentType<OuterProps> = connect<SelectorProps, _, _>(
       mutedUsers: getMutedUsers(state),
       ownUser: getOwnUser(state),
       streams: getStreamsById(state),
-      streamsByName: getStreamsByName(state),
       subscriptions: getSubscriptionsById(state),
       unread: getUnread(state),
       theme: globalSettings.theme,

--- a/src/webview/html/__tests__/__snapshots__/messageListElementHtml-test.js.snap.android
+++ b/src/webview/html/__tests__/__snapshots__/messageListElementHtml-test.js.snap.android
@@ -10,11 +10,11 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
 
 <div class=\\"msglist-element header-wrapper header stream-header topic-header\\"
     data-msg-id=\\"1024\\"
-    data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAx\\">
+    data-narrow=\\"dG9waWM6ZDoxOnN0cmVhbSAxAHRvcGljIDE=\\">
   <div class=\\"header stream-text\\"
        style=\\"color: black;
               background: hsl(0, 0%, 80%)\\"
-       data-narrow=\\"c3RyZWFtOnM6c3RyZWFtIDE=\\">
+       data-narrow=\\"c3RyZWFtOmQ6MTpzdHJlYW0gMQ==\\">
     # stream 1
   </div>
   <div class=\\"topic-text\\">topic 1</div>
@@ -88,11 +88,11 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
 
 <div class=\\"msglist-element header-wrapper header stream-header topic-header\\"
     data-msg-id=\\"7938\\"
-    data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAx\\">
+    data-narrow=\\"dG9waWM6ZDoxOnN0cmVhbSAxAHRvcGljIDE=\\">
   <div class=\\"header stream-text\\"
        style=\\"color: black;
               background: hsl(0, 0%, 80%)\\"
-       data-narrow=\\"c3RyZWFtOnM6c3RyZWFtIDE=\\">
+       data-narrow=\\"c3RyZWFtOmQ6MTpzdHJlYW0gMQ==\\">
     # stream 1
   </div>
   <div class=\\"topic-text\\">topic 1</div>
@@ -171,11 +171,11 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
 
 <div class=\\"msglist-element header-wrapper header stream-header topic-header\\"
     data-msg-id=\\"4948\\"
-    data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAx\\">
+    data-narrow=\\"dG9waWM6ZDoxOnN0cmVhbSAxAHRvcGljIDE=\\">
   <div class=\\"header stream-text\\"
        style=\\"color: black;
               background: hsl(0, 0%, 80%)\\"
-       data-narrow=\\"c3RyZWFtOnM6c3RyZWFtIDE=\\">
+       data-narrow=\\"c3RyZWFtOmQ6MTpzdHJlYW0gMQ==\\">
     # stream 1
   </div>
   <div class=\\"topic-text\\">topic 1</div>
@@ -214,11 +214,11 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
 
 <div class=\\"msglist-element header-wrapper header stream-header topic-header\\"
     data-msg-id=\\"5083\\"
-    data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAy\\">
+    data-narrow=\\"dG9waWM6ZDoxOnN0cmVhbSAxAHRvcGljIDI=\\">
   <div class=\\"header stream-text\\"
        style=\\"color: black;
               background: hsl(0, 0%, 80%)\\"
-       data-narrow=\\"c3RyZWFtOnM6c3RyZWFtIDE=\\">
+       data-narrow=\\"c3RyZWFtOmQ6MTpzdHJlYW0gMQ==\\">
     # stream 1
   </div>
   <div class=\\"topic-text\\">topic 2</div>
@@ -267,11 +267,11 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
 
 <div class=\\"msglist-element header-wrapper header stream-header topic-header\\"
     data-msg-id=\\"6789\\"
-    data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAx\\">
+    data-narrow=\\"dG9waWM6ZDoxOnN0cmVhbSAxAHRvcGljIDE=\\">
   <div class=\\"header stream-text\\"
        style=\\"color: black;
               background: hsl(0, 0%, 80%)\\"
-       data-narrow=\\"c3RyZWFtOnM6c3RyZWFtIDE=\\">
+       data-narrow=\\"c3RyZWFtOmQ6MTpzdHJlYW0gMQ==\\">
     # stream 1
   </div>
   <div class=\\"topic-text\\">topic 1</div>
@@ -310,11 +310,11 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
 
 <div class=\\"msglist-element header-wrapper header stream-header topic-header\\"
     data-msg-id=\\"7727\\"
-    data-narrow=\\"dG9waWM6czpzdHJlYW0gMgB0b3BpYyAy\\">
+    data-narrow=\\"dG9waWM6ZDoyOnN0cmVhbSAyAHRvcGljIDI=\\">
   <div class=\\"header stream-text\\"
        style=\\"color: black;
               background: hsl(0, 0%, 80%)\\"
-       data-narrow=\\"c3RyZWFtOnM6c3RyZWFtIDI=\\">
+       data-narrow=\\"c3RyZWFtOmQ6MjpzdHJlYW0gMg==\\">
     # stream 2
   </div>
   <div class=\\"topic-text\\">topic 2</div>
@@ -363,11 +363,11 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
 
 <div class=\\"msglist-element header-wrapper header stream-header topic-header\\"
     data-msg-id=\\"9181\\"
-    data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAx\\">
+    data-narrow=\\"dG9waWM6ZDoxOnN0cmVhbSAxAHRvcGljIDE=\\">
   <div class=\\"header stream-text\\"
        style=\\"color: black;
               background: hsl(0, 0%, 80%)\\"
-       data-narrow=\\"c3RyZWFtOnM6c3RyZWFtIDE=\\">
+       data-narrow=\\"c3RyZWFtOmQ6MTpzdHJlYW0gMQ==\\">
     # stream 1
   </div>
   <div class=\\"topic-text\\">topic 1</div>
@@ -910,11 +910,11 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
 
 <div class=\\"msglist-element header-wrapper header stream-header topic-header\\"
     data-msg-id=\\"1024\\"
-    data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAx\\">
+    data-narrow=\\"dG9waWM6ZDoxOnN0cmVhbSAxAHRvcGljIDE=\\">
   <div class=\\"header stream-text\\"
        style=\\"color: black;
               background: hsl(0, 0%, 80%)\\"
-       data-narrow=\\"c3RyZWFtOnM6c3RyZWFtIDE=\\">
+       data-narrow=\\"c3RyZWFtOmQ6MTpzdHJlYW0gMQ==\\">
     # stream 1
   </div>
   <div class=\\"topic-text\\">topic 1</div>
@@ -1056,11 +1056,11 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
 
 <div class=\\"msglist-element header-wrapper header stream-header topic-header\\"
     data-msg-id=\\"4948\\"
-    data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAx\\">
+    data-narrow=\\"dG9waWM6ZDoxOnN0cmVhbSAxAHRvcGljIDE=\\">
   <div class=\\"header stream-text\\"
        style=\\"color: black;
               background: hsl(0, 0%, 80%)\\"
-       data-narrow=\\"c3RyZWFtOnM6c3RyZWFtIDE=\\">
+       data-narrow=\\"c3RyZWFtOmQ6MTpzdHJlYW0gMQ==\\">
     # stream 1
   </div>
   <div class=\\"topic-text\\">topic 1</div>
@@ -1099,11 +1099,11 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
 
 <div class=\\"msglist-element header-wrapper header stream-header topic-header\\"
     data-msg-id=\\"5083\\"
-    data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAy\\">
+    data-narrow=\\"dG9waWM6ZDoxOnN0cmVhbSAxAHRvcGljIDI=\\">
   <div class=\\"header stream-text\\"
        style=\\"color: black;
               background: hsl(0, 0%, 80%)\\"
-       data-narrow=\\"c3RyZWFtOnM6c3RyZWFtIDE=\\">
+       data-narrow=\\"c3RyZWFtOmQ6MTpzdHJlYW0gMQ==\\">
     # stream 1
   </div>
   <div class=\\"topic-text\\">topic 2</div>
@@ -1402,11 +1402,11 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
 
 <div class=\\"msglist-element header-wrapper header stream-header topic-header\\"
     data-msg-id=\\"6789\\"
-    data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAx\\">
+    data-narrow=\\"dG9waWM6ZDoxOnN0cmVhbSAxAHRvcGljIDE=\\">
   <div class=\\"header stream-text\\"
        style=\\"color: black;
               background: hsl(0, 0%, 80%)\\"
-       data-narrow=\\"c3RyZWFtOnM6c3RyZWFtIDE=\\">
+       data-narrow=\\"c3RyZWFtOmQ6MTpzdHJlYW0gMQ==\\">
     # stream 1
   </div>
   <div class=\\"topic-text\\">topic 1</div>
@@ -1445,11 +1445,11 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
 
 <div class=\\"msglist-element header-wrapper header stream-header topic-header\\"
     data-msg-id=\\"7727\\"
-    data-narrow=\\"dG9waWM6czpzdHJlYW0gMgB0b3BpYyAy\\">
+    data-narrow=\\"dG9waWM6ZDoyOnN0cmVhbSAyAHRvcGljIDI=\\">
   <div class=\\"header stream-text\\"
        style=\\"color: black;
               background: hsl(0, 0%, 80%)\\"
-       data-narrow=\\"c3RyZWFtOnM6c3RyZWFtIDI=\\">
+       data-narrow=\\"c3RyZWFtOmQ6MjpzdHJlYW0gMg==\\">
     # stream 2
   </div>
   <div class=\\"topic-text\\">topic 2</div>
@@ -1488,11 +1488,11 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
 
 <div class=\\"msglist-element header-wrapper header stream-header topic-header\\"
     data-msg-id=\\"7938\\"
-    data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAx\\">
+    data-narrow=\\"dG9waWM6ZDoxOnN0cmVhbSAxAHRvcGljIDE=\\">
   <div class=\\"header stream-text\\"
        style=\\"color: black;
               background: hsl(0, 0%, 80%)\\"
-       data-narrow=\\"c3RyZWFtOnM6c3RyZWFtIDE=\\">
+       data-narrow=\\"c3RyZWFtOmQ6MTpzdHJlYW0gMQ==\\">
     # stream 1
   </div>
   <div class=\\"topic-text\\">topic 1</div>
@@ -1622,11 +1622,11 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
 
 <div class=\\"msglist-element header-wrapper header stream-header topic-header\\"
     data-msg-id=\\"9181\\"
-    data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAx\\">
+    data-narrow=\\"dG9waWM6ZDoxOnN0cmVhbSAxAHRvcGljIDE=\\">
   <div class=\\"header stream-text\\"
        style=\\"color: black;
               background: hsl(0, 0%, 80%)\\"
-       data-narrow=\\"c3RyZWFtOnM6c3RyZWFtIDE=\\">
+       data-narrow=\\"c3RyZWFtOmQ6MTpzdHJlYW0gMQ==\\">
     # stream 1
   </div>
   <div class=\\"topic-text\\">topic 1</div>
@@ -3373,7 +3373,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2
 "
 `;
 
-exports[`messages -> piece descriptors -> content HTML is stable/sensible stream:s:stream 1 1`] = `
+exports[`messages -> piece descriptors -> content HTML is stable/sensible stream:d:1:stream 1 1`] = `
 "
   <div class=\\"msglist-element timerow\\" data-msg-id=\\"1024\\">
     <div class=\\"timerow-left\\"></div>
@@ -3383,7 +3383,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible stream
 
 <div
   class=\\"msglist-element header-wrapper header topic-header\\"
-  data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAx\\"
+  data-narrow=\\"dG9waWM6ZDoxOnN0cmVhbSAxAHRvcGljIDE=\\"
   data-msg-id=\\"1024\\"
 >
   <div class=\\"topic-text\\">topic 1</div>
@@ -3447,7 +3447,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible stream
 "
 `;
 
-exports[`messages -> piece descriptors -> content HTML is stable/sensible stream:s:stream 1 2`] = `
+exports[`messages -> piece descriptors -> content HTML is stable/sensible stream:d:1:stream 1 2`] = `
 "
   <div class=\\"msglist-element timerow\\" data-msg-id=\\"7938\\">
     <div class=\\"timerow-left\\"></div>
@@ -3457,7 +3457,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible stream
 
 <div
   class=\\"msglist-element header-wrapper header topic-header\\"
-  data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAx\\"
+  data-narrow=\\"dG9waWM6ZDoxOnN0cmVhbSAxAHRvcGljIDE=\\"
   data-msg-id=\\"7938\\"
 >
   <div class=\\"topic-text\\">topic 1</div>
@@ -3526,7 +3526,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible stream
 "
 `;
 
-exports[`messages -> piece descriptors -> content HTML is stable/sensible stream:s:stream 1 3`] = `
+exports[`messages -> piece descriptors -> content HTML is stable/sensible stream:d:1:stream 1 3`] = `
 "
   <div class=\\"msglist-element timerow\\" data-msg-id=\\"4948\\">
     <div class=\\"timerow-left\\"></div>
@@ -3536,7 +3536,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible stream
 
 <div
   class=\\"msglist-element header-wrapper header topic-header\\"
-  data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAx\\"
+  data-narrow=\\"dG9waWM6ZDoxOnN0cmVhbSAxAHRvcGljIDE=\\"
   data-msg-id=\\"4948\\"
 >
   <div class=\\"topic-text\\">topic 1</div>
@@ -3575,7 +3575,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible stream
 
 <div
   class=\\"msglist-element header-wrapper header topic-header\\"
-  data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAy\\"
+  data-narrow=\\"dG9waWM6ZDoxOnN0cmVhbSAxAHRvcGljIDI=\\"
   data-msg-id=\\"5083\\"
 >
   <div class=\\"topic-text\\">topic 2</div>
@@ -3614,7 +3614,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible stream
 "
 `;
 
-exports[`messages -> piece descriptors -> content HTML is stable/sensible stream:s:stream 1 4`] = `
+exports[`messages -> piece descriptors -> content HTML is stable/sensible stream:d:1:stream 1 4`] = `
 "
   <div class=\\"msglist-element timerow\\" data-msg-id=\\"9181\\">
     <div class=\\"timerow-left\\"></div>
@@ -3624,7 +3624,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible stream
 
 <div
   class=\\"msglist-element header-wrapper header topic-header\\"
-  data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAx\\"
+  data-narrow=\\"dG9waWM6ZDoxOnN0cmVhbSAxAHRvcGljIDE=\\"
   data-msg-id=\\"9181\\"
 >
   <div class=\\"topic-text\\">topic 1</div>
@@ -3699,7 +3699,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible stream
 "
 `;
 
-exports[`messages -> piece descriptors -> content HTML is stable/sensible stream:s:stream 1 5`] = `
+exports[`messages -> piece descriptors -> content HTML is stable/sensible stream:d:1:stream 1 5`] = `
 "
   <div class=\\"msglist-element timerow\\" data-msg-id=\\"1024\\">
     <div class=\\"timerow-left\\"></div>
@@ -3709,7 +3709,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible stream
 
 <div
   class=\\"msglist-element header-wrapper header topic-header\\"
-  data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAx\\"
+  data-narrow=\\"dG9waWM6ZDoxOnN0cmVhbSAxAHRvcGljIDE=\\"
   data-msg-id=\\"1024\\"
 >
   <div class=\\"topic-text\\">topic 1</div>
@@ -3809,7 +3809,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible stream
 
 <div
   class=\\"msglist-element header-wrapper header topic-header\\"
-  data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAy\\"
+  data-narrow=\\"dG9waWM6ZDoxOnN0cmVhbSAxAHRvcGljIDI=\\"
   data-msg-id=\\"5083\\"
 >
   <div class=\\"topic-text\\">topic 2</div>
@@ -3854,7 +3854,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible stream
 
 <div
   class=\\"msglist-element header-wrapper header topic-header\\"
-  data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAx\\"
+  data-narrow=\\"dG9waWM6ZDoxOnN0cmVhbSAxAHRvcGljIDE=\\"
   data-msg-id=\\"7938\\"
 >
   <div class=\\"topic-text\\">topic 1</div>
@@ -3989,7 +3989,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible stream
 "
 `;
 
-exports[`messages -> piece descriptors -> content HTML is stable/sensible topic:s:stream 1 topic 1 1`] = `
+exports[`messages -> piece descriptors -> content HTML is stable/sensible topic:d:1:stream 1 topic 1 1`] = `
 "
   <div class=\\"msglist-element timerow\\" data-msg-id=\\"1024\\">
     <div class=\\"timerow-left\\"></div>
@@ -4054,7 +4054,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible topic:
 "
 `;
 
-exports[`messages -> piece descriptors -> content HTML is stable/sensible topic:s:stream 1 topic 1 2`] = `
+exports[`messages -> piece descriptors -> content HTML is stable/sensible topic:d:1:stream 1 topic 1 2`] = `
 "
   <div class=\\"msglist-element timerow\\" data-msg-id=\\"7938\\">
     <div class=\\"timerow-left\\"></div>
@@ -4124,7 +4124,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible topic:
 "
 `;
 
-exports[`messages -> piece descriptors -> content HTML is stable/sensible topic:s:stream 1 topic 1 3`] = `
+exports[`messages -> piece descriptors -> content HTML is stable/sensible topic:d:1:stream 1 topic 1 3`] = `
 "
   <div class=\\"msglist-element timerow\\" data-msg-id=\\"9181\\">
     <div class=\\"timerow-left\\"></div>
@@ -4200,7 +4200,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible topic:
 "
 `;
 
-exports[`messages -> piece descriptors -> content HTML is stable/sensible topic:s:stream 1 topic 1 4`] = `
+exports[`messages -> piece descriptors -> content HTML is stable/sensible topic:d:1:stream 1 topic 1 4`] = `
 "
   <div class=\\"msglist-element timerow\\" data-msg-id=\\"1024\\">
     <div class=\\"timerow-left\\"></div>

--- a/src/webview/html/__tests__/__snapshots__/messageListElementHtml-test.js.snap.android
+++ b/src/webview/html/__tests__/__snapshots__/messageListElementHtml-test.js.snap.android
@@ -10,11 +10,11 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
 
 <div class=\\"msglist-element header-wrapper header stream-header topic-header\\"
     data-msg-id=\\"1024\\"
-    data-narrow=\\"dG9waWM6ZDoxOnN0cmVhbSAxAHRvcGljIDE=\\">
+    data-narrow=\\"dG9waWM6MTp0b3BpYyAx\\">
   <div class=\\"header stream-text\\"
        style=\\"color: black;
               background: hsl(0, 0%, 80%)\\"
-       data-narrow=\\"c3RyZWFtOmQ6MTpzdHJlYW0gMQ==\\">
+       data-narrow=\\"c3RyZWFtOjE=\\">
     # stream 1
   </div>
   <div class=\\"topic-text\\">topic 1</div>
@@ -88,11 +88,11 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
 
 <div class=\\"msglist-element header-wrapper header stream-header topic-header\\"
     data-msg-id=\\"7938\\"
-    data-narrow=\\"dG9waWM6ZDoxOnN0cmVhbSAxAHRvcGljIDE=\\">
+    data-narrow=\\"dG9waWM6MTp0b3BpYyAx\\">
   <div class=\\"header stream-text\\"
        style=\\"color: black;
               background: hsl(0, 0%, 80%)\\"
-       data-narrow=\\"c3RyZWFtOmQ6MTpzdHJlYW0gMQ==\\">
+       data-narrow=\\"c3RyZWFtOjE=\\">
     # stream 1
   </div>
   <div class=\\"topic-text\\">topic 1</div>
@@ -171,11 +171,11 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
 
 <div class=\\"msglist-element header-wrapper header stream-header topic-header\\"
     data-msg-id=\\"4948\\"
-    data-narrow=\\"dG9waWM6ZDoxOnN0cmVhbSAxAHRvcGljIDE=\\">
+    data-narrow=\\"dG9waWM6MTp0b3BpYyAx\\">
   <div class=\\"header stream-text\\"
        style=\\"color: black;
               background: hsl(0, 0%, 80%)\\"
-       data-narrow=\\"c3RyZWFtOmQ6MTpzdHJlYW0gMQ==\\">
+       data-narrow=\\"c3RyZWFtOjE=\\">
     # stream 1
   </div>
   <div class=\\"topic-text\\">topic 1</div>
@@ -214,11 +214,11 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
 
 <div class=\\"msglist-element header-wrapper header stream-header topic-header\\"
     data-msg-id=\\"5083\\"
-    data-narrow=\\"dG9waWM6ZDoxOnN0cmVhbSAxAHRvcGljIDI=\\">
+    data-narrow=\\"dG9waWM6MTp0b3BpYyAy\\">
   <div class=\\"header stream-text\\"
        style=\\"color: black;
               background: hsl(0, 0%, 80%)\\"
-       data-narrow=\\"c3RyZWFtOmQ6MTpzdHJlYW0gMQ==\\">
+       data-narrow=\\"c3RyZWFtOjE=\\">
     # stream 1
   </div>
   <div class=\\"topic-text\\">topic 2</div>
@@ -267,11 +267,11 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
 
 <div class=\\"msglist-element header-wrapper header stream-header topic-header\\"
     data-msg-id=\\"6789\\"
-    data-narrow=\\"dG9waWM6ZDoxOnN0cmVhbSAxAHRvcGljIDE=\\">
+    data-narrow=\\"dG9waWM6MTp0b3BpYyAx\\">
   <div class=\\"header stream-text\\"
        style=\\"color: black;
               background: hsl(0, 0%, 80%)\\"
-       data-narrow=\\"c3RyZWFtOmQ6MTpzdHJlYW0gMQ==\\">
+       data-narrow=\\"c3RyZWFtOjE=\\">
     # stream 1
   </div>
   <div class=\\"topic-text\\">topic 1</div>
@@ -310,11 +310,11 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
 
 <div class=\\"msglist-element header-wrapper header stream-header topic-header\\"
     data-msg-id=\\"7727\\"
-    data-narrow=\\"dG9waWM6ZDoyOnN0cmVhbSAyAHRvcGljIDI=\\">
+    data-narrow=\\"dG9waWM6Mjp0b3BpYyAy\\">
   <div class=\\"header stream-text\\"
        style=\\"color: black;
               background: hsl(0, 0%, 80%)\\"
-       data-narrow=\\"c3RyZWFtOmQ6MjpzdHJlYW0gMg==\\">
+       data-narrow=\\"c3RyZWFtOjI=\\">
     # stream 2
   </div>
   <div class=\\"topic-text\\">topic 2</div>
@@ -363,11 +363,11 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
 
 <div class=\\"msglist-element header-wrapper header stream-header topic-header\\"
     data-msg-id=\\"9181\\"
-    data-narrow=\\"dG9waWM6ZDoxOnN0cmVhbSAxAHRvcGljIDE=\\">
+    data-narrow=\\"dG9waWM6MTp0b3BpYyAx\\">
   <div class=\\"header stream-text\\"
        style=\\"color: black;
               background: hsl(0, 0%, 80%)\\"
-       data-narrow=\\"c3RyZWFtOmQ6MTpzdHJlYW0gMQ==\\">
+       data-narrow=\\"c3RyZWFtOjE=\\">
     # stream 1
   </div>
   <div class=\\"topic-text\\">topic 1</div>
@@ -910,11 +910,11 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
 
 <div class=\\"msglist-element header-wrapper header stream-header topic-header\\"
     data-msg-id=\\"1024\\"
-    data-narrow=\\"dG9waWM6ZDoxOnN0cmVhbSAxAHRvcGljIDE=\\">
+    data-narrow=\\"dG9waWM6MTp0b3BpYyAx\\">
   <div class=\\"header stream-text\\"
        style=\\"color: black;
               background: hsl(0, 0%, 80%)\\"
-       data-narrow=\\"c3RyZWFtOmQ6MTpzdHJlYW0gMQ==\\">
+       data-narrow=\\"c3RyZWFtOjE=\\">
     # stream 1
   </div>
   <div class=\\"topic-text\\">topic 1</div>
@@ -1056,11 +1056,11 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
 
 <div class=\\"msglist-element header-wrapper header stream-header topic-header\\"
     data-msg-id=\\"4948\\"
-    data-narrow=\\"dG9waWM6ZDoxOnN0cmVhbSAxAHRvcGljIDE=\\">
+    data-narrow=\\"dG9waWM6MTp0b3BpYyAx\\">
   <div class=\\"header stream-text\\"
        style=\\"color: black;
               background: hsl(0, 0%, 80%)\\"
-       data-narrow=\\"c3RyZWFtOmQ6MTpzdHJlYW0gMQ==\\">
+       data-narrow=\\"c3RyZWFtOjE=\\">
     # stream 1
   </div>
   <div class=\\"topic-text\\">topic 1</div>
@@ -1099,11 +1099,11 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
 
 <div class=\\"msglist-element header-wrapper header stream-header topic-header\\"
     data-msg-id=\\"5083\\"
-    data-narrow=\\"dG9waWM6ZDoxOnN0cmVhbSAxAHRvcGljIDI=\\">
+    data-narrow=\\"dG9waWM6MTp0b3BpYyAy\\">
   <div class=\\"header stream-text\\"
        style=\\"color: black;
               background: hsl(0, 0%, 80%)\\"
-       data-narrow=\\"c3RyZWFtOmQ6MTpzdHJlYW0gMQ==\\">
+       data-narrow=\\"c3RyZWFtOjE=\\">
     # stream 1
   </div>
   <div class=\\"topic-text\\">topic 2</div>
@@ -1402,11 +1402,11 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
 
 <div class=\\"msglist-element header-wrapper header stream-header topic-header\\"
     data-msg-id=\\"6789\\"
-    data-narrow=\\"dG9waWM6ZDoxOnN0cmVhbSAxAHRvcGljIDE=\\">
+    data-narrow=\\"dG9waWM6MTp0b3BpYyAx\\">
   <div class=\\"header stream-text\\"
        style=\\"color: black;
               background: hsl(0, 0%, 80%)\\"
-       data-narrow=\\"c3RyZWFtOmQ6MTpzdHJlYW0gMQ==\\">
+       data-narrow=\\"c3RyZWFtOjE=\\">
     # stream 1
   </div>
   <div class=\\"topic-text\\">topic 1</div>
@@ -1445,11 +1445,11 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
 
 <div class=\\"msglist-element header-wrapper header stream-header topic-header\\"
     data-msg-id=\\"7727\\"
-    data-narrow=\\"dG9waWM6ZDoyOnN0cmVhbSAyAHRvcGljIDI=\\">
+    data-narrow=\\"dG9waWM6Mjp0b3BpYyAy\\">
   <div class=\\"header stream-text\\"
        style=\\"color: black;
               background: hsl(0, 0%, 80%)\\"
-       data-narrow=\\"c3RyZWFtOmQ6MjpzdHJlYW0gMg==\\">
+       data-narrow=\\"c3RyZWFtOjI=\\">
     # stream 2
   </div>
   <div class=\\"topic-text\\">topic 2</div>
@@ -1488,11 +1488,11 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
 
 <div class=\\"msglist-element header-wrapper header stream-header topic-header\\"
     data-msg-id=\\"7938\\"
-    data-narrow=\\"dG9waWM6ZDoxOnN0cmVhbSAxAHRvcGljIDE=\\">
+    data-narrow=\\"dG9waWM6MTp0b3BpYyAx\\">
   <div class=\\"header stream-text\\"
        style=\\"color: black;
               background: hsl(0, 0%, 80%)\\"
-       data-narrow=\\"c3RyZWFtOmQ6MTpzdHJlYW0gMQ==\\">
+       data-narrow=\\"c3RyZWFtOjE=\\">
     # stream 1
   </div>
   <div class=\\"topic-text\\">topic 1</div>
@@ -1622,11 +1622,11 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
 
 <div class=\\"msglist-element header-wrapper header stream-header topic-header\\"
     data-msg-id=\\"9181\\"
-    data-narrow=\\"dG9waWM6ZDoxOnN0cmVhbSAxAHRvcGljIDE=\\">
+    data-narrow=\\"dG9waWM6MTp0b3BpYyAx\\">
   <div class=\\"header stream-text\\"
        style=\\"color: black;
               background: hsl(0, 0%, 80%)\\"
-       data-narrow=\\"c3RyZWFtOmQ6MTpzdHJlYW0gMQ==\\">
+       data-narrow=\\"c3RyZWFtOjE=\\">
     # stream 1
   </div>
   <div class=\\"topic-text\\">topic 1</div>
@@ -3373,7 +3373,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2
 "
 `;
 
-exports[`messages -> piece descriptors -> content HTML is stable/sensible stream:d:1:stream 1 1`] = `
+exports[`messages -> piece descriptors -> content HTML is stable/sensible stream:1 1`] = `
 "
   <div class=\\"msglist-element timerow\\" data-msg-id=\\"1024\\">
     <div class=\\"timerow-left\\"></div>
@@ -3383,7 +3383,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible stream
 
 <div
   class=\\"msglist-element header-wrapper header topic-header\\"
-  data-narrow=\\"dG9waWM6ZDoxOnN0cmVhbSAxAHRvcGljIDE=\\"
+  data-narrow=\\"dG9waWM6MTp0b3BpYyAx\\"
   data-msg-id=\\"1024\\"
 >
   <div class=\\"topic-text\\">topic 1</div>
@@ -3447,7 +3447,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible stream
 "
 `;
 
-exports[`messages -> piece descriptors -> content HTML is stable/sensible stream:d:1:stream 1 2`] = `
+exports[`messages -> piece descriptors -> content HTML is stable/sensible stream:1 2`] = `
 "
   <div class=\\"msglist-element timerow\\" data-msg-id=\\"7938\\">
     <div class=\\"timerow-left\\"></div>
@@ -3457,7 +3457,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible stream
 
 <div
   class=\\"msglist-element header-wrapper header topic-header\\"
-  data-narrow=\\"dG9waWM6ZDoxOnN0cmVhbSAxAHRvcGljIDE=\\"
+  data-narrow=\\"dG9waWM6MTp0b3BpYyAx\\"
   data-msg-id=\\"7938\\"
 >
   <div class=\\"topic-text\\">topic 1</div>
@@ -3526,7 +3526,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible stream
 "
 `;
 
-exports[`messages -> piece descriptors -> content HTML is stable/sensible stream:d:1:stream 1 3`] = `
+exports[`messages -> piece descriptors -> content HTML is stable/sensible stream:1 3`] = `
 "
   <div class=\\"msglist-element timerow\\" data-msg-id=\\"4948\\">
     <div class=\\"timerow-left\\"></div>
@@ -3536,7 +3536,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible stream
 
 <div
   class=\\"msglist-element header-wrapper header topic-header\\"
-  data-narrow=\\"dG9waWM6ZDoxOnN0cmVhbSAxAHRvcGljIDE=\\"
+  data-narrow=\\"dG9waWM6MTp0b3BpYyAx\\"
   data-msg-id=\\"4948\\"
 >
   <div class=\\"topic-text\\">topic 1</div>
@@ -3575,7 +3575,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible stream
 
 <div
   class=\\"msglist-element header-wrapper header topic-header\\"
-  data-narrow=\\"dG9waWM6ZDoxOnN0cmVhbSAxAHRvcGljIDI=\\"
+  data-narrow=\\"dG9waWM6MTp0b3BpYyAy\\"
   data-msg-id=\\"5083\\"
 >
   <div class=\\"topic-text\\">topic 2</div>
@@ -3614,7 +3614,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible stream
 "
 `;
 
-exports[`messages -> piece descriptors -> content HTML is stable/sensible stream:d:1:stream 1 4`] = `
+exports[`messages -> piece descriptors -> content HTML is stable/sensible stream:1 4`] = `
 "
   <div class=\\"msglist-element timerow\\" data-msg-id=\\"9181\\">
     <div class=\\"timerow-left\\"></div>
@@ -3624,7 +3624,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible stream
 
 <div
   class=\\"msglist-element header-wrapper header topic-header\\"
-  data-narrow=\\"dG9waWM6ZDoxOnN0cmVhbSAxAHRvcGljIDE=\\"
+  data-narrow=\\"dG9waWM6MTp0b3BpYyAx\\"
   data-msg-id=\\"9181\\"
 >
   <div class=\\"topic-text\\">topic 1</div>
@@ -3699,7 +3699,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible stream
 "
 `;
 
-exports[`messages -> piece descriptors -> content HTML is stable/sensible stream:d:1:stream 1 5`] = `
+exports[`messages -> piece descriptors -> content HTML is stable/sensible stream:1 5`] = `
 "
   <div class=\\"msglist-element timerow\\" data-msg-id=\\"1024\\">
     <div class=\\"timerow-left\\"></div>
@@ -3709,7 +3709,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible stream
 
 <div
   class=\\"msglist-element header-wrapper header topic-header\\"
-  data-narrow=\\"dG9waWM6ZDoxOnN0cmVhbSAxAHRvcGljIDE=\\"
+  data-narrow=\\"dG9waWM6MTp0b3BpYyAx\\"
   data-msg-id=\\"1024\\"
 >
   <div class=\\"topic-text\\">topic 1</div>
@@ -3809,7 +3809,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible stream
 
 <div
   class=\\"msglist-element header-wrapper header topic-header\\"
-  data-narrow=\\"dG9waWM6ZDoxOnN0cmVhbSAxAHRvcGljIDI=\\"
+  data-narrow=\\"dG9waWM6MTp0b3BpYyAy\\"
   data-msg-id=\\"5083\\"
 >
   <div class=\\"topic-text\\">topic 2</div>
@@ -3854,7 +3854,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible stream
 
 <div
   class=\\"msglist-element header-wrapper header topic-header\\"
-  data-narrow=\\"dG9waWM6ZDoxOnN0cmVhbSAxAHRvcGljIDE=\\"
+  data-narrow=\\"dG9waWM6MTp0b3BpYyAx\\"
   data-msg-id=\\"7938\\"
 >
   <div class=\\"topic-text\\">topic 1</div>
@@ -3989,7 +3989,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible stream
 "
 `;
 
-exports[`messages -> piece descriptors -> content HTML is stable/sensible topic:d:1:stream 1 topic 1 1`] = `
+exports[`messages -> piece descriptors -> content HTML is stable/sensible topic:1:topic 1 1`] = `
 "
   <div class=\\"msglist-element timerow\\" data-msg-id=\\"1024\\">
     <div class=\\"timerow-left\\"></div>
@@ -4054,7 +4054,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible topic:
 "
 `;
 
-exports[`messages -> piece descriptors -> content HTML is stable/sensible topic:d:1:stream 1 topic 1 2`] = `
+exports[`messages -> piece descriptors -> content HTML is stable/sensible topic:1:topic 1 2`] = `
 "
   <div class=\\"msglist-element timerow\\" data-msg-id=\\"7938\\">
     <div class=\\"timerow-left\\"></div>
@@ -4124,7 +4124,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible topic:
 "
 `;
 
-exports[`messages -> piece descriptors -> content HTML is stable/sensible topic:d:1:stream 1 topic 1 3`] = `
+exports[`messages -> piece descriptors -> content HTML is stable/sensible topic:1:topic 1 3`] = `
 "
   <div class=\\"msglist-element timerow\\" data-msg-id=\\"9181\\">
     <div class=\\"timerow-left\\"></div>
@@ -4200,7 +4200,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible topic:
 "
 `;
 
-exports[`messages -> piece descriptors -> content HTML is stable/sensible topic:d:1:stream 1 topic 1 4`] = `
+exports[`messages -> piece descriptors -> content HTML is stable/sensible topic:1:topic 1 4`] = `
 "
   <div class=\\"msglist-element timerow\\" data-msg-id=\\"1024\\">
     <div class=\\"timerow-left\\"></div>

--- a/src/webview/html/__tests__/__snapshots__/messageListElementHtml-test.js.snap.ios
+++ b/src/webview/html/__tests__/__snapshots__/messageListElementHtml-test.js.snap.ios
@@ -10,11 +10,11 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
 
 <div class=\\"msglist-element header-wrapper header stream-header topic-header\\"
     data-msg-id=\\"1024\\"
-    data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAx\\">
+    data-narrow=\\"dG9waWM6ZDoxOnN0cmVhbSAxAHRvcGljIDE=\\">
   <div class=\\"header stream-text\\"
        style=\\"color: black;
               background: hsl(0, 0%, 80%)\\"
-       data-narrow=\\"c3RyZWFtOnM6c3RyZWFtIDE=\\">
+       data-narrow=\\"c3RyZWFtOmQ6MTpzdHJlYW0gMQ==\\">
     # stream 1
   </div>
   <div class=\\"topic-text\\">topic 1</div>
@@ -88,11 +88,11 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
 
 <div class=\\"msglist-element header-wrapper header stream-header topic-header\\"
     data-msg-id=\\"7938\\"
-    data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAx\\">
+    data-narrow=\\"dG9waWM6ZDoxOnN0cmVhbSAxAHRvcGljIDE=\\">
   <div class=\\"header stream-text\\"
        style=\\"color: black;
               background: hsl(0, 0%, 80%)\\"
-       data-narrow=\\"c3RyZWFtOnM6c3RyZWFtIDE=\\">
+       data-narrow=\\"c3RyZWFtOmQ6MTpzdHJlYW0gMQ==\\">
     # stream 1
   </div>
   <div class=\\"topic-text\\">topic 1</div>
@@ -171,11 +171,11 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
 
 <div class=\\"msglist-element header-wrapper header stream-header topic-header\\"
     data-msg-id=\\"4948\\"
-    data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAx\\">
+    data-narrow=\\"dG9waWM6ZDoxOnN0cmVhbSAxAHRvcGljIDE=\\">
   <div class=\\"header stream-text\\"
        style=\\"color: black;
               background: hsl(0, 0%, 80%)\\"
-       data-narrow=\\"c3RyZWFtOnM6c3RyZWFtIDE=\\">
+       data-narrow=\\"c3RyZWFtOmQ6MTpzdHJlYW0gMQ==\\">
     # stream 1
   </div>
   <div class=\\"topic-text\\">topic 1</div>
@@ -214,11 +214,11 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
 
 <div class=\\"msglist-element header-wrapper header stream-header topic-header\\"
     data-msg-id=\\"5083\\"
-    data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAy\\">
+    data-narrow=\\"dG9waWM6ZDoxOnN0cmVhbSAxAHRvcGljIDI=\\">
   <div class=\\"header stream-text\\"
        style=\\"color: black;
               background: hsl(0, 0%, 80%)\\"
-       data-narrow=\\"c3RyZWFtOnM6c3RyZWFtIDE=\\">
+       data-narrow=\\"c3RyZWFtOmQ6MTpzdHJlYW0gMQ==\\">
     # stream 1
   </div>
   <div class=\\"topic-text\\">topic 2</div>
@@ -267,11 +267,11 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
 
 <div class=\\"msglist-element header-wrapper header stream-header topic-header\\"
     data-msg-id=\\"6789\\"
-    data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAx\\">
+    data-narrow=\\"dG9waWM6ZDoxOnN0cmVhbSAxAHRvcGljIDE=\\">
   <div class=\\"header stream-text\\"
        style=\\"color: black;
               background: hsl(0, 0%, 80%)\\"
-       data-narrow=\\"c3RyZWFtOnM6c3RyZWFtIDE=\\">
+       data-narrow=\\"c3RyZWFtOmQ6MTpzdHJlYW0gMQ==\\">
     # stream 1
   </div>
   <div class=\\"topic-text\\">topic 1</div>
@@ -310,11 +310,11 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
 
 <div class=\\"msglist-element header-wrapper header stream-header topic-header\\"
     data-msg-id=\\"7727\\"
-    data-narrow=\\"dG9waWM6czpzdHJlYW0gMgB0b3BpYyAy\\">
+    data-narrow=\\"dG9waWM6ZDoyOnN0cmVhbSAyAHRvcGljIDI=\\">
   <div class=\\"header stream-text\\"
        style=\\"color: black;
               background: hsl(0, 0%, 80%)\\"
-       data-narrow=\\"c3RyZWFtOnM6c3RyZWFtIDI=\\">
+       data-narrow=\\"c3RyZWFtOmQ6MjpzdHJlYW0gMg==\\">
     # stream 2
   </div>
   <div class=\\"topic-text\\">topic 2</div>
@@ -363,11 +363,11 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
 
 <div class=\\"msglist-element header-wrapper header stream-header topic-header\\"
     data-msg-id=\\"9181\\"
-    data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAx\\">
+    data-narrow=\\"dG9waWM6ZDoxOnN0cmVhbSAxAHRvcGljIDE=\\">
   <div class=\\"header stream-text\\"
        style=\\"color: black;
               background: hsl(0, 0%, 80%)\\"
-       data-narrow=\\"c3RyZWFtOnM6c3RyZWFtIDE=\\">
+       data-narrow=\\"c3RyZWFtOmQ6MTpzdHJlYW0gMQ==\\">
     # stream 1
   </div>
   <div class=\\"topic-text\\">topic 1</div>
@@ -910,11 +910,11 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
 
 <div class=\\"msglist-element header-wrapper header stream-header topic-header\\"
     data-msg-id=\\"1024\\"
-    data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAx\\">
+    data-narrow=\\"dG9waWM6ZDoxOnN0cmVhbSAxAHRvcGljIDE=\\">
   <div class=\\"header stream-text\\"
        style=\\"color: black;
               background: hsl(0, 0%, 80%)\\"
-       data-narrow=\\"c3RyZWFtOnM6c3RyZWFtIDE=\\">
+       data-narrow=\\"c3RyZWFtOmQ6MTpzdHJlYW0gMQ==\\">
     # stream 1
   </div>
   <div class=\\"topic-text\\">topic 1</div>
@@ -1056,11 +1056,11 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
 
 <div class=\\"msglist-element header-wrapper header stream-header topic-header\\"
     data-msg-id=\\"4948\\"
-    data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAx\\">
+    data-narrow=\\"dG9waWM6ZDoxOnN0cmVhbSAxAHRvcGljIDE=\\">
   <div class=\\"header stream-text\\"
        style=\\"color: black;
               background: hsl(0, 0%, 80%)\\"
-       data-narrow=\\"c3RyZWFtOnM6c3RyZWFtIDE=\\">
+       data-narrow=\\"c3RyZWFtOmQ6MTpzdHJlYW0gMQ==\\">
     # stream 1
   </div>
   <div class=\\"topic-text\\">topic 1</div>
@@ -1099,11 +1099,11 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
 
 <div class=\\"msglist-element header-wrapper header stream-header topic-header\\"
     data-msg-id=\\"5083\\"
-    data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAy\\">
+    data-narrow=\\"dG9waWM6ZDoxOnN0cmVhbSAxAHRvcGljIDI=\\">
   <div class=\\"header stream-text\\"
        style=\\"color: black;
               background: hsl(0, 0%, 80%)\\"
-       data-narrow=\\"c3RyZWFtOnM6c3RyZWFtIDE=\\">
+       data-narrow=\\"c3RyZWFtOmQ6MTpzdHJlYW0gMQ==\\">
     # stream 1
   </div>
   <div class=\\"topic-text\\">topic 2</div>
@@ -1402,11 +1402,11 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
 
 <div class=\\"msglist-element header-wrapper header stream-header topic-header\\"
     data-msg-id=\\"6789\\"
-    data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAx\\">
+    data-narrow=\\"dG9waWM6ZDoxOnN0cmVhbSAxAHRvcGljIDE=\\">
   <div class=\\"header stream-text\\"
        style=\\"color: black;
               background: hsl(0, 0%, 80%)\\"
-       data-narrow=\\"c3RyZWFtOnM6c3RyZWFtIDE=\\">
+       data-narrow=\\"c3RyZWFtOmQ6MTpzdHJlYW0gMQ==\\">
     # stream 1
   </div>
   <div class=\\"topic-text\\">topic 1</div>
@@ -1445,11 +1445,11 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
 
 <div class=\\"msglist-element header-wrapper header stream-header topic-header\\"
     data-msg-id=\\"7727\\"
-    data-narrow=\\"dG9waWM6czpzdHJlYW0gMgB0b3BpYyAy\\">
+    data-narrow=\\"dG9waWM6ZDoyOnN0cmVhbSAyAHRvcGljIDI=\\">
   <div class=\\"header stream-text\\"
        style=\\"color: black;
               background: hsl(0, 0%, 80%)\\"
-       data-narrow=\\"c3RyZWFtOnM6c3RyZWFtIDI=\\">
+       data-narrow=\\"c3RyZWFtOmQ6MjpzdHJlYW0gMg==\\">
     # stream 2
   </div>
   <div class=\\"topic-text\\">topic 2</div>
@@ -1488,11 +1488,11 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
 
 <div class=\\"msglist-element header-wrapper header stream-header topic-header\\"
     data-msg-id=\\"7938\\"
-    data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAx\\">
+    data-narrow=\\"dG9waWM6ZDoxOnN0cmVhbSAxAHRvcGljIDE=\\">
   <div class=\\"header stream-text\\"
        style=\\"color: black;
               background: hsl(0, 0%, 80%)\\"
-       data-narrow=\\"c3RyZWFtOnM6c3RyZWFtIDE=\\">
+       data-narrow=\\"c3RyZWFtOmQ6MTpzdHJlYW0gMQ==\\">
     # stream 1
   </div>
   <div class=\\"topic-text\\">topic 1</div>
@@ -1622,11 +1622,11 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
 
 <div class=\\"msglist-element header-wrapper header stream-header topic-header\\"
     data-msg-id=\\"9181\\"
-    data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAx\\">
+    data-narrow=\\"dG9waWM6ZDoxOnN0cmVhbSAxAHRvcGljIDE=\\">
   <div class=\\"header stream-text\\"
        style=\\"color: black;
               background: hsl(0, 0%, 80%)\\"
-       data-narrow=\\"c3RyZWFtOnM6c3RyZWFtIDE=\\">
+       data-narrow=\\"c3RyZWFtOmQ6MTpzdHJlYW0gMQ==\\">
     # stream 1
   </div>
   <div class=\\"topic-text\\">topic 1</div>
@@ -3373,7 +3373,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2
 "
 `;
 
-exports[`messages -> piece descriptors -> content HTML is stable/sensible stream:s:stream 1 1`] = `
+exports[`messages -> piece descriptors -> content HTML is stable/sensible stream:d:1:stream 1 1`] = `
 "
   <div class=\\"msglist-element timerow\\" data-msg-id=\\"1024\\">
     <div class=\\"timerow-left\\"></div>
@@ -3383,7 +3383,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible stream
 
 <div
   class=\\"msglist-element header-wrapper header topic-header\\"
-  data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAx\\"
+  data-narrow=\\"dG9waWM6ZDoxOnN0cmVhbSAxAHRvcGljIDE=\\"
   data-msg-id=\\"1024\\"
 >
   <div class=\\"topic-text\\">topic 1</div>
@@ -3447,7 +3447,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible stream
 "
 `;
 
-exports[`messages -> piece descriptors -> content HTML is stable/sensible stream:s:stream 1 2`] = `
+exports[`messages -> piece descriptors -> content HTML is stable/sensible stream:d:1:stream 1 2`] = `
 "
   <div class=\\"msglist-element timerow\\" data-msg-id=\\"7938\\">
     <div class=\\"timerow-left\\"></div>
@@ -3457,7 +3457,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible stream
 
 <div
   class=\\"msglist-element header-wrapper header topic-header\\"
-  data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAx\\"
+  data-narrow=\\"dG9waWM6ZDoxOnN0cmVhbSAxAHRvcGljIDE=\\"
   data-msg-id=\\"7938\\"
 >
   <div class=\\"topic-text\\">topic 1</div>
@@ -3526,7 +3526,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible stream
 "
 `;
 
-exports[`messages -> piece descriptors -> content HTML is stable/sensible stream:s:stream 1 3`] = `
+exports[`messages -> piece descriptors -> content HTML is stable/sensible stream:d:1:stream 1 3`] = `
 "
   <div class=\\"msglist-element timerow\\" data-msg-id=\\"4948\\">
     <div class=\\"timerow-left\\"></div>
@@ -3536,7 +3536,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible stream
 
 <div
   class=\\"msglist-element header-wrapper header topic-header\\"
-  data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAx\\"
+  data-narrow=\\"dG9waWM6ZDoxOnN0cmVhbSAxAHRvcGljIDE=\\"
   data-msg-id=\\"4948\\"
 >
   <div class=\\"topic-text\\">topic 1</div>
@@ -3575,7 +3575,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible stream
 
 <div
   class=\\"msglist-element header-wrapper header topic-header\\"
-  data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAy\\"
+  data-narrow=\\"dG9waWM6ZDoxOnN0cmVhbSAxAHRvcGljIDI=\\"
   data-msg-id=\\"5083\\"
 >
   <div class=\\"topic-text\\">topic 2</div>
@@ -3614,7 +3614,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible stream
 "
 `;
 
-exports[`messages -> piece descriptors -> content HTML is stable/sensible stream:s:stream 1 4`] = `
+exports[`messages -> piece descriptors -> content HTML is stable/sensible stream:d:1:stream 1 4`] = `
 "
   <div class=\\"msglist-element timerow\\" data-msg-id=\\"9181\\">
     <div class=\\"timerow-left\\"></div>
@@ -3624,7 +3624,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible stream
 
 <div
   class=\\"msglist-element header-wrapper header topic-header\\"
-  data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAx\\"
+  data-narrow=\\"dG9waWM6ZDoxOnN0cmVhbSAxAHRvcGljIDE=\\"
   data-msg-id=\\"9181\\"
 >
   <div class=\\"topic-text\\">topic 1</div>
@@ -3699,7 +3699,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible stream
 "
 `;
 
-exports[`messages -> piece descriptors -> content HTML is stable/sensible stream:s:stream 1 5`] = `
+exports[`messages -> piece descriptors -> content HTML is stable/sensible stream:d:1:stream 1 5`] = `
 "
   <div class=\\"msglist-element timerow\\" data-msg-id=\\"1024\\">
     <div class=\\"timerow-left\\"></div>
@@ -3709,7 +3709,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible stream
 
 <div
   class=\\"msglist-element header-wrapper header topic-header\\"
-  data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAx\\"
+  data-narrow=\\"dG9waWM6ZDoxOnN0cmVhbSAxAHRvcGljIDE=\\"
   data-msg-id=\\"1024\\"
 >
   <div class=\\"topic-text\\">topic 1</div>
@@ -3809,7 +3809,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible stream
 
 <div
   class=\\"msglist-element header-wrapper header topic-header\\"
-  data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAy\\"
+  data-narrow=\\"dG9waWM6ZDoxOnN0cmVhbSAxAHRvcGljIDI=\\"
   data-msg-id=\\"5083\\"
 >
   <div class=\\"topic-text\\">topic 2</div>
@@ -3854,7 +3854,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible stream
 
 <div
   class=\\"msglist-element header-wrapper header topic-header\\"
-  data-narrow=\\"dG9waWM6czpzdHJlYW0gMQB0b3BpYyAx\\"
+  data-narrow=\\"dG9waWM6ZDoxOnN0cmVhbSAxAHRvcGljIDE=\\"
   data-msg-id=\\"7938\\"
 >
   <div class=\\"topic-text\\">topic 1</div>
@@ -3989,7 +3989,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible stream
 "
 `;
 
-exports[`messages -> piece descriptors -> content HTML is stable/sensible topic:s:stream 1 topic 1 1`] = `
+exports[`messages -> piece descriptors -> content HTML is stable/sensible topic:d:1:stream 1 topic 1 1`] = `
 "
   <div class=\\"msglist-element timerow\\" data-msg-id=\\"1024\\">
     <div class=\\"timerow-left\\"></div>
@@ -4054,7 +4054,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible topic:
 "
 `;
 
-exports[`messages -> piece descriptors -> content HTML is stable/sensible topic:s:stream 1 topic 1 2`] = `
+exports[`messages -> piece descriptors -> content HTML is stable/sensible topic:d:1:stream 1 topic 1 2`] = `
 "
   <div class=\\"msglist-element timerow\\" data-msg-id=\\"7938\\">
     <div class=\\"timerow-left\\"></div>
@@ -4124,7 +4124,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible topic:
 "
 `;
 
-exports[`messages -> piece descriptors -> content HTML is stable/sensible topic:s:stream 1 topic 1 3`] = `
+exports[`messages -> piece descriptors -> content HTML is stable/sensible topic:d:1:stream 1 topic 1 3`] = `
 "
   <div class=\\"msglist-element timerow\\" data-msg-id=\\"9181\\">
     <div class=\\"timerow-left\\"></div>
@@ -4200,7 +4200,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible topic:
 "
 `;
 
-exports[`messages -> piece descriptors -> content HTML is stable/sensible topic:s:stream 1 topic 1 4`] = `
+exports[`messages -> piece descriptors -> content HTML is stable/sensible topic:d:1:stream 1 topic 1 4`] = `
 "
   <div class=\\"msglist-element timerow\\" data-msg-id=\\"1024\\">
     <div class=\\"timerow-left\\"></div>

--- a/src/webview/html/__tests__/__snapshots__/messageListElementHtml-test.js.snap.ios
+++ b/src/webview/html/__tests__/__snapshots__/messageListElementHtml-test.js.snap.ios
@@ -10,11 +10,11 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
 
 <div class=\\"msglist-element header-wrapper header stream-header topic-header\\"
     data-msg-id=\\"1024\\"
-    data-narrow=\\"dG9waWM6ZDoxOnN0cmVhbSAxAHRvcGljIDE=\\">
+    data-narrow=\\"dG9waWM6MTp0b3BpYyAx\\">
   <div class=\\"header stream-text\\"
        style=\\"color: black;
               background: hsl(0, 0%, 80%)\\"
-       data-narrow=\\"c3RyZWFtOmQ6MTpzdHJlYW0gMQ==\\">
+       data-narrow=\\"c3RyZWFtOjE=\\">
     # stream 1
   </div>
   <div class=\\"topic-text\\">topic 1</div>
@@ -88,11 +88,11 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
 
 <div class=\\"msglist-element header-wrapper header stream-header topic-header\\"
     data-msg-id=\\"7938\\"
-    data-narrow=\\"dG9waWM6ZDoxOnN0cmVhbSAxAHRvcGljIDE=\\">
+    data-narrow=\\"dG9waWM6MTp0b3BpYyAx\\">
   <div class=\\"header stream-text\\"
        style=\\"color: black;
               background: hsl(0, 0%, 80%)\\"
-       data-narrow=\\"c3RyZWFtOmQ6MTpzdHJlYW0gMQ==\\">
+       data-narrow=\\"c3RyZWFtOjE=\\">
     # stream 1
   </div>
   <div class=\\"topic-text\\">topic 1</div>
@@ -171,11 +171,11 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
 
 <div class=\\"msglist-element header-wrapper header stream-header topic-header\\"
     data-msg-id=\\"4948\\"
-    data-narrow=\\"dG9waWM6ZDoxOnN0cmVhbSAxAHRvcGljIDE=\\">
+    data-narrow=\\"dG9waWM6MTp0b3BpYyAx\\">
   <div class=\\"header stream-text\\"
        style=\\"color: black;
               background: hsl(0, 0%, 80%)\\"
-       data-narrow=\\"c3RyZWFtOmQ6MTpzdHJlYW0gMQ==\\">
+       data-narrow=\\"c3RyZWFtOjE=\\">
     # stream 1
   </div>
   <div class=\\"topic-text\\">topic 1</div>
@@ -214,11 +214,11 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
 
 <div class=\\"msglist-element header-wrapper header stream-header topic-header\\"
     data-msg-id=\\"5083\\"
-    data-narrow=\\"dG9waWM6ZDoxOnN0cmVhbSAxAHRvcGljIDI=\\">
+    data-narrow=\\"dG9waWM6MTp0b3BpYyAy\\">
   <div class=\\"header stream-text\\"
        style=\\"color: black;
               background: hsl(0, 0%, 80%)\\"
-       data-narrow=\\"c3RyZWFtOmQ6MTpzdHJlYW0gMQ==\\">
+       data-narrow=\\"c3RyZWFtOjE=\\">
     # stream 1
   </div>
   <div class=\\"topic-text\\">topic 2</div>
@@ -267,11 +267,11 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
 
 <div class=\\"msglist-element header-wrapper header stream-header topic-header\\"
     data-msg-id=\\"6789\\"
-    data-narrow=\\"dG9waWM6ZDoxOnN0cmVhbSAxAHRvcGljIDE=\\">
+    data-narrow=\\"dG9waWM6MTp0b3BpYyAx\\">
   <div class=\\"header stream-text\\"
        style=\\"color: black;
               background: hsl(0, 0%, 80%)\\"
-       data-narrow=\\"c3RyZWFtOmQ6MTpzdHJlYW0gMQ==\\">
+       data-narrow=\\"c3RyZWFtOjE=\\">
     # stream 1
   </div>
   <div class=\\"topic-text\\">topic 1</div>
@@ -310,11 +310,11 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
 
 <div class=\\"msglist-element header-wrapper header stream-header topic-header\\"
     data-msg-id=\\"7727\\"
-    data-narrow=\\"dG9waWM6ZDoyOnN0cmVhbSAyAHRvcGljIDI=\\">
+    data-narrow=\\"dG9waWM6Mjp0b3BpYyAy\\">
   <div class=\\"header stream-text\\"
        style=\\"color: black;
               background: hsl(0, 0%, 80%)\\"
-       data-narrow=\\"c3RyZWFtOmQ6MjpzdHJlYW0gMg==\\">
+       data-narrow=\\"c3RyZWFtOjI=\\">
     # stream 2
   </div>
   <div class=\\"topic-text\\">topic 2</div>
@@ -363,11 +363,11 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
 
 <div class=\\"msglist-element header-wrapper header stream-header topic-header\\"
     data-msg-id=\\"9181\\"
-    data-narrow=\\"dG9waWM6ZDoxOnN0cmVhbSAxAHRvcGljIDE=\\">
+    data-narrow=\\"dG9waWM6MTp0b3BpYyAx\\">
   <div class=\\"header stream-text\\"
        style=\\"color: black;
               background: hsl(0, 0%, 80%)\\"
-       data-narrow=\\"c3RyZWFtOmQ6MTpzdHJlYW0gMQ==\\">
+       data-narrow=\\"c3RyZWFtOjE=\\">
     # stream 1
   </div>
   <div class=\\"topic-text\\">topic 1</div>
@@ -910,11 +910,11 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
 
 <div class=\\"msglist-element header-wrapper header stream-header topic-header\\"
     data-msg-id=\\"1024\\"
-    data-narrow=\\"dG9waWM6ZDoxOnN0cmVhbSAxAHRvcGljIDE=\\">
+    data-narrow=\\"dG9waWM6MTp0b3BpYyAx\\">
   <div class=\\"header stream-text\\"
        style=\\"color: black;
               background: hsl(0, 0%, 80%)\\"
-       data-narrow=\\"c3RyZWFtOmQ6MTpzdHJlYW0gMQ==\\">
+       data-narrow=\\"c3RyZWFtOjE=\\">
     # stream 1
   </div>
   <div class=\\"topic-text\\">topic 1</div>
@@ -1056,11 +1056,11 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
 
 <div class=\\"msglist-element header-wrapper header stream-header topic-header\\"
     data-msg-id=\\"4948\\"
-    data-narrow=\\"dG9waWM6ZDoxOnN0cmVhbSAxAHRvcGljIDE=\\">
+    data-narrow=\\"dG9waWM6MTp0b3BpYyAx\\">
   <div class=\\"header stream-text\\"
        style=\\"color: black;
               background: hsl(0, 0%, 80%)\\"
-       data-narrow=\\"c3RyZWFtOmQ6MTpzdHJlYW0gMQ==\\">
+       data-narrow=\\"c3RyZWFtOjE=\\">
     # stream 1
   </div>
   <div class=\\"topic-text\\">topic 1</div>
@@ -1099,11 +1099,11 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
 
 <div class=\\"msglist-element header-wrapper header stream-header topic-header\\"
     data-msg-id=\\"5083\\"
-    data-narrow=\\"dG9waWM6ZDoxOnN0cmVhbSAxAHRvcGljIDI=\\">
+    data-narrow=\\"dG9waWM6MTp0b3BpYyAy\\">
   <div class=\\"header stream-text\\"
        style=\\"color: black;
               background: hsl(0, 0%, 80%)\\"
-       data-narrow=\\"c3RyZWFtOmQ6MTpzdHJlYW0gMQ==\\">
+       data-narrow=\\"c3RyZWFtOjE=\\">
     # stream 1
   </div>
   <div class=\\"topic-text\\">topic 2</div>
@@ -1402,11 +1402,11 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
 
 <div class=\\"msglist-element header-wrapper header stream-header topic-header\\"
     data-msg-id=\\"6789\\"
-    data-narrow=\\"dG9waWM6ZDoxOnN0cmVhbSAxAHRvcGljIDE=\\">
+    data-narrow=\\"dG9waWM6MTp0b3BpYyAx\\">
   <div class=\\"header stream-text\\"
        style=\\"color: black;
               background: hsl(0, 0%, 80%)\\"
-       data-narrow=\\"c3RyZWFtOmQ6MTpzdHJlYW0gMQ==\\">
+       data-narrow=\\"c3RyZWFtOjE=\\">
     # stream 1
   </div>
   <div class=\\"topic-text\\">topic 1</div>
@@ -1445,11 +1445,11 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
 
 <div class=\\"msglist-element header-wrapper header stream-header topic-header\\"
     data-msg-id=\\"7727\\"
-    data-narrow=\\"dG9waWM6ZDoyOnN0cmVhbSAyAHRvcGljIDI=\\">
+    data-narrow=\\"dG9waWM6Mjp0b3BpYyAy\\">
   <div class=\\"header stream-text\\"
        style=\\"color: black;
               background: hsl(0, 0%, 80%)\\"
-       data-narrow=\\"c3RyZWFtOmQ6MjpzdHJlYW0gMg==\\">
+       data-narrow=\\"c3RyZWFtOjI=\\">
     # stream 2
   </div>
   <div class=\\"topic-text\\">topic 2</div>
@@ -1488,11 +1488,11 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
 
 <div class=\\"msglist-element header-wrapper header stream-header topic-header\\"
     data-msg-id=\\"7938\\"
-    data-narrow=\\"dG9waWM6ZDoxOnN0cmVhbSAxAHRvcGljIDE=\\">
+    data-narrow=\\"dG9waWM6MTp0b3BpYyAx\\">
   <div class=\\"header stream-text\\"
        style=\\"color: black;
               background: hsl(0, 0%, 80%)\\"
-       data-narrow=\\"c3RyZWFtOmQ6MTpzdHJlYW0gMQ==\\">
+       data-narrow=\\"c3RyZWFtOjE=\\">
     # stream 1
   </div>
   <div class=\\"topic-text\\">topic 1</div>
@@ -1622,11 +1622,11 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
 
 <div class=\\"msglist-element header-wrapper header stream-header topic-header\\"
     data-msg-id=\\"9181\\"
-    data-narrow=\\"dG9waWM6ZDoxOnN0cmVhbSAxAHRvcGljIDE=\\">
+    data-narrow=\\"dG9waWM6MTp0b3BpYyAx\\">
   <div class=\\"header stream-text\\"
        style=\\"color: black;
               background: hsl(0, 0%, 80%)\\"
-       data-narrow=\\"c3RyZWFtOmQ6MTpzdHJlYW0gMQ==\\">
+       data-narrow=\\"c3RyZWFtOjE=\\">
     # stream 1
   </div>
   <div class=\\"topic-text\\">topic 1</div>
@@ -3373,7 +3373,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2
 "
 `;
 
-exports[`messages -> piece descriptors -> content HTML is stable/sensible stream:d:1:stream 1 1`] = `
+exports[`messages -> piece descriptors -> content HTML is stable/sensible stream:1 1`] = `
 "
   <div class=\\"msglist-element timerow\\" data-msg-id=\\"1024\\">
     <div class=\\"timerow-left\\"></div>
@@ -3383,7 +3383,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible stream
 
 <div
   class=\\"msglist-element header-wrapper header topic-header\\"
-  data-narrow=\\"dG9waWM6ZDoxOnN0cmVhbSAxAHRvcGljIDE=\\"
+  data-narrow=\\"dG9waWM6MTp0b3BpYyAx\\"
   data-msg-id=\\"1024\\"
 >
   <div class=\\"topic-text\\">topic 1</div>
@@ -3447,7 +3447,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible stream
 "
 `;
 
-exports[`messages -> piece descriptors -> content HTML is stable/sensible stream:d:1:stream 1 2`] = `
+exports[`messages -> piece descriptors -> content HTML is stable/sensible stream:1 2`] = `
 "
   <div class=\\"msglist-element timerow\\" data-msg-id=\\"7938\\">
     <div class=\\"timerow-left\\"></div>
@@ -3457,7 +3457,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible stream
 
 <div
   class=\\"msglist-element header-wrapper header topic-header\\"
-  data-narrow=\\"dG9waWM6ZDoxOnN0cmVhbSAxAHRvcGljIDE=\\"
+  data-narrow=\\"dG9waWM6MTp0b3BpYyAx\\"
   data-msg-id=\\"7938\\"
 >
   <div class=\\"topic-text\\">topic 1</div>
@@ -3526,7 +3526,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible stream
 "
 `;
 
-exports[`messages -> piece descriptors -> content HTML is stable/sensible stream:d:1:stream 1 3`] = `
+exports[`messages -> piece descriptors -> content HTML is stable/sensible stream:1 3`] = `
 "
   <div class=\\"msglist-element timerow\\" data-msg-id=\\"4948\\">
     <div class=\\"timerow-left\\"></div>
@@ -3536,7 +3536,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible stream
 
 <div
   class=\\"msglist-element header-wrapper header topic-header\\"
-  data-narrow=\\"dG9waWM6ZDoxOnN0cmVhbSAxAHRvcGljIDE=\\"
+  data-narrow=\\"dG9waWM6MTp0b3BpYyAx\\"
   data-msg-id=\\"4948\\"
 >
   <div class=\\"topic-text\\">topic 1</div>
@@ -3575,7 +3575,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible stream
 
 <div
   class=\\"msglist-element header-wrapper header topic-header\\"
-  data-narrow=\\"dG9waWM6ZDoxOnN0cmVhbSAxAHRvcGljIDI=\\"
+  data-narrow=\\"dG9waWM6MTp0b3BpYyAy\\"
   data-msg-id=\\"5083\\"
 >
   <div class=\\"topic-text\\">topic 2</div>
@@ -3614,7 +3614,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible stream
 "
 `;
 
-exports[`messages -> piece descriptors -> content HTML is stable/sensible stream:d:1:stream 1 4`] = `
+exports[`messages -> piece descriptors -> content HTML is stable/sensible stream:1 4`] = `
 "
   <div class=\\"msglist-element timerow\\" data-msg-id=\\"9181\\">
     <div class=\\"timerow-left\\"></div>
@@ -3624,7 +3624,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible stream
 
 <div
   class=\\"msglist-element header-wrapper header topic-header\\"
-  data-narrow=\\"dG9waWM6ZDoxOnN0cmVhbSAxAHRvcGljIDE=\\"
+  data-narrow=\\"dG9waWM6MTp0b3BpYyAx\\"
   data-msg-id=\\"9181\\"
 >
   <div class=\\"topic-text\\">topic 1</div>
@@ -3699,7 +3699,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible stream
 "
 `;
 
-exports[`messages -> piece descriptors -> content HTML is stable/sensible stream:d:1:stream 1 5`] = `
+exports[`messages -> piece descriptors -> content HTML is stable/sensible stream:1 5`] = `
 "
   <div class=\\"msglist-element timerow\\" data-msg-id=\\"1024\\">
     <div class=\\"timerow-left\\"></div>
@@ -3709,7 +3709,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible stream
 
 <div
   class=\\"msglist-element header-wrapper header topic-header\\"
-  data-narrow=\\"dG9waWM6ZDoxOnN0cmVhbSAxAHRvcGljIDE=\\"
+  data-narrow=\\"dG9waWM6MTp0b3BpYyAx\\"
   data-msg-id=\\"1024\\"
 >
   <div class=\\"topic-text\\">topic 1</div>
@@ -3809,7 +3809,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible stream
 
 <div
   class=\\"msglist-element header-wrapper header topic-header\\"
-  data-narrow=\\"dG9waWM6ZDoxOnN0cmVhbSAxAHRvcGljIDI=\\"
+  data-narrow=\\"dG9waWM6MTp0b3BpYyAy\\"
   data-msg-id=\\"5083\\"
 >
   <div class=\\"topic-text\\">topic 2</div>
@@ -3854,7 +3854,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible stream
 
 <div
   class=\\"msglist-element header-wrapper header topic-header\\"
-  data-narrow=\\"dG9waWM6ZDoxOnN0cmVhbSAxAHRvcGljIDE=\\"
+  data-narrow=\\"dG9waWM6MTp0b3BpYyAx\\"
   data-msg-id=\\"7938\\"
 >
   <div class=\\"topic-text\\">topic 1</div>
@@ -3989,7 +3989,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible stream
 "
 `;
 
-exports[`messages -> piece descriptors -> content HTML is stable/sensible topic:d:1:stream 1 topic 1 1`] = `
+exports[`messages -> piece descriptors -> content HTML is stable/sensible topic:1:topic 1 1`] = `
 "
   <div class=\\"msglist-element timerow\\" data-msg-id=\\"1024\\">
     <div class=\\"timerow-left\\"></div>
@@ -4054,7 +4054,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible topic:
 "
 `;
 
-exports[`messages -> piece descriptors -> content HTML is stable/sensible topic:d:1:stream 1 topic 1 2`] = `
+exports[`messages -> piece descriptors -> content HTML is stable/sensible topic:1:topic 1 2`] = `
 "
   <div class=\\"msglist-element timerow\\" data-msg-id=\\"7938\\">
     <div class=\\"timerow-left\\"></div>
@@ -4124,7 +4124,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible topic:
 "
 `;
 
-exports[`messages -> piece descriptors -> content HTML is stable/sensible topic:d:1:stream 1 topic 1 3`] = `
+exports[`messages -> piece descriptors -> content HTML is stable/sensible topic:1:topic 1 3`] = `
 "
   <div class=\\"msglist-element timerow\\" data-msg-id=\\"9181\\">
     <div class=\\"timerow-left\\"></div>
@@ -4200,7 +4200,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible topic:
 "
 `;
 
-exports[`messages -> piece descriptors -> content HTML is stable/sensible topic:d:1:stream 1 topic 1 4`] = `
+exports[`messages -> piece descriptors -> content HTML is stable/sensible topic:1:topic 1 4`] = `
 "
   <div class=\\"msglist-element timerow\\" data-msg-id=\\"1024\\">
     <div class=\\"timerow-left\\"></div>

--- a/src/webview/html/__tests__/messageListElementHtml-test.js
+++ b/src/webview/html/__tests__/messageListElementHtml-test.js
@@ -273,7 +273,7 @@ describe('messages -> piece descriptors -> content HTML is stable/sensible', () 
     ].forEach(testCase => check(testCase));
   });
 
-  const streamNarrow1 = streamNarrow(stream1.name, stream1.stream_id);
+  const streamNarrow1 = streamNarrow(stream1.stream_id);
   test(`${keyFromNarrow(streamNarrow1)}`, () => {
     [
       { narrow: streamNarrow1, messages: streamMessages1 },
@@ -294,7 +294,7 @@ describe('messages -> piece descriptors -> content HTML is stable/sensible', () 
     ].forEach(testCase => check(testCase));
   });
 
-  const topicNarrow1 = topicNarrow(stream1.name, stream1.stream_id, topic1);
+  const topicNarrow1 = topicNarrow(stream1.stream_id, topic1);
   test(`${keyFromNarrow(topicNarrow1)}`, () => {
     [
       { narrow: topicNarrow1, messages: streamMessages1 },

--- a/src/webview/html/__tests__/messageListElementHtml-test.js
+++ b/src/webview/html/__tests__/messageListElementHtml-test.js
@@ -273,7 +273,7 @@ describe('messages -> piece descriptors -> content HTML is stable/sensible', () 
     ].forEach(testCase => check(testCase));
   });
 
-  const streamNarrow1 = streamNarrow(stream1.name);
+  const streamNarrow1 = streamNarrow(stream1.name, stream1.stream_id);
   test(`${keyFromNarrow(streamNarrow1)}`, () => {
     [
       { narrow: streamNarrow1, messages: streamMessages1 },
@@ -294,7 +294,7 @@ describe('messages -> piece descriptors -> content HTML is stable/sensible', () 
     ].forEach(testCase => check(testCase));
   });
 
-  const topicNarrow1 = topicNarrow(stream1.name, topic1);
+  const topicNarrow1 = topicNarrow(stream1.name, stream1.stream_id, topic1);
   test(`${keyFromNarrow(topicNarrow1)}`, () => {
     [
       { narrow: topicNarrow1, messages: streamMessages1 },

--- a/src/webview/html/header.js
+++ b/src/webview/html/header.js
@@ -39,7 +39,9 @@ export default (
 
   if (message.type === 'stream') {
     const streamName = streamNameOfStreamMessage(message);
-    const topicNarrowStr = keyFromNarrow(topicNarrow(streamName, message.subject));
+    const topicNarrowStr = keyFromNarrow(
+      topicNarrow(streamName, message.stream_id, message.subject),
+    );
     const topicHtml = renderSubject(message);
 
     if (headerStyle === 'topic+date') {
@@ -57,7 +59,7 @@ export default (
       const subscription = subscriptions.get(message.stream_id);
       const backgroundColor = subscription ? subscription.color : 'hsl(0, 0%, 80%)';
       const textColor = foregroundColorFromBackground(backgroundColor);
-      const streamNarrowStr = keyFromNarrow(streamNarrow(streamName));
+      const streamNarrowStr = keyFromNarrow(streamNarrow(streamName, message.stream_id));
 
       return template`
 <div class="msglist-element header-wrapper header stream-header topic-header"

--- a/src/webview/html/header.js
+++ b/src/webview/html/header.js
@@ -39,9 +39,7 @@ export default (
 
   if (message.type === 'stream') {
     const streamName = streamNameOfStreamMessage(message);
-    const topicNarrowStr = keyFromNarrow(
-      topicNarrow(streamName, message.stream_id, message.subject),
-    );
+    const topicNarrowStr = keyFromNarrow(topicNarrow(message.stream_id, message.subject));
     const topicHtml = renderSubject(message);
 
     if (headerStyle === 'topic+date') {
@@ -59,7 +57,7 @@ export default (
       const subscription = subscriptions.get(message.stream_id);
       const backgroundColor = subscription ? subscription.color : 'hsl(0, 0%, 80%)';
       const textColor = foregroundColorFromBackground(backgroundColor);
-      const streamNarrowStr = keyFromNarrow(streamNarrow(streamName, message.stream_id));
+      const streamNarrowStr = keyFromNarrow(streamNarrow(message.stream_id));
 
       return template`
 <div class="msglist-element header-wrapper header stream-header topic-header"


### PR DESCRIPTION
This does for streams and stream IDs what #4346 and #4382 did for users and user IDs: in `Narrow` values, we stop using stream names and switch to stream IDs instead.

This builds on #5183 and #5069. It completes #4333, and accounts for most of the remaining cases of #3918.

Fixes: #4333
