### PR TITLE
flow: Simplify module.name_mapper `types/` entry by generalizing

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -118,9 +118,10 @@ munge_underscores=true
 
 module.name_mapper='^react-native/\(.*\)$' -> '<PROJECT_ROOT>/node_modules/react-native/\1'
 module.name_mapper='^@?[./a-zA-Z0-9$_-]+\.\(bmp\|gif\|jpg\|jpeg\|png\|psd\|svg\|webp\|m4v\|mov\|mp4\|mpeg\|mpg\|webm\|aac\|aiff\|caf\|m4a\|mp3\|wav\|html\|pdf\)$' -> '<PROJECT_ROOT>/node_modules/react-native/Libraries/Image/RelativeImageStub'
-# This lets us write .js.flow files instead of libdefs.
-# Add more libraries as needed to this pattern with `\|`: `foo\|bar\|…`.
-module.name_mapper='^\(sqlite3\|@react-native-community/netinfo\|react-native-safe-area-context\|react-intl\|@react-navigation/bottom-tabs\|@react-navigation/drawer\|@react-navigation/material-top-tabs\|@react-navigation/native\|@react-navigation/stack\)$' -> '<PROJECT_ROOT>/types/\0'
+# This causes Flow to find our `types/foo/bar.js.flow`, if one exists,
+# when looking at an import from `foo/bar`.  (The `[^.]` is so Flow doesn't
+# try to apply this to relative imports.)
+module.name_mapper='^\([^.].*\)$' -> '<PROJECT_ROOT>/types/\0'
 
 suppress_type=$FlowIssue
 suppress_type=$FlowFixMe

--- a/docs/howto/libdefs.md
+++ b/docs/howto/libdefs.md
@@ -39,11 +39,9 @@ Bar { … }` and so on.
 
 In order to be able to write a `.js.flow` file for the library in our
 tree (rather than under `node_modules/`) and have Flow find it, we
-added the following line to `.flowconfig`:
-
-    module.name_mapper='^\(sqlite3\)$' -> '<PROJECT_ROOT>/types/\0'
-
-Then the file goes at `types/sqlite3.js.flow`.
+added a `module.name_mapper` line to `.flowconfig` causing Flow to
+look under our `types/` subtree.  Then the file for `sqlite3` goes at
+`types/sqlite3.js.flow`.
 
 The actual contents of the `.js.flow` file were based on the library's
 API documentation, and consulting its implementation for points where


### PR DESCRIPTION
As we move more and more modules into `.js.flow` files in this tree,
I wondered if we could avoid having to keep making this line longer
and longer to enumerate them.

Happily it seems we can!  I tested like so:

 * Flow passes.

 * If I edit something in `types/` in a way that should break a use
   site in `src/`, I correctly get an error.

 * Same if I instead edit something in `node_modules/react-native/`,
   something we import directly from some path `react-native/…` --
   the case covered by another of these `module.name_mapper` lines.
   (I used the EditingEvent type imported by our SearchMessagesScreen
   et al.)

 * Same if I instead edit something in `node_modules` that has its
   own Flow types.  (I used `@react-native-community/cameraroll`,
   imported by our `src/lightbox/download.js`.)

 * Same if I instead edit something in `flow-typed/`.

So Flow is successfully finding definitions in `types/` when that's
where the module exists, and successfully finding them elsewhere
when not -- whether that be through a different `name_mapper` line,
or through the `node_modules/` search, or in a libdef in `flow-typed/`.