### PR TITLE
events: Remove brittle `needsInitialFetch` system

### DIFF
--- a/docs/architecture/realtime.md
+++ b/docs/architecture/realtime.md
@@ -386,31 +386,14 @@ In the current Zulip mobile app, the structure looks like
   created by the nullary action creator `registerAndStartPolling`
   (in `eventActions.js`), which invokes `registerForEvents`, which is
   `/register` in the API binding.
-* (TODO: We'll rework the rest of this section soon.)
-* Which is invoked by `AppDataFetcher`.  This is a Redux-`connect`ed
-  component that appears near the very top of the hierarchy in
-  `ZulipMobile.js`.  The component's one job is to listen for changes
-  to a boolean field `needsInitialFetch` in the Redux state, and
-  dispatch this action when it becomes true.
-* That field, in turn, belongs to a state machine with several
-  transitions:
-  * On startup, it's set to true just if the persisted data contains
-    authentication credentials for an account.  (It's false in
-    `initialState`, and then set on a `REHYDRATE` action.)
-  * It's set to true when the user logs into a server, or switches
-    accounts (action types `LOGIN_SUCCESS` and `ACCOUNT_SWITCH`.)
-  * It's set to true on an `DEAD_QUEUE` action -- which is dispatched
+* In turn `registerAndStartPolling` is invoked in several situations:
+  * On startup, by `AppDataFetcher`, just if there's an active, logged-in
+    account.
+  * When the user logs into a server, or switches accounts (along with
+    action types `LOGIN_SUCCESS` and `ACCOUNT_SWITCH`.)
+  * Along with the `DEAD_QUEUE` action -- which is dispatched
     exclusively by the long-poll loop in `startEventPolling`, when it
     finds the event queue has expired.
-  * It's set to false on a `REGISTER_COMPLETE` action -- which is dispatched
-    exclusively by `registerAndStartPolling`, just before it dispatches a
-    `startEventPolling` action.
-
-Essentially, the `AppDataFetcher` React component is used as a way of
-listening for certain Redux actions (notably `REHYDRATE` and
-`LOGIN_SUCCESS`) and firing off another one (from `registerAndStartPolling`)
-when any of those happen.  And the latter action is a thunk action
-which kicks off a complex series of further thunk actions.
 
 ## TODO
 

--- a/docs/architecture/realtime.md
+++ b/docs/architecture/realtime.md
@@ -383,10 +383,9 @@ In the current Zulip mobile app, the structure looks like
   The code is in `eventActions.js` as `startEventPolling`, an action
   creator which takes the events finger as parameters.
 * That action creator is in turn invoked within the thunk action
-  created by the nullary action creator `doInitialFetch`
-  (in `fetchActions.js`), which does a number of other things but in
-  particular first invokes `registerForEvents`, which is `/register`
-  in the API binding.
+  created by the nullary action creator `registerAndStartPolling`
+  (in `fetchActions.js`), which invokes `registerForEvents`, which is
+  `/register` in the API binding.
 * Which is invoked by `AppDataFetcher`.  This is a Redux-`connect`ed
   component that appears near the very top of the hierarchy in
   `ZulipMobile.js`.  The component's one job is to listen for changes
@@ -403,12 +402,12 @@ In the current Zulip mobile app, the structure looks like
     exclusively by the long-poll loop in `startEventPolling`, when it
     finds the event queue has expired.
   * It's set to false on a `REGISTER_COMPLETE` action -- which is dispatched
-    exclusively by `doInitialFetch`, just before it dispatches a
+    exclusively by `registerAndStartPolling`, just before it dispatches a
     `startEventPolling` action.
 
 Essentially, the `AppDataFetcher` React component is used as a way of
 listening for certain Redux actions (notably `REHYDRATE` and
-`LOGIN_SUCCESS`) and firing off another one (from `doInitialFetch`)
+`LOGIN_SUCCESS`) and firing off another one (from `registerAndStartPolling`)
 when any of those happen.  And the latter action is a thunk action
 which kicks off a complex series of further thunk actions.
 

--- a/docs/architecture/realtime.md
+++ b/docs/architecture/realtime.md
@@ -384,7 +384,7 @@ In the current Zulip mobile app, the structure looks like
   creator which takes the events finger as parameters.
 * That action creator is in turn invoked within the thunk action
   created by the nullary action creator `registerAndStartPolling`
-  (in `fetchActions.js`), which invokes `registerForEvents`, which is
+  (in `eventActions.js`), which invokes `registerForEvents`, which is
   `/register` in the API binding.
 * Which is invoked by `AppDataFetcher`.  This is a Redux-`connect`ed
   component that appears near the very top of the hierarchy in

--- a/docs/architecture/realtime.md
+++ b/docs/architecture/realtime.md
@@ -386,6 +386,7 @@ In the current Zulip mobile app, the structure looks like
   created by the nullary action creator `registerAndStartPolling`
   (in `eventActions.js`), which invokes `registerForEvents`, which is
   `/register` in the API binding.
+* (TODO: We'll rework the rest of this section soon.)
 * Which is invoked by `AppDataFetcher`.  This is a Redux-`connect`ed
   component that appears near the very top of the hierarchy in
   `ZulipMobile.js`.  The component's one job is to listen for changes

--- a/src/ZulipMobile.js
+++ b/src/ZulipMobile.js
@@ -11,14 +11,13 @@ import RootErrorBoundary from './RootErrorBoundary';
 import { BRAND_COLOR } from './styles';
 import ZulipNavigationContainer from './nav/ZulipNavigationContainer';
 import StoreProvider from './boot/StoreProvider';
-import HideIfNotHydrated from './boot/HideIfNotHydrated';
+import StoreHydratedGate from './boot/StoreHydratedGate';
 import TranslationProvider from './boot/TranslationProvider';
 import ThemeProvider from './boot/ThemeProvider';
 import CompatibilityChecker from './boot/CompatibilityChecker';
 import AppEventHandlers from './boot/AppEventHandlers';
 import AppDataFetcher from './boot/AppDataFetcher';
 import { initializeSentry } from './sentry';
-import FullScreenLoading from './common/FullScreenLoading';
 
 initializeSentry();
 
@@ -60,7 +59,7 @@ export default function ZulipMobile(): Node {
               backgroundColor: BRAND_COLOR,
             }}
           >
-            <HideIfNotHydrated PlaceholderComponent={FullScreenLoading}>
+            <StoreHydratedGate>
               <AppEventHandlers>
                 <AppDataFetcher>
                   <TranslationProvider>
@@ -72,7 +71,7 @@ export default function ZulipMobile(): Node {
                   </TranslationProvider>
                 </AppDataFetcher>
               </AppEventHandlers>
-            </HideIfNotHydrated>
+            </StoreHydratedGate>
           </SafeAreaProvider>
         </StoreProvider>
       </CompatibilityChecker>

--- a/src/account-info/ProfileScreen.js
+++ b/src/account-info/ProfileScreen.js
@@ -10,7 +10,7 @@ import type { MainTabsNavigationProp } from '../main/MainTabsScreen';
 import { createStyleSheet } from '../styles';
 import { useDispatch, useSelector } from '../react-redux';
 import ZulipButton from '../common/ZulipButton';
-import { logout } from '../actions';
+import { logout } from '../account/logoutActions';
 import { tryStopNotifications } from '../notification/notifTokens';
 import AccountDetails from './AccountDetails';
 import AwayStatusSwitch from './AwayStatusSwitch';

--- a/src/account/accountActions.js
+++ b/src/account/accountActions.js
@@ -7,7 +7,10 @@ import {
   LOGIN_SUCCESS,
   DISMISS_SERVER_PUSH_SETUP_NOTICE,
 } from '../actionConstants';
+import { registerAndStartPolling } from '../events/eventActions';
 import { resetToMainTabs } from '../nav/navActions';
+import { sendOutbox } from '../outbox/outboxActions';
+import { initNotifications } from '../notification/notifTokens';
 
 export const dismissServerPushSetupNotice = (): PerAccountAction => ({
   type: DISMISS_SERVER_PUSH_SETUP_NOTICE,
@@ -43,8 +46,15 @@ const loginSuccessPlain = (realm: URL, email: string, apiKey: string): AllAccoun
 });
 
 export const loginSuccess =
-  (realm: URL, email: string, apiKey: string): ThunkAction<void> =>
-  (dispatch, getState) => {
+  (realm: URL, email: string, apiKey: string): ThunkAction<Promise<void>> =>
+  async (dispatch, getState) => {
     NavigationService.dispatch(resetToMainTabs());
     dispatch(loginSuccessPlain(realm, email, apiKey));
+
+    await dispatch(registerAndStartPolling());
+
+    // TODO(#3881): Lots of issues with outbox sending
+    dispatch(sendOutbox());
+
+    dispatch(initNotifications());
   };

--- a/src/account/accountActions.js
+++ b/src/account/accountActions.js
@@ -5,10 +5,9 @@ import {
   ACCOUNT_SWITCH,
   ACCOUNT_REMOVE,
   LOGIN_SUCCESS,
-  LOGOUT,
   DISMISS_SERVER_PUSH_SETUP_NOTICE,
 } from '../actionConstants';
-import { resetToAccountPicker, resetToMainTabs } from '../nav/navActions';
+import { resetToMainTabs } from '../nav/navActions';
 
 export const dismissServerPushSetupNotice = (): PerAccountAction => ({
   type: DISMISS_SERVER_PUSH_SETUP_NOTICE,
@@ -49,12 +48,3 @@ export const loginSuccess =
     NavigationService.dispatch(resetToMainTabs());
     dispatch(loginSuccessPlain(realm, email, apiKey));
   };
-
-const logoutPlain = (): AllAccountsAction => ({
-  type: LOGOUT,
-});
-
-export const logout = (): ThunkAction<Promise<void>> => async (dispatch, getState) => {
-  NavigationService.dispatch(resetToAccountPicker());
-  dispatch(logoutPlain());
-};

--- a/src/account/logoutActions.js
+++ b/src/account/logoutActions.js
@@ -1,0 +1,18 @@
+/* @flow strict-local */
+import * as NavigationService from '../nav/NavigationService';
+import type { AllAccountsAction, ThunkAction } from '../types';
+import { LOGOUT } from '../actionConstants';
+import { resetToAccountPicker } from '../nav/navActions';
+
+const logoutPlain = (): AllAccountsAction => ({
+  type: LOGOUT,
+});
+
+/**
+ * Forget this user's API key and erase their content.
+ */
+// In its own file just to prevent import cycles.
+export const logout = (): ThunkAction<Promise<void>> => async (dispatch, getState) => {
+  NavigationService.dispatch(resetToAccountPicker());
+  dispatch(logoutPlain());
+};

--- a/src/boot/AppDataFetcher.js
+++ b/src/boot/AppDataFetcher.js
@@ -1,10 +1,10 @@
 /* @flow strict-local */
 
-import React, { useCallback } from 'react';
+import { useCallback, useEffect } from 'react';
 import type { Node } from 'react';
 
-import { useSelector, useDispatch } from '../react-redux';
-import { getSession } from '../directSelectors';
+import { useGlobalSelector, useDispatch } from '../react-redux';
+import { getHasAuth } from '../selectors';
 import { registerAndStartPolling } from '../events/eventActions';
 import { sendOutbox } from '../outbox/outboxActions';
 import { initNotifications } from '../notification/notifTokens';
@@ -14,11 +14,14 @@ type Props = $ReadOnly<{|
 |}>;
 
 export default function AppDataFetcher(props: Props): Node {
-  const needsInitialFetch = useSelector(state => getSession(state).needsInitialFetch);
   const dispatch = useDispatch();
 
+  const hasAuth = useGlobalSelector(getHasAuth);
+
   const init = useCallback(async () => {
-    if (needsInitialFetch) {
+    // Init right away if there's an active, logged-in account.
+    // NB `getInitialRouteInfo` depends intimately on this behavior.
+    if (hasAuth) {
       await dispatch(registerAndStartPolling());
 
       // TODO(#3881): Lots of issues with outbox sending
@@ -26,11 +29,31 @@ export default function AppDataFetcher(props: Props): Node {
 
       dispatch(initNotifications());
     }
-  }, [needsInitialFetch, dispatch]);
+  }, [hasAuth, dispatch]);
 
-  React.useEffect(() => {
-    init();
-  }, [init]);
+  useEffect(
+    () => {
+      init();
+    },
+
+    // This effect does its work only if `hasAuth` is true at first startup
+    // (after rehydrate; this component is under HideIfNotHydrated, so it
+    // only exists then) -- not if `hasAuth` later becomes true.
+    //
+    // This breaks the normal rules of Hooks.  We make it OK because if
+    // `hasAuth` later becomes true, that can only be via ACCOUNT_SWITCH or
+    // LOGIN_SUCCESS; and when we dispatch one of those, we make sure to
+    // also dispatch much the same set of actions as this effect would.
+    //
+    // The reason we do it this way is that at account switch or login, we
+    // want to do these things even if `hasAuth` was already true with a
+    // previously active account.  It's also just more readable to have them
+    // be invoked directly from the code for switching account or logging
+    // in, rather than indirectly at a distance as this effect would be.
+    //
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [],
+  );
 
   return props.children;
 }

--- a/src/boot/AppDataFetcher.js
+++ b/src/boot/AppDataFetcher.js
@@ -5,7 +5,7 @@ import type { Node } from 'react';
 
 import { useSelector, useDispatch } from '../react-redux';
 import { getSession } from '../directSelectors';
-import { registerAndStartPolling } from '../message/fetchActions';
+import { registerAndStartPolling } from '../events/eventActions';
 import { sendOutbox } from '../outbox/outboxActions';
 import { initNotifications } from '../notification/notifTokens';
 

--- a/src/boot/AppDataFetcher.js
+++ b/src/boot/AppDataFetcher.js
@@ -37,7 +37,7 @@ export default function AppDataFetcher(props: Props): Node {
     },
 
     // This effect does its work only if `hasAuth` is true at first startup
-    // (after rehydrate; this component is under HideIfNotHydrated, so it
+    // (after rehydrate; this component is under StoreHydratedGate, so it
     // only exists then) -- not if `hasAuth` later becomes true.
     //
     // This breaks the normal rules of Hooks.  We make it OK because if

--- a/src/boot/StoreHydratedGate.js
+++ b/src/boot/StoreHydratedGate.js
@@ -14,13 +14,9 @@ type Props = $ReadOnly<{|
  * Where we prevent everything from rendering while waiting for rehydration.
  */
 export default function StoreHydratedGate(props: Props): Node {
-  const isHydrated = useGlobalSelector(getIsHydrated);
-
   const { children } = props;
 
-  if (!isHydrated) {
-    return <FullScreenLoading />;
-  }
+  const isHydrated = useGlobalSelector(getIsHydrated);
 
-  return children;
+  return isHydrated ? children : <FullScreenLoading />;
 }

--- a/src/boot/StoreHydratedGate.js
+++ b/src/boot/StoreHydratedGate.js
@@ -4,20 +4,22 @@ import type { Node } from 'react';
 
 import { useGlobalSelector } from '../react-redux';
 import { getIsHydrated } from '../selectors';
+import FullScreenLoading from '../common/FullScreenLoading';
 
 type Props = $ReadOnly<{|
   children: Node,
-
-  PlaceholderComponent?: React$ComponentType<{||}>,
 |}>;
 
-export default function HideIfNotHydrated(props: Props): Node {
+/**
+ * Where we prevent everything from rendering while waiting for rehydration.
+ */
+export default function StoreHydratedGate(props: Props): Node {
   const isHydrated = useGlobalSelector(getIsHydrated);
 
-  const { children, PlaceholderComponent } = props;
+  const { children } = props;
 
   if (!isHydrated) {
-    return PlaceholderComponent ? <PlaceholderComponent /> : null;
+    return <FullScreenLoading />;
   }
 
   return children;

--- a/src/events/eventActions.js
+++ b/src/events/eventActions.js
@@ -48,13 +48,9 @@ const registerAbort =
       // can look at stale data while waiting.
       //
       // Do so by lying that the server has told us our queue is invalid and
-      // we need a new one. Note that this must fire *after*
-      // `registerAbortPlain()`, so that AppDataFetcher sees
-      // `needsInitialFetch` go from `false` to `true`. We don't call
-      // `registerAndStartPolling` directly here because that would go against
-      // `AppDataFetcher`'s implicit interface.
+      // we need a new one.
       //
-      // TODO: Clean up all this brittle logic.
+      // TODO: Stop lying. ;)
       // TODO: Instead, let the retry be on-demand, with a banner.
       dispatch(deadQueue()); // eslint-disable-line no-use-before-define
     } else {

--- a/src/events/eventActions.js
+++ b/src/events/eventActions.js
@@ -10,9 +10,8 @@ import type { InitialData } from '../api/initialDataTypes';
 import type { GeneralEvent, ThunkAction, PerAccountAction } from '../types';
 import type { RegisterAbortReason } from '../actionTypes';
 import * as api from '../api';
-import { REGISTER_START, REGISTER_ABORT, REGISTER_COMPLETE } from '../actionConstants';
+import { REGISTER_START, REGISTER_ABORT, REGISTER_COMPLETE, DEAD_QUEUE } from '../actionConstants';
 import { logout } from '../account/logoutActions';
-import { deadQueue } from '../session/sessionActions';
 import eventToAction from './eventToAction';
 import doEventActionSideEffects from './doEventActionSideEffects';
 import { getAuth, tryGetAuth, getIdentity } from '../selectors';
@@ -55,7 +54,7 @@ const registerAbort =
       //
       // TODO: Clean up all this brittle logic.
       // TODO: Instead, let the retry be on-demand, with a banner.
-      dispatch(deadQueue());
+      dispatch(deadQueue()); // eslint-disable-line no-use-before-define
     } else {
       // Tell the user we've given up and let them try the same account or a
       // different account from the account picker.
@@ -298,7 +297,7 @@ export const startEventPolling =
 
         if (e instanceof ApiError && e.code === 'BAD_EVENT_QUEUE_ID') {
           // The event queue is too old or has been garbage collected.
-          dispatch(deadQueue());
+          dispatch(deadQueue()); // eslint-disable-line no-use-before-define
           break;
         }
 
@@ -312,3 +311,7 @@ export const startEventPolling =
       lastEventId = Math.max(lastEventId, ...events.map(x => x.id));
     }
   };
+
+const deadQueue = (): PerAccountAction => ({
+  type: DEAD_QUEUE,
+});

--- a/src/events/eventActions.js
+++ b/src/events/eventActions.js
@@ -18,7 +18,7 @@ import * as logging from '../utils/logging';
 /**
  * Handle a single Zulip event from the server.
  *
- * This is part of our use of the Zulip events system; see `doInitialFetch`
+ * This is part of our use of the Zulip events system; see `registerAndStartPolling`
  * for discussion.
  */
 const handleEvent = (event: GeneralEvent, dispatch, getState) => {
@@ -50,7 +50,7 @@ const handleEvent = (event: GeneralEvent, dispatch, getState) => {
 /**
  * Poll an event queue on the Zulip server for updates, in a loop.
  *
- * This is part of our use of the Zulip events system; see `doInitialFetch`
+ * This is part of our use of the Zulip events system; see `registerAndStartPolling`
  * for discussion.
  */
 export const startEventPolling =

--- a/src/events/eventActions.js
+++ b/src/events/eventActions.js
@@ -5,7 +5,7 @@ import isEqual from 'lodash.isequal';
 
 import type { GeneralEvent, ThunkAction } from '../types';
 import * as api from '../api';
-import { logout } from '../account/accountActions';
+import { logout } from '../account/logoutActions';
 import { deadQueue } from '../session/sessionActions';
 import eventToAction from './eventToAction';
 import doEventActionSideEffects from './doEventActionSideEffects';

--- a/src/events/eventActions.js
+++ b/src/events/eventActions.js
@@ -38,7 +38,7 @@ const registerAbortPlain = (reason: RegisterAbortReason): PerAccountAction => ({
   reason,
 });
 
-export const registerAbort =
+const registerAbort =
   (reason: RegisterAbortReason): ThunkAction<Promise<void>> =>
   async (dispatch, getState) => {
     dispatch(registerAbortPlain(reason));

--- a/src/haveServerDataSelectors.js
+++ b/src/haveServerDataSelectors.js
@@ -69,9 +69,9 @@ export const getHaveServerData = (state: PerAccountState): boolean => {
   //    fetch.  Specifically:
   //    * If at startup (upon rehydrate) we show the main UI, we do so.
   //      This is controlled by `getInitialRouteInfo`, together with
-  //      `sessionReducer` as it sets `needsInitialFetch`.
+  //      AppDataFetcher.
   //    * When we navigate to the main UI (via `resetToMainTabs`), we always
-  //      also dispatch an action that causes `needsInitialFetch` to be set.
+  //      also dispatch an action that causes an initial fetch.
   //    * Plus, that initial fetch has a timeout, so it will always take us
   //      away from a loading screen regardless of server/network behavior.
   //
@@ -80,7 +80,7 @@ export const getHaveServerData = (state: PerAccountState): boolean => {
   //    Specifically:
   //    * Between this function and the reducers, we should only stop having
   //      server data upon certain actions in `accountActions`.
-  //    * Some of those actions cause `needsInitialFetch` to be set, as above.
+  //    * Some of those actions cause an initial fetch, as above.
   //    * Those that don't should always be accompanied by navigating away
   //      from the main UI, with `resetToAccountPicker`.
   //
@@ -89,8 +89,8 @@ export const getHaveServerData = (state: PerAccountState): boolean => {
   // be possible to confirm they align without so much nonlocal reasoning.
 
   // Specific facts used in the reasoning below (within the strategy above):
-  //  * The actions LOGIN_SUCCESS and ACCOUNT_SWITCH cause
-  //    `needsInitialFetch` to be set.
+  //  * The actions LOGIN_SUCCESS and ACCOUNT_SWITCH are dispatched along
+  //    with an initial fetch.
   //  * The action LOGOUT is always accompanied by navigating away from the
   //    main UI.
   //  * A successful initial fetch causes a REGISTER_COMPLETE action.  A failed one

--- a/src/message/fetchActions.js
+++ b/src/message/fetchActions.js
@@ -271,10 +271,7 @@ export const registerAbort =
       // `registerAbortPlain()`, so that AppDataFetcher sees
       // `needsInitialFetch` go from `false` to `true`. We don't call
       // `doInitialFetch` directly here because that would go against
-      // `AppDataFetcher`'s implicit interface. (Also, `needsInitialFetch` is
-      // dubiously being read outside `AppDataFetcher`, in
-      // `fetchOlder`/`fetchNewer`, and we don't want to break something
-      // there.)
+      // `AppDataFetcher`'s implicit interface.
       //
       // TODO: Clean up all this brittle logic.
       // TODO: Instead, let the retry be on-demand, with a banner.

--- a/src/message/fetchActions.js
+++ b/src/message/fetchActions.js
@@ -565,7 +565,9 @@ export const doInitialFetch = (): ThunkAction<Promise<void>> => async (dispatch,
     dispatch(fetchPrivateMessages());
   }
 
+  // TODO(#3881): Lots of issues with outbox sending
   dispatch(sendOutbox());
+
   dispatch(initNotifications());
 };
 

--- a/src/message/fetchActions.js
+++ b/src/message/fetchActions.js
@@ -1,6 +1,5 @@
 /* @flow strict-local */
 import * as logging from '../utils/logging';
-import * as NavigationService from '../nav/NavigationService';
 import type {
   Auth,
   Narrow,
@@ -11,13 +10,8 @@ import type {
   ThunkAction,
   UserId,
 } from '../types';
-import { ensureUnreachable } from '../types';
-import type { RegisterAbortReason } from '../actionTypes';
-import type { InitialData } from '../api/initialDataTypes';
 import * as api from '../api';
-import { ApiError, Server5xxError, NetworkError } from '../api/apiErrors';
-import { resetToAccountPicker } from '../nav/navActions';
-import { deadQueue } from '../session/sessionActions';
+import { Server5xxError, NetworkError } from '../api/apiErrors';
 import {
   getAuth,
   getSession,
@@ -25,33 +19,20 @@ import {
   getLastMessageId,
   getCaughtUpForNarrow,
   getFetchingForNarrow,
-  getIdentity,
   getStreamsById,
   getZulipFeatureLevel,
 } from '../selectors';
 import config from '../config';
 import {
-  REGISTER_START,
-  REGISTER_ABORT,
-  REGISTER_COMPLETE,
   MESSAGE_FETCH_START,
   MESSAGE_FETCH_ERROR,
   MESSAGE_FETCH_COMPLETE,
 } from '../actionConstants';
 import { FIRST_UNREAD_ANCHOR, LAST_MESSAGE_ANCHOR } from '../anchor';
-import { showErrorAlert } from '../utils/info';
 import { ALL_PRIVATE_NARROW, apiNarrowOfNarrow, caseNarrow, topicNarrow } from '../utils/narrow';
 import { BackoffMachine, promiseTimeout, TimeoutError } from '../utils/async';
 import { addToOutbox } from '../outbox/outboxActions';
-import { startEventPolling } from '../events/eventActions';
-import { logout } from '../account/logoutActions';
-import { ZulipVersion } from '../utils/zulipVersion';
 import { getAllUsersById, getOwnUserId } from '../users/userSelectors';
-import { getHaveServerData } from '../haveServerDataSelectors';
-import { MIN_RECENTPMS_SERVER_VERSION } from '../pm-conversations/pmConversationsModel';
-import { kNextMinSupportedVersion } from '../common/ServerCompatBanner';
-import { getOwnUserRole, roleIsAtLeast } from '../permissionSelectors';
-import { Role } from '../api/permissionsTypes';
 
 const messageFetchStart = (
   narrow: Narrow,
@@ -248,71 +229,6 @@ export async function fetchSomeMessageIdForConversation(
   return message?.id;
 }
 
-const registerStart = (): PerAccountAction => ({
-  type: REGISTER_START,
-});
-
-const registerAbortPlain = (reason: RegisterAbortReason): PerAccountAction => ({
-  type: REGISTER_ABORT,
-  reason,
-});
-
-export const registerAbort =
-  (reason: RegisterAbortReason): ThunkAction<Promise<void>> =>
-  async (dispatch, getState) => {
-    dispatch(registerAbortPlain(reason));
-    if (getHaveServerData(getState()) && reason !== 'unexpected') {
-      // Try again, forever if necessary; the user has an interactable UI and
-      // can look at stale data while waiting.
-      //
-      // Do so by lying that the server has told us our queue is invalid and
-      // we need a new one. Note that this must fire *after*
-      // `registerAbortPlain()`, so that AppDataFetcher sees
-      // `needsInitialFetch` go from `false` to `true`. We don't call
-      // `registerAndStartPolling` directly here because that would go against
-      // `AppDataFetcher`'s implicit interface.
-      //
-      // TODO: Clean up all this brittle logic.
-      // TODO: Instead, let the retry be on-demand, with a banner.
-      dispatch(deadQueue());
-    } else {
-      // Tell the user we've given up and let them try the same account or a
-      // different account from the account picker.
-      showErrorAlert(
-        // TODO: Set up these user-facing strings for translation once
-        // `initialFetchAbort`'s callers all have access to a `GetText`
-        // function. As of adding the strings, the initial fetch is dispatched
-        // from `AppDataFetcher` which isn't a descendant of
-        // `TranslationProvider`.
-        'Connection failed',
-        (() => {
-          const realmStr = getIdentity(getState()).realm.toString();
-          switch (reason) {
-            case 'server':
-              return roleIsAtLeast(getOwnUserRole(getState()), Role.Admin)
-                ? `Could not connect to ${realmStr} because the server encountered an error. Please check the server logs.`
-                : `Could not connect to ${realmStr} because the server encountered an error. Please ask an admin to check the server logs.`;
-            case 'network':
-              return `The network request to ${realmStr} failed.`;
-            case 'timeout':
-              return `Gave up trying to connect to ${realmStr} after waiting too long.`;
-            case 'unexpected':
-              return `Unexpected error while trying to connect to ${realmStr}.`;
-            default:
-              ensureUnreachable(reason);
-              return '';
-          }
-        })(),
-      );
-      NavigationService.dispatch(resetToAccountPicker());
-    }
-  };
-
-const registerComplete = (data: InitialData): PerAccountAction => ({
-  type: REGISTER_COMPLETE,
-  data,
-});
-
 /** Private; exported only for tests. */
 export const isFetchNeededAtAnchor = (
   state: PerAccountState,
@@ -468,109 +384,6 @@ export async function tryFetch<T>(
     throw e;
   }
 }
-
-/**
- * Connect to the Zulip event system for real-time updates.
- *
- * For background on the Zulip event system and how we use it, see docs from
- * the client-side perspective:
- *   https://github.com/zulip/zulip-mobile/blob/main/docs/architecture/realtime.md
- * and a mainly server-side perspective:
- *   https://zulip.readthedocs.io/en/latest/subsystems/events-system.html
- *
- * First does POST /register, which is sometimes called the "initial fetch".
- * because the response comes with a large payload of current-state data
- * that we fetch as part of initializing the event queue:
- *   https://zulip.readthedocs.io/en/latest/subsystems/events-system.html#the-initial-data-fetch
- *
- * Then immediately starts an async loop to poll for events.
- *
- * We fetch private messages here so that we can show something useful in
- * the PM conversations screen, but we hope to stop doing this soon (see
- * note at `fetchPrivateMessages`). We fetch messages in a few other places:
- * to initially populate a message list (`ChatScreen`), to grab more
- * messages on scrolling to the top or bottom of the message list
- * (`fetchOlder` and `fetchNewer`), and to grab search results
- * (`SearchMessagesScreen`).
- */
-export const registerAndStartPolling =
-  (): ThunkAction<Promise<void>> => async (dispatch, getState) => {
-    const auth = getAuth(getState());
-
-    const haveServerData = getHaveServerData(getState());
-
-    dispatch(registerStart());
-    let initData: InitialData;
-    try {
-      initData = await tryFetch(
-        // Currently, no input we're giving `registerForEvents` is
-        // conditional on the server version / feature level. If we
-        // need to do that, make sure that data is up-to-date -- we've
-        // been using this `registerForEvents` call to update the
-        // feature level in Redux, which means the value in Redux will
-        // be from the *last* time it was run. That could be a long
-        // time ago, like from the previous app startup.
-        () => api.registerForEvents(auth),
-        // We might have (potentially stale) server data already. If
-        // we do, we'll be showing some UI that lets the user see that
-        // data. If we don't, we'll be showing a full-screen loading
-        // indicator that prevents the user from doing anything useful
-        // -- if that's the case, don't bother retrying on 5xx errors,
-        // to save the user's time and patience. They can retry
-        // manually if they want.
-        haveServerData,
-      );
-    } catch (errorIllTyped) {
-      const e: mixed = errorIllTyped; // https://github.com/facebook/flow/issues/2470
-      if (e instanceof ApiError) {
-        // This should only happen when `auth` is no longer valid. No
-        // use retrying; just log out.
-        dispatch(logout());
-      } else if (e instanceof Server5xxError) {
-        dispatch(registerAbort('server'));
-      } else if (e instanceof NetworkError) {
-        dispatch(registerAbort('network'));
-      } else if (e instanceof TimeoutError) {
-        // We always want to abort if we've kept the user waiting an
-        // unreasonably long time.
-        dispatch(registerAbort('timeout'));
-      } else {
-        dispatch(registerAbort('unexpected'));
-        // $FlowFixMe[incompatible-cast]: assuming caught exception was Error
-        logging.warn((e: Error), {
-          message: 'Unexpected error during /register.',
-        });
-      }
-      return;
-    }
-
-    const serverVersion = new ZulipVersion(initData.zulip_version);
-
-    // Set Sentry tags for the server version immediately, so they're accurate
-    // in case we hit an exception in reducers on `registerComplete` below.
-    logging.setTagsFromServerVersion(serverVersion);
-
-    if (!serverVersion.isAtLeast(kNextMinSupportedVersion)) {
-      // The server version is either one we already don't support, or one
-      // we'll stop supporting the next time we increase our minimum supported
-      // version.  Warn so that we have an idea of how widespread this is.
-      // (Include the coarse version in the warning message, so that it splits
-      // into separate Sentry "issues" by coarse version.  The Sentry events
-      // will also have the detailed version, from the call above to
-      // `logging.setTagsFromServerVersion`.)
-      logging.warn(`Old server version: ${serverVersion.classify().coarse}`);
-    }
-
-    dispatch(registerComplete(initData));
-
-    dispatch(startEventPolling(initData.queue_id, initData.last_event_id));
-
-    // This is part of "register" in that it fills in some missing /register
-    // functionality for older servers; see fetchPrivateMessages for detail.
-    if (!serverVersion.isAtLeast(MIN_RECENTPMS_SERVER_VERSION)) {
-      dispatch(fetchPrivateMessages());
-    }
-  };
 
 export const uploadFile =
   (destinationNarrow: Narrow, uri: string, name: string): ThunkAction<Promise<void>> =>

--- a/src/message/fetchActions.js
+++ b/src/message/fetchActions.js
@@ -45,7 +45,7 @@ import { BackoffMachine, promiseTimeout, TimeoutError } from '../utils/async';
 import { initNotifications } from '../notification/notifTokens';
 import { addToOutbox, sendOutbox } from '../outbox/outboxActions';
 import { startEventPolling } from '../events/eventActions';
-import { logout } from '../account/accountActions';
+import { logout } from '../account/logoutActions';
 import { ZulipVersion } from '../utils/zulipVersion';
 import { getAllUsersById, getOwnUserId } from '../users/userSelectors';
 import { getHaveServerData } from '../haveServerDataSelectors';

--- a/src/nav/getInitialRouteInfo.js
+++ b/src/nav/getInitialRouteInfo.js
@@ -30,8 +30,7 @@ export default (args: {|
   // Show the main UI screen.
   //
   // If we don't have server data yet, that screen will show a loading
-  // indicator until the data is loaded. Crucially, `sessionReducer`
-  // will have set `needsInitialFetch`, too, so we really will be
-  // loading.
+  // indicator until the data is loaded. Crucially, AppDataFetcher will make
+  // sure we really will be loading.
   return { initialRouteName: 'main-tabs' };
 };

--- a/src/notification/notifOpen.js
+++ b/src/notification/notifOpen.js
@@ -234,7 +234,8 @@ export const narrowToNotification =
       // the active account, and want to dispatch a per-account action there.
       // For the present, we just use the fact that our GlobalDispatch value
       // is the same function as we use for Dispatch.
-      // TODO(#5006): perhaps have an extra `activeAccountDispatch: Dispatch`?
+      // TODO(#5006): perhaps have an `activeAccountDispatch: Dispatch` in a
+      //   new GlobalThunkExtras, modeled on ThunkExtras?
       (dispatch: $FlowFixMe)(doNarrow(narrow));
     }
   };

--- a/src/reduxTypes.js
+++ b/src/reduxTypes.js
@@ -148,7 +148,7 @@ export type FlagName = $Keys<FlagsState>;
  *
  * For almost all types of data we need from the server, we use the Zulip
  * event system to get a complete snapshot and to maintain it incrementally.
- * See `doInitialFetch` for discussion, and see our docs from the
+ * See `registerAndStartPolling` for discussion, and see our docs from the
  * client-side perspective:
  *   https://github.com/zulip/zulip-mobile/blob/main/docs/architecture/realtime.md
  * and a mainly server-side perspective:
@@ -161,7 +161,8 @@ export type FlagName = $Keys<FlagsState>;
  * online, and updates to existing messages, we learn them in real time
  * through the event system; but because the full history of messages can be
  * very large, it's left out of the snapshot obtained through `/register` by
- * `doInitialFetch`.  Instead, we fetch specific message history as needed.
+ * `registerAndStartPolling`.  Instead, we fetch specific message history as
+ * needed.
  *
  * This subtree of our state stores all the messages we've fetched, prompted
  * by any of a variety of reasons.

--- a/src/session/__tests__/sessionReducer-test.js
+++ b/src/session/__tests__/sessionReducer-test.js
@@ -35,7 +35,7 @@ describe('sessionReducer', () => {
 
   test('LOGIN_SUCCESS', () => {
     const newState = sessionReducer(baseState, eg.action.login_success);
-    expect(newState).toEqual({ ...baseState, needsInitialFetch: true });
+    expect(newState).toEqual(baseState);
   });
 
   test('DEAD_QUEUE', () => {

--- a/src/session/__tests__/sessionReducer-test.js
+++ b/src/session/__tests__/sessionReducer-test.js
@@ -37,7 +37,7 @@ describe('sessionReducer', () => {
   test('DEAD_QUEUE', () => {
     const state = deepFreeze({ ...baseState, needsInitialFetch: false, loading: true });
     const newState = sessionReducer(state, deepFreeze({ type: DEAD_QUEUE }));
-    expect(newState).toEqual({ ...baseState, needsInitialFetch: true, loading: false });
+    expect(newState).toEqual({ ...baseState, loading: false });
   });
 
   test('LOGOUT', () => {

--- a/src/session/__tests__/sessionReducer-test.js
+++ b/src/session/__tests__/sessionReducer-test.js
@@ -22,7 +22,6 @@ describe('sessionReducer', () => {
   test('ACCOUNT_SWITCH', () => {
     const state = deepFreeze({
       ...baseState,
-      needsInitialFetch: false,
       loading: true,
     });
     const newState = sessionReducer(state, eg.action.account_switch);
@@ -35,7 +34,7 @@ describe('sessionReducer', () => {
   });
 
   test('DEAD_QUEUE', () => {
-    const state = deepFreeze({ ...baseState, needsInitialFetch: false, loading: true });
+    const state = deepFreeze({ ...baseState, loading: true });
     const newState = sessionReducer(state, deepFreeze({ type: DEAD_QUEUE }));
     expect(newState).toEqual({ ...baseState, loading: false });
   });
@@ -43,24 +42,21 @@ describe('sessionReducer', () => {
   test('LOGOUT', () => {
     const state = deepFreeze({
       ...baseState,
-      needsInitialFetch: true,
       loading: true,
     });
     const newState = sessionReducer(state, deepFreeze({ type: LOGOUT }));
     expect(newState).toEqual({
       ...baseState,
-      needsInitialFetch: false,
       loading: false,
     });
   });
 
   test('REGISTER_COMPLETE', () => {
-    const state = deepFreeze({ ...baseState, needsInitialFetch: true, loading: true });
+    const state = deepFreeze({ ...baseState, loading: true });
     const action = eg.mkActionRegisterComplete({ queue_id: '100' });
     const newState = sessionReducer(state, action);
     expect(newState).toEqual({
       ...baseState,
-      needsInitialFetch: false,
       loading: false,
       eventQueueId: '100',
     });
@@ -74,9 +70,9 @@ describe('sessionReducer', () => {
   });
 
   test('REGISTER_ABORT', () => {
-    const state = deepFreeze({ ...baseState, needsInitialFetch: true, loading: true });
+    const state = deepFreeze({ ...baseState, loading: true });
     const newState = sessionReducer(state, deepFreeze({ type: REGISTER_ABORT, reason: 'server' }));
-    expect(newState).toEqual({ ...baseState, needsInitialFetch: false, loading: false });
+    expect(newState).toEqual({ ...baseState, loading: false });
   });
 
   test('REGISTER_START', () => {

--- a/src/session/__tests__/sessionReducer-test.js
+++ b/src/session/__tests__/sessionReducer-test.js
@@ -26,11 +26,7 @@ describe('sessionReducer', () => {
       loading: true,
     });
     const newState = sessionReducer(state, eg.action.account_switch);
-    expect(newState).toEqual({
-      ...baseState,
-      needsInitialFetch: true,
-      loading: false,
-    });
+    expect(newState).toEqual({ ...baseState, loading: false });
   });
 
   test('LOGIN_SUCCESS', () => {

--- a/src/session/sessionActions.js
+++ b/src/session/sessionActions.js
@@ -3,7 +3,6 @@ import type { PerAccountAction, AccountIndependentAction, Orientation } from '..
 import {
   APP_ONLINE,
   APP_ORIENTATION,
-  DEAD_QUEUE,
   DEBUG_FLAG_TOGGLE,
   DISMISS_SERVER_COMPAT_NOTICE,
 } from '../actionConstants';
@@ -11,10 +10,6 @@ import {
 export const appOnline = (isOnline: boolean | null): AccountIndependentAction => ({
   type: APP_ONLINE,
   isOnline,
-});
-
-export const deadQueue = (): PerAccountAction => ({
-  type: DEAD_QUEUE,
 });
 
 export const appOrientation = (orientation: Orientation): AccountIndependentAction => ({

--- a/src/session/sessionReducer.js
+++ b/src/session/sessionReducer.js
@@ -201,7 +201,6 @@ export default (state: SessionState = initialState, action: Action): SessionStat
     case ACCOUNT_SWITCH:
       return {
         ...state,
-        needsInitialFetch: true,
         loading: false,
 
         // Stop polling this event queue.  (We'll request a new one soon,

--- a/src/session/sessionReducer.js
+++ b/src/session/sessionReducer.js
@@ -43,6 +43,7 @@ export type PerAccountSessionState = $ReadOnly<{
    */
   loading: boolean,
 
+  // TODO: We'll finish getting rid of this soon.
   needsInitialFetch: boolean,
 
   outboxSending: boolean,
@@ -181,7 +182,6 @@ export default (state: SessionState = initialState, action: Action): SessionStat
     case LOGIN_SUCCESS:
       return {
         ...state,
-        needsInitialFetch: true,
 
         // We're about to request a new event queue; no use hanging on to
         // any old one we might have.

--- a/src/session/sessionReducer.js
+++ b/src/session/sessionReducer.js
@@ -42,9 +42,6 @@ export type PerAccountSessionState = $ReadOnly<{
    */
   loading: boolean,
 
-  // TODO: We'll finish getting rid of this soon.
-  needsInitialFetch: boolean,
-
   outboxSending: boolean,
 
   /**
@@ -129,7 +126,6 @@ const initialState: SessionState = {
 
   isHydrated: false,
   loading: false,
-  needsInitialFetch: false,
   orientation: 'PORTRAIT',
   outboxSending: false,
   pushToken: null,
@@ -162,7 +158,6 @@ export default (state: SessionState = initialState, action: Action): SessionStat
     case LOGOUT:
       return {
         ...state,
-        needsInitialFetch: false,
         loading: false,
 
         // Stop polling this event queue.
@@ -191,7 +186,6 @@ export default (state: SessionState = initialState, action: Action): SessionStat
       return {
         ...state,
         loading: false,
-        needsInitialFetch: false,
         eventQueueId: action.data.queue_id,
       };
 
@@ -211,7 +205,6 @@ export default (state: SessionState = initialState, action: Action): SessionStat
       return {
         ...state,
         loading: false,
-        needsInitialFetch: false,
       };
 
     case APP_ORIENTATION:

--- a/src/session/sessionReducer.js
+++ b/src/session/sessionReducer.js
@@ -171,7 +171,6 @@ export default (state: SessionState = initialState, action: Action): SessionStat
     case DEAD_QUEUE:
       return {
         ...state,
-        needsInitialFetch: true,
         loading: false,
 
         // The server told us that the old queue ID is invalid. Forget it,

--- a/tools/formatting.eslintrc.yaml
+++ b/tools/formatting.eslintrc.yaml
@@ -9,6 +9,7 @@ plugins:
   - import
   - jest
   - react
+  - react-hooks
 
 rules:
   # Disallow tucking a condition or loop body in at the end of a line, like


### PR DESCRIPTION
This is the next PR in my series toward better offline handling for the `/register` request.

We've long thought that the current logic is complex and fragile;
see for example
  https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/Stuck.20on.20loading.20screen/near/907688