### PR TITLE
msglist: Stop checking narrow where we no longer need to

### DIFF
--- a/src/webview/MessageList.js
+++ b/src/webview/MessageList.js
@@ -209,7 +209,6 @@ class MessageListInner extends Component<Props> {
       backgroundData,
       messageListElementsForShownMessages,
       initialScrollMessageId,
-      narrow,
       showMessagePlaceholders,
       _,
     } = this.props;
@@ -217,7 +216,6 @@ class MessageListInner extends Component<Props> {
       .map(element =>
         messageListElementHtml({
           backgroundData,
-          narrow,
           element,
           _,
         }),

--- a/src/webview/__tests__/generateInboundEventEditSequence-test.js
+++ b/src/webview/__tests__/generateInboundEventEditSequence-test.js
@@ -249,8 +249,8 @@ describe('messages -> piece descriptors -> content HTML is stable/sensible', () 
     // Simulate applying an edit-sequence event to the DOM.
     applyEditSequence(
       getEditSequence(
-        { backgroundData, narrow, elements: [], _: mock_ },
-        { backgroundData, narrow, elements: getMessageListElements(messages, narrow), _: mock_ },
+        { backgroundData, elements: [], _: mock_ },
+        { backgroundData, elements: getMessageListElements(messages, narrow), _: mock_ },
       ),
     );
 
@@ -409,8 +409,8 @@ describe('getEditSequence correct for interesting changes', () => {
 
     applyEditSequence(
       getEditSequence(
-        { backgroundData: newBackgroundData, narrow: newNarrow, elements: [], _: mock_ },
-        { backgroundData: newBackgroundData, narrow: newNarrow, elements: newElements, _: mock_ },
+        { backgroundData: newBackgroundData, elements: [], _: mock_ },
+        { backgroundData: newBackgroundData, elements: newElements, _: mock_ },
       ),
     );
 
@@ -420,14 +420,14 @@ describe('getEditSequence correct for interesting changes', () => {
 
     applyEditSequence(
       getEditSequence(
-        { backgroundData: oldBackgroundData, narrow: oldNarrow, elements: [], _: mock_ },
-        { backgroundData: oldBackgroundData, narrow: oldNarrow, elements: oldElements, _: mock_ },
+        { backgroundData: oldBackgroundData, elements: [], _: mock_ },
+        { backgroundData: oldBackgroundData, elements: oldElements, _: mock_ },
       ),
     );
 
     const realEditSequence = getEditSequence(
-      { backgroundData: oldBackgroundData, narrow: oldNarrow, elements: oldElements, _: mock_ },
-      { backgroundData: newBackgroundData, narrow: newNarrow, elements: newElements, _: mock_ },
+      { backgroundData: oldBackgroundData, elements: oldElements, _: mock_ },
+      { backgroundData: newBackgroundData, elements: newElements, _: mock_ },
     );
 
     expect(realEditSequence.length).toMatchSnapshot();

--- a/src/webview/generateInboundEventEditSequence.js
+++ b/src/webview/generateInboundEventEditSequence.js
@@ -3,9 +3,8 @@
 import isEqual from 'lodash.isequal';
 import invariant from 'invariant';
 
-import type { MessageListElement, Narrow, GetText } from '../types';
+import type { MessageListElement, GetText } from '../types';
 import { ensureUnreachable } from '../generics';
-import { keyFromNarrow } from '../utils/narrow';
 import type { BackgroundData } from './MessageList';
 import messageListElementHtml from './html/messageListElementHtml';
 
@@ -108,13 +107,11 @@ function doElementsDifferInterestingly(
 export function getEditSequence(
   oldArgs: {|
     backgroundData: BackgroundData,
-    narrow: Narrow,
     elements: $ReadOnlyArray<MessageListElement>,
     _: GetText,
   |},
   newArgs: {|
     backgroundData: BackgroundData,
-    narrow: Narrow,
     elements: $ReadOnlyArray<MessageListElement>,
     _: GetText,
   |},
@@ -128,8 +125,6 @@ export function getEditSequence(
   }
 
   const hasLanguageChanged = oldArgs._ !== newArgs._;
-  // We might not want to keep allowing this. We allow it, now, in search.
-  const hasNarrowChanged = keyFromNarrow(oldArgs.narrow) !== keyFromNarrow(newArgs.narrow);
 
   const result = [];
 
@@ -165,10 +160,6 @@ export function getEditSequence(
       if (
         // Replace any translated text, like muted-user placeholders.
         hasLanguageChanged
-        // Replace if `hasNarrowChanged`. Not sure if this triggers any
-        // changes that aren't otherwise triggered...but it might, or at
-        // least we could reasonably want it to.
-        || hasNarrowChanged
         || doElementsDifferInterestingly(
           oldElement,
           newElement,

--- a/src/webview/generateInboundEventEditSequence.js
+++ b/src/webview/generateInboundEventEditSequence.js
@@ -148,7 +148,6 @@ export function getEditSequence(
         index: j,
         html: messageListElementHtml({
           backgroundData: newArgs.backgroundData,
-          narrow: newArgs.narrow,
           element: newElement,
           _: newArgs._,
         }),
@@ -182,7 +181,6 @@ export function getEditSequence(
           index: j,
           html: messageListElementHtml({
             backgroundData: newArgs.backgroundData,
-            narrow: newArgs.narrow,
             element: newElement,
             _: newArgs._,
           }),
@@ -198,7 +196,6 @@ export function getEditSequence(
       index: j,
       html: messageListElementHtml({
         backgroundData: newArgs.backgroundData,
-        narrow: newArgs.narrow,
         element: newElements[j],
         _: newArgs._,
       }),

--- a/src/webview/generateInboundEvents.js
+++ b/src/webview/generateInboundEvents.js
@@ -56,7 +56,6 @@ const updateContent = (prevProps: Props, nextProps: Props): WebViewInboundEventC
       .map(element =>
         messageListElementHtml({
           backgroundData: nextProps.backgroundData,
-          narrow: nextProps.narrow,
           element,
           _: nextProps._,
         }),

--- a/src/webview/html/messageListElementHtml.js
+++ b/src/webview/html/messageListElementHtml.js
@@ -1,5 +1,5 @@
 /* @flow strict-local */
-import type { GetText, Narrow, MessageListElement } from '../../types';
+import type { GetText, MessageListElement } from '../../types';
 import { ensureUnreachable } from '../../generics';
 import type { BackgroundData } from '../MessageList';
 
@@ -9,12 +9,10 @@ import time from './time';
 
 export default ({
   backgroundData,
-  narrow,
   element,
   _,
 }: {|
   backgroundData: BackgroundData,
-  narrow: Narrow,
   element: MessageListElement,
   _: GetText,
 |}): string => {


### PR DESCRIPTION
I noticed this in `messageListElementHtml` while writing up the new `docs/howto/new-feature.md`. Then it propagates to a small nice change in the message-list diffing code.
