### PR TITLE
flow: Upgrade to v0.141

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -139,4 +139,4 @@ module.file_ext=.ios.js
 exact_by_default=true
 
 [version]
-^0.137.0
+^0.141.0

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "eslint-plugin-prettier": "^3.2.0",
     "eslint-plugin-react": "^7.24.0",
     "eslint-plugin-react-hooks": "^4.2.0",
-    "flow-bin": "^0.137.0",
+    "flow-bin": "^0.141.0",
     "flow-coverage-report": "^0.8.0",
     "flow-typed": "^3.3.1",
     "immutable-devtools": "^0.1.5",

--- a/src/message/messagesReducer.js
+++ b/src/message/messagesReducer.js
@@ -184,7 +184,7 @@ export default (
           last_edit_timestamp: action.edit_timestamp ?? oldMessage.last_edit_timestamp,
         };
 
-        return messageWithNewCommonFields.type === 'stream'
+        return messageWithNewCommonFields.type === ('stream': 'stream')
           ? {
               ...messageWithNewCommonFields,
               subject: action.subject ?? messageWithNewCommonFields.subject,

--- a/src/outbox/outboxReducer.js
+++ b/src/outbox/outboxReducer.js
@@ -34,7 +34,7 @@ export default (
       return messageSendStart(state, action);
 
     case MESSAGE_SEND_COMPLETE:
-      return state.map(<O: Outbox>(item: O) =>
+      return state.map(<O: Outbox>(item: O): O =>
         item.id !== action.local_message_id ? item : { ...(item: O), isSent: true },
       );
 

--- a/src/webview/MessageList.js
+++ b/src/webview/MessageList.js
@@ -2,7 +2,7 @@
 import React, { Component, type ComponentType } from 'react';
 import { Platform, NativeModules } from 'react-native';
 import { WebView } from 'react-native-webview';
-import type { WebViewNavigation } from 'react-native-webview';
+import type { ShouldStartLoadRequest } from 'react-native-webview';
 
 import { connectActionSheet } from '../react-native-action-sheet';
 import type {
@@ -246,7 +246,7 @@ class MessageListInner extends Component<Props> {
 
     // Paranoia^WSecurity: only load `baseUrl`, and only load it once. Any other
     // requests should be handed off to the OS, not loaded inside the WebView.
-    const onShouldStartLoadWithRequest: (event: WebViewNavigation) => boolean = (() => {
+    const onShouldStartLoadWithRequest: (event: ShouldStartLoadRequest) => boolean = (() => {
       // Inner closure to actually test the URL.
       const urlTester: (url: string) => boolean = (() => {
         // On Android this function is documented to be skipped on first load:
@@ -269,7 +269,7 @@ class MessageListInner extends Component<Props> {
       })();
 
       // Outer closure to perform logging.
-      return (event: WebViewNavigation) => {
+      return (event: ShouldStartLoadRequest) => {
         const ok = urlTester(event.url);
         if (!ok) {
           logging.warn('webview: rejected navigation event', {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5368,10 +5368,10 @@ flow-annotation-check@^1.8.1:
     glob "7.1.6"
     load-pkg "^4.0.0"
 
-flow-bin@^0.137.0:
-  version "0.137.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.137.0.tgz#322a15b3744195af1e02bf1fec0a716296aee7d5"
-  integrity sha512-ytwUn68fPKK/VWVpCxJ4KNeNIjCC/uX0Ll6Z1E98sOXfMknB000WtgQjKYDdO6tOR8mvXBE0adzjgCrChVympw==
+flow-bin@^0.141.0:
+  version "0.141.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.141.0.tgz#f9e33ad29392824823c97b6db7de5ab972c7f872"
+  integrity sha512-NxaECTjIWfs2Y91GuA1PlgPd5uCulZcqR9wiXRg6n7/AbmvVetM2ewoGxCKxJm7wIml3f0/5KXIZvZa/3msqXg==
 
 flow-coverage-report@^0.8.0:
   version "0.8.0"


### PR DESCRIPTION
Normally, we'd only upgrade Flow along with React Native, because
otherwise we'd see new errors flagged in node_modules/react-native,
and we don't want to have to suppress them. But we get no such
errors this time!

See the changelog:
  https://github.com/facebook/flow/blob/main/Changelog.md#01410

In particular, this one is interesting --

  * Improved inference of chained generic method calls, such as
    `Array` methods. For example, given
    `[1, 2].map(a => a).forEach(b => b)`
    , Flow now infers that `b` is a `number` rather than
    `any | number`.

-- because that issue has been a major source of complaints in our
Flow coverage report:
  https://github.com/zulip/zulip-mobile/issues/2052#issuecomment-934685281