### PR TITLE
Mostly handle topic edits / stream moves

### DIFF
--- a/src/__tests__/lib/exampleData.js
+++ b/src/__tests__/lib/exampleData.js
@@ -467,7 +467,7 @@ export const streamMessage = (args?: {|
     content_type: 'text/html',
     id: randMessageId(),
     subject: 'example topic',
-    subject_links: [],
+    topic_links: ([]: {| text: string, url: string |}[]),
     timestamp: 1556579727,
     type: 'stream',
   };

--- a/src/__tests__/lib/exampleData.js
+++ b/src/__tests__/lib/exampleData.js
@@ -53,6 +53,7 @@ import { HOME_NARROW } from '../../utils/narrow';
 import type { BackgroundData } from '../../webview/MessageList';
 import { getSettings, getStreamsById, getSubscriptionsById } from '../../selectors';
 import { getGlobalSettings } from '../../directSelectors';
+import { messageMoved } from '../../api/misc';
 
 /* ========================================================================
  * Utilities
@@ -907,15 +908,19 @@ export const mkActionEventNewMessage = (
  */
 export const mkActionEventUpdateMessage = (args: {|
   ...$Rest<UpdateMessageEvent, { id: mixed, type: mixed, flags?: mixed }>,
-|}): PerAccountAction => ({
-  type: EVENT_UPDATE_MESSAGE,
-  event: {
+|}): PerAccountAction => {
+  const event = {
     id: 1,
     type: EventTypes.update_message,
     flags: [],
     ...args,
-  },
-});
+  };
+  return {
+    type: EVENT_UPDATE_MESSAGE,
+    event,
+    move: messageMoved(event),
+  };
+};
 
 // If a given action is only relevant to a single test file, no need to
 // provide a generic factory for it here; just define the test data there.

--- a/src/__tests__/lib/exampleData.js
+++ b/src/__tests__/lib/exampleData.js
@@ -18,7 +18,7 @@ import type {
 } from '../../api/modelTypes';
 import { makeUserId } from '../../api/idTypes';
 import type { InitialData } from '../../api/apiTypes';
-import { type UpdateMessageEvent } from '../../api/eventTypes';
+import { EventTypes, type UpdateMessageEvent } from '../../api/eventTypes';
 import type {
   AccountSwitchAction,
   LoginSuccessAction,
@@ -908,10 +908,13 @@ export const mkActionEventNewMessage = (
 export const mkActionEventUpdateMessage = (args: {|
   ...$Rest<UpdateMessageEvent, { id: mixed, type: mixed, flags?: mixed }>,
 |}): PerAccountAction => ({
-  id: 1,
   type: EVENT_UPDATE_MESSAGE,
-  flags: [],
-  ...args,
+  event: {
+    id: 1,
+    type: EventTypes.update_message,
+    flags: [],
+    ...args,
+  },
 });
 
 // If a given action is only relevant to a single test file, no need to

--- a/src/__tests__/lib/exampleData.js
+++ b/src/__tests__/lib/exampleData.js
@@ -18,6 +18,7 @@ import type {
 } from '../../api/modelTypes';
 import { makeUserId } from '../../api/idTypes';
 import type { InitialData } from '../../api/apiTypes';
+import { type UpdateMessageEvent } from '../../api/eventTypes';
 import type {
   AccountSwitchAction,
   LoginSuccessAction,
@@ -44,6 +45,7 @@ import {
   EVENT_NEW_MESSAGE,
   MESSAGE_FETCH_START,
   MESSAGE_FETCH_COMPLETE,
+  EVENT_UPDATE_MESSAGE,
 } from '../../actionConstants';
 import rootReducer from '../../boot/reducers';
 import { authOfAccount } from '../../account/accountMisc';
@@ -899,6 +901,18 @@ export const mkActionEventNewMessage = (
 
     message: { ...message, flags: message.flags ?? [] },
   });
+
+/**
+ * An EVENT_UPDATE_MESSAGE action.
+ */
+export const mkActionEventUpdateMessage = (args: {|
+  ...$Rest<UpdateMessageEvent, { id: mixed, type: mixed, flags?: mixed }>,
+|}): PerAccountAction => ({
+  id: 1,
+  type: EVENT_UPDATE_MESSAGE,
+  flags: [],
+  ...args,
+});
 
 // If a given action is only relevant to a single test file, no need to
 // provide a generic factory for it here; just define the test data there.

--- a/src/actionTypes.js
+++ b/src/actionTypes.js
@@ -344,8 +344,8 @@ type EventMessageDeleteAction = $ReadOnly<{|
 |}>;
 
 type EventUpdateMessageAction = $ReadOnly<{|
-  ...UpdateMessageEvent,
   type: typeof EVENT_UPDATE_MESSAGE,
+  event: UpdateMessageEvent,
 |}>;
 
 type EventReactionCommon = $ReadOnly<{|

--- a/src/actionTypes.js
+++ b/src/actionTypes.js
@@ -346,6 +346,7 @@ type EventMessageDeleteAction = $ReadOnly<{|
 
 type EventUpdateMessageAction = $ReadOnly<{|
   type: typeof EVENT_UPDATE_MESSAGE,
+  /** Here `message_ids` is sorted.  (This isn't guaranteed in the server event.) */
   event: UpdateMessageEvent,
   move: null | MessageMove,
 |}>;

--- a/src/actionTypes.js
+++ b/src/actionTypes.js
@@ -69,6 +69,7 @@ import type {
   RealmUpdateDictEvent,
   SubmessageEvent,
   RestartEvent,
+  UpdateMessageEvent,
 } from './api/eventTypes';
 import type { MutedTopicTuple, PresenceSnapshot } from './api/apiTypes';
 
@@ -342,45 +343,9 @@ type EventMessageDeleteAction = $ReadOnly<{|
   messageIds: $ReadOnlyArray<number>,
 |}>;
 
-// This is current to feature level 109:
-//   https://zulip.com/api/get-events#update_message
 type EventUpdateMessageAction = $ReadOnly<{|
-  ...ServerEvent,
+  ...UpdateMessageEvent,
   type: typeof EVENT_UPDATE_MESSAGE,
-
-  // Future servers might send `null` here:
-  //   https://chat.zulip.org/#narrow/stream/378-api-design/topic/.60update_message.60.20event/near/1309241
-  // TODO(server-5.0): Update this and/or simplify.
-  user_id?: UserId | null,
-
-  // Any content changes apply to just message_id.
-  message_id: number,
-
-  // Any stream/topic changes apply to all of message_ids, which is
-  //   guaranteed to include message_id.
-  message_ids: $ReadOnlyArray<number>,
-
-  flags: $ReadOnlyArray<string>,
-  edit_timestamp?: number,
-  stream_name?: string,
-  stream_id?: number,
-  new_stream_id?: number,
-  propagate_mode?: 'change_one' | 'change_later' | 'change_all',
-  orig_subject?: string,
-  subject?: string,
-
-  // TODO(server-4.0): Changed in feat. 46 to array-of-objects shape, from $ReadOnlyArray<string>
-  topic_links?: $ReadOnlyArray<{| +text: string, +url: string |}> | $ReadOnlyArray<string>,
-
-  // TODO(server-3.0): Replaced in feat. 1 by topic_links
-  subject_links?: $ReadOnlyArray<string>,
-
-  orig_content?: string,
-  orig_rendered_content?: string,
-  prev_rendered_content_version?: number,
-  content?: string,
-  rendered_content?: string,
-  is_me_message?: boolean,
 |}>;
 
 type EventReactionCommon = $ReadOnly<{|

--- a/src/actionTypes.js
+++ b/src/actionTypes.js
@@ -72,6 +72,7 @@ import type {
   UpdateMessageEvent,
 } from './api/eventTypes';
 import type { MutedTopicTuple, PresenceSnapshot } from './api/apiTypes';
+import type { MessageMove } from './api/misc';
 
 import type {
   Orientation,
@@ -346,6 +347,7 @@ type EventMessageDeleteAction = $ReadOnly<{|
 type EventUpdateMessageAction = $ReadOnly<{|
   type: typeof EVENT_UPDATE_MESSAGE,
   event: UpdateMessageEvent,
+  move: null | MessageMove,
 |}>;
 
 type EventReactionCommon = $ReadOnly<{|

--- a/src/api/eventTypes.js
+++ b/src/api/eventTypes.js
@@ -208,8 +208,13 @@ export type RealmUpdateDictEvent = $ReadOnly<{|
   data: $Rest<RealmDataForUpdate, { ... }>,
 |}>;
 
-/** https://zulip.com/api/get-events#update_message */
+/**
+ * https://zulip.com/api/get-events#update_message
+ *
+ * See also `messageMoved` in `misc.js`.
+ */
 // This is current to feature level 109.
+// NB if this ever gains a feature of moving PMs, `messageMoved` needs updating.
 export type UpdateMessageEvent = $ReadOnly<{|
   ...EventCommon,
   type: typeof EventTypes.update_message,

--- a/src/api/eventTypes.js
+++ b/src/api/eventTypes.js
@@ -207,3 +207,44 @@ export type RealmUpdateDictEvent = $ReadOnly<{|
   property: 'default',
   data: $Rest<RealmDataForUpdate, { ... }>,
 |}>;
+
+/** https://zulip.com/api/get-events#update_message */
+// This is current to feature level 109.
+export type UpdateMessageEvent = $ReadOnly<{|
+  ...EventCommon,
+  type: typeof EventTypes.update_message,
+
+  // Future servers might send `null` here:
+  //   https://chat.zulip.org/#narrow/stream/378-api-design/topic/.60update_message.60.20event/near/1309241
+  // TODO(server-5.0): Update this and/or simplify.
+  user_id?: UserId | null,
+
+  // Any content changes apply to just message_id.
+  message_id: number,
+
+  // Any stream/topic changes apply to all of message_ids, which is
+  //   guaranteed to include message_id.
+  message_ids: $ReadOnlyArray<number>,
+
+  flags: $ReadOnlyArray<string>,
+  edit_timestamp?: number,
+  stream_name?: string,
+  stream_id?: number,
+  new_stream_id?: number,
+  propagate_mode?: 'change_one' | 'change_later' | 'change_all',
+  orig_subject?: string,
+  subject?: string,
+
+  // TODO(server-4.0): Changed in feat. 46 to array-of-objects shape, from $ReadOnlyArray<string>
+  topic_links?: $ReadOnlyArray<{| +text: string, +url: string |}> | $ReadOnlyArray<string>,
+
+  // TODO(server-3.0): Replaced in feat. 1 by topic_links
+  subject_links?: $ReadOnlyArray<string>,
+
+  orig_content?: string,
+  orig_rendered_content?: string,
+  prev_rendered_content_version?: number,
+  content?: string,
+  rendered_content?: string,
+  is_me_message?: boolean,
+|}>;

--- a/src/api/eventTypes.js
+++ b/src/api/eventTypes.js
@@ -229,6 +229,9 @@ export type UpdateMessageEvent = $ReadOnly<{|
 
   // Any stream/topic changes apply to all of message_ids, which is
   //   guaranteed to include message_id.
+  // TODO(server-future): It'd be nice for these to be sorted; NB they may
+  //   not be.  As of server 5.0-dev-3868-gca17a452f (2022-02), there's no
+  //   guarantee of that in the API nor, apparently, in the implementation.
   message_ids: $ReadOnlyArray<number>,
 
   flags: $ReadOnlyArray<string>,

--- a/src/api/misc.js
+++ b/src/api/misc.js
@@ -1,0 +1,54 @@
+/**
+ * Functions to interpret some data from the API.
+ *
+ * @flow strict-local
+ */
+import invariant from 'invariant';
+
+import type { UpdateMessageEvent } from './eventTypes';
+import * as logging from '../utils/logging';
+
+export type MessageMove = $ReadOnly<{|
+  orig_stream_id: number,
+  new_stream_id: number,
+  orig_topic: string,
+  new_topic: string,
+|}>;
+
+/**
+ * Determine if and where this edit moved the message.
+ *
+ * If a move did occur, returns the relevant information in a form with a
+ * consistent naming convention.
+ *
+ * Returns null if the message stayed at the same conversation.
+ */
+export function messageMoved(event: UpdateMessageEvent): null | MessageMove {
+  // The API uses "new" for the stream IDs and "orig" for the topics.
+  // Put them both in a consistent naming convention.
+  const orig_stream_id = event.stream_id;
+  if (orig_stream_id == null) {
+    // Not stream messages, or else a pure content edit (no stream/topic change.)
+    // TODO(server-5.0): Simplify comment: since FL 112 this means it's
+    //   just not a stream message.
+    return null;
+  }
+  const new_stream_id = event.new_stream_id ?? orig_stream_id;
+  const orig_topic = event.orig_subject;
+  const new_topic = event.subject ?? orig_topic;
+
+  if (new_topic === orig_topic && new_stream_id === orig_stream_id) {
+    // Stream and topic didn't change.
+    return null;
+  }
+
+  if (orig_topic == null) {
+    // `orig_subject` is documented to be present when either the
+    // stream or topic changed.
+    logging.warn('Got update_message event with stream/topic change and no orig_subject');
+    return null;
+  }
+  invariant(new_topic != null, 'new_topic must be non-nullish when orig_topic is, by `??`');
+
+  return { orig_stream_id, new_stream_id, orig_topic, new_topic };
+}

--- a/src/api/modelTypes.js
+++ b/src/api/modelTypes.js
@@ -675,7 +675,15 @@ export type StreamMessage = $ReadOnly<{|
    * (see point 4). We assume this has always been the case.
    */
   subject: string,
-  subject_links: $ReadOnlyArray<string>,
+
+  // We don't actually use this property.  If and when we do, we'll probably
+  // want in our internal model to canonicalize it to the newest form (with
+  // the name topic_links rather than subject_links, and newest type.)
+  // TODO(server-4.0): Changed in feat. 46 to array-of-objects shape, from $ReadOnlyArray<string>
+  topic_links?: $ReadOnlyArray<{| +text: string, +url: string |}> | $ReadOnlyArray<string>,
+
+  // TODO(server-3.0): Replaced in feat. 1 by topic_links
+  subject_links?: $ReadOnlyArray<string>,
 |}>;
 
 /**

--- a/src/caughtup/caughtUpReducer.js
+++ b/src/caughtup/caughtUpReducer.js
@@ -8,12 +8,26 @@ import {
   MESSAGE_FETCH_START,
   MESSAGE_FETCH_ERROR,
   MESSAGE_FETCH_COMPLETE,
+  EVENT_UPDATE_MESSAGE,
+  EVENT_UPDATE_MESSAGE_FLAGS,
 } from '../actionConstants';
 import { NULL_OBJECT } from '../nullObjects';
 import { DEFAULT_CAUGHTUP } from './caughtUpSelectors';
-import { isSearchNarrow, keyFromNarrow } from '../utils/narrow';
+import { isSearchNarrow, keyFromNarrow, streamNarrow, topicNarrow } from '../utils/narrow';
 
 const initialState: CaughtUpState = NULL_OBJECT;
+
+/** Corresponds to the same-name function in the narrows reducer. */
+function addMessages(state: CaughtUpState, narrow, messageIds): CaughtUpState {
+  // NOTE: This behavior must stay parallel with how the narrows reducer
+  //   handles the same cases.
+  // See narrowsReducer.js for discussion.
+  const key = keyFromNarrow(narrow);
+
+  // eslint-disable-next-line no-unused-vars
+  const { [key]: ignored, ...rest } = state;
+  return rest;
+}
 
 export default (
   state: CaughtUpState = initialState,
@@ -60,6 +74,33 @@ export default (
         },
       };
     }
+
+    case EVENT_UPDATE_MESSAGE: {
+      // Compare the corresponding narrowsReducer case.
+
+      let result = state;
+      const { event, move } = action;
+
+      if (move) {
+        const { orig_stream_id, new_stream_id, new_topic } = move;
+        result = addMessages(result, topicNarrow(new_stream_id, new_topic), event.message_ids);
+        if (new_stream_id !== orig_stream_id) {
+          result = addMessages(result, streamNarrow(new_stream_id), event.message_ids);
+        }
+      }
+
+      // We don't attempt to update search narrows.
+
+      // The other way editing a message can affect what narrows it falls
+      // into is by changing its flags.  Those cause a separate event; see
+      // the EVENT_UPDATE_MESSAGE_FLAGS case.
+
+      return result;
+    }
+
+    case EVENT_UPDATE_MESSAGE_FLAGS:
+      // TODO(#3408): Handle this to parallel narrowsReducer.
+      return state;
 
     default:
       return state;

--- a/src/chat/ChatScreen.js
+++ b/src/chat/ChatScreen.js
@@ -69,6 +69,9 @@ const useMessagesWithFetch = args => {
   // like using instance variables in class components:
   //   https://reactjs.org/docs/hooks-faq.html#is-there-something-like-instance-variables
   const shouldFetchWhenNextFocused = React.useRef<boolean>(false);
+  const scheduleFetch = () => {
+    shouldFetchWhenNextFocused.current = true;
+  };
 
   const [fetchError, setFetchError] = React.useState<Error | null>(null);
 
@@ -85,9 +88,7 @@ const useMessagesWithFetch = args => {
   // set this to null from a non-null value, so this really does mean the
   // event queue has changed; it can't mean that we had a queue ID and
   // dropped it.)
-  React.useEffect(() => {
-    shouldFetchWhenNextFocused.current = true;
-  }, [eventQueueId]);
+  React.useEffect(scheduleFetch, [eventQueueId]);
 
   // On first mount, fetch. Also unset `shouldFetchWhenNextFocused.current`
   // that was set in the previous `useEffect`, so the fetch below doesn't

--- a/src/chat/ChatScreen.js
+++ b/src/chat/ChatScreen.js
@@ -101,8 +101,9 @@ const useMessagesWithFetch = args => {
     if (shouldFetchWhenNextFocused.current && isFocused === true) {
       fetch();
     }
-    // `eventQueueId` needed here because it affects `shouldFetchWhenNextFocused`.
-  }, [isFocused, eventQueueId, fetch]);
+    // No dependencies list, to run this effect after every render.  This
+    // effect does its own checking of whether any work needs to be done.
+  });
 
   return { fetchError, isFetching, messages, firstUnreadIdInNarrow };
 };

--- a/src/events/doEventActionSideEffects.js
+++ b/src/events/doEventActionSideEffects.js
@@ -1,10 +1,19 @@
 /* @flow strict-local */
 // import { Vibration } from 'react-native';
+import { CommonActions } from '@react-navigation/native';
 
-import type { ThunkAction } from '../types';
+import type { Narrow, ThunkAction } from '../types';
 import type { EventAction } from '../actionTypes';
-import { EVENT_TYPING_START } from '../actionConstants';
+import { EVENT_TYPING_START, EVENT_UPDATE_MESSAGE } from '../actionConstants';
 import { ensureTypingStatusExpiryLoop } from '../typing/typingActions';
+import * as NavigationService from '../nav/NavigationService';
+import {
+  isStreamNarrow,
+  isTopicNarrow,
+  streamIdOfNarrow,
+  topicNarrow,
+  topicOfNarrow,
+} from '../utils/narrow';
 
 /**
  * React to actions dispatched for Zulip server events.
@@ -16,6 +25,68 @@ export default (action: EventAction): ThunkAction<Promise<void>> => async (dispa
     case EVENT_TYPING_START:
       dispatch(ensureTypingStatusExpiryLoop());
       break;
+
+    case EVENT_UPDATE_MESSAGE: {
+      // If the conversation we were looking at got moved, follow it.
+      // See #5251 for background.
+
+      const { event, move } = action;
+      const { propagate_mode } = event;
+      if (!move || !(propagate_mode === 'change_all' || propagate_mode === 'change_later')) {
+        // This edit wasn't a move, or was targeted to a specific message.
+        break;
+      }
+
+      const navState = NavigationService.getState();
+      for (const route of navState.routes) {
+        if (route.name !== 'chat') {
+          continue;
+        }
+
+        // TODO(#5005): Only make these updates if this ChatScreen is for
+        //   the account that this event applies to.  (I.e., just if this is
+        //   the active account.)
+
+        // $FlowFixMe[incompatible-use]: relying on ChatScreen having route params
+        // $FlowFixMe[incompatible-type]: relying on ChatScreen route-params type
+        const narrow: Narrow = route.params.narrow;
+        if (
+          isTopicNarrow(narrow)
+          && streamIdOfNarrow(narrow) === move.orig_stream_id
+          && topicOfNarrow(narrow) === move.orig_topic
+        ) {
+          // A ChatScreen showing the very conversation that was moved.
+
+          // Change the ChatScreen's narrow to follow the move.
+          //
+          // Web does this only if the blue box is on one of the affected
+          // messages, in case only some of the conversation was moved.
+          // We don't have a blue box, but:
+          // TODO: Ideally if the moved messages are all offscreen we'd skip this.
+          NavigationService.dispatch({
+            ...CommonActions.setParams({
+              narrow: topicNarrow(move.new_stream_id, move.new_topic),
+            }),
+            // Spreading the `setParams` action and adding `source` like
+            // this is the documented way to specify a route (rather than
+            // apply to the focused route):
+            //   https://reactnavigation.org/docs/5.x/navigation-actions#setparams
+            source: route.key,
+          });
+
+          // TODO(#5251): If compose box is open and topic was resolved, warn.
+        } else if (isStreamNarrow(narrow) && streamIdOfNarrow(narrow) === move.orig_stream_id) {
+          // A ChatScreen showing the stream that contained the moved messages.
+          //
+          // TODO(#5251): Update topic input, if it matches.  (If the stream
+          //   changed too, unclear what to do.  Possibly change the
+          //   screen's narrow, as if narrowed to the moved topic?)
+        }
+      }
+
+      break;
+    }
+
     default:
   }
 };

--- a/src/events/eventToAction.js
+++ b/src/events/eventToAction.js
@@ -164,7 +164,7 @@ export default (state: PerAccountState, event: $FlowFixMe): EventAction | null =
     case EventTypes.update_message:
       return {
         type: EVENT_UPDATE_MESSAGE,
-        event,
+        event: { ...event, message_ids: event.message_ids.sort((a, b) => a - b) },
         move: messageMoved(event),
       };
 

--- a/src/events/eventToAction.js
+++ b/src/events/eventToAction.js
@@ -56,7 +56,6 @@ const opToActionTyping = {
 };
 
 const actionTypeOfEventType = {
-  update_message: EVENT_UPDATE_MESSAGE,
   subscription: EVENT_SUBSCRIPTION,
   presence: EVENT_PRESENCE,
   muted_topics: EVENT_MUTED_TOPICS,
@@ -161,7 +160,12 @@ export default (state: PerAccountState, event: $FlowFixMe): EventAction | null =
         event,
       };
 
-    case 'update_message':
+    case EventTypes.update_message:
+      return {
+        type: EVENT_UPDATE_MESSAGE,
+        event,
+      };
+
     case 'subscription':
     case 'presence':
     case 'muted_topics':

--- a/src/events/eventToAction.js
+++ b/src/events/eventToAction.js
@@ -36,6 +36,7 @@ import {
 import { getOwnUserId, tryGetUserForId } from '../users/userSelectors';
 import { AvatarURL } from '../utils/avatar';
 import { getRealmUrl } from '../account/accountsSelectors';
+import { messageMoved } from '../api/misc';
 
 const opToActionUserGroup = {
   add: EVENT_USER_GROUP_ADD,
@@ -164,6 +165,7 @@ export default (state: PerAccountState, event: $FlowFixMe): EventAction | null =
       return {
         type: EVENT_UPDATE_MESSAGE,
         event,
+        move: messageMoved(event),
       };
 
     case 'subscription':

--- a/src/message/__tests__/messagesReducer-test.js
+++ b/src/message/__tests__/messagesReducer-test.js
@@ -32,7 +32,7 @@ describe('messagesReducer', () => {
         },
       });
       const expectedState = eg.makeMessagesState([message1, message2, message3]);
-      const newState = messagesReducer(prevState, action);
+      const newState = messagesReducer(prevState, action, eg.plusReduxState);
       expect(newState).toEqual(expectedState);
       expect(newState).not.toBe(prevState);
     });
@@ -50,7 +50,7 @@ describe('messagesReducer', () => {
           },
         },
       });
-      const newState = messagesReducer(prevState, action);
+      const newState = messagesReducer(prevState, action, eg.plusReduxState);
       expect(newState).toEqual(prevState);
     });
   });
@@ -70,7 +70,7 @@ describe('messagesReducer', () => {
         msg_type: 'widget',
         content: eg.randString(),
       });
-      const newState = messagesReducer(prevState, action);
+      const newState = messagesReducer(prevState, action, eg.plusReduxState);
       expect(newState).toBe(prevState);
     });
 
@@ -118,7 +118,7 @@ describe('messagesReducer', () => {
           ],
         },
       ]);
-      const newState = messagesReducer(prevState, action);
+      const newState = messagesReducer(prevState, action, eg.plusReduxState);
       expect(newState).toEqual(expectedState);
       expect(newState).not.toBe(prevState);
     });
@@ -130,7 +130,7 @@ describe('messagesReducer', () => {
 
       const prevState = eg.makeMessagesState([message1]);
       const action = deepFreeze({ type: EVENT_MESSAGE_DELETE, messageIds: [2] });
-      const newState = messagesReducer(prevState, action);
+      const newState = messagesReducer(prevState, action, eg.plusReduxState);
       expect(newState).toEqual(prevState);
       expect(newState).toBe(prevState);
     });
@@ -142,7 +142,7 @@ describe('messagesReducer', () => {
       const prevState = eg.makeMessagesState([message1, message2]);
       const action = deepFreeze({ type: EVENT_MESSAGE_DELETE, messageIds: [message2.id] });
       const expectedState = eg.makeMessagesState([message1]);
-      const newState = messagesReducer(prevState, action);
+      const newState = messagesReducer(prevState, action, eg.plusReduxState);
       expect(newState).toEqual(expectedState);
     });
 
@@ -157,7 +157,7 @@ describe('messagesReducer', () => {
         messageIds: [message2.id, message3.id, 4],
       });
       const expectedState = eg.makeMessagesState([message1]);
-      const newState = messagesReducer(prevState, action);
+      const newState = messagesReducer(prevState, action, eg.plusReduxState);
       expect(newState).toEqual(expectedState);
     });
   });
@@ -195,7 +195,7 @@ describe('messagesReducer', () => {
         rendered_content: eg.randString(),
         content: eg.randString(),
       });
-      const newState = messagesReducer(prevState, action);
+      const newState = messagesReducer(prevState, action, eg.plusReduxState);
       expect(newState).toBe(prevState);
     });
 
@@ -220,7 +220,7 @@ describe('messagesReducer', () => {
         content: 'New content',
       });
       const expectedState = eg.makeMessagesState([message1, message2, message3New]);
-      const newState = messagesReducer(prevState, action);
+      const newState = messagesReducer(prevState, action, eg.plusReduxState);
       expect(newState).toEqual(expectedState);
     });
 
@@ -245,7 +245,7 @@ describe('messagesReducer', () => {
         subject: message1New.subject,
       });
       const expectedState = eg.makeMessagesState([message1New]);
-      const newState = messagesReducer(prevState, action);
+      const newState = messagesReducer(prevState, action, eg.plusReduxState);
       expect(newState).toEqual(expectedState);
     });
 
@@ -282,7 +282,7 @@ describe('messagesReducer', () => {
         prev_rendered_content_version: 1,
       });
       const expectedState = eg.makeMessagesState([message1New]);
-      const newState = messagesReducer(prevState, action);
+      const newState = messagesReducer(prevState, action, eg.plusReduxState);
       expect(newState).toEqual(expectedState);
     });
 
@@ -305,7 +305,7 @@ describe('messagesReducer', () => {
         rendered_content: messageAfter.content,
         prev_rendered_content_version: 1,
       });
-      expect(messagesReducer(eg.makeMessagesState([message]), action)).toEqual(
+      expect(messagesReducer(eg.makeMessagesState([message]), action, eg.plusReduxState)).toEqual(
         eg.makeMessagesState([messageAfter]),
       );
     });
@@ -332,7 +332,7 @@ describe('messagesReducer', () => {
         rendered_content: messageAfter.content,
         prev_rendered_content_version: 1,
       });
-      expect(messagesReducer(eg.makeMessagesState([message]), action)).toEqual(
+      expect(messagesReducer(eg.makeMessagesState([message]), action, eg.plusReduxState)).toEqual(
         eg.makeMessagesState([messageAfter]),
       );
     });
@@ -358,7 +358,7 @@ describe('messagesReducer', () => {
           reactions: [reaction],
         },
       ]);
-      const actualState = messagesReducer(prevState, action);
+      const actualState = messagesReducer(prevState, action, eg.plusReduxState);
       expect(actualState).toEqual(expectedState);
     });
   });
@@ -376,7 +376,7 @@ describe('messagesReducer', () => {
         ...reaction,
       });
       const expectedState = eg.makeMessagesState([message1]);
-      const actualState = messagesReducer(prevState, action);
+      const actualState = messagesReducer(prevState, action, eg.plusReduxState);
       expect(actualState).toEqual(expectedState);
     });
 
@@ -411,7 +411,7 @@ describe('messagesReducer', () => {
       const expectedState = eg.makeMessagesState([
         { ...message1, reactions: [reaction2, reaction3] },
       ]);
-      const actualState = messagesReducer(prevState, action);
+      const actualState = messagesReducer(prevState, action, eg.plusReduxState);
       expect(actualState).toEqual(expectedState);
     });
   });
@@ -443,7 +443,7 @@ describe('messagesReducer', () => {
         message4,
         message5,
       ]);
-      const newState = messagesReducer(prevState, action);
+      const newState = messagesReducer(prevState, action, eg.plusReduxState);
       expect(newState).toEqual(expectedState);
     });
 
@@ -465,7 +465,7 @@ describe('messagesReducer', () => {
         ownUserId: eg.selfUser.user_id,
       });
 
-      const newState = messagesReducer(prevState, action);
+      const newState = messagesReducer(prevState, action, eg.plusReduxState);
 
       expect(newState.get(message2.id)).toEqual(message2);
       expect(newState.get(message3.id)).toEqual(message3);
@@ -490,7 +490,7 @@ describe('messagesReducer', () => {
         foundNewest: false,
         ownUserId: eg.selfUser.user_id,
       });
-      const newState = messagesReducer(prevState, action);
+      const newState = messagesReducer(prevState, action, eg.plusReduxState);
       expect(newState.get(message2.id)).toEqual(message2);
       expect(newState.get(message3.id)).toEqual(message3);
       expect(newState.get(message4New.id)).toEqual(message4New);

--- a/src/message/__tests__/messagesReducer-test.js
+++ b/src/message/__tests__/messagesReducer-test.js
@@ -206,14 +206,6 @@ describe('messagesReducer', () => {
       const message3New = {
         ...message3Old,
         content: '<p>New content</p>',
-        edit_history: [
-          {
-            prev_rendered_content: '<p>Old content</p>',
-            prev_rendered_content_version: 1,
-            timestamp: 123,
-            user_id: message3Old.sender_id,
-          },
-        ],
         last_edit_timestamp: 123,
       };
 
@@ -245,13 +237,6 @@ describe('messagesReducer', () => {
         subject: 'New topic',
         last_edit_timestamp: 123,
         subject_links: [],
-        edit_history: [
-          {
-            timestamp: 123,
-            user_id: message1Old.sender_id,
-            prev_subject: message1Old.subject,
-          },
-        ],
       };
       const prevState = eg.makeMessagesState([message1Old]);
       const action = mkAction({
@@ -267,7 +252,7 @@ describe('messagesReducer', () => {
       expect(newState).toEqual(expectedState);
     });
 
-    test('when event contains a new subject and a new content, update both and update edit history object', () => {
+    test('when event contains a new subject and a new content, update both', () => {
       const message1Old = eg.streamMessage({
         content: '<p>Old content</p>',
         subject: 'Old subject',
@@ -287,16 +272,6 @@ describe('messagesReducer', () => {
         subject: 'New updated topic',
         last_edit_timestamp: 456,
         subject_links: [],
-        edit_history: [
-          {
-            prev_rendered_content: '<p>Old content</p>',
-            prev_rendered_content_version: 1,
-            prev_subject: 'Old subject',
-            timestamp: 456,
-            user_id: message1Old.sender_id,
-          },
-          ...message1Old.edit_history,
-        ],
       };
 
       const prevState = eg.makeMessagesState([message1Old]);

--- a/src/message/__tests__/messagesReducer-test.js
+++ b/src/message/__tests__/messagesReducer-test.js
@@ -8,7 +8,6 @@ import {
   MESSAGE_FETCH_COMPLETE,
   EVENT_SUBMESSAGE,
   EVENT_MESSAGE_DELETE,
-  EVENT_UPDATE_MESSAGE,
   EVENT_REACTION_ADD,
   EVENT_REACTION_REMOVE,
 } from '../../actionConstants';
@@ -171,17 +170,14 @@ describe('messagesReducer', () => {
       // stealth server-edits.)
       const forEdit: { user_id?: UserId } =
         restArgs.edit_timestamp != null ? { user_id: message.sender_id } : Object.freeze({});
-      return {
-        id: 1,
-        type: EVENT_UPDATE_MESSAGE,
+      return eg.mkActionEventUpdateMessage({
         ...forEdit,
         message_id: message.id,
         message_ids: [message.id],
-        flags: [],
         propagate_mode: 'change_one',
         is_me_message: false,
         ...restArgs,
-      };
+      });
     };
 
     test('if a message does not exist no changes are made', () => {

--- a/src/message/__tests__/messagesReducer-test.js
+++ b/src/message/__tests__/messagesReducer-test.js
@@ -229,14 +229,12 @@ describe('messagesReducer', () => {
         content: 'Old content',
         subject: 'Old subject',
         last_edit_timestamp: 123,
-        subject_links: [],
         edit_history: [],
       });
       const message1New = {
         ...message1Old,
         subject: 'New topic',
         last_edit_timestamp: 123,
-        subject_links: [],
       };
       const prevState = eg.makeMessagesState([message1Old]);
       const action = mkAction({
@@ -244,7 +242,6 @@ describe('messagesReducer', () => {
         message: message1New,
         stream_id: message1Old.stream_id,
         orig_subject: message1Old.subject,
-        subject_links: [],
         subject: message1New.subject,
       });
       const expectedState = eg.makeMessagesState([message1New]);
@@ -257,7 +254,6 @@ describe('messagesReducer', () => {
         content: '<p>Old content</p>',
         subject: 'Old subject',
         last_edit_timestamp: 123,
-        subject_links: [],
         edit_history: [
           {
             prev_subject: 'Old subject',
@@ -271,7 +267,6 @@ describe('messagesReducer', () => {
         content: '<p>New content</p>',
         subject: 'New updated topic',
         last_edit_timestamp: 456,
-        subject_links: [],
       };
 
       const prevState = eg.makeMessagesState([message1Old]);
@@ -285,7 +280,6 @@ describe('messagesReducer', () => {
         subject: message1New.subject,
         orig_subject: message1Old.subject,
         prev_rendered_content_version: 1,
-        subject_links: [],
       });
       const expectedState = eg.makeMessagesState([message1New]);
       const newState = messagesReducer(prevState, action);

--- a/src/message/messagesReducer.js
+++ b/src/message/messagesReducer.js
@@ -3,7 +3,7 @@
 import omit from 'lodash.omit';
 import Immutable from 'immutable';
 
-import type { MessagesState, Message, PerAccountApplicableAction } from '../types';
+import type { MessagesState, Message, PerAccountApplicableAction, PerAccountState } from '../types';
 import {
   REGISTER_COMPLETE,
   LOGOUT,
@@ -65,6 +65,7 @@ const eventNewMessage = (state, action) => {
 export default (
   state: MessagesState = initialState,
   action: PerAccountApplicableAction,
+  globalState: PerAccountState,
 ): MessagesState => {
   switch (action.type) {
     case REGISTER_COMPLETE:

--- a/src/message/messagesReducer.js
+++ b/src/message/messagesReducer.js
@@ -142,52 +142,12 @@ export default (
           return oldMessage;
         }
 
-        const historyEntry = (() => {
-          if (event.edit_timestamp == null || event.user_id == null) {
-            // The update isn't a real edit; rather it's just filling in an
-            // inline URL preview (which can require the server to make an
-            // external request, so we don't let it block delivering the
-            // message to clients) and shouldn't appear in the edit history.
-            return null;
-          }
-          // TODO(#3408): This should handle the full complexity of update_message
-          //   events: in particular, moves between streams.  (Probably the
-          //   first step is to refactor this logic for less duplication.)
-          //   This is OK for now because we don't actually have any UI that
-          //   exposes this history: #4134.
-          if (event.orig_rendered_content !== undefined) {
-            if (event.orig_subject !== undefined) {
-              return {
-                prev_rendered_content: event.orig_rendered_content,
-                prev_subject: oldMessage.subject,
-                timestamp: event.edit_timestamp,
-                prev_rendered_content_version: event.prev_rendered_content_version,
-                user_id: event.user_id,
-              };
-            } else {
-              return {
-                prev_rendered_content: event.orig_rendered_content,
-                timestamp: event.edit_timestamp,
-                prev_rendered_content_version: event.prev_rendered_content_version,
-                user_id: event.user_id,
-              };
-            }
-          } else {
-            return {
-              prev_subject: oldMessage.subject,
-              timestamp: event.edit_timestamp,
-              user_id: event.user_id,
-            };
-          }
-        })();
-
         const messageWithNewCommonFields: M = {
           ...(oldMessage: M),
           content: event.rendered_content ?? oldMessage.content,
-          edit_history: historyEntry
-            ? [historyEntry, ...(oldMessage.edit_history ?? [])]
-            : oldMessage.edit_history,
           last_edit_timestamp: event.edit_timestamp ?? oldMessage.last_edit_timestamp,
+          // TODO(#3408): Update edit_history, too.  This is OK for now
+          //   because we don't actually have any UI to expose it: #4134.
         };
 
         // FlowIssue: https://github.com/facebook/flow/issues/8833

--- a/src/message/messagesReducer.js
+++ b/src/message/messagesReducer.js
@@ -157,7 +157,8 @@ export default (
           ? {
               ...messageWithNewCommonFields,
               subject: event.subject ?? messageWithNewCommonFields.subject,
-              subject_links: event.subject_links ?? messageWithNewCommonFields.subject_links,
+              // TODO(#3408): Update topic_links.  This is OK for now
+              //   because we don't have any UI to expose it.
             }
           : messageWithNewCommonFields;
       });

--- a/src/nav/navActions.js
+++ b/src/nav/navActions.js
@@ -42,6 +42,7 @@ export const resetToMainTabs = (): GenericNavigationAction =>
 
 /** Only call this via `doNarrow`.  See there for details. */
 export const navigateToChat = (narrow: Narrow): GenericNavigationAction =>
+  // This route name 'chat' appears in one more place than usual: doEventActionSideEffects.js .
   StackActions.push('chat', { narrow, editMessage: null });
 
 export const replaceWithChat = (narrow: Narrow): GenericNavigationAction =>

--- a/src/reactUtils.js
+++ b/src/reactUtils.js
@@ -83,3 +83,35 @@ export const useHasStayedTrueForMs = (value: boolean, duration: number): boolean
 
   return result;
 };
+
+/**
+ * Invoke the callback as an effect when `value` turns from false to true.
+ *
+ * This differs from putting `value` in a `useEffect` dependency list in
+ * that the callback will *not* be invoked when the value changes in the
+ * other direction, from true to false.
+ *
+ * `includeStart` controls what happens if `value` is true on the very first
+ * render.  If `includeStart` is true, then the effect is triggered (so
+ * treating its previous state of nonexistence as equivalent to being
+ * false).  If `includeStart` is false, then the effect is not triggered (so
+ * treating its previous state of nonexistence as not a valid state to
+ * compare to.)
+ *
+ * The callback is not permitted to return a cleanup function, because it's
+ * not clear what the semantics should be of when such a cleanup function
+ * would be run.
+ */
+export const useEdgeTriggeredEffect = (
+  cb: () => void,
+  value: boolean,
+  includeStart: boolean,
+): void => {
+  const prev = usePrevious(value, !includeStart);
+  useEffect(() => {
+    if (value && !prev) {
+      cb();
+    }
+    // No dependencies list -- the effect itself decides whether to act.
+  });
+};

--- a/src/unread/__tests__/unreadModel-test.js
+++ b/src/unread/__tests__/unreadModel-test.js
@@ -1,11 +1,7 @@
 /* @flow strict-local */
 import Immutable from 'immutable';
 
-import {
-  ACCOUNT_SWITCH,
-  EVENT_UPDATE_MESSAGE_FLAGS,
-  EVENT_UPDATE_MESSAGE,
-} from '../../actionConstants';
+import { ACCOUNT_SWITCH, EVENT_UPDATE_MESSAGE_FLAGS } from '../../actionConstants';
 import { reducer } from '../unreadModel';
 import { type UnreadState } from '../unreadModelTypes';
 import * as eg from '../../__tests__/lib/exampleData';
@@ -65,16 +61,13 @@ describe('stream substate', () => {
   describe('EVENT_UPDATE_MESSAGE', () => {
     const mkAction = args => {
       const { message_ids, ...restArgs } = args;
-      return {
-        id: 1,
-        type: EVENT_UPDATE_MESSAGE,
+      return eg.mkActionEventUpdateMessage({
         user_id: eg.selfUser.user_id,
         message_id: message_ids[0],
         message_ids,
-        flags: [],
         edit_timestamp: 10000,
         ...restArgs,
-      };
+      });
     };
 
     const baseState = (() => {

--- a/src/unread/unreadModel.js
+++ b/src/unread/unreadModel.js
@@ -28,7 +28,6 @@ import {
   REGISTER_COMPLETE,
 } from '../actionConstants';
 import DefaultMap from '../utils/DefaultMap';
-import { messageMoved } from '../api/misc';
 
 //
 //
@@ -224,8 +223,7 @@ function streamsReducer(
     }
 
     case EVENT_UPDATE_MESSAGE: {
-      const { event } = action;
-      const move = messageMoved(event);
+      const { event, move } = action;
       if (!move) {
         return state;
       }


### PR DESCRIPTION
The main things this does are:
* Fix an existing bug where if you have a ChatScreen and all the messages go away, we'll show NoMessages and get stuck there (until the user navigates out of the screen and back in), even if our `state.caughtUp` correctly says that we actually don't know if there are any messages in the narrow.
  * This is a bit of an edge case today, but would get much more easily triggered after the other changes.
* #2688
* #5251, or rather the most conspicuous part of it; I'll open followup issues for the rest.

Fixes: #2688 
Fixes: #5251 
