### PR TITLE
topic [nfc]: Fix internal references to "subject"; add TODO-server for others

### DIFF
--- a/src/api/messages/sendMessage.js
+++ b/src/api/messages/sendMessage.js
@@ -9,6 +9,7 @@ export default async (
   params: {|
     type: 'private' | 'stream',
     to: string,
+    // TODO(server-2.0): Say "topic", not "subject"
     subject?: string,
     content: string,
     localId?: number,

--- a/src/api/messages/updateMessage.js
+++ b/src/api/messages/updateMessage.js
@@ -6,6 +6,7 @@ import { apiPatch } from '../apiFetch';
 export default async (
   auth: Auth,
   params: $ReadOnly<{|
+    // TODO(server-2.0): Say "topic", not "subject"
     subject?: string,
     propagate_mode?: boolean,
     content?: string,

--- a/src/api/modelTypes.js
+++ b/src/api/modelTypes.js
@@ -487,6 +487,7 @@ export type MessageEdit = $ReadOnly<{|
   prev_content?: string,
   prev_rendered_content?: string,
   prev_rendered_content_version?: number,
+  // TODO(server-5.0): Say "topic", not "subject"
   prev_subject?: string,
   timestamp: number,
   user_id: UserId,

--- a/src/chat/ChatScreen.js
+++ b/src/chat/ChatScreen.js
@@ -152,17 +152,15 @@ export default function ChatScreen(props: Props): Node {
     (message: string, destinationNarrow: Narrow) => {
       if (editMessage) {
         const content = editMessage.content !== message ? message : undefined;
-        const subject = caseNarrowDefault(
+        const topic = caseNarrowDefault(
           destinationNarrow,
+          // eslint-disable-next-line no-shadow
           { topic: (streamId, topic) => (topic !== editMessage.topic ? topic : undefined) },
           () => undefined,
         );
 
-        if (
-          (content !== undefined && content !== '')
-          || (subject !== undefined && subject !== '')
-        ) {
-          api.updateMessage(auth, { content, subject }, editMessage.id).catch(error => {
+        if ((content !== undefined && content !== '') || (topic !== undefined && topic !== '')) {
+          api.updateMessage(auth, { content, subject: topic }, editMessage.id).catch(error => {
             showErrorAlert(_('Failed to edit message'), error.message);
           });
         }

--- a/src/message/__tests__/messagesReducer-test.js
+++ b/src/message/__tests__/messagesReducer-test.js
@@ -321,7 +321,7 @@ describe('messagesReducer', () => {
     test('when event contains a new subject but no new content only subject is updated', () => {
       const message1Old = eg.streamMessage({
         content: 'Old content',
-        subject: 'Old subject',
+        subject: 'Old topic',
         last_edit_timestamp: 123,
         edit_history: [],
       });
@@ -344,11 +344,11 @@ describe('messagesReducer', () => {
     test('when event contains a new subject and a new content, update both', () => {
       const message1Old = eg.streamMessage({
         content: '<p>Old content</p>',
-        subject: 'Old subject',
+        subject: 'Old topic',
         last_edit_timestamp: 123,
         edit_history: [
           {
-            prev_subject: 'Old subject',
+            prev_subject: 'Old topic',
             timestamp: 123,
             user_id: eg.otherUser.user_id,
           },

--- a/src/webview/html/header.js
+++ b/src/webview/html/header.js
@@ -20,7 +20,7 @@ import {
 } from '../../utils/recipient';
 import { base64Utf8Encode } from '../../utils/encoding';
 
-const renderSubject = message =>
+const renderTopic = message =>
   // TODO: pin down if '' happens, and what its proper semantics are.
   message.match_subject !== undefined && message.match_subject !== ''
     ? message.match_subject
@@ -40,7 +40,7 @@ export default (
   if (message.type === 'stream') {
     const streamName = streamNameOfStreamMessage(message);
     const topicNarrowStr = keyFromNarrow(topicNarrow(message.stream_id, message.subject));
-    const topicHtml = renderSubject(message);
+    const topicHtml = renderTopic(message);
 
     if (headerStyle === 'topic+date') {
       return template`\


### PR DESCRIPTION
The bulk of the places we mention "subject" are direct references to
either the property of that name on `Message` or somewhere else in
the server API.  Most of those, and in particular `Message#subject`,
are still that way in the current API.

Those will be an annoying giant conversion, so I have no desire to be
in a rush to do them.  In particular, for any given piece of API, I
won't want to make a conversion before we've at least settled on the
API change so that we can convert to what we know is the future API.

However, there are a handful of places where we say "subject" to
mean "topic" and it's entirely internal to the mobile app.  So
here we go ahead and fix those.

---

And in the handful of places where the API change has already happened on the server and we didn't already have a TODO-server comment for it, add one now. Including in messages' edit history, where the server-side change hasn't yet landed but is expected to soon: zulip/zulip#21309.
