### PR TITLE
streams: Add "Copy link to stream" stream action.

### DIFF
--- a/src/action-sheets/index.js
+++ b/src/action-sheets/index.js
@@ -40,7 +40,7 @@ import { deleteMessagesForTopic } from '../topics/topicActions';
 import * as logging from '../utils/logging';
 import { getUnreadCountForTopic } from '../unread/unreadModel';
 import getIsNotificationEnabled from '../streams/getIsNotificationEnabled';
-import { getStreamTopicUrl } from '../utils/internalLinks';
+import { getStreamTopicUrl, getStreamUrl } from '../utils/internalLinks';
 
 // TODO really this belongs in a libdef.
 export type ShowActionSheetWithOptions = (
@@ -234,6 +234,16 @@ const muteStream = {
   },
 };
 
+const copyLinkToStream = {
+  title: 'Copy link to stream',
+  errorMessage: 'Failed to copy stream link',
+  action: async ({ auth, streamId, streams, _ }) => {
+    const streamUrl = getStreamUrl(auth.realm, streamId, streams);
+    Clipboard.setString(streamUrl.toString());
+    showToast(_('Link copied'));
+  },
+};
+
 const showStreamSettings = {
   title: 'Stream settings',
   errorMessage: 'Failed to show stream settings',
@@ -378,6 +388,7 @@ export const constructStreamActionButtons = (args: {|
     } else {
       buttons.push(muteStream);
     }
+    buttons.push(copyLinkToStream);
     if (sub.pin_to_top) {
       buttons.push(unpinFromTop);
     } else {

--- a/src/utils/internalLinks.js
+++ b/src/utils/internalLinks.js
@@ -230,3 +230,13 @@ export const getStreamTopicUrl = (
   const path = internal_url.by_stream_topic_url(streamId, topic, maybe_get_stream_name);
   return new URL(path, realm);
 };
+
+export const getStreamUrl = (
+  realm: URL,
+  streamId: number,
+  streamsById: Map<number, Stream>,
+): URL => {
+  const maybe_get_stream_name = id => streamsById.get(streamId)?.name;
+  const path = internal_url.by_stream_url(streamId, maybe_get_stream_name);
+  return new URL(path, realm);
+};

--- a/static/translations/messages_en.json
+++ b/static/translations/messages_en.json
@@ -292,5 +292,7 @@
   "Remove account": "Remove account",
   "Search topics": "Search topics",
   "Copy link to topic": "Copy link to topic",
-  "Failed to copy topic link": "Failed to copy topic link"
+  "Failed to copy topic link": "Failed to copy topic link",
+  "Copy link to stream": "Copy link to stream",
+  "Failed to copy stream link": "Failed to copy stream link"
 }


### PR DESCRIPTION
Adds a "Copy link to stream" action to the stream action sheet which
copies the full URL to a stream narrow to the system clipboard.

Fixes #5154.