### PR TITLE
settings_page: Add marks as read on scroll options

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@react-native-community/masked-view": "^0.1.10",
     "@react-native-community/netinfo": "6.0.0",
     "@react-native-community/push-notification-ios": "^1.5.0",
+    "@react-native-picker/picker": "^2.4.1",
     "@react-navigation/bottom-tabs": "npm:@zulip/react-navigation-bottom-tabs@5.11.16-0.zulip.1",
     "@react-navigation/drawer": "^5.9.3",
     "@react-navigation/material-top-tabs": "^5.2.19",

--- a/src/reduxTypes.js
+++ b/src/reduxTypes.js
@@ -344,7 +344,7 @@ export type GlobalSettingsState = $ReadOnly<{
 
   // Possibly this should be per-account.  If so it should probably be put
   // on the server, so it can also be cross-device for the account.
-  doNotMarkMessagesAsRead: boolean,
+  shouldMarkAsReadOnScroll: 'never' | 'always' | 'conversation',
 
   ...
 }>;

--- a/src/settings/SettingsScreen.js
+++ b/src/settings/SettingsScreen.js
@@ -2,7 +2,9 @@
 
 import React, { useCallback } from 'react';
 import type { Node } from 'react';
-
+import { View } from 'react-native';
+// $FlowFixMe[untyped-import]
+import { Picker } from '@react-native-picker/picker';
 import type { RouteProp } from '../react-navigation';
 import type { MainTabsNavigationProp } from '../main/MainTabsScreen';
 import * as NavigationService from '../nav/NavigationService';
@@ -10,6 +12,7 @@ import { useGlobalSelector, useDispatch } from '../react-redux';
 import { getGlobalSettings } from '../selectors';
 import NestedNavRow from '../common/NestedNavRow';
 import SwitchRow from '../common/SwitchRow';
+import ZulipTextIntl from '../common/ZulipTextIntl';
 import Screen from '../common/Screen';
 import {
   IconDiagnostics,
@@ -34,8 +37,8 @@ type Props = $ReadOnly<{|
 export default function SettingsScreen(props: Props): Node {
   const theme = useGlobalSelector(state => getGlobalSettings(state).theme);
   const browser = useGlobalSelector(state => getGlobalSettings(state).browser);
-  const doNotMarkMessagesAsRead = useGlobalSelector(
-    state => getGlobalSettings(state).doNotMarkMessagesAsRead,
+  const shouldMarkAsReadOnScroll = useGlobalSelector(
+    state => getGlobalSettings(state).shouldMarkAsReadOnScroll,
   );
   const dispatch = useDispatch();
 
@@ -53,13 +56,32 @@ export default function SettingsScreen(props: Props): Node {
           dispatch(setGlobalSettings({ browser: value ? 'embedded' : 'external' }));
         }}
       />
-      <SwitchRow
-        label="Do not mark messages read on scroll"
-        value={doNotMarkMessagesAsRead}
-        onValueChange={value => {
-          dispatch(setGlobalSettings({ doNotMarkMessagesAsRead: value }));
+      <View
+        style={{
+          flex: 1,
+          flexDirection: 'row',
+          alignContent: 'space-around',
+          flexWrap: 'wrap',
+          paddingLeft: 15,
         }}
-      />
+      >
+        <ZulipTextIntl
+          style={{ fontSize: 15, alignSelf: 'center' }}
+          text="Mark as read on scroll"
+        />
+        <Picker
+          selectedValue={shouldMarkAsReadOnScroll}
+          onValueChange={(itemValue, itemIndex) => {
+            dispatch(setGlobalSettings({ shouldMarkAsReadOnScroll: itemValue }));
+          }}
+          style={{ height: '100%', width: '50%' }}
+        >
+          <Picker.Item label="Always" value="always" />
+          <Picker.Item label="Conversation" value="conversation" />
+          <Picker.Item label="Never" value="never" />
+        </Picker>
+      </View>
+
       <NestedNavRow
         Icon={IconNotifications}
         label="Notifications"

--- a/src/settings/settingsReducer.js
+++ b/src/settings/settingsReducer.js
@@ -15,7 +15,7 @@ const initialState: SettingsState = {
   experimentalFeaturesEnabled: false,
   streamNotification: false,
   browser: 'default',
-  doNotMarkMessagesAsRead: false,
+  shouldMarkAsReadOnScroll: 'always',
 };
 
 export default (state: SettingsState = initialState, action: Action): SettingsState => {

--- a/src/storage/__tests__/migrations-test.js
+++ b/src/storage/__tests__/migrations-test.js
@@ -80,7 +80,7 @@ describe('migrations', () => {
       streamNotification: false,
       // added:
       browser: 'default',
-      doNotMarkMessagesAsRead: false,
+      shouldMarkAsReadOnScroll: 'always',
     },
   };
 
@@ -204,14 +204,19 @@ describe('migrations', () => {
     ],
     // 36 covered by whole
     [
-      'check 37 with setting already false',
-      { ...base15, settings: { ...base15.settings, doNotMarkMessagesAsRead: false } },
-      { ...endBase, settings: { ...endBase.settings, doNotMarkMessagesAsRead: false } },
+      'check 37 with setting - always',
+      { ...base15, settings: { ...base15.settings, shouldMarkAsReadOnScroll: 'always' } },
+      { ...endBase, settings: { ...endBase.settings, shouldMarkAsReadOnScroll: 'always' } },
     ],
     [
-      'check 37 with setting already true',
-      { ...base15, settings: { ...base15.settings, doNotMarkMessagesAsRead: true } },
-      { ...endBase, settings: { ...endBase.settings, doNotMarkMessagesAsRead: true } },
+      'check 37 with setting - conversation',
+      { ...base15, settings: { ...base15.settings, shouldMarkAsReadOnScroll: 'conversation' } },
+      { ...endBase, settings: { ...endBase.settings, shouldMarkAsReadOnScroll: 'conversation' } },
+    ],
+    [
+      'check 37 with setting - never',
+      { ...base15, settings: { ...base15.settings, shouldMarkAsReadOnScroll: 'never' } },
+      { ...endBase, settings: { ...endBase.settings, shouldMarkAsReadOnScroll: 'never' } },
     ],
     [
       'check 38',

--- a/src/storage/migrations.js
+++ b/src/storage/migrations.js
@@ -377,7 +377,7 @@ const migrationsInner: {| [string]: (LessPartialState) => LessPartialState |} = 
     // Handle the migration before 30.
     settings: {
       ...state.settings,
-      doNotMarkMessagesAsRead: state.settings.doNotMarkMessagesAsRead ?? false,
+      shouldMarkAsReadOnScroll: state.settings.shouldMarkAsReadOnScroll ?? 'always',
     },
   }),
 

--- a/src/webview/__tests__/generateInboundEvents-test.js
+++ b/src/webview/__tests__/generateInboundEvents-test.js
@@ -15,7 +15,7 @@ describe('generateInboundEvents', () => {
     messages: [],
     messageListElementsForShownMessages: [],
     typingUsers: [],
-    doNotMarkMessagesAsRead: eg.baseReduxState.settings.doNotMarkMessagesAsRead,
+    shouldMarkAsReadOnScroll: eg.baseReduxState.settings.shouldMarkAsReadOnScroll,
   });
 
   type FudgedProps = {|

--- a/src/webview/handleOutboundEvents.js
+++ b/src/webview/handleOutboundEvents.js
@@ -13,7 +13,7 @@ import { pmKeyRecipientsFromMessage } from '../utils/recipient';
 import { isUrlAnImage } from '../utils/url';
 import * as logging from '../utils/logging';
 import { filterUnreadMessagesInRange } from '../utils/unread';
-import { parseNarrow } from '../utils/narrow';
+import { parseNarrow, isTopicNarrow, isPmNarrow } from '../utils/narrow';
 import {
   fetchOlder,
   fetchNewer,
@@ -166,7 +166,7 @@ type Props = $ReadOnly<{
   dispatch: Dispatch,
   messages: $ReadOnlyArray<Message | Outbox>,
   narrow: Narrow,
-  doNotMarkMessagesAsRead: boolean,
+  shouldMarkAsReadOnScroll: 'never' | 'always' | 'conversation',
   showActionSheetWithOptions: ShowActionSheetWithOptions,
   startEditMessage: (editMessage: EditMessage) => void,
   ...
@@ -185,7 +185,14 @@ const fetchMore = (props: Props, event: WebViewOutboundEventScroll) => {
 
 const markRead = (props: Props, event: WebViewOutboundEventScroll) => {
   const { flags, auth } = props.backgroundData;
-  if (props.doNotMarkMessagesAsRead) {
+  if (props.shouldMarkAsReadOnScroll === 'never') {
+    return;
+  }
+  if (
+    props.shouldMarkAsReadOnScroll === 'conversation'
+    && !isTopicNarrow(props.narrow)
+    && !isPmNarrow(props.narrow)
+  ) {
     return;
   }
   const unreadMessageIds = filterUnreadMessagesInRange(

--- a/src/webview/html/html.js
+++ b/src/webview/html/html.js
@@ -9,7 +9,7 @@ type InitOptionsType = {|
   scrollMessageId: number | null,
   auth: Auth,
   showMessagePlaceholders: boolean,
-  doNotMarkMessagesAsRead: boolean,
+  shouldMarkAsReadOnScroll: 'never' | 'always' | 'conversation',
 |};
 
 /**
@@ -45,7 +45,7 @@ export default (
   theme: ThemeName,
   initOptions: InitOptionsType,
 ): string => template`
-$!${script(initOptions.scrollMessageId, initOptions.auth, initOptions.doNotMarkMessagesAsRead)}
+$!${script(initOptions.scrollMessageId, initOptions.auth, initOptions.shouldMarkAsReadOnScroll)}
 $!${css(theme)}
 
 <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">

--- a/src/webview/js/generatedEs3.js
+++ b/src/webview/js/generatedEs3.js
@@ -554,7 +554,7 @@ var compiledWebviewJs = (function (exports) {
       endMessageId: rangeHull.last
     });
 
-    if (!doNotMarkMessagesAsRead) {
+    if (shouldMarkAsReadOnScroll === 'always' || shouldMarkAsReadOnScroll === 'conversation') {
       setMessagesReadAttributes(rangeHull);
     }
 

--- a/src/webview/js/js.js
+++ b/src/webview/js/js.js
@@ -81,7 +81,7 @@ declare var isDevelopment: boolean;
  * defined in `handleInitialLoad`.
  * declared globally so as to use across functions.
  */
-declare var doNotMarkMessagesAsRead: boolean;
+declare var shouldMarkAsReadOnScroll: 'never' | 'always' | 'conversation';
 
 // We pull out document.body in one place, and check it's not null, in order
 // to provide that assertion to the type-checker.
@@ -471,7 +471,7 @@ const sendScrollMessage = () => {
     startMessageId: rangeHull.first,
     endMessageId: rangeHull.last,
   });
-  if (!doNotMarkMessagesAsRead) {
+  if (shouldMarkAsReadOnScroll === 'always' || shouldMarkAsReadOnScroll === 'conversation') {
     setMessagesReadAttributes(rangeHull);
   }
   // If there are no visible + read messages (for instance, the entire screen

--- a/src/webview/js/script.js
+++ b/src/webview/js/script.js
@@ -15,7 +15,7 @@ import compiledWebviewJs from './generatedEs3';
 export default (
   scrollMessageId: number | null,
   auth: Auth,
-  doNotMarkMessagesAsRead: boolean,
+  shouldMarkAsReadOnScroll: 'never' | 'always' | 'conversation',
 ): string => `
 <script>
 window.__forceSmoothScrollPolyfill__ = true;
@@ -24,7 +24,7 @@ ${matchesPolyfill}
 document.addEventListener('DOMContentLoaded', function() {
   var platformOS = ${JSON.stringify(Platform.OS)};
   var isDevelopment = ${JSON.stringify(process.env.NODE_ENV === 'development')};
-  var doNotMarkMessagesAsRead = ${JSON.stringify(doNotMarkMessagesAsRead)};
+  var shouldMarkAsReadOnScroll = ${JSON.stringify(shouldMarkAsReadOnScroll)};
   ${compiledWebviewJs}
   compiledWebviewJs.handleInitialLoad(
     ${JSON.stringify(scrollMessageId)},

--- a/static/translations/messages_en.json
+++ b/static/translations/messages_en.json
@@ -102,6 +102,7 @@
   "Settings": "Settings",
   "Night mode": "Night mode",
   "Open links with in-app browser": "Open links with in-app browser",
+  "Mark as read on scroll": "Mark as read on scroll",
   "Language": "Language",
   "Arabic": "Arabic",
   "Bokmål": "Bokmål",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1967,6 +1967,11 @@
   dependencies:
     invariant "^2.2.4"
 
+"@react-native-picker/picker@^2.4.1":
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/@react-native-picker/picker/-/picker-2.4.1.tgz#92feb7e0672d739624517dae04bf4de1452dfcdc"
+  integrity sha512-1XWy3IQgwr7MWd30KdY1iUh2gQZD+JiotN1ifj/ptFUYKon/0UFwngKQaWCO/CP/FdLl20/huSSLwKedYrdMMA==
+
 "@react-native/assets@1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@react-native/assets/-/assets-1.0.0.tgz#c6f9bf63d274bafc8e970628de24986b30a55c8e"


### PR DESCRIPTION
Closes: #5241 

Making a draft pull request since I am not sure about the implementation. 

The main change is basically changing the type of the variable `doNotMarkMessagesAsRead` from boolean to a string union. 

Added a dropdown menu on the settings page to choose the options from the string union.

So the messages will mark as read based on the option.

Also, the tests for `doNotMarkMessagesAsRead` are written on migrations-test.js. If the implementation is correct can I get a few pointers for the new tests.

Screenshots:

<img src="https://user-images.githubusercontent.com/73246484/158023207-a34851dc-3f9a-475c-916d-9121e47ac2f3.png" width=275 height=600><img src="https://user-images.githubusercontent.com/73246484/158023250-054c6b36-a844-4bde-8fff-5fb1ba1c8aec.png" width=275 height=600>

