### PR TITLE
streams: Display error if stream update fails.

### DIFF
--- a/src/streams/CreateStreamScreen.js
+++ b/src/streams/CreateStreamScreen.js
@@ -22,8 +22,8 @@ export default function CreateStreamScreen(props: Props): Node {
   const ownEmail = useSelector(getOwnEmail);
 
   const handleComplete = useCallback(
-    (name: string, description: string, isPrivate: boolean) => {
-      api.createStream(auth, name, description, [ownEmail], isPrivate);
+    async (name: string, description: string, isPrivate: boolean) => {
+      await api.createStream(auth, name, description, [ownEmail], isPrivate);
       NavigationService.dispatch(navigateBack());
     },
     [auth, ownEmail],

--- a/src/streams/EditStreamCard.js
+++ b/src/streams/EditStreamCard.js
@@ -24,7 +24,7 @@ type Props = $ReadOnly<{|
     description: string,
     invite_only: boolean,
   |},
-  onComplete: (name: string, description: string, isPrivate: boolean) => void,
+  onComplete: (name: string, description: string, isPrivate: boolean) => Promise<void>,
 |}>;
 
 type State = {|

--- a/src/streams/EditStreamScreen.js
+++ b/src/streams/EditStreamScreen.js
@@ -8,6 +8,7 @@ import * as NavigationService from '../nav/NavigationService';
 import { useSelector, useDispatch } from '../react-redux';
 import { updateExistingStream, navigateBack } from '../actions';
 import { getStreamForId } from '../selectors';
+import { showToast } from '../utils/info';
 import Screen from '../common/Screen';
 import EditStreamCard from './EditStreamCard';
 
@@ -21,8 +22,14 @@ export default function EditStreamScreen(props: Props): Node {
   const stream = useSelector(state => getStreamForId(state, props.route.params.streamId));
 
   const handleComplete = useCallback(
-    (name: string, description: string, isPrivate: boolean) => {
-      dispatch(updateExistingStream(stream.stream_id, stream, { name, description, isPrivate }));
+    async (name: string, description: string, isPrivate: boolean) => {
+      try {
+        await dispatch(
+          updateExistingStream(stream.stream_id, stream, { name, description, isPrivate }),
+        );
+      } catch (error) {
+        showToast(error.message);
+      }
       NavigationService.dispatch(navigateBack());
     },
     [stream, dispatch],


### PR DESCRIPTION
Displays a toast containing an error string if a call to
updateExistingStream returns a failed promise.

Fixes: #5286