### PR TITLE
event: Log less, but better organized, on unhandled events

### DIFF
--- a/src/events/eventToAction.js
+++ b/src/events/eventToAction.js
@@ -336,7 +336,10 @@ export default (state: PerAccountState, event: $FlowFixMe): EventAction | null =
       return null;
 
     default:
-      logging.error('Unhandled Zulip API event', event);
+      // Note there are also some event types that are mentioned above
+      // (so don't reach this default case), but that at some later stage
+      // we don't fully handle: #3408.
+      logging.error(`Unhandled Zulip API event type: ${event.type}`);
       return null;
   }
 };


### PR DESCRIPTION
Putting the event type into the error message will cause Sentry
to split these up as separate Sentry issues by event type, which
will make it much easier to quickly see what types are missing
and which of those are most frequent.

On the other hand, other than the type there's really no information
that we need here from the event; the type tells us what case we need
to add.  (For some event types, the code to handle it will be further
subdivided by `op`, but that'd be a separate conditional or switch
and wouldn't reach this default case anyway.)  So drop the rest.

Also add a comment noting that this isn't the only way that events go
unhandled, linking to the issue about that.