### PR TITLE
msglist-diffing: More tests! 🛠️

### DIFF
--- a/src/__tests__/lib/exampleData.js
+++ b/src/__tests__/lib/exampleData.js
@@ -317,6 +317,20 @@ export const unicodeEmojiReaction: Reaction = deepFreeze({
   emoji_name: 'thumbs_up',
 });
 
+export const zulipExtraEmojiReaction: Reaction = deepFreeze({
+  user_id: randUserId(),
+  reaction_type: 'zulip_extra_emoji',
+  emoji_code: 'zulip',
+  emoji_name: 'zulip',
+});
+
+export const realmEmojiReaction: Reaction = deepFreeze({
+  user_id: randUserId(),
+  reaction_type: 'realm_emoji',
+  emoji_code: '80',
+  emoji_name: 'github_parrot',
+});
+
 export const displayRecipientFromUser = (user: User): PmRecipientUser => {
   const { email, full_name, user_id: id } = user;
   return deepFreeze({
@@ -583,7 +597,19 @@ export const plusReduxState: GlobalState & PerAccountState = reduxState({
       lastDismissedServerPushSetupNotice: null,
     },
   ],
-  realm: { ...baseReduxState.realm, user_id: selfUser.user_id, email: selfUser.email },
+  realm: {
+    ...baseReduxState.realm,
+    user_id: selfUser.user_id,
+    email: selfUser.email,
+    emoji: {
+      [realmEmojiReaction.emoji_code]: {
+        deactivated: false,
+        code: realmEmojiReaction.emoji_code,
+        name: realmEmojiReaction.emoji_name,
+        source_url: `/user_avatars/2/emoji/images/${realmEmojiReaction.emoji_code}.gif`,
+      },
+    },
+  },
   // TODO add crossRealmBot
   users: [selfUser, otherUser, thirdUser],
   streams: [stream, otherStream],

--- a/src/action-sheets/index.js
+++ b/src/action-sheets/index.js
@@ -391,7 +391,7 @@ export const constructPmConversationActionButtons = ({
 |}): Button<PmArgs>[] => {
   const buttons = [];
 
-  // TODO: If 1:1 PM, give a mute/unmute-user button, with a confirmation
+  // TODO(#4655): If 1:1 PM, give a mute/unmute-user button, with a confirmation
   //   dialog saying that it also affects the muted users' stream messages,
   //   and linking to https://zulip.com/help/mute-a-user
 

--- a/src/webview/__tests__/__snapshots__/generateInboundEventEditSequence-test.js.snap.android
+++ b/src/webview/__tests__/__snapshots__/generateInboundEventEditSequence-test.js.snap.android
@@ -1494,6 +1494,498 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm
 </div>"
 `;
 
+exports[`messages -> piece descriptors -> content HTML is stable/sensible other interesting cases (single messages) message with a poll 1`] = `
+"<div class=\\"msglist-element timerow\\" data-msg-id=\\"-1\\">
+  <div class=\\"timerow-left\\"></div>
+  Dec 31, 1969
+  <div class=\\"timerow-right\\"></div>
+</div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"-1\\" data-narrow=\\"dG9waWM6MTpleGFtcGxlIHRvcGlj\\">
+  <div class=\\"header stream-text\\" style=\\"color: black;
+              background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
+    # nonrandom stream
+  </div>
+  <div class=\\"topic-text\\">example topic</div>
+  <div class=\\"topic-date\\">Dec 31, 1969</div>
+</div><div class=\\"msglist-element message message-full\\" id=\\"msg--1\\" data-msg-id=\\"-1\\" data-mute-state=\\"shown\\">
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20sender.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
+  </div>
+  <div class=\\"content\\">
+    <div class=\\"subheader\\">
+  <div class=\\"username\\" data-sender-id=\\"10\\">
+    Nonrandom name sender User
+  </div>
+  <div class=\\"static-timestamp\\">11:59 PM</div>
+</div>
+    <div class=\\"poll-widget\\">
+  <p class=\\"poll-question\\">Choose a choice:</p>
+  <ul>
+    
+        <li>
+          <button class=\\"poll-vote\\" data-voted=\\"true\\" data-key=\\"10,1\\">3</button>
+          <span class=\\"poll-option\\">Choice A</span>
+        </li>
+        <li>
+          <button class=\\"poll-vote\\" data-voted=\\"false\\" data-key=\\"10,2\\">1</button>
+          <span class=\\"poll-option\\">Choice B</span>
+        </li>
+  </ul>
+</div>
+  </div>
+  
+</div>"
+`;
+
+exports[`messages -> piece descriptors -> content HTML is stable/sensible other interesting cases (single messages) message with flag: collapsed 1`] = `
+"<div class=\\"msglist-element timerow\\" data-msg-id=\\"-1\\">
+  <div class=\\"timerow-left\\"></div>
+  Dec 31, 1969
+  <div class=\\"timerow-right\\"></div>
+</div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"-1\\" data-narrow=\\"dG9waWM6MTpleGFtcGxlIHRvcGlj\\">
+  <div class=\\"header stream-text\\" style=\\"color: black;
+              background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
+    # nonrandom stream
+  </div>
+  <div class=\\"topic-text\\">example topic</div>
+  <div class=\\"topic-date\\">Dec 31, 1969</div>
+</div><div class=\\"msglist-element message message-full\\" id=\\"msg--1\\" data-msg-id=\\"-1\\" data-mute-state=\\"shown\\" data-collapsed=\\"true\\">
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20sender.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
+  </div>
+  <div class=\\"content\\">
+    <div class=\\"subheader\\">
+  <div class=\\"username\\" data-sender-id=\\"10\\">
+    Nonrandom name sender User
+  </div>
+  <div class=\\"static-timestamp\\">11:59 PM</div>
+</div>
+    <p>This is an example stream message.</p>
+
+
+
+  </div>
+  
+</div>"
+`;
+
+exports[`messages -> piece descriptors -> content HTML is stable/sensible other interesting cases (single messages) message with flag: force_collapse 1`] = `
+"<div class=\\"msglist-element timerow\\" data-msg-id=\\"-1\\">
+  <div class=\\"timerow-left\\"></div>
+  Dec 31, 1969
+  <div class=\\"timerow-right\\"></div>
+</div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"-1\\" data-narrow=\\"dG9waWM6MTpleGFtcGxlIHRvcGlj\\">
+  <div class=\\"header stream-text\\" style=\\"color: black;
+              background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
+    # nonrandom stream
+  </div>
+  <div class=\\"topic-text\\">example topic</div>
+  <div class=\\"topic-date\\">Dec 31, 1969</div>
+</div><div class=\\"msglist-element message message-full\\" id=\\"msg--1\\" data-msg-id=\\"-1\\" data-mute-state=\\"shown\\" data-force_collapse=\\"true\\">
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20sender.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
+  </div>
+  <div class=\\"content\\">
+    <div class=\\"subheader\\">
+  <div class=\\"username\\" data-sender-id=\\"10\\">
+    Nonrandom name sender User
+  </div>
+  <div class=\\"static-timestamp\\">11:59 PM</div>
+</div>
+    <p>This is an example stream message.</p>
+
+
+
+  </div>
+  
+</div>"
+`;
+
+exports[`messages -> piece descriptors -> content HTML is stable/sensible other interesting cases (single messages) message with flag: force_expand 1`] = `
+"<div class=\\"msglist-element timerow\\" data-msg-id=\\"-1\\">
+  <div class=\\"timerow-left\\"></div>
+  Dec 31, 1969
+  <div class=\\"timerow-right\\"></div>
+</div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"-1\\" data-narrow=\\"dG9waWM6MTpleGFtcGxlIHRvcGlj\\">
+  <div class=\\"header stream-text\\" style=\\"color: black;
+              background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
+    # nonrandom stream
+  </div>
+  <div class=\\"topic-text\\">example topic</div>
+  <div class=\\"topic-date\\">Dec 31, 1969</div>
+</div><div class=\\"msglist-element message message-full\\" id=\\"msg--1\\" data-msg-id=\\"-1\\" data-mute-state=\\"shown\\" data-force_expand=\\"true\\">
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20sender.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
+  </div>
+  <div class=\\"content\\">
+    <div class=\\"subheader\\">
+  <div class=\\"username\\" data-sender-id=\\"10\\">
+    Nonrandom name sender User
+  </div>
+  <div class=\\"static-timestamp\\">11:59 PM</div>
+</div>
+    <p>This is an example stream message.</p>
+
+
+
+  </div>
+  
+</div>"
+`;
+
+exports[`messages -> piece descriptors -> content HTML is stable/sensible other interesting cases (single messages) message with flag: has_alert_word 1`] = `
+"<div class=\\"msglist-element timerow\\" data-msg-id=\\"-1\\">
+  <div class=\\"timerow-left\\"></div>
+  Dec 31, 1969
+  <div class=\\"timerow-right\\"></div>
+</div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"-1\\" data-narrow=\\"dG9waWM6MTpleGFtcGxlIHRvcGlj\\">
+  <div class=\\"header stream-text\\" style=\\"color: black;
+              background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
+    # nonrandom stream
+  </div>
+  <div class=\\"topic-text\\">example topic</div>
+  <div class=\\"topic-date\\">Dec 31, 1969</div>
+</div><div class=\\"msglist-element message message-full\\" id=\\"msg--1\\" data-msg-id=\\"-1\\" data-mute-state=\\"shown\\" data-has_alert_word=\\"true\\">
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20sender.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
+  </div>
+  <div class=\\"content\\">
+    <div class=\\"subheader\\">
+  <div class=\\"username\\" data-sender-id=\\"10\\">
+    Nonrandom name sender User
+  </div>
+  <div class=\\"static-timestamp\\">11:59 PM</div>
+</div>
+    <p>This is an example stream message.</p>
+
+
+
+  </div>
+  
+</div>"
+`;
+
+exports[`messages -> piece descriptors -> content HTML is stable/sensible other interesting cases (single messages) message with flag: historical 1`] = `
+"<div class=\\"msglist-element timerow\\" data-msg-id=\\"-1\\">
+  <div class=\\"timerow-left\\"></div>
+  Dec 31, 1969
+  <div class=\\"timerow-right\\"></div>
+</div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"-1\\" data-narrow=\\"dG9waWM6MTpleGFtcGxlIHRvcGlj\\">
+  <div class=\\"header stream-text\\" style=\\"color: black;
+              background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
+    # nonrandom stream
+  </div>
+  <div class=\\"topic-text\\">example topic</div>
+  <div class=\\"topic-date\\">Dec 31, 1969</div>
+</div><div class=\\"msglist-element message message-full\\" id=\\"msg--1\\" data-msg-id=\\"-1\\" data-mute-state=\\"shown\\" data-historical=\\"true\\">
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20sender.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
+  </div>
+  <div class=\\"content\\">
+    <div class=\\"subheader\\">
+  <div class=\\"username\\" data-sender-id=\\"10\\">
+    Nonrandom name sender User
+  </div>
+  <div class=\\"static-timestamp\\">11:59 PM</div>
+</div>
+    <p>This is an example stream message.</p>
+
+
+
+  </div>
+  
+</div>"
+`;
+
+exports[`messages -> piece descriptors -> content HTML is stable/sensible other interesting cases (single messages) message with flag: is_me_message 1`] = `
+"<div class=\\"msglist-element timerow\\" data-msg-id=\\"-1\\">
+  <div class=\\"timerow-left\\"></div>
+  Dec 31, 1969
+  <div class=\\"timerow-right\\"></div>
+</div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"-1\\" data-narrow=\\"dG9waWM6MTpleGFtcGxlIHRvcGlj\\">
+  <div class=\\"header stream-text\\" style=\\"color: black;
+              background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
+    # nonrandom stream
+  </div>
+  <div class=\\"topic-text\\">example topic</div>
+  <div class=\\"topic-date\\">Dec 31, 1969</div>
+</div><div class=\\"msglist-element message message-full\\" id=\\"msg--1\\" data-msg-id=\\"-1\\" data-mute-state=\\"shown\\" data-is_me_message=\\"true\\">
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20sender.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
+  </div>
+  <div class=\\"content\\">
+    <div class=\\"subheader\\">
+  <div class=\\"username\\" data-sender-id=\\"10\\">
+    Nonrandom name sender User
+  </div>
+  <div class=\\"static-timestamp\\">11:59 PM</div>
+</div>
+    <p>This is an example stream message.</p>
+
+
+
+  </div>
+  
+</div>"
+`;
+
+exports[`messages -> piece descriptors -> content HTML is stable/sensible other interesting cases (single messages) message with flag: mentioned 1`] = `
+"<div class=\\"msglist-element timerow\\" data-msg-id=\\"-1\\">
+  <div class=\\"timerow-left\\"></div>
+  Dec 31, 1969
+  <div class=\\"timerow-right\\"></div>
+</div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"-1\\" data-narrow=\\"dG9waWM6MTpleGFtcGxlIHRvcGlj\\">
+  <div class=\\"header stream-text\\" style=\\"color: black;
+              background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
+    # nonrandom stream
+  </div>
+  <div class=\\"topic-text\\">example topic</div>
+  <div class=\\"topic-date\\">Dec 31, 1969</div>
+</div><div class=\\"msglist-element message message-full\\" id=\\"msg--1\\" data-msg-id=\\"-1\\" data-mute-state=\\"shown\\" data-mentioned=\\"true\\">
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20sender.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
+  </div>
+  <div class=\\"content\\">
+    <div class=\\"subheader\\">
+  <div class=\\"username\\" data-sender-id=\\"10\\">
+    Nonrandom name sender User
+  </div>
+  <div class=\\"static-timestamp\\">11:59 PM</div>
+</div>
+    <p>This is an example stream message.</p>
+
+
+
+  </div>
+  
+</div>"
+`;
+
+exports[`messages -> piece descriptors -> content HTML is stable/sensible other interesting cases (single messages) message with flag: read 1`] = `
+"<div class=\\"msglist-element timerow\\" data-msg-id=\\"-1\\">
+  <div class=\\"timerow-left\\"></div>
+  Dec 31, 1969
+  <div class=\\"timerow-right\\"></div>
+</div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"-1\\" data-narrow=\\"dG9waWM6MTpleGFtcGxlIHRvcGlj\\">
+  <div class=\\"header stream-text\\" style=\\"color: black;
+              background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
+    # nonrandom stream
+  </div>
+  <div class=\\"topic-text\\">example topic</div>
+  <div class=\\"topic-date\\">Dec 31, 1969</div>
+</div><div class=\\"msglist-element message message-full\\" id=\\"msg--1\\" data-msg-id=\\"-1\\" data-mute-state=\\"shown\\" data-read=\\"true\\">
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20sender.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
+  </div>
+  <div class=\\"content\\">
+    <div class=\\"subheader\\">
+  <div class=\\"username\\" data-sender-id=\\"10\\">
+    Nonrandom name sender User
+  </div>
+  <div class=\\"static-timestamp\\">11:59 PM</div>
+</div>
+    <p>This is an example stream message.</p>
+
+
+
+  </div>
+  
+</div>"
+`;
+
+exports[`messages -> piece descriptors -> content HTML is stable/sensible other interesting cases (single messages) message with flag: starred 1`] = `
+"<div class=\\"msglist-element timerow\\" data-msg-id=\\"-1\\">
+  <div class=\\"timerow-left\\"></div>
+  Dec 31, 1969
+  <div class=\\"timerow-right\\"></div>
+</div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"-1\\" data-narrow=\\"dG9waWM6MTpleGFtcGxlIHRvcGlj\\">
+  <div class=\\"header stream-text\\" style=\\"color: black;
+              background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
+    # nonrandom stream
+  </div>
+  <div class=\\"topic-text\\">example topic</div>
+  <div class=\\"topic-date\\">Dec 31, 1969</div>
+</div><div class=\\"msglist-element message message-full\\" id=\\"msg--1\\" data-msg-id=\\"-1\\" data-mute-state=\\"shown\\" data-starred=\\"true\\">
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20sender.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
+  </div>
+  <div class=\\"content\\">
+    <div class=\\"subheader\\">
+  <div class=\\"username\\" data-sender-id=\\"10\\">
+    Nonrandom name sender User
+  </div>
+  <div class=\\"static-timestamp\\">11:59 PM</div>
+</div>
+    <p>This is an example stream message.</p>
+
+<div class=\\"message-tags\\"><span class=\\"message-tag\\">starred</span></div>
+
+  </div>
+  
+</div>"
+`;
+
+exports[`messages -> piece descriptors -> content HTML is stable/sensible other interesting cases (single messages) message with flag: summarize_in_home 1`] = `
+"<div class=\\"msglist-element timerow\\" data-msg-id=\\"-1\\">
+  <div class=\\"timerow-left\\"></div>
+  Dec 31, 1969
+  <div class=\\"timerow-right\\"></div>
+</div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"-1\\" data-narrow=\\"dG9waWM6MTpleGFtcGxlIHRvcGlj\\">
+  <div class=\\"header stream-text\\" style=\\"color: black;
+              background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
+    # nonrandom stream
+  </div>
+  <div class=\\"topic-text\\">example topic</div>
+  <div class=\\"topic-date\\">Dec 31, 1969</div>
+</div><div class=\\"msglist-element message message-full\\" id=\\"msg--1\\" data-msg-id=\\"-1\\" data-mute-state=\\"shown\\" data-summarize_in_home=\\"true\\">
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20sender.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
+  </div>
+  <div class=\\"content\\">
+    <div class=\\"subheader\\">
+  <div class=\\"username\\" data-sender-id=\\"10\\">
+    Nonrandom name sender User
+  </div>
+  <div class=\\"static-timestamp\\">11:59 PM</div>
+</div>
+    <p>This is an example stream message.</p>
+
+
+
+  </div>
+  
+</div>"
+`;
+
+exports[`messages -> piece descriptors -> content HTML is stable/sensible other interesting cases (single messages) message with flag: summarize_in_stream 1`] = `
+"<div class=\\"msglist-element timerow\\" data-msg-id=\\"-1\\">
+  <div class=\\"timerow-left\\"></div>
+  Dec 31, 1969
+  <div class=\\"timerow-right\\"></div>
+</div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"-1\\" data-narrow=\\"dG9waWM6MTpleGFtcGxlIHRvcGlj\\">
+  <div class=\\"header stream-text\\" style=\\"color: black;
+              background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
+    # nonrandom stream
+  </div>
+  <div class=\\"topic-text\\">example topic</div>
+  <div class=\\"topic-date\\">Dec 31, 1969</div>
+</div><div class=\\"msglist-element message message-full\\" id=\\"msg--1\\" data-msg-id=\\"-1\\" data-mute-state=\\"shown\\" data-summarize_in_stream=\\"true\\">
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20sender.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
+  </div>
+  <div class=\\"content\\">
+    <div class=\\"subheader\\">
+  <div class=\\"username\\" data-sender-id=\\"10\\">
+    Nonrandom name sender User
+  </div>
+  <div class=\\"static-timestamp\\">11:59 PM</div>
+</div>
+    <p>This is an example stream message.</p>
+
+
+
+  </div>
+  
+</div>"
+`;
+
+exports[`messages -> piece descriptors -> content HTML is stable/sensible other interesting cases (single messages) message with flag: wildcard_mentioned 1`] = `
+"<div class=\\"msglist-element timerow\\" data-msg-id=\\"-1\\">
+  <div class=\\"timerow-left\\"></div>
+  Dec 31, 1969
+  <div class=\\"timerow-right\\"></div>
+</div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"-1\\" data-narrow=\\"dG9waWM6MTpleGFtcGxlIHRvcGlj\\">
+  <div class=\\"header stream-text\\" style=\\"color: black;
+              background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
+    # nonrandom stream
+  </div>
+  <div class=\\"topic-text\\">example topic</div>
+  <div class=\\"topic-date\\">Dec 31, 1969</div>
+</div><div class=\\"msglist-element message message-full\\" id=\\"msg--1\\" data-msg-id=\\"-1\\" data-mute-state=\\"shown\\" data-wildcard_mentioned=\\"true\\">
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20sender.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
+  </div>
+  <div class=\\"content\\">
+    <div class=\\"subheader\\">
+  <div class=\\"username\\" data-sender-id=\\"10\\">
+    Nonrandom name sender User
+  </div>
+  <div class=\\"static-timestamp\\">11:59 PM</div>
+</div>
+    <p>This is an example stream message.</p>
+
+
+
+  </div>
+  
+</div>"
+`;
+
+exports[`messages -> piece descriptors -> content HTML is stable/sensible other interesting cases (single messages) message with reactions 1`] = `
+"<div class=\\"msglist-element timerow\\" data-msg-id=\\"-1\\">
+  <div class=\\"timerow-left\\"></div>
+  Dec 31, 1969
+  <div class=\\"timerow-right\\"></div>
+</div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"-1\\" data-narrow=\\"dG9waWM6MTpleGFtcGxlIHRvcGlj\\">
+  <div class=\\"header stream-text\\" style=\\"color: black;
+              background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
+    # nonrandom stream
+  </div>
+  <div class=\\"topic-text\\">example topic</div>
+  <div class=\\"topic-date\\">Dec 31, 1969</div>
+</div><div class=\\"msglist-element message message-full\\" id=\\"msg--1\\" data-msg-id=\\"-1\\" data-mute-state=\\"shown\\">
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20sender.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
+  </div>
+  <div class=\\"content\\">
+    <div class=\\"subheader\\">
+  <div class=\\"username\\" data-sender-id=\\"10\\">
+    Nonrandom name sender User
+  </div>
+  <div class=\\"static-timestamp\\">11:59 PM</div>
+</div>
+    <p>This is an example stream message.</p>
+
+
+<div class=\\"reaction-list\\"><span onclick=\\"\\" class=\\"reaction\\" data-name=\\"github_parrot\\" data-code=\\"80\\" data-type=\\"realm_emoji\\">&nbsp;2</span><span onclick=\\"\\" class=\\"reaction\\" data-name=\\"thumbs_up\\" data-code=\\"1f44d\\" data-type=\\"unicode_emoji\\">👍&nbsp;1</span><span onclick=\\"\\" class=\\"reaction\\" data-name=\\"zulip\\" data-code=\\"zulip\\" data-type=\\"zulip_extra_emoji\\">&nbsp;1</span></div>
+  </div>
+  
+</div>"
+`;
+
+exports[`messages -> piece descriptors -> content HTML is stable/sensible other interesting cases (single messages) muted sender 1`] = `
+"<div class=\\"msglist-element timerow\\" data-msg-id=\\"-1\\">
+  <div class=\\"timerow-left\\"></div>
+  Dec 31, 1969
+  <div class=\\"timerow-right\\"></div>
+</div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"-1\\" data-narrow=\\"dG9waWM6MTpleGFtcGxlIHRvcGlj\\">
+  <div class=\\"header stream-text\\" style=\\"color: black;
+              background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
+    # nonrandom stream
+  </div>
+  <div class=\\"topic-text\\">example topic</div>
+  <div class=\\"topic-date\\">Dec 31, 1969</div>
+</div><div class=\\"msglist-element message message-full\\" id=\\"msg--1\\" data-msg-id=\\"-1\\" data-mute-state=\\"hidden\\">
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20sender.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
+  </div>
+  <div class=\\"content\\">
+    <div class=\\"subheader\\">
+  <div class=\\"username\\" data-sender-id=\\"10\\">
+    Nonrandom name sender User
+  </div>
+  <div class=\\"static-timestamp\\">11:59 PM</div>
+</div>
+    <p>This is an example stream message.</p>
+
+
+
+  </div>
+  <div class=\\"special-message muted-message-explanation\\">
+  This message was hidden because it is from a user you have muted. Long-press to view.
+</div>
+</div>"
+`;
+
 exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2 1`] = `
 "<div class=\\"msglist-element timerow\\" data-msg-id=\\"8849\\">
   <div class=\\"timerow-left\\"></div>

--- a/src/webview/__tests__/__snapshots__/generateInboundEventEditSequence-test.js.snap.android
+++ b/src/webview/__tests__/__snapshots__/generateInboundEventEditSequence-test.js.snap.android
@@ -34,6 +34,22 @@ exports[`getEditSequence correct for interesting changes from many messages to d
 
 exports[`getEditSequence correct for interesting changes from many messages to empty 1`] = `40`;
 
+exports[`getEditSequence correct for interesting changes within a given message add reactions to a message 1`] = `3`;
+
+exports[`getEditSequence correct for interesting changes within a given message mute a sender 1`] = `1`;
+
+exports[`getEditSequence correct for interesting changes within a given message polls choice added 1`] = `3`;
+
+exports[`getEditSequence correct for interesting changes within a given message polls vote added 1`] = `3`;
+
+exports[`getEditSequence correct for interesting changes within a given message remove reactions from a message 1`] = `3`;
+
+exports[`getEditSequence correct for interesting changes within a given message star a message 1`] = `1`;
+
+exports[`getEditSequence correct for interesting changes within a given message unmute a sender 1`] = `1`;
+
+exports[`getEditSequence correct for interesting changes within a given message unstar a message 1`] = `1`;
+
 exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_NARROW 1`] = `
 "<div class=\\"msglist-element timerow\\" data-msg-id=\\"1024\\">
   <div class=\\"timerow-left\\"></div>

--- a/src/webview/__tests__/__snapshots__/generateInboundEventEditSequence-test.js.snap.ios
+++ b/src/webview/__tests__/__snapshots__/generateInboundEventEditSequence-test.js.snap.ios
@@ -1494,6 +1494,498 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm
 </div>"
 `;
 
+exports[`messages -> piece descriptors -> content HTML is stable/sensible other interesting cases (single messages) message with a poll 1`] = `
+"<div class=\\"msglist-element timerow\\" data-msg-id=\\"-1\\">
+  <div class=\\"timerow-left\\"></div>
+  Dec 31, 1969
+  <div class=\\"timerow-right\\"></div>
+</div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"-1\\" data-narrow=\\"dG9waWM6MTpleGFtcGxlIHRvcGlj\\">
+  <div class=\\"header stream-text\\" style=\\"color: black;
+              background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
+    # nonrandom stream
+  </div>
+  <div class=\\"topic-text\\">example topic</div>
+  <div class=\\"topic-date\\">Dec 31, 1969</div>
+</div><div class=\\"msglist-element message message-full\\" id=\\"msg--1\\" data-msg-id=\\"-1\\" data-mute-state=\\"shown\\">
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20sender.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
+  </div>
+  <div class=\\"content\\">
+    <div class=\\"subheader\\">
+  <div class=\\"username\\" data-sender-id=\\"10\\">
+    Nonrandom name sender User
+  </div>
+  <div class=\\"static-timestamp\\">11:59 PM</div>
+</div>
+    <div class=\\"poll-widget\\">
+  <p class=\\"poll-question\\">Choose a choice:</p>
+  <ul>
+    
+        <li>
+          <button class=\\"poll-vote\\" data-voted=\\"true\\" data-key=\\"10,1\\">3</button>
+          <span class=\\"poll-option\\">Choice A</span>
+        </li>
+        <li>
+          <button class=\\"poll-vote\\" data-voted=\\"false\\" data-key=\\"10,2\\">1</button>
+          <span class=\\"poll-option\\">Choice B</span>
+        </li>
+  </ul>
+</div>
+  </div>
+  
+</div>"
+`;
+
+exports[`messages -> piece descriptors -> content HTML is stable/sensible other interesting cases (single messages) message with flag: collapsed 1`] = `
+"<div class=\\"msglist-element timerow\\" data-msg-id=\\"-1\\">
+  <div class=\\"timerow-left\\"></div>
+  Dec 31, 1969
+  <div class=\\"timerow-right\\"></div>
+</div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"-1\\" data-narrow=\\"dG9waWM6MTpleGFtcGxlIHRvcGlj\\">
+  <div class=\\"header stream-text\\" style=\\"color: black;
+              background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
+    # nonrandom stream
+  </div>
+  <div class=\\"topic-text\\">example topic</div>
+  <div class=\\"topic-date\\">Dec 31, 1969</div>
+</div><div class=\\"msglist-element message message-full\\" id=\\"msg--1\\" data-msg-id=\\"-1\\" data-mute-state=\\"shown\\" data-collapsed=\\"true\\">
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20sender.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
+  </div>
+  <div class=\\"content\\">
+    <div class=\\"subheader\\">
+  <div class=\\"username\\" data-sender-id=\\"10\\">
+    Nonrandom name sender User
+  </div>
+  <div class=\\"static-timestamp\\">11:59 PM</div>
+</div>
+    <p>This is an example stream message.</p>
+
+
+
+  </div>
+  
+</div>"
+`;
+
+exports[`messages -> piece descriptors -> content HTML is stable/sensible other interesting cases (single messages) message with flag: force_collapse 1`] = `
+"<div class=\\"msglist-element timerow\\" data-msg-id=\\"-1\\">
+  <div class=\\"timerow-left\\"></div>
+  Dec 31, 1969
+  <div class=\\"timerow-right\\"></div>
+</div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"-1\\" data-narrow=\\"dG9waWM6MTpleGFtcGxlIHRvcGlj\\">
+  <div class=\\"header stream-text\\" style=\\"color: black;
+              background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
+    # nonrandom stream
+  </div>
+  <div class=\\"topic-text\\">example topic</div>
+  <div class=\\"topic-date\\">Dec 31, 1969</div>
+</div><div class=\\"msglist-element message message-full\\" id=\\"msg--1\\" data-msg-id=\\"-1\\" data-mute-state=\\"shown\\" data-force_collapse=\\"true\\">
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20sender.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
+  </div>
+  <div class=\\"content\\">
+    <div class=\\"subheader\\">
+  <div class=\\"username\\" data-sender-id=\\"10\\">
+    Nonrandom name sender User
+  </div>
+  <div class=\\"static-timestamp\\">11:59 PM</div>
+</div>
+    <p>This is an example stream message.</p>
+
+
+
+  </div>
+  
+</div>"
+`;
+
+exports[`messages -> piece descriptors -> content HTML is stable/sensible other interesting cases (single messages) message with flag: force_expand 1`] = `
+"<div class=\\"msglist-element timerow\\" data-msg-id=\\"-1\\">
+  <div class=\\"timerow-left\\"></div>
+  Dec 31, 1969
+  <div class=\\"timerow-right\\"></div>
+</div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"-1\\" data-narrow=\\"dG9waWM6MTpleGFtcGxlIHRvcGlj\\">
+  <div class=\\"header stream-text\\" style=\\"color: black;
+              background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
+    # nonrandom stream
+  </div>
+  <div class=\\"topic-text\\">example topic</div>
+  <div class=\\"topic-date\\">Dec 31, 1969</div>
+</div><div class=\\"msglist-element message message-full\\" id=\\"msg--1\\" data-msg-id=\\"-1\\" data-mute-state=\\"shown\\" data-force_expand=\\"true\\">
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20sender.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
+  </div>
+  <div class=\\"content\\">
+    <div class=\\"subheader\\">
+  <div class=\\"username\\" data-sender-id=\\"10\\">
+    Nonrandom name sender User
+  </div>
+  <div class=\\"static-timestamp\\">11:59 PM</div>
+</div>
+    <p>This is an example stream message.</p>
+
+
+
+  </div>
+  
+</div>"
+`;
+
+exports[`messages -> piece descriptors -> content HTML is stable/sensible other interesting cases (single messages) message with flag: has_alert_word 1`] = `
+"<div class=\\"msglist-element timerow\\" data-msg-id=\\"-1\\">
+  <div class=\\"timerow-left\\"></div>
+  Dec 31, 1969
+  <div class=\\"timerow-right\\"></div>
+</div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"-1\\" data-narrow=\\"dG9waWM6MTpleGFtcGxlIHRvcGlj\\">
+  <div class=\\"header stream-text\\" style=\\"color: black;
+              background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
+    # nonrandom stream
+  </div>
+  <div class=\\"topic-text\\">example topic</div>
+  <div class=\\"topic-date\\">Dec 31, 1969</div>
+</div><div class=\\"msglist-element message message-full\\" id=\\"msg--1\\" data-msg-id=\\"-1\\" data-mute-state=\\"shown\\" data-has_alert_word=\\"true\\">
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20sender.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
+  </div>
+  <div class=\\"content\\">
+    <div class=\\"subheader\\">
+  <div class=\\"username\\" data-sender-id=\\"10\\">
+    Nonrandom name sender User
+  </div>
+  <div class=\\"static-timestamp\\">11:59 PM</div>
+</div>
+    <p>This is an example stream message.</p>
+
+
+
+  </div>
+  
+</div>"
+`;
+
+exports[`messages -> piece descriptors -> content HTML is stable/sensible other interesting cases (single messages) message with flag: historical 1`] = `
+"<div class=\\"msglist-element timerow\\" data-msg-id=\\"-1\\">
+  <div class=\\"timerow-left\\"></div>
+  Dec 31, 1969
+  <div class=\\"timerow-right\\"></div>
+</div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"-1\\" data-narrow=\\"dG9waWM6MTpleGFtcGxlIHRvcGlj\\">
+  <div class=\\"header stream-text\\" style=\\"color: black;
+              background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
+    # nonrandom stream
+  </div>
+  <div class=\\"topic-text\\">example topic</div>
+  <div class=\\"topic-date\\">Dec 31, 1969</div>
+</div><div class=\\"msglist-element message message-full\\" id=\\"msg--1\\" data-msg-id=\\"-1\\" data-mute-state=\\"shown\\" data-historical=\\"true\\">
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20sender.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
+  </div>
+  <div class=\\"content\\">
+    <div class=\\"subheader\\">
+  <div class=\\"username\\" data-sender-id=\\"10\\">
+    Nonrandom name sender User
+  </div>
+  <div class=\\"static-timestamp\\">11:59 PM</div>
+</div>
+    <p>This is an example stream message.</p>
+
+
+
+  </div>
+  
+</div>"
+`;
+
+exports[`messages -> piece descriptors -> content HTML is stable/sensible other interesting cases (single messages) message with flag: is_me_message 1`] = `
+"<div class=\\"msglist-element timerow\\" data-msg-id=\\"-1\\">
+  <div class=\\"timerow-left\\"></div>
+  Dec 31, 1969
+  <div class=\\"timerow-right\\"></div>
+</div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"-1\\" data-narrow=\\"dG9waWM6MTpleGFtcGxlIHRvcGlj\\">
+  <div class=\\"header stream-text\\" style=\\"color: black;
+              background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
+    # nonrandom stream
+  </div>
+  <div class=\\"topic-text\\">example topic</div>
+  <div class=\\"topic-date\\">Dec 31, 1969</div>
+</div><div class=\\"msglist-element message message-full\\" id=\\"msg--1\\" data-msg-id=\\"-1\\" data-mute-state=\\"shown\\" data-is_me_message=\\"true\\">
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20sender.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
+  </div>
+  <div class=\\"content\\">
+    <div class=\\"subheader\\">
+  <div class=\\"username\\" data-sender-id=\\"10\\">
+    Nonrandom name sender User
+  </div>
+  <div class=\\"static-timestamp\\">11:59 PM</div>
+</div>
+    <p>This is an example stream message.</p>
+
+
+
+  </div>
+  
+</div>"
+`;
+
+exports[`messages -> piece descriptors -> content HTML is stable/sensible other interesting cases (single messages) message with flag: mentioned 1`] = `
+"<div class=\\"msglist-element timerow\\" data-msg-id=\\"-1\\">
+  <div class=\\"timerow-left\\"></div>
+  Dec 31, 1969
+  <div class=\\"timerow-right\\"></div>
+</div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"-1\\" data-narrow=\\"dG9waWM6MTpleGFtcGxlIHRvcGlj\\">
+  <div class=\\"header stream-text\\" style=\\"color: black;
+              background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
+    # nonrandom stream
+  </div>
+  <div class=\\"topic-text\\">example topic</div>
+  <div class=\\"topic-date\\">Dec 31, 1969</div>
+</div><div class=\\"msglist-element message message-full\\" id=\\"msg--1\\" data-msg-id=\\"-1\\" data-mute-state=\\"shown\\" data-mentioned=\\"true\\">
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20sender.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
+  </div>
+  <div class=\\"content\\">
+    <div class=\\"subheader\\">
+  <div class=\\"username\\" data-sender-id=\\"10\\">
+    Nonrandom name sender User
+  </div>
+  <div class=\\"static-timestamp\\">11:59 PM</div>
+</div>
+    <p>This is an example stream message.</p>
+
+
+
+  </div>
+  
+</div>"
+`;
+
+exports[`messages -> piece descriptors -> content HTML is stable/sensible other interesting cases (single messages) message with flag: read 1`] = `
+"<div class=\\"msglist-element timerow\\" data-msg-id=\\"-1\\">
+  <div class=\\"timerow-left\\"></div>
+  Dec 31, 1969
+  <div class=\\"timerow-right\\"></div>
+</div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"-1\\" data-narrow=\\"dG9waWM6MTpleGFtcGxlIHRvcGlj\\">
+  <div class=\\"header stream-text\\" style=\\"color: black;
+              background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
+    # nonrandom stream
+  </div>
+  <div class=\\"topic-text\\">example topic</div>
+  <div class=\\"topic-date\\">Dec 31, 1969</div>
+</div><div class=\\"msglist-element message message-full\\" id=\\"msg--1\\" data-msg-id=\\"-1\\" data-mute-state=\\"shown\\" data-read=\\"true\\">
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20sender.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
+  </div>
+  <div class=\\"content\\">
+    <div class=\\"subheader\\">
+  <div class=\\"username\\" data-sender-id=\\"10\\">
+    Nonrandom name sender User
+  </div>
+  <div class=\\"static-timestamp\\">11:59 PM</div>
+</div>
+    <p>This is an example stream message.</p>
+
+
+
+  </div>
+  
+</div>"
+`;
+
+exports[`messages -> piece descriptors -> content HTML is stable/sensible other interesting cases (single messages) message with flag: starred 1`] = `
+"<div class=\\"msglist-element timerow\\" data-msg-id=\\"-1\\">
+  <div class=\\"timerow-left\\"></div>
+  Dec 31, 1969
+  <div class=\\"timerow-right\\"></div>
+</div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"-1\\" data-narrow=\\"dG9waWM6MTpleGFtcGxlIHRvcGlj\\">
+  <div class=\\"header stream-text\\" style=\\"color: black;
+              background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
+    # nonrandom stream
+  </div>
+  <div class=\\"topic-text\\">example topic</div>
+  <div class=\\"topic-date\\">Dec 31, 1969</div>
+</div><div class=\\"msglist-element message message-full\\" id=\\"msg--1\\" data-msg-id=\\"-1\\" data-mute-state=\\"shown\\" data-starred=\\"true\\">
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20sender.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
+  </div>
+  <div class=\\"content\\">
+    <div class=\\"subheader\\">
+  <div class=\\"username\\" data-sender-id=\\"10\\">
+    Nonrandom name sender User
+  </div>
+  <div class=\\"static-timestamp\\">11:59 PM</div>
+</div>
+    <p>This is an example stream message.</p>
+
+<div class=\\"message-tags\\"><span class=\\"message-tag\\">starred</span></div>
+
+  </div>
+  
+</div>"
+`;
+
+exports[`messages -> piece descriptors -> content HTML is stable/sensible other interesting cases (single messages) message with flag: summarize_in_home 1`] = `
+"<div class=\\"msglist-element timerow\\" data-msg-id=\\"-1\\">
+  <div class=\\"timerow-left\\"></div>
+  Dec 31, 1969
+  <div class=\\"timerow-right\\"></div>
+</div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"-1\\" data-narrow=\\"dG9waWM6MTpleGFtcGxlIHRvcGlj\\">
+  <div class=\\"header stream-text\\" style=\\"color: black;
+              background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
+    # nonrandom stream
+  </div>
+  <div class=\\"topic-text\\">example topic</div>
+  <div class=\\"topic-date\\">Dec 31, 1969</div>
+</div><div class=\\"msglist-element message message-full\\" id=\\"msg--1\\" data-msg-id=\\"-1\\" data-mute-state=\\"shown\\" data-summarize_in_home=\\"true\\">
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20sender.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
+  </div>
+  <div class=\\"content\\">
+    <div class=\\"subheader\\">
+  <div class=\\"username\\" data-sender-id=\\"10\\">
+    Nonrandom name sender User
+  </div>
+  <div class=\\"static-timestamp\\">11:59 PM</div>
+</div>
+    <p>This is an example stream message.</p>
+
+
+
+  </div>
+  
+</div>"
+`;
+
+exports[`messages -> piece descriptors -> content HTML is stable/sensible other interesting cases (single messages) message with flag: summarize_in_stream 1`] = `
+"<div class=\\"msglist-element timerow\\" data-msg-id=\\"-1\\">
+  <div class=\\"timerow-left\\"></div>
+  Dec 31, 1969
+  <div class=\\"timerow-right\\"></div>
+</div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"-1\\" data-narrow=\\"dG9waWM6MTpleGFtcGxlIHRvcGlj\\">
+  <div class=\\"header stream-text\\" style=\\"color: black;
+              background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
+    # nonrandom stream
+  </div>
+  <div class=\\"topic-text\\">example topic</div>
+  <div class=\\"topic-date\\">Dec 31, 1969</div>
+</div><div class=\\"msglist-element message message-full\\" id=\\"msg--1\\" data-msg-id=\\"-1\\" data-mute-state=\\"shown\\" data-summarize_in_stream=\\"true\\">
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20sender.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
+  </div>
+  <div class=\\"content\\">
+    <div class=\\"subheader\\">
+  <div class=\\"username\\" data-sender-id=\\"10\\">
+    Nonrandom name sender User
+  </div>
+  <div class=\\"static-timestamp\\">11:59 PM</div>
+</div>
+    <p>This is an example stream message.</p>
+
+
+
+  </div>
+  
+</div>"
+`;
+
+exports[`messages -> piece descriptors -> content HTML is stable/sensible other interesting cases (single messages) message with flag: wildcard_mentioned 1`] = `
+"<div class=\\"msglist-element timerow\\" data-msg-id=\\"-1\\">
+  <div class=\\"timerow-left\\"></div>
+  Dec 31, 1969
+  <div class=\\"timerow-right\\"></div>
+</div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"-1\\" data-narrow=\\"dG9waWM6MTpleGFtcGxlIHRvcGlj\\">
+  <div class=\\"header stream-text\\" style=\\"color: black;
+              background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
+    # nonrandom stream
+  </div>
+  <div class=\\"topic-text\\">example topic</div>
+  <div class=\\"topic-date\\">Dec 31, 1969</div>
+</div><div class=\\"msglist-element message message-full\\" id=\\"msg--1\\" data-msg-id=\\"-1\\" data-mute-state=\\"shown\\" data-wildcard_mentioned=\\"true\\">
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20sender.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
+  </div>
+  <div class=\\"content\\">
+    <div class=\\"subheader\\">
+  <div class=\\"username\\" data-sender-id=\\"10\\">
+    Nonrandom name sender User
+  </div>
+  <div class=\\"static-timestamp\\">11:59 PM</div>
+</div>
+    <p>This is an example stream message.</p>
+
+
+
+  </div>
+  
+</div>"
+`;
+
+exports[`messages -> piece descriptors -> content HTML is stable/sensible other interesting cases (single messages) message with reactions 1`] = `
+"<div class=\\"msglist-element timerow\\" data-msg-id=\\"-1\\">
+  <div class=\\"timerow-left\\"></div>
+  Dec 31, 1969
+  <div class=\\"timerow-right\\"></div>
+</div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"-1\\" data-narrow=\\"dG9waWM6MTpleGFtcGxlIHRvcGlj\\">
+  <div class=\\"header stream-text\\" style=\\"color: black;
+              background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
+    # nonrandom stream
+  </div>
+  <div class=\\"topic-text\\">example topic</div>
+  <div class=\\"topic-date\\">Dec 31, 1969</div>
+</div><div class=\\"msglist-element message message-full\\" id=\\"msg--1\\" data-msg-id=\\"-1\\" data-mute-state=\\"shown\\">
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20sender.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
+  </div>
+  <div class=\\"content\\">
+    <div class=\\"subheader\\">
+  <div class=\\"username\\" data-sender-id=\\"10\\">
+    Nonrandom name sender User
+  </div>
+  <div class=\\"static-timestamp\\">11:59 PM</div>
+</div>
+    <p>This is an example stream message.</p>
+
+
+<div class=\\"reaction-list\\"><span onclick=\\"\\" class=\\"reaction\\" data-name=\\"github_parrot\\" data-code=\\"80\\" data-type=\\"realm_emoji\\">&nbsp;2</span><span onclick=\\"\\" class=\\"reaction\\" data-name=\\"thumbs_up\\" data-code=\\"1f44d\\" data-type=\\"unicode_emoji\\">👍&nbsp;1</span><span onclick=\\"\\" class=\\"reaction\\" data-name=\\"zulip\\" data-code=\\"zulip\\" data-type=\\"zulip_extra_emoji\\">&nbsp;1</span></div>
+  </div>
+  
+</div>"
+`;
+
+exports[`messages -> piece descriptors -> content HTML is stable/sensible other interesting cases (single messages) muted sender 1`] = `
+"<div class=\\"msglist-element timerow\\" data-msg-id=\\"-1\\">
+  <div class=\\"timerow-left\\"></div>
+  Dec 31, 1969
+  <div class=\\"timerow-right\\"></div>
+</div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"-1\\" data-narrow=\\"dG9waWM6MTpleGFtcGxlIHRvcGlj\\">
+  <div class=\\"header stream-text\\" style=\\"color: black;
+              background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
+    # nonrandom stream
+  </div>
+  <div class=\\"topic-text\\">example topic</div>
+  <div class=\\"topic-date\\">Dec 31, 1969</div>
+</div><div class=\\"msglist-element message message-full\\" id=\\"msg--1\\" data-msg-id=\\"-1\\" data-mute-state=\\"hidden\\">
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20sender.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
+  </div>
+  <div class=\\"content\\">
+    <div class=\\"subheader\\">
+  <div class=\\"username\\" data-sender-id=\\"10\\">
+    Nonrandom name sender User
+  </div>
+  <div class=\\"static-timestamp\\">11:59 PM</div>
+</div>
+    <p>This is an example stream message.</p>
+
+
+
+  </div>
+  <div class=\\"special-message muted-message-explanation\\">
+  This message was hidden because it is from a user you have muted. Long-press to view.
+</div>
+</div>"
+`;
+
 exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2 1`] = `
 "<div class=\\"msglist-element timerow\\" data-msg-id=\\"8849\\">
   <div class=\\"timerow-left\\"></div>

--- a/src/webview/__tests__/__snapshots__/generateInboundEventEditSequence-test.js.snap.ios
+++ b/src/webview/__tests__/__snapshots__/generateInboundEventEditSequence-test.js.snap.ios
@@ -34,6 +34,22 @@ exports[`getEditSequence correct for interesting changes from many messages to d
 
 exports[`getEditSequence correct for interesting changes from many messages to empty 1`] = `40`;
 
+exports[`getEditSequence correct for interesting changes within a given message add reactions to a message 1`] = `3`;
+
+exports[`getEditSequence correct for interesting changes within a given message mute a sender 1`] = `1`;
+
+exports[`getEditSequence correct for interesting changes within a given message polls choice added 1`] = `3`;
+
+exports[`getEditSequence correct for interesting changes within a given message polls vote added 1`] = `3`;
+
+exports[`getEditSequence correct for interesting changes within a given message remove reactions from a message 1`] = `3`;
+
+exports[`getEditSequence correct for interesting changes within a given message star a message 1`] = `1`;
+
+exports[`getEditSequence correct for interesting changes within a given message unmute a sender 1`] = `1`;
+
+exports[`getEditSequence correct for interesting changes within a given message unstar a message 1`] = `1`;
+
 exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_NARROW 1`] = `
 "<div class=\\"msglist-element timerow\\" data-msg-id=\\"1024\\">
   <div class=\\"timerow-left\\"></div>

--- a/src/webview/__tests__/generateInboundEventEditSequence-test.js
+++ b/src/webview/__tests__/generateInboundEventEditSequence-test.js
@@ -399,8 +399,16 @@ describe('getEditSequence correct for interesting changes', () => {
 
   const check = (
     // TODO: Test with a variety of different things in background data
-    { oldBackgroundData = baseBackgroundData, oldNarrow = HOME_NARROW, oldMessages },
-    { newBackgroundData = baseBackgroundData, newNarrow = HOME_NARROW, newMessages },
+    {
+      backgroundData: oldBackgroundData = baseBackgroundData,
+      narrow: oldNarrow = HOME_NARROW,
+      messages: oldMessages,
+    },
+    {
+      backgroundData: newBackgroundData = baseBackgroundData,
+      narrow: newNarrow = HOME_NARROW,
+      messages: newMessages,
+    },
   ) => {
     const oldElements = getMessageListElements(oldMessages, oldNarrow);
     const newElements = getMessageListElements(newMessages, newNarrow);
@@ -459,56 +467,50 @@ describe('getEditSequence correct for interesting changes', () => {
 
   describe('from empty', () => {
     test('to empty', () => {
-      check({ oldMessages: [] }, { newMessages: [] });
+      check({ messages: [] }, { messages: [] });
     });
 
     test('to one message', () => {
-      check({ oldMessages: [] }, { newMessages: [allMessages[0]] });
+      check({ messages: [] }, { messages: [allMessages[0]] });
     });
 
     test('to many messages', () => {
-      check({ oldMessages: [] }, { newMessages: allMessages });
+      check({ messages: [] }, { messages: allMessages });
     });
   });
 
   describe('from many messages', () => {
     test('to empty', () => {
-      check({ oldMessages: allMessages }, { newMessages: [] });
+      check({ messages: allMessages }, { messages: [] });
     });
 
     test('to disjoint set of many later messages', () => {
       check(
-        { oldMessages: allMessages.slice(0, allMessages.length / 2) },
-        { newMessages: allMessages.slice(allMessages.length / 2, allMessages.length) },
+        { messages: allMessages.slice(0, allMessages.length / 2) },
+        { messages: allMessages.slice(allMessages.length / 2, allMessages.length) },
       );
     });
 
     test('to disjoint set of many earlier messages', () => {
       check(
-        { oldMessages: allMessages.slice(allMessages.length / 2, allMessages.length) },
-        { newMessages: allMessages.slice(0, allMessages.length / 2) },
+        { messages: allMessages.slice(allMessages.length / 2, allMessages.length) },
+        { messages: allMessages.slice(0, allMessages.length / 2) },
       );
     });
 
     test('insert one message at end', () => {
-      check(
-        { oldMessages: allMessages.slice(0, allMessages.length - 1) },
-        { newMessages: allMessages },
-      );
+      check({ messages: allMessages.slice(0, allMessages.length - 1) }, { messages: allMessages });
     });
 
     test('delete one message at end', () => {
-      check(
-        { oldMessages: allMessages },
-        { newMessages: allMessages.slice(0, allMessages.length - 1) },
-      );
+      check({ messages: allMessages }, { messages: allMessages.slice(0, allMessages.length - 1) });
     });
 
     test('replace one message at end with new content', () => {
       check(
-        { oldMessages: allMessages },
+        { messages: allMessages },
         {
-          newMessages: [
+          messages: [
             ...allMessages.slice(0, allMessages.length - 1),
             withContentReplaced(allMessages[allMessages.length - 1]),
           ],
@@ -517,39 +519,27 @@ describe('getEditSequence correct for interesting changes', () => {
     });
 
     test('insert one message at start', () => {
-      check(
-        { oldMessages: allMessages.slice(1, allMessages.length) },
-        { newMessages: allMessages },
-      );
+      check({ messages: allMessages.slice(1, allMessages.length) }, { messages: allMessages });
     });
 
     test('delete one message at start', () => {
-      check(
-        { oldMessages: allMessages },
-        { newMessages: allMessages.slice(1, allMessages.length) },
-      );
+      check({ messages: allMessages }, { messages: allMessages.slice(1, allMessages.length) });
     });
 
     test('replace one message at start with new content', () => {
       const [firstMessage, ...rest] = allMessages;
 
-      check(
-        { oldMessages: allMessages },
-        { newMessages: [withContentReplaced(firstMessage), ...rest] },
-      );
+      check({ messages: allMessages }, { messages: [withContentReplaced(firstMessage), ...rest] });
     });
 
     test('insert many messages at end', () => {
-      check(
-        { oldMessages: allMessages.slice(0, allMessages.length / 2) },
-        { newMessages: allMessages },
-      );
+      check({ messages: allMessages.slice(0, allMessages.length / 2) }, { messages: allMessages });
     });
 
     test('insert many messages at start', () => {
       check(
-        { oldMessages: allMessages.slice(allMessages.length / 2, allMessages.length - 1) },
-        { newMessages: allMessages },
+        { messages: allMessages.slice(allMessages.length / 2, allMessages.length - 1) },
+        { messages: allMessages },
       );
     });
 
@@ -557,8 +547,8 @@ describe('getEditSequence correct for interesting changes', () => {
       const firstThirdIndex = Math.floor(allMessages.length / 3);
       const secondThirdIndex = Math.floor(allMessages.length * (2 / 3));
       check(
-        { oldMessages: allMessages.slice(firstThirdIndex, secondThirdIndex) },
-        { newMessages: allMessages },
+        { messages: allMessages.slice(firstThirdIndex, secondThirdIndex) },
+        { messages: allMessages },
       );
     });
 
@@ -566,9 +556,9 @@ describe('getEditSequence correct for interesting changes', () => {
       const firstThirdIndex = Math.floor(allMessages.length / 3);
       const secondThirdIndex = Math.floor(allMessages.length * (2 / 3));
       check(
-        { oldMessages: allMessages },
+        { messages: allMessages },
         {
-          newMessages: [
+          messages: [
             ...allMessages.slice(0, firstThirdIndex),
             ...allMessages.slice(secondThirdIndex, allMessages.length - 1),
           ],
@@ -579,9 +569,9 @@ describe('getEditSequence correct for interesting changes', () => {
     test('replace one message in middle with new content', () => {
       const midIndex = Math.floor(allMessages.length / 2);
       check(
-        { oldMessages: allMessages },
+        { messages: allMessages },
         {
-          newMessages: [
+          messages: [
             ...allMessages.slice(0, midIndex),
             withContentReplaced(allMessages[midIndex]),
             ...allMessages.slice(midIndex + 1, allMessages.length - 1),

--- a/src/webview/generateInboundEventEditSequence.js
+++ b/src/webview/generateInboundEventEditSequence.js
@@ -92,6 +92,8 @@ function doElementsDifferInterestingly(
             && oldBackgroundData.flags[flagName][oldElement.message.id]
               !== newBackgroundData.flags[flagName][newElement.message.id],
         )
+        || oldBackgroundData.mutedUsers.get(oldElement.message.sender_id)
+          !== newBackgroundData.mutedUsers.get(newElement.message.sender_id)
       );
     }
     default: {

--- a/src/webview/generateInboundEvents.js
+++ b/src/webview/generateInboundEvents.js
@@ -105,6 +105,8 @@ export default function generateInboundEvents(
       nextProps.messageListElementsForShownMessages,
     )
     || !equalFlagsExcludingRead(prevProps.backgroundData.flags, nextProps.backgroundData.flags)
+    // TODO(#4655): Should also update here if backgroundData.mutedUsers
+    //   changes, e.g. because the user muted someone.
   ) {
     uevents.push(updateContent(prevProps, nextProps));
   }


### PR DESCRIPTION
And a bugfix caught by one of the new tests!

I'm going down the list at https://github.com/zulip/zulip-mobile/pull/5188#issuecomment-1009484564, and Greg's comment on [CZO](https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/msglist-diffing.20tests/near/1320910):

> These do give us a reminder that it'd be good to have HTML snapshots testing those features of the message list, though:
> * reactions
> * polls
> * starred messages
> * muted senders

This PR does those HTML snapshots in those four bullet points, and most of this part of https://github.com/zulip/zulip-mobile/pull/5188#issuecomment-1009484564:

> And for within a given message:
> 
> * Add/remove reactions to a message.
> * Update a poll's data.
>   
>   * Hmm, I wonder if our existing shortcut I mentioned here: [Implement message-list diffing algorithm! #5188 (comment)](https://github.com/zulip/zulip-mobile/pull/5188#discussion_r781663996) is correct for this case. These new tests will make it possible to check that!
> * Star/unstar a message.
> * Change a sender's name or avatar.
> * Mute/unmute a sender.

I haven't done "Change a sender's name or avatar" yet because I think we can't until #5208 settles.