### PR TITLE
flow: Upgrade to Flow v0.141.0

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -139,4 +139,4 @@ module.file_ext=.ios.js
 exact_by_default=true
 
 [version]
-^0.137.0
+^0.141.0

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "eslint-plugin-prettier": "^3.2.0",
     "eslint-plugin-react": "^7.24.0",
     "eslint-plugin-react-hooks": "^4.2.0",
-    "flow-bin": "^0.137.0",
+    "flow-bin": "^0.141.0",
     "flow-coverage-report": "^0.8.0",
     "flow-typed": "^3.3.1",
     "immutable-devtools": "^0.1.5",

--- a/src/message/messagesReducer.js
+++ b/src/message/messagesReducer.js
@@ -184,7 +184,10 @@ export default (
           last_edit_timestamp: action.edit_timestamp ?? oldMessage.last_edit_timestamp,
         };
 
-        return messageWithNewCommonFields.type === 'stream'
+        // FlowIssue: https://github.com/facebook/flow/issues/8833
+        //   The cast `: 'stream'` is silly but harmless, and works
+        //   around a Flow issue which causes an error.
+        return messageWithNewCommonFields.type === ('stream': 'stream')
           ? {
               ...messageWithNewCommonFields,
               subject: action.subject ?? messageWithNewCommonFields.subject,

--- a/src/outbox/outboxReducer.js
+++ b/src/outbox/outboxReducer.js
@@ -34,7 +34,7 @@ export default (
       return messageSendStart(state, action);
 
     case MESSAGE_SEND_COMPLETE:
-      return state.map(<O: Outbox>(item: O) =>
+      return state.map(<O: Outbox>(item: O): O =>
         item.id !== action.local_message_id ? item : { ...(item: O), isSent: true },
       );
 

--- a/src/webview/MessageList.js
+++ b/src/webview/MessageList.js
@@ -2,7 +2,6 @@
 import React, { Component, type ComponentType } from 'react';
 import { Platform, NativeModules } from 'react-native';
 import { WebView } from 'react-native-webview';
-import type { WebViewNavigation } from 'react-native-webview';
 
 import { connectActionSheet } from '../react-native-action-sheet';
 import type {
@@ -248,7 +247,7 @@ class MessageListInner extends Component<Props> {
 
     // Paranoia^WSecurity: only load `baseUrl`, and only load it once. Any other
     // requests should be handed off to the OS, not loaded inside the WebView.
-    const onShouldStartLoadWithRequest: (event: WebViewNavigation) => boolean = (() => {
+    const onShouldStartLoadWithRequest = (() => {
       // Inner closure to actually test the URL.
       const urlTester: (url: string) => boolean = (() => {
         // On Android this function is documented to be skipped on first load:
@@ -271,7 +270,7 @@ class MessageListInner extends Component<Props> {
       })();
 
       // Outer closure to perform logging.
-      return (event: WebViewNavigation) => {
+      return event => {
         const ok = urlTester(event.url);
         if (!ok) {
           logging.warn('webview: rejected navigation event', {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5368,10 +5368,10 @@ flow-annotation-check@^1.8.1:
     glob "7.1.6"
     load-pkg "^4.0.0"
 
-flow-bin@^0.137.0:
-  version "0.137.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.137.0.tgz#322a15b3744195af1e02bf1fec0a716296aee7d5"
-  integrity sha512-ytwUn68fPKK/VWVpCxJ4KNeNIjCC/uX0Ll6Z1E98sOXfMknB000WtgQjKYDdO6tOR8mvXBE0adzjgCrChVympw==
+flow-bin@^0.141.0:
+  version "0.141.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.141.0.tgz#f9e33ad29392824823c97b6db7de5ab972c7f872"
+  integrity sha512-NxaECTjIWfs2Y91GuA1PlgPd5uCulZcqR9wiXRg6n7/AbmvVetM2ewoGxCKxJm7wIml3f0/5KXIZvZa/3msqXg==
 
 flow-coverage-report@^0.8.0:
   version "0.8.0"


### PR DESCRIPTION
This version fixes a bug I've noticed regularly, and am glad to see
gone:

  > Improved inference of chained generic method calls, such as `Array`
  > methods. For example, given `[1, 2].map(a => a).forEach(b => b)`,
  > Flow now infers that `b` is a `number` rather than `any | number`.

  https://github.com/facebook/flow/blob/main/Changelog.md#01400

This happens in a number of places in our codebase; the `userIds`
local in `pmUnreadsKeyFromMessage` is the first one I find just now
when I go look for one.

I believe this hasn't been likely to conceal type errors (and indeed
fixing it didn't reveal any.)  That's because the `| number` means
that anything consuming that data still needs to be prepared to handle
a `number`.  But it is disconcerting to have those `any`s showing up
regularly when inspecting types in the IDE, and good to have that fixed.
This also makes a good chunk of progress on #2052, type coverage.

Before that come a couple of small fixes for errors Flow newly spots, and one workaround for a new Flow issue: facebook/flow#8833.
