### PR TITLE
deps: Upgrade react-native-vector-icons to 9.1.0, the latest

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -400,8 +400,8 @@ PODS:
   - RNSentry (3.2.13):
     - React-Core
     - Sentry (= 7.9.0)
-  - RNVectorIcons (7.0.0):
-    - React
+  - RNVectorIcons (9.1.0):
+    - React-Core
   - Sentry (7.9.0):
     - Sentry/Core (= 7.9.0)
   - Sentry/Core (7.9.0)
@@ -686,7 +686,7 @@ SPEC CHECKSUMS:
   RNGestureHandler: a479ebd5ed4221a810967000735517df0d2db211
   RNReanimated: 024eff8202342abf4b24e11575a16afc441dabfe
   RNSentry: 0aa1567f66c20390f3834637fc4f73380dcd0774
-  RNVectorIcons: da6fe858f5a65d7bbc3379540a889b0b12aa5976
+  RNVectorIcons: 7923e585eaeb139b9f4531d25a125a1500162a0b
   Sentry: 2f7e91f247cfb05b05bd01e0b5d0692557a7687b
   Toast: 91b396c56ee72a5790816f40d3a94dd357abc196
   Yoga: e6ecf3fa25af9d4c87e94ad7d5d292eedef49749

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "react-native-simple-toast": "^1.0.0",
     "react-native-tab-view": "^2.15.2",
     "react-native-url-polyfill": "^1.3.0",
-    "react-native-vector-icons": ">=7.0.0 <7.1.0",
+    "react-native-vector-icons": "^9.1.0",
     "react-native-webview": "^11.6.4",
     "react-redux": "^7.2.4",
     "redux": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9652,14 +9652,13 @@ react-native-url-polyfill@^1.3.0:
   dependencies:
     whatwg-url-without-unicode "8.0.0-3"
 
-"react-native-vector-icons@>=7.0.0 <7.1.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/react-native-vector-icons/-/react-native-vector-icons-7.0.0.tgz#5b92ed363c867645daad48c559e1f99efcfbb813"
-  integrity sha512-Ku8+dTUAnR9pexRPQqsUcQEZlxEpFZsIy8iOFqVL/3mrUyncZJHtqJyx2cUOmltZIC6W2GI4IkD3EYzPerXV5g==
+react-native-vector-icons@^9.1.0:
+  version "9.1.0"
+  resolved "https://registry.yarnpkg.com/react-native-vector-icons/-/react-native-vector-icons-9.1.0.tgz#52eaa205f5954d567b7048eb93d58ac854a2c59e"
+  integrity sha512-2AHZ/h9d/+rC0odz+OwbGNlc1Lik/pHhSixn4HfC8RtQ8CxfSBZ6gg7bTLcZhdSvZN+ZEGi30Fj+ZnOSQy+smg==
   dependencies:
-    lodash "^4.17.15"
     prop-types "^15.7.2"
-    yargs "^15.0.2"
+    yargs "^16.1.1"
 
 react-native-webview@^11.6.4:
   version "11.17.2"
@@ -11811,7 +11810,7 @@ yargs@^13.2.4:
     y18n "^4.0.0"
     yargs-parser "^13.1.2"
 
-yargs@^15.0.2, yargs@^15.1.0, yargs@^15.3.1, yargs@^15.4.1:
+yargs@^15.1.0, yargs@^15.3.1, yargs@^15.4.1:
   version "15.4.1"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-15.4.1.tgz#0d87a16de01aee9d8bec2bfbf74f67851730f4f8"
   integrity sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==
@@ -11828,7 +11827,7 @@ yargs@^15.0.2, yargs@^15.1.0, yargs@^15.3.1, yargs@^15.4.1:
     y18n "^4.0.0"
     yargs-parser "^18.1.2"
 
-yargs@^16.0.3, yargs@^16.2.0:
+yargs@^16.0.3, yargs@^16.1.1, yargs@^16.2.0:
   version "16.2.0"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-16.2.0.tgz#1c82bf0f6b6a66eafce7ef30e376f49a12477f66"
   integrity sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==


### PR DESCRIPTION
This release reportedly fixes the issue that made the "@" icon look
weird (the issue that was keeping us below 7.1.0):
  https://github.com/oblador/react-native-vector-icons/pull/1311#issuecomment-1038258615
I've checked on iOS and Android, and the icon looks right at this
version.

See changelog:
  https://github.com/oblador/react-native-vector-icons/releases

A few breaking changes were announced, but none that would affect
us:

- Icon.TabBarItemIOS convenience component removed as it was removed
  from React Native core.
- Breaking change: Drop support for
  react-native-web/react-native-desktop aliasing.

I didn't notice anything wrong with the icons on a quick tour of the
app at this version, on iOS or Android.