### PR TITLE
Clean up action-sheet code and example BackgroundData

### DIFF
--- a/src/__tests__/lib/exampleData.js
+++ b/src/__tests__/lib/exampleData.js
@@ -285,6 +285,7 @@ export const makeSubscription = (
     stream?: Stream,
     in_home_view?: boolean,
     pin_to_top?: boolean,
+    push_notifications?: boolean,
     color?: string,
   |} = Object.freeze({}),
 ): Subscription => {
@@ -298,7 +299,7 @@ export const makeSubscription = (
     desktop_notifications: false,
     email_address: '??? make this value representative before using in a test :)',
     is_old_stream: true,
-    push_notifications: null,
+    push_notifications: args.push_notifications ?? null,
     stream_weekly_traffic: 84,
   });
 };

--- a/src/__tests__/lib/exampleData.js
+++ b/src/__tests__/lib/exampleData.js
@@ -934,7 +934,6 @@ export const backgroundData: BackgroundData = deepFreeze({
   allImageEmojiById: {}, // in reality would also have :zulip:
   auth: selfAuth,
   debug: baseReduxState.session.debug,
-  doNotMarkMessagesAsRead: baseReduxState.settings.doNotMarkMessagesAsRead,
   flags: baseReduxState.flags,
   allUsersById: new Map([[selfUser.user_id, selfUser]]),
   mute: baseReduxState.mute,

--- a/src/__tests__/lib/exampleData.js
+++ b/src/__tests__/lib/exampleData.js
@@ -929,7 +929,13 @@ export const mkActionEventUpdateMessage = (args: {|
  * Miscellaneous
  */
 
-export const backgroundData: BackgroundData = deepFreeze({
+/**
+ * A BackgroundData value corresponding mostly to baseReduxState.
+ *
+ * Includes a few elements of plusReduxState, where necessary for
+ * constructing a valid BackgroundData.
+ */
+export const baseBackgroundData: BackgroundData = deepFreeze({
   alertWords: baseReduxState.alertWords,
   allImageEmojiById: {}, // in reality would also have :zulip:
   auth: selfAuth,

--- a/src/__tests__/lib/exampleData.js
+++ b/src/__tests__/lib/exampleData.js
@@ -945,3 +945,8 @@ export const baseBackgroundData: BackgroundData = deepFreeze(
     getDebug(baseReduxState),
   ),
 );
+
+/** A BackgroundData value corresponding to plusReduxState. */
+export const plusBackgroundData: BackgroundData = deepFreeze(
+  getBackgroundData(plusReduxState, getGlobalSettings(plusReduxState), getDebug(plusReduxState)),
+);

--- a/src/__tests__/lib/exampleData.js
+++ b/src/__tests__/lib/exampleData.js
@@ -50,9 +50,8 @@ import {
 import rootReducer from '../../boot/reducers';
 import { authOfAccount } from '../../account/accountMisc';
 import { HOME_NARROW } from '../../utils/narrow';
-import type { BackgroundData } from '../../webview/backgroundData';
-import { getSettings, getStreamsById, getSubscriptionsById } from '../../selectors';
-import { getGlobalSettings } from '../../directSelectors';
+import { type BackgroundData, getBackgroundData } from '../../webview/backgroundData';
+import { getDebug, getGlobalSettings } from '../../directSelectors';
 import { messageMoved } from '../../api/misc';
 
 /* ========================================================================
@@ -935,20 +934,14 @@ export const mkActionEventUpdateMessage = (args: {|
  * Includes a few elements of plusReduxState, where necessary for
  * constructing a valid BackgroundData.
  */
-export const baseBackgroundData: BackgroundData = deepFreeze({
-  alertWords: baseReduxState.alertWords,
-  allImageEmojiById: {}, // in reality would also have :zulip:
-  auth: selfAuth,
-  debug: baseReduxState.session.debug,
-  flags: baseReduxState.flags,
-  allUsersById: new Map([[selfUser.user_id, selfUser]]),
-  mute: baseReduxState.mute,
-  mutedUsers: baseReduxState.mutedUsers,
-  ownUser: selfUser,
-  streams: getStreamsById(baseReduxState),
-  subscriptions: getSubscriptionsById(baseReduxState),
-  unread: baseReduxState.unread,
-  theme: getGlobalSettings(baseReduxState).theme,
-  twentyFourHourTime: baseReduxState.realm.twentyFourHourTime,
-  userSettingStreamNotification: getSettings(baseReduxState).streamNotification,
-});
+export const baseBackgroundData: BackgroundData = deepFreeze(
+  getBackgroundData(
+    reduxState({
+      accounts: plusReduxState.accounts,
+      realm: { ...baseReduxState.realm, user_id: plusReduxState.realm.user_id },
+      users: [selfUser],
+    }),
+    getGlobalSettings(baseReduxState),
+    getDebug(baseReduxState),
+  ),
+);

--- a/src/__tests__/lib/exampleData.js
+++ b/src/__tests__/lib/exampleData.js
@@ -50,7 +50,7 @@ import {
 import rootReducer from '../../boot/reducers';
 import { authOfAccount } from '../../account/accountMisc';
 import { HOME_NARROW } from '../../utils/narrow';
-import type { BackgroundData } from '../../webview/MessageList';
+import type { BackgroundData } from '../../webview/backgroundData';
 import { getSettings, getStreamsById, getSubscriptionsById } from '../../selectors';
 import { getGlobalSettings } from '../../directSelectors';
 import { messageMoved } from '../../api/misc';

--- a/src/action-sheets/__tests__/action-sheet-test.js
+++ b/src/action-sheets/__tests__/action-sheet-test.js
@@ -8,8 +8,7 @@ import {
   constructTopicActionButtons,
   constructStreamActionButtons,
 } from '../index';
-import { reducer } from '../../unread/unreadModel';
-import { initialState } from '../../unread/__tests__/unread-testlib';
+import { makeUnreadState } from '../../unread/__tests__/unread-testlib';
 import { makeMuteState } from '../../mute/__tests__/mute-testlib';
 
 const buttonTitles = buttons => buttons.map(button => button.title);
@@ -56,15 +55,8 @@ describe('constructTopicActionButtons', () => {
   const streamId = streamMessage.stream_id;
   const streams = deepFreeze(new Map([[stream.stream_id, stream]]));
 
-  const baseState = (() => {
-    const r = (state, action) => reducer(state, action, eg.plusReduxState);
-    let state = initialState;
-    state = r(state, eg.mkActionEventNewMessage(streamMessage));
-    return state;
-  })();
-
   test('show mark as read if topic is unread', () => {
-    const unread = baseState;
+    const unread = makeUnreadState(eg.plusReduxState, [streamMessage]);
     const buttons = constructTopicActionButtons({
       backgroundData: { ...eg.baseBackgroundData, streams, unread },
       streamId,

--- a/src/action-sheets/__tests__/action-sheet-test.js
+++ b/src/action-sheets/__tests__/action-sheet-test.js
@@ -19,9 +19,9 @@ describe('constructActionButtons', () => {
 
   test('show star message option if message is not starred', () => {
     const message = eg.streamMessage();
-    const flags = { ...eg.backgroundData.flags, starred: {} };
+    const flags = { ...eg.baseBackgroundData.flags, starred: {} };
     const buttons = constructMessageActionButtons({
-      backgroundData: { ...eg.backgroundData, flags },
+      backgroundData: { ...eg.baseBackgroundData, flags },
       message,
       narrow,
     });
@@ -30,9 +30,9 @@ describe('constructActionButtons', () => {
 
   test('show unstar message option if message is starred', () => {
     const message = eg.streamMessage();
-    const flags = { ...eg.backgroundData.flags, starred: { [message.id]: true } };
+    const flags = { ...eg.baseBackgroundData.flags, starred: { [message.id]: true } };
     const buttons = constructMessageActionButtons({
-      backgroundData: { ...eg.backgroundData, flags },
+      backgroundData: { ...eg.baseBackgroundData, flags },
       message,
       narrow,
     });
@@ -41,7 +41,7 @@ describe('constructActionButtons', () => {
 
   test('show reactions option if message is has at least one reaction', () => {
     const buttons = constructMessageActionButtons({
-      backgroundData: eg.backgroundData,
+      backgroundData: eg.baseBackgroundData,
       message: eg.streamMessage({ reactions: [eg.unicodeEmojiReaction] }),
       narrow,
     });
@@ -66,7 +66,7 @@ describe('constructTopicActionButtons', () => {
   test('show mark as read if topic is unread', () => {
     const unread = baseState;
     const buttons = constructTopicActionButtons({
-      backgroundData: { ...eg.backgroundData, streams, unread },
+      backgroundData: { ...eg.baseBackgroundData, streams, unread },
       streamId,
       topic,
     });
@@ -75,7 +75,7 @@ describe('constructTopicActionButtons', () => {
 
   test('do not show mark as read if topic is read', () => {
     const buttons = constructTopicActionButtons({
-      backgroundData: { ...eg.backgroundData, streams },
+      backgroundData: { ...eg.baseBackgroundData, streams },
       streamId,
       topic,
     });
@@ -85,7 +85,7 @@ describe('constructTopicActionButtons', () => {
   test('show Unmute topic option if topic is muted', () => {
     const mute = makeMuteState([[stream, topic]]);
     const buttons = constructTopicActionButtons({
-      backgroundData: { ...eg.backgroundData, streams, mute },
+      backgroundData: { ...eg.baseBackgroundData, streams, mute },
       streamId,
       topic,
     });
@@ -94,7 +94,7 @@ describe('constructTopicActionButtons', () => {
 
   test('show mute topic option if topic is not muted', () => {
     const buttons = constructTopicActionButtons({
-      backgroundData: { ...eg.backgroundData, streams, mute: makeMuteState([]) },
+      backgroundData: { ...eg.baseBackgroundData, streams, mute: makeMuteState([]) },
       streamId,
       topic,
     });
@@ -106,7 +106,7 @@ describe('constructTopicActionButtons', () => {
       new Map([[stream.stream_id, { ...eg.subscription, in_home_view: false, ...stream }]]),
     );
     const buttons = constructTopicActionButtons({
-      backgroundData: { ...eg.backgroundData, subscriptions, streams },
+      backgroundData: { ...eg.baseBackgroundData, subscriptions, streams },
       streamId,
       topic,
     });
@@ -118,7 +118,7 @@ describe('constructTopicActionButtons', () => {
       new Map([[stream.stream_id, { ...eg.subscription, in_home_view: true, ...stream }]]),
     );
     const buttons = constructTopicActionButtons({
-      backgroundData: { ...eg.backgroundData, subscriptions, streams },
+      backgroundData: { ...eg.baseBackgroundData, subscriptions, streams },
       streamId,
       topic,
     });
@@ -127,7 +127,7 @@ describe('constructTopicActionButtons', () => {
 
   test('show "subscribe" option, if stream is not subscribed yet', () => {
     const buttons = constructStreamActionButtons({
-      backgroundData: { ...eg.backgroundData, streams },
+      backgroundData: { ...eg.baseBackgroundData, streams },
       streamId,
     });
     expect(buttonTitles(buttons)).toContain('Subscribe');
@@ -136,7 +136,7 @@ describe('constructTopicActionButtons', () => {
   test('show "unsubscribe" option, if stream is subscribed', () => {
     const subscriptions = deepFreeze(new Map([[eg.subscription.stream_id, eg.subscription]]));
     const buttons = constructStreamActionButtons({
-      backgroundData: { ...eg.backgroundData, subscriptions },
+      backgroundData: { ...eg.baseBackgroundData, subscriptions },
       streamId: eg.subscription.stream_id,
     });
     expect(buttonTitles(buttons)).toContain('Unsubscribe');
@@ -147,7 +147,7 @@ describe('constructTopicActionButtons', () => {
       new Map([[stream.stream_id, { ...eg.subscription, push_notifications: false, ...stream }]]),
     );
     const buttons = constructStreamActionButtons({
-      backgroundData: { ...eg.backgroundData, subscriptions },
+      backgroundData: { ...eg.baseBackgroundData, subscriptions },
       streamId,
     });
     expect(buttonTitles(buttons)).toContain('Enable notifications');
@@ -158,7 +158,7 @@ describe('constructTopicActionButtons', () => {
       new Map([[stream.stream_id, { ...eg.subscription, push_notifications: true, ...stream }]]),
     );
     const buttons = constructStreamActionButtons({
-      backgroundData: { ...eg.backgroundData, subscriptions },
+      backgroundData: { ...eg.baseBackgroundData, subscriptions },
       streamId,
     });
     expect(buttonTitles(buttons)).toContain('Disable notifications');
@@ -169,7 +169,7 @@ describe('constructTopicActionButtons', () => {
       new Map([[stream.stream_id, { ...eg.subscription, pin_to_top: false, ...stream }]]),
     );
     const buttons = constructStreamActionButtons({
-      backgroundData: { ...eg.backgroundData, subscriptions },
+      backgroundData: { ...eg.baseBackgroundData, subscriptions },
       streamId,
     });
     expect(buttonTitles(buttons)).toContain('Pin to top');
@@ -180,7 +180,7 @@ describe('constructTopicActionButtons', () => {
       new Map([[stream.stream_id, { ...eg.subscription, pin_to_top: true, ...stream }]]),
     );
     const buttons = constructStreamActionButtons({
-      backgroundData: { ...eg.backgroundData, subscriptions },
+      backgroundData: { ...eg.baseBackgroundData, subscriptions },
       streamId,
     });
     expect(buttonTitles(buttons)).toContain('Unpin from top');
@@ -189,7 +189,7 @@ describe('constructTopicActionButtons', () => {
   test('show delete topic option if current user is an admin', () => {
     const ownUser = { ...eg.selfUser, is_admin: true };
     const buttons = constructTopicActionButtons({
-      backgroundData: { ...eg.backgroundData, ownUser, streams },
+      backgroundData: { ...eg.baseBackgroundData, ownUser, streams },
       streamId,
       topic,
     });
@@ -198,7 +198,7 @@ describe('constructTopicActionButtons', () => {
 
   test('do not show delete topic option if current user is not an admin', () => {
     const buttons = constructTopicActionButtons({
-      backgroundData: { ...eg.backgroundData, streams },
+      backgroundData: { ...eg.baseBackgroundData, streams },
       streamId,
       topic,
     });

--- a/src/action-sheets/__tests__/action-sheet-test.js
+++ b/src/action-sheets/__tests__/action-sheet-test.js
@@ -16,35 +16,24 @@ const buttonTitles = buttons => buttons.map(button => button.title);
 describe('constructMessageActionButtons', () => {
   const narrow = deepFreeze(HOME_NARROW);
 
+  const titles = (backgroundData, message) =>
+    buttonTitles(constructMessageActionButtons({ backgroundData, message, narrow }));
+
   test('show star message option if message is not starred', () => {
     const message = eg.streamMessage();
     const flags = { ...eg.plusBackgroundData.flags, starred: {} };
-    const buttons = constructMessageActionButtons({
-      backgroundData: { ...eg.plusBackgroundData, flags },
-      message,
-      narrow,
-    });
-    expect(buttonTitles(buttons)).toContain('Star message');
+    expect(titles({ ...eg.plusBackgroundData, flags }, message)).toContain('Star message');
   });
 
   test('show unstar message option if message is starred', () => {
     const message = eg.streamMessage();
     const flags = { ...eg.plusBackgroundData.flags, starred: { [message.id]: true } };
-    const buttons = constructMessageActionButtons({
-      backgroundData: { ...eg.plusBackgroundData, flags },
-      message,
-      narrow,
-    });
-    expect(buttonTitles(buttons)).toContain('Unstar message');
+    expect(titles({ ...eg.plusBackgroundData, flags }, message)).toContain('Unstar message');
   });
 
   test('show reactions option if message is has at least one reaction', () => {
-    const buttons = constructMessageActionButtons({
-      backgroundData: eg.plusBackgroundData,
-      message: eg.streamMessage({ reactions: [eg.unicodeEmojiReaction] }),
-      narrow,
-    });
-    expect(buttonTitles(buttons)).toContain('See who reacted');
+    const message = eg.streamMessage({ reactions: [eg.unicodeEmojiReaction] });
+    expect(titles(eg.plusBackgroundData, message)).toContain('See who reacted');
   });
 });
 
@@ -53,148 +42,90 @@ describe('constructTopicActionButtons', () => {
   const topic = streamMessage.subject;
   const streamId = eg.stream.stream_id;
 
+  const titles = backgroundData =>
+    buttonTitles(constructTopicActionButtons({ backgroundData, streamId, topic }));
+
   test('show mark as read if topic is unread', () => {
     const unread = makeUnreadState(eg.plusReduxState, [streamMessage]);
-    const buttons = constructTopicActionButtons({
-      backgroundData: { ...eg.plusBackgroundData, unread },
-      streamId,
-      topic,
-    });
-    expect(buttonTitles(buttons)).toContain('Mark topic as read');
+    expect(titles({ ...eg.plusBackgroundData, unread })).toContain('Mark topic as read');
   });
 
   test('do not show mark as read if topic is read', () => {
-    const buttons = constructTopicActionButtons({
-      backgroundData: { ...eg.plusBackgroundData },
-      streamId,
-      topic,
-    });
-    expect(buttonTitles(buttons)).not.toContain('Mark topic as read');
+    expect(titles({ ...eg.plusBackgroundData })).not.toContain('Mark topic as read');
   });
 
   test('show Unmute topic option if topic is muted', () => {
     const mute = makeMuteState([[eg.stream, topic]]);
-    const buttons = constructTopicActionButtons({
-      backgroundData: { ...eg.plusBackgroundData, mute },
-      streamId,
-      topic,
-    });
-    expect(buttonTitles(buttons)).toContain('Unmute topic');
+    expect(titles({ ...eg.plusBackgroundData, mute })).toContain('Unmute topic');
   });
 
   test('show mute topic option if topic is not muted', () => {
-    const buttons = constructTopicActionButtons({
-      backgroundData: { ...eg.plusBackgroundData, mute: makeMuteState([]) },
-      streamId,
-      topic,
-    });
-    expect(buttonTitles(buttons)).toContain('Mute topic');
+    expect(titles({ ...eg.plusBackgroundData, mute: makeMuteState([]) })).toContain('Mute topic');
   });
 
   test('show Unmute stream option if stream is not in home view', () => {
     const subscriptions = new Map([
       [eg.stream.stream_id, eg.makeSubscription({ in_home_view: false })],
     ]);
-    const buttons = constructTopicActionButtons({
-      backgroundData: { ...eg.plusBackgroundData, subscriptions },
-      streamId,
-      topic,
-    });
-    expect(buttonTitles(buttons)).toContain('Unmute stream');
+    expect(titles({ ...eg.plusBackgroundData, subscriptions })).toContain('Unmute stream');
   });
 
   test('show mute stream option if stream is in home view', () => {
     const subscriptions = new Map([
       [eg.stream.stream_id, eg.makeSubscription({ in_home_view: true })],
     ]);
-    const buttons = constructTopicActionButtons({
-      backgroundData: { ...eg.plusBackgroundData, subscriptions },
-      streamId,
-      topic,
-    });
-    expect(buttonTitles(buttons)).toContain('Mute stream');
+    expect(titles({ ...eg.plusBackgroundData, subscriptions })).toContain('Mute stream');
   });
 
   test('show delete topic option if current user is an admin', () => {
     const ownUser = { ...eg.selfUser, is_admin: true };
-    const buttons = constructTopicActionButtons({
-      backgroundData: { ...eg.plusBackgroundData, ownUser },
-      streamId,
-      topic,
-    });
-    expect(buttonTitles(buttons)).toContain('Delete topic');
+    expect(titles({ ...eg.plusBackgroundData, ownUser })).toContain('Delete topic');
   });
 
   test('do not show delete topic option if current user is not an admin', () => {
-    const buttons = constructTopicActionButtons({
-      backgroundData: { ...eg.plusBackgroundData },
-      streamId,
-      topic,
-    });
-    expect(buttonTitles(buttons)).not.toContain('Delete topic');
+    expect(titles({ ...eg.plusBackgroundData })).not.toContain('Delete topic');
   });
 });
 
 describe('constructStreamActionButtons', () => {
   const streamId = eg.stream.stream_id;
 
+  const titles = backgroundData =>
+    buttonTitles(constructStreamActionButtons({ backgroundData, streamId }));
+
   test('show "subscribe" option, if stream is not subscribed yet', () => {
-    const buttons = constructStreamActionButtons({
-      backgroundData: { ...eg.plusBackgroundData, subscriptions: new Map() },
-      streamId,
-    });
-    expect(buttonTitles(buttons)).toContain('Subscribe');
+    expect(titles({ ...eg.plusBackgroundData, subscriptions: new Map() })).toContain('Subscribe');
   });
 
   test('show "unsubscribe" option, if stream is subscribed', () => {
-    const buttons = constructStreamActionButtons({
-      backgroundData: { ...eg.plusBackgroundData },
-      streamId,
-    });
-    expect(buttonTitles(buttons)).toContain('Unsubscribe');
+    expect(titles({ ...eg.plusBackgroundData })).toContain('Unsubscribe');
   });
 
   test('show "enable notification" if push notifications are not enabled for stream', () => {
     const subscriptions = new Map([
       [eg.stream.stream_id, eg.makeSubscription({ push_notifications: false })],
     ]);
-    const buttons = constructStreamActionButtons({
-      backgroundData: { ...eg.plusBackgroundData, subscriptions },
-      streamId,
-    });
-    expect(buttonTitles(buttons)).toContain('Enable notifications');
+    expect(titles({ ...eg.plusBackgroundData, subscriptions })).toContain('Enable notifications');
   });
 
   test('show "disable notification" if push notifications are enabled for stream', () => {
     const subscriptions = new Map([
       [eg.stream.stream_id, eg.makeSubscription({ push_notifications: true })],
     ]);
-    const buttons = constructStreamActionButtons({
-      backgroundData: { ...eg.plusBackgroundData, subscriptions },
-      streamId,
-    });
-    expect(buttonTitles(buttons)).toContain('Disable notifications');
+    expect(titles({ ...eg.plusBackgroundData, subscriptions })).toContain('Disable notifications');
   });
 
   test('show "pin to top" if stream is not pinned to top', () => {
     const subscriptions = new Map([
       [eg.stream.stream_id, eg.makeSubscription({ pin_to_top: false })],
     ]);
-    const buttons = constructStreamActionButtons({
-      backgroundData: { ...eg.plusBackgroundData, subscriptions },
-      streamId,
-    });
-    expect(buttonTitles(buttons)).toContain('Pin to top');
+    expect(titles({ ...eg.plusBackgroundData, subscriptions })).toContain('Pin to top');
   });
 
   test('show "unpin from top" if stream is pinned to top', () => {
     const subscriptions = new Map([
       [eg.stream.stream_id, eg.makeSubscription({ pin_to_top: true })],
     ]);
-    const buttons = constructStreamActionButtons({
-      backgroundData: { ...eg.plusBackgroundData, subscriptions },
-      streamId,
-    });
-    expect(buttonTitles(buttons)).toContain('Unpin from top');
+    expect(titles({ ...eg.plusBackgroundData, subscriptions })).toContain('Unpin from top');
   });
 });

--- a/src/action-sheets/__tests__/action-sheet-test.js
+++ b/src/action-sheets/__tests__/action-sheet-test.js
@@ -13,27 +13,46 @@ import { makeMuteState } from '../../mute/__tests__/mute-testlib';
 
 const buttonTitles = buttons => buttons.map(button => button.title);
 
-describe('constructMessageActionButtons', () => {
-  const narrow = deepFreeze(HOME_NARROW);
+describe('constructStreamActionButtons', () => {
+  const streamId = eg.stream.stream_id;
 
-  const titles = (backgroundData, message) =>
-    buttonTitles(constructMessageActionButtons({ backgroundData, message, narrow }));
+  const titles = backgroundData =>
+    buttonTitles(constructStreamActionButtons({ backgroundData, streamId }));
 
-  test('show star message option if message is not starred', () => {
-    const message = eg.streamMessage();
-    const flags = { ...eg.plusBackgroundData.flags, starred: {} };
-    expect(titles({ ...eg.plusBackgroundData, flags }, message)).toContain('Star message');
+  test('show "subscribe" option, if stream is not subscribed yet', () => {
+    expect(titles({ ...eg.plusBackgroundData, subscriptions: new Map() })).toContain('Subscribe');
   });
 
-  test('show unstar message option if message is starred', () => {
-    const message = eg.streamMessage();
-    const flags = { ...eg.plusBackgroundData.flags, starred: { [message.id]: true } };
-    expect(titles({ ...eg.plusBackgroundData, flags }, message)).toContain('Unstar message');
+  test('show "unsubscribe" option, if stream is subscribed', () => {
+    expect(titles({ ...eg.plusBackgroundData })).toContain('Unsubscribe');
   });
 
-  test('show reactions option if message is has at least one reaction', () => {
-    const message = eg.streamMessage({ reactions: [eg.unicodeEmojiReaction] });
-    expect(titles(eg.plusBackgroundData, message)).toContain('See who reacted');
+  test('show "enable notification" if push notifications are not enabled for stream', () => {
+    const subscriptions = new Map([
+      [eg.stream.stream_id, eg.makeSubscription({ push_notifications: false })],
+    ]);
+    expect(titles({ ...eg.plusBackgroundData, subscriptions })).toContain('Enable notifications');
+  });
+
+  test('show "disable notification" if push notifications are enabled for stream', () => {
+    const subscriptions = new Map([
+      [eg.stream.stream_id, eg.makeSubscription({ push_notifications: true })],
+    ]);
+    expect(titles({ ...eg.plusBackgroundData, subscriptions })).toContain('Disable notifications');
+  });
+
+  test('show "pin to top" if stream is not pinned to top', () => {
+    const subscriptions = new Map([
+      [eg.stream.stream_id, eg.makeSubscription({ pin_to_top: false })],
+    ]);
+    expect(titles({ ...eg.plusBackgroundData, subscriptions })).toContain('Pin to top');
+  });
+
+  test('show "unpin from top" if stream is pinned to top', () => {
+    const subscriptions = new Map([
+      [eg.stream.stream_id, eg.makeSubscription({ pin_to_top: true })],
+    ]);
+    expect(titles({ ...eg.plusBackgroundData, subscriptions })).toContain('Unpin from top');
   });
 });
 
@@ -87,45 +106,26 @@ describe('constructTopicActionButtons', () => {
   });
 });
 
-describe('constructStreamActionButtons', () => {
-  const streamId = eg.stream.stream_id;
+describe('constructMessageActionButtons', () => {
+  const narrow = deepFreeze(HOME_NARROW);
 
-  const titles = backgroundData =>
-    buttonTitles(constructStreamActionButtons({ backgroundData, streamId }));
+  const titles = (backgroundData, message) =>
+    buttonTitles(constructMessageActionButtons({ backgroundData, message, narrow }));
 
-  test('show "subscribe" option, if stream is not subscribed yet', () => {
-    expect(titles({ ...eg.plusBackgroundData, subscriptions: new Map() })).toContain('Subscribe');
+  test('show star message option if message is not starred', () => {
+    const message = eg.streamMessage();
+    const flags = { ...eg.plusBackgroundData.flags, starred: {} };
+    expect(titles({ ...eg.plusBackgroundData, flags }, message)).toContain('Star message');
   });
 
-  test('show "unsubscribe" option, if stream is subscribed', () => {
-    expect(titles({ ...eg.plusBackgroundData })).toContain('Unsubscribe');
+  test('show unstar message option if message is starred', () => {
+    const message = eg.streamMessage();
+    const flags = { ...eg.plusBackgroundData.flags, starred: { [message.id]: true } };
+    expect(titles({ ...eg.plusBackgroundData, flags }, message)).toContain('Unstar message');
   });
 
-  test('show "enable notification" if push notifications are not enabled for stream', () => {
-    const subscriptions = new Map([
-      [eg.stream.stream_id, eg.makeSubscription({ push_notifications: false })],
-    ]);
-    expect(titles({ ...eg.plusBackgroundData, subscriptions })).toContain('Enable notifications');
-  });
-
-  test('show "disable notification" if push notifications are enabled for stream', () => {
-    const subscriptions = new Map([
-      [eg.stream.stream_id, eg.makeSubscription({ push_notifications: true })],
-    ]);
-    expect(titles({ ...eg.plusBackgroundData, subscriptions })).toContain('Disable notifications');
-  });
-
-  test('show "pin to top" if stream is not pinned to top', () => {
-    const subscriptions = new Map([
-      [eg.stream.stream_id, eg.makeSubscription({ pin_to_top: false })],
-    ]);
-    expect(titles({ ...eg.plusBackgroundData, subscriptions })).toContain('Pin to top');
-  });
-
-  test('show "unpin from top" if stream is pinned to top', () => {
-    const subscriptions = new Map([
-      [eg.stream.stream_id, eg.makeSubscription({ pin_to_top: true })],
-    ]);
-    expect(titles({ ...eg.plusBackgroundData, subscriptions })).toContain('Unpin from top');
+  test('show reactions option if message is has at least one reaction', () => {
+    const message = eg.streamMessage({ reactions: [eg.unicodeEmojiReaction] });
+    expect(titles(eg.plusBackgroundData, message)).toContain('See who reacted');
   });
 });

--- a/src/action-sheets/__tests__/action-sheet-test.js
+++ b/src/action-sheets/__tests__/action-sheet-test.js
@@ -19,12 +19,20 @@ describe('constructStreamActionButtons', () => {
   const titles = backgroundData =>
     buttonTitles(constructStreamActionButtons({ backgroundData, streamId }));
 
-  test('show "subscribe" option, if stream is not subscribed yet', () => {
-    expect(titles({ ...eg.plusBackgroundData, subscriptions: new Map() })).toContain('Subscribe');
+  // TODO: test constructStreamActionButtons for mute/unmute
+
+  test('show "pin to top" if stream is not pinned to top', () => {
+    const subscriptions = new Map([
+      [eg.stream.stream_id, eg.makeSubscription({ pin_to_top: false })],
+    ]);
+    expect(titles({ ...eg.plusBackgroundData, subscriptions })).toContain('Pin to top');
   });
 
-  test('show "unsubscribe" option, if stream is subscribed', () => {
-    expect(titles({ ...eg.plusBackgroundData })).toContain('Unsubscribe');
+  test('show "unpin from top" if stream is pinned to top', () => {
+    const subscriptions = new Map([
+      [eg.stream.stream_id, eg.makeSubscription({ pin_to_top: true })],
+    ]);
+    expect(titles({ ...eg.plusBackgroundData, subscriptions })).toContain('Unpin from top');
   });
 
   test('show "enable notification" if push notifications are not enabled for stream', () => {
@@ -41,19 +49,15 @@ describe('constructStreamActionButtons', () => {
     expect(titles({ ...eg.plusBackgroundData, subscriptions })).toContain('Disable notifications');
   });
 
-  test('show "pin to top" if stream is not pinned to top', () => {
-    const subscriptions = new Map([
-      [eg.stream.stream_id, eg.makeSubscription({ pin_to_top: false })],
-    ]);
-    expect(titles({ ...eg.plusBackgroundData, subscriptions })).toContain('Pin to top');
+  test('show "subscribe" option, if stream is not subscribed yet', () => {
+    expect(titles({ ...eg.plusBackgroundData, subscriptions: new Map() })).toContain('Subscribe');
   });
 
-  test('show "unpin from top" if stream is pinned to top', () => {
-    const subscriptions = new Map([
-      [eg.stream.stream_id, eg.makeSubscription({ pin_to_top: true })],
-    ]);
-    expect(titles({ ...eg.plusBackgroundData, subscriptions })).toContain('Unpin from top');
+  test('show "unsubscribe" option, if stream is subscribed', () => {
+    expect(titles({ ...eg.plusBackgroundData })).toContain('Unsubscribe');
   });
+
+  // TODO: test constructStreamActionButtons for showStreamSettings
 });
 
 describe('constructTopicActionButtons', () => {
@@ -63,6 +67,15 @@ describe('constructTopicActionButtons', () => {
 
   const titles = backgroundData =>
     buttonTitles(constructTopicActionButtons({ backgroundData, streamId, topic }));
+
+  test('show delete topic option if current user is an admin', () => {
+    const ownUser = { ...eg.selfUser, is_admin: true };
+    expect(titles({ ...eg.plusBackgroundData, ownUser })).toContain('Delete topic');
+  });
+
+  test('do not show delete topic option if current user is not an admin', () => {
+    expect(titles({ ...eg.plusBackgroundData })).not.toContain('Delete topic');
+  });
 
   test('show mark as read if topic is unread', () => {
     const unread = makeUnreadState(eg.plusReduxState, [streamMessage]);
@@ -96,21 +109,35 @@ describe('constructTopicActionButtons', () => {
     expect(titles({ ...eg.plusBackgroundData, subscriptions })).toContain('Mute stream');
   });
 
-  test('show delete topic option if current user is an admin', () => {
-    const ownUser = { ...eg.selfUser, is_admin: true };
-    expect(titles({ ...eg.plusBackgroundData, ownUser })).toContain('Delete topic');
-  });
-
-  test('do not show delete topic option if current user is not an admin', () => {
-    expect(titles({ ...eg.plusBackgroundData })).not.toContain('Delete topic');
-  });
+  // TODO: test constructStreamActionButtons for showStreamSettings
 });
+
+// TODO: test constructPmConversationActionButtons
 
 describe('constructMessageActionButtons', () => {
   const narrow = deepFreeze(HOME_NARROW);
 
   const titles = (backgroundData, message) =>
     buttonTitles(constructMessageActionButtons({ backgroundData, message, narrow }));
+
+  // TODO: test constructMessageActionButtons on Outbox
+
+  // TODO: test constructMessageActionButtons for addReaction
+
+  test('show reactions option if message is has at least one reaction', () => {
+    const message = eg.streamMessage({ reactions: [eg.unicodeEmojiReaction] });
+    expect(titles(eg.plusBackgroundData, message)).toContain('See who reacted');
+  });
+
+  // TODO: test constructMessageActionButtons for hide showReactions
+
+  // TODO: test constructMessageActionButtons for reply
+
+  // TODO: test constructMessageActionButtons for copy and share
+
+  // TODO: test constructMessageActionButtons for edit
+
+  // TODO: test constructMessageActionButtons for delete
 
   test('show star message option if message is not starred', () => {
     const message = eg.streamMessage();
@@ -122,10 +149,5 @@ describe('constructMessageActionButtons', () => {
     const message = eg.streamMessage();
     const flags = { ...eg.plusBackgroundData.flags, starred: { [message.id]: true } };
     expect(titles({ ...eg.plusBackgroundData, flags }, message)).toContain('Unstar message');
-  });
-
-  test('show reactions option if message is has at least one reaction', () => {
-    const message = eg.streamMessage({ reactions: [eg.unicodeEmojiReaction] });
-    expect(titles(eg.plusBackgroundData, message)).toContain('See who reacted');
   });
 });

--- a/src/action-sheets/__tests__/action-sheet-test.js
+++ b/src/action-sheets/__tests__/action-sheet-test.js
@@ -21,39 +21,39 @@ describe('constructStreamActionButtons', () => {
 
   // TODO: test constructStreamActionButtons for mute/unmute
 
-  test('show "pin to top" if stream is not pinned to top', () => {
+  test('show pinToTop', () => {
     const subscriptions = new Map([
       [eg.stream.stream_id, eg.makeSubscription({ pin_to_top: false })],
     ]);
     expect(titles({ ...eg.plusBackgroundData, subscriptions })).toContain('Pin to top');
   });
 
-  test('show "unpin from top" if stream is pinned to top', () => {
+  test('show unpinFromTop', () => {
     const subscriptions = new Map([
       [eg.stream.stream_id, eg.makeSubscription({ pin_to_top: true })],
     ]);
     expect(titles({ ...eg.plusBackgroundData, subscriptions })).toContain('Unpin from top');
   });
 
-  test('show "enable notification" if push notifications are not enabled for stream', () => {
+  test('show enableNotifications', () => {
     const subscriptions = new Map([
       [eg.stream.stream_id, eg.makeSubscription({ push_notifications: false })],
     ]);
     expect(titles({ ...eg.plusBackgroundData, subscriptions })).toContain('Enable notifications');
   });
 
-  test('show "disable notification" if push notifications are enabled for stream', () => {
+  test('show disableNotifications', () => {
     const subscriptions = new Map([
       [eg.stream.stream_id, eg.makeSubscription({ push_notifications: true })],
     ]);
     expect(titles({ ...eg.plusBackgroundData, subscriptions })).toContain('Disable notifications');
   });
 
-  test('show "subscribe" option, if stream is not subscribed yet', () => {
+  test('show subscribe', () => {
     expect(titles({ ...eg.plusBackgroundData, subscriptions: new Map() })).toContain('Subscribe');
   });
 
-  test('show "unsubscribe" option, if stream is subscribed', () => {
+  test('show unsubscribe', () => {
     expect(titles({ ...eg.plusBackgroundData })).toContain('Unsubscribe');
   });
 
@@ -68,41 +68,44 @@ describe('constructTopicActionButtons', () => {
   const titles = backgroundData =>
     buttonTitles(constructTopicActionButtons({ backgroundData, streamId, topic }));
 
-  test('show delete topic option if current user is an admin', () => {
+  test('show deleteTopic', () => {
     const ownUser = { ...eg.selfUser, is_admin: true };
     expect(titles({ ...eg.plusBackgroundData, ownUser })).toContain('Delete topic');
   });
 
-  test('do not show delete topic option if current user is not an admin', () => {
-    expect(titles({ ...eg.plusBackgroundData })).not.toContain('Delete topic');
+  test('hide deleteTopic', () => {
+    const ownUser = { ...eg.selfUser, is_admin: false };
+    expect(titles({ ...eg.plusBackgroundData, ownUser })).not.toContain('Delete topic');
   });
 
-  test('show mark as read if topic is unread', () => {
+  test('show markTopicAsRead', () => {
     const unread = makeUnreadState(eg.plusReduxState, [streamMessage]);
     expect(titles({ ...eg.plusBackgroundData, unread })).toContain('Mark topic as read');
   });
 
-  test('do not show mark as read if topic is read', () => {
-    expect(titles({ ...eg.plusBackgroundData })).not.toContain('Mark topic as read');
+  test('hide markTopicAsRead', () => {
+    const unread = makeUnreadState(eg.plusReduxState, []);
+    expect(titles({ ...eg.plusBackgroundData, unread })).not.toContain('Mark topic as read');
   });
 
-  test('show Unmute topic option if topic is muted', () => {
+  test('show unmuteTopic', () => {
     const mute = makeMuteState([[eg.stream, topic]]);
     expect(titles({ ...eg.plusBackgroundData, mute })).toContain('Unmute topic');
   });
 
-  test('show mute topic option if topic is not muted', () => {
-    expect(titles({ ...eg.plusBackgroundData, mute: makeMuteState([]) })).toContain('Mute topic');
+  test('show muteTopic', () => {
+    const mute = makeMuteState([]);
+    expect(titles({ ...eg.plusBackgroundData, mute })).toContain('Mute topic');
   });
 
-  test('show Unmute stream option if stream is not in home view', () => {
+  test('show unmuteStream', () => {
     const subscriptions = new Map([
       [eg.stream.stream_id, eg.makeSubscription({ in_home_view: false })],
     ]);
     expect(titles({ ...eg.plusBackgroundData, subscriptions })).toContain('Unmute stream');
   });
 
-  test('show mute stream option if stream is in home view', () => {
+  test('show muteStream', () => {
     const subscriptions = new Map([
       [eg.stream.stream_id, eg.makeSubscription({ in_home_view: true })],
     ]);
@@ -124,7 +127,7 @@ describe('constructMessageActionButtons', () => {
 
   // TODO: test constructMessageActionButtons for addReaction
 
-  test('show reactions option if message is has at least one reaction', () => {
+  test('show showReactions', () => {
     const message = eg.streamMessage({ reactions: [eg.unicodeEmojiReaction] });
     expect(titles(eg.plusBackgroundData, message)).toContain('See who reacted');
   });
@@ -139,13 +142,13 @@ describe('constructMessageActionButtons', () => {
 
   // TODO: test constructMessageActionButtons for delete
 
-  test('show star message option if message is not starred', () => {
+  test('show starMessage', () => {
     const message = eg.streamMessage();
     const flags = { ...eg.plusBackgroundData.flags, starred: {} };
     expect(titles({ ...eg.plusBackgroundData, flags }, message)).toContain('Star message');
   });
 
-  test('show unstar message option if message is starred', () => {
+  test('show unstarMessage', () => {
     const message = eg.streamMessage();
     const flags = { ...eg.plusBackgroundData.flags, starred: { [message.id]: true } };
     expect(titles({ ...eg.plusBackgroundData, flags }, message)).toContain('Unstar message');

--- a/src/action-sheets/__tests__/action-sheet-test.js
+++ b/src/action-sheets/__tests__/action-sheet-test.js
@@ -13,7 +13,7 @@ import { makeMuteState } from '../../mute/__tests__/mute-testlib';
 
 const buttonTitles = buttons => buttons.map(button => button.title);
 
-describe('constructActionButtons', () => {
+describe('constructMessageActionButtons', () => {
   const narrow = deepFreeze(HOME_NARROW);
 
   test('show star message option if message is not starred', () => {
@@ -117,6 +117,32 @@ describe('constructTopicActionButtons', () => {
     expect(buttonTitles(buttons)).toContain('Mute stream');
   });
 
+  test('show delete topic option if current user is an admin', () => {
+    const ownUser = { ...eg.selfUser, is_admin: true };
+    const buttons = constructTopicActionButtons({
+      backgroundData: { ...eg.baseBackgroundData, ownUser, streams },
+      streamId,
+      topic,
+    });
+    expect(buttonTitles(buttons)).toContain('Delete topic');
+  });
+
+  test('do not show delete topic option if current user is not an admin', () => {
+    const buttons = constructTopicActionButtons({
+      backgroundData: { ...eg.baseBackgroundData, streams },
+      streamId,
+      topic,
+    });
+    expect(buttonTitles(buttons)).not.toContain('Delete topic');
+  });
+});
+
+describe('constructStreamActionButtons', () => {
+  const stream = eg.makeStream();
+  const streamMessage = eg.streamMessage({ stream });
+  const streamId = streamMessage.stream_id;
+  const streams = deepFreeze(new Map([[stream.stream_id, stream]]));
+
   test('show "subscribe" option, if stream is not subscribed yet', () => {
     const buttons = constructStreamActionButtons({
       backgroundData: { ...eg.baseBackgroundData, streams },
@@ -176,24 +202,5 @@ describe('constructTopicActionButtons', () => {
       streamId,
     });
     expect(buttonTitles(buttons)).toContain('Unpin from top');
-  });
-
-  test('show delete topic option if current user is an admin', () => {
-    const ownUser = { ...eg.selfUser, is_admin: true };
-    const buttons = constructTopicActionButtons({
-      backgroundData: { ...eg.baseBackgroundData, ownUser, streams },
-      streamId,
-      topic,
-    });
-    expect(buttonTitles(buttons)).toContain('Delete topic');
-  });
-
-  test('do not show delete topic option if current user is not an admin', () => {
-    const buttons = constructTopicActionButtons({
-      backgroundData: { ...eg.baseBackgroundData, streams },
-      streamId,
-      topic,
-    });
-    expect(buttonTitles(buttons)).not.toContain('Delete topic');
   });
 });

--- a/src/action-sheets/index.js
+++ b/src/action-sheets/index.js
@@ -189,33 +189,19 @@ const muteTopic = {
 const deleteTopic = {
   title: 'Delete topic',
   errorMessage: 'Failed to delete topic',
-  action: async ({ auth, streamId, topic, dispatch, _ }) => {
-    const alertTitle = _('Are you sure you want to delete the topic “{topic}”?', { topic });
-    const AsyncAlert = async (): Promise<boolean> =>
-      new Promise((resolve, reject) => {
-        Alert.alert(
-          alertTitle,
-          _('This will also delete all messages in the topic.'),
-          [
-            {
-              text: _('Delete topic'),
-              onPress: () => {
-                resolve(true);
-              },
-              style: 'destructive',
-            },
-            {
-              text: _('Cancel'),
-              onPress: () => {
-                resolve(false);
-              },
-              style: 'cancel',
-            },
-          ],
-          { cancelable: true },
-        );
-      });
-    if (await AsyncAlert()) {
+  action: async ({ streamId, topic, dispatch, _ }) => {
+    const confirmed = await new Promise((resolve, reject) => {
+      Alert.alert(
+        _('Are you sure you want to delete the topic “{topic}”?', { topic }),
+        _('This will also delete all messages in the topic.'),
+        [
+          { text: _('Delete topic'), onPress: () => resolve(true), style: 'destructive' },
+          { text: _('Cancel'), onPress: () => resolve(false), style: 'cancel' },
+        ],
+        { cancelable: true },
+      );
+    });
+    if (confirmed) {
       await dispatch(deleteMessagesForTopic(streamId, topic));
     }
   },

--- a/src/action-sheets/index.js
+++ b/src/action-sheets/index.js
@@ -440,27 +440,26 @@ export const constructPmConversationActionButtons = (args: {|
   return buttons;
 };
 
-export const constructOutboxActionButtons = (): Button<MessageArgs>[] => {
-  const buttons = [];
-  buttons.push(copyToClipboard);
-  buttons.push(shareMessage);
-  buttons.push(deleteMessage);
-  buttons.push(cancel);
-  return buttons;
-};
-
 const messageNotDeleted = (message: Message | Outbox): boolean =>
   message.content !== '<p>(deleted)</p>';
 
 export const constructMessageActionButtons = (args: {|
   backgroundData: $ReadOnly<{ ownUser: User, flags: FlagsState, ... }>,
-  message: Message,
+  message: Message | Outbox,
   narrow: Narrow,
 |}): Button<MessageArgs>[] => {
   const { backgroundData, message, narrow } = args;
   const { ownUser, flags } = backgroundData;
-
   const buttons = [];
+
+  if (message.isOutbox) {
+    buttons.push(copyToClipboard);
+    buttons.push(shareMessage);
+    buttons.push(deleteMessage);
+    buttons.push(cancel);
+    return buttons;
+  }
+
   if (messageNotDeleted(message)) {
     buttons.push(addReaction);
   }
@@ -495,19 +494,6 @@ export const constructMessageActionButtons = (args: {|
   return buttons;
 };
 
-export const constructNonHeaderActionButtons = (args: {|
-  backgroundData: $ReadOnly<{ ownUser: User, flags: FlagsState, ... }>,
-  message: Message | Outbox,
-  narrow: Narrow,
-|}): Button<MessageArgs>[] => {
-  const { backgroundData, message, narrow } = args;
-  if (message.isOutbox) {
-    return constructOutboxActionButtons();
-  } else {
-    return constructMessageActionButtons({ backgroundData, message, narrow });
-  }
-};
-
 //
 //
 // Actually showing an action sheet.
@@ -538,7 +524,7 @@ export const showMessageActionSheet = (args: {|
   narrow: Narrow,
 |}): void => {
   const { showActionSheetWithOptions, callbacks, backgroundData, message, narrow } = args;
-  const buttonList = constructNonHeaderActionButtons({ backgroundData, message, narrow });
+  const buttonList = constructMessageActionButtons({ backgroundData, message, narrow });
   showActionSheetWithOptions(
     {
       options: buttonList.map(button => callbacks._(button.title)),

--- a/src/action-sheets/index.js
+++ b/src/action-sheets/index.js
@@ -102,7 +102,8 @@ type Button<Args: StreamArgs | TopicArgs | PmArgs | MessageArgs> = {|
 |};
 
 //
-// Options for the action sheet go below: ...
+//
+// The options for the action sheets.
 //
 
 const reply = ({ message, dispatch, ownUser }) => {
@@ -306,6 +307,13 @@ const cancel = params => {};
 cancel.title = 'Cancel';
 cancel.errorMessage = 'Failed to hide menu';
 
+//
+//
+// Assembling the list of options for an action sheet.
+//
+// These are separate from their callers mainly for the sake of unit tests.
+//
+
 export const constructStreamActionButtons = ({
   backgroundData: { ownUser, subscriptions, userSettingStreamNotification },
   streamId,
@@ -483,6 +491,11 @@ export const constructNonHeaderActionButtons = ({
     return constructMessageActionButtons({ backgroundData, message, narrow });
   }
 };
+
+//
+//
+// Actually showing an action sheet.
+//
 
 function makeButtonCallback<Args: StreamArgs | TopicArgs | PmArgs | MessageArgs>(
   buttonList: Button<Args>[],

--- a/src/action-sheets/index.js
+++ b/src/action-sheets/index.js
@@ -348,20 +348,18 @@ const cancel: Button<{ ... }> = {
 // These are separate from their callers mainly for the sake of unit tests.
 //
 
-export const constructStreamActionButtons = ({
-  backgroundData: { ownUser, subscriptions, userSettingStreamNotification },
-  streamId,
-}: {|
+export const constructStreamActionButtons = (args: {|
   backgroundData: $ReadOnly<{
-    ownUser: User,
     subscriptions: Map<number, Subscription>,
     userSettingStreamNotification: boolean,
     ...
   }>,
   streamId: number,
 |}): Button<StreamArgs>[] => {
-  const buttons = [];
+  const { backgroundData, streamId } = args;
+  const { subscriptions, userSettingStreamNotification } = backgroundData;
 
+  const buttons = [];
   const sub = subscriptions.get(streamId);
   if (sub) {
     if (!sub.in_home_view) {
@@ -389,21 +387,20 @@ export const constructStreamActionButtons = ({
   return buttons;
 };
 
-export const constructTopicActionButtons = ({
-  backgroundData: { mute, ownUser, subscriptions, unread },
-  streamId,
-  topic,
-}: {|
+export const constructTopicActionButtons = (args: {|
   backgroundData: $ReadOnly<{
     mute: MuteState,
+    ownUser: User,
     subscriptions: Map<number, Subscription>,
     unread: UnreadState,
-    ownUser: User,
     ...
   }>,
   streamId: number,
   topic: string,
 |}): Button<TopicArgs>[] => {
+  const { backgroundData, streamId, topic } = args;
+  const { mute, ownUser, subscriptions, unread } = backgroundData;
+
   const buttons = [];
   if (ownUser.is_admin) {
     buttons.push(deleteTopic);
@@ -428,10 +425,7 @@ export const constructTopicActionButtons = ({
   return buttons;
 };
 
-export const constructPmConversationActionButtons = ({
-  backgroundData,
-  pmKeyRecipients,
-}: {|
+export const constructPmConversationActionButtons = (args: {|
   backgroundData: $ReadOnly<{ ownUser: User, ... }>,
   pmKeyRecipients: PmKeyRecipients,
 |}): Button<PmArgs>[] => {
@@ -458,19 +452,14 @@ export const constructOutboxActionButtons = (): Button<MessageArgs>[] => {
 const messageNotDeleted = (message: Message | Outbox): boolean =>
   message.content !== '<p>(deleted)</p>';
 
-export const constructMessageActionButtons = ({
-  backgroundData: { ownUser, flags },
-  message,
-  narrow,
-}: {|
-  backgroundData: $ReadOnly<{
-    ownUser: User,
-    flags: FlagsState,
-    ...
-  }>,
+export const constructMessageActionButtons = (args: {|
+  backgroundData: $ReadOnly<{ ownUser: User, flags: FlagsState, ... }>,
   message: Message,
   narrow: Narrow,
 |}): Button<MessageArgs>[] => {
+  const { backgroundData, message, narrow } = args;
+  const { ownUser, flags } = backgroundData;
+
   const buttons = [];
   if (messageNotDeleted(message)) {
     buttons.push(addReaction);
@@ -506,19 +495,12 @@ export const constructMessageActionButtons = ({
   return buttons;
 };
 
-export const constructNonHeaderActionButtons = ({
-  backgroundData,
-  message,
-  narrow,
-}: {|
-  backgroundData: $ReadOnly<{
-    ownUser: User,
-    flags: FlagsState,
-    ...
-  }>,
+export const constructNonHeaderActionButtons = (args: {|
+  backgroundData: $ReadOnly<{ ownUser: User, flags: FlagsState, ... }>,
   message: Message | Outbox,
   narrow: Narrow,
 |}): Button<MessageArgs>[] => {
+  const { backgroundData, message, narrow } = args;
   if (message.isOutbox) {
     return constructOutboxActionButtons();
   } else {
@@ -544,28 +526,18 @@ function makeButtonCallback<Args: { _: GetText, ... }>(buttonList: Button<Args>[
   };
 }
 
-export const showMessageActionSheet = ({
-  showActionSheetWithOptions,
-  callbacks,
-  backgroundData,
-  message,
-  narrow,
-}: {|
+export const showMessageActionSheet = (args: {|
   showActionSheetWithOptions: ShowActionSheetWithOptions,
   callbacks: {|
     dispatch: Dispatch,
     startEditMessage: (editMessage: EditMessage) => void,
     _: GetText,
   |},
-  backgroundData: $ReadOnly<{
-    auth: Auth,
-    ownUser: User,
-    flags: FlagsState,
-    ...
-  }>,
+  backgroundData: $ReadOnly<{ auth: Auth, ownUser: User, flags: FlagsState, ... }>,
   message: Message | Outbox,
   narrow: Narrow,
 |}): void => {
+  const { showActionSheetWithOptions, callbacks, backgroundData, message, narrow } = args;
   const buttonList = constructNonHeaderActionButtons({ backgroundData, message, narrow });
   showActionSheetWithOptions(
     {
@@ -581,13 +553,7 @@ export const showMessageActionSheet = ({
   );
 };
 
-export const showTopicActionSheet = ({
-  showActionSheetWithOptions,
-  callbacks,
-  backgroundData,
-  topic,
-  streamId,
-}: {|
+export const showTopicActionSheet = (args: {|
   showActionSheetWithOptions: ShowActionSheetWithOptions,
   callbacks: {|
     dispatch: Dispatch,
@@ -605,6 +571,7 @@ export const showTopicActionSheet = ({
   streamId: number,
   topic: string,
 |}): void => {
+  const { showActionSheetWithOptions, callbacks, backgroundData, topic, streamId } = args;
   const buttonList = constructTopicActionButtons({
     backgroundData,
     streamId,
@@ -627,12 +594,7 @@ export const showTopicActionSheet = ({
   );
 };
 
-export const showStreamActionSheet = ({
-  showActionSheetWithOptions,
-  callbacks,
-  backgroundData,
-  streamId,
-}: {|
+export const showStreamActionSheet = (args: {|
   showActionSheetWithOptions: ShowActionSheetWithOptions,
   callbacks: {|
     dispatch: Dispatch,
@@ -640,7 +602,6 @@ export const showStreamActionSheet = ({
   |},
   backgroundData: $ReadOnly<{
     auth: Auth,
-    ownUser: User,
     streams: Map<number, Stream>,
     subscriptions: Map<number, Subscription>,
     userSettingStreamNotification: boolean,
@@ -648,6 +609,7 @@ export const showStreamActionSheet = ({
   }>,
   streamId: number,
 |}): void => {
+  const { showActionSheetWithOptions, callbacks, backgroundData, streamId } = args;
   const buttonList = constructStreamActionButtons({
     backgroundData,
     streamId,
@@ -668,23 +630,15 @@ export const showStreamActionSheet = ({
   );
 };
 
-export const showPmConversationActionSheet = ({
-  showActionSheetWithOptions,
-  callbacks,
-  backgroundData,
-  pmKeyRecipients,
-}: {|
+export const showPmConversationActionSheet = (args: {|
   showActionSheetWithOptions: ShowActionSheetWithOptions,
   callbacks: {|
     _: GetText,
   |},
-  backgroundData: $ReadOnly<{
-    ownUser: User,
-    allUsersById: Map<UserId, UserOrBot>,
-    ...
-  }>,
+  backgroundData: $ReadOnly<{ ownUser: User, allUsersById: Map<UserId, UserOrBot>, ... }>,
   pmKeyRecipients: PmKeyRecipients,
 |}): void => {
+  const { showActionSheetWithOptions, callbacks, backgroundData, pmKeyRecipients } = args;
   const buttonList = constructPmConversationActionButtons({ backgroundData, pmKeyRecipients });
 
   showActionSheetWithOptions(

--- a/src/action-sheets/index.js
+++ b/src/action-sheets/index.js
@@ -545,10 +545,7 @@ export const constructNonHeaderActionButtons = ({
 // Actually showing an action sheet.
 //
 
-function makeButtonCallback<Args: StreamArgs | TopicArgs | PmArgs | MessageArgs>(
-  buttonList: Button<Args>[],
-  args: Args,
-) {
+function makeButtonCallback<Args: { _: GetText, ... }>(buttonList: Button<Args>[], args: Args) {
   return buttonIndex => {
     (async () => {
       const pressedButton: Button<Args> = buttonList[buttonIndex];

--- a/src/action-sheets/index.js
+++ b/src/action-sheets/index.js
@@ -312,8 +312,8 @@ const unstarMessage = {
 const shareMessage = {
   title: 'Share',
   errorMessage: 'Failed to share message',
-  action: ({ message }) => {
-    Share.share({
+  action: async ({ message }) => {
+    await Share.share({
       message: message.content.replace(/<(?:.|\n)*?>/gm, ''),
     });
   },

--- a/src/action-sheets/index.js
+++ b/src/action-sheets/index.js
@@ -129,7 +129,7 @@ const copyToClipboard = {
 const editMessage = {
   title: 'Edit message',
   errorMessage: 'Failed to edit message',
-  action: async ({ message, dispatch, startEditMessage, auth }) => {
+  action: async ({ message, startEditMessage, auth }) => {
     if (message.isOutbox) {
       logging.warn('Attempted "Edit message" for outbox message');
       return;
@@ -210,7 +210,7 @@ const deleteTopic = {
 const unmuteStream = {
   title: 'Unmute stream',
   errorMessage: 'Failed to unmute stream',
-  action: async ({ auth, streamId, subscriptions }) => {
+  action: async ({ auth, streamId }) => {
     await api.setSubscriptionProperty(auth, streamId, 'is_muted', false);
   },
 };
@@ -218,7 +218,7 @@ const unmuteStream = {
 const muteStream = {
   title: 'Mute stream',
   errorMessage: 'Failed to mute stream',
-  action: async ({ auth, streamId, subscriptions }) => {
+  action: async ({ auth, streamId }) => {
     await api.setSubscriptionProperty(auth, streamId, 'is_muted', true);
   },
 };
@@ -226,7 +226,7 @@ const muteStream = {
 const showStreamSettings = {
   title: 'Stream settings',
   errorMessage: 'Failed to show stream settings',
-  action: ({ streamId, subscriptions }) => {
+  action: ({ streamId }) => {
     NavigationService.dispatch(navigateToStream(streamId));
   },
 };
@@ -322,7 +322,7 @@ const shareMessage = {
 const addReaction = {
   title: 'Add a reaction',
   errorMessage: 'Failed to add reaction',
-  action: ({ message, dispatch }) => {
+  action: ({ message }) => {
     NavigationService.dispatch(navigateToEmojiPicker(message.id));
   },
 };
@@ -330,7 +330,7 @@ const addReaction = {
 const showReactions = {
   title: 'See who reacted',
   errorMessage: 'Failed to show reactions',
-  action: ({ message, dispatch }) => {
+  action: ({ message }) => {
     NavigationService.dispatch(navigateToMessageReactionScreen(message.id));
   },
 };
@@ -338,7 +338,7 @@ const showReactions = {
 const cancel: Button<{ ... }> = {
   title: 'Cancel',
   errorMessage: 'Failed to hide menu',
-  action: params => {},
+  action: () => {},
 };
 
 //

--- a/src/topics/__tests__/topicsSelectors-test.js
+++ b/src/topics/__tests__/topicsSelectors-test.js
@@ -1,9 +1,9 @@
 /* @flow strict-local */
 import { getTopicsForNarrow, getTopicsForStream } from '../topicSelectors';
 import { HOME_NARROW, streamNarrow } from '../../utils/narrow';
-import { reducer as unreadReducer } from '../../unread/unreadModel';
 import * as eg from '../../__tests__/lib/exampleData';
 import { makeMuteState } from '../../mute/__tests__/mute-testlib';
+import { makeUnreadState } from '../../unread/__tests__/unread-testlib';
 
 describe('getTopicsForNarrow', () => {
   test('when no topics return an empty list', () => {
@@ -67,16 +67,13 @@ describe('getTopicsForStream', () => {
         [eg.stream, 'topic 3'],
         [eg.otherStream, 'topic 2'],
       ]),
-      unread: [
+      unread: makeUnreadState(eg.plusReduxState, [
         eg.streamMessage({ stream: eg.stream, subject: 'topic 2', id: 1 }),
         eg.streamMessage({ stream: eg.stream, subject: 'topic 2', id: 5 }),
         eg.streamMessage({ stream: eg.stream, subject: 'topic 2', id: 6 }),
         eg.streamMessage({ stream: eg.stream, subject: 'topic 4', id: 7 }),
         eg.streamMessage({ stream: eg.stream, subject: 'topic 4', id: 8 }),
-      ].reduce(
-        (st, message) => unreadReducer(st, eg.mkActionEventNewMessage(message), eg.plusReduxState),
-        eg.plusReduxState.unread,
-      ),
+      ]),
     });
     const expected = [
       { name: 'topic 1', max_id: 5, isMuted: true, unreadCount: 0 },

--- a/src/unread/__tests__/unread-testlib.js
+++ b/src/unread/__tests__/unread-testlib.js
@@ -2,7 +2,8 @@
 
 import { reducer } from '../unreadModel';
 import type { UnreadState } from '../unreadModelTypes';
-import type { Stream } from '../../api/apiTypes';
+import type { Message, Stream } from '../../api/apiTypes';
+import type { PerAccountState } from '../../reduxTypes';
 import * as eg from '../../__tests__/lib/exampleData';
 
 export const initialState: UnreadState = reducer(
@@ -18,6 +19,15 @@ const [user0, user1, user2, user3, user4, user5] = [0, 1, 2, 3, 4, 5].map(user_i
   eg.makeUser({ user_id }),
 );
 
+export const makeUnreadState = (
+  globalState: PerAccountState,
+  messages: $ReadOnlyArray<Message>,
+): UnreadState =>
+  messages.reduce(
+    (state, message) => reducer(state, eg.mkActionEventNewMessage(message), globalState),
+    initialState,
+  );
+
 export const selectorBaseState: UnreadState = (() => {
   // We take user1 to be self.
   // It might be convenient to convert this to the standard eg.selfUser,
@@ -29,8 +39,7 @@ export const selectorBaseState: UnreadState = (() => {
     streams: [stream0, stream2],
   });
 
-  let state = initialState;
-  for (const message of [
+  return makeUnreadState(globalState, [
     eg.streamMessage({ stream_id: 0, subject: 'a topic', id: 1, flags: ['mentioned'] }),
     eg.streamMessage({ stream_id: 0, subject: 'a topic', id: 2, flags: ['mentioned'] }),
     eg.streamMessage({ stream_id: 0, subject: 'a topic', id: 3, flags: ['mentioned'] }),
@@ -48,8 +57,5 @@ export const selectorBaseState: UnreadState = (() => {
     eg.pmMessageFromTo(user4, [user1, user5], { id: 23 }),
     eg.pmMessageFromTo(user4, [user1, user5], { id: 24 }),
     eg.pmMessageFromTo(user4, [user1, user5], { id: 25 }),
-  ]) {
-    state = reducer(state, eg.mkActionEventNewMessage(message), globalState);
-  }
-  return state;
+  ]);
 })();

--- a/src/unread/__tests__/unreadModel-test.js
+++ b/src/unread/__tests__/unreadModel-test.js
@@ -5,7 +5,7 @@ import { ACCOUNT_SWITCH, EVENT_UPDATE_MESSAGE_FLAGS } from '../../actionConstant
 import { reducer } from '../unreadModel';
 import { type UnreadState } from '../unreadModelTypes';
 import * as eg from '../../__tests__/lib/exampleData';
-import { initialState } from './unread-testlib';
+import { initialState, makeUnreadState } from './unread-testlib';
 
 // These are the tests corresponding to unreadStreamsReducer-test.js.
 // Ultimately we'll want to flip this way of organizing the tests, and
@@ -20,11 +20,7 @@ describe('stream substate', () => {
 
   describe('ACCOUNT_SWITCH', () => {
     test('resets state to initial state', () => {
-      const state = reducer(
-        initialState,
-        eg.mkActionEventNewMessage(eg.streamMessage()),
-        eg.plusReduxState,
-      );
+      const state = makeUnreadState(eg.plusReduxState, [eg.streamMessage()]);
       expect(state).not.toEqual(initialState);
 
       const action = { type: ACCOUNT_SWITCH, index: 1 };
@@ -70,19 +66,15 @@ describe('stream substate', () => {
       });
     };
 
-    const baseState = (() => {
-      const streamAction = args => eg.mkActionEventNewMessage(eg.streamMessage(args));
-      const r = (state, action) => reducer(state, action, eg.plusReduxState);
-      let state = initialState;
-      state = r(state, streamAction({ stream_id: 123, subject: 'foo', id: 1 }));
-      state = r(state, streamAction({ stream_id: 123, subject: 'foo', id: 2 }));
-      state = r(state, streamAction({ stream_id: 123, subject: 'foo', id: 3 }));
-      state = r(state, streamAction({ stream_id: 123, subject: 'foo', id: 4 }));
-      state = r(state, streamAction({ stream_id: 456, subject: 'zzz', id: 6 }));
-      state = r(state, streamAction({ stream_id: 456, subject: 'zzz', id: 7 }));
-      state = r(state, streamAction({ stream_id: 123, subject: 'foo', id: 15 }));
-      return state;
-    })();
+    const baseState = makeUnreadState(eg.plusReduxState, [
+      eg.streamMessage({ stream_id: 123, subject: 'foo', id: 1 }),
+      eg.streamMessage({ stream_id: 123, subject: 'foo', id: 2 }),
+      eg.streamMessage({ stream_id: 123, subject: 'foo', id: 3 }),
+      eg.streamMessage({ stream_id: 123, subject: 'foo', id: 4 }),
+      eg.streamMessage({ stream_id: 456, subject: 'zzz', id: 6 }),
+      eg.streamMessage({ stream_id: 456, subject: 'zzz', id: 7 }),
+      eg.streamMessage({ stream_id: 123, subject: 'foo', id: 15 }),
+    ]);
 
     test('(base state, for comparison)', () => {
       // prettier-ignore
@@ -159,15 +151,9 @@ describe('stream substate', () => {
   describe('EVENT_NEW_MESSAGE', () => {
     const action = eg.mkActionEventNewMessage;
 
-    const baseState = (() => {
-      let state = initialState;
-      state = reducer(
-        state,
-        action(eg.streamMessage({ id: 1, subject: 'some topic' })),
-        eg.plusReduxState,
-      );
-      return state;
-    })();
+    const baseState = makeUnreadState(eg.plusReduxState, [
+      eg.streamMessage({ id: 1, subject: 'some topic' }),
+    ]);
 
     test('(base state, for comparison)', () => {
       // prettier-ignore
@@ -245,16 +231,13 @@ describe('stream substate', () => {
 
     const streamAction = args => eg.mkActionEventNewMessage(eg.streamMessage(args));
 
-    const baseState = (() => {
-      const r = (state, action) => reducer(state, action, eg.plusReduxState);
-      let state = initialState;
-      state = r(state, streamAction({ stream_id: 123, subject: 'foo', id: 1 }));
-      state = r(state, streamAction({ stream_id: 123, subject: 'foo', id: 2 }));
-      state = r(state, streamAction({ stream_id: 123, subject: 'foo', id: 3 }));
-      state = r(state, streamAction({ stream_id: 234, subject: 'bar', id: 4 }));
-      state = r(state, streamAction({ stream_id: 234, subject: 'bar', id: 5 }));
-      return state;
-    })();
+    const baseState = makeUnreadState(eg.plusReduxState, [
+      eg.streamMessage({ stream_id: 123, subject: 'foo', id: 1 }),
+      eg.streamMessage({ stream_id: 123, subject: 'foo', id: 2 }),
+      eg.streamMessage({ stream_id: 123, subject: 'foo', id: 3 }),
+      eg.streamMessage({ stream_id: 234, subject: 'bar', id: 4 }),
+      eg.streamMessage({ stream_id: 234, subject: 'bar', id: 5 }),
+    ]);
 
     test('(base state, for comparison)', () => {
       // prettier-ignore

--- a/src/unread/__tests__/unreadSelectors-test.js
+++ b/src/unread/__tests__/unreadSelectors-test.js
@@ -1,6 +1,5 @@
 /* @flow strict-local */
 
-import { reducer } from '../unreadModel';
 import {
   getUnreadByStream,
   getUnreadStreamTotal,
@@ -15,7 +14,13 @@ import {
 } from '../unreadSelectors';
 
 import * as eg from '../../__tests__/lib/exampleData';
-import { initialState, selectorBaseState as unreadState, stream0, stream2 } from './unread-testlib';
+import {
+  initialState,
+  makeUnreadState,
+  selectorBaseState as unreadState,
+  stream0,
+  stream2,
+} from './unread-testlib';
 import { makeMuteState } from '../../mute/__tests__/mute-testlib';
 
 const subscription0 = eg.makeSubscription({ stream: stream0, color: 'red' });
@@ -382,7 +387,7 @@ describe('getUnreadStreamsAndTopics', () => {
         eg.makeSubscription({ stream: stream1, color: 'blue', pin_to_top: true }),
         { ...subscription0, name: 'abc stream' },
       ],
-      unread: [
+      unread: makeUnreadState(eg.plusReduxState, [
         eg.streamMessage({ stream_id: 0, subject: 'z topic', id: 1 }),
         eg.streamMessage({ stream_id: 0, subject: 'z topic', id: 2 }),
         eg.streamMessage({ stream_id: 0, subject: 'z topic', id: 3 }),
@@ -394,10 +399,7 @@ describe('getUnreadStreamsAndTopics', () => {
         eg.streamMessage({ stream_id: 2, subject: 'c topic', id: 8 }),
         eg.streamMessage({ stream_id: 1, subject: 'e topic', id: 10 }),
         eg.streamMessage({ stream_id: 1, subject: 'd topic', id: 9 }),
-      ].reduce(
-        (st, message) => reducer(st, eg.mkActionEventNewMessage(message), eg.plusReduxState),
-        eg.plusReduxState.unread,
-      ),
+      ]),
       // TODO yuck at constructing this modified stream as a throwaway, with magic string
       mute: makeMuteState([[{ ...stream2, name: 'def stream' }, 'c topic']]),
     });

--- a/src/webview/MessageList.js
+++ b/src/webview/MessageList.js
@@ -83,7 +83,6 @@ export type BackgroundData = $ReadOnly<{|
   allImageEmojiById: $ReadOnly<{| [id: string]: ImageEmojiType |}>,
   auth: Auth,
   debug: Debug,
-  doNotMarkMessagesAsRead: boolean,
   flags: FlagsState,
   mute: MuteState,
   allUsersById: Map<UserId, UserOrBot>,
@@ -115,6 +114,7 @@ type SelectorProps = {|
   fetching: Fetching,
   messageListElementsForShownMessages: $ReadOnlyArray<MessageListElement>,
   typingUsers: $ReadOnlyArray<UserOrBot>,
+  doNotMarkMessagesAsRead: boolean,
 |};
 
 export type Props = $ReadOnly<{|
@@ -210,6 +210,7 @@ class MessageListInner extends Component<Props> {
       messageListElementsForShownMessages,
       initialScrollMessageId,
       showMessagePlaceholders,
+      doNotMarkMessagesAsRead,
       _,
     } = this.props;
     const contentHtml = messageListElementsForShownMessages
@@ -221,7 +222,7 @@ class MessageListInner extends Component<Props> {
         }),
       )
       .join('');
-    const { auth, theme, doNotMarkMessagesAsRead } = backgroundData;
+    const { auth, theme } = backgroundData;
     const html: string = getHtml(contentHtml, theme, {
       scrollMessageId: initialScrollMessageId,
       auth,
@@ -355,8 +356,6 @@ const MessageList: ComponentType<OuterProps> = connect<SelectorProps, _, _>(
       allImageEmojiById: getAllImageEmojiById(state),
       auth: getAuth(state),
       debug,
-      doNotMarkMessagesAsRead:
-        !marksMessagesAsRead(props.narrow) || globalSettings.doNotMarkMessagesAsRead,
       flags: getFlags(state),
       mute: getMute(state),
       allUsersById: getAllUsersById(state),
@@ -378,6 +377,8 @@ const MessageList: ComponentType<OuterProps> = connect<SelectorProps, _, _>(
         props.narrow,
       ),
       typingUsers: getCurrentTypingUsers(state, props.narrow),
+      doNotMarkMessagesAsRead:
+        !marksMessagesAsRead(props.narrow) || globalSettings.doNotMarkMessagesAsRead,
     };
   },
 )(connectActionSheet(withGetText(MessageListInner)));

--- a/src/webview/__tests__/__snapshots__/generateInboundEventEditSequence-test.js.snap.android
+++ b/src/webview/__tests__/__snapshots__/generateInboundEventEditSequence-test.js.snap.android
@@ -1946,7 +1946,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible other 
     <p>This is an example stream message.</p>
 
 
-<div class=\\"reaction-list\\"><span onclick=\\"\\" class=\\"reaction\\" data-name=\\"github_parrot\\" data-code=\\"80\\" data-type=\\"realm_emoji\\">&nbsp;2</span><span onclick=\\"\\" class=\\"reaction\\" data-name=\\"thumbs_up\\" data-code=\\"1f44d\\" data-type=\\"unicode_emoji\\">👍&nbsp;1</span><span onclick=\\"\\" class=\\"reaction\\" data-name=\\"zulip\\" data-code=\\"zulip\\" data-type=\\"zulip_extra_emoji\\">&nbsp;1</span></div>
+<div class=\\"reaction-list\\"><span onclick=\\"\\" class=\\"reaction\\" data-name=\\"github_parrot\\" data-code=\\"80\\" data-type=\\"realm_emoji\\">&nbsp;2</span><span onclick=\\"\\" class=\\"reaction\\" data-name=\\"thumbs_up\\" data-code=\\"1f44d\\" data-type=\\"unicode_emoji\\">👍&nbsp;1</span><span onclick=\\"\\" class=\\"reaction\\" data-name=\\"zulip\\" data-code=\\"zulip\\" data-type=\\"zulip_extra_emoji\\"><img src=\\"https://zulip.example.org/static/generated/emoji/images/emoji/unicode/zulip.png\\">&nbsp;1</span></div>
   </div>
   
 </div>"

--- a/src/webview/__tests__/__snapshots__/generateInboundEventEditSequence-test.js.snap.ios
+++ b/src/webview/__tests__/__snapshots__/generateInboundEventEditSequence-test.js.snap.ios
@@ -1946,7 +1946,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible other 
     <p>This is an example stream message.</p>
 
 
-<div class=\\"reaction-list\\"><span onclick=\\"\\" class=\\"reaction\\" data-name=\\"github_parrot\\" data-code=\\"80\\" data-type=\\"realm_emoji\\">&nbsp;2</span><span onclick=\\"\\" class=\\"reaction\\" data-name=\\"thumbs_up\\" data-code=\\"1f44d\\" data-type=\\"unicode_emoji\\">👍&nbsp;1</span><span onclick=\\"\\" class=\\"reaction\\" data-name=\\"zulip\\" data-code=\\"zulip\\" data-type=\\"zulip_extra_emoji\\">&nbsp;1</span></div>
+<div class=\\"reaction-list\\"><span onclick=\\"\\" class=\\"reaction\\" data-name=\\"github_parrot\\" data-code=\\"80\\" data-type=\\"realm_emoji\\">&nbsp;2</span><span onclick=\\"\\" class=\\"reaction\\" data-name=\\"thumbs_up\\" data-code=\\"1f44d\\" data-type=\\"unicode_emoji\\">👍&nbsp;1</span><span onclick=\\"\\" class=\\"reaction\\" data-name=\\"zulip\\" data-code=\\"zulip\\" data-type=\\"zulip_extra_emoji\\"><img src=\\"https://zulip.example.org/static/generated/emoji/images/emoji/unicode/zulip.png\\">&nbsp;1</span></div>
   </div>
   
 </div>"

--- a/src/webview/__tests__/generateInboundEventEditSequence-test.js
+++ b/src/webview/__tests__/generateInboundEventEditSequence-test.js
@@ -185,7 +185,7 @@ const pmMessages6 = [
 ];
 
 const baseBackgroundData = {
-  ...eg.backgroundData,
+  ...eg.baseBackgroundData,
   streams: new Map([stream1, stream2].map(s => [s.stream_id, s])),
 };
 
@@ -418,7 +418,7 @@ describe('messages -> piece descriptors -> content HTML is stable/sensible', () 
       check({
         narrow: HOME_NARROW,
         backgroundData: {
-          ...eg.backgroundData,
+          ...eg.baseBackgroundData,
           ownUser: stableSelfUser,
           allUsersById: new Map([
             [singleMessageSender.user_id, singleMessageSender],
@@ -488,12 +488,12 @@ describe('messages -> piece descriptors -> content HTML is stable/sensible', () 
 
     Object.keys(eg.baseReduxState.flags).forEach(flag => {
       test(`message with flag: ${flag}`, () => {
-        const flags: ReadWrite<FlagsState> = { ...eg.backgroundData.flags };
+        const flags: ReadWrite<FlagsState> = { ...eg.baseBackgroundData.flags };
         flags[flag] = { [baseSingleMessage.id]: true };
         check({
           narrow: HOME_NARROW,
           messages: [baseSingleMessage],
-          backgroundData: { ...eg.backgroundData, flags },
+          backgroundData: { ...eg.baseBackgroundData, flags },
         });
       });
     });
@@ -503,7 +503,7 @@ describe('messages -> piece descriptors -> content HTML is stable/sensible', () 
         narrow: HOME_NARROW,
         messages: [baseSingleMessage],
         backgroundData: {
-          ...eg.backgroundData,
+          ...eg.baseBackgroundData,
           mutedUsers: Immutable.Map([[baseSingleMessage.sender_id, 1644366787]]),
         },
       });
@@ -779,15 +779,15 @@ describe('getEditSequence correct for interesting changes', () => {
         {
           messages: [message],
           backgroundData: {
-            ...eg.backgroundData,
-            flags: { ...eg.backgroundData.flags, starred: {} },
+            ...eg.baseBackgroundData,
+            flags: { ...eg.baseBackgroundData.flags, starred: {} },
           },
         },
         {
           messages: [message],
           backgroundData: {
-            ...eg.backgroundData,
-            flags: { ...eg.backgroundData.flags, starred: { [message.id]: true } },
+            ...eg.baseBackgroundData,
+            flags: { ...eg.baseBackgroundData.flags, starred: { [message.id]: true } },
           },
         },
       );
@@ -799,15 +799,15 @@ describe('getEditSequence correct for interesting changes', () => {
         {
           messages: [message],
           backgroundData: {
-            ...eg.backgroundData,
-            flags: { ...eg.backgroundData.flags, starred: { [message.id]: true } },
+            ...eg.baseBackgroundData,
+            flags: { ...eg.baseBackgroundData.flags, starred: { [message.id]: true } },
           },
         },
         {
           messages: [message],
           backgroundData: {
-            ...eg.backgroundData,
-            flags: { ...eg.backgroundData.flags, starred: {} },
+            ...eg.baseBackgroundData,
+            flags: { ...eg.baseBackgroundData.flags, starred: {} },
           },
         },
       );
@@ -821,12 +821,12 @@ describe('getEditSequence correct for interesting changes', () => {
       check(
         {
           messages: [message],
-          backgroundData: { ...eg.backgroundData, mutedUsers: Immutable.Map() },
+          backgroundData: { ...eg.baseBackgroundData, mutedUsers: Immutable.Map() },
         },
         {
           messages: [message],
           backgroundData: {
-            ...eg.backgroundData,
+            ...eg.baseBackgroundData,
             mutedUsers: Immutable.Map([[message.sender_id, 1644366787]]),
           },
         },
@@ -839,13 +839,13 @@ describe('getEditSequence correct for interesting changes', () => {
         {
           messages: [message],
           backgroundData: {
-            ...eg.backgroundData,
+            ...eg.baseBackgroundData,
             mutedUsers: Immutable.Map([[message.sender_id, 1644366787]]),
           },
         },
         {
           messages: [message],
-          backgroundData: { ...eg.backgroundData, mutedUsers: Immutable.Map() },
+          backgroundData: { ...eg.baseBackgroundData, mutedUsers: Immutable.Map() },
         },
       );
     });

--- a/src/webview/__tests__/generateInboundEvents-test.js
+++ b/src/webview/__tests__/generateInboundEvents-test.js
@@ -9,7 +9,7 @@ import type { Props } from '../MessageList';
 
 describe('generateInboundEvents', () => {
   const baseSelectorProps = deepFreeze({
-    backgroundData: eg.backgroundData,
+    backgroundData: eg.baseBackgroundData,
     initialScrollMessageId: null,
     fetching: { older: false, newer: false },
     messages: [],
@@ -162,9 +162,9 @@ describe('generateInboundEvents', () => {
     const prevProps = {
       ...baseProps,
       backgroundData: {
-        ...eg.backgroundData,
+        ...eg.baseBackgroundData,
         flags: {
-          ...eg.backgroundData.flags,
+          ...eg.baseBackgroundData.flags,
           read: { [message2.id]: true },
         },
       },
@@ -172,9 +172,9 @@ describe('generateInboundEvents', () => {
     const nextProps = {
       ...baseProps,
       backgroundData: {
-        ...eg.backgroundData,
+        ...eg.baseBackgroundData,
         flags: {
-          ...eg.backgroundData.flags,
+          ...eg.baseBackgroundData.flags,
           read: { [message1.id]: true, [message2.id]: true, [message3.id]: true },
         },
       },

--- a/src/webview/__tests__/generateInboundEvents-test.js
+++ b/src/webview/__tests__/generateInboundEvents-test.js
@@ -15,6 +15,7 @@ describe('generateInboundEvents', () => {
     messages: [],
     messageListElementsForShownMessages: [],
     typingUsers: [],
+    doNotMarkMessagesAsRead: eg.baseReduxState.settings.doNotMarkMessagesAsRead,
   });
 
   type FudgedProps = {|

--- a/src/webview/backgroundData.js
+++ b/src/webview/backgroundData.js
@@ -1,0 +1,89 @@
+// @flow strict-local
+
+import type {
+  AlertWordsState,
+  Auth,
+  Debug,
+  FlagsState,
+  GlobalSettingsState,
+  ImageEmojiType,
+  MuteState,
+  MutedUsersState,
+  PerAccountState,
+  Subscription,
+  Stream,
+  ThemeName,
+  UserId,
+  User,
+  UserOrBot,
+} from '../types';
+import type { UnreadState } from '../unread/unreadModelTypes';
+import {
+  getAuth,
+  getAllImageEmojiById,
+  getFlags,
+  getAllUsersById,
+  getMutedUsers,
+  getOwnUser,
+  getSettings,
+  getSubscriptionsById,
+  getStreamsById,
+  getRealm,
+} from '../selectors';
+import { getMute } from '../mute/muteModel';
+import { getUnread } from '../unread/unreadModel';
+
+/**
+ * Data about the user, the realm, and all known messages.
+ *
+ * This data is all independent of the specific narrow or specific messages
+ * we're displaying; data about those goes elsewhere.
+ *
+ * We pass this object down to a variety of lower layers and helper
+ * functions, where it saves us from individually wiring through all the
+ * overlapping subsets of this data they respectively need.
+ */
+export type BackgroundData = $ReadOnly<{|
+  alertWords: AlertWordsState,
+  allImageEmojiById: $ReadOnly<{| [id: string]: ImageEmojiType |}>,
+  auth: Auth,
+  debug: Debug,
+  flags: FlagsState,
+  mute: MuteState,
+  allUsersById: Map<UserId, UserOrBot>,
+  mutedUsers: MutedUsersState,
+  ownUser: User,
+  streams: Map<number, Stream>,
+  subscriptions: Map<number, Subscription>,
+  unread: UnreadState,
+  theme: ThemeName,
+  twentyFourHourTime: boolean,
+  userSettingStreamNotification: boolean,
+|}>;
+
+// TODO: Ideally this ought to be a caching selector that doesn't change
+//   when the inputs don't.  Doesn't matter in a practical way as used in
+//   MessageList, because we have a `shouldComponentUpdate` that doesn't
+//   look at this prop... but it'd be better to set an example of the right
+//   general pattern.
+export const getBackgroundData = (
+  state: PerAccountState,
+  globalSettings: GlobalSettingsState,
+  debug: Debug,
+): BackgroundData => ({
+  alertWords: state.alertWords,
+  allImageEmojiById: getAllImageEmojiById(state),
+  auth: getAuth(state),
+  debug,
+  flags: getFlags(state),
+  mute: getMute(state),
+  allUsersById: getAllUsersById(state),
+  mutedUsers: getMutedUsers(state),
+  ownUser: getOwnUser(state),
+  streams: getStreamsById(state),
+  subscriptions: getSubscriptionsById(state),
+  unread: getUnread(state),
+  theme: globalSettings.theme,
+  twentyFourHourTime: getRealm(state).twentyFourHourTime,
+  userSettingStreamNotification: getSettings(state).streamNotification,
+});

--- a/src/webview/generateInboundEventEditSequence.js
+++ b/src/webview/generateInboundEventEditSequence.js
@@ -5,7 +5,7 @@ import invariant from 'invariant';
 
 import type { MessageListElement, GetText } from '../types';
 import { ensureUnreachable } from '../generics';
-import type { BackgroundData } from './MessageList';
+import type { BackgroundData } from './backgroundData';
 import messageListElementHtml from './html/messageListElementHtml';
 
 const NODE_ENV = process.env.NODE_ENV;

--- a/src/webview/handleOutboundEvents.js
+++ b/src/webview/handleOutboundEvents.js
@@ -5,7 +5,7 @@ import * as NavigationService from '../nav/NavigationService';
 import * as api from '../api';
 import config from '../config';
 import type { Dispatch, GetText, Message, Narrow, Outbox, EditMessage, UserId } from '../types';
-import type { BackgroundData } from './MessageList';
+import type { BackgroundData } from './backgroundData';
 import type { ShowActionSheetWithOptions } from '../action-sheets';
 import type { JSONableDict } from '../utils/jsonable';
 import { showToast } from '../utils/info';

--- a/src/webview/handleOutboundEvents.js
+++ b/src/webview/handleOutboundEvents.js
@@ -166,6 +166,7 @@ type Props = $ReadOnly<{
   dispatch: Dispatch,
   messages: $ReadOnlyArray<Message | Outbox>,
   narrow: Narrow,
+  doNotMarkMessagesAsRead: boolean,
   showActionSheetWithOptions: ShowActionSheetWithOptions,
   startEditMessage: (editMessage: EditMessage) => void,
   ...
@@ -183,8 +184,8 @@ const fetchMore = (props: Props, event: WebViewOutboundEventScroll) => {
 };
 
 const markRead = (props: Props, event: WebViewOutboundEventScroll) => {
-  const { doNotMarkMessagesAsRead, flags, auth } = props.backgroundData;
-  if (doNotMarkMessagesAsRead) {
+  const { flags, auth } = props.backgroundData;
+  if (props.doNotMarkMessagesAsRead) {
     return;
   }
   const unreadMessageIds = filterUnreadMessagesInRange(

--- a/src/webview/html/__tests__/header-test.js
+++ b/src/webview/html/__tests__/header-test.js
@@ -2,7 +2,7 @@
 
 import * as eg from '../../../__tests__/lib/exampleData';
 import header from '../header';
-import type { BackgroundData } from '../../MessageList';
+import type { BackgroundData } from '../../backgroundData';
 
 const backgroundData: BackgroundData = ({
   ownEmail: eg.selfUser.email,

--- a/src/webview/html/header.js
+++ b/src/webview/html/header.js
@@ -4,7 +4,7 @@ import invariant from 'invariant';
 import template from './template';
 import { ensureUnreachable } from '../../types';
 import type { HeaderMessageListElement } from '../../types';
-import type { BackgroundData } from '../MessageList';
+import type { BackgroundData } from '../backgroundData';
 import {
   streamNarrow,
   topicNarrow,

--- a/src/webview/html/message.js
+++ b/src/webview/html/message.js
@@ -20,7 +20,7 @@ import type {
   UserId,
   WidgetData,
 } from '../../types';
-import type { BackgroundData } from '../MessageList';
+import type { BackgroundData } from '../backgroundData';
 import { shortTime } from '../../utils/date';
 import aggregateReactions from '../../reactions/aggregateReactions';
 import { codeToEmojiMap } from '../../emoji/data';

--- a/src/webview/html/messageListElementHtml.js
+++ b/src/webview/html/messageListElementHtml.js
@@ -1,7 +1,7 @@
 /* @flow strict-local */
 import type { GetText, MessageListElement } from '../../types';
 import { ensureUnreachable } from '../../generics';
-import type { BackgroundData } from '../MessageList';
+import type { BackgroundData } from '../backgroundData';
 
 import message from './message';
 import header from './header';


### PR DESCRIPTION
This makes a series of cleanups to the action-sheet code and its tests, in preparation for #5202 adding another option to one of the action sheets.

The first part of the branch pulls a selector `getBackgroundData` out of MessageList and uses that to replace the ad-hoc code for constructing a BackgroundData in exampleData.js. That's done here because the action-sheet tests wanted it; it also covers the first step or two of the plan discussed at https://github.com/zulip/zulip-mobile/pull/5225#discussion_r803329533 for the message-list-diff tests.

A followup to do sometime is to take the other action sheet, the one in `LightboxActionSheet.js`, and fold it into using the same system we have for these other action sheets. (That doesn't necessarily mean moving it to this file; it might be best to keep it in a lightbox-specific file in `src/lightbox/`.) Leaving that out for now because it has its own error-handling logic that overlaps with what's in this action-sheet system.
