### PR TITLE
    compat: Warn on unsupported or soon-unsupported server versions

### DIFF
--- a/src/common/ServerCompatBanner.js
+++ b/src/common/ServerCompatBanner.js
@@ -9,15 +9,23 @@ import { getIdentity, getServerVersion } from '../account/accountsSelectors';
 import { getIsAdmin, getSession, getGlobalSettings } from '../directSelectors';
 import { dismissCompatNotice } from '../session/sessionActions';
 import { openLinkWithUserPreference } from '../utils/openLink';
+import { ZulipVersion } from '../utils/zulipVersion';
 
 // The oldest version we currently support. Should match what we say at
 //   https://zulip.readthedocs.io/en/stable/overview/release-lifecycle.html#compatibility-and-upgrading.
-const minSupportedVersion = '2.1.0';
+export const kMinSupportedVersion: ZulipVersion = new ZulipVersion('2.1.0');
 // Notes on known breakage at older versions:
 //  * Before 1.8, the server doesn't send found_newest / found_oldest on
 //    fetching messages, and so `state.caughtUp` will never have truthy
 //    values.  This probably means annoying behavior in a message list,
 //    as we keep trying to fetch newer messages.
+
+/**
+ * The next value we'll give to kMinSupportedVersion in the future.
+ *
+ * This should be the next major Zulip Server version after kMinSupportedVersion.
+ */
+export const kNextMinSupportedVersion: ZulipVersion = new ZulipVersion('3.0');
 
 type Props = $ReadOnly<{||}>;
 
@@ -36,7 +44,7 @@ export default function ServerCompatBanner(props: Props): Node {
 
   let visible = false;
   let text = '';
-  if (zulipVersion.isAtLeast(minSupportedVersion)) {
+  if (zulipVersion.isAtLeast(kMinSupportedVersion)) {
     // don't show
   } else if (hasDismissedServerCompatNotice) {
     // don't show

--- a/src/utils/__tests__/zulipVersion-test.js
+++ b/src/utils/__tests__/zulipVersion-test.js
@@ -93,3 +93,16 @@ describe('ZulipVersion.prototype.elements()', () => {
     });
   });
 });
+
+describe('ZulipVersion.prototype.classify()', () => {
+  for (const [coarse, fine, raw] of [
+    ['1.9.x', '1.9.1', '1.9.1-23-gabcabcabc'],
+    ['2.1.x', '2.1.3', '2.1.3'],
+    ['3.x', '3.1', '3.1'],
+    ['4.x', '4.0', '4.0'],
+  ]) {
+    test(raw, () => {
+      expect(new ZulipVersion(raw).classify()).toStrictEqual({ raw, coarse, fine });
+    });
+  }
+});

--- a/src/utils/logging.js
+++ b/src/utils/logging.js
@@ -76,29 +76,8 @@ const getServerVersionTags = (zulipVersion: ?ZulipVersion): ServerVersionTags =>
     };
   }
 
-  const raw = zulipVersion.raw();
-
-  const OMITTED = 'x';
-  const UNKNOWN = '?';
-
-  const elements = zulipVersion.elements();
-  const major = elements.major ?? UNKNOWN;
-  const minor = elements.minor ?? UNKNOWN;
-  const patch = elements.patch ?? UNKNOWN;
-
-  let coarseServerVersion = undefined;
-  let fineServerVersion = undefined;
-  // Effective with 3.0, we changed our numbering conventions; 3.x and
-  // 4.x are each the same level of granularity as 2.1.x or 2.0.x.
-  if (zulipVersion.isAtLeast('3.0')) {
-    coarseServerVersion = [major, OMITTED].join('.');
-    fineServerVersion = [major, minor].join('.');
-  } else {
-    coarseServerVersion = [major, minor, OMITTED].join('.');
-    fineServerVersion = [major, minor, patch].join('.');
-  }
-
-  return { rawServerVersion: raw, coarseServerVersion, fineServerVersion };
+  const { raw, fine, coarse } = zulipVersion.classify();
+  return { rawServerVersion: raw, coarseServerVersion: coarse, fineServerVersion: fine };
 };
 
 export function setTagsFromServerVersion(zulipVersion: ?ZulipVersion) {

--- a/src/utils/zulipVersion.js
+++ b/src/utils/zulipVersion.js
@@ -73,6 +73,33 @@ export class ZulipVersion {
   }
 
   /**
+   * This version, classified by release and by major release.
+   */
+  classify(): {| raw: string, fine: string, coarse: string |} {
+    const OMITTED = 'x';
+    const UNKNOWN = '?';
+
+    const elements = this.elements();
+    const major = elements.major ?? UNKNOWN;
+    const minor = elements.minor ?? UNKNOWN;
+    const patch = elements.patch ?? UNKNOWN;
+
+    let coarse = undefined;
+    let fine = undefined;
+    // Effective with 3.0, we changed our numbering conventions; 3.x and
+    // 4.x are each the same level of granularity as 2.1.x or 2.0.x.
+    if (this.isAtLeast('3.0')) {
+      coarse = [major, OMITTED].join('.');
+      fine = [major, minor].join('.');
+    } else {
+      coarse = [major, minor, OMITTED].join('.');
+      fine = [major, minor, patch].join('.');
+    }
+
+    return { coarse, fine, raw: this.raw() };
+  }
+
+  /**
    * Parse the raw string into a VersionElements.
    */
   static _getElements(raw: string): VersionElements {


### PR DESCRIPTION
This will let us get a better idea of how many (or few) users
will be affected as we drop support for an old version, or as
we remove compatibility hacks for old versions we already say
we don't support.

---

In particular, I have a draft branch to start relying on server 2.0+, following up on #5192. One of the main things it does is clean up how we send messages, to use stream IDs and user IDs instead of emails and stream names. That'll be a much-appreciated improvement… but it will also mean we break some pretty core functionality for any users interacting with a server that's still on a pre-2.0 version.

We announced rather a while ago, the middle of last year, that we were no longer supporting such old versions. We even started showing a warning banner for any users on such a server, and haven't heard a peep from users seeing it. So we aren't going to shy away from making that change. But it might be the cue for us to start outright refusing to operate on those servers, as discussed at 401b3a2e3. Knowing how many users are still in this situation will help us decide whether to build that now.

This will also help us decide when it's a good time to drop support for server 2.1 and start requiring server 3.x+, and so on in the future.
