### PR TITLE
react-nav config [nfc]: Further simplify bottom-tabs and top-tabs configs

### DIFF
--- a/src/main/MainTabsScreen.js
+++ b/src/main/MainTabsScreen.js
@@ -1,7 +1,6 @@
 /* @flow strict-local */
 import React, { useContext } from 'react';
 import type { Node } from 'react';
-import { Platform } from 'react-native';
 import {
   createBottomTabNavigator,
   type BottomTabNavigationProp,
@@ -52,19 +51,7 @@ export default function MainTabsScreen(props: Props): Node {
   return (
     <SafeAreaView mode="padding" edges={['top']} style={[styles.flexed, { backgroundColor }]}>
       <OfflineNotice />
-      <Tab.Navigator
-        {...bottomTabNavigatorConfig({
-          // TODO: Find a way to tell if we're on an Android tablet,
-          // and use that -- we don't want to assume Android users
-          // aren't on tablets, but `isPad` is iOS only and `Platform`
-          // doesn't have something else for Android (yet):
-          // https://reactnative.dev/docs/platform#ispad-ios
-          showLabel: Platform.OS === 'ios' && Platform.isPad,
-          showIcon: true,
-        })}
-        lazy={false}
-        backBehavior="none"
-      >
+      <Tab.Navigator {...bottomTabNavigatorConfig()} lazy={false} backBehavior="none">
         <Tab.Screen
           name="home"
           component={HomeScreen}

--- a/src/main/StreamTabsScreen.js
+++ b/src/main/StreamTabsScreen.js
@@ -44,13 +44,7 @@ type Props = $ReadOnly<{|
 
 export default function StreamTabsScreen(props: Props): Node {
   return (
-    <Tab.Navigator
-      {...materialTopTabNavigatorConfig({
-        showLabel: true,
-        showIcon: false,
-      })}
-      swipeEnabled
-    >
+    <Tab.Navigator {...materialTopTabNavigatorConfig()} swipeEnabled>
       <Tab.Screen
         name="subscribed"
         component={SubscriptionsCard}

--- a/src/reactions/MessageReactionsScreen.js
+++ b/src/reactions/MessageReactionsScreen.js
@@ -98,11 +98,7 @@ class MessageReactionsScreenInner extends PureComponent<Props> {
               initialRouteName={
                 aggregatedReactions.some(aR => aR.name === reactionName) ? reactionName : undefined
               }
-              {...materialTopTabNavigatorConfig({
-                style: {
-                  borderWidth: 0.15,
-                },
-              })}
+              {...materialTopTabNavigatorConfig()}
               swipeEnabled
             >
               {

--- a/src/reactions/MessageReactionsScreen.js
+++ b/src/reactions/MessageReactionsScreen.js
@@ -99,8 +99,6 @@ class MessageReactionsScreenInner extends PureComponent<Props> {
                 aggregatedReactions.some(aR => aR.name === reactionName) ? reactionName : undefined
               }
               {...materialTopTabNavigatorConfig({
-                showLabel: true,
-                showIcon: false,
                 style: {
                   borderWidth: 0.15,
                 },

--- a/src/sharing/SharingScreen.js
+++ b/src/sharing/SharingScreen.js
@@ -61,13 +61,7 @@ export default function SharingScreen(props: Props): Node {
 
   return (
     <Screen canGoBack={false} title="Share on Zulip" shouldShowLoadingBanner={false}>
-      <Tab.Navigator
-        {...materialTopTabNavigatorConfig({
-          showLabel: true,
-          showIcon: false,
-        })}
-        swipeEnabled
-      >
+      <Tab.Navigator {...materialTopTabNavigatorConfig()} swipeEnabled>
         <Tab.Screen
           name="share-to-stream"
           component={ShareToStream}

--- a/src/styles/tabs.js
+++ b/src/styles/tabs.js
@@ -1,56 +1,50 @@
 /* @flow strict-local */
+import { Platform } from 'react-native';
 import type { ViewStyle } from 'react-native/Libraries/StyleSheet/StyleSheet';
 import type { ExtraMaterialTopTabNavigatorProps } from '@react-navigation/material-top-tabs';
 import type { ExtraBottomTabNavigatorProps } from '@react-navigation/bottom-tabs';
 
 import { BRAND_COLOR } from './constants';
 
-export const bottomTabNavigatorConfig = (
-  args: $ReadOnly<{|
-    showLabel: boolean,
-    showIcon: boolean,
-    style?: ViewStyle,
-  |}>,
-): ExtraBottomTabNavigatorProps => {
-  const { showLabel, showIcon, style } = args;
-  return {
-    tabBarOptions: {
-      showLabel,
-      showIcon,
-      activeTintColor: BRAND_COLOR,
-      inactiveTintColor: 'gray',
-      labelStyle: {
-        fontSize: 13,
-        margin: 0,
-      },
-      tabStyle: {
-        flex: 1,
-      },
-      style: {
-        backgroundColor: 'transparent',
+export const bottomTabNavigatorConfig = (): ExtraBottomTabNavigatorProps => ({
+  tabBarOptions: {
+    // TODO: Find a way to tell if we're on an Android tablet,
+    //   and use that -- we don't want to assume Android users
+    //   aren't on tablets, but `isPad` is iOS only and `Platform`
+    //   doesn't have something else for Android (yet):
+    //   https://reactnative.dev/docs/platform#ispad-ios
+    showLabel: Platform.OS === 'ios' && Platform.isPad,
+    showIcon: true,
 
-        // Fix a bug introduced in React Navigation v5 that is exposed
-        // by setting `backgroundColor` to 'transparent', as we do.
-        elevation: 0,
-
-        ...style,
-      },
+    activeTintColor: BRAND_COLOR,
+    inactiveTintColor: 'gray',
+    labelStyle: {
+      fontSize: 13,
+      margin: 0,
     },
-  };
-};
+    tabStyle: {
+      flex: 1,
+    },
+    style: {
+      backgroundColor: 'transparent',
+
+      // Fix a bug introduced in React Navigation v5 that is exposed
+      // by setting `backgroundColor` to 'transparent', as we do.
+      elevation: 0,
+    },
+  },
+});
 
 export const materialTopTabNavigatorConfig = (
-  args: $ReadOnly<{|
-    showLabel: boolean,
-    showIcon: boolean,
+  args?: $ReadOnly<{|
     style?: ViewStyle,
   |}>,
 ): ExtraMaterialTopTabNavigatorProps => {
-  const { showLabel, showIcon, style } = args;
+  const { style } = args ?? {};
   return {
     tabBarOptions: {
-      showLabel,
-      showIcon,
+      showLabel: true,
+      showIcon: false,
       activeTintColor: BRAND_COLOR,
       inactiveTintColor: 'gray',
       labelStyle: {

--- a/src/styles/tabs.js
+++ b/src/styles/tabs.js
@@ -1,6 +1,5 @@
 /* @flow strict-local */
 import { Platform } from 'react-native';
-import type { ViewStyle } from 'react-native/Libraries/StyleSheet/StyleSheet';
 import type { ExtraMaterialTopTabNavigatorProps } from '@react-navigation/material-top-tabs';
 import type { ExtraBottomTabNavigatorProps } from '@react-navigation/bottom-tabs';
 
@@ -35,61 +34,52 @@ export const bottomTabNavigatorConfig = (): ExtraBottomTabNavigatorProps => ({
   },
 });
 
-export const materialTopTabNavigatorConfig = (
-  args?: $ReadOnly<{|
-    style?: ViewStyle,
-  |}>,
-): ExtraMaterialTopTabNavigatorProps => {
-  const { style } = args ?? {};
-  return {
-    tabBarOptions: {
-      showLabel: true,
-      showIcon: false,
-      activeTintColor: BRAND_COLOR,
-      inactiveTintColor: 'gray',
-      labelStyle: {
-        fontSize: 13,
-        margin: 0,
-      },
-      tabStyle: {
-        flex: 1,
-      },
-
-      pressColor: BRAND_COLOR,
-      indicatorStyle: {
-        backgroundColor: BRAND_COLOR,
-      },
-      // TODO: `upperCaseLabel` vanished in react-navigation v5. We
-      // used to use `false` for this, but it appears that the
-      // effective default value is `true`, at least for material top
-      // tab navigators:
-      // https://github.com/react-navigation/react-navigation/issues/7952
-      //
-      // The coercion into uppercase only happens when the tab-bar
-      // label (whether that comes directly from
-      // `options.tabBarLabel`, or from `options.title`) is a string,
-      // not a more complex React node. It also doesn't seem to happen
-      // on bottom tab navigators, just material top ones; this
-      // difference seems to align with Material Design choices (see
-      // Greg's comment at
-      // https://github.com/zulip/zulip-mobile/pull/4393#discussion_r556949209f).
-      style: {
-        backgroundColor: 'transparent',
-
-        // Fix a bug introduced in React Navigation v5 that is exposed
-        // by setting `backgroundColor` to 'transparent', as we do.
-        elevation: 0,
-
-        ...style,
-
-        // Setting borderWidth and elevation to 0 works around an issue
-        // affecting react-navigation's createMaterialTopTabNavigator.
-        // https://github.com/zulip/zulip-mobile/issues/2065
-        // https://github.com/satya164/react-native-tab-view/pull/519#issuecomment-689724208
-        // TODO: Brief testing suggests this workaround isn't needed; confirm.
-        borderWidth: 0,
-        elevation: 0, // eslint-disable-line no-dupe-keys
-      },
+export const materialTopTabNavigatorConfig = (): ExtraMaterialTopTabNavigatorProps => ({
+  tabBarOptions: {
+    showLabel: true,
+    showIcon: false,
+    activeTintColor: BRAND_COLOR,
+    inactiveTintColor: 'gray',
+    labelStyle: {
+      fontSize: 13,
+      margin: 0,
     },
-  };
-};
+    tabStyle: {
+      flex: 1,
+    },
+
+    pressColor: BRAND_COLOR,
+    indicatorStyle: {
+      backgroundColor: BRAND_COLOR,
+    },
+    // TODO: `upperCaseLabel` vanished in react-navigation v5. We
+    // used to use `false` for this, but it appears that the
+    // effective default value is `true`, at least for material top
+    // tab navigators:
+    // https://github.com/react-navigation/react-navigation/issues/7952
+    //
+    // The coercion into uppercase only happens when the tab-bar
+    // label (whether that comes directly from
+    // `options.tabBarLabel`, or from `options.title`) is a string,
+    // not a more complex React node. It also doesn't seem to happen
+    // on bottom tab navigators, just material top ones; this
+    // difference seems to align with Material Design choices (see
+    // Greg's comment at
+    // https://github.com/zulip/zulip-mobile/pull/4393#discussion_r556949209f).
+    style: {
+      backgroundColor: 'transparent',
+
+      // Fix a bug introduced in React Navigation v5 that is exposed
+      // by setting `backgroundColor` to 'transparent', as we do.
+      elevation: 0,
+
+      // Setting borderWidth and elevation to 0 works around an issue
+      // affecting react-navigation's createMaterialTopTabNavigator.
+      // https://github.com/zulip/zulip-mobile/issues/2065
+      // https://github.com/satya164/react-native-tab-view/pull/519#issuecomment-689724208
+      // TODO: Brief testing suggests this workaround isn't needed; confirm.
+      borderWidth: 0,
+      elevation: 0, // eslint-disable-line no-dupe-keys
+    },
+  },
+});


### PR DESCRIPTION
While reading #5234, noticed this followup opportunity.

/cc @chrisbobbe 
