### PR TITLE
storage: Use SQLite to replace AsyncStorage

### DIFF
--- a/docs/howto/build-run.md
+++ b/docs/howto/build-run.md
@@ -598,6 +598,31 @@ separately, using `react-native start`. Once the server starts up, run
 `tools/run-android` again, and the app should not crash.
 
 
+### App hangs at Zulip loading screen, while debugging, on iOS
+
+After starting a debug version of the app, on iOS, while [debugging in the
+Chrome DevTools](debugging.md#chrome-devtools), you may find the app stays
+on the loading screen (with the Zulip-purple background, and a progress
+spinner around the Zulip logo) indefinitely.
+
+If you weren't making use of the Chrome debugging features, you can avoid
+this issue by simply turning that back off.
+
+Alternatively, you can get past the issue by tapping on the screen about
+five or ten times over the course of a second or two.
+
+See chat discussion: [start][devtools-hang-discussion], and
+[workaround][devtools-hang-workaround].  This [may go
+away][devtools-hang-hermes] when we switch to Hermes ([#5313][]), where the
+debugger's architecture is simpler and less likely to affect the running of
+the app.
+
+[devtools-hang-discussion]: https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/.23M5309.20sound.20storage/near/1352459
+[devtools-hang-workaround]: https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/.23M5309.20sound.20storage/near/1354570
+[devtools-hang-hermes]: https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/.23M5309.20sound.20storage/near/1354571
+[#5313]: https://github.com/zulip/zulip-mobile/issues/5313
+
+
 ### Red error banner about method `-[RCTAppState getCurrentAppState:error:]`
 
 This should only happen when building old versions of the app, from

--- a/src/boot/store.js
+++ b/src/boot/store.js
@@ -16,7 +16,7 @@ import type { Action, GlobalState, ThunkExtras } from '../types';
 import config from '../config';
 import { REHYDRATE } from '../actionConstants';
 import rootReducer from './reducers';
-import ZulipAsyncStorage from '../storage/ZulipAsyncStorage';
+import CompressedAsyncStorage from '../storage/CompressedAsyncStorage';
 import createMigration from '../redux-persist-migrate/index';
 import { getGlobalSession, getGlobalSettings } from '../directSelectors';
 import { migrations } from '../storage/migrations';
@@ -165,7 +165,7 @@ const reduxPersistConfig: Config = {
 
   // Store data through our own wrapper for AsyncStorage, in particular
   // to get compression.
-  storage: ZulipAsyncStorage,
+  storage: CompressedAsyncStorage,
   serialize: stringify,
   deserialize: parse,
 };

--- a/src/storage/AsyncStorage.js
+++ b/src/storage/AsyncStorage.js
@@ -22,7 +22,7 @@ import { SQLDatabase } from './sqlite';
 //   too, and not have to follow the old names.
 
 // A better name for this class might be simply AsyncStorage.
-// But for now we reserve that name for the thing that's a drop-in
+// But for now we reserve that name for the thing that's a (nearly) drop-in
 // replacement for the upstream AsyncStorage, which isn't this class itself
 // but rather an instance of it.
 export class AsyncStorageImpl {
@@ -108,5 +108,28 @@ export class AsyncStorageImpl {
   }
 }
 
-// Drop-in replacement for (certain methods of) RN's AsyncStorage.
+/**
+ * A sound, nearly-drop-in replacement for RN's AsyncStorage.
+ *
+ * The methods should be invoked as methods, like `AsyncStorage.foo()`.
+ *
+ * Under that convention, and for the methods it has, this is a perfectly
+ * drop-in replacement for the upstream AsyncStorage, meaning that it will
+ * always satisfy the spec for how the upstream AsyncStorage behaves.
+ *
+ * The difference is that it also satisfies a tighter spec: each operation
+ * either happens completely or not at all.  No operation corrupts the
+ * database or has only partial effect, even if the process is killed or
+ * encounters I/O errors.
+ *
+ * This is accomplished by using SQLite, and doing each operation in a
+ * transaction.  The upstream AsyncStorage does the same thing on Android;
+ * but on iOS, it uses an ad-hoc database which is susceptible to complete
+ * corruption if interrupted.
+ *
+ * (If one pokes around other than by invoking the methods as methods, this
+ * implementation has incidental other differences: these are real methods
+ * that come from a prototype and use `this`, while the upstream
+ * AsyncStorage is a plain object with functions as its own properties.)
+ */
 export const AsyncStorage: AsyncStorageImpl = new AsyncStorageImpl();

--- a/src/storage/AsyncStorage.js
+++ b/src/storage/AsyncStorage.js
@@ -1,0 +1,105 @@
+/* @flow strict-local */
+import { SQLDatabase } from './sqlite';
+
+/* eslint-disable no-underscore-dangle */
+
+// This is a Promise rather than directly a SQLDatabase because... well,
+// anything that wants to consume it needs to be prepared to wait in any
+// case, so will be calling something like `_db()` that returns a Promise.
+// And then that might as well return the same Promise every time, rather
+// than unwrapping it up front and wrapping it in a new Promise on each call.
+let dbSingleton: void | Promise<SQLDatabase> = undefined;
+
+// TODO: This needs a migration strategy!  How do we move the user's data
+//   from the old AsyncStorage to the new database?
+//
+//   On Android, we could bypass this by arranging to use the old thing's
+//   database and table name.  Might need some tweaking of expo-sqlite in
+//   order to control the database name fully enough.
+//
+//   But on iOS, it's not so simple.  Values over 1024 characters
+//   (RCTInlineValueThreshold, in RNCAsyncStorage.m) are written as separate
+//   files.  Values up to that threshold go into a single JSON blob (for the
+//   whole key-value store) that's written as one file.  So really our
+//   sanest path is probably to keep the legacy AsyncStorage as a dependency
+//   indefinitely, and use it to read the old data if the new doesn't exist.
+//
+//   Then once we're doing that for iOS, might as well do it for Android
+//   too, and not have to follow the old names.
+
+// Drop-in replacement for (certain methods of) RN's AsyncStorage.
+export class AsyncStorage {
+  static _db(): Promise<SQLDatabase> {
+    if (dbSingleton) {
+      return dbSingleton;
+    }
+
+    dbSingleton = AsyncStorage._initDb();
+    return dbSingleton;
+  }
+
+  static async _initDb() {
+    const db = new SQLDatabase('zulip.db');
+    await db.transaction(tx => {
+      // This schema is just like the one in RN's AsyncStorage (see
+      // ReactDatabaseSupplier.java), except for a small fix: the latter
+      // doesn't mention NOT NULL on the `key` column.  In standard SQL
+      // that'd be redundant with PRIMARY KEY (though c'mon, EIBTI)… but
+      // SQLite has a quirk that PRIMARY KEY does *not* imply NOT NULL:
+      //   https://www.sqlite.org/lang_createtable.html#the_primary_key
+      tx.executeSql(`
+        CREATE TABLE IF NOT EXISTS keyvalue (
+          key TEXT PRIMARY KEY NOT NULL,
+          value TEXT NOT NULL
+        )
+      `);
+      // TODO consider adding STRICT to the schema; requires SQLite 3.37,
+      //   from 2021-11: https://www.sqlite.org/stricttables.html
+    });
+    return db;
+  }
+
+  static async getItem(key: string): Promise<string | null> {
+    const db = await AsyncStorage._db();
+    const rows = await db.query<{ value: string }>('SELECT value FROM keyvalue WHERE key = ?', [
+      key,
+    ]);
+    return rows.length > 0 ? rows[0].value : null;
+  }
+
+  static async setItem(key: string, value: string): Promise<void> {
+    const db = await AsyncStorage._db();
+    return db.transaction(tx => {
+      tx.executeSql('INSERT OR REPLACE INTO keyvalue (key, value) VALUES (?, ?)', [key, value]);
+    });
+  }
+
+  static async multiSet(keyValuePairs: Array<Array<string>>): Promise<void> {
+    const db = await AsyncStorage._db();
+    return db.transaction(tx => {
+      for (const kv of keyValuePairs) {
+        tx.executeSql('INSERT OR REPLACE INTO keyvalue (key, value) VALUES (?, ?)', kv);
+      }
+    });
+  }
+
+  static async removeItem(key: string): Promise<void> {
+    const db = await AsyncStorage._db();
+    return db.transaction(tx => {
+      tx.executeSql('DELETE FROM keyvalue WHERE key = ?', [key]);
+    });
+  }
+
+  static async getAllKeys(): Promise<string[]> {
+    const db = await AsyncStorage._db();
+    const rows = await db.query<{ key: string }>('SELECT key FROM keyvalue');
+    return rows.map(r => r.key);
+  }
+
+  static async clear(): Promise<void> {
+    const db = await AsyncStorage._db();
+    return db.transaction(tx => {
+      tx.executeSql('DELETE FROM keyvalue');
+    });
+  }
+}

--- a/src/storage/CompressedAsyncStorage.js
+++ b/src/storage/CompressedAsyncStorage.js
@@ -1,8 +1,8 @@
 /* @flow strict-local */
-import AsyncStorage from '@react-native-async-storage/async-storage';
 import invariant from 'invariant';
 import { NativeModules } from 'react-native';
 
+import { AsyncStorage } from './AsyncStorage';
 import * as logging from '../utils/logging';
 
 const NODE_ENV = process.env.NODE_ENV;

--- a/src/storage/CompressedAsyncStorage.js
+++ b/src/storage/CompressedAsyncStorage.js
@@ -105,9 +105,9 @@ export default class CompressedAsyncStorage {
     );
   }
 
-  static removeItem: typeof AsyncStorage.removeItem = AsyncStorage.removeItem;
+  static removeItem: typeof AsyncStorage.removeItem = key => AsyncStorage.removeItem(key);
 
-  static getAllKeys: typeof AsyncStorage.getAllKeys = AsyncStorage.getAllKeys;
+  static getAllKeys: typeof AsyncStorage.getAllKeys = () => AsyncStorage.getAllKeys();
 
-  static clear: typeof AsyncStorage.clear = AsyncStorage.clear;
+  static clear: typeof AsyncStorage.clear = () => AsyncStorage.clear();
 }

--- a/src/storage/CompressedAsyncStorage.js
+++ b/src/storage/CompressedAsyncStorage.js
@@ -17,7 +17,7 @@ function assertPlausiblyJSONEncoded(value: string) {
   invariant(/^[ntf\-0-9"[{]/.test(value), 'value must be JSON-encoded');
 }
 
-export default class ZulipAsyncStorage {
+export default class CompressedAsyncStorage {
   static async getItem(key: string): Promise<string | null> {
     const item = await AsyncStorage.getItem(key);
 

--- a/src/storage/ZulipAsyncStorage.js
+++ b/src/storage/ZulipAsyncStorage.js
@@ -44,6 +44,9 @@ export default class ZulipAsyncStorage {
         NativeModules.TextCompressionModule
         && header === NativeModules.TextCompressionModule.header
       ) {
+        // TODO: It'd be real nice to handle this decompression on the
+        //   native side within getItem, so that we pass the data one way
+        //   native->JS instead of three ways native->JS->native->JS.
         return NativeModules.TextCompressionModule.decompress(item);
       } else {
         // Panic! If we are confronted with an unknown format, there is
@@ -92,6 +95,9 @@ export default class ZulipAsyncStorage {
         ? await Promise.all(
             keyValuePairs.map(async ([key, value]) => [
               key,
+              // TODO: It'd be real nice to handle this compression on the
+              //   native side within multiSet, so that we pass the data one
+              //   way JS->native instead of three ways JS->native->JS->native.
               await NativeModules.TextCompressionModule.compress(value),
             ]),
           )

--- a/src/storage/__tests__/AsyncStorage-test.js
+++ b/src/storage/__tests__/AsyncStorage-test.js
@@ -1,0 +1,55 @@
+// @flow strict-local
+
+import { AsyncStorage } from '../AsyncStorage';
+
+/* eslint-disable no-underscore-dangle */
+
+describe('AsyncStorage', () => {
+  afterEach(async () => {
+    await AsyncStorage.clear();
+  });
+
+  test('getItem / setItem', async () => {
+    expect(await AsyncStorage.getItem('a')).toEqual(null);
+
+    await AsyncStorage.setItem('a', '1');
+    expect(await AsyncStorage.getItem('a')).toEqual('1');
+
+    await AsyncStorage.setItem('a', '2');
+    expect(await AsyncStorage.getItem('a')).toEqual('2');
+
+    expect(await AsyncStorage.getItem('b')).toEqual(null);
+  });
+
+  test('multiSet', async () => {
+    await AsyncStorage.multiSet([
+      ['a', '1'],
+      ['b', '2'],
+    ]);
+    expect(await AsyncStorage.getItem('a')).toEqual('1');
+    expect(await AsyncStorage.getItem('b')).toEqual('2');
+  });
+
+  test('removeItem', async () => {
+    await AsyncStorage.setItem('a', '1');
+    expect(await AsyncStorage.getItem('a')).toEqual('1');
+    await AsyncStorage.removeItem('a');
+    expect(await AsyncStorage.getItem('a')).toEqual(null);
+    await AsyncStorage.removeItem('a');
+    expect(await AsyncStorage.getItem('a')).toEqual(null);
+  });
+
+  test('getAllKeys', async () => {
+    await AsyncStorage.setItem('a', '1');
+    await AsyncStorage.setItem('b', '2');
+    expect(await AsyncStorage.getAllKeys()).toEqual(['a', 'b']);
+  });
+
+  test('clear', async () => {
+    await AsyncStorage.setItem('a', '1');
+    await AsyncStorage.setItem('b', '2');
+    expect(await AsyncStorage.getAllKeys()).toEqual(['a', 'b']);
+    await AsyncStorage.clear();
+    expect(await AsyncStorage.getAllKeys()).toEqual([]);
+  });
+});

--- a/src/storage/__tests__/AsyncStorage-test.js
+++ b/src/storage/__tests__/AsyncStorage-test.js
@@ -1,6 +1,11 @@
 // @flow strict-local
 
+// $FlowFixMe[missing-export] -- present in test version of module
+import { deleteDatabase } from 'expo-sqlite';
+import LegacyAsyncStorage from '@react-native-async-storage/async-storage';
+
 import { AsyncStorage } from '../AsyncStorage';
+import { SQLDatabase } from '../sqlite';
 
 /* eslint-disable no-underscore-dangle */
 
@@ -51,5 +56,62 @@ describe('AsyncStorage', () => {
     expect(await AsyncStorage.getAllKeys()).toEqual(['a', 'b']);
     await AsyncStorage.clear();
     expect(await AsyncStorage.getAllKeys()).toEqual([]);
+  });
+});
+
+describe('AsyncStorage: migration from legacy AsyncStorage', () => {
+  beforeAll(async () => {
+    await AsyncStorage.devForgetState();
+    await deleteDatabase('zulip.db');
+    await LegacyAsyncStorage.clear();
+  });
+
+  afterEach(async () => {
+    await AsyncStorage.devForgetState();
+    await deleteDatabase('zulip.db');
+    await LegacyAsyncStorage.clear();
+  });
+
+  test('with no legacy data', async () => {
+    expect(await AsyncStorage.getAllKeys()).toEqual([]);
+  });
+
+  test('with legacy data', async () => {
+    LegacyAsyncStorage.setItem('a', '1');
+    LegacyAsyncStorage.setItem('b', '2');
+    expect(await AsyncStorage.getAllKeys()).toEqual(['a', 'b']);
+    expect(await AsyncStorage.getItem('a')).toEqual('1');
+    expect(await AsyncStorage.getItem('b')).toEqual('2');
+
+    // Make some updates, then simulate the program exiting and restarting.
+    await AsyncStorage.setItem('c', '3');
+    await AsyncStorage.removeItem('b');
+    await AsyncStorage.devForgetState();
+
+    // Expect to still get the updated state, not a newly-re-migrated state.
+    expect(await AsyncStorage.getAllKeys()).toEqual(['a', 'c']);
+    expect(await AsyncStorage.getItem('a')).toEqual('1');
+    expect(await AsyncStorage.getItem('c')).toEqual('3');
+  });
+
+  test('with legacy data and failed migration', async () => {
+    LegacyAsyncStorage.setItem('a', '1');
+    LegacyAsyncStorage.setItem('b', '2');
+    expect(await AsyncStorage.getAllKeys()).toEqual(['a', 'b']);
+
+    // Simulate the migration having not completed:
+    // Pretend one of the keys didn't make it over…
+    await AsyncStorage.removeItem('b');
+    await AsyncStorage.devForgetState();
+    const db = new SQLDatabase('zulip.db');
+    await db.transaction(tx => {
+      // … and that the migration didn't record success.
+      tx.executeSql('DELETE FROM migration');
+    });
+
+    // Expect to get the original legacy data, re-migrated.
+    expect(await AsyncStorage.getAllKeys()).toEqual(['a', 'b']);
+    expect(await AsyncStorage.getItem('a')).toEqual('1');
+    expect(await AsyncStorage.getItem('b')).toEqual('2');
   });
 });

--- a/src/storage/__tests__/CompressedAsyncStorage-test.js
+++ b/src/storage/__tests__/CompressedAsyncStorage-test.js
@@ -5,6 +5,28 @@ import CompressedAsyncStorage from '../CompressedAsyncStorage';
 import * as logging from '../../utils/logging';
 import * as eg from '../../__tests__/lib/exampleData';
 
+test('smoke-test all methods, end to end', async () => {
+  await CompressedAsyncStorage.clear();
+  expect(await CompressedAsyncStorage.getAllKeys()).toEqual([]);
+
+  await CompressedAsyncStorage.setItem('a', JSON.stringify('aa'));
+  await CompressedAsyncStorage.multiSet([
+    ['b', JSON.stringify('bb')],
+    ['c', JSON.stringify('cc')],
+  ]);
+  expect([...(await CompressedAsyncStorage.getAllKeys())].sort()).toEqual(['a', 'b', 'c']);
+  expect(await CompressedAsyncStorage.getItem('a')).toEqual(JSON.stringify('aa'));
+  expect(await CompressedAsyncStorage.getItem('b')).toEqual(JSON.stringify('bb'));
+  expect(await CompressedAsyncStorage.getItem('d')).toEqual(null);
+
+  await CompressedAsyncStorage.removeItem('b');
+  expect([...(await CompressedAsyncStorage.getAllKeys())].sort()).toEqual(['a', 'c']);
+  expect(await CompressedAsyncStorage.getItem('b')).toEqual(null);
+
+  await CompressedAsyncStorage.clear();
+  expect(await CompressedAsyncStorage.getAllKeys()).toEqual([]);
+});
+
 describe('setItem', () => {
   const key = 'foo!';
   const value = '123!';

--- a/src/storage/__tests__/CompressedAsyncStorage-test.js
+++ b/src/storage/__tests__/CompressedAsyncStorage-test.js
@@ -1,6 +1,7 @@
 /* @flow strict-local */
 import { Platform, NativeModules } from 'react-native';
-import AsyncStorage from '@react-native-async-storage/async-storage';
+
+import { AsyncStorage } from '../AsyncStorage';
 import CompressedAsyncStorage from '../CompressedAsyncStorage';
 import * as logging from '../../utils/logging';
 import * as eg from '../../__tests__/lib/exampleData';
@@ -39,7 +40,7 @@ describe('setItem', () => {
 
   describe('success', () => {
     test('resolves correctly', async () => {
-      await expect(run()).resolves.toBe(null);
+      await expect(run()).resolves.toBe(undefined);
     });
 
     test('AsyncStorage.setItem called correctly', async () => {

--- a/src/storage/__tests__/CompressedAsyncStorage-test.js
+++ b/src/storage/__tests__/CompressedAsyncStorage-test.js
@@ -1,7 +1,7 @@
 /* @flow strict-local */
 import { Platform, NativeModules } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import ZulipAsyncStorage from '../ZulipAsyncStorage';
+import CompressedAsyncStorage from '../CompressedAsyncStorage';
 import * as logging from '../../utils/logging';
 import * as eg from '../../__tests__/lib/exampleData';
 
@@ -13,7 +13,7 @@ describe('setItem', () => {
   const asyncStorageSetItemSpy = jest.spyOn(AsyncStorage, 'setItem');
   beforeEach(() => asyncStorageSetItemSpy.mockClear());
 
-  const run = async () => ZulipAsyncStorage.setItem(key, value);
+  const run = async () => CompressedAsyncStorage.setItem(key, value);
 
   describe('success', () => {
     // AsyncStorage provides its own mock for `.setItem`, which gives
@@ -66,7 +66,7 @@ describe('multiSet', () => {
   const asyncStorageMultiSetSpy = jest.spyOn(AsyncStorage, 'multiSet');
   beforeEach(() => asyncStorageMultiSetSpy.mockClear());
 
-  const run = async () => ZulipAsyncStorage.multiSet(keyValuePairs);
+  const run = async () => CompressedAsyncStorage.multiSet(keyValuePairs);
 
   describe('success', () => {
     // AsyncStorage provides its own mock for `.multiSet`, which gives
@@ -122,7 +122,7 @@ describe('getItem', () => {
   beforeAll(async () => {
     // `AsyncStorage` mocks storage by writing to a variable instead
     // of to the disk. Put something there for our
-    // `ZulipAsyncStorage.getItem` to retrieve.
+    // `CompressedAsyncStorage.getItem` to retrieve.
     await AsyncStorage.setItem(
       key,
       Platform.OS === 'ios' ? value : await NativeModules.TextCompressionModule.compress(value),
@@ -133,7 +133,7 @@ describe('getItem', () => {
     logging.error.mockReturnValue();
   });
 
-  const run = async () => ZulipAsyncStorage.getItem(key);
+  const run = async () => CompressedAsyncStorage.getItem(key);
 
   describe('success', () => {
     // AsyncStorage provides its own mock for `.getItem`, which gives
@@ -182,7 +182,7 @@ describe('getItem', () => {
           `${unknownHeader}${Buffer.from('123!').toString('hex')}`,
         );
 
-        await expect(ZulipAsyncStorage.getItem(`${key}-unknown`)).rejects.toThrow(
+        await expect(CompressedAsyncStorage.getItem(`${key}-unknown`)).rejects.toThrow(
           `No decompression module found for format ${unknownHeader}`,
         );
       });
@@ -197,8 +197,8 @@ describe('set/get together', () => {
   test('round-tripping of single key-value pair works', async () => {
     const key = eg.randString();
     const value = JSON.stringify(eg.randString());
-    await ZulipAsyncStorage.setItem(key, value);
-    expect(await ZulipAsyncStorage.getItem(key)).toEqual(value);
+    await CompressedAsyncStorage.setItem(key, value);
+    expect(await CompressedAsyncStorage.getItem(key)).toEqual(value);
   });
 
   test('round-tripping of multiple key-value pairs works', async () => {
@@ -206,10 +206,10 @@ describe('set/get together', () => {
       [eg.randString(), JSON.stringify(eg.randString())],
       [eg.randString(), JSON.stringify(eg.randString())],
     ];
-    await ZulipAsyncStorage.multiSet(keyValuePairs);
+    await CompressedAsyncStorage.multiSet(keyValuePairs);
     expect(
       await Promise.all(
-        keyValuePairs.map(async ([key, _]) => [key, await ZulipAsyncStorage.getItem(key)]),
+        keyValuePairs.map(async ([key, _]) => [key, await CompressedAsyncStorage.getItem(key)]),
       ),
     ).toEqual(keyValuePairs);
   });

--- a/src/storage/__tests__/CompressedAsyncStorage-test.js
+++ b/src/storage/__tests__/CompressedAsyncStorage-test.js
@@ -38,10 +38,6 @@ describe('setItem', () => {
   const run = async () => CompressedAsyncStorage.setItem(key, value);
 
   describe('success', () => {
-    // AsyncStorage provides its own mock for `.setItem`, which gives
-    // success every time. So, no need to mock that behavior
-    // ourselves.
-
     test('resolves correctly', async () => {
       await expect(run()).resolves.toBe(null);
     });
@@ -57,10 +53,8 @@ describe('setItem', () => {
   });
 
   describe('failure', () => {
-    // AsyncStorage provides its own mock for `.setItem`, but it's
-    // not set up to simulate failure. So, mock that behavior
-    // ourselves, and reset to the global mock when we're done.
-    const globalMock = AsyncStorage.setItem;
+    // Mock `.setItem` to simulate failure, and reset when we're done.
+    const savedMethod = AsyncStorage.setItem;
     beforeEach(() => {
       // $FlowFixMe[cannot-write] Make Flow understand about mocking.
       AsyncStorage.setItem = jest.fn(async (k: string, v: string): Promise<null> => {
@@ -69,7 +63,7 @@ describe('setItem', () => {
     });
     afterAll(() => {
       // $FlowFixMe[cannot-write] Make Flow understand about mocking.
-      AsyncStorage.setItem = globalMock;
+      AsyncStorage.setItem = savedMethod;
     });
 
     test('rejects correctly', async () => {
@@ -91,10 +85,6 @@ describe('multiSet', () => {
   const run = async () => CompressedAsyncStorage.multiSet(keyValuePairs);
 
   describe('success', () => {
-    // AsyncStorage provides its own mock for `.multiSet`, which gives
-    // success every time. So, no need to mock that behavior
-    // ourselves.
-
     test('resolves correctly', async () => {
       await run();
       expect(asyncStorageMultiSetSpy).toHaveBeenCalledTimes(1);
@@ -112,10 +102,8 @@ describe('multiSet', () => {
   });
 
   describe('failure', () => {
-    // AsyncStorage provides its own mock for `.multiSet`, but it's
-    // not set up to simulate failure. So, mock that behavior
-    // ourselves, and reset to the global mock when we're done.
-    const globalMock = AsyncStorage.multiSet;
+    // Mock `.multiSet` to simulate failure, and reset when we're done.
+    const savedMethod = AsyncStorage.multiSet;
     beforeEach(() => {
       // $FlowFixMe[cannot-write] Make Flow understand about mocking.
       AsyncStorage.multiSet = jest.fn(async (p: string[][]): Promise<null> => {
@@ -124,7 +112,7 @@ describe('multiSet', () => {
     });
     afterAll(() => {
       // $FlowFixMe[cannot-write] Make Flow understand about mocking.
-      AsyncStorage.multiSet = globalMock;
+      AsyncStorage.multiSet = savedMethod;
     });
 
     test('rejects correctly', async () => {
@@ -142,8 +130,7 @@ describe('getItem', () => {
   beforeEach(() => asyncStorageGetItemSpy.mockClear());
 
   beforeAll(async () => {
-    // `AsyncStorage` mocks storage by writing to a variable instead
-    // of to the disk. Put something there for our
+    // Store something in `AsyncStorage` for our
     // `CompressedAsyncStorage.getItem` to retrieve.
     await AsyncStorage.setItem(
       key,
@@ -158,10 +145,6 @@ describe('getItem', () => {
   const run = async () => CompressedAsyncStorage.getItem(key);
 
   describe('success', () => {
-    // AsyncStorage provides its own mock for `.getItem`, which gives
-    // success every time. So, no need to mock that behavior
-    // ourselves.
-
     test('calls AsyncStorage.getItem as we expect it to', async () => {
       await run();
       expect(asyncStorageGetItemSpy).toHaveBeenCalledTimes(1);
@@ -174,10 +157,8 @@ describe('getItem', () => {
   });
 
   describe('failure', () => {
-    // AsyncStorage provides its own mock for `.getItem`, but it's
-    // not set up to simulate failure. So, mock that behavior
-    // ourselves.
-    const globalMock = AsyncStorage.getItem;
+    // Mock `.getItem` to simulate failure, and reset when we're done.
+    const savedMethod = AsyncStorage.getItem;
     beforeEach(() => {
       // $FlowFixMe[cannot-write] Make Flow understand about mocking.
       AsyncStorage.getItem = jest.fn(async (k: string): Promise<string | null> => {
@@ -186,7 +167,7 @@ describe('getItem', () => {
     });
     afterAll(() => {
       // $FlowFixMe[cannot-write] Make Flow understand about mocking.
-      AsyncStorage.getItem = globalMock;
+      AsyncStorage.getItem = savedMethod;
     });
 
     test('rejects correctly', async () => {
@@ -213,9 +194,6 @@ describe('getItem', () => {
 });
 
 describe('set/get together', () => {
-  // AsyncStorage provides its own mocks for `.getItem`, `.setItem`, and
-  // `.multiSet`; it writes to a variable instead of storage.
-
   test('round-tripping of single key-value pair works', async () => {
     const key = eg.randString();
     const value = JSON.stringify(eg.randString());

--- a/src/storage/__tests__/storage-test.js
+++ b/src/storage/__tests__/storage-test.js
@@ -4,7 +4,7 @@ import invariant from 'invariant';
 import * as eg from '../../__tests__/lib/exampleData';
 import objectEntries from '../../utils/objectEntries';
 import type { GlobalState } from '../../types';
-import ZulipAsyncStorage from '../ZulipAsyncStorage';
+import CompressedAsyncStorage from '../CompressedAsyncStorage';
 import { stringify, parse } from '../replaceRevive';
 
 const getRoundTrippedStateValue = async <K: $Keys<GlobalState>, V: $Values<GlobalState>>(
@@ -19,14 +19,14 @@ const getRoundTrippedStateValue = async <K: $Keys<GlobalState>, V: $Values<Globa
   //    - Compression via TextCompressionModule on Android
   //    - AsyncStorage: the library provides a mock implementation
   //      that writes to a variable instead of to the disk
-  await ZulipAsyncStorage.setItem(key, stringifiedValue);
+  await CompressedAsyncStorage.setItem(key, stringifiedValue);
 
   // 3: Read from storage. Parts of this are mocked; so, stress-test
   // those mocks:
   //    - Decompression via TextCompressionModule on Android
   //    - AsyncStorage: the library provides a mock implementation
   //      that reads from a variable instead of from the disk
-  const valueFromStorage = await ZulipAsyncStorage.getItem(key);
+  const valueFromStorage = await CompressedAsyncStorage.getItem(key);
   invariant(valueFromStorage != null, 'valueFromStorage is not null/undefined');
 
   // 4: "revive", e.g., a ZulipVersion instance.

--- a/src/utils/zulipVersion.js
+++ b/src/utils/zulipVersion.js
@@ -20,7 +20,7 @@ type VersionElements = {|
  *   for the data needed to make other tags to help with event
  *   aggregation.
  *
- * The ZulipVersion instance itself cannot be persisted in ZulipAsyncStorage or
+ * The ZulipVersion instance itself cannot be persisted in CompressedAsyncStorage or
  * sent to Sentry because it isn't serializable. Instead, persist the raw
  * version string.
  */


### PR DESCRIPTION
This adds our own sound, nearly-drop-in replacement for RN's AsyncStorage.

The interface is (at least for now) nearly the same as the upstream AsyncStorage; it skips some methods we don't use, but when you call the methods it does have, it will always satisfy the spec for how the upstream AsyncStorage behaves.

The difference is that it also satisfies a tighter spec: each operation either happens completely or not at all.  No operation corrupts the database or has only partial effect, even if the process is killed or encounters I/O errors.

This is accomplished by using SQLite, and doing each operation in a transaction.  The upstream AsyncStorage does the same thing on Android; but on iOS, it uses an ad-hoc database which is susceptible to complete corruption if interrupted.

(Somehow I'd thought that the upstream version was unsound even on Android, when it comes to `multiSet`!  But, looking at the implementation again in the past week, it sure seems to use a single transaction; and that's true already in the initial release from 2015.)

So this gives us soundness on both platforms (#4841), which is a big relief and opens up opportunities for more fearless improvements to our schema.  It also gives us direct control over the database, which we'll use for migrations and to get more flexibility in the schema (in particular for #5006.)

Fixes: #4841
