### PR TITLE
Revert "webview html: Get stream name from stream, rather than message"

### DIFF
--- a/src/webview/html/header.js
+++ b/src/webview/html/header.js
@@ -13,7 +13,11 @@ import {
 } from '../../utils/narrow';
 import { foregroundColorFromBackground } from '../../utils/color';
 import { humanDate } from '../../utils/date';
-import { pmUiRecipientsFromMessage, pmKeyRecipientsFromMessage } from '../../utils/recipient';
+import {
+  pmUiRecipientsFromMessage,
+  pmKeyRecipientsFromMessage,
+  streamNameOfStreamMessage,
+} from '../../utils/recipient';
 import { base64Utf8Encode } from '../../utils/encoding';
 
 const renderSubject = message =>
@@ -28,16 +32,14 @@ const renderSubject = message =>
  * This is a private helper of messageListElementHtml.
  */
 export default (
-  { ownUser, streams, subscriptions }: BackgroundData,
+  { ownUser, subscriptions }: BackgroundData,
   element: HeaderMessageListElement,
 ): string => {
   const { subsequentMessage: message, style: headerStyle } = element;
 
   if (message.type === 'stream') {
-    const stream = streams.get(message.stream_id);
-    invariant(stream, 'stream should exist for message');
-
-    const topicNarrowStr = keyFromNarrow(topicNarrow(stream.name, message.subject));
+    const streamName = streamNameOfStreamMessage(message);
+    const topicNarrowStr = keyFromNarrow(topicNarrow(streamName, message.subject));
     const topicHtml = renderSubject(message);
 
     if (headerStyle === 'topic+date') {
@@ -55,7 +57,7 @@ export default (
       const subscription = subscriptions.get(message.stream_id);
       const backgroundColor = subscription ? subscription.color : 'hsl(0, 0%, 80%)';
       const textColor = foregroundColorFromBackground(backgroundColor);
-      const streamNarrowStr = keyFromNarrow(streamNarrow(stream.name));
+      const streamNarrowStr = keyFromNarrow(streamNarrow(streamName));
 
       return template`
 <div class="msglist-element header-wrapper header stream-header topic-header"
@@ -65,7 +67,7 @@ export default (
        style="color: ${textColor};
               background: ${backgroundColor}"
        data-narrow="${base64Utf8Encode(streamNarrowStr)}">
-    # ${stream.name}
+    # ${streamName}
   </div>
   <div class="topic-text">$!${topicHtml}</div>
   <div class="topic-date">${humanDate(new Date(message.timestamp * 1000))}</div>


### PR DESCRIPTION
This reverts most of commit 9d05bbaf6fc9937ac9a776e28cbc988cc3b47b45 (from #5183).
We leave the test changes in place, because those just set up better
fixture data.

It's possible for the message list to show messages in streams that
we don't actually have data for: in particular, streams that our user
was previously a member of (and received some messages there while
they were), but no longer is, and can't see (because it's private and
they're not an admin, or because they're a guest.)  As a result, we
can't simply get the stream name here from our streams data.

There are a couple of ways we could go to fix the issue that commit
originally fixed, so that recipient headers get updated when a stream
is renamed; I'll discuss those in or linked from the issue #5206.
In the meantime, revert, because a crash when you've left the stream
is a lot worse than an out-of-date name when it's been renamed.

Fixes: #5206