### PR TITLE
Fix some more stream names to be IDs, and mark the rest

### DIFF
--- a/android/app/src/main/java/com/zulipmobile/notifications/FcmMessage.kt
+++ b/android/app/src/main/java/com/zulipmobile/notifications/FcmMessage.kt
@@ -55,6 +55,8 @@ sealed class Recipient {
     }
 
     /** A stream message. */
+    // TODO(server-5.0): Require the stream ID (#3918).
+    // TODO(#3918): Get the stream ID, when present.
     data class Stream(val streamName: String, val topic: String) : Recipient()
 }
 

--- a/android/app/src/main/java/com/zulipmobile/notifications/NotificationUiManager.kt
+++ b/android/app/src/main/java/com/zulipmobile/notifications/NotificationUiManager.kt
@@ -195,11 +195,13 @@ private fun extractGroupKey(identity: Identity): String {
 private fun extractConversationKey(fcmMessage: MessageFcmMessage): String {
     val groupKey = extractGroupKey(fcmMessage.identity)
     val conversation = when (fcmMessage.recipient) {
-        // TODO(#3918): Use the stream ID here instead of the stream name,
-        //   so things stay together if the stream is renamed.
-        // So long as this does use the stream name, we use `\u0000` as the delimiter because
+        // So long as this uses the stream name, we use `\u0000` as the delimiter because
         // it's the one character not allowed in Zulip stream names.
         // (See `check_stream_name` in zulip.git:zerver/lib/streams.py.)
+        // TODO(server-5.0): Rely on the stream ID (#3918).
+        // TODO(#3918): When we have the stream ID, use that here instead of the
+        //   stream name, so things stay together if the stream is renamed.
+        //   See: https://github.com/zulip/zulip/issues/18067
         is Recipient.Stream -> "stream:${fcmMessage.recipient.streamName}\u0000${fcmMessage.recipient.topic}"
         is Recipient.GroupPm -> "groupPM:${fcmMessage.recipient.pmUsers.toString()}"
         is Recipient.Pm -> "private:${fcmMessage.sender.id}"

--- a/src/action-sheets/index.js
+++ b/src/action-sheets/index.js
@@ -223,6 +223,7 @@ showStreamSettings.errorMessage = 'Failed to show stream settings';
 const subscribe = async ({ auth, streamId, streams }) => {
   const stream = streams.get(streamId);
   invariant(stream !== undefined, 'Stream with provided streamId not found.');
+  // This still uses a stream name (#3918) because the API method does; see there.
   await api.subscriptionAdd(auth, [{ name: stream.name }]);
 };
 subscribe.title = 'Subscribe';
@@ -231,6 +232,7 @@ subscribe.errorMessage = 'Failed to subscribe';
 const unsubscribe = async ({ auth, streamId, subscriptions }) => {
   const sub = subscriptions.get(streamId);
   invariant(sub !== undefined, 'Subscription with provided streamId not found.');
+  // This still uses a stream name (#3918) because the API method does; see there.
   await api.subscriptionRemove(auth, [sub.name]);
 };
 unsubscribe.title = 'Unsubscribe';

--- a/src/action-sheets/index.js
+++ b/src/action-sheets/index.js
@@ -156,6 +156,7 @@ markTopicAsRead.errorMessage = 'Failed to mark topic as read';
 const unmuteTopic = async ({ auth, streamId, topic, streams }) => {
   const stream = streams.get(streamId);
   invariant(stream !== undefined, 'Stream with provided streamId must exist.');
+  // This still uses a stream name (#3918) because the API method does; see there.
   await api.setTopicMute(auth, stream.name, topic, false);
 };
 unmuteTopic.title = 'Unmute topic';
@@ -164,6 +165,7 @@ unmuteTopic.errorMessage = 'Failed to unmute topic';
 const muteTopic = async ({ auth, streamId, topic, streams }) => {
   const stream = streams.get(streamId);
   invariant(stream !== undefined, 'Stream with provided streamId must exist.');
+  // This still uses a stream name (#3918) because the API method does; see there.
   await api.setTopicMute(auth, stream.name, topic, true);
 };
 muteTopic.title = 'Mute topic';

--- a/src/actionTypes.js
+++ b/src/actionTypes.js
@@ -288,7 +288,7 @@ type EventSubscriptionRemoveAction = $ReadOnly<{|
   ...ServerEvent,
   type: typeof EVENT_SUBSCRIPTION,
   op: 'remove',
-  subscriptions: $ReadOnlyArray<{| +stream_id: number, +name: string |}>,
+  subscriptions: $ReadOnlyArray<{| +stream_id: number, -name: string |}>,
 |}>;
 
 type EventSubscriptionUpdateAction = $ReadOnly<{|

--- a/src/api/modelTypes.js
+++ b/src/api/modelTypes.js
@@ -369,7 +369,7 @@ export type NarrowElement =
  //  * `group-pm-with` since 2.1-dev-1813-gb338fd130
  //  * `sender` since 2.1-dev-1812-gc067c155a
  //  * `pm-with` since 2.1-dev-1350-gd7b4de234
- // TODO(server-2.1): Stop sending stream names or user emails here.
+ // TODO(server-2.1): Stop sending stream names (#3918) or user emails (#3764) here.
  | {| +operator: 'stream', +operand: string | number |} // stream ID
  | {| +operator: 'pm-with', +operand: string | $ReadOnlyArray<UserId> |}
  | {| +operator: 'sender', +operand: string | UserId |}

--- a/src/api/modelTypes.js
+++ b/src/api/modelTypes.js
@@ -304,20 +304,20 @@ export type MutedUser = $ReadOnly<{|
 //
 //
 
-export type Stream = $ReadOnly<{|
-  stream_id: number,
-  description: string,
-  name: string,
-  invite_only: boolean,
-  is_announcement_only: boolean,
+export type Stream = {|
+  +stream_id: number,
+  +description: string,
+  +name: string,
+  +invite_only: boolean,
+  +is_announcement_only: boolean,
   // TODO(server-2.1): is_web_public was added in Zulip version 2.1;
   //   absence implies the stream is not web-public.
-  is_web_public?: boolean,
-  history_public_to_subscribers: boolean,
-|}>;
+  +is_web_public?: boolean,
+  +history_public_to_subscribers: boolean,
+|};
 
 export type Subscription = {|
-  ...$ReadOnly<$Exact<Stream>>,
+  ...Stream,
   +color: string,
   +in_home_view: boolean,
   +pin_to_top: boolean,

--- a/src/api/notificationTypes.js
+++ b/src/api/notificationTypes.js
@@ -2,6 +2,22 @@
 
 import { type UserId } from './idTypes';
 
+//
+// Note: No code actually refers to these type definitions!
+//
+// The code that consumes this part of the API is in:
+//   src/notification/extract.js
+//   android/app/src/main/java/com/zulipmobile/notifications/FcmMessage.kt
+// of which the latter is used on Android, and the former on iOS.
+//
+// The Android-side code doesn't use these because it's not in JS.
+// (Moreover the data it receives is slightly different; see that code, or
+// the server at zerver/lib/push_notifications.py , for details.)
+//
+// The JS-side code has a signature taking an arbitrary JSON blob, so that
+// the type-checker can verify it systematically validates all the pieces it
+// uses.  But these types describe the form of data it *expects* to receive.
+
 // This format is as of 2020-02, commit 3.0~3347.
 type BaseData = {|
   /** The realm URL, same as in the `/server_settings` response. */
@@ -17,8 +33,8 @@ type BaseData = {|
    * (This lets us distinguish different accounts in the same realm.)
    */
   // added 2.1-dev-540-g447a517e6f, release 2.1.0+
-  // TODO(server-2.1): Simplify comment.
-  +user_id: UserId,
+  // TODO(server-2.1): Mark required; simplify comment.
+  +user_id?: UserId,
 
   // The rest of the data is about the Zulip message we're being notified
   // about.
@@ -62,6 +78,8 @@ type PmData = {|
 |};
 
 /** An APNs message sent by the Zulip server. */
+// Note that no code actually refers to this type!  Rather it serves as
+// documentation.  See module comment.
 export type ApnsPayload = {|
   /** Our own data. */
   +zulip: StreamData | PmData,

--- a/src/api/notificationTypes.js
+++ b/src/api/notificationTypes.js
@@ -54,10 +54,11 @@ type StreamData = {|
 
   /**
    * The name of the message's stream.
-   *
-   * Sadly no stream ID: https://github.com/zulip/zulip/issues/18067
    */
   +stream: string,
+
+  // TODO(server-5.0): Require stream_id (#3918).
+  // +stream_id?: number, // TODO(#3918): Add this, and use it.
 
   +topic: string,
 |};

--- a/src/api/streams/createStream.js
+++ b/src/api/streams/createStream.js
@@ -7,6 +7,7 @@ export default (
   auth: Auth,
   name: string,
   description?: string = '',
+  // TODO(server-3.0): Send numeric user IDs (#3764), not emails.
   principals?: $ReadOnlyArray<string> = [],
   inviteOnly?: boolean = false,
   announce?: boolean = false,

--- a/src/api/subscriptions/setTopicMute.js
+++ b/src/api/subscriptions/setTopicMute.js
@@ -5,6 +5,12 @@ import { apiPatch } from '../apiFetch';
 /** See https://zulip.com/api/mute-topic */
 export default async (
   auth: Auth,
+  // TODO(server-2.0): Switch to stream ID (#3918), instead of name.
+  //   (The version that was introduced in isn't documented:
+  //     https://github.com/zulip/zulip/issues/11136#issuecomment-1033046851
+  //   but see:
+  //     https://github.com/zulip/zulip-mobile/issues/3244#issuecomment-840200325
+  //   )
   stream: string,
   topic: string,
   value: boolean,

--- a/src/api/subscriptions/subscriptionAdd.js
+++ b/src/api/subscriptions/subscriptionAdd.js
@@ -10,6 +10,7 @@ type SubscriptionObj = {|
 export default (
   auth: Auth,
   subscriptions: $ReadOnlyArray<SubscriptionObj>,
+  // TODO(server-3.0): Send numeric user IDs (#3764), not emails.
   principals?: $ReadOnlyArray<string>,
 ): Promise<ApiResponse> =>
   apiPost(auth, 'users/me/subscriptions', {

--- a/src/api/subscriptions/subscriptionAdd.js
+++ b/src/api/subscriptions/subscriptionAdd.js
@@ -3,6 +3,9 @@ import type { ApiResponse, Auth } from '../transportTypes';
 import { apiPost } from '../apiFetch';
 
 type SubscriptionObj = {|
+  // TODO(server-future): This should use a stream ID (#3918), not stream name.
+  //   Server issue: https://github.com/zulip/zulip/issues/10744
+  // TODO(#3918): Change example in docs/style.md to something without this issue.
   name: string,
 |};
 

--- a/src/api/subscriptions/subscriptionRemove.js
+++ b/src/api/subscriptions/subscriptionRemove.js
@@ -6,6 +6,7 @@ import { apiDelete } from '../apiFetch';
 export default (
   auth: Auth,
   subscriptions: $ReadOnlyArray<string>,
+  // TODO(server-3.0): Send numeric user IDs (#3764), not emails.
   principals?: $ReadOnlyArray<string>,
 ): Promise<ApiResponse> =>
   apiDelete(auth, 'users/me/subscriptions', {

--- a/src/api/subscriptions/subscriptionRemove.js
+++ b/src/api/subscriptions/subscriptionRemove.js
@@ -5,6 +5,8 @@ import { apiDelete } from '../apiFetch';
 /** See https://zulip.com/api/unsubscribe */
 export default (
   auth: Auth,
+  // TODO(server-future): This should use a stream ID (#3918), not stream name.
+  //   Server issue: https://github.com/zulip/zulip/issues/10744
   subscriptions: $ReadOnlyArray<string>,
   // TODO(server-3.0): Send numeric user IDs (#3764), not emails.
   principals?: $ReadOnlyArray<string>,

--- a/src/autocomplete/StreamAutocomplete.js
+++ b/src/autocomplete/StreamAutocomplete.js
@@ -18,12 +18,9 @@ export default function StreamAutocomplete(props: Props): Node {
   const { filter, onAutocomplete } = props;
   const subscriptions = useSelector(getSubscriptions);
 
-  const handleStreamItemAutocomplete = useCallback(
-    (streamId: number, streamName: string): void => {
-      onAutocomplete(`**${streamName}**`);
-    },
-    [onAutocomplete],
-  );
+  const handleStreamItemAutocomplete = useCallback(stream => onAutocomplete(`**${stream.name}**`), [
+    onAutocomplete,
+  ]);
 
   const isPrefixMatch = x => x.name.toLowerCase().startsWith(filter.toLowerCase());
 

--- a/src/chat/narrowsSelectors.js
+++ b/src/chat/narrowsSelectors.js
@@ -99,6 +99,7 @@ const showStreamInHomeNarrow = (
   streamName: string,
   subscriptions: $ReadOnlyArray<Subscription>,
 ): boolean => {
+  // TODO(#3918): Use the stream ID.
   const sub = subscriptions.find(x => x.name === streamName);
   if (!sub) {
     // If there's no matching subscription, then the user must have

--- a/src/message/MentionedUserNotSubscribed.js
+++ b/src/message/MentionedUserNotSubscribed.js
@@ -59,6 +59,7 @@ export default function MentionedUserNotSubscribed(props: Props): Node {
   }, [user, onDismiss]);
 
   const subscribeToStream = useCallback(() => {
+    // This still uses a stream name (#3918) because the API method does; see there.
     api.subscriptionAdd(auth, [{ name: stream.name }], [user.email]);
     handleDismiss();
   }, [auth, handleDismiss, stream, user]);

--- a/src/message/NotSubscribed.js
+++ b/src/message/NotSubscribed.js
@@ -22,6 +22,7 @@ export default function NotSubscribed(props: Props): Node {
   );
 
   const subscribeToStream = useCallback(() => {
+    // This still uses a stream name (#3918) because the API method does; see there.
     api.subscriptionAdd(auth, [{ name: stream.name }]);
   }, [auth, stream]);
 

--- a/src/notification/extract.js
+++ b/src/notification/extract.js
@@ -38,6 +38,9 @@ export const fromAPNsImpl = (rawData: ?JSONableDict): Notification | void => {
   //
   // For the format this parses, see `ApnsPayload` in src/api/notificationTypes.js .
   //
+  // Though what it actually receives is more like this:
+  //   $Rest<ApnsPayload, {| aps: mixed |}>
+  // See comment below about PushNotificationsIOS.
 
   /** Helper function: fail. */
   const err = (style: string) =>

--- a/src/notification/index.js
+++ b/src/notification/index.js
@@ -160,6 +160,8 @@ export const getNarrowFromNotificationData = (
   //   we settle for not crashing.
 
   if (data.recipient_type === 'stream') {
+    // TODO(server-5.0): Always use the stream ID (#3918).
+    // TODO(#3918): Use the notification's own stream_id, where present.
     const stream = streamsByName.get(data.stream_name);
     return (stream && topicNarrow(stream.stream_id, data.topic)) ?? null;
   }

--- a/src/notification/types.js
+++ b/src/notification/types.js
@@ -19,6 +19,10 @@ type NotificationBase = {|
  */
 // NOTE: Keep the Android-side code in sync with this type definition.
 export type Notification =
+  // TODO(server-5.0): Rely on stream ID (#3918).  (We'll still want the
+  //   stream name, as a hint for display in case the stream is unknown;
+  //   see comment in getNarrowFromNotificationData.)
+  // TODO(#3918): Add stream_id.
   | {| ...NotificationBase, recipient_type: 'stream', stream_name: string, topic: string |}
   // Group PM messages have `pm_users`, which is sorted, comma-separated IDs.
   | {| ...NotificationBase, recipient_type: 'private', pm_users: string |}

--- a/src/outbox/outboxActions.js
+++ b/src/outbox/outboxActions.js
@@ -72,9 +72,9 @@ const trySendMessages = (dispatch, getState): boolean => {
       // prettier-ignore
       const to =
         item.type === 'private'
-            // TODO(server-2.0): switch to numeric user IDs, not emails.
+            // TODO(server-2.0): switch to numeric user IDs (#3764), not emails.
           ? recipientsOfPrivateMessage(item).map(r => r.email).join(',')
-            // TODO(server-2.0): switch to numeric stream IDs, not names.
+            // TODO(server-2.0): switch to numeric stream IDs (#3918), not names.
             // HACK: the server attempts to interpret this argument as JSON, then
             //   CSV, then a literal. To avoid misparsing, always use JSON.
           : JSON.stringify([streamNameOfStreamMessage(item)]);

--- a/src/sharing/ShareWrapper.js
+++ b/src/sharing/ShareWrapper.js
@@ -23,7 +23,7 @@ import { IconAttachment, IconCancel } from '../common/Icons';
 
 type SendTo =
   | {| type: 'pm', selectedRecipients: $ReadOnlyArray<UserId> |}
-  // TODO(#3918): Drop streamName.  Used below for sending, and for narrow.
+  // TODO(#3918): Drop streamName.  Used below for sending.
   | {| type: 'stream', streamName: string, streamId: number, topic: string |};
 
 const styles = createStyleSheet({
@@ -174,7 +174,8 @@ class ShareWrapperInner extends React.Component<Props, State> {
             content: messageToSend,
             type: 'stream',
             subject: sendTo.topic || apiConstants.NO_TOPIC_TOPIC,
-            // TODO(server-2.0): switch to numeric stream ID, not name
+            // TODO(server-2.0): switch to numeric stream ID, not name;
+            //   then drop streamName from SendTo
             to: sendTo.streamName,
           };
 

--- a/src/streams/InviteUsersScreen.js
+++ b/src/streams/InviteUsersScreen.js
@@ -27,6 +27,7 @@ export default function InviteUsersScreen(props: Props): Node {
   const handleInviteUsers = useCallback(
     (selected: $ReadOnlyArray<UserOrBot>) => {
       const recipients = selected.map(user => user.email);
+      // This still uses a stream name (#3918) because the API method does; see there.
       api.subscriptionAdd(auth, [{ name: stream.name }], recipients);
       NavigationService.dispatch(navigateBack());
     },

--- a/src/streams/StreamItem.js
+++ b/src/streams/StreamItem.js
@@ -51,6 +51,8 @@ type Props = $ReadOnly<{|
   unreadCount?: number,
   iconSize: number,
   showSwitch?: boolean,
+  // TODO(#3918): Cut streamName from these callbacks; or at least bury it
+  //   so that only the use-sites that actually want it need to mention it.
   onPress: (streamId: number, streamName: string) => void,
   onSwitch?: (streamId: number, streamName: string, newValue: boolean) => void,
 |}>;

--- a/src/streams/StreamItem.js
+++ b/src/streams/StreamItem.js
@@ -51,10 +51,10 @@ type Props = $ReadOnly<{|
   unreadCount?: number,
   iconSize: number,
   showSwitch?: boolean,
-  // TODO(#3918): Cut streamName from these callbacks; or at least bury it
-  //   so that only the use-sites that actually want it need to mention it.
-  onPress: (streamId: number, streamName: string) => void,
-  onSwitch?: (streamId: number, streamName: string, newValue: boolean) => void,
+  // These stream names are here for a mix of good reasons and (#3918) bad ones.
+  // To audit all uses, change `name` to write-only (`-name:`), and run Flow.
+  onPress: ({ stream_id: number, name: string, ... }) => void,
+  onSwitch?: ({ stream_id: number, name: string, ... }, newValue: boolean) => void,
 |}>;
 
 /**
@@ -75,8 +75,8 @@ type Props = $ReadOnly<{|
  * @prop unreadCount - number of unread messages
  * @prop iconSize
  * @prop showSwitch - whether to show a toggle switch (ZulipSwitch)
- * @prop onPress - press handler for the item; receives the stream name
- * @prop onSwitch - if switch exists; receives stream name and new value
+ * @prop onPress - press handler for the item
+ * @prop onSwitch - if switch exists
  */
 export default function StreamItem(props: Props): Node {
   const {
@@ -125,7 +125,7 @@ export default function StreamItem(props: Props): Node {
 
   return (
     <Touchable
-      onPress={() => onPress(streamId, name)}
+      onPress={() => onPress({ stream_id: streamId, name })}
       onLongPress={() => {
         showStreamActionSheet({
           showActionSheetWithOptions,
@@ -165,7 +165,7 @@ export default function StreamItem(props: Props): Node {
             value={!!isSubscribed}
             onValueChange={(newValue: boolean) => {
               if (onSwitch) {
-                onSwitch(streamId, name, newValue);
+                onSwitch({ stream_id: streamId, name }, newValue);
               }
             }}
             disabled={!isSubscribed && isPrivate}

--- a/src/streams/StreamSettingsScreen.js
+++ b/src/streams/StreamSettingsScreen.js
@@ -56,10 +56,12 @@ export default function StreamSettingsScreen(props: Props): Node {
   }, [stream]);
 
   const handlePressSubscribe = useCallback(() => {
+    // This still uses a stream name (#3918) because the API method does; see there.
     api.subscriptionAdd(auth, [{ name: stream.name }]);
   }, [auth, stream]);
 
   const handlePressUnsubscribe = useCallback(() => {
+    // This still uses a stream name (#3918) because the API method does; see there.
     api.subscriptionRemove(auth, [stream.name]);
   }, [auth, stream]);
 

--- a/src/streams/SubscriptionsCard.js
+++ b/src/streams/SubscriptionsCard.js
@@ -48,10 +48,9 @@ export default function SubscriptionsCard(props: Props): Node {
     ];
   }, [subscriptions]);
 
-  const handleNarrow = useCallback(
-    (streamId: number) => dispatch(doNarrow(streamNarrow(streamId))),
-    [dispatch],
-  );
+  const handleNarrow = useCallback(stream => dispatch(doNarrow(streamNarrow(stream.stream_id))), [
+    dispatch,
+  ]);
 
   return (
     <View style={styles.container}>

--- a/src/streams/TopicItem.js
+++ b/src/streams/TopicItem.js
@@ -32,11 +32,13 @@ const componentStyles = createStyleSheet({
 
 type Props = $ReadOnly<{|
   streamId: number,
+  // TODO(#3918): Stop taking a stream name here.
   streamName: string,
   name: string,
   isMuted?: boolean,
   isSelected?: boolean,
   unreadCount?: number,
+  // TODO(#3918): Stop passing stream name to this callback.
   onPress: (streamId: number, streamName: string, topic: string) => void,
 |}>;
 

--- a/src/streams/TopicItem.js
+++ b/src/streams/TopicItem.js
@@ -38,20 +38,11 @@ type Props = $ReadOnly<{|
   isMuted?: boolean,
   isSelected?: boolean,
   unreadCount?: number,
-  // TODO(#3918): Stop passing stream name to this callback.
-  onPress: (streamId: number, streamName: string, topic: string) => void,
+  onPress: (streamId: number, topic: string) => void,
 |}>;
 
 export default function TopicItem(props: Props): Node {
-  const {
-    streamId,
-    streamName,
-    name,
-    isMuted = false,
-    isSelected = false,
-    unreadCount = 0,
-    onPress,
-  } = props;
+  const { streamId, name, isMuted = false, isSelected = false, unreadCount = 0, onPress } = props;
 
   const showActionSheetWithOptions: ShowActionSheetWithOptions = useActionSheet()
     .showActionSheetWithOptions;
@@ -69,7 +60,7 @@ export default function TopicItem(props: Props): Node {
 
   return (
     <Touchable
-      onPress={() => onPress(streamId, streamName, name)}
+      onPress={() => onPress(streamId, name)}
       onLongPress={() => {
         showTopicActionSheet({
           showActionSheetWithOptions,

--- a/src/streams/TopicItem.js
+++ b/src/streams/TopicItem.js
@@ -32,8 +32,6 @@ const componentStyles = createStyleSheet({
 
 type Props = $ReadOnly<{|
   streamId: number,
-  // TODO(#3918): Stop taking a stream name here.
-  streamName: string,
   name: string,
   isMuted?: boolean,
   isSelected?: boolean,

--- a/src/subscriptions/StreamListCard.js
+++ b/src/subscriptions/StreamListCard.js
@@ -52,8 +52,10 @@ export default function StreamListCard(props: Props): Node {
   const handleSwitchChange = useCallback(
     (streamId: number, streamName: string, switchValue: boolean) => {
       if (switchValue) {
+        // This still uses a stream name (#3918) because the API method does; see there.
         api.subscriptionAdd(auth, [{ name: streamName }]);
       } else {
+        // This still uses a stream name (#3918) because the API method does; see there.
         api.subscriptionRemove(auth, [streamName]);
       }
     },

--- a/src/subscriptions/StreamListCard.js
+++ b/src/subscriptions/StreamListCard.js
@@ -50,22 +50,21 @@ export default function StreamListCard(props: Props): Node {
   );
 
   const handleSwitchChange = useCallback(
-    (streamId: number, streamName: string, switchValue: boolean) => {
+    (stream, switchValue: boolean) => {
       if (switchValue) {
         // This still uses a stream name (#3918) because the API method does; see there.
-        api.subscriptionAdd(auth, [{ name: streamName }]);
+        api.subscriptionAdd(auth, [{ name: stream.name }]);
       } else {
         // This still uses a stream name (#3918) because the API method does; see there.
-        api.subscriptionRemove(auth, [streamName]);
+        api.subscriptionRemove(auth, [stream.name]);
       }
     },
     [auth],
   );
 
-  const handleNarrow = useCallback(
-    (streamId: number) => dispatch(doNarrow(streamNarrow(streamId))),
-    [dispatch],
-  );
+  const handleNarrow = useCallback(stream => dispatch(doNarrow(streamNarrow(stream.stream_id))), [
+    dispatch,
+  ]);
 
   return (
     <View style={styles.wrapper}>

--- a/src/topics/TopicList.js
+++ b/src/topics/TopicList.js
@@ -18,8 +18,7 @@ const styles = createStyleSheet({
 type Props = $ReadOnly<{|
   stream: Stream,
   topics: ?$ReadOnlyArray<TopicExtended>,
-  // TODO(#3918): Stop passing stream name to this callback.
-  onPress: (streamId: number, streamName: string, topic: string) => void,
+  onPress: (streamId: number, topic: string) => void,
 |}>;
 
 export default class TopicList extends PureComponent<Props> {

--- a/src/topics/TopicList.js
+++ b/src/topics/TopicList.js
@@ -18,6 +18,7 @@ const styles = createStyleSheet({
 type Props = $ReadOnly<{|
   stream: Stream,
   topics: ?$ReadOnlyArray<TopicExtended>,
+  // TODO(#3918): Stop passing stream name to this callback.
   onPress: (streamId: number, streamName: string, topic: string) => void,
 |}>;
 

--- a/src/topics/TopicList.js
+++ b/src/topics/TopicList.js
@@ -42,7 +42,6 @@ export default class TopicList extends PureComponent<Props> {
         renderItem={({ item }) => (
           <TopicItem
             streamId={stream.stream_id}
-            streamName={stream.name}
             name={item.name}
             isMuted={item.isMuted}
             unreadCount={item.unreadCount}

--- a/src/topics/TopicListScreen.js
+++ b/src/topics/TopicListScreen.js
@@ -26,7 +26,7 @@ export default function TopicListScreen(props: Props): Node {
   const [filter, setFilter] = useState<string>('');
 
   const handlePress = useCallback(
-    (streamId: number, _ignored_streamName: string, topic: string) => {
+    (streamId: number, topic: string) => {
       dispatch(doNarrow(topicNarrow(streamId, topic)));
     },
     [dispatch],

--- a/src/unread/UnreadCards.js
+++ b/src/unread/UnreadCards.js
@@ -94,7 +94,6 @@ export default function UnreadCards(props: Props): Node {
         ) : (
           <TopicItem
             streamId={section.streamId}
-            streamName={section.streamName}
             name={item.topic}
             isMuted={section.isMuted || item.isMuted}
             isSelected={false}

--- a/src/unread/UnreadCards.js
+++ b/src/unread/UnreadCards.js
@@ -82,8 +82,8 @@ export default function UnreadCards(props: Props): Node {
             isWebPublic={section.isWebPublic}
             backgroundColor={section.color}
             unreadCount={section.unread}
-            onPress={(streamId: number) => {
-              setTimeout(() => dispatch(doNarrow(streamNarrow(streamId))));
+            onPress={stream => {
+              setTimeout(() => dispatch(doNarrow(streamNarrow(stream.stream_id))));
             }}
           />
         )

--- a/src/unread/UnreadCards.js
+++ b/src/unread/UnreadCards.js
@@ -94,7 +94,7 @@ export default function UnreadCards(props: Props): Node {
         ) : (
           <TopicItem
             streamId={section.streamId}
-            streamName={section.streamName || ''}
+            streamName={section.streamName}
             name={item.topic}
             isMuted={section.isMuted || item.isMuted}
             isSelected={false}

--- a/src/unread/UnreadCards.js
+++ b/src/unread/UnreadCards.js
@@ -99,7 +99,7 @@ export default function UnreadCards(props: Props): Node {
             isMuted={section.isMuted || item.isMuted}
             isSelected={false}
             unreadCount={item.unread}
-            onPress={(streamId: number, _ignored_streamName: string, topic: string) => {
+            onPress={(streamId: number, topic: string) => {
               setTimeout(() => dispatch(doNarrow(topicNarrow(streamId, topic))));
             }}
           />

--- a/src/unread/unreadSelectors.js
+++ b/src/unread/unreadSelectors.js
@@ -137,7 +137,7 @@ export const getUnreadStreamsAndTopics: Selector<$ReadOnlyArray<UnreadStreamItem
         subscriptionsById.get(streamId) || NULL_SUBSCRIPTION;
 
       const total = {
-        key: `stream:${name}`,
+        key: `stream:${name}`, // TODO(#3918): should use stream ID
         streamId,
         streamName: name,
         isMuted: !in_home_view,

--- a/src/utils/narrow.js
+++ b/src/utils/narrow.js
@@ -360,7 +360,7 @@ export const streamIdOfNarrow = (narrow: Narrow): number =>
  * The topic for a topic narrow; else error.
  *
  * Most callers of this should probably be getting passed a topic (and a
- * stream name) instead of a Narrow in the first place; or if they do handle
+ * stream ID) instead of a Narrow in the first place; or if they do handle
  * other kinds of narrows, should be using `caseNarrow`.
  */
 export const topicOfNarrow = (narrow: Narrow): string =>

--- a/src/utils/recipient.js
+++ b/src/utils/recipient.js
@@ -16,11 +16,22 @@ import type {
   UserOrBot,
 } from '../types';
 
-/** The stream name a stream message was sent to. */
+/**
+ * The stream name a stream message was sent to.
+ *
+ * BUG(#5208): This is as of whenever we learned about the message;
+ *   it doesn't get updated if the stream is renamed.
+ */
 export const streamNameOfStreamMessage = (message: StreamMessage | StreamOutbox): string =>
   message.display_recipient;
 
-/** The recipients of a PM, in the form found on PmMessage. */
+/**
+ * The recipients of a PM, in the form found on PmMessage.
+ *
+ * BUG(#5208): This is as of whenever we learned about the message;
+ *   it doesn't get updated if one of these users changes their
+ *   name, email, avatar, or other details.
+ */
 export const recipientsOfPrivateMessage = (
   message: PmMessage | PmOutbox,
 ): $ReadOnlyArray<PmRecipientUser> => message.display_recipient;
@@ -142,6 +153,10 @@ export const normalizeRecipientsAsUserIdsSansMe = (
  *    data structures.
  *  * `pmUiRecipientsFromKeyRecipients`, which takes a `PmKeyRecipients`
  *    as input instead of a message.
+ *
+ * BUG(#5208): This is as of whenever we learned about the message;
+ *   it doesn't get updated if one of these users changes their
+ *   name, email, avatar, or other details.
  */
 export const pmUiRecipientsFromMessage = (
   message: PmMessage | PmOutbox,


### PR DESCRIPTION
Our goal in this series isn't yet to resolve the issue #3918, but to
get to where it's easy to *audit* our code for the remaining things we
need to do to complete it.

The first 10 commits in this PR are focused on that. The remaining
6 commits go on to fix some of the remaining instances of the issue.
There are a handful of others that remain.

---

There are two kinds of searches one wants to do in such an audit:

* (a) Searching for *known* instances of the issue, in order to find
     remaining items to work on and eventually to confirm there are
     none left.  For this, we want simple systematic patterns to
     search for.

* (b) Searching for yet-*unknown* instances of the issue.  This is
     inherently fuzzier; one searches for patterns like /stream.name/
     or /streamName/ or even /stream.*name/i to try to find code that
     refers to stream names, which produce a lot of matches including
     some legitimate uses and some that aren't even about stream names.

     For this, the main thing we can do is make it as simple as
     possible when reading such search results to confirm that a given
     spot is a known instance of the issue, in order to focus on those
     that might be unknown.

For the sake of (a), we add TODO-3918 comments at each instance
that's actionable on its own, and references to #3918 where there's
another TODO comment that the fix blocks on.

For the sake of (b), when a given instance of the issue pops up in a
number of scattered places (like the definition and each call site of
a given function that takes a stream name), we add references to #3918
at each of those places even when we only need one TODO comment.

---

I believe this covers all remaining instances of #3918.  That means
that every place we refer to a stream name should either:
 * be a legitimate use of stream names;
 * have a TODO-3918 comment; or
 * have a different kind of TODO comment (as it happens, always a
   TODO-server comment), and a mention of #3918.

As a result, a search like `git grep TODO..3918` will find all the
remaining places we need to act in order to close issue #3918,
according to the plan I described here:
  https://github.com/zulip/zulip-mobile/issues/3918#issuecomment-1026479673

The broader search `git grep -w 3918` will additionally find all the
places that are (known) instances of the issue but are blocked purely
on server upgrades.

