### PR TITLE
streams: Decorate web public streams

### DIFF
--- a/src/__tests__/lib/exampleData.js
+++ b/src/__tests__/lib/exampleData.js
@@ -263,6 +263,7 @@ export const makeStream = (
     description: args.description ?? `On the ${randString()} of ${name}`,
     invite_only: false,
     is_announcement_only: false,
+    is_web_public: false,
     history_public_to_subscribers: true,
   });
 };

--- a/src/api/modelTypes.js
+++ b/src/api/modelTypes.js
@@ -303,6 +303,9 @@ export type Stream = $ReadOnly<{|
   name: string,
   invite_only: boolean,
   is_announcement_only: boolean,
+  // TODO(server-2.1): is_web_public was added in Zulip version 2.1;
+  //   absence implies the stream is not web-public.
+  is_web_public?: boolean,
   history_public_to_subscribers: boolean,
 |}>;
 

--- a/src/autocomplete/StreamAutocomplete.js
+++ b/src/autocomplete/StreamAutocomplete.js
@@ -51,6 +51,7 @@ export default function StreamAutocomplete(props: Props): Node {
             name={item.name}
             isMuted={!item.in_home_view}
             isPrivate={item.invite_only}
+            isWebPublic={item.is_web_public}
             iconSize={12}
             color={item.color}
             onPress={handleStreamItemAutocomplete}

--- a/src/common/Icons.js
+++ b/src/common/Icons.js
@@ -88,3 +88,4 @@ export const IconUserMuted: SpecificIconType = makeIcon(FontAwesome, 'user');
 export const IconAttach: SpecificIconType = makeIcon(Feather, 'paperclip');
 export const IconAttachment: SpecificIconType = makeIcon(IoniconsIcon, 'document-attach-outline');
 export const IconGroup: SpecificIconType = makeIcon(FontAwesome, 'group');
+export const IconPublic: SpecificIconType = makeIcon(FontAwesome, 'globe');

--- a/src/nullObjects.js
+++ b/src/nullObjects.js
@@ -45,5 +45,6 @@ export const NULL_SUBSCRIPTION: Subscription = {
   push_notifications: false,
   is_old_stream: false,
   is_announcement_only: false,
+  is_web_public: false,
   history_public_to_subscribers: false,
 };

--- a/src/storage/__tests__/migrations-test.js
+++ b/src/storage/__tests__/migrations-test.js
@@ -87,7 +87,7 @@ describe('migrations', () => {
   // What `base` becomes after all migrations.
   const endBase = {
     ...base37,
-    migrations: { version: 40 },
+    migrations: { version: 41 },
   };
 
   for (const [desc, before, after] of [
@@ -110,8 +110,8 @@ describe('migrations', () => {
     // redundant with this one, because none of the migration steps notice
     // whether any properties outside `storeKeys` are present or not.
     [
-      'check dropCache at 40',
-      { ...endBase, migrations: { version: 39 }, mute: [], nonsense: [1, 2, 3] },
+      'check dropCache at 41',
+      { ...endBase, migrations: { version: 40 }, mute: [], nonsense: [1, 2, 3] },
       endBase,
     ],
 

--- a/src/storage/migrations.js
+++ b/src/storage/migrations.js
@@ -397,6 +397,9 @@ const migrationsInner: {| [string]: (LessPartialState) => LessPartialState |} = 
   // Change `state.mute` data structure: was an array with stream names.
   '40': dropCache,
 
+  // Add is_web_public to Stream and Subscription.
+  '41': dropCache,
+
   // TIP: When adding a migration, consider just using `dropCache`.
   //   (See its jsdoc for guidance on when that's the right answer.)
 };

--- a/src/streams/StreamCard.js
+++ b/src/streams/StreamCard.js
@@ -44,6 +44,7 @@ export default class StreamCard extends PureComponent<Props> {
             color={subscription?.color || NULL_SUBSCRIPTION.color}
             isMuted={subscription ? !subscription.in_home_view : false}
             isPrivate={stream.invite_only}
+            isWebPublic={stream.is_web_public}
           />
           <ZulipText
             style={componentStyles.streamText}

--- a/src/streams/StreamCard.js
+++ b/src/streams/StreamCard.js
@@ -43,7 +43,7 @@ export default class StreamCard extends PureComponent<Props> {
             size={22}
             color={subscription?.color || NULL_SUBSCRIPTION.color}
             isMuted={subscription ? !subscription.in_home_view : false}
-            isPrivate={stream && stream.invite_only}
+            isPrivate={stream.invite_only}
           />
           <ZulipText
             style={componentStyles.streamText}

--- a/src/streams/StreamIcon.js
+++ b/src/streams/StreamIcon.js
@@ -14,7 +14,14 @@ type Props = $ReadOnly<{|
 |}>;
 
 export default ({ color, style, isPrivate, isMuted, size }: Props): Node => {
-  const StreamIcon = isMuted ? IconMute : isPrivate ? IconPrivate : IconStream;
+  let StreamIcon = undefined;
+  if (isMuted) {
+    StreamIcon = IconMute;
+  } else if (isPrivate) {
+    StreamIcon = IconPrivate;
+  } else {
+    StreamIcon = IconStream;
+  }
 
   return <StreamIcon size={size} color={color} style={style} />;
 };

--- a/src/streams/StreamIcon.js
+++ b/src/streams/StreamIcon.js
@@ -3,22 +3,25 @@ import React from 'react';
 import type { Node } from 'react';
 import type { TextStyleProp } from 'react-native/Libraries/StyleSheet/StyleSheet';
 
-import { IconMute, IconStream, IconPrivate } from '../common/Icons';
+import { IconMute, IconStream, IconPrivate, IconPublic } from '../common/Icons';
 
 type Props = $ReadOnly<{|
   color?: string,
   isPrivate: boolean,
   isMuted: boolean,
+  isWebPublic: boolean | void,
   size: number,
   style?: TextStyleProp,
 |}>;
 
-export default ({ color, style, isPrivate, isMuted, size }: Props): Node => {
+export default ({ color, style, isPrivate, isMuted, isWebPublic, size }: Props): Node => {
   let StreamIcon = undefined;
   if (isMuted) {
     StreamIcon = IconMute;
   } else if (isPrivate) {
     StreamIcon = IconPrivate;
+  } else if (isWebPublic ?? false) {
+    StreamIcon = IconPublic;
   } else {
     StreamIcon = IconStream;
   }

--- a/src/streams/StreamItem.js
+++ b/src/streams/StreamItem.js
@@ -44,6 +44,7 @@ type Props = $ReadOnly<{|
   isMuted: boolean,
   isPrivate: boolean,
   isSubscribed?: boolean,
+  isWebPublic: boolean | void,
   color?: string,
   backgroundColor?: string,
 
@@ -83,6 +84,7 @@ export default function StreamItem(props: Props): Node {
     backgroundColor,
     isPrivate,
     isMuted,
+    isWebPublic,
     isSubscribed = false,
     iconSize,
     showSwitch = false,
@@ -131,7 +133,13 @@ export default function StreamItem(props: Props): Node {
       }}
     >
       <View style={wrapperStyle}>
-        <StreamIcon size={iconSize} color={iconColor} isMuted={isMuted} isPrivate={isPrivate} />
+        <StreamIcon
+          size={iconSize}
+          color={iconColor}
+          isMuted={isMuted}
+          isPrivate={isPrivate}
+          isWebPublic={isWebPublic}
+        />
         <View style={componentStyles.text}>
           <ZulipText
             numberOfLines={1}

--- a/src/streams/StreamList.js
+++ b/src/streams/StreamList.js
@@ -88,6 +88,7 @@ export default function StreamList(props: Props): Node {
           name={item.name}
           iconSize={16}
           isPrivate={item.invite_only}
+          isWebPublic={item.is_web_public}
           description={showDescriptions ? item.description : ''}
           color={item.color}
           unreadCount={unreadByStream[item.stream_id]}

--- a/src/title/TitleStream.js
+++ b/src/title/TitleStream.js
@@ -93,6 +93,7 @@ export default function TitleStream(props: Props): Node {
             style={styles.halfMarginRight}
             isMuted={!stream.in_home_view}
             isPrivate={stream.invite_only}
+            isWebPublic={stream.is_web_public}
             color={color}
             size={styles.navTitle.fontSize}
           />

--- a/src/types.js
+++ b/src/types.js
@@ -362,6 +362,7 @@ export type UnreadStreamItem = {|
   isMuted: boolean,
   isPinned: boolean,
   isPrivate: boolean,
+  isWebPublic: boolean | void,
   data: Array<{|
     key: string,
     topic: string,

--- a/src/unread/UnreadCards.js
+++ b/src/unread/UnreadCards.js
@@ -52,6 +52,7 @@ export default function UnreadCards(props: Props): Node {
             iconSize={16}
             isMuted={section.isMuted}
             isPrivate={section.isPrivate}
+            isWebPublic={section.isWebPublic}
             backgroundColor={section.color}
             unreadCount={section.unread}
             onPress={(streamId: number) => {

--- a/src/unread/__tests__/unreadSelectors-test.js
+++ b/src/unread/__tests__/unreadSelectors-test.js
@@ -232,6 +232,7 @@ describe('getUnreadStreamsAndTopics', () => {
         isMuted: true,
         isPinned: false,
         isPrivate: false,
+        isWebPublic: false,
         key: 'stream:stream 0',
         streamId: 0,
         streamName: 'stream 0',
@@ -251,6 +252,7 @@ describe('getUnreadStreamsAndTopics', () => {
         isMuted: true,
         isPinned: false,
         isPrivate: false,
+        isWebPublic: false,
         key: 'stream:stream 2',
         streamId: 2,
         streamName: 'stream 2',
@@ -290,6 +292,7 @@ describe('getUnreadStreamsAndTopics', () => {
         isMuted: false,
         isPinned: false,
         isPrivate: false,
+        isWebPublic: false,
         key: 'stream:stream 0',
         streamId: 0,
         streamName: 'stream 0',
@@ -309,6 +312,7 @@ describe('getUnreadStreamsAndTopics', () => {
         isMuted: false,
         isPinned: false,
         isPrivate: false,
+        isWebPublic: false,
         key: 'stream:stream 2',
         streamId: 2,
         streamName: 'stream 2',
@@ -335,6 +339,7 @@ describe('getUnreadStreamsAndTopics', () => {
         isMuted: false,
         isPinned: false,
         isPrivate: false,
+        isWebPublic: false,
         data: [
           {
             key: 'another topic',
@@ -355,6 +360,7 @@ describe('getUnreadStreamsAndTopics', () => {
         isMuted: false,
         isPinned: false,
         isPrivate: false,
+        isWebPublic: false,
         data: [
           {
             key: 'some other topic',
@@ -407,6 +413,7 @@ describe('getUnreadStreamsAndTopics', () => {
         isMuted: false,
         isPrivate: false,
         isPinned: true,
+        isWebPublic: false,
         unread: 2,
         data: [
           { key: 'e topic', topic: 'e topic', unread: 1, isMuted: false, lastUnreadMsgId: 10 },
@@ -421,6 +428,7 @@ describe('getUnreadStreamsAndTopics', () => {
         isMuted: false,
         isPrivate: false,
         isPinned: false,
+        isWebPublic: false,
         unread: 5,
         data: [
           { key: 'a topic', topic: 'a topic', unread: 2, isMuted: false, lastUnreadMsgId: 5 },
@@ -435,6 +443,7 @@ describe('getUnreadStreamsAndTopics', () => {
         isMuted: false,
         isPrivate: false,
         isPinned: false,
+        isWebPublic: false,
         unread: 2,
         data: [
           { key: 'c topic', topic: 'c topic', unread: 2, isMuted: true, lastUnreadMsgId: 8 },
@@ -481,6 +490,7 @@ describe('getUnreadStreamsAndTopicsSansMuted', () => {
         isMuted: false,
         isPinned: false,
         isPrivate: false,
+        isWebPublic: false,
         key: 'stream:stream 0',
         streamId: 0,
         streamName: 'stream 0',

--- a/src/unread/unreadSelectors.js
+++ b/src/unread/unreadSelectors.js
@@ -132,7 +132,7 @@ export const getUnreadStreamsAndTopics: Selector<$ReadOnlyArray<UnreadStreamItem
   (subscriptionsById, unreadStreams, mute) => {
     const totals = new Map();
     for (const [streamId, streamData] of unreadStreams.entries()) {
-      const { name, color, in_home_view, invite_only, pin_to_top } =
+      const { name, color, in_home_view, invite_only, pin_to_top, is_web_public } =
         subscriptionsById.get(streamId) || NULL_SUBSCRIPTION;
 
       const total = {
@@ -142,6 +142,7 @@ export const getUnreadStreamsAndTopics: Selector<$ReadOnlyArray<UnreadStreamItem
         isMuted: !in_home_view,
         isPrivate: invite_only,
         isPinned: pin_to_top,
+        isWebPublic: is_web_public,
         color,
         unread: 0,
         data: [],


### PR DESCRIPTION
This PR ensures that when a stream is web-public the icon representing
it is displayed as a globe - unless the stream is private or muted in
which case those icons take precedence.

This PR addresses one part of https://github.com/zulip/zulip-mobile/issues/5014
![image](https://user-images.githubusercontent.com/3046397/154335242-f97bec15-4814-4b43-a374-650b423025fb.png)
