### PR TITLE
Remove flowtype/generic-spacing lint.

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -316,7 +316,6 @@ rules:
   flowtype/boolean-style: [error, boolean]
   flowtype/define-flow-type: warn
   flowtype/delimiter-dangle: off
-  flowtype/generic-spacing: [error, never]
   flowtype/no-dupe-keys: error
   flowtype/no-primitive-constructor-types: error
   flowtype/no-types-missing-file-annotation: error

--- a/src/__flow-tests__/nav-test.js
+++ b/src/__flow-tests__/nav-test.js
@@ -9,8 +9,6 @@ import { createStackNavigator, type StackNavigationProp } from '@react-navigatio
 
 import { type RouteProp, type RouteParamsOf } from '../react-navigation';
 
-/* eslint-disable flowtype/generic-spacing */
-
 // Test that `RouteProp` gives route.params the right type.
 function testRouteParamTypes() {
   type ProfileProps = {|

--- a/src/api/realmDataTypes.js
+++ b/src/api/realmDataTypes.js
@@ -11,7 +11,6 @@ import type { InitialDataRealm } from './initialDataTypes';
  * in the /register response (InitialDataRealm has lots of properties that
  * start with "realm_"). But we expect the values to be typed the same.
  */
-/* eslint-disable flowtype/generic-spacing */
 /* prettier-ignore */
 export type RealmDataForUpdate = $ReadOnly<{
   //

--- a/src/common/ZulipButton.js
+++ b/src/common/ZulipButton.js
@@ -65,7 +65,6 @@ const styles = createStyleSheet({
 });
 
 type Props = $ReadOnly<{|
-  /* eslint-disable flowtype/generic-spacing */
   style?: SubsetProperties<
     ViewStyle,
     {|

--- a/src/generics.js
+++ b/src/generics.js
@@ -3,8 +3,6 @@
  * Tools for manipulating generic types in the Flow type system.
  */
 
-/* eslint-disable flowtype/generic-spacing */
-
 /**
  * The type `S`, plus a check that `S` is a supertype of `T`.
  *

--- a/src/react-native-action-sheet.js
+++ b/src/react-native-action-sheet.js
@@ -5,8 +5,6 @@ import { connectActionSheet as connectActionSheetInner } from '@expo/react-nativ
 
 import type { BoundedDiff } from './generics';
 
-/* eslint-disable flowtype/generic-spacing */
-
 export type ShowActionSheetWithOptions = (
   { options: string[], cancelButtonIndex: number, ... },
   (number) => void,

--- a/src/react-native-safe-area-context.js
+++ b/src/react-native-safe-area-context.js
@@ -7,8 +7,6 @@ import {
 
 import type { BoundedDiff } from './generics';
 
-/* eslint-disable flowtype/generic-spacing */
-
 /**
  * Exactly like `withSafeAreaInsets` upstream, but properly typed.
  *

--- a/src/react-navigation.js
+++ b/src/react-navigation.js
@@ -14,8 +14,6 @@ import {
 
 import type { GlobalParamList } from './nav/globalTypes';
 
-/* eslint-disable flowtype/generic-spacing */
-
 /**
  * A type to use for the `route` prop on a screen component.
  *

--- a/src/react-redux.js
+++ b/src/react-redux.js
@@ -27,8 +27,6 @@ import type { BoundedDiff } from './generics';
 // eslint-disable-next-line no-restricted-imports
 export { Provider } from 'react-redux';
 
-/* eslint-disable flowtype/generic-spacing */
-
 // We leave this as invariant in `C` (i.e., we don't write `-C` or `+C`)
 // because Flow says `ElementConfig` is invariant.  (If you try writing
 // `OwnProps<-C, …` or `OwnProps<+C, …`, Flow gives an error saying the `C`

--- a/src/start/IosCompliantAppleAuthButton/index.js
+++ b/src/start/IosCompliantAppleAuthButton/index.js
@@ -13,7 +13,6 @@ import { getGlobalSettings } from '../../selectors';
 type Props = $ReadOnly<{|
   // See `ZulipButton`'s `style` prop, where a comment discusses this
   // idea.
-  /* eslint-disable flowtype/generic-spacing */
   style?: SubsetProperties<
     ViewStyle,
     {|

--- a/src/types.js
+++ b/src/types.js
@@ -205,7 +205,6 @@ type OutboxBase = $ReadOnly<{|
   // It's used for sending the message to the server.
   markdownContent: string,
 
-  /* eslint-disable flowtype/generic-spacing */
   ...SubsetProperties<
     // Could use `MessageBase` here.  Then Flow would check that the listed
     // properties are in `MessageBase`, rather than just in both branches of

--- a/tools/fmt
+++ b/tools/fmt
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -e
 
+this_dir=${BASH_SOURCE[0]%/*}
+. "${this_dir}"/lib/eslintignore.sh
+
+
 ## CLI PARSING
 
 usage() {
@@ -30,10 +34,10 @@ cd "$(git rev-parse --show-toplevel)"
 PATH=node_modules/.bin:"$PATH"
 
 if [ -z "$all" ]; then
-    files=( $(tools/info changed-files | grep '^src/.*\.js$') ) \
+    files=( $(apply_eslintignore $(tools/info changed-files | grep '^src/.*\.js$') ) ) \
         || exit 0
 else
-    files=( 'src/**/*.js' )
+    files=( $(apply_eslintignore 'src/**/*.js' ) )
 fi
 
 prettier-eslint \

--- a/tools/fmt
+++ b/tools/fmt
@@ -36,5 +36,9 @@ else
     files=( 'src/**/*.js' )
 fi
 
-prettier --write --loglevel=warn "${files[@]}"
+prettier-eslint \
+    --write \
+    --eslint-config-path ./tools/formatting.eslintrc.yaml \
+    --log-level=warn \
+    "${files[@]}"
 eslint --no-eslintrc -c tools/formatting.eslintrc.yaml --fix "${files[@]}"

--- a/tools/lib/eslintignore.sh
+++ b/tools/lib/eslintignore.sh
@@ -1,0 +1,32 @@
+# shellcheck shell=bash
+
+# Filter out filenames excluded by our .eslintignore.
+#
+# Filenames are expected as arguments, and printed, leaving out those that
+# should be ignored.
+#
+# (This is a workaround: the ideal solution would be for ESLint to accept an
+# option saying to apply its ignore rules and to not worry if that filters
+# out some or all of the files we named, and then we wouldn't need this.)
+apply_eslintignore() {
+    # This uses only the .eslintignore file at the root.  It relies on us
+    # having no other sources of ESLint file ignores: other .eslintignore
+    # files, `ignorePatterns` in the eslintrc, etc.
+    #
+    # But if we do, the worst case is that we'll reintroduce #5081: the
+    # interactive `tools/test` (never CI) will fail when one of those
+    # ignored files is touched, because of an awkward CLI choice in ESLint.
+
+    # ESLint ignore files are documented as having the gitignore syntax:
+    #   https://eslint.org/docs/user-guide/configuring/ignoring-code
+    # So we ask Git to interpret the file for us.  The main limitation is
+    # that while we can tell it one file to apply, we can't give it several,
+    # or tell it to look for .eslintignore files throughout the tree.
+    #
+    # The `git check-ignore` command wants to tell us what files have been
+    # excluded, not included.  With `-nv` it gives us both and we can
+    # extract which is which.
+    (( $# )) || return 0  # if no arguments, no output
+    git -c core.excludesFile=.eslintignore check-ignore --no-index -nv "$@" \
+    | perl -lne 'print if (s/^::\t//)'
+}

--- a/tools/test
+++ b/tools/test
@@ -16,6 +16,10 @@
 # function.
 set -e
 
+this_dir=${BASH_SOURCE[0]%/*}
+. "${this_dir}"/lib/eslintignore.sh
+
+
 ## CLI PARSING
 
 usage() {
@@ -175,37 +179,6 @@ run_native() {
         # echo 'Running iOS native tests...';
         run_native_ios || return
     fi
-}
-
-# Filter out filenames excluded by our .eslintignore.
-#
-# Filenames are expected as arguments, and printed, leaving out those that
-# should be ignored.
-#
-# (This is a workaround: the ideal solution would be for ESLint to accept an
-# option saying to apply its ignore rules and to not worry if that filters
-# out some or all of the files we named, and then we wouldn't need this.)
-apply_eslintignore() {
-    # This uses only the .eslintignore file at the root.  It relies on us
-    # having no other sources of ESLint file ignores: other .eslintignore
-    # files, `ignorePatterns` in the eslintrc, etc.
-    #
-    # But if we do, the worst case is that we'll reintroduce #5081: the
-    # interactive `tools/test` (never CI) will fail when one of those
-    # ignored files is touched, because of an awkward CLI choice in ESLint.
-
-    # ESLint ignore files are documented as having the gitignore syntax:
-    #   https://eslint.org/docs/user-guide/configuring/ignoring-code
-    # So we ask Git to interpret the file for us.  The main limitation is
-    # that while we can tell it one file to apply, we can't give it several,
-    # or tell it to look for .eslintignore files throughout the tree.
-    #
-    # The `git check-ignore` command wants to tell us what files have been
-    # excluded, not included.  With `-nv` it gives us both and we can
-    # extract which is which.
-    (( $# )) || return 0  # if no arguments, no output
-    git -c core.excludesFile=.eslintignore check-ignore --no-index -nv "$@" \
-    | perl -lne 'print if (s/^::\t//)'
 }
 
 run_lint() {


### PR DESCRIPTION
This conflicts with our prettier config, and doesn't seem to be very
useful. It's disabled by default upstream, and was added in a1edcaa16
without any explanation. We frequently needed to disable it.

See https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/fmt.2Ftest.20prettier.20mismatch/near/1326785