### PR TITLE
Untangle eg.makeUser names; simplify some tests

### DIFF
--- a/src/__tests__/lib/exampleData.js
+++ b/src/__tests__/lib/exampleData.js
@@ -129,7 +129,6 @@ export const diverseCharacters: string =
  */
 
 type UserOrBotPropertiesArgs = {|
-  name?: string,
   user_id?: number, // accept a plain number, for convenience in tests
   email?: string,
   full_name?: string,
@@ -151,7 +150,7 @@ const randUserId: () => UserId = (mk => () => makeUserId(mk()))(
   makeUniqueRandInt('user IDs', 10000),
 );
 const userOrBotProperties = (args: UserOrBotPropertiesArgs) => {
-  const name = args.name ?? randString();
+  const name = randString();
   const capsName = name.substring(0, 1).toUpperCase() + name.substring(1);
   const user_id = args.user_id != null ? makeUserId(args.user_id) : randUserId();
   return deepFreeze({

--- a/src/__tests__/lib/exampleData.js
+++ b/src/__tests__/lib/exampleData.js
@@ -263,17 +263,30 @@ export const makeUserGroup = (extra?: $Rest<UserGroup, { ... }>): UserGroup => {
   return deepFreeze({ ...baseUserGroup, ...extra });
 };
 
-export const selfUser: User = makeUser({ name: 'self' });
-export const selfAccount: Account = makeAccount({
-  user: selfUser,
-  realm,
+export const selfUser: User = makeUser({
+  full_name: 'Self User',
+  email: 'self@example.org',
+  avatar_url: makeAvatarUrl('self'),
 });
+export const selfAccount: Account = makeAccount({ user: selfUser, realm });
 export const selfAuth: Auth = deepFreeze(authOfAccount(selfAccount));
 
-export const otherUser: User = makeUser({ name: 'other' });
-export const thirdUser: User = makeUser({ name: 'third' });
+export const otherUser: User = makeUser({
+  full_name: 'Other User',
+  email: 'other@example.org',
+  avatar_url: makeAvatarUrl('other'),
+});
+export const thirdUser: User = makeUser({
+  full_name: 'Third User',
+  email: 'third@example.org',
+  avatar_url: makeAvatarUrl('third'),
+});
 
-export const crossRealmBot: CrossRealmBot = makeCrossRealmBot({ name: 'bot' });
+export const crossRealmBot: CrossRealmBot = makeCrossRealmBot({
+  full_name: 'Bot User',
+  email: 'bot@example.org',
+  avatar_url: makeAvatarUrl('bot'),
+});
 
 /* ========================================================================
  * Streams and subscriptions

--- a/src/__tests__/lib/exampleData.js
+++ b/src/__tests__/lib/exampleData.js
@@ -624,6 +624,7 @@ export const plusReduxState: GlobalState & PerAccountState = reduxState({
     ...baseReduxState.realm,
     user_id: selfUser.user_id,
     email: selfUser.email,
+    crossRealmBots: [crossRealmBot],
     emoji: {
       [realmEmojiReaction.emoji_code]: {
         deactivated: false,
@@ -633,7 +634,6 @@ export const plusReduxState: GlobalState & PerAccountState = reduxState({
       },
     },
   },
-  // TODO add crossRealmBot
   users: [selfUser, otherUser, thirdUser],
   streams: [stream, otherStream],
   subscriptions: [subscription, otherSubscription],

--- a/src/__tests__/lib/exampleData.js
+++ b/src/__tests__/lib/exampleData.js
@@ -150,9 +150,8 @@ const randUserId: () => UserId = (mk => () => makeUserId(mk()))(
   makeUniqueRandInt('user IDs', 10000),
 );
 const userOrBotProperties = (args: UserOrBotPropertiesArgs) => {
-  const name = randString();
-  const capsName = name.substring(0, 1).toUpperCase() + name.substring(1);
   const user_id = args.user_id != null ? makeUserId(args.user_id) : randUserId();
+  const randName = randString();
   return deepFreeze({
     avatar_url: args.avatar_url ?? makeAvatarUrl(user_id.toString()),
 
@@ -160,8 +159,8 @@ const userOrBotProperties = (args: UserOrBotPropertiesArgs) => {
       .toString()
       .padStart(2, '0')}`,
 
-    email: args.email ?? `${name}@example.org`,
-    full_name: args.full_name ?? `${capsName} User`,
+    email: args.email ?? `${randName}@example.org`,
+    full_name: args.full_name ?? `${randName} User`,
     is_admin: false,
     timezone: 'UTC',
     user_id,

--- a/src/__tests__/lib/exampleData.js
+++ b/src/__tests__/lib/exampleData.js
@@ -132,6 +132,7 @@ type UserOrBotPropertiesArgs = {|
   name?: string,
   user_id?: number, // accept a plain number, for convenience in tests
   email?: string,
+  full_name?: string,
   avatar_url?: AvatarURL,
 |};
 
@@ -140,7 +141,6 @@ const randUserId: () => UserId = (mk => () => makeUserId(mk()))(
 );
 const userOrBotProperties = (args: UserOrBotPropertiesArgs) => {
   const name = args.name ?? randString();
-  const email = args.email ?? `${name}@example.org`;
   const capsName = name.substring(0, 1).toUpperCase() + name.substring(1);
   return deepFreeze({
     // Internally the UploadedAvatarURL mutates itself for memoization.
@@ -154,8 +154,8 @@ const userOrBotProperties = (args: UserOrBotPropertiesArgs) => {
       .toString()
       .padStart(2, '0')}`,
 
-    email,
-    full_name: `${capsName} User`,
+    email: args.email ?? `${name}@example.org`,
+    full_name: args.full_name ?? `${capsName} User`,
     is_admin: false,
     timezone: 'UTC',
     user_id: args.user_id != null ? makeUserId(args.user_id) : randUserId(),

--- a/src/__tests__/lib/exampleData.js
+++ b/src/__tests__/lib/exampleData.js
@@ -136,6 +136,17 @@ type UserOrBotPropertiesArgs = {|
   avatar_url?: AvatarURL,
 |};
 
+/**
+ * An avatar URL, containing the given tag to make it recognizable in debugging.
+ *
+ * Beware!  This value may not be representative.
+ */
+const makeAvatarUrl = (tag: string) =>
+  // Internally the UploadedAvatarURL mutates itself for memoization.
+  // That conflicts with the deepFreeze we do for tests; so construct it
+  // here with a full-blown URL object in the first place to prevent that.
+  new UploadedAvatarURL(new URL(`https://zulip.example.org/yo/avatar-${tag}.png`));
+
 const randUserId: () => UserId = (mk => () => makeUserId(mk()))(
   makeUniqueRandInt('user IDs', 10000),
 );
@@ -143,12 +154,7 @@ const userOrBotProperties = (args: UserOrBotPropertiesArgs) => {
   const name = args.name ?? randString();
   const capsName = name.substring(0, 1).toUpperCase() + name.substring(1);
   return deepFreeze({
-    // Internally the UploadedAvatarURL mutates itself for memoization.
-    // That conflicts with the deepFreeze we do for tests; so construct it
-    // here with a full-blown URL object in the first place to prevent that.
-    avatar_url:
-      args.avatar_url
-      ?? new UploadedAvatarURL(new URL(`https://zulip.example.org/yo/avatar-${name}.png`)),
+    avatar_url: args.avatar_url ?? makeAvatarUrl(name),
 
     date_joined: `2014-04-${randInt(30)
       .toString()

--- a/src/__tests__/lib/exampleData.js
+++ b/src/__tests__/lib/exampleData.js
@@ -153,8 +153,9 @@ const randUserId: () => UserId = (mk => () => makeUserId(mk()))(
 const userOrBotProperties = (args: UserOrBotPropertiesArgs) => {
   const name = args.name ?? randString();
   const capsName = name.substring(0, 1).toUpperCase() + name.substring(1);
+  const user_id = args.user_id != null ? makeUserId(args.user_id) : randUserId();
   return deepFreeze({
-    avatar_url: args.avatar_url ?? makeAvatarUrl(name),
+    avatar_url: args.avatar_url ?? makeAvatarUrl(user_id.toString()),
 
     date_joined: `2014-04-${randInt(30)
       .toString()
@@ -164,7 +165,7 @@ const userOrBotProperties = (args: UserOrBotPropertiesArgs) => {
     full_name: args.full_name ?? `${capsName} User`,
     is_admin: false,
     timezone: 'UTC',
-    user_id: args.user_id != null ? makeUserId(args.user_id) : randUserId(),
+    user_id,
   });
 };
 

--- a/src/__tests__/lib/exampleData.js
+++ b/src/__tests__/lib/exampleData.js
@@ -223,7 +223,7 @@ export const makeAccount = (
   |} = Object.freeze({}),
 ): Account => {
   const {
-    user = makeUser({ name: randString() }),
+    user = makeUser(),
     userId = user.user_id,
     email = user.email,
     realm: realmInner = realm,

--- a/src/chat/__tests__/narrowsSelectors-test.js
+++ b/src/chat/__tests__/narrowsSelectors-test.js
@@ -334,159 +334,54 @@ describe('getStreamInNarrow', () => {
 
 describe('isNarrowValid', () => {
   test('narrowing to a special narrow is always valid', () => {
-    const state = eg.reduxState();
     const narrow = STARRED_NARROW;
-
-    const result = isNarrowValid(state, narrow);
-
-    expect(result).toBe(true);
+    expect(isNarrowValid(eg.plusReduxState, narrow)).toBe(true);
   });
 
   test('narrowing to an existing stream is valid', () => {
-    const stream = eg.makeStream({ name: 'some stream' });
-
-    const state = eg.reduxState({
-      streams: [stream],
-    });
-    const narrow = streamNarrow(stream.stream_id);
-
-    const result = isNarrowValid(state, narrow);
-
-    expect(result).toBe(true);
+    const narrow = streamNarrow(eg.stream.stream_id);
+    expect(isNarrowValid(eg.plusReduxState, narrow)).toBe(true);
   });
 
   test('narrowing to a non-existing stream is invalid', () => {
-    const state = eg.reduxState({
-      streams: [],
-    });
-    const narrow = streamNarrow(eg.stream.stream_id);
-
-    const result = isNarrowValid(state, narrow);
-
-    expect(result).toBe(false);
+    const narrow = streamNarrow(eg.makeStream().stream_id);
+    expect(isNarrowValid(eg.plusReduxState, narrow)).toBe(false);
   });
 
   test('narrowing to an existing stream is valid regardless of topic', () => {
-    const stream = eg.makeStream({ name: 'some stream' });
-
-    const state = eg.reduxState({
-      streams: [stream],
-    });
-    const narrow = topicNarrow(stream.stream_id, 'topic does not matter');
-
-    const result = isNarrowValid(state, narrow);
-
-    expect(result).toBe(true);
+    const narrow = topicNarrow(eg.stream.stream_id, 'topic does not matter');
+    expect(isNarrowValid(eg.plusReduxState, narrow)).toBe(true);
   });
 
   test('narrowing to a PM with existing user is valid', () => {
-    const user = eg.makeUser({ name: 'bob' });
-    const state = eg.reduxState({
-      realm: {
-        ...eg.realmState(),
-        crossRealmBots: [],
-        nonActiveUsers: [],
-      },
-      streams: [],
-      users: [user],
-    });
-    const narrow = pm1to1NarrowFromUser(user);
-
-    const result = isNarrowValid(state, narrow);
-
-    expect(result).toBe(true);
+    const narrow = pm1to1NarrowFromUser(eg.otherUser);
+    expect(isNarrowValid(eg.plusReduxState, narrow)).toBe(true);
   });
 
   test('narrowing to a PM with non-existing user is not valid', () => {
-    const user = eg.makeUser({ name: 'bob' });
-    const state = eg.reduxState({
-      realm: {
-        ...eg.realmState(),
-        crossRealmBots: [],
-        nonActiveUsers: [],
-      },
-      streams: [],
-      users: [],
-    });
-    const narrow = pm1to1NarrowFromUser(user);
-
-    const result = isNarrowValid(state, narrow);
-
-    expect(result).toBe(false);
+    const narrow = pm1to1NarrowFromUser(eg.makeUser());
+    expect(isNarrowValid(eg.plusReduxState, narrow)).toBe(false);
   });
 
   test('narrowing to a group chat with existing users is valid', () => {
-    const john = eg.makeUser({ name: 'john' });
-    const mark = eg.makeUser({ name: 'mark' });
-
-    const state = eg.reduxState({
-      realm: {
-        ...eg.realmState(),
-        crossRealmBots: [],
-        nonActiveUsers: [],
-      },
-      streams: [],
-      users: [john, mark],
-    });
-    const narrow = pmNarrowFromUsersUnsafe([john, mark]);
-
-    const result = isNarrowValid(state, narrow);
-
-    expect(result).toBe(true);
+    const narrow = pmNarrowFromUsersUnsafe([eg.otherUser, eg.thirdUser]);
+    expect(isNarrowValid(eg.plusReduxState, narrow)).toBe(true);
   });
 
   test('narrowing to a group chat with non-existing users is not valid', () => {
-    const john = eg.makeUser({ name: 'john' });
-    const mark = eg.makeUser({ name: 'mark' });
-    const state = eg.reduxState({
-      realm: {
-        ...eg.realmState(),
-        crossRealmBots: [],
-        nonActiveUsers: [],
-      },
-      streams: [],
-      users: [john],
-    });
-    const narrow = pmNarrowFromUsersUnsafe([john, mark]);
-
-    const result = isNarrowValid(state, narrow);
-
-    expect(result).toBe(false);
+    const narrow = pmNarrowFromUsersUnsafe([eg.otherUser, eg.makeUser()]);
+    expect(isNarrowValid(eg.plusReduxState, narrow)).toBe(false);
   });
 
   test('narrowing to a PM with bots is valid', () => {
-    const bot = eg.makeCrossRealmBot({ name: 'some-bot' });
-    const state = eg.reduxState({
-      realm: {
-        ...eg.realmState(),
-        crossRealmBots: [bot],
-        nonActiveUsers: [],
-      },
-      streams: [],
-      users: [],
-    });
-    const narrow = pm1to1NarrowFromUser(bot);
-
-    const result = isNarrowValid(state, narrow);
-
-    expect(result).toBe(true);
+    const narrow = pm1to1NarrowFromUser(eg.crossRealmBot);
+    expect(isNarrowValid(eg.plusReduxState, narrow)).toBe(true);
   });
 
   test('narrowing to non active users is valid', () => {
-    const notActiveUser = eg.makeUser({ name: 'not active' });
-    const state = eg.reduxState({
-      realm: {
-        ...eg.realmState(),
-        crossRealmBots: [],
-        nonActiveUsers: [notActiveUser],
-      },
-      streams: [],
-      users: [],
-    });
+    const notActiveUser = eg.makeUser();
+    const state = eg.reduxState({ realm: { ...eg.realmState(), nonActiveUsers: [notActiveUser] } });
     const narrow = pm1to1NarrowFromUser(notActiveUser);
-
-    const result = isNarrowValid(state, narrow);
-
-    expect(result).toBe(true);
+    expect(isNarrowValid(state, narrow)).toBe(true);
   });
 });

--- a/src/storage/__tests__/storage-test.js
+++ b/src/storage/__tests__/storage-test.js
@@ -82,6 +82,8 @@ test('`eg.plusReduxState` round-trips through storage', async () => {
   // states by "waking up" their `AvatarURL`s.
   [stateBefore, stateAfter].forEach(s => {
     s.users.forEach(u => u.avatar_url.get(100));
+    s.realm.nonActiveUsers.forEach(u => u.avatar_url.get(100));
+    s.realm.crossRealmBots.forEach(u => u.avatar_url.get(100));
     s.messages.forEach(m => m.avatar_url.get(100));
   });
 

--- a/src/users/__tests__/userHelpers-test.js
+++ b/src/users/__tests__/userHelpers-test.js
@@ -7,7 +7,6 @@ import {
   filterUserList,
   getAutocompleteSuggestion,
   getAutocompleteUserGroupSuggestions,
-  sortAlphabetically,
   filterUserStartWith,
   filterUserThatContains,
   filterUserMatchesEmail,
@@ -206,22 +205,6 @@ describe('sortUserList', () => {
     const sortedUsers = sortUserList(users, presences);
 
     expect(sortedUsers).toEqual(shouldMatch);
-  });
-});
-
-describe('sortAlphabetically', () => {
-  test('alphabetically sort user list by full_name', () => {
-    const user1 = eg.makeUser({ full_name: 'zoe' });
-    const user2 = eg.makeUser({ full_name: 'Ring' });
-    const user3 = eg.makeUser({ full_name: 'watch' });
-    const user4 = eg.makeUser({ full_name: 'mobile' });
-    const user5 = eg.makeUser({ full_name: 'Ring' });
-    const user6 = eg.makeUser({ full_name: 'hardware' });
-    const user7 = eg.makeUser({ full_name: 'Bob' });
-    const users = deepFreeze([user1, user2, user3, user4, user5, user6, user7]);
-
-    const expectedUsers = [user7, user6, user4, user2, user5, user3, user1];
-    expect(sortAlphabetically(users)).toEqual(expectedUsers);
   });
 });
 

--- a/src/users/__tests__/userHelpers-test.js
+++ b/src/users/__tests__/userHelpers-test.js
@@ -178,10 +178,10 @@ describe('sortUserList', () => {
   });
 
   test('prioritizes status', () => {
-    const user1 = eg.makeUser({ full_name: 'Mark', email: 'mark@example.com' });
-    const user2 = eg.makeUser({ full_name: 'John', email: 'john@example.com' });
-    const user3 = eg.makeUser({ full_name: 'Bob', email: 'bob@example.com' });
-    const user4 = eg.makeUser({ full_name: 'Rick', email: 'rick@example.com' });
+    const user1 = eg.makeUser({ full_name: 'Mark' });
+    const user2 = eg.makeUser({ full_name: 'John' });
+    const user3 = eg.makeUser({ full_name: 'Bob' });
+    const user4 = eg.makeUser({ full_name: 'Rick' });
     const users = deepFreeze([user1, user2, user3, user4]);
     const presences = {
       [user1.email]: {
@@ -211,13 +211,13 @@ describe('sortUserList', () => {
 
 describe('sortAlphabetically', () => {
   test('alphabetically sort user list by full_name', () => {
-    const user1 = eg.makeUser({ full_name: 'zoe', email: 'allen@example.com' });
-    const user2 = eg.makeUser({ full_name: 'Ring', email: 'got@example.com' });
-    const user3 = eg.makeUser({ full_name: 'watch', email: 'see@example.com' });
-    const user4 = eg.makeUser({ full_name: 'mobile', email: 'phone@example.com' });
-    const user5 = eg.makeUser({ full_name: 'Ring', email: 'got@example.com' });
-    const user6 = eg.makeUser({ full_name: 'hardware', email: 'software@example.com' });
-    const user7 = eg.makeUser({ full_name: 'Bob', email: 'tester@example.com' });
+    const user1 = eg.makeUser({ full_name: 'zoe' });
+    const user2 = eg.makeUser({ full_name: 'Ring' });
+    const user3 = eg.makeUser({ full_name: 'watch' });
+    const user4 = eg.makeUser({ full_name: 'mobile' });
+    const user5 = eg.makeUser({ full_name: 'Ring' });
+    const user6 = eg.makeUser({ full_name: 'hardware' });
+    const user7 = eg.makeUser({ full_name: 'Bob' });
     const users = deepFreeze([user1, user2, user3, user4, user5, user6, user7]);
 
     const expectedUsers = [user7, user6, user4, user2, user5, user3, user1];
@@ -227,12 +227,12 @@ describe('sortAlphabetically', () => {
 
 describe('filterUserStartWith', () => {
   test('returns users whose name starts with filter excluding self', () => {
-    const user1 = eg.makeUser({ full_name: 'Apple', email: 'a@example.com' });
-    const user2 = eg.makeUser({ full_name: 'bob', email: 'f@app.com' });
-    const user3 = eg.makeUser({ full_name: 'app', email: 'p@p.com' });
-    const user4 = eg.makeUser({ full_name: 'Mobile app', email: 'p3@p.com' });
-    const user5 = eg.makeUser({ full_name: 'Mac App', email: 'p@p2.com' });
-    const selfUser = eg.makeUser({ full_name: 'app', email: 'own@example.com' });
+    const user1 = eg.makeUser({ full_name: 'Apple' });
+    const user2 = eg.makeUser({ full_name: 'bob' });
+    const user3 = eg.makeUser({ full_name: 'app' });
+    const user4 = eg.makeUser({ full_name: 'Mobile app' });
+    const user5 = eg.makeUser({ full_name: 'Mac App' });
+    const selfUser = eg.makeUser({ full_name: 'app' });
     const users = deepFreeze([user1, user2, user3, user4, user5, selfUser]);
 
     const expectedUsers = [user1, user3];
@@ -240,20 +240,20 @@ describe('filterUserStartWith', () => {
   });
 
   test('returns users whose name contains diacritics but otherwise starts with filter', () => {
-    const withDiacritics = eg.makeUser({ full_name: 'Frödö', email: 'bagginsf@example.com' });
-    const withoutDiacritics = eg.makeUser({ full_name: 'Frodo', email: 'bagginz@example.com' });
-    const nonMatchingUser = eg.makeUser({ full_name: 'Zalix', email: 'zalix@example.com' });
+    const withDiacritics = eg.makeUser({ full_name: 'Frödö' });
+    const withoutDiacritics = eg.makeUser({ full_name: 'Frodo' });
+    const nonMatchingUser = eg.makeUser({ full_name: 'Zalix' });
     const users = deepFreeze([withDiacritics, withoutDiacritics, nonMatchingUser]);
     const expectedUsers = [withDiacritics, withoutDiacritics];
     expect(filterUserStartWith(users, 'Fro', eg.makeUser().user_id)).toEqual(expectedUsers);
   });
 
   test('returns users whose name contains diacritics and filter uses diacritics', () => {
-    const withDiacritics = eg.makeUser({ full_name: 'Frödö', email: 'bagginsf@example.com' });
-    const withoutDiacritics = eg.makeUser({ full_name: 'Frodo', email: 'bagginz@example.com' });
-    const wrongDiacritics = eg.makeUser({ full_name: 'Frōdō', email: 'baggins@example.com' });
-    const notIncludedDiactritic = eg.makeUser({ full_name: 'Fřödo', email: 'baggins@example.com' });
-    const nonMatchingUser = eg.makeUser({ full_name: 'Zalix', email: 'zalix@example.com' });
+    const withDiacritics = eg.makeUser({ full_name: 'Frödö' });
+    const withoutDiacritics = eg.makeUser({ full_name: 'Frodo' });
+    const wrongDiacritics = eg.makeUser({ full_name: 'Frōdō' });
+    const notIncludedDiactritic = eg.makeUser({ full_name: 'Fřödo' });
+    const nonMatchingUser = eg.makeUser({ full_name: 'Zalix' });
     const users = deepFreeze([
       withDiacritics,
       withoutDiacritics,
@@ -276,10 +276,10 @@ describe('groupUsersByStatus', () => {
   });
 
   test('sort input by status, when no presence entry consider offline', () => {
-    const user1 = eg.makeUser({ email: 'allen@example.com' });
-    const user2 = eg.makeUser({ email: 'bob@example.com' });
-    const user3 = eg.makeUser({ email: 'carter@example.com' });
-    const user4 = eg.makeUser({ email: 'dan@example.com' });
+    const user1 = eg.makeUser();
+    const user2 = eg.makeUser();
+    const user3 = eg.makeUser();
+    const user4 = eg.makeUser();
     const users = deepFreeze([user1, user2, user3, user4]);
     const presence = {
       [user1.email]: {
@@ -306,13 +306,13 @@ describe('groupUsersByStatus', () => {
 
 describe('filterUserThatContains', () => {
   test('returns users whose full_name contains filter excluding self', () => {
-    const user1 = eg.makeUser({ full_name: 'Apple', email: 'a@example.com' });
-    const user2 = eg.makeUser({ full_name: 'mam', email: 'f@app.com' });
-    const user3 = eg.makeUser({ full_name: 'app', email: 'p@p.com' });
-    const user4 = eg.makeUser({ full_name: 'Mobile app', email: 'p3@p.com' });
-    const user5 = eg.makeUser({ full_name: 'Mac App', email: 'p@p2.com' });
-    const user6 = eg.makeUser({ full_name: 'app', email: 'p@p.com' });
-    const selfUser = eg.makeUser({ full_name: 'app', email: 'own@example.com' });
+    const user1 = eg.makeUser({ full_name: 'Apple' });
+    const user2 = eg.makeUser({ full_name: 'mam' });
+    const user3 = eg.makeUser({ full_name: 'app' });
+    const user4 = eg.makeUser({ full_name: 'Mobile app' });
+    const user5 = eg.makeUser({ full_name: 'Mac App' });
+    const user6 = eg.makeUser({ full_name: 'app' });
+    const selfUser = eg.makeUser({ full_name: 'app' });
 
     const users = deepFreeze([user1, user2, user3, user4, user5, user6, selfUser]);
 
@@ -321,23 +321,20 @@ describe('filterUserThatContains', () => {
   });
 
   test('returns users whose full_name has diacritics but otherwise contains filter', () => {
-    const withDiacritics = eg.makeUser({ full_name: 'Aärdvärk', email: 'aardvark@example.com' });
-    const withoutDiacritics = eg.makeUser({ full_name: 'Aardvark', email: 'ard@example.com' });
-    const nonMatchingUser = eg.makeUser({ full_name: 'Turtle', email: 'turtle@example.com' });
+    const withDiacritics = eg.makeUser({ full_name: 'Aärdvärk' });
+    const withoutDiacritics = eg.makeUser({ full_name: 'Aardvark' });
+    const nonMatchingUser = eg.makeUser({ full_name: 'Turtle' });
     const users = deepFreeze([withDiacritics, withoutDiacritics, nonMatchingUser]);
     const expectedUsers = [withDiacritics, withoutDiacritics];
     expect(filterUserThatContains(users, 'vark', eg.makeUser().user_id)).toEqual(expectedUsers);
   });
 
   test('returns users whose full_name has diacritics and filter uses diacritics', () => {
-    const withDiacritics = eg.makeUser({ full_name: 'Aärdvärk', email: 'aardvark@example.com' });
-    const withoutDiacritics = eg.makeUser({ full_name: 'Aardvark', email: 'aardvark@example.com' });
-    const wrongDiacritics = eg.makeUser({ full_name: 'Aärdvãrk', email: 'aadvark@example.com' });
-    const notIncludedDiactritic = eg.makeUser({
-      full_name: 'Aärdväŕk',
-      email: 'aadvark@example.com',
-    });
-    const nonMatchingUser = eg.makeUser({ full_name: 'Turtle', email: 'turtle@example.com' });
+    const withDiacritics = eg.makeUser({ full_name: 'Aärdvärk' });
+    const withoutDiacritics = eg.makeUser({ full_name: 'Aardvark' });
+    const wrongDiacritics = eg.makeUser({ full_name: 'Aärdvãrk' });
+    const notIncludedDiactritic = eg.makeUser({ full_name: 'Aärdväŕk' });
+    const nonMatchingUser = eg.makeUser({ full_name: 'Turtle' });
     const users = deepFreeze([
       withDiacritics,
       withoutDiacritics,
@@ -352,13 +349,13 @@ describe('filterUserThatContains', () => {
 
 describe('filterUserMatchesEmail', () => {
   test('returns users whose email matches filter excluding self', () => {
-    const user1 = eg.makeUser({ full_name: 'Apple', email: 'a@example.com' });
-    const user2 = eg.makeUser({ full_name: 'mam', email: 'f@app.com' });
-    const user3 = eg.makeUser({ full_name: 'app', email: 'p@p.com' });
-    const user4 = eg.makeUser({ full_name: 'Mobile app', email: 'p3@p.com' });
-    const user5 = eg.makeUser({ full_name: 'Mac App', email: 'p@p2.com' });
-    const user6 = eg.makeUser({ full_name: 'app', email: 'p@p.com' });
-    const selfUser = eg.makeUser({ full_name: 'app', email: 'own@example.com' });
+    const user1 = eg.makeUser({ email: 'a@example.com' });
+    const user2 = eg.makeUser({ email: 'f@app.com' });
+    const user3 = eg.makeUser({ email: 'p@p.com' });
+    const user4 = eg.makeUser({ email: 'p3@p.com' });
+    const user5 = eg.makeUser({ email: 'p@p2.com' });
+    const user6 = eg.makeUser({ email: 'p@p.com' });
+    const selfUser = eg.makeUser({ email: 'own@example.com' });
 
     const users = deepFreeze([user1, user2, user3, user4, user5, user6, selfUser]);
     const expectedUsers = [user1];
@@ -368,14 +365,14 @@ describe('filterUserMatchesEmail', () => {
 
 describe('getUniqueUsers', () => {
   test('returns unique users check by email', () => {
-    const user1 = eg.makeUser({ full_name: 'Apple', email: 'a@example.com' });
-    const user2 = eg.makeUser({ full_name: 'Apple', email: 'a@example.com' });
-    const user3 = eg.makeUser({ full_name: 'app', email: 'p@p.com' });
-    const user4 = eg.makeUser({ full_name: 'app', email: 'p@p.com' });
-    const user5 = eg.makeUser({ full_name: 'Mac App', email: 'p@p2.com' });
-    const user6 = eg.makeUser({ full_name: 'Mac App', email: 'p@p2.com' });
-    const user7 = eg.makeUser({ full_name: 'Mac App 2', email: 'p@p2.com' });
-    const user8 = eg.makeUser({ full_name: 'app', email: 'own@example.com' });
+    const user1 = eg.makeUser({ email: 'a@example.com' });
+    const user2 = eg.makeUser({ email: 'a@example.com' });
+    const user3 = eg.makeUser({ email: 'p@p.com' });
+    const user4 = eg.makeUser({ email: 'p@p.com' });
+    const user5 = eg.makeUser({ email: 'p@p2.com' });
+    const user6 = eg.makeUser({ email: 'p@p2.com' });
+    const user7 = eg.makeUser({ email: 'p@p2.com' });
+    const user8 = eg.makeUser({ email: 'own@example.com' });
 
     const users = deepFreeze([user1, user2, user3, user4, user5, user6, user7, user8]);
 

--- a/src/users/__tests__/userHelpers-test.js
+++ b/src/users/__tests__/userHelpers-test.js
@@ -24,25 +24,6 @@ describe('filterUserList', () => {
     expect(filteredUsers).toEqual(users);
   });
 
-  test('returns same list if no filter', () => {
-    const user1 = eg.makeUser({ name: 'user1' });
-    const user2 = eg.makeUser({ name: 'user2' });
-    const users = deepFreeze([user1, user2]);
-
-    const filteredUsers = filterUserList(users);
-    expect(filteredUsers).toEqual(users);
-  });
-
-  test("filters out user's own entry", () => {
-    const user1 = eg.makeUser({ name: 'user1' });
-    const user2 = eg.makeUser({ name: 'user2' });
-    const users = deepFreeze([user1, user2]);
-
-    const shouldMatch = [user1];
-    const filteredUsers = filterUserList(users, '', user2.user_id);
-    expect(filteredUsers).toEqual(shouldMatch);
-  });
-
   test('searches in name, email and is case insensitive', () => {
     const user1 = eg.makeUser({ name: 'match', email: 'any@example.com' });
     const user2 = eg.makeUser({ name: 'partial match', email: 'any@example.com' });

--- a/src/users/__tests__/userHelpers-test.js
+++ b/src/users/__tests__/userHelpers-test.js
@@ -25,11 +25,11 @@ describe('filterUserList', () => {
   });
 
   test('searches in name, email and is case insensitive', () => {
-    const user1 = eg.makeUser({ name: 'match', email: 'any@example.com' });
-    const user2 = eg.makeUser({ name: 'partial match', email: 'any@example.com' });
-    const user3 = eg.makeUser({ name: 'Case Insensitive MaTcH', email: 'any@example.com' });
-    const user4 = eg.makeUser({ name: 'Any Name', email: 'match@example.com' });
-    const user5 = eg.makeUser({ name: 'some name', email: 'another@example.com' });
+    const user1 = eg.makeUser({ full_name: 'match', email: 'any@example.com' });
+    const user2 = eg.makeUser({ full_name: 'partial match', email: 'any@example.com' });
+    const user3 = eg.makeUser({ full_name: 'Case Insensitive MaTcH', email: 'any@example.com' });
+    const user4 = eg.makeUser({ full_name: 'Any Name', email: 'match@example.com' });
+    const user5 = eg.makeUser({ full_name: 'some name', email: 'another@example.com' });
     const allUsers = deepFreeze([user1, user2, user3, user4, user5]);
 
     const shouldMatch = [user1, user2, user3, user4];
@@ -52,8 +52,8 @@ describe('getAutocompleteSuggestion', () => {
   });
 
   test("filters out user's own entry", () => {
-    const someGuyUser = eg.makeUser({ name: 'Some Guy' });
-    const meUser = eg.makeUser({ name: 'Me' });
+    const someGuyUser = eg.makeUser({ full_name: 'Some Guy' });
+    const meUser = eg.makeUser({ full_name: 'Me' });
     const users = deepFreeze([someGuyUser, meUser]);
 
     const shouldMatch = [
@@ -65,8 +65,8 @@ describe('getAutocompleteSuggestion', () => {
   });
 
   test('filters out muted user', () => {
-    const mutedUser = eg.makeUser({ name: 'Muted User' });
-    const meUser = eg.makeUser({ name: 'Me' });
+    const mutedUser = eg.makeUser({ full_name: 'Muted User' });
+    const meUser = eg.makeUser({ full_name: 'Me' });
     const users = deepFreeze([mutedUser, meUser]);
 
     const mutedUsers = Immutable.Map([[mutedUser.user_id, 0]]);
@@ -78,11 +78,11 @@ describe('getAutocompleteSuggestion', () => {
   });
 
   test('searches in name, email and is case insensitive', () => {
-    const user1 = eg.makeUser({ name: 'match', email: 'any1@example.com' });
-    const user2 = eg.makeUser({ name: 'match this', email: 'any2@example.com' });
-    const user3 = eg.makeUser({ name: 'MaTcH Case Insensitive', email: 'any3@example.com' });
-    const user4 = eg.makeUser({ name: 'some name', email: 'another@example.com' });
-    const user5 = eg.makeUser({ name: 'Example', email: 'match@example.com' });
+    const user1 = eg.makeUser({ full_name: 'match', email: 'any1@example.com' });
+    const user2 = eg.makeUser({ full_name: 'match this', email: 'any2@example.com' });
+    const user3 = eg.makeUser({ full_name: 'MaTcH Case Insensitive', email: 'any3@example.com' });
+    const user4 = eg.makeUser({ full_name: 'some name', email: 'another@example.com' });
+    const user5 = eg.makeUser({ full_name: 'Example', email: 'match@example.com' });
     const allUsers = deepFreeze([user1, user2, user3, user4, user5]);
 
     const shouldMatch = [user1, user2, user3, user5];
@@ -96,17 +96,17 @@ describe('getAutocompleteSuggestion', () => {
   });
 
   test('result should be in priority of startsWith, contains in name, matches in email', () => {
-    const user1 = eg.makeUser({ name: 'M Apple', email: 'any1@example.com' }); // does not match
-    const user2 = eg.makeUser({ name: 'Normal boy', email: 'any2@example.com' }); // satisfy full_name contains condition
-    const user3 = eg.makeUser({ name: 'example', email: 'example@example.com' }); // random entry
-    const user4 = eg.makeUser({ name: 'Example', email: 'match@example.com' }); // satisfy email match condition
-    const user5 = eg.makeUser({ name: 'match', email: 'any@example.com' }); // satisfy full_name starts with condition
-    const user6 = eg.makeUser({ name: 'match', email: 'normal@example.com' }); // satisfy starts with and email condition
-    const user7 = eg.makeUser({ name: 'Match App Normal', email: 'any3@example.com' }); // satisfy all conditions
-    const user8 = eg.makeUser({ name: 'match', email: 'any@example.com' }); // duplicate
-    const user9 = eg.makeUser({ name: 'Laptop', email: 'laptop@example.com' }); // random entry
-    const user10 = eg.makeUser({ name: 'Mobile App', email: 'any@match.com' }); // satisfy email condition
-    const user11 = eg.makeUser({ name: 'Normal', email: 'match2@example.com' }); // satisfy contains in name and matches in email condition
+    const user1 = eg.makeUser({ full_name: 'M Apple', email: 'any1@example.com' }); // does not match
+    const user2 = eg.makeUser({ full_name: 'Normal boy', email: 'any2@example.com' }); // satisfy full_name contains condition
+    const user3 = eg.makeUser({ full_name: 'example', email: 'example@example.com' }); // random entry
+    const user4 = eg.makeUser({ full_name: 'Example', email: 'match@example.com' }); // satisfy email match condition
+    const user5 = eg.makeUser({ full_name: 'match', email: 'any@example.com' }); // satisfy full_name starts with condition
+    const user6 = eg.makeUser({ full_name: 'match', email: 'normal@example.com' }); // satisfy starts with and email condition
+    const user7 = eg.makeUser({ full_name: 'Match App Normal', email: 'any3@example.com' }); // satisfy all conditions
+    const user8 = eg.makeUser({ full_name: 'match', email: 'any@example.com' }); // duplicate
+    const user9 = eg.makeUser({ full_name: 'Laptop', email: 'laptop@example.com' }); // random entry
+    const user10 = eg.makeUser({ full_name: 'Mobile App', email: 'any@match.com' }); // satisfy email condition
+    const user11 = eg.makeUser({ full_name: 'Normal', email: 'match2@example.com' }); // satisfy contains in name and matches in email condition
     const allUsers = deepFreeze([
       user1,
       user2,
@@ -165,9 +165,9 @@ describe('getAutocompleteUserGroupSuggestions', () => {
 
 describe('sortUserList', () => {
   test('sorts list by name', () => {
-    const user1 = eg.makeUser({ name: 'abc' });
-    const user2 = eg.makeUser({ name: 'xyz' });
-    const user3 = eg.makeUser({ name: 'jkl' });
+    const user1 = eg.makeUser({ full_name: 'abc' });
+    const user2 = eg.makeUser({ full_name: 'xyz' });
+    const user3 = eg.makeUser({ full_name: 'jkl' });
     const users = deepFreeze([user1, user2, user3]);
     const presences = {};
     const shouldMatch = [user1, user3, user2];
@@ -178,10 +178,10 @@ describe('sortUserList', () => {
   });
 
   test('prioritizes status', () => {
-    const user1 = eg.makeUser({ name: 'Mark', email: 'mark@example.com' });
-    const user2 = eg.makeUser({ name: 'John', email: 'john@example.com' });
-    const user3 = eg.makeUser({ name: 'Bob', email: 'bob@example.com' });
-    const user4 = eg.makeUser({ name: 'Rick', email: 'rick@example.com' });
+    const user1 = eg.makeUser({ full_name: 'Mark', email: 'mark@example.com' });
+    const user2 = eg.makeUser({ full_name: 'John', email: 'john@example.com' });
+    const user3 = eg.makeUser({ full_name: 'Bob', email: 'bob@example.com' });
+    const user4 = eg.makeUser({ full_name: 'Rick', email: 'rick@example.com' });
     const users = deepFreeze([user1, user2, user3, user4]);
     const presences = {
       [user1.email]: {
@@ -211,13 +211,13 @@ describe('sortUserList', () => {
 
 describe('sortAlphabetically', () => {
   test('alphabetically sort user list by full_name', () => {
-    const user1 = eg.makeUser({ name: 'zoe', email: 'allen@example.com' });
-    const user2 = eg.makeUser({ name: 'Ring', email: 'got@example.com' });
-    const user3 = eg.makeUser({ name: 'watch', email: 'see@example.com' });
-    const user4 = eg.makeUser({ name: 'mobile', email: 'phone@example.com' });
-    const user5 = eg.makeUser({ name: 'Ring', email: 'got@example.com' });
-    const user6 = eg.makeUser({ name: 'hardware', email: 'software@example.com' });
-    const user7 = eg.makeUser({ name: 'Bob', email: 'tester@example.com' });
+    const user1 = eg.makeUser({ full_name: 'zoe', email: 'allen@example.com' });
+    const user2 = eg.makeUser({ full_name: 'Ring', email: 'got@example.com' });
+    const user3 = eg.makeUser({ full_name: 'watch', email: 'see@example.com' });
+    const user4 = eg.makeUser({ full_name: 'mobile', email: 'phone@example.com' });
+    const user5 = eg.makeUser({ full_name: 'Ring', email: 'got@example.com' });
+    const user6 = eg.makeUser({ full_name: 'hardware', email: 'software@example.com' });
+    const user7 = eg.makeUser({ full_name: 'Bob', email: 'tester@example.com' });
     const users = deepFreeze([user1, user2, user3, user4, user5, user6, user7]);
 
     const expectedUsers = [user7, user6, user4, user2, user5, user3, user1];
@@ -227,12 +227,12 @@ describe('sortAlphabetically', () => {
 
 describe('filterUserStartWith', () => {
   test('returns users whose name starts with filter excluding self', () => {
-    const user1 = eg.makeUser({ name: 'Apple', email: 'a@example.com' });
-    const user2 = eg.makeUser({ name: 'bob', email: 'f@app.com' });
-    const user3 = eg.makeUser({ name: 'app', email: 'p@p.com' });
-    const user4 = eg.makeUser({ name: 'Mobile app', email: 'p3@p.com' });
-    const user5 = eg.makeUser({ name: 'Mac App', email: 'p@p2.com' });
-    const selfUser = eg.makeUser({ name: 'app', email: 'own@example.com' });
+    const user1 = eg.makeUser({ full_name: 'Apple', email: 'a@example.com' });
+    const user2 = eg.makeUser({ full_name: 'bob', email: 'f@app.com' });
+    const user3 = eg.makeUser({ full_name: 'app', email: 'p@p.com' });
+    const user4 = eg.makeUser({ full_name: 'Mobile app', email: 'p3@p.com' });
+    const user5 = eg.makeUser({ full_name: 'Mac App', email: 'p@p2.com' });
+    const selfUser = eg.makeUser({ full_name: 'app', email: 'own@example.com' });
     const users = deepFreeze([user1, user2, user3, user4, user5, selfUser]);
 
     const expectedUsers = [user1, user3];
@@ -240,20 +240,20 @@ describe('filterUserStartWith', () => {
   });
 
   test('returns users whose name contains diacritics but otherwise starts with filter', () => {
-    const withDiacritics = eg.makeUser({ name: 'Frödö', email: 'bagginsf@example.com' });
-    const withoutDiacritics = eg.makeUser({ name: 'Frodo', email: 'bagginz@example.com' });
-    const nonMatchingUser = eg.makeUser({ name: 'Zalix', email: 'zalix@example.com' });
+    const withDiacritics = eg.makeUser({ full_name: 'Frödö', email: 'bagginsf@example.com' });
+    const withoutDiacritics = eg.makeUser({ full_name: 'Frodo', email: 'bagginz@example.com' });
+    const nonMatchingUser = eg.makeUser({ full_name: 'Zalix', email: 'zalix@example.com' });
     const users = deepFreeze([withDiacritics, withoutDiacritics, nonMatchingUser]);
     const expectedUsers = [withDiacritics, withoutDiacritics];
     expect(filterUserStartWith(users, 'Fro', eg.makeUser().user_id)).toEqual(expectedUsers);
   });
 
   test('returns users whose name contains diacritics and filter uses diacritics', () => {
-    const withDiacritics = eg.makeUser({ name: 'Frödö', email: 'bagginsf@example.com' });
-    const withoutDiacritics = eg.makeUser({ name: 'Frodo', email: 'bagginz@example.com' });
-    const wrongDiacritics = eg.makeUser({ name: 'Frōdō', email: 'baggins@example.com' });
-    const notIncludedDiactritic = eg.makeUser({ name: 'Fřödo', email: 'baggins@example.com' });
-    const nonMatchingUser = eg.makeUser({ name: 'Zalix', email: 'zalix@example.com' });
+    const withDiacritics = eg.makeUser({ full_name: 'Frödö', email: 'bagginsf@example.com' });
+    const withoutDiacritics = eg.makeUser({ full_name: 'Frodo', email: 'bagginz@example.com' });
+    const wrongDiacritics = eg.makeUser({ full_name: 'Frōdō', email: 'baggins@example.com' });
+    const notIncludedDiactritic = eg.makeUser({ full_name: 'Fřödo', email: 'baggins@example.com' });
+    const nonMatchingUser = eg.makeUser({ full_name: 'Zalix', email: 'zalix@example.com' });
     const users = deepFreeze([
       withDiacritics,
       withoutDiacritics,
@@ -306,13 +306,13 @@ describe('groupUsersByStatus', () => {
 
 describe('filterUserThatContains', () => {
   test('returns users whose full_name contains filter excluding self', () => {
-    const user1 = eg.makeUser({ name: 'Apple', email: 'a@example.com' });
-    const user2 = eg.makeUser({ name: 'mam', email: 'f@app.com' });
-    const user3 = eg.makeUser({ name: 'app', email: 'p@p.com' });
-    const user4 = eg.makeUser({ name: 'Mobile app', email: 'p3@p.com' });
-    const user5 = eg.makeUser({ name: 'Mac App', email: 'p@p2.com' });
-    const user6 = eg.makeUser({ name: 'app', email: 'p@p.com' });
-    const selfUser = eg.makeUser({ name: 'app', email: 'own@example.com' });
+    const user1 = eg.makeUser({ full_name: 'Apple', email: 'a@example.com' });
+    const user2 = eg.makeUser({ full_name: 'mam', email: 'f@app.com' });
+    const user3 = eg.makeUser({ full_name: 'app', email: 'p@p.com' });
+    const user4 = eg.makeUser({ full_name: 'Mobile app', email: 'p3@p.com' });
+    const user5 = eg.makeUser({ full_name: 'Mac App', email: 'p@p2.com' });
+    const user6 = eg.makeUser({ full_name: 'app', email: 'p@p.com' });
+    const selfUser = eg.makeUser({ full_name: 'app', email: 'own@example.com' });
 
     const users = deepFreeze([user1, user2, user3, user4, user5, user6, selfUser]);
 
@@ -321,20 +321,23 @@ describe('filterUserThatContains', () => {
   });
 
   test('returns users whose full_name has diacritics but otherwise contains filter', () => {
-    const withDiacritics = eg.makeUser({ name: 'Aärdvärk', email: 'aardvark@example.com' });
-    const withoutDiacritics = eg.makeUser({ name: 'Aardvark', email: 'ard@example.com' });
-    const nonMatchingUser = eg.makeUser({ name: 'Turtle', email: 'turtle@example.com' });
+    const withDiacritics = eg.makeUser({ full_name: 'Aärdvärk', email: 'aardvark@example.com' });
+    const withoutDiacritics = eg.makeUser({ full_name: 'Aardvark', email: 'ard@example.com' });
+    const nonMatchingUser = eg.makeUser({ full_name: 'Turtle', email: 'turtle@example.com' });
     const users = deepFreeze([withDiacritics, withoutDiacritics, nonMatchingUser]);
     const expectedUsers = [withDiacritics, withoutDiacritics];
     expect(filterUserThatContains(users, 'vark', eg.makeUser().user_id)).toEqual(expectedUsers);
   });
 
   test('returns users whose full_name has diacritics and filter uses diacritics', () => {
-    const withDiacritics = eg.makeUser({ name: 'Aärdvärk', email: 'aardvark@example.com' });
-    const withoutDiacritics = eg.makeUser({ name: 'Aardvark', email: 'aardvark@example.com' });
-    const wrongDiacritics = eg.makeUser({ name: 'Aärdvãrk', email: 'aadvark@example.com' });
-    const notIncludedDiactritic = eg.makeUser({ name: 'Aärdväŕk', email: 'aadvark@example.com' });
-    const nonMatchingUser = eg.makeUser({ name: 'Turtle', email: 'turtle@example.com' });
+    const withDiacritics = eg.makeUser({ full_name: 'Aärdvärk', email: 'aardvark@example.com' });
+    const withoutDiacritics = eg.makeUser({ full_name: 'Aardvark', email: 'aardvark@example.com' });
+    const wrongDiacritics = eg.makeUser({ full_name: 'Aärdvãrk', email: 'aadvark@example.com' });
+    const notIncludedDiactritic = eg.makeUser({
+      full_name: 'Aärdväŕk',
+      email: 'aadvark@example.com',
+    });
+    const nonMatchingUser = eg.makeUser({ full_name: 'Turtle', email: 'turtle@example.com' });
     const users = deepFreeze([
       withDiacritics,
       withoutDiacritics,
@@ -349,13 +352,13 @@ describe('filterUserThatContains', () => {
 
 describe('filterUserMatchesEmail', () => {
   test('returns users whose email matches filter excluding self', () => {
-    const user1 = eg.makeUser({ name: 'Apple', email: 'a@example.com' });
-    const user2 = eg.makeUser({ name: 'mam', email: 'f@app.com' });
-    const user3 = eg.makeUser({ name: 'app', email: 'p@p.com' });
-    const user4 = eg.makeUser({ name: 'Mobile app', email: 'p3@p.com' });
-    const user5 = eg.makeUser({ name: 'Mac App', email: 'p@p2.com' });
-    const user6 = eg.makeUser({ name: 'app', email: 'p@p.com' });
-    const selfUser = eg.makeUser({ name: 'app', email: 'own@example.com' });
+    const user1 = eg.makeUser({ full_name: 'Apple', email: 'a@example.com' });
+    const user2 = eg.makeUser({ full_name: 'mam', email: 'f@app.com' });
+    const user3 = eg.makeUser({ full_name: 'app', email: 'p@p.com' });
+    const user4 = eg.makeUser({ full_name: 'Mobile app', email: 'p3@p.com' });
+    const user5 = eg.makeUser({ full_name: 'Mac App', email: 'p@p2.com' });
+    const user6 = eg.makeUser({ full_name: 'app', email: 'p@p.com' });
+    const selfUser = eg.makeUser({ full_name: 'app', email: 'own@example.com' });
 
     const users = deepFreeze([user1, user2, user3, user4, user5, user6, selfUser]);
     const expectedUsers = [user1];
@@ -365,14 +368,14 @@ describe('filterUserMatchesEmail', () => {
 
 describe('getUniqueUsers', () => {
   test('returns unique users check by email', () => {
-    const user1 = eg.makeUser({ name: 'Apple', email: 'a@example.com' });
-    const user2 = eg.makeUser({ name: 'Apple', email: 'a@example.com' });
-    const user3 = eg.makeUser({ name: 'app', email: 'p@p.com' });
-    const user4 = eg.makeUser({ name: 'app', email: 'p@p.com' });
-    const user5 = eg.makeUser({ name: 'Mac App', email: 'p@p2.com' });
-    const user6 = eg.makeUser({ name: 'Mac App', email: 'p@p2.com' });
-    const user7 = eg.makeUser({ name: 'Mac App 2', email: 'p@p2.com' });
-    const user8 = eg.makeUser({ name: 'app', email: 'own@example.com' });
+    const user1 = eg.makeUser({ full_name: 'Apple', email: 'a@example.com' });
+    const user2 = eg.makeUser({ full_name: 'Apple', email: 'a@example.com' });
+    const user3 = eg.makeUser({ full_name: 'app', email: 'p@p.com' });
+    const user4 = eg.makeUser({ full_name: 'app', email: 'p@p.com' });
+    const user5 = eg.makeUser({ full_name: 'Mac App', email: 'p@p2.com' });
+    const user6 = eg.makeUser({ full_name: 'Mac App', email: 'p@p2.com' });
+    const user7 = eg.makeUser({ full_name: 'Mac App 2', email: 'p@p2.com' });
+    const user8 = eg.makeUser({ full_name: 'app', email: 'own@example.com' });
 
     const users = deepFreeze([user1, user2, user3, user4, user5, user6, user7, user8]);
 

--- a/src/users/userHelpers.js
+++ b/src/users/userHelpers.js
@@ -6,7 +6,6 @@ import * as typeahead from '@zulip/shared/js/typeahead';
 import type {
   MutedUsersState,
   UserPresence,
-  User,
   UserId,
   UserGroup,
   PresenceState,
@@ -77,9 +76,6 @@ export const filterUserList = (
       || user.full_name.toLowerCase().includes(filter.toLowerCase())
       || user.email.toLowerCase().includes(filter.toLowerCase()),
   );
-
-export const sortAlphabetically = (users: $ReadOnlyArray<User>): $ReadOnlyArray<User> =>
-  [...users].sort((x1, x2) => x1.full_name.toLowerCase().localeCompare(x2.full_name.toLowerCase()));
 
 export const filterUserStartWith = (
   users: $ReadOnlyArray<AutocompleteOption>,

--- a/src/users/userHelpers.js
+++ b/src/users/userHelpers.js
@@ -69,15 +69,13 @@ export type AutocompleteOption = $ReadOnly<{
 
 export const filterUserList = (
   users: $ReadOnlyArray<UserOrBot>,
-  filter: string = '',
-  ownUserId: ?UserId,
+  filter: string,
 ): $ReadOnlyArray<UserOrBot> =>
   users.filter(
     user =>
-      user.user_id !== ownUserId
-      && (filter === ''
-        || user.full_name.toLowerCase().includes(filter.toLowerCase())
-        || user.email.toLowerCase().includes(filter.toLowerCase())),
+      filter === ''
+      || user.full_name.toLowerCase().includes(filter.toLowerCase())
+      || user.email.toLowerCase().includes(filter.toLowerCase()),
   );
 
 export const sortAlphabetically = (users: $ReadOnlyArray<User>): $ReadOnlyArray<User> =>

--- a/src/webview/__tests__/__snapshots__/generateInboundEventEditSequence-test.js.snap.android
+++ b/src/webview/__tests__/__snapshots__/generateInboundEventEditSequence-test.js.snap.android
@@ -96,7 +96,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
   <div class=\\"topic-date\\">Feb 5, 1995</div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-1024\\" data-msg-id=\\"1024\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -140,7 +140,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
   <div class=\\"topic-date\\">Mar 5, 1995</div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-7938\\" data-msg-id=\\"7938\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -157,7 +157,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
   
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-8060\\" data-msg-id=\\"8060\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20two.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-2.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -189,7 +189,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
   <div class=\\"topic-date\\">Feb 19, 1995</div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-4948\\" data-msg-id=\\"4948\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -213,7 +213,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
   <div class=\\"topic-date\\">Feb 19, 1995</div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-5083\\" data-msg-id=\\"5083\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -245,7 +245,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
   <div class=\\"topic-date\\">Mar 5, 1995</div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-6789\\" data-msg-id=\\"6789\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -269,7 +269,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
   <div class=\\"topic-date\\">Mar 5, 1995</div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-7727\\" data-msg-id=\\"7727\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -301,7 +301,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
   <div class=\\"topic-date\\">Mar 5, 1995</div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-9181\\" data-msg-id=\\"9181\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -322,7 +322,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
   <div class=\\"timerow-right\\"></div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-9815\\" data-msg-id=\\"9815\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -349,7 +349,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
   Nonrandom name one User, Nonrandom name two User
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-8849\\" data-msg-id=\\"8849\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -388,7 +388,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
   Nonrandom name one User, Nonrandom name two User
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-5287\\" data-msg-id=\\"5287\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -405,7 +405,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
   
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-5309\\" data-msg-id=\\"5309\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20two.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-2.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -432,7 +432,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
   Nonrandom name one User, Nonrandom name two User
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-5829\\" data-msg-id=\\"5829\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -453,7 +453,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
   <div class=\\"timerow-right\\"></div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-5963\\" data-msg-id=\\"5963\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -480,7 +480,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
   Nonrandom name one User, Nonrandom name three User, Nonrandom name two User
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-5377\\" data-msg-id=\\"5377\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -519,7 +519,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
   Nonrandom name one User, Nonrandom name three User, Nonrandom name two User
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-5637\\" data-msg-id=\\"5637\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -536,7 +536,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
   
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-5727\\" data-msg-id=\\"5727\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20two.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-2.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -563,7 +563,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
   Nonrandom name one User, Nonrandom name three User, Nonrandom name two User
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-2794\\" data-msg-id=\\"2794\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -584,7 +584,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
   <div class=\\"timerow-right\\"></div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-4581\\" data-msg-id=\\"4581\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -616,7 +616,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
   <div class=\\"topic-date\\">Feb 5, 1995</div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-1024\\" data-msg-id=\\"1024\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -647,7 +647,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
   Nonrandom name one User, Nonrandom name three User, Nonrandom name two User
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-2794\\" data-msg-id=\\"2794\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -668,7 +668,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
   <div class=\\"timerow-right\\"></div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-4581\\" data-msg-id=\\"4581\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -696,7 +696,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
   <div class=\\"topic-date\\">Feb 19, 1995</div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-4948\\" data-msg-id=\\"4948\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -720,7 +720,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
   <div class=\\"topic-date\\">Feb 19, 1995</div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-5083\\" data-msg-id=\\"5083\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -739,7 +739,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
   Nonrandom name one User, Nonrandom name two User
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-5287\\" data-msg-id=\\"5287\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -756,7 +756,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
   
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-5309\\" data-msg-id=\\"5309\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20two.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-2.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -775,7 +775,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
   Nonrandom name one User, Nonrandom name three User, Nonrandom name two User
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-5377\\" data-msg-id=\\"5377\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -816,7 +816,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
   </div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-5727\\" data-msg-id=\\"5727\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20two.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-2.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -835,7 +835,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
   Nonrandom name one User, Nonrandom name two User
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-5829\\" data-msg-id=\\"5829\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -856,7 +856,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
   <div class=\\"timerow-right\\"></div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-5963\\" data-msg-id=\\"5963\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -884,7 +884,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
   <div class=\\"topic-date\\">Mar 5, 1995</div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-6789\\" data-msg-id=\\"6789\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -908,7 +908,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
   <div class=\\"topic-date\\">Mar 5, 1995</div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-7727\\" data-msg-id=\\"7727\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -932,7 +932,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
   <div class=\\"topic-date\\">Mar 5, 1995</div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-7938\\" data-msg-id=\\"7938\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -949,7 +949,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
   
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-8060\\" data-msg-id=\\"8060\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20two.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-2.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -968,7 +968,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
   Nonrandom name one User, Nonrandom name two User
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-8849\\" data-msg-id=\\"8849\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -1004,7 +1004,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
   <div class=\\"topic-date\\">Mar 5, 1995</div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-9181\\" data-msg-id=\\"9181\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -1025,7 +1025,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
   <div class=\\"timerow-right\\"></div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-9815\\" data-msg-id=\\"9815\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -1052,7 +1052,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm
   Nonrandom name one User, Nonrandom name two User
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-8849\\" data-msg-id=\\"8849\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -1091,7 +1091,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm
   Nonrandom name one User, Nonrandom name two User
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-5287\\" data-msg-id=\\"5287\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -1108,7 +1108,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm
   
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-5309\\" data-msg-id=\\"5309\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20two.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-2.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -1135,7 +1135,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm
   Nonrandom name one User, Nonrandom name two User
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-5829\\" data-msg-id=\\"5829\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -1156,7 +1156,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm
   <div class=\\"timerow-right\\"></div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-5963\\" data-msg-id=\\"5963\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -1183,7 +1183,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm
   Nonrandom name one User, Nonrandom name three User, Nonrandom name two User
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-5377\\" data-msg-id=\\"5377\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -1222,7 +1222,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm
   Nonrandom name one User, Nonrandom name three User, Nonrandom name two User
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-5637\\" data-msg-id=\\"5637\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -1239,7 +1239,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm
   
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-5727\\" data-msg-id=\\"5727\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20two.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-2.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -1266,7 +1266,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm
   Nonrandom name one User, Nonrandom name three User, Nonrandom name two User
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-2794\\" data-msg-id=\\"2794\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -1287,7 +1287,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm
   <div class=\\"timerow-right\\"></div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-4581\\" data-msg-id=\\"4581\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -1314,7 +1314,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm
   Nonrandom name one User, Nonrandom name three User, Nonrandom name two User
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-2794\\" data-msg-id=\\"2794\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -1335,7 +1335,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm
   <div class=\\"timerow-right\\"></div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-4581\\" data-msg-id=\\"4581\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -1358,7 +1358,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm
   Nonrandom name one User, Nonrandom name two User
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-5287\\" data-msg-id=\\"5287\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -1375,7 +1375,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm
   
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-5309\\" data-msg-id=\\"5309\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20two.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-2.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -1394,7 +1394,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm
   Nonrandom name one User, Nonrandom name three User, Nonrandom name two User
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-5377\\" data-msg-id=\\"5377\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -1435,7 +1435,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm
   </div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-5727\\" data-msg-id=\\"5727\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20two.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-2.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -1454,7 +1454,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm
   Nonrandom name one User, Nonrandom name two User
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-5829\\" data-msg-id=\\"5829\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -1475,7 +1475,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm
   <div class=\\"timerow-right\\"></div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-5963\\" data-msg-id=\\"5963\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -1496,7 +1496,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm
   <div class=\\"timerow-right\\"></div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-8849\\" data-msg-id=\\"8849\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -1540,7 +1540,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible other 
   <div class=\\"topic-date\\">Dec 31, 1969</div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg--1\\" data-msg-id=\\"-1\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20sender.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-10.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -1572,7 +1572,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible other 
   <div class=\\"topic-date\\">Dec 31, 1969</div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg--1\\" data-msg-id=\\"-1\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20sender.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-10.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -1614,7 +1614,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible other 
   <div class=\\"topic-date\\">Dec 31, 1969</div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg--1\\" data-msg-id=\\"-1\\" data-mute-state=\\"shown\\" data-collapsed=\\"true\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20sender.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-10.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -1646,7 +1646,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible other 
   <div class=\\"topic-date\\">Dec 31, 1969</div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg--1\\" data-msg-id=\\"-1\\" data-mute-state=\\"shown\\" data-force_collapse=\\"true\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20sender.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-10.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -1678,7 +1678,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible other 
   <div class=\\"topic-date\\">Dec 31, 1969</div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg--1\\" data-msg-id=\\"-1\\" data-mute-state=\\"shown\\" data-force_expand=\\"true\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20sender.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-10.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -1710,7 +1710,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible other 
   <div class=\\"topic-date\\">Dec 31, 1969</div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg--1\\" data-msg-id=\\"-1\\" data-mute-state=\\"shown\\" data-has_alert_word=\\"true\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20sender.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-10.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -1742,7 +1742,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible other 
   <div class=\\"topic-date\\">Dec 31, 1969</div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg--1\\" data-msg-id=\\"-1\\" data-mute-state=\\"shown\\" data-historical=\\"true\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20sender.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-10.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -1774,7 +1774,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible other 
   <div class=\\"topic-date\\">Dec 31, 1969</div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg--1\\" data-msg-id=\\"-1\\" data-mute-state=\\"shown\\" data-is_me_message=\\"true\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20sender.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-10.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -1806,7 +1806,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible other 
   <div class=\\"topic-date\\">Dec 31, 1969</div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg--1\\" data-msg-id=\\"-1\\" data-mute-state=\\"shown\\" data-mentioned=\\"true\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20sender.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-10.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -1838,7 +1838,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible other 
   <div class=\\"topic-date\\">Dec 31, 1969</div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg--1\\" data-msg-id=\\"-1\\" data-mute-state=\\"shown\\" data-read=\\"true\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20sender.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-10.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -1870,7 +1870,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible other 
   <div class=\\"topic-date\\">Dec 31, 1969</div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg--1\\" data-msg-id=\\"-1\\" data-mute-state=\\"shown\\" data-starred=\\"true\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20sender.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-10.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -1902,7 +1902,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible other 
   <div class=\\"topic-date\\">Dec 31, 1969</div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg--1\\" data-msg-id=\\"-1\\" data-mute-state=\\"shown\\" data-summarize_in_home=\\"true\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20sender.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-10.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -1934,7 +1934,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible other 
   <div class=\\"topic-date\\">Dec 31, 1969</div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg--1\\" data-msg-id=\\"-1\\" data-mute-state=\\"shown\\" data-summarize_in_stream=\\"true\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20sender.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-10.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -1966,7 +1966,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible other 
   <div class=\\"topic-date\\">Dec 31, 1969</div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg--1\\" data-msg-id=\\"-1\\" data-mute-state=\\"shown\\" data-wildcard_mentioned=\\"true\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20sender.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-10.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -1998,7 +1998,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible other 
   <div class=\\"topic-date\\">Dec 31, 1969</div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg--1\\" data-msg-id=\\"-1\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20sender.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-10.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -2030,7 +2030,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible other 
   <div class=\\"topic-date\\">Dec 31, 1969</div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg--1\\" data-msg-id=\\"-1\\" data-mute-state=\\"hidden\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20sender.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-10.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -2064,7 +2064,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible other 
   <div class=\\"topic-date\\">Dec 31, 1969</div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg--1\\" data-msg-id=\\"-1\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20sender.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-10.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -2096,7 +2096,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible other 
   <div class=\\"topic-date\\">Dec 31, 1969</div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg--1\\" data-msg-id=\\"-1\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20sender.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-10.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -2128,7 +2128,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible other 
   <div class=\\"topic-date\\">Dec 31, 1969</div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg--1\\" data-msg-id=\\"-1\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20sender.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-10.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -2160,7 +2160,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible other 
   <div class=\\"topic-date\\">Dec 31, 1969</div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg--1\\" data-msg-id=\\"-1\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20sender.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-10.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -2185,7 +2185,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2
   <div class=\\"timerow-right\\"></div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-8849\\" data-msg-id=\\"8849\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -2222,7 +2222,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2
   <div class=\\"timerow-right\\"></div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-5287\\" data-msg-id=\\"5287\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -2239,7 +2239,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2
   
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-5309\\" data-msg-id=\\"5309\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20two.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-2.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -2264,7 +2264,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2
   <div class=\\"timerow-right\\"></div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-5829\\" data-msg-id=\\"5829\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -2285,7 +2285,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2
   <div class=\\"timerow-right\\"></div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-5963\\" data-msg-id=\\"5963\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -2310,7 +2310,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2
   <div class=\\"timerow-right\\"></div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-5287\\" data-msg-id=\\"5287\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -2327,7 +2327,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2
   
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-5309\\" data-msg-id=\\"5309\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20two.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-2.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -2344,7 +2344,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2
   
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-5829\\" data-msg-id=\\"5829\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -2365,7 +2365,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2
   <div class=\\"timerow-right\\"></div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-5963\\" data-msg-id=\\"5963\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -2386,7 +2386,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2
   <div class=\\"timerow-right\\"></div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-8849\\" data-msg-id=\\"8849\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -2423,7 +2423,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2
   <div class=\\"timerow-right\\"></div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-5377\\" data-msg-id=\\"5377\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -2460,7 +2460,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2
   <div class=\\"timerow-right\\"></div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-5637\\" data-msg-id=\\"5637\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -2477,7 +2477,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2
   
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-5727\\" data-msg-id=\\"5727\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20two.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-2.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -2502,7 +2502,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2
   <div class=\\"timerow-right\\"></div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-2794\\" data-msg-id=\\"2794\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -2523,7 +2523,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2
   <div class=\\"timerow-right\\"></div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-4581\\" data-msg-id=\\"4581\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -2548,7 +2548,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2
   <div class=\\"timerow-right\\"></div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-2794\\" data-msg-id=\\"2794\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -2569,7 +2569,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2
   <div class=\\"timerow-right\\"></div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-4581\\" data-msg-id=\\"4581\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -2590,7 +2590,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2
   <div class=\\"timerow-right\\"></div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-5377\\" data-msg-id=\\"5377\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -2631,7 +2631,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2
   </div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-5727\\" data-msg-id=\\"5727\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20two.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-2.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -2659,7 +2659,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible stream
   <div class=\\"topic-date\\">Feb 5, 1995</div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-1024\\" data-msg-id=\\"1024\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -2699,7 +2699,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible stream
   <div class=\\"topic-date\\">Mar 5, 1995</div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-7938\\" data-msg-id=\\"7938\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -2716,7 +2716,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible stream
   
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-8060\\" data-msg-id=\\"8060\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20two.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-2.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -2744,7 +2744,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible stream
   <div class=\\"topic-date\\">Feb 19, 1995</div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-4948\\" data-msg-id=\\"4948\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -2764,7 +2764,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible stream
   <div class=\\"topic-date\\">Feb 19, 1995</div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-5083\\" data-msg-id=\\"5083\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -2792,7 +2792,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible stream
   <div class=\\"topic-date\\">Mar 5, 1995</div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-9181\\" data-msg-id=\\"9181\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -2813,7 +2813,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible stream
   <div class=\\"timerow-right\\"></div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-9815\\" data-msg-id=\\"9815\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -2841,7 +2841,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible stream
   <div class=\\"topic-date\\">Feb 5, 1995</div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-1024\\" data-msg-id=\\"1024\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -2874,7 +2874,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible stream
   <div class=\\"timerow-right\\"></div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-4948\\" data-msg-id=\\"4948\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -2894,7 +2894,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible stream
   <div class=\\"topic-date\\">Feb 19, 1995</div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-5083\\" data-msg-id=\\"5083\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -2918,7 +2918,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible stream
   <div class=\\"topic-date\\">Mar 5, 1995</div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-7938\\" data-msg-id=\\"7938\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -2935,7 +2935,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible stream
   
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-8060\\" data-msg-id=\\"8060\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20two.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-2.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -2952,7 +2952,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible stream
   
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-9181\\" data-msg-id=\\"9181\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -2973,7 +2973,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible stream
   <div class=\\"timerow-right\\"></div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-9815\\" data-msg-id=\\"9815\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -2998,7 +2998,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible topic:
   <div class=\\"timerow-right\\"></div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-1024\\" data-msg-id=\\"1024\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -3035,7 +3035,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible topic:
   <div class=\\"timerow-right\\"></div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-7938\\" data-msg-id=\\"7938\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -3052,7 +3052,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible topic:
   
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-8060\\" data-msg-id=\\"8060\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20two.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-2.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -3077,7 +3077,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible topic:
   <div class=\\"timerow-right\\"></div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-9181\\" data-msg-id=\\"9181\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -3098,7 +3098,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible topic:
   <div class=\\"timerow-right\\"></div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-9815\\" data-msg-id=\\"9815\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -3123,7 +3123,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible topic:
   <div class=\\"timerow-right\\"></div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-1024\\" data-msg-id=\\"1024\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -3156,7 +3156,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible topic:
   <div class=\\"timerow-right\\"></div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-7938\\" data-msg-id=\\"7938\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -3173,7 +3173,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible topic:
   
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-8060\\" data-msg-id=\\"8060\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20two.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-2.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -3190,7 +3190,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible topic:
   
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-9181\\" data-msg-id=\\"9181\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -3211,7 +3211,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible topic:
   <div class=\\"timerow-right\\"></div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-9815\\" data-msg-id=\\"9815\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">

--- a/src/webview/__tests__/__snapshots__/generateInboundEventEditSequence-test.js.snap.ios
+++ b/src/webview/__tests__/__snapshots__/generateInboundEventEditSequence-test.js.snap.ios
@@ -96,7 +96,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
   <div class=\\"topic-date\\">Feb 5, 1995</div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-1024\\" data-msg-id=\\"1024\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -140,7 +140,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
   <div class=\\"topic-date\\">Mar 5, 1995</div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-7938\\" data-msg-id=\\"7938\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -157,7 +157,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
   
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-8060\\" data-msg-id=\\"8060\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20two.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-2.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -189,7 +189,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
   <div class=\\"topic-date\\">Feb 19, 1995</div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-4948\\" data-msg-id=\\"4948\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -213,7 +213,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
   <div class=\\"topic-date\\">Feb 19, 1995</div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-5083\\" data-msg-id=\\"5083\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -245,7 +245,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
   <div class=\\"topic-date\\">Mar 5, 1995</div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-6789\\" data-msg-id=\\"6789\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -269,7 +269,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
   <div class=\\"topic-date\\">Mar 5, 1995</div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-7727\\" data-msg-id=\\"7727\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -301,7 +301,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
   <div class=\\"topic-date\\">Mar 5, 1995</div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-9181\\" data-msg-id=\\"9181\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -322,7 +322,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
   <div class=\\"timerow-right\\"></div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-9815\\" data-msg-id=\\"9815\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -349,7 +349,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
   Nonrandom name one User, Nonrandom name two User
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-8849\\" data-msg-id=\\"8849\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -388,7 +388,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
   Nonrandom name one User, Nonrandom name two User
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-5287\\" data-msg-id=\\"5287\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -405,7 +405,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
   
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-5309\\" data-msg-id=\\"5309\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20two.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-2.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -432,7 +432,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
   Nonrandom name one User, Nonrandom name two User
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-5829\\" data-msg-id=\\"5829\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -453,7 +453,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
   <div class=\\"timerow-right\\"></div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-5963\\" data-msg-id=\\"5963\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -480,7 +480,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
   Nonrandom name one User, Nonrandom name three User, Nonrandom name two User
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-5377\\" data-msg-id=\\"5377\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -519,7 +519,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
   Nonrandom name one User, Nonrandom name three User, Nonrandom name two User
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-5637\\" data-msg-id=\\"5637\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -536,7 +536,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
   
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-5727\\" data-msg-id=\\"5727\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20two.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-2.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -563,7 +563,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
   Nonrandom name one User, Nonrandom name three User, Nonrandom name two User
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-2794\\" data-msg-id=\\"2794\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -584,7 +584,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
   <div class=\\"timerow-right\\"></div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-4581\\" data-msg-id=\\"4581\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -616,7 +616,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
   <div class=\\"topic-date\\">Feb 5, 1995</div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-1024\\" data-msg-id=\\"1024\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -647,7 +647,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
   Nonrandom name one User, Nonrandom name three User, Nonrandom name two User
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-2794\\" data-msg-id=\\"2794\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -668,7 +668,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
   <div class=\\"timerow-right\\"></div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-4581\\" data-msg-id=\\"4581\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -696,7 +696,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
   <div class=\\"topic-date\\">Feb 19, 1995</div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-4948\\" data-msg-id=\\"4948\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -720,7 +720,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
   <div class=\\"topic-date\\">Feb 19, 1995</div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-5083\\" data-msg-id=\\"5083\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -739,7 +739,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
   Nonrandom name one User, Nonrandom name two User
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-5287\\" data-msg-id=\\"5287\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -756,7 +756,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
   
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-5309\\" data-msg-id=\\"5309\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20two.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-2.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -775,7 +775,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
   Nonrandom name one User, Nonrandom name three User, Nonrandom name two User
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-5377\\" data-msg-id=\\"5377\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -816,7 +816,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
   </div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-5727\\" data-msg-id=\\"5727\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20two.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-2.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -835,7 +835,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
   Nonrandom name one User, Nonrandom name two User
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-5829\\" data-msg-id=\\"5829\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -856,7 +856,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
   <div class=\\"timerow-right\\"></div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-5963\\" data-msg-id=\\"5963\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -884,7 +884,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
   <div class=\\"topic-date\\">Mar 5, 1995</div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-6789\\" data-msg-id=\\"6789\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -908,7 +908,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
   <div class=\\"topic-date\\">Mar 5, 1995</div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-7727\\" data-msg-id=\\"7727\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -932,7 +932,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
   <div class=\\"topic-date\\">Mar 5, 1995</div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-7938\\" data-msg-id=\\"7938\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -949,7 +949,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
   
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-8060\\" data-msg-id=\\"8060\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20two.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-2.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -968,7 +968,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
   Nonrandom name one User, Nonrandom name two User
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-8849\\" data-msg-id=\\"8849\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -1004,7 +1004,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
   <div class=\\"topic-date\\">Mar 5, 1995</div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-9181\\" data-msg-id=\\"9181\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -1025,7 +1025,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible HOME_N
   <div class=\\"timerow-right\\"></div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-9815\\" data-msg-id=\\"9815\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -1052,7 +1052,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm
   Nonrandom name one User, Nonrandom name two User
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-8849\\" data-msg-id=\\"8849\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -1091,7 +1091,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm
   Nonrandom name one User, Nonrandom name two User
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-5287\\" data-msg-id=\\"5287\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -1108,7 +1108,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm
   
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-5309\\" data-msg-id=\\"5309\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20two.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-2.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -1135,7 +1135,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm
   Nonrandom name one User, Nonrandom name two User
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-5829\\" data-msg-id=\\"5829\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -1156,7 +1156,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm
   <div class=\\"timerow-right\\"></div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-5963\\" data-msg-id=\\"5963\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -1183,7 +1183,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm
   Nonrandom name one User, Nonrandom name three User, Nonrandom name two User
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-5377\\" data-msg-id=\\"5377\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -1222,7 +1222,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm
   Nonrandom name one User, Nonrandom name three User, Nonrandom name two User
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-5637\\" data-msg-id=\\"5637\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -1239,7 +1239,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm
   
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-5727\\" data-msg-id=\\"5727\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20two.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-2.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -1266,7 +1266,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm
   Nonrandom name one User, Nonrandom name three User, Nonrandom name two User
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-2794\\" data-msg-id=\\"2794\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -1287,7 +1287,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm
   <div class=\\"timerow-right\\"></div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-4581\\" data-msg-id=\\"4581\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -1314,7 +1314,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm
   Nonrandom name one User, Nonrandom name three User, Nonrandom name two User
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-2794\\" data-msg-id=\\"2794\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -1335,7 +1335,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm
   <div class=\\"timerow-right\\"></div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-4581\\" data-msg-id=\\"4581\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -1358,7 +1358,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm
   Nonrandom name one User, Nonrandom name two User
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-5287\\" data-msg-id=\\"5287\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -1375,7 +1375,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm
   
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-5309\\" data-msg-id=\\"5309\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20two.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-2.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -1394,7 +1394,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm
   Nonrandom name one User, Nonrandom name three User, Nonrandom name two User
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-5377\\" data-msg-id=\\"5377\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -1435,7 +1435,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm
   </div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-5727\\" data-msg-id=\\"5727\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20two.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-2.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -1454,7 +1454,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm
   Nonrandom name one User, Nonrandom name two User
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-5829\\" data-msg-id=\\"5829\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -1475,7 +1475,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm
   <div class=\\"timerow-right\\"></div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-5963\\" data-msg-id=\\"5963\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -1496,7 +1496,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm
   <div class=\\"timerow-right\\"></div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-8849\\" data-msg-id=\\"8849\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -1540,7 +1540,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible other 
   <div class=\\"topic-date\\">Dec 31, 1969</div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg--1\\" data-msg-id=\\"-1\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20sender.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-10.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -1572,7 +1572,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible other 
   <div class=\\"topic-date\\">Dec 31, 1969</div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg--1\\" data-msg-id=\\"-1\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20sender.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-10.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -1614,7 +1614,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible other 
   <div class=\\"topic-date\\">Dec 31, 1969</div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg--1\\" data-msg-id=\\"-1\\" data-mute-state=\\"shown\\" data-collapsed=\\"true\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20sender.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-10.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -1646,7 +1646,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible other 
   <div class=\\"topic-date\\">Dec 31, 1969</div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg--1\\" data-msg-id=\\"-1\\" data-mute-state=\\"shown\\" data-force_collapse=\\"true\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20sender.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-10.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -1678,7 +1678,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible other 
   <div class=\\"topic-date\\">Dec 31, 1969</div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg--1\\" data-msg-id=\\"-1\\" data-mute-state=\\"shown\\" data-force_expand=\\"true\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20sender.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-10.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -1710,7 +1710,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible other 
   <div class=\\"topic-date\\">Dec 31, 1969</div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg--1\\" data-msg-id=\\"-1\\" data-mute-state=\\"shown\\" data-has_alert_word=\\"true\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20sender.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-10.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -1742,7 +1742,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible other 
   <div class=\\"topic-date\\">Dec 31, 1969</div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg--1\\" data-msg-id=\\"-1\\" data-mute-state=\\"shown\\" data-historical=\\"true\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20sender.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-10.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -1774,7 +1774,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible other 
   <div class=\\"topic-date\\">Dec 31, 1969</div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg--1\\" data-msg-id=\\"-1\\" data-mute-state=\\"shown\\" data-is_me_message=\\"true\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20sender.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-10.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -1806,7 +1806,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible other 
   <div class=\\"topic-date\\">Dec 31, 1969</div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg--1\\" data-msg-id=\\"-1\\" data-mute-state=\\"shown\\" data-mentioned=\\"true\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20sender.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-10.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -1838,7 +1838,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible other 
   <div class=\\"topic-date\\">Dec 31, 1969</div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg--1\\" data-msg-id=\\"-1\\" data-mute-state=\\"shown\\" data-read=\\"true\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20sender.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-10.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -1870,7 +1870,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible other 
   <div class=\\"topic-date\\">Dec 31, 1969</div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg--1\\" data-msg-id=\\"-1\\" data-mute-state=\\"shown\\" data-starred=\\"true\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20sender.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-10.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -1902,7 +1902,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible other 
   <div class=\\"topic-date\\">Dec 31, 1969</div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg--1\\" data-msg-id=\\"-1\\" data-mute-state=\\"shown\\" data-summarize_in_home=\\"true\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20sender.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-10.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -1934,7 +1934,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible other 
   <div class=\\"topic-date\\">Dec 31, 1969</div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg--1\\" data-msg-id=\\"-1\\" data-mute-state=\\"shown\\" data-summarize_in_stream=\\"true\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20sender.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-10.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -1966,7 +1966,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible other 
   <div class=\\"topic-date\\">Dec 31, 1969</div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg--1\\" data-msg-id=\\"-1\\" data-mute-state=\\"shown\\" data-wildcard_mentioned=\\"true\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20sender.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-10.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -1998,7 +1998,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible other 
   <div class=\\"topic-date\\">Dec 31, 1969</div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg--1\\" data-msg-id=\\"-1\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20sender.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-10.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -2030,7 +2030,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible other 
   <div class=\\"topic-date\\">Dec 31, 1969</div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg--1\\" data-msg-id=\\"-1\\" data-mute-state=\\"hidden\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20sender.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-10.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -2064,7 +2064,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible other 
   <div class=\\"topic-date\\">Dec 31, 1969</div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg--1\\" data-msg-id=\\"-1\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20sender.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-10.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -2096,7 +2096,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible other 
   <div class=\\"topic-date\\">Dec 31, 1969</div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg--1\\" data-msg-id=\\"-1\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20sender.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-10.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -2128,7 +2128,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible other 
   <div class=\\"topic-date\\">Dec 31, 1969</div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg--1\\" data-msg-id=\\"-1\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20sender.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-10.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -2160,7 +2160,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible other 
   <div class=\\"topic-date\\">Dec 31, 1969</div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg--1\\" data-msg-id=\\"-1\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20sender.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-10.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -2185,7 +2185,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2
   <div class=\\"timerow-right\\"></div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-8849\\" data-msg-id=\\"8849\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -2222,7 +2222,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2
   <div class=\\"timerow-right\\"></div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-5287\\" data-msg-id=\\"5287\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -2239,7 +2239,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2
   
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-5309\\" data-msg-id=\\"5309\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20two.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-2.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -2264,7 +2264,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2
   <div class=\\"timerow-right\\"></div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-5829\\" data-msg-id=\\"5829\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -2285,7 +2285,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2
   <div class=\\"timerow-right\\"></div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-5963\\" data-msg-id=\\"5963\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -2310,7 +2310,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2
   <div class=\\"timerow-right\\"></div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-5287\\" data-msg-id=\\"5287\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -2327,7 +2327,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2
   
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-5309\\" data-msg-id=\\"5309\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20two.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-2.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -2344,7 +2344,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2
   
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-5829\\" data-msg-id=\\"5829\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -2365,7 +2365,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2
   <div class=\\"timerow-right\\"></div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-5963\\" data-msg-id=\\"5963\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -2386,7 +2386,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2
   <div class=\\"timerow-right\\"></div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-8849\\" data-msg-id=\\"8849\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -2423,7 +2423,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2
   <div class=\\"timerow-right\\"></div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-5377\\" data-msg-id=\\"5377\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -2460,7 +2460,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2
   <div class=\\"timerow-right\\"></div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-5637\\" data-msg-id=\\"5637\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -2477,7 +2477,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2
   
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-5727\\" data-msg-id=\\"5727\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20two.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-2.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -2502,7 +2502,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2
   <div class=\\"timerow-right\\"></div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-2794\\" data-msg-id=\\"2794\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -2523,7 +2523,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2
   <div class=\\"timerow-right\\"></div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-4581\\" data-msg-id=\\"4581\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -2548,7 +2548,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2
   <div class=\\"timerow-right\\"></div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-2794\\" data-msg-id=\\"2794\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -2569,7 +2569,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2
   <div class=\\"timerow-right\\"></div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-4581\\" data-msg-id=\\"4581\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -2590,7 +2590,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2
   <div class=\\"timerow-right\\"></div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-5377\\" data-msg-id=\\"5377\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -2631,7 +2631,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible pm:1,2
   </div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-5727\\" data-msg-id=\\"5727\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20two.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-2.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -2659,7 +2659,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible stream
   <div class=\\"topic-date\\">Feb 5, 1995</div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-1024\\" data-msg-id=\\"1024\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -2699,7 +2699,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible stream
   <div class=\\"topic-date\\">Mar 5, 1995</div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-7938\\" data-msg-id=\\"7938\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -2716,7 +2716,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible stream
   
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-8060\\" data-msg-id=\\"8060\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20two.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-2.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -2744,7 +2744,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible stream
   <div class=\\"topic-date\\">Feb 19, 1995</div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-4948\\" data-msg-id=\\"4948\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -2764,7 +2764,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible stream
   <div class=\\"topic-date\\">Feb 19, 1995</div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-5083\\" data-msg-id=\\"5083\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -2792,7 +2792,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible stream
   <div class=\\"topic-date\\">Mar 5, 1995</div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-9181\\" data-msg-id=\\"9181\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -2813,7 +2813,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible stream
   <div class=\\"timerow-right\\"></div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-9815\\" data-msg-id=\\"9815\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -2841,7 +2841,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible stream
   <div class=\\"topic-date\\">Feb 5, 1995</div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-1024\\" data-msg-id=\\"1024\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -2874,7 +2874,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible stream
   <div class=\\"timerow-right\\"></div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-4948\\" data-msg-id=\\"4948\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -2894,7 +2894,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible stream
   <div class=\\"topic-date\\">Feb 19, 1995</div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-5083\\" data-msg-id=\\"5083\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -2918,7 +2918,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible stream
   <div class=\\"topic-date\\">Mar 5, 1995</div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-7938\\" data-msg-id=\\"7938\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -2935,7 +2935,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible stream
   
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-8060\\" data-msg-id=\\"8060\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20two.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-2.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -2952,7 +2952,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible stream
   
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-9181\\" data-msg-id=\\"9181\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -2973,7 +2973,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible stream
   <div class=\\"timerow-right\\"></div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-9815\\" data-msg-id=\\"9815\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -2998,7 +2998,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible topic:
   <div class=\\"timerow-right\\"></div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-1024\\" data-msg-id=\\"1024\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -3035,7 +3035,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible topic:
   <div class=\\"timerow-right\\"></div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-7938\\" data-msg-id=\\"7938\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -3052,7 +3052,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible topic:
   
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-8060\\" data-msg-id=\\"8060\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20two.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-2.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -3077,7 +3077,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible topic:
   <div class=\\"timerow-right\\"></div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-9181\\" data-msg-id=\\"9181\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -3098,7 +3098,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible topic:
   <div class=\\"timerow-right\\"></div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-9815\\" data-msg-id=\\"9815\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -3123,7 +3123,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible topic:
   <div class=\\"timerow-right\\"></div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-1024\\" data-msg-id=\\"1024\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -3156,7 +3156,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible topic:
   <div class=\\"timerow-right\\"></div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-7938\\" data-msg-id=\\"7938\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -3173,7 +3173,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible topic:
   
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-8060\\" data-msg-id=\\"8060\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20two.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-2.png\\" alt=\\"Nonrandom name two User\\" class=\\"avatar-img\\" data-sender-id=\\"2\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -3190,7 +3190,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible topic:
   
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-9181\\" data-msg-id=\\"9181\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">
@@ -3211,7 +3211,7 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible topic:
   <div class=\\"timerow-right\\"></div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-9815\\" data-msg-id=\\"9815\\" data-mute-state=\\"shown\\">
   <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-nonrandom%20name%20one.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-1.png\\" alt=\\"Nonrandom name one User\\" class=\\"avatar-img\\" data-sender-id=\\"1\\">
   </div>
   <div class=\\"content\\">
     <div class=\\"subheader\\">

--- a/src/webview/__tests__/generateInboundEventEditSequence-test.js
+++ b/src/webview/__tests__/generateInboundEventEditSequence-test.js
@@ -37,9 +37,9 @@ import { getBackgroundData } from '../backgroundData';
 // Our translation function, usually given the name _.
 const mock_ = m => m; // eslint-disable-line no-underscore-dangle
 
-const user1 = eg.makeUser({ user_id: 1, name: 'nonrandom name one' });
-const user2 = eg.makeUser({ user_id: 2, name: 'nonrandom name two' });
-const user3 = eg.makeUser({ user_id: 3, name: 'nonrandom name three' });
+const user1 = eg.makeUser({ user_id: 1, full_name: 'Nonrandom name one User' });
+const user2 = eg.makeUser({ user_id: 2, full_name: 'Nonrandom name two User' });
+const user3 = eg.makeUser({ user_id: 3, full_name: 'Nonrandom name three User' });
 
 const stream1 = eg.makeStream({ stream_id: 1, name: 'stream 1' });
 const stream2 = eg.makeStream({ stream_id: 2, name: 'stream 2' });
@@ -414,11 +414,14 @@ describe('messages -> piece descriptors -> content HTML is stable/sensible', () 
   });
 
   describe('other interesting cases (single messages)', () => {
-    const stableSelfUser = eg.makeUser({ user_id: 1, name: 'nonrandom name self' });
-    const stableOtherUser = eg.makeUser({ user_id: 2, name: 'nonrandom name other' });
-    const stableThirdUser = eg.makeUser({ user_id: 3, name: 'nonrandom name third' });
+    const stableSelfUser = eg.makeUser({ user_id: 1, full_name: 'Nonrandom name self User' });
+    const stableOtherUser = eg.makeUser({ user_id: 2, full_name: 'Nonrandom name other User' });
+    const stableThirdUser = eg.makeUser({ user_id: 3, full_name: 'Nonrandom name third User' });
 
-    const singleMessageSender = eg.makeUser({ user_id: 10, name: 'nonrandom name sender' });
+    const singleMessageSender = eg.makeUser({
+      user_id: 10,
+      full_name: 'Nonrandom name sender User',
+    });
     const baseSingleMessage = eg.streamMessage({
       id: -1,
       timestamp: -1,

--- a/src/webview/html/__tests__/render-test.js
+++ b/src/webview/html/__tests__/render-test.js
@@ -5,7 +5,7 @@ import * as eg from '../../../__tests__/lib/exampleData';
 describe('typing', () => {
   it('escapes &< (e.g., in `avatar_url` and `email`', () => {
     const name = '&<name';
-    const user = eg.makeUser({ name, email: `${name}@example.com` });
+    const user = eg.makeUser({ full_name: name, email: `${name}@example.com` });
     expect(messageTypingAsHtml(eg.realm, [user])).not.toContain('&<');
   });
 });


### PR DESCRIPTION
I was looking at the tests in `userHelpers-test.js` while reviewing #5292 (which added a few more tests there), and after merging that I wanted to make that file simpler and better set up to add more such tests.

Along the way I realized that `eg.makeUser` has a hidden gotcha in the `name` parameter, so I made a series of commits to untangle that.

There are still further improvements I might make to this file that I didn't get to today, but I think this is significantly better already.
