### PR TITLE
logging: Set server-version tags immediately on fetch

### DIFF
--- a/src/boot/StoreProvider.js
+++ b/src/boot/StoreProvider.js
@@ -35,6 +35,10 @@ export default class StoreProvider extends PureComponent<Props> {
       zulipVersion => {
         // TODO(#5005): This is for the *active* account; that may not be
         //   the one a given piece of code is working with!
+        //
+        // On fetch, we'll have called this already before entering the
+        // reducers, so this will be redundant.  But on switching accounts,
+        // this is the call that will make the change.
         logging.setTagsFromServerVersion(zulipVersion);
       },
     );


### PR DESCRIPTION
We've been updating these only after the reducers do their work.
But there's quite a bit of surface area in the reducers -- and
particularly so in the handling of REGISTER_COMPLETE actions.
So we do sometimes have bugs that cause exceptions there.

When we do, make sure we get accurate information about what
Zulip server versions might be involved in triggering them,
to help with debugging.