### PR TITLE
msglist tests: Use Redux state in inputs, not background data

### DIFF
--- a/src/webview/__tests__/__snapshots__/generateInboundEventEditSequence-test.js.snap.android
+++ b/src/webview/__tests__/__snapshots__/generateInboundEventEditSequence-test.js.snap.android
@@ -1526,6 +1526,38 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm
 </div>"
 `;
 
+exports[`messages -> piece descriptors -> content HTML is stable/sensible other interesting cases (single messages) message in unsubscribed stream 1`] = `
+"<div class=\\"msglist-element timerow\\" data-msg-id=\\"-1\\">
+  <div class=\\"timerow-left\\"></div>
+  Dec 31, 1969
+  <div class=\\"timerow-right\\"></div>
+</div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"-1\\" data-narrow=\\"dG9waWM6MTpleGFtcGxlIHRvcGlj\\">
+  <div class=\\"header stream-text\\" style=\\"color: black;
+              background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
+    # stream 1
+  </div>
+  <div class=\\"topic-text\\">example topic</div>
+  <div class=\\"topic-date\\">Dec 31, 1969</div>
+</div><div class=\\"msglist-element message message-full\\" id=\\"msg--1\\" data-msg-id=\\"-1\\" data-mute-state=\\"shown\\">
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20sender.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
+  </div>
+  <div class=\\"content\\">
+    <div class=\\"subheader\\">
+  <div class=\\"name-and-status-emoji\\" data-sender-id=\\"10\\">
+    Nonrandom name sender User
+  </div>
+  <div class=\\"static-timestamp\\">11:59 PM</div>
+</div>
+    <p>This is an example stream message.</p>
+
+
+
+  </div>
+  
+</div>"
+`;
+
 exports[`messages -> piece descriptors -> content HTML is stable/sensible other interesting cases (single messages) message with a poll 1`] = `
 "<div class=\\"msglist-element timerow\\" data-msg-id=\\"-1\\">
   <div class=\\"timerow-left\\"></div>

--- a/src/webview/__tests__/__snapshots__/generateInboundEventEditSequence-test.js.snap.android
+++ b/src/webview/__tests__/__snapshots__/generateInboundEventEditSequence-test.js.snap.android
@@ -88,8 +88,8 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
   Feb 5, 1995
   <div class=\\"timerow-right\\"></div>
 </div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"1024\\" data-narrow=\\"dG9waWM6MTp0b3BpYyAx\\">
-  <div class=\\"header stream-text\\" style=\\"color: black;
-              background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
+  <div class=\\"header stream-text\\" style=\\"color: white;
+              background: #123456\\" data-narrow=\\"c3RyZWFtOjE=\\">
     # stream 1
   </div>
   <div class=\\"topic-text\\">topic 1</div>
@@ -132,8 +132,8 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
   Mar 5, 1995
   <div class=\\"timerow-right\\"></div>
 </div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"7938\\" data-narrow=\\"dG9waWM6MTp0b3BpYyAx\\">
-  <div class=\\"header stream-text\\" style=\\"color: black;
-              background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
+  <div class=\\"header stream-text\\" style=\\"color: white;
+              background: #123456\\" data-narrow=\\"c3RyZWFtOjE=\\">
     # stream 1
   </div>
   <div class=\\"topic-text\\">topic 1</div>
@@ -181,8 +181,8 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
   Feb 19, 1995
   <div class=\\"timerow-right\\"></div>
 </div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"4948\\" data-narrow=\\"dG9waWM6MTp0b3BpYyAx\\">
-  <div class=\\"header stream-text\\" style=\\"color: black;
-              background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
+  <div class=\\"header stream-text\\" style=\\"color: white;
+              background: #123456\\" data-narrow=\\"c3RyZWFtOjE=\\">
     # stream 1
   </div>
   <div class=\\"topic-text\\">topic 1</div>
@@ -205,8 +205,8 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
   </div>
   
 </div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"5083\\" data-narrow=\\"dG9waWM6MTp0b3BpYyAy\\">
-  <div class=\\"header stream-text\\" style=\\"color: black;
-              background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
+  <div class=\\"header stream-text\\" style=\\"color: white;
+              background: #123456\\" data-narrow=\\"c3RyZWFtOjE=\\">
     # stream 1
   </div>
   <div class=\\"topic-text\\">topic 2</div>
@@ -237,8 +237,8 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
   Mar 5, 1995
   <div class=\\"timerow-right\\"></div>
 </div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"6789\\" data-narrow=\\"dG9waWM6MTp0b3BpYyAx\\">
-  <div class=\\"header stream-text\\" style=\\"color: black;
-              background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
+  <div class=\\"header stream-text\\" style=\\"color: white;
+              background: #123456\\" data-narrow=\\"c3RyZWFtOjE=\\">
     # stream 1
   </div>
   <div class=\\"topic-text\\">topic 1</div>
@@ -261,8 +261,8 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
   </div>
   
 </div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"7727\\" data-narrow=\\"dG9waWM6Mjp0b3BpYyAy\\">
-  <div class=\\"header stream-text\\" style=\\"color: black;
-              background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjI=\\">
+  <div class=\\"header stream-text\\" style=\\"color: white;
+              background: #123456\\" data-narrow=\\"c3RyZWFtOjI=\\">
     # stream 2
   </div>
   <div class=\\"topic-text\\">topic 2</div>
@@ -293,8 +293,8 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
   Mar 5, 1995
   <div class=\\"timerow-right\\"></div>
 </div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"9181\\" data-narrow=\\"dG9waWM6MTp0b3BpYyAx\\">
-  <div class=\\"header stream-text\\" style=\\"color: black;
-              background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
+  <div class=\\"header stream-text\\" style=\\"color: white;
+              background: #123456\\" data-narrow=\\"c3RyZWFtOjE=\\">
     # stream 1
   </div>
   <div class=\\"topic-text\\">topic 1</div>
@@ -608,8 +608,8 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
   Feb 5, 1995
   <div class=\\"timerow-right\\"></div>
 </div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"1024\\" data-narrow=\\"dG9waWM6MTp0b3BpYyAx\\">
-  <div class=\\"header stream-text\\" style=\\"color: black;
-              background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
+  <div class=\\"header stream-text\\" style=\\"color: white;
+              background: #123456\\" data-narrow=\\"c3RyZWFtOjE=\\">
     # stream 1
   </div>
   <div class=\\"topic-text\\">topic 1</div>
@@ -688,8 +688,8 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
   Feb 19, 1995
   <div class=\\"timerow-right\\"></div>
 </div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"4948\\" data-narrow=\\"dG9waWM6MTp0b3BpYyAx\\">
-  <div class=\\"header stream-text\\" style=\\"color: black;
-              background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
+  <div class=\\"header stream-text\\" style=\\"color: white;
+              background: #123456\\" data-narrow=\\"c3RyZWFtOjE=\\">
     # stream 1
   </div>
   <div class=\\"topic-text\\">topic 1</div>
@@ -712,8 +712,8 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
   </div>
   
 </div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"5083\\" data-narrow=\\"dG9waWM6MTp0b3BpYyAy\\">
-  <div class=\\"header stream-text\\" style=\\"color: black;
-              background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
+  <div class=\\"header stream-text\\" style=\\"color: white;
+              background: #123456\\" data-narrow=\\"c3RyZWFtOjE=\\">
     # stream 1
   </div>
   <div class=\\"topic-text\\">topic 2</div>
@@ -876,8 +876,8 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
   Mar 5, 1995
   <div class=\\"timerow-right\\"></div>
 </div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"6789\\" data-narrow=\\"dG9waWM6MTp0b3BpYyAx\\">
-  <div class=\\"header stream-text\\" style=\\"color: black;
-              background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
+  <div class=\\"header stream-text\\" style=\\"color: white;
+              background: #123456\\" data-narrow=\\"c3RyZWFtOjE=\\">
     # stream 1
   </div>
   <div class=\\"topic-text\\">topic 1</div>
@@ -900,8 +900,8 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
   </div>
   
 </div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"7727\\" data-narrow=\\"dG9waWM6Mjp0b3BpYyAy\\">
-  <div class=\\"header stream-text\\" style=\\"color: black;
-              background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjI=\\">
+  <div class=\\"header stream-text\\" style=\\"color: white;
+              background: #123456\\" data-narrow=\\"c3RyZWFtOjI=\\">
     # stream 2
   </div>
   <div class=\\"topic-text\\">topic 2</div>
@@ -924,8 +924,8 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
   </div>
   
 </div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"7938\\" data-narrow=\\"dG9waWM6MTp0b3BpYyAx\\">
-  <div class=\\"header stream-text\\" style=\\"color: black;
-              background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
+  <div class=\\"header stream-text\\" style=\\"color: white;
+              background: #123456\\" data-narrow=\\"c3RyZWFtOjE=\\">
     # stream 1
   </div>
   <div class=\\"topic-text\\">topic 1</div>
@@ -996,8 +996,8 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
 
   </div>
 </div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"9181\\" data-narrow=\\"dG9waWM6MTp0b3BpYyAx\\">
-  <div class=\\"header stream-text\\" style=\\"color: black;
-              background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
+  <div class=\\"header stream-text\\" style=\\"color: white;
+              background: #123456\\" data-narrow=\\"c3RyZWFtOjE=\\">
     # stream 1
   </div>
   <div class=\\"topic-text\\">topic 1</div>
@@ -1958,8 +1958,8 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible other 
   Dec 31, 1969
   <div class=\\"timerow-right\\"></div>
 </div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"-1\\" data-narrow=\\"dG9waWM6MTpleGFtcGxlIHRvcGlj\\">
-  <div class=\\"header stream-text\\" style=\\"color: black;
-              background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
+  <div class=\\"header stream-text\\" style=\\"color: white;
+              background: #123456\\" data-narrow=\\"c3RyZWFtOjE=\\">
     # nonrandom stream
   </div>
   <div class=\\"topic-text\\">example topic</div>

--- a/src/webview/__tests__/__snapshots__/generateInboundEventEditSequence-test.js.snap.android
+++ b/src/webview/__tests__/__snapshots__/generateInboundEventEditSequence-test.js.snap.android
@@ -1534,7 +1534,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible other 
 </div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"-1\\" data-narrow=\\"dG9waWM6MTpleGFtcGxlIHRvcGlj\\">
   <div class=\\"header stream-text\\" style=\\"color: black;
               background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
-    # nonrandom stream
+    # stream 1
   </div>
   <div class=\\"topic-text\\">example topic</div>
   <div class=\\"topic-date\\">Dec 31, 1969</div>
@@ -1576,7 +1576,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible other 
 </div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"-1\\" data-narrow=\\"dG9waWM6MTpleGFtcGxlIHRvcGlj\\">
   <div class=\\"header stream-text\\" style=\\"color: black;
               background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
-    # nonrandom stream
+    # stream 1
   </div>
   <div class=\\"topic-text\\">example topic</div>
   <div class=\\"topic-date\\">Dec 31, 1969</div>
@@ -1608,7 +1608,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible other 
 </div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"-1\\" data-narrow=\\"dG9waWM6MTpleGFtcGxlIHRvcGlj\\">
   <div class=\\"header stream-text\\" style=\\"color: black;
               background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
-    # nonrandom stream
+    # stream 1
   </div>
   <div class=\\"topic-text\\">example topic</div>
   <div class=\\"topic-date\\">Dec 31, 1969</div>
@@ -1640,7 +1640,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible other 
 </div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"-1\\" data-narrow=\\"dG9waWM6MTpleGFtcGxlIHRvcGlj\\">
   <div class=\\"header stream-text\\" style=\\"color: black;
               background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
-    # nonrandom stream
+    # stream 1
   </div>
   <div class=\\"topic-text\\">example topic</div>
   <div class=\\"topic-date\\">Dec 31, 1969</div>
@@ -1672,7 +1672,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible other 
 </div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"-1\\" data-narrow=\\"dG9waWM6MTpleGFtcGxlIHRvcGlj\\">
   <div class=\\"header stream-text\\" style=\\"color: black;
               background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
-    # nonrandom stream
+    # stream 1
   </div>
   <div class=\\"topic-text\\">example topic</div>
   <div class=\\"topic-date\\">Dec 31, 1969</div>
@@ -1704,7 +1704,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible other 
 </div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"-1\\" data-narrow=\\"dG9waWM6MTpleGFtcGxlIHRvcGlj\\">
   <div class=\\"header stream-text\\" style=\\"color: black;
               background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
-    # nonrandom stream
+    # stream 1
   </div>
   <div class=\\"topic-text\\">example topic</div>
   <div class=\\"topic-date\\">Dec 31, 1969</div>
@@ -1736,7 +1736,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible other 
 </div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"-1\\" data-narrow=\\"dG9waWM6MTpleGFtcGxlIHRvcGlj\\">
   <div class=\\"header stream-text\\" style=\\"color: black;
               background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
-    # nonrandom stream
+    # stream 1
   </div>
   <div class=\\"topic-text\\">example topic</div>
   <div class=\\"topic-date\\">Dec 31, 1969</div>
@@ -1768,7 +1768,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible other 
 </div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"-1\\" data-narrow=\\"dG9waWM6MTpleGFtcGxlIHRvcGlj\\">
   <div class=\\"header stream-text\\" style=\\"color: black;
               background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
-    # nonrandom stream
+    # stream 1
   </div>
   <div class=\\"topic-text\\">example topic</div>
   <div class=\\"topic-date\\">Dec 31, 1969</div>
@@ -1800,7 +1800,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible other 
 </div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"-1\\" data-narrow=\\"dG9waWM6MTpleGFtcGxlIHRvcGlj\\">
   <div class=\\"header stream-text\\" style=\\"color: black;
               background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
-    # nonrandom stream
+    # stream 1
   </div>
   <div class=\\"topic-text\\">example topic</div>
   <div class=\\"topic-date\\">Dec 31, 1969</div>
@@ -1832,7 +1832,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible other 
 </div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"-1\\" data-narrow=\\"dG9waWM6MTpleGFtcGxlIHRvcGlj\\">
   <div class=\\"header stream-text\\" style=\\"color: black;
               background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
-    # nonrandom stream
+    # stream 1
   </div>
   <div class=\\"topic-text\\">example topic</div>
   <div class=\\"topic-date\\">Dec 31, 1969</div>
@@ -1864,7 +1864,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible other 
 </div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"-1\\" data-narrow=\\"dG9waWM6MTpleGFtcGxlIHRvcGlj\\">
   <div class=\\"header stream-text\\" style=\\"color: black;
               background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
-    # nonrandom stream
+    # stream 1
   </div>
   <div class=\\"topic-text\\">example topic</div>
   <div class=\\"topic-date\\">Dec 31, 1969</div>
@@ -1896,7 +1896,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible other 
 </div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"-1\\" data-narrow=\\"dG9waWM6MTpleGFtcGxlIHRvcGlj\\">
   <div class=\\"header stream-text\\" style=\\"color: black;
               background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
-    # nonrandom stream
+    # stream 1
   </div>
   <div class=\\"topic-text\\">example topic</div>
   <div class=\\"topic-date\\">Dec 31, 1969</div>
@@ -1928,7 +1928,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible other 
 </div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"-1\\" data-narrow=\\"dG9waWM6MTpleGFtcGxlIHRvcGlj\\">
   <div class=\\"header stream-text\\" style=\\"color: black;
               background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
-    # nonrandom stream
+    # stream 1
   </div>
   <div class=\\"topic-text\\">example topic</div>
   <div class=\\"topic-date\\">Dec 31, 1969</div>
@@ -1960,7 +1960,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible other 
 </div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"-1\\" data-narrow=\\"dG9waWM6MTpleGFtcGxlIHRvcGlj\\">
   <div class=\\"header stream-text\\" style=\\"color: white;
               background: #123456\\" data-narrow=\\"c3RyZWFtOjE=\\">
-    # nonrandom stream
+    # stream 1
   </div>
   <div class=\\"topic-text\\">example topic</div>
   <div class=\\"topic-date\\">Dec 31, 1969</div>
@@ -1992,7 +1992,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible other 
 </div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"-1\\" data-narrow=\\"dG9waWM6MTpleGFtcGxlIHRvcGlj\\">
   <div class=\\"header stream-text\\" style=\\"color: black;
               background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
-    # nonrandom stream
+    # stream 1
   </div>
   <div class=\\"topic-text\\">example topic</div>
   <div class=\\"topic-date\\">Dec 31, 1969</div>
@@ -2026,7 +2026,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible other 
 </div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"-1\\" data-narrow=\\"dG9waWM6MTpleGFtcGxlIHRvcGlj\\">
   <div class=\\"header stream-text\\" style=\\"color: black;
               background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
-    # nonrandom stream
+    # stream 1
   </div>
   <div class=\\"topic-text\\">example topic</div>
   <div class=\\"topic-date\\">Dec 31, 1969</div>
@@ -2058,7 +2058,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible other 
 </div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"-1\\" data-narrow=\\"dG9waWM6MTpleGFtcGxlIHRvcGlj\\">
   <div class=\\"header stream-text\\" style=\\"color: black;
               background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
-    # nonrandom stream
+    # stream 1
   </div>
   <div class=\\"topic-text\\">example topic</div>
   <div class=\\"topic-date\\">Dec 31, 1969</div>
@@ -2090,7 +2090,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible other 
 </div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"-1\\" data-narrow=\\"dG9waWM6MTpleGFtcGxlIHRvcGlj\\">
   <div class=\\"header stream-text\\" style=\\"color: black;
               background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
-    # nonrandom stream
+    # stream 1
   </div>
   <div class=\\"topic-text\\">example topic</div>
   <div class=\\"topic-date\\">Dec 31, 1969</div>
@@ -2122,7 +2122,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible other 
 </div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"-1\\" data-narrow=\\"dG9waWM6MTpleGFtcGxlIHRvcGlj\\">
   <div class=\\"header stream-text\\" style=\\"color: black;
               background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
-    # nonrandom stream
+    # stream 1
   </div>
   <div class=\\"topic-text\\">example topic</div>
   <div class=\\"topic-date\\">Dec 31, 1969</div>

--- a/src/webview/__tests__/__snapshots__/generateInboundEventEditSequence-test.js.snap.ios
+++ b/src/webview/__tests__/__snapshots__/generateInboundEventEditSequence-test.js.snap.ios
@@ -1526,6 +1526,38 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm
 </div>"
 `;
 
+exports[`messages -> piece descriptors -> content HTML is stable/sensible other interesting cases (single messages) message in unsubscribed stream 1`] = `
+"<div class=\\"msglist-element timerow\\" data-msg-id=\\"-1\\">
+  <div class=\\"timerow-left\\"></div>
+  Dec 31, 1969
+  <div class=\\"timerow-right\\"></div>
+</div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"-1\\" data-narrow=\\"dG9waWM6MTpleGFtcGxlIHRvcGlj\\">
+  <div class=\\"header stream-text\\" style=\\"color: black;
+              background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
+    # stream 1
+  </div>
+  <div class=\\"topic-text\\">example topic</div>
+  <div class=\\"topic-date\\">Dec 31, 1969</div>
+</div><div class=\\"msglist-element message message-full\\" id=\\"msg--1\\" data-msg-id=\\"-1\\" data-mute-state=\\"shown\\">
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20sender.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
+  </div>
+  <div class=\\"content\\">
+    <div class=\\"subheader\\">
+  <div class=\\"name-and-status-emoji\\" data-sender-id=\\"10\\">
+    Nonrandom name sender User
+  </div>
+  <div class=\\"static-timestamp\\">11:59 PM</div>
+</div>
+    <p>This is an example stream message.</p>
+
+
+
+  </div>
+  
+</div>"
+`;
+
 exports[`messages -> piece descriptors -> content HTML is stable/sensible other interesting cases (single messages) message with a poll 1`] = `
 "<div class=\\"msglist-element timerow\\" data-msg-id=\\"-1\\">
   <div class=\\"timerow-left\\"></div>

--- a/src/webview/__tests__/__snapshots__/generateInboundEventEditSequence-test.js.snap.ios
+++ b/src/webview/__tests__/__snapshots__/generateInboundEventEditSequence-test.js.snap.ios
@@ -88,8 +88,8 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
   Feb 5, 1995
   <div class=\\"timerow-right\\"></div>
 </div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"1024\\" data-narrow=\\"dG9waWM6MTp0b3BpYyAx\\">
-  <div class=\\"header stream-text\\" style=\\"color: black;
-              background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
+  <div class=\\"header stream-text\\" style=\\"color: white;
+              background: #123456\\" data-narrow=\\"c3RyZWFtOjE=\\">
     # stream 1
   </div>
   <div class=\\"topic-text\\">topic 1</div>
@@ -132,8 +132,8 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
   Mar 5, 1995
   <div class=\\"timerow-right\\"></div>
 </div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"7938\\" data-narrow=\\"dG9waWM6MTp0b3BpYyAx\\">
-  <div class=\\"header stream-text\\" style=\\"color: black;
-              background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
+  <div class=\\"header stream-text\\" style=\\"color: white;
+              background: #123456\\" data-narrow=\\"c3RyZWFtOjE=\\">
     # stream 1
   </div>
   <div class=\\"topic-text\\">topic 1</div>
@@ -181,8 +181,8 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
   Feb 19, 1995
   <div class=\\"timerow-right\\"></div>
 </div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"4948\\" data-narrow=\\"dG9waWM6MTp0b3BpYyAx\\">
-  <div class=\\"header stream-text\\" style=\\"color: black;
-              background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
+  <div class=\\"header stream-text\\" style=\\"color: white;
+              background: #123456\\" data-narrow=\\"c3RyZWFtOjE=\\">
     # stream 1
   </div>
   <div class=\\"topic-text\\">topic 1</div>
@@ -205,8 +205,8 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
   </div>
   
 </div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"5083\\" data-narrow=\\"dG9waWM6MTp0b3BpYyAy\\">
-  <div class=\\"header stream-text\\" style=\\"color: black;
-              background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
+  <div class=\\"header stream-text\\" style=\\"color: white;
+              background: #123456\\" data-narrow=\\"c3RyZWFtOjE=\\">
     # stream 1
   </div>
   <div class=\\"topic-text\\">topic 2</div>
@@ -237,8 +237,8 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
   Mar 5, 1995
   <div class=\\"timerow-right\\"></div>
 </div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"6789\\" data-narrow=\\"dG9waWM6MTp0b3BpYyAx\\">
-  <div class=\\"header stream-text\\" style=\\"color: black;
-              background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
+  <div class=\\"header stream-text\\" style=\\"color: white;
+              background: #123456\\" data-narrow=\\"c3RyZWFtOjE=\\">
     # stream 1
   </div>
   <div class=\\"topic-text\\">topic 1</div>
@@ -261,8 +261,8 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
   </div>
   
 </div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"7727\\" data-narrow=\\"dG9waWM6Mjp0b3BpYyAy\\">
-  <div class=\\"header stream-text\\" style=\\"color: black;
-              background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjI=\\">
+  <div class=\\"header stream-text\\" style=\\"color: white;
+              background: #123456\\" data-narrow=\\"c3RyZWFtOjI=\\">
     # stream 2
   </div>
   <div class=\\"topic-text\\">topic 2</div>
@@ -293,8 +293,8 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
   Mar 5, 1995
   <div class=\\"timerow-right\\"></div>
 </div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"9181\\" data-narrow=\\"dG9waWM6MTp0b3BpYyAx\\">
-  <div class=\\"header stream-text\\" style=\\"color: black;
-              background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
+  <div class=\\"header stream-text\\" style=\\"color: white;
+              background: #123456\\" data-narrow=\\"c3RyZWFtOjE=\\">
     # stream 1
   </div>
   <div class=\\"topic-text\\">topic 1</div>
@@ -608,8 +608,8 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
   Feb 5, 1995
   <div class=\\"timerow-right\\"></div>
 </div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"1024\\" data-narrow=\\"dG9waWM6MTp0b3BpYyAx\\">
-  <div class=\\"header stream-text\\" style=\\"color: black;
-              background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
+  <div class=\\"header stream-text\\" style=\\"color: white;
+              background: #123456\\" data-narrow=\\"c3RyZWFtOjE=\\">
     # stream 1
   </div>
   <div class=\\"topic-text\\">topic 1</div>
@@ -688,8 +688,8 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
   Feb 19, 1995
   <div class=\\"timerow-right\\"></div>
 </div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"4948\\" data-narrow=\\"dG9waWM6MTp0b3BpYyAx\\">
-  <div class=\\"header stream-text\\" style=\\"color: black;
-              background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
+  <div class=\\"header stream-text\\" style=\\"color: white;
+              background: #123456\\" data-narrow=\\"c3RyZWFtOjE=\\">
     # stream 1
   </div>
   <div class=\\"topic-text\\">topic 1</div>
@@ -712,8 +712,8 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
   </div>
   
 </div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"5083\\" data-narrow=\\"dG9waWM6MTp0b3BpYyAy\\">
-  <div class=\\"header stream-text\\" style=\\"color: black;
-              background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
+  <div class=\\"header stream-text\\" style=\\"color: white;
+              background: #123456\\" data-narrow=\\"c3RyZWFtOjE=\\">
     # stream 1
   </div>
   <div class=\\"topic-text\\">topic 2</div>
@@ -876,8 +876,8 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
   Mar 5, 1995
   <div class=\\"timerow-right\\"></div>
 </div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"6789\\" data-narrow=\\"dG9waWM6MTp0b3BpYyAx\\">
-  <div class=\\"header stream-text\\" style=\\"color: black;
-              background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
+  <div class=\\"header stream-text\\" style=\\"color: white;
+              background: #123456\\" data-narrow=\\"c3RyZWFtOjE=\\">
     # stream 1
   </div>
   <div class=\\"topic-text\\">topic 1</div>
@@ -900,8 +900,8 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
   </div>
   
 </div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"7727\\" data-narrow=\\"dG9waWM6Mjp0b3BpYyAy\\">
-  <div class=\\"header stream-text\\" style=\\"color: black;
-              background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjI=\\">
+  <div class=\\"header stream-text\\" style=\\"color: white;
+              background: #123456\\" data-narrow=\\"c3RyZWFtOjI=\\">
     # stream 2
   </div>
   <div class=\\"topic-text\\">topic 2</div>
@@ -924,8 +924,8 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
   </div>
   
 </div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"7938\\" data-narrow=\\"dG9waWM6MTp0b3BpYyAx\\">
-  <div class=\\"header stream-text\\" style=\\"color: black;
-              background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
+  <div class=\\"header stream-text\\" style=\\"color: white;
+              background: #123456\\" data-narrow=\\"c3RyZWFtOjE=\\">
     # stream 1
   </div>
   <div class=\\"topic-text\\">topic 1</div>
@@ -996,8 +996,8 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
 
   </div>
 </div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"9181\\" data-narrow=\\"dG9waWM6MTp0b3BpYyAx\\">
-  <div class=\\"header stream-text\\" style=\\"color: black;
-              background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
+  <div class=\\"header stream-text\\" style=\\"color: white;
+              background: #123456\\" data-narrow=\\"c3RyZWFtOjE=\\">
     # stream 1
   </div>
   <div class=\\"topic-text\\">topic 1</div>
@@ -1958,8 +1958,8 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible other 
   Dec 31, 1969
   <div class=\\"timerow-right\\"></div>
 </div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"-1\\" data-narrow=\\"dG9waWM6MTpleGFtcGxlIHRvcGlj\\">
-  <div class=\\"header stream-text\\" style=\\"color: black;
-              background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
+  <div class=\\"header stream-text\\" style=\\"color: white;
+              background: #123456\\" data-narrow=\\"c3RyZWFtOjE=\\">
     # nonrandom stream
   </div>
   <div class=\\"topic-text\\">example topic</div>

--- a/src/webview/__tests__/__snapshots__/generateInboundEventEditSequence-test.js.snap.ios
+++ b/src/webview/__tests__/__snapshots__/generateInboundEventEditSequence-test.js.snap.ios
@@ -1534,7 +1534,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible other 
 </div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"-1\\" data-narrow=\\"dG9waWM6MTpleGFtcGxlIHRvcGlj\\">
   <div class=\\"header stream-text\\" style=\\"color: black;
               background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
-    # nonrandom stream
+    # stream 1
   </div>
   <div class=\\"topic-text\\">example topic</div>
   <div class=\\"topic-date\\">Dec 31, 1969</div>
@@ -1576,7 +1576,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible other 
 </div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"-1\\" data-narrow=\\"dG9waWM6MTpleGFtcGxlIHRvcGlj\\">
   <div class=\\"header stream-text\\" style=\\"color: black;
               background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
-    # nonrandom stream
+    # stream 1
   </div>
   <div class=\\"topic-text\\">example topic</div>
   <div class=\\"topic-date\\">Dec 31, 1969</div>
@@ -1608,7 +1608,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible other 
 </div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"-1\\" data-narrow=\\"dG9waWM6MTpleGFtcGxlIHRvcGlj\\">
   <div class=\\"header stream-text\\" style=\\"color: black;
               background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
-    # nonrandom stream
+    # stream 1
   </div>
   <div class=\\"topic-text\\">example topic</div>
   <div class=\\"topic-date\\">Dec 31, 1969</div>
@@ -1640,7 +1640,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible other 
 </div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"-1\\" data-narrow=\\"dG9waWM6MTpleGFtcGxlIHRvcGlj\\">
   <div class=\\"header stream-text\\" style=\\"color: black;
               background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
-    # nonrandom stream
+    # stream 1
   </div>
   <div class=\\"topic-text\\">example topic</div>
   <div class=\\"topic-date\\">Dec 31, 1969</div>
@@ -1672,7 +1672,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible other 
 </div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"-1\\" data-narrow=\\"dG9waWM6MTpleGFtcGxlIHRvcGlj\\">
   <div class=\\"header stream-text\\" style=\\"color: black;
               background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
-    # nonrandom stream
+    # stream 1
   </div>
   <div class=\\"topic-text\\">example topic</div>
   <div class=\\"topic-date\\">Dec 31, 1969</div>
@@ -1704,7 +1704,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible other 
 </div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"-1\\" data-narrow=\\"dG9waWM6MTpleGFtcGxlIHRvcGlj\\">
   <div class=\\"header stream-text\\" style=\\"color: black;
               background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
-    # nonrandom stream
+    # stream 1
   </div>
   <div class=\\"topic-text\\">example topic</div>
   <div class=\\"topic-date\\">Dec 31, 1969</div>
@@ -1736,7 +1736,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible other 
 </div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"-1\\" data-narrow=\\"dG9waWM6MTpleGFtcGxlIHRvcGlj\\">
   <div class=\\"header stream-text\\" style=\\"color: black;
               background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
-    # nonrandom stream
+    # stream 1
   </div>
   <div class=\\"topic-text\\">example topic</div>
   <div class=\\"topic-date\\">Dec 31, 1969</div>
@@ -1768,7 +1768,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible other 
 </div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"-1\\" data-narrow=\\"dG9waWM6MTpleGFtcGxlIHRvcGlj\\">
   <div class=\\"header stream-text\\" style=\\"color: black;
               background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
-    # nonrandom stream
+    # stream 1
   </div>
   <div class=\\"topic-text\\">example topic</div>
   <div class=\\"topic-date\\">Dec 31, 1969</div>
@@ -1800,7 +1800,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible other 
 </div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"-1\\" data-narrow=\\"dG9waWM6MTpleGFtcGxlIHRvcGlj\\">
   <div class=\\"header stream-text\\" style=\\"color: black;
               background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
-    # nonrandom stream
+    # stream 1
   </div>
   <div class=\\"topic-text\\">example topic</div>
   <div class=\\"topic-date\\">Dec 31, 1969</div>
@@ -1832,7 +1832,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible other 
 </div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"-1\\" data-narrow=\\"dG9waWM6MTpleGFtcGxlIHRvcGlj\\">
   <div class=\\"header stream-text\\" style=\\"color: black;
               background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
-    # nonrandom stream
+    # stream 1
   </div>
   <div class=\\"topic-text\\">example topic</div>
   <div class=\\"topic-date\\">Dec 31, 1969</div>
@@ -1864,7 +1864,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible other 
 </div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"-1\\" data-narrow=\\"dG9waWM6MTpleGFtcGxlIHRvcGlj\\">
   <div class=\\"header stream-text\\" style=\\"color: black;
               background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
-    # nonrandom stream
+    # stream 1
   </div>
   <div class=\\"topic-text\\">example topic</div>
   <div class=\\"topic-date\\">Dec 31, 1969</div>
@@ -1896,7 +1896,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible other 
 </div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"-1\\" data-narrow=\\"dG9waWM6MTpleGFtcGxlIHRvcGlj\\">
   <div class=\\"header stream-text\\" style=\\"color: black;
               background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
-    # nonrandom stream
+    # stream 1
   </div>
   <div class=\\"topic-text\\">example topic</div>
   <div class=\\"topic-date\\">Dec 31, 1969</div>
@@ -1928,7 +1928,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible other 
 </div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"-1\\" data-narrow=\\"dG9waWM6MTpleGFtcGxlIHRvcGlj\\">
   <div class=\\"header stream-text\\" style=\\"color: black;
               background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
-    # nonrandom stream
+    # stream 1
   </div>
   <div class=\\"topic-text\\">example topic</div>
   <div class=\\"topic-date\\">Dec 31, 1969</div>
@@ -1960,7 +1960,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible other 
 </div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"-1\\" data-narrow=\\"dG9waWM6MTpleGFtcGxlIHRvcGlj\\">
   <div class=\\"header stream-text\\" style=\\"color: white;
               background: #123456\\" data-narrow=\\"c3RyZWFtOjE=\\">
-    # nonrandom stream
+    # stream 1
   </div>
   <div class=\\"topic-text\\">example topic</div>
   <div class=\\"topic-date\\">Dec 31, 1969</div>
@@ -1992,7 +1992,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible other 
 </div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"-1\\" data-narrow=\\"dG9waWM6MTpleGFtcGxlIHRvcGlj\\">
   <div class=\\"header stream-text\\" style=\\"color: black;
               background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
-    # nonrandom stream
+    # stream 1
   </div>
   <div class=\\"topic-text\\">example topic</div>
   <div class=\\"topic-date\\">Dec 31, 1969</div>
@@ -2026,7 +2026,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible other 
 </div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"-1\\" data-narrow=\\"dG9waWM6MTpleGFtcGxlIHRvcGlj\\">
   <div class=\\"header stream-text\\" style=\\"color: black;
               background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
-    # nonrandom stream
+    # stream 1
   </div>
   <div class=\\"topic-text\\">example topic</div>
   <div class=\\"topic-date\\">Dec 31, 1969</div>
@@ -2058,7 +2058,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible other 
 </div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"-1\\" data-narrow=\\"dG9waWM6MTpleGFtcGxlIHRvcGlj\\">
   <div class=\\"header stream-text\\" style=\\"color: black;
               background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
-    # nonrandom stream
+    # stream 1
   </div>
   <div class=\\"topic-text\\">example topic</div>
   <div class=\\"topic-date\\">Dec 31, 1969</div>
@@ -2090,7 +2090,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible other 
 </div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"-1\\" data-narrow=\\"dG9waWM6MTpleGFtcGxlIHRvcGlj\\">
   <div class=\\"header stream-text\\" style=\\"color: black;
               background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
-    # nonrandom stream
+    # stream 1
   </div>
   <div class=\\"topic-text\\">example topic</div>
   <div class=\\"topic-date\\">Dec 31, 1969</div>
@@ -2122,7 +2122,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible other 
 </div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"-1\\" data-narrow=\\"dG9waWM6MTpleGFtcGxlIHRvcGlj\\">
   <div class=\\"header stream-text\\" style=\\"color: black;
               background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
-    # nonrandom stream
+    # stream 1
   </div>
   <div class=\\"topic-text\\">example topic</div>
   <div class=\\"topic-date\\">Dec 31, 1969</div>

--- a/src/webview/__tests__/generateInboundEventEditSequence-test.js
+++ b/src/webview/__tests__/generateInboundEventEditSequence-test.js
@@ -422,7 +422,7 @@ describe('messages -> piece descriptors -> content HTML is stable/sensible', () 
     const baseSingleMessage = eg.streamMessage({
       id: -1,
       timestamp: -1,
-      stream: eg.makeStream({ stream_id: 1, name: 'nonrandom stream' }),
+      stream: stream1,
       sender: singleMessageSender,
     });
 

--- a/src/webview/__tests__/generateInboundEventEditSequence-test.js
+++ b/src/webview/__tests__/generateInboundEventEditSequence-test.js
@@ -196,6 +196,10 @@ const pmMessages6 = [
 
 const baseState = eg.reduxStatePlus({
   streams: [stream1, stream2],
+  subscriptions: [
+    eg.makeSubscription({ stream: stream1 }),
+    eg.makeSubscription({ stream: stream2 }),
+  ],
 });
 
 /**
@@ -234,7 +238,7 @@ const baseState = eg.reduxStatePlus({
  */
 describe('messages -> piece descriptors -> content HTML is stable/sensible', () => {
   const check = ({
-    state = eg.plusReduxState,
+    state = baseState,
     globalSettings = getGlobalSettings(eg.plusReduxState),
     debug = getDebug(eg.plusReduxState),
     narrow,

--- a/src/webview/__tests__/generateInboundEventEditSequence-test.js
+++ b/src/webview/__tests__/generateInboundEventEditSequence-test.js
@@ -426,6 +426,21 @@ describe('messages -> piece descriptors -> content HTML is stable/sensible', () 
       sender: singleMessageSender,
     });
 
+    test('message in unsubscribed stream', () => {
+      check({
+        narrow: HOME_NARROW,
+        messages: [baseSingleMessage],
+        state: eg.reduxStatePlus({
+          streams: [...eg.plusReduxState.streams, stream1, stream2],
+          subscriptions: [
+            ...eg.plusReduxState.subscriptions,
+            // no subscription for stream1
+            eg.makeSubscription({ stream: stream2 }),
+          ],
+        }),
+      });
+    });
+
     test('message with reactions', () => {
       check({
         narrow: HOME_NARROW,

--- a/src/webview/__tests__/generateInboundEventEditSequence-test.js
+++ b/src/webview/__tests__/generateInboundEventEditSequence-test.js
@@ -195,8 +195,9 @@ const pmMessages6 = [
 ];
 
 const baseState = eg.reduxStatePlus({
-  streams: [stream1, stream2],
+  streams: [...eg.plusReduxState.streams, stream1, stream2],
   subscriptions: [
+    ...eg.plusReduxState.subscriptions,
     eg.makeSubscription({ stream: stream1 }),
     eg.makeSubscription({ stream: stream2 }),
   ],


### PR DESCRIPTION
See https://github.com/zulip/zulip-mobile/pull/5225#discussion_r803329533.

Thanks to Greg's #5272, which pulled out a `getBackgroundData` that this uses.