### PR TITLE
mention_count: Fixed `@` mention_count badge position correctly.

### DIFF
--- a/src/common/ComponentWithOverlay.js
+++ b/src/common/ComponentWithOverlay.js
@@ -41,6 +41,7 @@ type Props = $ReadOnly<{|
   overlayColor: string,
   overlayPosition: 'top-right' | 'top-left' | 'bottom-right' | 'bottom-left',
   style?: ViewStyleProp,
+  customOverlayStyle?: ViewStyleProp,
 |}>;
 
 /**
@@ -53,6 +54,7 @@ type Props = $ReadOnly<{|
  * @prop overlayColor - Background color for overlay.
  * @prop overlayPosition - What corner to align the overlay to.
  * @prop [style] - Applied to a wrapper View.
+ * @prop [customOverlayStyle] - Apply custom style to overlay.
  */
 export default function ComponentWithOverlay(props: Props): Node {
   const {
@@ -63,6 +65,7 @@ export default function ComponentWithOverlay(props: Props): Node {
     overlayPosition,
     overlaySize,
     overlayColor,
+    customOverlayStyle,
   } = props;
 
   const wrapperStyle = [styles.wrapper, style];
@@ -76,6 +79,7 @@ export default function ComponentWithOverlay(props: Props): Node {
       borderRadius: overlaySize,
       backgroundColor: overlayColor,
     },
+    customOverlayStyle,
   ];
 
   return (

--- a/src/common/CountOverlay.js
+++ b/src/common/CountOverlay.js
@@ -12,6 +12,10 @@ const styles = createStyleSheet({
   button: {
     flex: 1,
   },
+  overlayStyle: {
+    right: -10,
+    top: 10,
+  },
 });
 
 type Props = $ReadOnly<{|
@@ -27,10 +31,13 @@ export default class CountOverlay extends PureComponent<Props> {
       <View>
         <ComponentWithOverlay
           style={styles.button}
-          overlaySize={15}
+          // It looks like what we want to match is 25 * 0.75, which is 18.75,
+          // https://github.com/react-navigation/react-navigation/blob/%40react-navigation/bottom-tabs%405.11.15/packages/bottom-tabs/src/views/TabBarIcon.tsx#L69
+          overlaySize={18.75}
           overlayColor={BRAND_COLOR}
           overlayPosition="top-right"
           showOverlay={unreadCount > 0}
+          customOverlayStyle={styles.overlayStyle}
           overlay={<UnreadCount count={unreadCount} />}
         >
           {children}


### PR DESCRIPTION
This commit fixes `@` mention_count badge position.

Fixes: #5278