### PR TITLE
Fix major startup lag, by using Animated.loop instead of giant duration

### DIFF
--- a/src/animation/AnimatedRotateComponent.js
+++ b/src/animation/AnimatedRotateComponent.js
@@ -16,12 +16,14 @@ export default class AnimatedRotateComponent extends PureComponent<Props> {
 
   componentDidMount() {
     this.rotation.setValue(0);
-    Animated.timing(this.rotation, {
-      toValue: 360 * 1000,
-      duration: 1000 * 1000,
-      easing: Easing.linear,
-      useNativeDriver: true,
-    }).start();
+    Animated.loop(
+      Animated.timing(this.rotation, {
+        toValue: 360,
+        duration: 1000,
+        easing: Easing.linear,
+        useNativeDriver: true,
+      }),
+    ).start();
   }
 
   render(): Node {


### PR DESCRIPTION
This was always a silly-looking hack: what we really want is for
this animation to loop indefinitely, and we do that by saying it
runs for 1000 seconds.

It turns out that doing that makes it extremely slow to start up!
Specifically, in my desktop Android emulator (which is typically
1x-2x the speed of my physical Pixel 4), it takes about 500ms.

Worse: it blocks the entire JS thread while it does that.  So
the app's whole UI is stalled.

Because we use this at startup (in LoadingIndicator), it's been
adding that 500ms of lag (likely more like 1000ms on many devices)
to our startup time since forever.  Moreover, we use
LoadingIndicator in the "Connecting..." banner... which there's
*four* of, one on each of the app's main-screen tabs.  So when we
start loading -- which is promptly after each startup, if you're
already logged in -- the UI hangs for another 2000ms, or more
depending on device.

There are a number of things we could do here.  It seems like a
performance bug in RN's `Animated`.  Also we could shorten the
1000 seconds to like 100 seconds, or 50 seconds -- better that
you occasionally see a stopped spinner, if you've already waited
a long time, than that you find the app completely stuck for a
full second or more every time you start it.

But in fact a very simple solution is available: if you take a look
at the upstream docs for Animated:
  https://reactnative.dev/docs/animated
there is built-in support for just explicitly having a loop.
There's no need for this hack at all.  Even in RN v0.47.2, the
version we were using when this hack was introduced in 2017 in
6594f8ebc, there was an `Animated.loop` and there was no need
for this hack.

So use that.