### PR TITLE
android build: Split up APKs per ABI

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,9 +1,6 @@
 apply plugin: "com.android.application"
 apply plugin: "kotlin-android"
 apply plugin: "kotlin-android-extensions"
-
-import com.android.build.OutputFile
-
 /**
  * The react.gradle file registers a task for each build variant (e.g. bundleDebugJsAndAssets
  * and bundleReleaseJsAndAssets).
@@ -197,21 +194,6 @@ android {
                 signingConfig signingConfigs.release
             } else {
                 signingConfig signingConfigs.debug
-            }
-        }
-    }
-
-    // applicationVariants are e.g. debug, release
-    applicationVariants.all { variant ->
-        variant.outputs.each { output ->
-            // For each separate APK per architecture, set a unique version code as described here:
-            // https://developer.android.com/studio/build/configure-apk-splits.html
-            // Example: versionCode 1 will generate 1001 for armeabi-v7a, 1002 for x86, etc.
-            def versionCodes = ["armeabi-v7a": 1, "x86": 2, "arm64-v8a": 3, "x86_64": 4]
-            def abi = output.getFilter(OutputFile.ABI)
-            if (abi != null) {  // null for the universal-debug, universal-release variants
-                output.versionCodeOverride =
-                        defaultConfig.versionCode * 1000 + versionCodes.get(abi)
             }
         }
     }

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -102,16 +102,6 @@ try {
 }
 
 /**
- * Set this to true to create two separate APKs instead of one:
- *   - An APK that only works on ARM devices
- *   - An APK that only works on x86 devices
- * The advantage is the size of the APK is reduced by about 4MB.
- * Upload all the APKs to the Play Store and people will download
- * the correct one based on the CPU architecture of their device.
- */
-def enableSeparateBuildPerCPUArchitecture = false
-
-/**
  * Run Proguard to shrink the Java bytecode in release builds.
  */
 def enableProguardInReleaseBuilds = false
@@ -175,7 +165,7 @@ android {
     splits {
         abi {
             reset()
-            enable enableSeparateBuildPerCPUArchitecture
+            enable true // Build a separate APK for each ABI.
             universalApk false  // If true, also generate a universal APK
             include "armeabi-v7a", "x86", "arm64-v8a", "x86_64"
         }

--- a/docs/howto/build-run.md
+++ b/docs/howto/build-run.md
@@ -109,14 +109,14 @@ might look through the other tools and try some more of them out.
 * Commands once you've set up:
   * `tools/run-android` - build, then run on an active emulator
     or USB-connected device.  This won't start the emulator automatically.
-  * `yarn build:android-nokeys` - build an APK in release mode, just
+  * `yarn build:android-nokeys` - build APKs in release mode, just
     skipping Sentry setup (which requires an authentication token), and
-    using your debug keystore for signing.  The output APK will be at
-    `android/app/build/outputs/apk/release/app-release.apk`.
-  * `yarn build:android-nokeys -Psigned` - build an APK in release
+    using your debug keystore for signing.  The output APKs will be in
+    `android/app/build/outputs/apk/release/`.
+  * `yarn build:android-nokeys -Psigned` - build APKs in release
     mode, just skipping Sentry setup (which requires an authentication
-    token).  The output APK will be at
-    `android/app/build/outputs/apk/release/app-release.apk`.
+    token).  The output APKs will be in
+    `android/app/build/outputs/apk/release/`.
 
 [android-emu-cmd-line]: https://developer.android.com/studio/run/emulator-commandline.html
 

--- a/docs/howto/release.md
+++ b/docs/howto/release.md
@@ -1,7 +1,7 @@
 # Release guide
 
 This doc explains how to make a release of Zulip Mobile to the
-iOS App Store, to the Google Play Store, and as an APK on the web.
+iOS App Store, to the Google Play Store, and as APKs on the web.
 
 
 ## Terminology
@@ -109,19 +109,19 @@ simple terminology for the process we follow with both.
   git rebase @ release-secrets
   ```
 
-* Build the app, as both a good old-fashioned APK and a fancy new AAB:
+* Build the app, as both good old-fashioned APKs and a fancy new AAB:
 
   ```
   tools/android aab && tools/android apk
   ```
 
 * This produces an AAB at `android/app/build/outputs/bundle/release/app-release.aab`
-  and an APK at `android/app/build/outputs/apk/release/app-release.apk`.
+  and a set of APKs at `android/app/build/outputs/apk/release/app-*-release.apk`.
 
 * Upload the AAB to Google Play via the "Create new release" button at
   the top of the
   [Release > Testing > Internal testing][play-internal-testing] page.
-  (We'll use the APK when posting the release on GitHub, at beta stage.)
+  (We'll use the APKs when posting the release on GitHub, at beta stage.)
 
   * For the release notes, use `tools/changelog user` and edit as
     needed.  (E.g., fix paragraph wrapping, and delete iOS-only items.)
@@ -297,13 +297,13 @@ simple terminology for the process we follow with both.
       the usual build-output locations mentioned [above](#alpha-android).
       Those should be the same files you upload.
 
-  * Upload both the AAB and the APK.
+  * Upload both the AAB and the APKs.
 
     (The AAB is more flexible and is the only version we use with
-    Google Play, but the APK is simpler and may be a bit easier for
+    Google Play, but the APKs are simpler and may be a bit easier for
     people to work with.  As of 2020 it seems likely that some people
-    consuming these builds will prefer the APK, and it's not much
-    burden to build it at the same time, so we keep posting it
+    consuming these builds will prefer the APKs, and it's not much
+    burden to build them at the same time, so we keep posting them
     alongside the AAB.)
 
   * Check the box "This is a pre-release".
@@ -474,7 +474,7 @@ vulnerable.
 
 * Push the tagged commit, and also push the corresponding changes to main.
 
-* Upload the APK to GitHub as usual.
+* Upload the APKs to GitHub as usual.
 
 * Discuss freely.
 

--- a/tools/changelog
+++ b/tools/changelog
@@ -47,7 +47,7 @@ cmd_user() {
 show_hash() {
     local artifacts filename output hash basename
     artifacts=(
-        "${root}"/android/app/build/outputs/apk/release/app-release.apk
+        "${root}"/android/app/build/outputs/apk/release/app-*-release.apk
         "${root}"/android/app/build/outputs/bundle/release/app-release.aab
     )
     echo "sha256sum -c <<EOF"


### PR DESCRIPTION
The great bulk of the size of our APK comes from the native
libraries in it (most of all libjsc.so).  Those exist in a
separate copy for each of our 4 ABIs, but any given device
is going to use only one of those.

So, build a separate APK for each ABI.  The new APK for armeabi-v7a
(the most widely-supported) is 35.1MB, compared to 132.3MB for the
old all-in-one APK.

This has no effect for the many Android users who get our app via
the Google Play Store: there, we already upload an AAB, which
Google splits up into several APKs still more finely.  See #3547.

Fixes: #5295

/cc @IzzySoft
