### PR TITLE
vscode: Specify what auto-formatter to use

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,7 +11,5 @@
     "[javascript]": {
         // Format JS code with prettier-eslint.
         "editor.defaultFormatter": "esbenp.prettier-vscode",
-
-        "editor.formatOnSave": true,
     },
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,8 +8,10 @@
     // https://github.com/Microsoft/vscode-react-native/blob/master/doc/intellisense.md .
     "flow.useNPMPackagedFlow": true,
 
-    // Format on save (with prettier-eslint).
     "[javascript]": {
+        // Format JS code with prettier-eslint.
+        "editor.defaultFormatter": "esbenp.prettier-vscode",
+
         "editor.formatOnSave": true,
     },
 }

--- a/docs/howto/editor.md
+++ b/docs/howto/editor.md
@@ -62,11 +62,13 @@ Take a look through some of VS Code's docs.  In particular:
   for your platform, and print it out.  It's a one-page PDF which is
   extremely helpful to refer to.
 
-* Open any JS file in our codebase, and try messing up some formatting by
-  adding random whitespace -- then hit Ctrl+S (or Cmd+S) to save.  You
-  should see the formatting get magically fixed!  Our workspace settings
-  enable this feature, and configure it to use our standard formatting
-  rules.
+* Consider enabling the setting "Editor: Format On Save".  (Go to the
+  settings UI, and type "format on save" into the search box to find
+  the setting.  Then check the box for the setting.)
+
+  After doing so, open any JS file in our codebase, and try messing up
+  some formatting by adding random whitespace -- then hit Ctrl+S (or
+  Cmd+S) to save.  You should see the formatting get magically fixed!
 
 
 ### Troubleshooting

--- a/docs/howto/editor.md
+++ b/docs/howto/editor.md
@@ -32,6 +32,12 @@ The following are the recommended extensions for reference.
     Support](https://marketplace.visualstudio.com/items?itemName=flowtype.flow-for-vscode)
 * [ESLint](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint)
 * [prettier-vscode](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode)
+  * For this one, use `code --install-extension esbenp.prettier-vscode@4.7.0`
+    to install an older version of the extension.  A later version
+    [removed important functionality][] that affects the resulting formatting.
+
+[removed important functionality]: https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/SOLVED.3A.20Prettier.20auto-formatting/near/893211
+
 
 If something doesn't seem right, see the items under "Troubleshooting" below.
 


### PR DESCRIPTION
This is needed in order for format-on-save to work; without it,
VS Code doesn't know whether to use this or its built-in TS/JS
formatter.

I'd had the same setting in my personal VS Code settings on my
main desktop, so hadn't noticed its absence.  But really it's a
project-specific fact that we use Prettier, so the project's
settings is where it belongs.