### PR TITLE
AuthScreen: Fall back to URI when realm name not available.

### DIFF
--- a/src/start/AuthScreen.js
+++ b/src/start/AuthScreen.js
@@ -333,7 +333,7 @@ class AuthScreenInner extends PureComponent<Props> {
       <Screen title="Log in" centerContent padding shouldShowLoadingBanner={false}>
         <Centerer>
           <RealmInfo
-            name={serverSettings.realm_name}
+            name={serverSettings.realm_name ?? serverSettings.realm_uri}
             iconUrl={new URL(serverSettings.realm_icon, this.props.realm).toString()}
           />
           {activeAuthentications(


### PR DESCRIPTION
The server does not guarantee that this property exists, although the
documentation is misleading in this respect. See CZO discussion:

https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/realm_name.20is.20null/near/1344778
https://chat.zulip.org/#narrow/stream/412-api-documentation/topic/.2Fserver_settings.3A.20.60realm_name.60.2C.20etc.2E/near/1332888