### PR TITLE
Fix all remaining stream names to be IDs, modulo server support

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -224,6 +224,7 @@ repositories {
 dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation "androidx.core:core-ktx:1.7.0"
     implementation 'androidx.appcompat:appcompat:1.0.0'
     implementation "androidx.swiperefreshlayout:swiperefreshlayout:1.0.0"
     implementation "com.google.firebase:firebase-messaging:17.3.4"

--- a/android/app/src/main/java/com/zulipmobile/notifications/FcmMessage.kt
+++ b/android/app/src/main/java/com/zulipmobile/notifications/FcmMessage.kt
@@ -1,7 +1,5 @@
 package com.zulipmobile.notifications
 
-import android.os.Bundle
-import androidx.core.os.bundleOf
 import java.net.MalformedURLException
 import java.net.URL
 import java.util.*
@@ -119,9 +117,9 @@ data class MessageFcmMessage(
      * For the corresponding type definition on the JS side, see `Notification`
      * in `src/notification/types.js`.
      */
-    fun dataForOpen(): Bundle =
+    fun dataForOpen(): Array<Pair<String, Any?>> =
         // NOTE: Keep the JS-side type definition in sync with this code.
-        bundleOf(*buildArray { list ->
+        buildArray { list ->
             list.add("realm_uri" to identity.realmUri.toString())
             identity.userId?.let { list.add("user_id" to it) }
             when (recipient) {
@@ -139,7 +137,7 @@ data class MessageFcmMessage(
                     list.add("sender_email" to sender.email)
                 }
             }
-        })
+        }
 
     companion object {
         fun fromFcmData(data: Map<String, String>): MessageFcmMessage {

--- a/android/app/src/main/java/com/zulipmobile/notifications/FcmMessage.kt
+++ b/android/app/src/main/java/com/zulipmobile/notifications/FcmMessage.kt
@@ -55,8 +55,7 @@ sealed class Recipient {
 
     /** A stream message. */
     // TODO(server-5.0): Require the stream ID (#3918).
-    // TODO(#3918): Get the stream ID, when present.
-    data class Stream(val streamName: String, val topic: String) : Recipient()
+    data class Stream(val streamId: Int?, val streamName: String, val topic: String) : Recipient()
 }
 
 /**
@@ -125,6 +124,7 @@ data class MessageFcmMessage(
             when (recipient) {
                 is Recipient.Stream -> {
                     list.add("recipient_type" to "stream")
+                    recipient.streamId?.let { list.add("stream_id" to it) }
                     list.add("stream_name" to recipient.streamName)
                     list.add("topic" to recipient.topic)
                 }
@@ -145,6 +145,7 @@ data class MessageFcmMessage(
             val recipient = when (recipientType) {
                 "stream" ->
                     Recipient.Stream(
+                        data["stream_id"]?.parseInt("stream_id"),
                         data.require("stream"),
                         data.require("topic")
                     )

--- a/android/app/src/main/java/com/zulipmobile/notifications/NotificationUiManager.kt
+++ b/android/app/src/main/java/com/zulipmobile/notifications/NotificationUiManager.kt
@@ -297,10 +297,10 @@ private fun updateNotification(
 
         setNumber(messagingStyle.messages.size)
 
-        setExtras(Bundle().apply {
+        setExtras(bundleOf(
             // We use this for deciding when a RemoveFcmMessage should clear this notification.
-            putInt("lastZulipMessageId", fcmMessage.zulipMessageId)
-        })
+            "lastZulipMessageId" to fcmMessage.zulipMessageId
+        ))
 
         // Our own code doesn't look at the message details in this URL,
         // the "data URL" we put on the intent.  Instead, we get data from

--- a/android/app/src/main/java/com/zulipmobile/notifications/NotificationUiManager.kt
+++ b/android/app/src/main/java/com/zulipmobile/notifications/NotificationUiManager.kt
@@ -16,6 +16,7 @@ import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import androidx.core.app.Person
 import androidx.core.graphics.drawable.IconCompat
+import androidx.core.os.bundleOf
 import com.zulipmobile.BuildConfig
 import com.zulipmobile.MainActivity
 import com.zulipmobile.R
@@ -334,7 +335,7 @@ private fun updateNotification(
                         //   all the activities on top of the target one.
                         Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
                     )
-                    .putExtra(EXTRA_NOTIFICATION_DATA, fcmMessage.dataForOpen()),
+                    .putExtra(EXTRA_NOTIFICATION_DATA, bundleOf(*fcmMessage.dataForOpen())),
                 PendingIntent.FLAG_IMMUTABLE))
         setAutoCancel(true)
     }.build()

--- a/android/app/src/main/java/com/zulipmobile/notifications/NotificationUiManager.kt
+++ b/android/app/src/main/java/com/zulipmobile/notifications/NotificationUiManager.kt
@@ -296,10 +296,10 @@ private fun updateNotification(
 
         setNumber(messagingStyle.messages.size)
 
-        extras = Bundle().apply {
+        setExtras(Bundle().apply {
             // We use this for deciding when a RemoveFcmMessage should clear this notification.
             putInt("lastZulipMessageId", fcmMessage.zulipMessageId)
-        }
+        })
 
         // Our own code doesn't look at the message details in this URL,
         // the "data URL" we put on the intent.  Instead, we get data from

--- a/android/app/src/test/java/com/zulipmobile/notifications/FcmMessageTest.kt
+++ b/android/app/src/test/java/com/zulipmobile/notifications/FcmMessageTest.kt
@@ -86,6 +86,7 @@ class MessageFcmMessageTest : FcmMessageTestBase() {
 
         val stream = base.plus(sequenceOf(
             "recipient_type" to "stream",
+            "stream_id" to "42",
             "stream" to "denmark",
             "topic" to "play",
 
@@ -131,6 +132,7 @@ class MessageFcmMessageTest : FcmMessageTestBase() {
                 ),
                 zulipMessageId = 12345,
                 recipient = Recipient.Stream(
+                    streamId = Example.stream["stream_id"]!!.toInt(),
                     streamName = Example.stream["stream"]!!,
                     topic = Example.stream["topic"]!!
                 ),
@@ -152,6 +154,7 @@ class MessageFcmMessageTest : FcmMessageTestBase() {
             "realm_uri" to Example.stream["realm_uri"]!!,
             "user_id" to Example.stream["user_id"]!!.toInt(),
             "recipient_type" to "stream",
+            "stream_id" to Example.stream["stream_id"]!!.toInt(),
             "stream_name" to Example.stream["stream"]!!,
             "topic" to Example.stream["topic"]!!,
         ))
@@ -171,6 +174,11 @@ class MessageFcmMessageTest : FcmMessageTestBase() {
 
     @Test
     fun `optional fields missing cause no error`() {
+        expect.that(parse(Example.stream.minus("stream_id")).recipient).isEqualTo(Recipient.Stream(
+            streamId = null,
+            streamName = Example.stream["stream"]!!,
+            topic = Example.stream["topic"]!!
+        ))
         expect.that(parse(Example.pm.minus("user_id")).identity.userId).isNull()
     }
 
@@ -180,11 +188,14 @@ class MessageFcmMessageTest : FcmMessageTestBase() {
             "realm_uri" to Example.stream["realm_uri"]!!,
             "user_id" to Example.stream["user_id"]!!.toInt(),
             "recipient_type" to "stream",
+            "stream_id" to Example.stream["stream_id"]!!.toInt(),
             "stream_name" to Example.stream["stream"]!!,
             "topic" to Example.stream["topic"]!!,
         )
         expect.that(dataForOpen(Example.stream.minus("user_id")))
             .isEqualTo(baseExpected.minus("user_id"))
+        expect.that(dataForOpen(Example.stream.minus("stream_id")))
+            .isEqualTo(baseExpected.minus("stream_id"))
     }
 
     @Test
@@ -206,6 +217,8 @@ class MessageFcmMessageTest : FcmMessageTestBase() {
         assertParseFails(Example.pm.plus("realm_uri" to "/examplecorp"))
 
         assertParseFails(Example.stream.minus("recipient_type"))
+        assertParseFails(Example.stream.plus("stream_id" to "12,34"))
+        assertParseFails(Example.stream.plus("stream_id" to "abc"))
         assertParseFails(Example.stream.minus("stream"))
         assertParseFails(Example.stream.minus("topic"))
         assertParseFails(Example.groupPm.minus("recipient_type"))

--- a/docs/style.md
+++ b/docs/style.md
@@ -654,7 +654,7 @@ import * as api from '../api';
 
 // …
 
-    api.subscriptionAdd(auth, [{ name: stream.name }]);
+    const response = await api.uploadFile(auth, url, name);
 
 ```
 
@@ -662,12 +662,12 @@ rather than like this:
 
 ```js
 // BAD
-import subscriptionAdd from '../api/subscriptions/subscriptionAdd';
+import uploadFile from '../api/uploadFile.js;
 
 // …
 
     // BAD
-    subscriptionAdd(auth, [{ name: stream.name }]);
+    const response = await uploadFile(auth, url, name);
 ```
 
 We do this because a lot of the names in our API bindings are also

--- a/src/api/notificationTypes.js
+++ b/src/api/notificationTypes.js
@@ -58,7 +58,7 @@ type StreamData = {|
   +stream: string,
 
   // TODO(server-5.0): Require stream_id (#3918).
-  // +stream_id?: number, // TODO(#3918): Add this, and use it.
+  +stream_id?: number,
 
   +topic: string,
 |};

--- a/src/api/subscriptions/subscriptionAdd.js
+++ b/src/api/subscriptions/subscriptionAdd.js
@@ -5,7 +5,6 @@ import { apiPost } from '../apiFetch';
 type SubscriptionObj = {|
   // TODO(server-future): This should use a stream ID (#3918), not stream name.
   //   Server issue: https://github.com/zulip/zulip/issues/10744
-  // TODO(#3918): Change example in docs/style.md to something without this issue.
   name: string,
 |};
 

--- a/src/diagnostics/StorageScreen.js
+++ b/src/diagnostics/StorageScreen.js
@@ -31,7 +31,6 @@ export default function StorageScreen(props: Props): Node {
     <Screen title="Storage" scrollEnabled={false}>
       <FlatList
         data={storageSizes}
-        keyExtractor={item => item.key}
         renderItem={({ item }) => <SizeItem text={item.key} size={item.size} />}
       />
     </Screen>

--- a/src/notification/__tests__/notification-test.js
+++ b/src/notification/__tests__/notification-test.js
@@ -168,26 +168,11 @@ describe('extract iOS notification data', () => {
     });
 
     test('optional data is typechecked', () => {
-      expect(
-        make({
-          ...barebones.stream,
-          realm_uri: null,
-        }),
-      ).toThrow(/invalid/);
-
-      expect(
-        make({
-          ...barebones['group PM'],
-          realm_uri: ['array', 'of', 'string'],
-        }),
-      ).toThrow(/invalid/);
-
-      expect(
-        make({
-          ...barebones.stream,
-          user_id: 'abc',
-        }),
-      ).toThrow(/invalid/);
+      expect(make({ ...barebones.stream, realm_uri: null })).toThrow(/invalid/);
+      expect(make({ ...barebones['group PM'], realm_uri: ['array', 'of', 'string'] })).toThrow(
+        /invalid/,
+      );
+      expect(make({ ...barebones.stream, user_id: 'abc' })).toThrow(/invalid/);
     });
 
     test('hypothetical future: different event types', () => {

--- a/src/notification/__tests__/notification-test.js
+++ b/src/notification/__tests__/notification-test.js
@@ -30,6 +30,22 @@ describe('getNarrowFromNotificationData', () => {
     const notification = {
       realm_uri,
       recipient_type: 'stream',
+      stream_id: eg.stream.stream_id,
+      // Name points to some other stream, but the ID prevails.
+      stream_name: 'some stream',
+      topic: 'some topic',
+    };
+    const narrow = getNarrowFromNotificationData(notification, new Map(), streamsByName, ownUserId);
+    expect(narrow).toEqual(topicNarrow(eg.stream.stream_id, 'some topic'));
+  });
+
+  test('recognizes stream notification missing stream_id', () => {
+    // TODO(server-5.0): this test's data will become ill-typed; delete it
+    const stream = eg.makeStream({ name: 'some stream' });
+    const streamsByName = new Map([[stream.name, stream]]);
+    const notification = {
+      realm_uri,
+      recipient_type: 'stream',
       stream_name: 'some stream',
       topic: 'some topic',
     };

--- a/src/notification/__tests__/notification-test.js
+++ b/src/notification/__tests__/notification-test.js
@@ -79,7 +79,20 @@ describe('getNarrowFromNotificationData', () => {
 
 describe('extract iOS notification data', () => {
   const barebones = deepFreeze({
-    stream: { recipient_type: 'stream', stream: 'announce', topic: 'New channel', realm_uri },
+    // TODO(server-5.0): this will become an error case
+    'stream, no ID': {
+      recipient_type: 'stream',
+      stream: 'announce',
+      topic: 'New channel',
+      realm_uri,
+    },
+    stream: {
+      recipient_type: 'stream',
+      stream_id: 234,
+      stream: 'announce',
+      topic: 'New channel',
+      realm_uri,
+    },
     '1:1 PM': { recipient_type: 'private', sender_email: 'nobody@example.com', realm_uri },
     'group PM': { recipient_type: 'private', pm_users: '54,321', realm_uri },
   });
@@ -169,6 +182,7 @@ describe('extract iOS notification data', () => {
 
     test('optional data is typechecked', () => {
       expect(make({ ...barebones.stream, realm_uri: null })).toThrow(/invalid/);
+      expect(make({ ...barebones.stream, stream_id: '234' })).toThrow(/invalid/);
       expect(make({ ...barebones['group PM'], realm_uri: ['array', 'of', 'string'] })).toThrow(
         /invalid/,
       );

--- a/src/notification/extract.js
+++ b/src/notification/extract.js
@@ -112,13 +112,17 @@ export const fromAPNsImpl = (data: ?JSONableDict): Notification | void => {
   };
 
   if (recipient_type === 'stream') {
-    const { stream: stream_name, topic } = zulip;
+    const { stream: stream_name, stream_id, topic } = zulip;
     if (typeof stream_name !== 'string' || typeof topic !== 'string') {
+      throw err('invalid');
+    }
+    if (stream_id !== undefined && typeof stream_id !== 'number') {
       throw err('invalid');
     }
     return {
       ...identity,
       recipient_type: 'stream',
+      ...((stream_id !== undefined ? { stream_id } : Object.freeze({})): { stream_id?: number }),
       stream_name,
       topic,
     };

--- a/src/notification/notifOpen.js
+++ b/src/notification/notifOpen.js
@@ -137,9 +137,7 @@ export const getNarrowFromNotificationData = (
   //   created, and we haven't yet learned about it in the event queue; see
   //   e068771d7, which fixed this issue for group PMs.)
   //
-  //   This version just silently ignores the notification.
-  //
-  //   A nicer version would navigate to ChatScreen for that unknown
+  //   A nice version would navigate to ChatScreen for that unknown
   //   conversation, which would show InvalidNarrow (with its sensible error
   //   message) and whatever the notification did tell us about the
   //   stream/user: in particular, the stream name.
@@ -148,10 +146,18 @@ export const getNarrowFromNotificationData = (
   //   require some alternate plumbing to pass the stream name through.  For
   //   now, we skip dealing with that; this should be an uncommon case, so
   //   we settle for not crashing.
+  //
+  //   Specifically, if the notification comes with a stream ID or user IDs,
+  //   we navigate to a ChatScreen and it shows InvalidNarrow, but we don't
+  //   report the stream name etc.  If not, we ignore the notification.
 
   if (data.recipient_type === 'stream') {
     // TODO(server-5.0): Always use the stream ID (#3918).
-    // TODO(#3918): Use the notification's own stream_id, where present.
+    if (data.stream_id !== undefined) {
+      // Ideally we'd also record the stream name here, for a better error
+      // UX in case the stream is unknown.  See long TODO comment above.
+      return topicNarrow(data.stream_id, data.topic);
+    }
     const stream = streamsByName.get(data.stream_name);
     return (stream && topicNarrow(stream.stream_id, data.topic)) ?? null;
   }

--- a/src/notification/types.js
+++ b/src/notification/types.js
@@ -19,11 +19,16 @@ type NotificationBase = {|
  */
 // NOTE: Keep the Android-side code in sync with this type definition.
 export type Notification =
-  // TODO(server-5.0): Rely on stream ID (#3918).  (We'll still want the
-  //   stream name, as a hint for display in case the stream is unknown;
-  //   see comment in getNarrowFromNotificationData.)
-  // TODO(#3918): Add stream_id.
-  | {| ...NotificationBase, recipient_type: 'stream', stream_name: string, topic: string |}
+  | {|
+      ...NotificationBase,
+      recipient_type: 'stream',
+      // TODO(server-5.0): Rely on stream ID (#3918).  (We'll still want the
+      //   stream name, as a hint for display in case the stream is unknown;
+      //   see comment in getNarrowFromNotificationData.)
+      stream_id?: number,
+      stream_name: string,
+      topic: string,
+    |}
   // Group PM messages have `pm_users`, which is sorted, comma-separated IDs.
   | {| ...NotificationBase, recipient_type: 'private', pm_users: string |}
   // 1:1 PM messages lack `pm_users`.

--- a/src/pm-conversations/PmConversationList.js
+++ b/src/pm-conversations/PmConversationList.js
@@ -52,7 +52,6 @@ export default function PmConversationList(props: Props): Node {
       style={styles.list}
       initialNumToRender={20}
       data={conversations}
-      keyExtractor={item => item.key}
       renderItem={({ item }) => {
         const users = item.keyRecipients;
         if (users.length === 1) {

--- a/src/sharing/ShareWrapper.js
+++ b/src/sharing/ShareWrapper.js
@@ -25,7 +25,7 @@ import { IconAttachment, IconCancel } from '../common/Icons';
 
 type SendTo =
   | {| type: 'pm', selectedRecipients: $ReadOnlyArray<UserId> |}
-  // TODO(#3918): Drop streamName.  Used below for sending.
+  // TODO(server-2.0): Drop streamName (#3918).  Used below for sending.
   | {| type: 'stream', streamName: string, streamId: number, topic: string |};
 
 const styles = createStyleSheet({
@@ -176,7 +176,7 @@ class ShareWrapperInner extends React.Component<Props, State> {
             content: messageToSend,
             type: 'stream',
             subject: sendTo.topic || apiConstants.NO_TOPIC_TOPIC,
-            // TODO(server-2.0): switch to numeric stream ID, not name;
+            // TODO(server-2.0): switch to numeric stream ID (#3918), not name;
             //   then drop streamName from SendTo
             to: sendTo.streamName,
           };

--- a/src/unread/UnreadCards.js
+++ b/src/unread/UnreadCards.js
@@ -70,7 +70,6 @@ export default function UnreadCards(props: Props): Node {
       stickySectionHeadersEnabled
       initialNumToRender={20}
       sections={unreadCards}
-      keyExtractor={item => item.key}
       renderSectionHeader={({ section }) =>
         section.key === 'private' ? null : (
           <StreamItem

--- a/src/unread/__tests__/unreadSelectors-test.js
+++ b/src/unread/__tests__/unreadSelectors-test.js
@@ -233,7 +233,7 @@ describe('getUnreadStreamsAndTopics', () => {
         isPinned: false,
         isPrivate: false,
         isWebPublic: false,
-        key: 'stream:stream 0',
+        key: 'stream:0',
         streamId: 0,
         streamName: 'stream 0',
         unread: 5,
@@ -253,7 +253,7 @@ describe('getUnreadStreamsAndTopics', () => {
         isPinned: false,
         isPrivate: false,
         isWebPublic: false,
-        key: 'stream:stream 2',
+        key: 'stream:2',
         streamId: 2,
         streamName: 'stream 2',
         unread: 2,
@@ -293,7 +293,7 @@ describe('getUnreadStreamsAndTopics', () => {
         isPinned: false,
         isPrivate: false,
         isWebPublic: false,
-        key: 'stream:stream 0',
+        key: 'stream:0',
         streamId: 0,
         streamName: 'stream 0',
         unread: 2,
@@ -313,7 +313,7 @@ describe('getUnreadStreamsAndTopics', () => {
         isPinned: false,
         isPrivate: false,
         isWebPublic: false,
-        key: 'stream:stream 2',
+        key: 'stream:2',
         streamId: 2,
         streamName: 'stream 2',
         unread: 2,
@@ -331,7 +331,7 @@ describe('getUnreadStreamsAndTopics', () => {
 
     expect(unreadCount).toEqual([
       {
-        key: 'stream:stream 0',
+        key: 'stream:0',
         streamId: 0,
         streamName: 'stream 0',
         color: 'red',
@@ -352,7 +352,7 @@ describe('getUnreadStreamsAndTopics', () => {
         ],
       },
       {
-        key: 'stream:stream 2',
+        key: 'stream:2',
         streamId: 2,
         streamName: 'stream 2',
         color: 'blue',
@@ -406,7 +406,7 @@ describe('getUnreadStreamsAndTopics', () => {
 
     expect(unreadCount).toEqual([
       {
-        key: 'stream:xyz stream',
+        key: 'stream:1',
         streamId: 1,
         streamName: 'xyz stream',
         color: 'blue',
@@ -421,7 +421,7 @@ describe('getUnreadStreamsAndTopics', () => {
         ],
       },
       {
-        key: 'stream:abc stream',
+        key: 'stream:0',
         streamId: 0,
         streamName: 'abc stream',
         color: 'red',
@@ -436,7 +436,7 @@ describe('getUnreadStreamsAndTopics', () => {
         ],
       },
       {
-        key: 'stream:def stream',
+        key: 'stream:2',
         streamId: 2,
         streamName: 'def stream',
         color: 'green',
@@ -491,7 +491,7 @@ describe('getUnreadStreamsAndTopicsSansMuted', () => {
         isPinned: false,
         isPrivate: false,
         isWebPublic: false,
-        key: 'stream:stream 0',
+        key: 'stream:0',
         streamId: 0,
         streamName: 'stream 0',
         unread: 2,

--- a/src/unread/unreadSelectors.js
+++ b/src/unread/unreadSelectors.js
@@ -137,7 +137,7 @@ export const getUnreadStreamsAndTopics: Selector<$ReadOnlyArray<UnreadStreamItem
         subscriptionsById.get(streamId) || NULL_SUBSCRIPTION;
 
       const total = {
-        key: `stream:${name}`, // TODO(#3918): should use stream ID
+        key: `stream:${streamId}`,
         streamId,
         streamName: name,
         isMuted: !in_home_view,


### PR DESCRIPTION
This follows #5246, #5223, #5205, #5183, #5069, #5056, #5000, and #4635 in switching us over from identifying streams by their names to doing so with their stable numeric IDs: #3918. This prevents buggy behavior when a stream gets renamed.

At this point the bulk of the work has been done already. The previous PR in this series, #5246, marked with `TODO(#3918):` all the remaining places we needed to fix. This PR then eliminates each of those in turn. Mostly this means parsing and using stream IDs when present in notifications; that's followed by a handful of trivial fixes.

As forecast at https://github.com/zulip/zulip-mobile/issues/3918#issuecomment-1026479673 , there remain some places where we use stream names that should be IDs, but these are limited to interacting with the server in places where it doesn't support IDs. For those, moreover:
 * We nevertheless make sure to convert promptly to stream IDs at the edge (e.g., maintaining the muted-topics model in terms of stream IDs). This means that while we're still exposed to bugs if a stream rename races with another interaction we have with the server about that stream, we at least don't hit a bug simply because a stream was renamed while the app was open -- in other words, the race window is much narrower.
 * Some of them were fixed in the server a while ago, and have comments like `TODO(server-2.0):`. We'll take care of those sometime soon in a followup to #5100, as we concretely drop support for ancient server versions we already don't support.
 * Some (well, one -- notifications) were fixed in the server recently, and have comments like `TODO(server-5.0):`. We'll take care of those circa late 2023, when we drop support for all server releases that exist today. In the meantime, we make sure to take advantage of stream IDs when the server is new enough to provide them.
 * Some aren't fixed yet: zulip/zulip#10744. These have `TODO(server-future):` comments.

Fixes: #3918
