### PR TITLE
streams: Show toast confirming topic link copied.

### DIFF
--- a/src/action-sheets/index.js
+++ b/src/action-sheets/index.js
@@ -190,9 +190,10 @@ const muteTopic = {
 const copyLinkToTopic = {
   title: 'Copy link to topic',
   errorMessage: 'Failed to copy topic link',
-  action: async ({ auth, streamId, topic, streams }) => {
+  action: async ({ auth, streamId, topic, streams, _ }) => {
     const topicUrl = getStreamTopicUrl(auth.realm, streamId, topic, streams);
     Clipboard.setString(topicUrl.toString());
+    showToast(_('Link copied'));
   },
 };
 


### PR DESCRIPTION
Provide visual feedback to the user when they copy a link to a topic to
the clipboard in the form of a toast displaying the message: "Link
copied".