### PR TITLE
libdefs: Fix/suppress most glossed-over errors in react-intl libdef

### DIFF
--- a/flow-typed/react-intl_vx.x.x.js
+++ b/flow-typed/react-intl_vx.x.x.js
@@ -395,7 +395,7 @@ declare module 'react-intl' {
       opts?: FormatNumberOptions,
     ): Intl.NumberFormatPart[];
     formatPlural(
-      value: $ElementType<Parameters<$PropertyType<Intl.PluralRules, 'select'>>, 0>,
+      value: number, // Param of Intl.PluralRules.prototype.select()
       opts?: FormatPluralOptions,
     ): $Call<<R>((...args: any[]) => R) => R, $PropertyType<Intl.PluralRules, 'select'>>;
     formatMessage(

--- a/flow-typed/react-intl_vx.x.x.js
+++ b/flow-typed/react-intl_vx.x.x.js
@@ -232,7 +232,6 @@ declare module 'react-intl' {
     |},
     // Changed `mixins` to `extends` in TS to Flow translation
   > extends React$Component<Props_3<V>> {
-    static displayName: string;
     shouldComponentUpdate(nextProps: Props_3<V>): boolean;
     render(): React$Node;
   }
@@ -261,7 +260,6 @@ declare module 'react-intl' {
   // Changed `mixins` to `extends` in TS to Flow translation
   declare export class FormattedRelativeTime extends React$PureComponent<Props, State_2> {
     _updateTimer: any;
-    static displayName: string;
     static defaultProps: Pick<Props, 'unit' | 'value'>;
     state: State_2;
     constructor(props: Props): this;
@@ -580,7 +578,6 @@ declare module 'react-intl' {
     |},
     State,
   > {
-    static displayName: string;
     static defaultProps: Pick<
       IntlConfig,
       | 'formats'

--- a/flow-typed/react-intl_vx.x.x.js
+++ b/flow-typed/react-intl_vx.x.x.js
@@ -292,22 +292,22 @@ declare module 'react-intl' {
   declare export interface Formatters {
     getDateTimeFormat(
       ...args: ConstructorParameters<typeof Intl.DateTimeFormat>
-    ): Intl.DateTimeFormat;
-    getNumberFormat(...args: ConstructorParameters<typeof Intl.NumberFormat>): Intl.NumberFormat;
+    ): Intl$DateTimeFormat;
+    getNumberFormat(...args: ConstructorParameters<typeof Intl.NumberFormat>): Intl$NumberFormat;
     getMessageFormat(...args: ConstructorParameters<typeof IntlMessageFormat>): IntlMessageFormat;
     getRelativeTimeFormat(
       ...args: ConstructorParameters<typeof RelativeTimeFormat>
     ): RelativeTimeFormat;
-    getPluralRules(...args: ConstructorParameters<typeof Intl.PluralRules>): Intl.PluralRules;
+    getPluralRules(...args: ConstructorParameters<typeof Intl.PluralRules>): Intl$PluralRules;
     getListFormat(...args: ConstructorParameters<typeof ListFormat>): ListFormat;
     getDisplayNames(...args: ConstructorParameters<typeof DisplayNames>): DisplayNames;
   }
   declare interface Formatters_2 {
-    getNumberFormat(...args: ConstructorParameters<typeof Intl.NumberFormat>): Intl.NumberFormat;
+    getNumberFormat(...args: ConstructorParameters<typeof Intl.NumberFormat>): Intl$NumberFormat;
     getDateTimeFormat(
       ...args: ConstructorParameters<typeof Intl.DateTimeFormat>
-    ): Intl.DateTimeFormat;
-    getPluralRules(...args: ConstructorParameters<typeof Intl.PluralRules>): Intl.PluralRules;
+    ): Intl$DateTimeFormat;
+    getPluralRules(...args: ConstructorParameters<typeof Intl.PluralRules>): Intl$PluralRules;
   }
   declare type FormatXMLElementFn<T, R = string | Array<string | T>> = (
     parts: Array<string | T>,

--- a/flow-typed/react-intl_vx.x.x.js
+++ b/flow-typed/react-intl_vx.x.x.js
@@ -189,7 +189,7 @@ declare module 'react-intl' {
   declare export type FormatListOptions = Exclude<IntlListFormatOptions, 'localeMatcher'>;
   declare export type FormatNumberOptions = Exclude<NumberFormatOptions, 'localeMatcher'> &
     CustomFormatConfig;
-  declare export type FormatPluralOptions = Exclude<Intl.PluralRulesOptions, 'localeMatcher'> &
+  declare export type FormatPluralOptions = Exclude<Intl$PluralRulesOptions, 'localeMatcher'> &
     CustomFormatConfig;
   declare export type FormatRelativeTimeOptions = Exclude<
     IntlRelativeTimeFormatOptions,
@@ -812,7 +812,7 @@ declare module 'react-intl' {
   declare type PluralElement = {
     options: {| [key: ValidPluralRule]: PluralOrSelectOption |},
     offset: number,
-    pluralType: $PropertyType<Intl.PluralRulesOptions, 'type'>,
+    pluralType: $PropertyType<Intl$PluralRulesOptions, 'type'>,
     ...
   } & BaseElement<typeof TYPE.plural>;
   declare interface PluralOrSelectOption {

--- a/flow-typed/react-intl_vx.x.x.js
+++ b/flow-typed/react-intl_vx.x.x.js
@@ -55,7 +55,7 @@ declare module 'react-intl' {
       | 'roc',
     numberingSystem?: string,
     ...
-  } & Intl.DateTimeFormatOptions;
+  } & Intl$DateTimeFormatOptions;
   declare interface DateTimeSkeleton {
     type: typeof SKELETON_TYPE.dateTime;
     pattern: string;
@@ -197,8 +197,8 @@ declare module 'react-intl' {
     CustomFormatConfig;
   declare interface Formats {
     number: {| [key: string]: Intl.NumberFormatOptions |};
-    date: {| [key: string]: Intl.DateTimeFormatOptions |};
-    time: {| [key: string]: Intl.DateTimeFormatOptions |};
+    date: {| [key: string]: Intl$DateTimeFormatOptions |};
+    time: {| [key: string]: Intl$DateTimeFormatOptions |};
   }
   declare type FormattableUnit = Unit | Units;
   declare export var FormattedDate: React$StatelessFunctionalComponent<

--- a/flow-typed/react-intl_vx.x.x.js
+++ b/flow-typed/react-intl_vx.x.x.js
@@ -289,6 +289,12 @@ declare module 'react-intl' {
     formatDisplayName: FormatDisplayNameOptions,
     ...
   };
+
+  // FlowIssue: Looks like we really want something like
+  //     getDateTimeFormat: ConstructorOf<Intl.DateTimeFormat>
+  //   but Flow doesn't have something like ConstructorOf; see
+  //     https://github.com/facebook/flow/issues/1409#issuecomment-184443566
+  declare type ConstructorParameters<C> = $FlowIssue[];
   declare export interface Formatters {
     getDateTimeFormat(
       ...args: ConstructorParameters<typeof Intl.DateTimeFormat>
@@ -309,6 +315,7 @@ declare module 'react-intl' {
     ): Intl$DateTimeFormat;
     getPluralRules(...args: ConstructorParameters<typeof Intl.PluralRules>): Intl$PluralRules;
   }
+
   declare type FormatXMLElementFn<T, R = string | Array<string | T>> = (
     parts: Array<string | T>,
   ) => R;

--- a/flow-typed/react-intl_vx.x.x.js
+++ b/flow-typed/react-intl_vx.x.x.js
@@ -210,7 +210,7 @@ declare module 'react-intl' {
   declare export var FormattedDateParts: React$StatelessFunctionalComponent<
     FormatDateOptions & {
       value: Date | number | string, // Param of Intl.DateTimeFormat.prototype.format(), or `string`
-      children(val: $Call<$PropertyType<Intl$DateTimeFormat, 'formatToParts'>, mixed[]>): React$Element | null,
+      children(val: $Call<$PropertyType<Intl$DateTimeFormat, 'formatToParts'>, mixed[]>): React$Element<React$ElementType> | null,
       ...
     }, >;
   declare export var FormattedDisplayName: React$StatelessFunctionalComponent<
@@ -227,7 +227,7 @@ declare module 'react-intl' {
     V: {| +[key: string]: any |} = {|
       +[key: string]:
         | PrimitiveType
-        | React$Element
+        | React$Element<React$ElementType>
         | FormatXMLElementFn<React$Node, React$Node>,
     |},
     // Changed `mixins` to `extends` in TS to Flow translation
@@ -251,7 +251,7 @@ declare module 'react-intl' {
       // Callers will get a Flow error until Flow adds a built-in
       // definition for Intl.NumberFormat.prototype.formatToParts():
       //   https://github.com/facebook/flow/issues/8859
-      children(val: $Call<$PropertyType<Intl$NumberFormat, 'formatToParts'>, mixed[]>): React$Element | null,
+      children(val: $Call<$PropertyType<Intl$NumberFormat, 'formatToParts'>, mixed[]>): React$Element<React$ElementType> | null,
       ...
     }, >;
   declare export var FormattedPlural: React$StatelessFunctionalComponent<WithIntlProps<Props_2>> & {
@@ -281,7 +281,7 @@ declare module 'react-intl' {
   declare export var FormattedTimeParts: React$StatelessFunctionalComponent<
     FormatDateOptions & {
       value: Date | number | string, // Param of Intl.DateTimeFormat.prototype.format(), or `string`
-      children(val: $Call<$PropertyType<Intl$DateTimeFormat, 'formatToParts'>, mixed[]>): React$Element | null,
+      children(val: $Call<$PropertyType<Intl$DateTimeFormat, 'formatToParts'>, mixed[]>): React$Element<React$ElementType> | null,
       ...
     }, >;
   declare type Formatter = {
@@ -847,7 +847,7 @@ declare module 'react-intl' {
     value?: number,
     unit?: Unit,
     updateIntervalInSeconds?: number,
-    children?: (value: string) => React$Element | string | number,
+    children?: (value: string) => React$Element<React$ElementType> | string | number,
     ...
   } & FormatRelativeTimeOptions;
   declare type Props_2 = {
@@ -859,7 +859,7 @@ declare module 'react-intl' {
     two?: React$Node,
     few?: React$Node,
     many?: React$Node,
-    children?: (value: React$Node) => React$Element | null,
+    children?: (value: React$Node) => React$Element<React$ElementType> | null,
     ...
   } & FormatPluralOptions;
   declare type Props_3<V: {| +[key: string]: any |} = {| +[key: string]: React$Node |}> = {

--- a/flow-typed/react-intl_vx.x.x.js
+++ b/flow-typed/react-intl_vx.x.x.js
@@ -196,7 +196,7 @@ declare module 'react-intl' {
     'localeMatcher', > &
     CustomFormatConfig;
   declare interface Formats {
-    number: {| [key: string]: Intl.NumberFormatOptions |};
+    number: {| [key: string]: Intl$NumberFormatOptions |};
     date: {| [key: string]: Intl$DateTimeFormatOptions |};
     time: {| [key: string]: Intl$DateTimeFormatOptions |};
   }
@@ -726,7 +726,7 @@ declare module 'react-intl' {
     maximumFractionDigits?: number;
   }
   declare type NumberFormatNotation = 'standard' | 'scientific' | 'engineering' | 'compact';
-  declare type NumberFormatOptions = Intl.NumberFormatOptions &
+  declare type NumberFormatOptions = Intl$NumberFormatOptions &
     NumberFormatDigitOptions & {
       localeMatcher?: NumberFormatOptionsLocaleMatcher,
       style?: NumberFormatOptionsStyle,

--- a/flow-typed/react-intl_vx.x.x.js
+++ b/flow-typed/react-intl_vx.x.x.js
@@ -210,7 +210,7 @@ declare module 'react-intl' {
   declare export var FormattedDateParts: React$StatelessFunctionalComponent<
     FormatDateOptions & {
       value: Date | number | string, // Param of Intl.DateTimeFormat.prototype.format(), or `string`
-      children(val: Intl.DateTimeFormatPart[]): React$Element | null,
+      children(val: $Call<$PropertyType<Intl$DateTimeFormat, 'formatToParts'>, mixed[]>): React$Element | null,
       ...
     }, >;
   declare export var FormattedDisplayName: React$StatelessFunctionalComponent<
@@ -278,7 +278,7 @@ declare module 'react-intl' {
   declare export var FormattedTimeParts: React$StatelessFunctionalComponent<
     FormatDateOptions & {
       value: Date | number | string, // Param of Intl.DateTimeFormat.prototype.format(), or `string`
-      children(val: Intl.DateTimeFormatPart[]): React$Element | null,
+      children(val: $Call<$PropertyType<Intl$DateTimeFormat, 'formatToParts'>, mixed[]>): React$Element | null,
       ...
     }, >;
   declare type Formatter = {
@@ -386,11 +386,11 @@ declare module 'react-intl' {
     formatDateToParts(
       value: Date | number | string, // Param of Intl.DateTimeFormat.prototype.format(), or `string`
       opts?: FormatDateOptions,
-    ): Intl.DateTimeFormatPart[];
+    ): $Call<$PropertyType<Intl$DateTimeFormat, 'formatToParts'>, mixed[]>;
     formatTimeToParts(
       value: Date | number | string, // Param of Intl.DateTimeFormat.prototype.format(), or `string`
       opts?: FormatDateOptions,
-    ): Intl.DateTimeFormatPart[];
+    ): $Call<$PropertyType<Intl$DateTimeFormat, 'formatToParts'>, mixed[]>;
     formatRelativeTime(
       value: number, // First param of our RelativeTimeFormat.prototype.format()
       unit?: FormattableUnit, // Second param of our RelativeTimeFormat.prototype.format()

--- a/flow-typed/react-intl_vx.x.x.js
+++ b/flow-typed/react-intl_vx.x.x.js
@@ -413,7 +413,9 @@ declare module 'react-intl' {
     formatList(values: Array<string>, opts?: FormatListOptions): string;
     formatList(values: Array<string | React$Node>, opts?: FormatListOptions): React$Node;
     formatDisplayName(
-      value: $ElementType<Parameters<$PropertyType<DisplayNames, 'of'>>, 0>,
+      // First param of our DisplayNames.prototype.of()
+      value: string | number | {| [key: string]: any |},
+
       opts?: FormatDisplayNameOptions,
     ): string | void;
   }

--- a/flow-typed/react-intl_vx.x.x.js
+++ b/flow-typed/react-intl_vx.x.x.js
@@ -248,7 +248,10 @@ declare module 'react-intl' {
        // IntlFormatters.formatNumber
       value: number,
 
-      children(val: Intl.NumberFormatPart[]): React$Element | null,
+      // Callers will get a Flow error until Flow adds a built-in
+      // definition for Intl.NumberFormat.prototype.formatToParts():
+      //   https://github.com/facebook/flow/issues/8859
+      children(val: $Call<$PropertyType<Intl$NumberFormat, 'formatToParts'>, mixed[]>): React$Element | null,
       ...
     }, >;
   declare export var FormattedPlural: React$StatelessFunctionalComponent<WithIntlProps<Props_2>> & {
@@ -403,7 +406,11 @@ declare module 'react-intl' {
     formatNumberToParts(
       value: number, // Param of Intl.NumberFormat.prototype.format()
       opts?: FormatNumberOptions,
-    ): Intl.NumberFormatPart[];
+
+      // Callers will get a Flow error until Flow adds a built-in
+      // definition for Intl.NumberFormat.prototype.formatToParts():
+      //   https://github.com/facebook/flow/issues/8859
+    ): $Call<$PropertyType<Intl$NumberFormat, 'formatToParts'>, mixed[]>;
     formatPlural(
       value: number, // Param of Intl.PluralRules.prototype.select()
       opts?: FormatPluralOptions,
@@ -923,7 +930,11 @@ declare module 'react-intl' {
   declare type RelativeTimeFormatNumberPart = {
     unit: Unit,
     ...
-  } & Intl.NumberFormatPart;
+
+    // Callers will get a Flow error until Flow adds a built-in
+    // definition for Intl.NumberFormat.prototype.formatToParts():
+    //   https://github.com/facebook/flow/issues/8859
+  } & $ElementType<$Call<$PropertyType<Intl$NumberFormat, 'formatToParts'>, mixed[]>, number>;
   declare type RelativeTimeLocaleData = LocaleData<LocaleFieldsData>;
   declare interface ResolvedIntlListFormatOptions {
     /**

--- a/flow-typed/react-intl_vx.x.x.js
+++ b/flow-typed/react-intl_vx.x.x.js
@@ -244,7 +244,10 @@ declare module 'react-intl' {
       }, >;
   declare export var FormattedNumberParts: React$StatelessFunctionalComponent<
     $PropertyType<Formatter, 'formatNumber'> & {
-      value: $ElementType<Parameters<$PropertyType<IntlShape, 'formatNumber'>>, 0>,
+       // Param type of our IntlShape.formatNumber, alias of our
+       // IntlFormatters.formatNumber
+      value: number,
+
       children(val: Intl.NumberFormatPart[]): React$Element | null,
       ...
     }, >;

--- a/flow-typed/react-intl_vx.x.x.js
+++ b/flow-typed/react-intl_vx.x.x.js
@@ -387,11 +387,11 @@ declare module 'react-intl' {
       opts?: FormatRelativeTimeOptions,
     ): string;
     formatNumber(
-      value: $ElementType<Parameters<$PropertyType<Intl.NumberFormat, 'format'>>, 0>,
+      value: number, // Param of Intl.NumberFormat.prototype.format()
       opts?: FormatNumberOptions,
     ): string;
     formatNumberToParts(
-      value: $ElementType<Parameters<$PropertyType<Intl.NumberFormat, 'format'>>, 0>,
+      value: number, // Param of Intl.NumberFormat.prototype.format()
       opts?: FormatNumberOptions,
     ): Intl.NumberFormatPart[];
     formatPlural(

--- a/flow-typed/react-intl_vx.x.x.js
+++ b/flow-typed/react-intl_vx.x.x.js
@@ -350,7 +350,7 @@ declare module 'react-intl' {
     number: {| [key: string]: Intl.NumberFormat |};
     message: {| [key: string]: IntlMessageFormat |};
     relativeTime: {| [key: string]: RelativeTimeFormat |};
-    pluralRules: {| [key: string]: Intl.PluralRules |};
+    pluralRules: {| [key: string]: typeof Intl.PluralRules |};
     list: {| [key: string]: ListFormat |};
     displayNames: {| [key: string]: DisplayNames |};
   }
@@ -412,7 +412,7 @@ declare module 'react-intl' {
     formatPlural(
       value: number, // Param of Intl.PluralRules.prototype.select()
       opts?: FormatPluralOptions,
-    ): $Call<<R>((...args: any[]) => R) => R, $PropertyType<Intl.PluralRules, 'select'>>;
+    ): $Call<<R>((...args: any[]) => R) => R, $PropertyType<typeof Intl.PluralRules, 'select'>>;
     formatMessage(
       descriptor: MessageDescriptor,
       // The `+` was added to make the properties covariant rather

--- a/flow-typed/react-intl_vx.x.x.js
+++ b/flow-typed/react-intl_vx.x.x.js
@@ -382,8 +382,8 @@ declare module 'react-intl' {
       opts?: FormatDateOptions,
     ): Intl.DateTimeFormatPart[];
     formatRelativeTime(
-      value: $ElementType<Parameters<$PropertyType<RelativeTimeFormat, 'format'>>, 0>,
-      unit?: $ElementType<Parameters<$PropertyType<RelativeTimeFormat, 'format'>>, 1>,
+      value: number, // First param of our RelativeTimeFormat.prototype.format()
+      unit?: FormattableUnit, // Second param of our RelativeTimeFormat.prototype.format()
       opts?: FormatRelativeTimeOptions,
     ): string;
     formatNumber(

--- a/flow-typed/react-intl_vx.x.x.js
+++ b/flow-typed/react-intl_vx.x.x.js
@@ -209,7 +209,7 @@ declare module 'react-intl' {
       }, >;
   declare export var FormattedDateParts: React$StatelessFunctionalComponent<
     FormatDateOptions & {
-      value: $ElementType<Parameters<$PropertyType<Intl.DateTimeFormat, 'format'>>, 0> | string,
+      value: Date | number | string, // Param of Intl.DateTimeFormat.prototype.format(), or `string`
       children(val: Intl.DateTimeFormatPart[]): React$Element | null,
       ...
     }, >;
@@ -274,7 +274,7 @@ declare module 'react-intl' {
       }, >;
   declare export var FormattedTimeParts: React$StatelessFunctionalComponent<
     FormatDateOptions & {
-      value: $ElementType<Parameters<$PropertyType<Intl.DateTimeFormat, 'format'>>, 0> | string,
+      value: Date | number | string, // Param of Intl.DateTimeFormat.prototype.format(), or `string`
       children(val: Intl.DateTimeFormatPart[]): React$Element | null,
       ...
     }, >;
@@ -366,19 +366,19 @@ declare module 'react-intl' {
   declare export var IntlContext: React$Context<IntlShape>;
   declare export interface IntlFormatters<T = React$Node, R = T> {
     formatDate(
-      value: $ElementType<Parameters<$PropertyType<Intl.DateTimeFormat, 'format'>>, 0> | string,
+      value: Date | number | string, // Param of Intl.DateTimeFormat.prototype.format(), or `string`
       opts?: FormatDateOptions,
     ): string;
     formatTime(
-      value: $ElementType<Parameters<$PropertyType<Intl.DateTimeFormat, 'format'>>, 0> | string,
+      value: Date | number | string, // Param of Intl.DateTimeFormat.prototype.format(), or `string`
       opts?: FormatDateOptions,
     ): string;
     formatDateToParts(
-      value: $ElementType<Parameters<$PropertyType<Intl.DateTimeFormat, 'format'>>, 0> | string,
+      value: Date | number | string, // Param of Intl.DateTimeFormat.prototype.format(), or `string`
       opts?: FormatDateOptions,
     ): Intl.DateTimeFormatPart[];
     formatTimeToParts(
-      value: $ElementType<Parameters<$PropertyType<Intl.DateTimeFormat, 'format'>>, 0> | string,
+      value: Date | number | string, // Param of Intl.DateTimeFormat.prototype.format(), or `string`
       opts?: FormatDateOptions,
     ): Intl.DateTimeFormatPart[];
     formatRelativeTime(


### PR DESCRIPTION
Like we did for React Nav's libdefs in #5263. This will help us toward the RN v0.65 upgrade, #5230, by preparing to upgrade Flow.

Done by temporarily upgrading to Flow v0.149, which has [this bugfix](https://github.com/facebook/flow/blob/main/Changelog.md#01430) from Flow v0.143—

> * Previously, errors in library files were sometimes being missed due to a bug. This has been fixed, which may expose errors in library files that were not previously being reported.

—and going through the newly caught errors.

@gnprice, three of these errors remain after this branch. Would you be up for taking a stab at the best approach for them? You could add some commits if you see something easy, or else let me know a good direction and I'll do it. Thanks!

```
Error ---------------------------------------------------------------------------- flow-typed/react-intl_vx.x.x.js:64:36

Cannot resolve name `Pick`. [cannot-resolve-name]

   64|   declare var DEFAULT_INTL_CONFIG: Pick<
                                          ^^^^


Error --------------------------------------------------------------------------- flow-typed/react-intl_vx.x.x.js:173:43

Cannot resolve name `Exclude`. [cannot-resolve-name]

   173|   declare export type FormatDateOptions = Exclude<DateTimeFormatOptions, 'localeMatcher'> &
                                                  ^^^^^^^


Error --------------------------------------------------------------------------- flow-typed/react-intl_vx.x.x.js:780:37

Cannot resolve name `Omit`. [cannot-resolve-name]

   780|   declare type OptionalIntlConfig = Omit<IntlConfig, $Keys<typeof DEFAULT_INTL_CONFIG>> &
                                            ^^^^
```

Looks like they're uses of TypeScript's [utility types with those names](https://www.typescriptlang.org/docs/handbook/utility-types.html#picktype-keys). (This libdef began from a TypeScript to Flow translation using Flowgen.) I am kind of puzzled by the uses of `Exclude` and I wonder if they really meant to be uses of `Omit`…