### PR TITLE
react-native-webview libdef: Trim out some not-so-helpful definitions

### DIFF
--- a/flow-typed/react-native-webview_v11.x.x.js
+++ b/flow-typed/react-native-webview_v11.x.x.js
@@ -1318,6 +1318,11 @@ declare module 'react-native-webview' {
   //
 
   declare export type WebViewProps = $ReadOnly<{| ...IOSWebViewProps, ...AndroidWebViewProps |}>;
+
+  // Incomplete; see methods at
+  //   https://github.com/react-native-webview/react-native-webview/blob/5e73b2089/docs/Reference.md#methods-index
+  // Some differ between platforms.
   declare export var WebView: React$ComponentType<WebViewProps>;
+
   declare export default typeof WebView;
 }

--- a/flow-typed/react-native-webview_v11.x.x.js
+++ b/flow-typed/react-native-webview_v11.x.x.js
@@ -21,144 +21,6 @@ declare module 'react-native-webview/@@react-native' {
     zoomScale: number,
   |};
 
-  declare export type UIManagerStatic = {|
-    /**
-     * Capture an image of the screen, window or an individual view. The image
-     * will be stored in a temporary file that will only exist for as long as the
-     * app is running.
-     *
-     * The `view` argument can be the literal string `window` if you want to
-     * capture the entire window, or it can be a reference to a specific
-     * React Native component.
-     *
-     * The `options` argument may include:
-     * - width/height (number) - the width and height of the image to capture.
-     * - format (string) - either 'png' or 'jpeg'. Defaults to 'png'.
-     * - quality (number) - the quality when using jpeg. 0.0 - 1.0 (default).
-     *
-     * Returns a Promise<string> (tempFilePath)
-     * @platform ios
-     */
-    takeSnapshot: (
-      view?: 'window' | React$Element<React$ElementType> | number,
-      options?: {|
-        width?: number,
-        height?: number,
-        format?: 'png' | 'jpeg',
-        quality?: number,
-      |},
-    ) => Promise<string>,
-
-    /**
-     * Determines the location on screen, width, and height of the given view and
-     * returns the values via an async callback. If successful, the callback will
-     * be called with the following arguments:
-     *
-     *  - x
-     *  - y
-     *  - width
-     *  - height
-     *  - pageX
-     *  - pageY
-     *
-     * Note that these measurements are not available until after the rendering
-     * has been completed in native. If you need the measurements as soon as
-     * possible, consider using the [`onLayout`
-     * prop](docs/view.html#onlayout) instead.
-     *
-     * @deprecated Use `ref.measure` instead.
-     */
-    measure(node: number, callback: MeasureOnSuccessCallback): void,
-
-    /**
-     * Determines the location of the given view in the window and returns the
-     * values via an async callback. If the React root view is embedded in
-     * another native view, this will give you the absolute coordinates. If
-     * successful, the callback will be called with the following
-     * arguments:
-     *
-     *  - x
-     *  - y
-     *  - width
-     *  - height
-     *
-     * Note that these measurements are not available until after the rendering
-     * has been completed in native.
-     *
-     * @deprecated Use `ref.measureInWindow` instead.
-     */
-    measureInWindow(node: number, callback: MeasureInWindowOnSuccessCallback): void,
-
-    /**
-     * Like [`measure()`](#measure), but measures the view relative an ancestor,
-     * specified as `relativeToNativeNode`. This means that the returned x, y
-     * are relative to the origin x, y of the ancestor view.
-     *
-     * As always, to obtain a native node handle for a component, you can use
-     * `React.findNodeHandle(component)`.
-     *
-     * @deprecated Use `ref.measureLayout` instead.
-     */
-    measureLayout(
-      node: number,
-      relativeToNativeNode: number,
-      onFail: () => void,
-      onSuccess: MeasureLayoutOnSuccessCallback,
-    ): void,
-
-    /**
-     * Automatically animates views to their new positions when the
-     * next layout happens.
-     *
-     * A common way to use this API is to call it before calling `setState`.
-     *
-     * Note that in order to get this to work on **Android** you need to set the following flags via `UIManager`:
-     *
-     *     UIManager.setLayoutAnimationEnabledExperimental && UIManager.setLayoutAnimationEnabledExperimental(true);
-     */
-    setLayoutAnimationEnabledExperimental(value: boolean): void,
-
-    /**
-     * Used to display an Android PopupMenu. If a menu item is pressed, the success callback will
-     * be called with the following arguments:
-     *
-     *  - item - the menu item.
-     *  - index - index of the pressed item in array. Returns `undefined` if cancelled.
-     *
-     * To obtain a native node handle for a component, you can use
-     * `React.findNodeHandle(component)`.
-     *
-     * Note that this works only on Android
-     */
-    showPopupMenu(
-      node: number,
-      items: string[],
-      error: () => void,
-      success: (item: string, index: number | void) => void,
-    ): void,
-
-    getViewManagerConfig: (
-      name: string,
-    ) => {|
-      Commands: {|
-        [key: string]: number,
-      |},
-    |},
-
-    /**
-     * Used to call a native view method from JavaScript
-     *
-     * reactTag - Id of react view.
-     * commandID - Id of the native method that should be called.
-     * commandArgs - Args of the native method that we can pass from JS to native.
-     */
-    dispatchViewManagerCommand: (
-      reactTag: number | null,
-      commandID: number,
-      commandArgs?: Array<any>,
-    ) => void,
-  |};
-
   declare type Falsy = void | null | false;
   declare type RecursiveArray<T> = Array<T | RecursiveArray<T> | $ReadOnlyArray<T>>;
   /**
@@ -199,34 +61,15 @@ declare module 'react-native-webview' {
     ViewProps,
     StyleProp,
     ViewStyle,
-    UIManagerStatic,
     NativeScrollEvent,
   } from 'react-native-webview/@@react-native';
 
-  declare type WebViewCommands =
-    | 'goForward'
-    | 'goBack'
-    | 'reload'
-    | 'stopLoading'
-    | 'postMessage'
-    | 'injectJavaScript'
-    | 'loadUrl'
-    | 'requestFocus';
-  declare type AndroidWebViewCommands = 'clearHistory' | 'clearCache' | 'clearFormData';
-  declare type RNCWebViewUIManager<Commands: string> = {|
-    ...$Exact<UIManagerStatic>,
+  // Not represented:
+  //   RNCWebViewUIManagerAndroid
+  //   RNCWebViewUIManagerIOS
+  //   RNCWebViewUIManagerMacOS
+  //   RNCWebViewUIManagerWindows
 
-    getViewManagerConfig: (
-      name: string,
-    ) => {|
-      Commands: $ObjMapi<{| [k: Commands]: any |}, <key>(key) => number>,
-    |},
-  |};
-  declare export type RNCWebViewUIManagerAndroid = RNCWebViewUIManager<
-    WebViewCommands | AndroidWebViewCommands, >;
-  declare export type RNCWebViewUIManagerIOS = RNCWebViewUIManager<WebViewCommands>;
-  declare export type RNCWebViewUIManagerMacOS = RNCWebViewUIManager<WebViewCommands>;
-  declare export type RNCWebViewUIManagerWindows = RNCWebViewUIManager<WebViewCommands>;
   declare type WebViewState = 'IDLE' | 'LOADING' | 'ERROR';
   declare type BaseState = {|
     viewState: WebViewState,

--- a/flow-typed/react-native-webview_v11.x.x.js
+++ b/flow-typed/react-native-webview_v11.x.x.js
@@ -1317,6 +1317,9 @@ declare module 'react-native-webview' {
   // node_modules/react-native-webview/lib/WebView.d.ts
   //
 
+  // A fudge: iOS will have IOSWebViewProps; Android will have
+  // AndroidWebViewProps. Hard to get Flow to check platform-specific
+  // codepaths separately.
   declare export type WebViewProps = $ReadOnly<{| ...IOSWebViewProps, ...AndroidWebViewProps |}>;
 
   // Incomplete; see methods at

--- a/flow-typed/react-native-webview_v11.x.x.js
+++ b/flow-typed/react-native-webview_v11.x.x.js
@@ -5,39 +5,6 @@
  * Done with `--interface-records` and `--no-inexact`, and edited lightly.
  */
 declare module 'react-native-webview/@@react-native' {
-  declare type Constructor<T> = (...args: any[]) => T;
-
-  /**
-   * NativeMethods provides methods to access the underlying native component directly.
-   * This can be useful in cases when you want to focus a view or measure its on-screen dimensions,
-   * for example.
-   * The methods described here are available on most of the default components provided by React Native.
-   * Note, however, that they are not available on composite components that aren't directly backed by a
-   * native view. This will generally include most components that you define in your own app.
-   * For more information, see [Direct Manipulation](http://facebook.github.io/react-native/docs/direct-manipulation.html).
-   * @see https://github.com/facebook/react-native/blob/master/Libraries/ReactIOS/NativeMethodsMixin.js
-   */
-  declare export type NativeMethods = {|
-    measure(callback: MeasureOnSuccessCallback): void,
-    measureInWindow(callback: MeasureInWindowOnSuccessCallback): void,
-    measureLayout(
-      relativeToNativeNode: number,
-      onSuccess: MeasureLayoutOnSuccessCallback,
-      onFail: () => void,
-    ): void,
-    setNativeProps(nativeProps: Object): void,
-    focus(): void,
-    blur(): void,
-    refs: {|
-      [key: string]: React$ComponentType<any, any>,
-    |},
-  |};
-
-  /**
-   * @deprecated Use NativeMethods instead.
-   */
-  declare export type NativeMethodsMixin = NativeMethods;
-
   declare type NodeHandle = number;
 
   // Similar to React.SyntheticEvent except for nativeEvent
@@ -232,8 +199,6 @@ declare module 'react-native-webview' {
     ViewProps,
     StyleProp,
     ViewStyle,
-    NativeMethodsMixin,
-    Constructor,
     UIManagerStatic,
     NativeScrollEvent,
   } from 'react-native-webview/@@react-native';
@@ -279,22 +244,13 @@ declare module 'react-native-webview' {
     lastErrorEvent: WebViewError,
   |};
   declare export type State = NormalState | ErrorState;
-  declare var NativeWebViewIOSComponent: React$ComponentType<IOSNativeWebViewProps>;
-  declare var NativeWebViewIOSBase: Constructor<NativeMethodsMixin> &
-    typeof NativeWebViewIOSComponent;
-  declare export class NativeWebViewIOS mixins NativeWebViewIOSBase {}
-  declare var NativeWebViewMacOSComponent: React$ComponentType<MacOSNativeWebViewProps>;
-  declare var NativeWebViewMacOSBase: Constructor<NativeMethodsMixin> &
-    typeof NativeWebViewMacOSComponent;
-  declare export class NativeWebViewMacOS mixins NativeWebViewMacOSBase {}
-  declare var NativeWebViewAndroidComponent: React$ComponentType<AndroidNativeWebViewProps>;
-  declare var NativeWebViewAndroidBase: Constructor<NativeMethodsMixin> &
-    typeof NativeWebViewAndroidComponent;
-  declare export class NativeWebViewAndroid mixins NativeWebViewAndroidBase {}
-  declare var NativeWebViewWindowsComponent: React$ComponentType<WindowsNativeWebViewProps>;
-  declare var NativeWebViewWindowsBase: Constructor<NativeMethodsMixin> &
-    typeof NativeWebViewWindowsComponent;
-  declare export class NativeWebViewWindows mixins NativeWebViewWindowsBase {}
+
+  // Exports not represented:
+  //   NativeWebViewIOS
+  //   NativeWebViewMacOS
+  //   NativeWebViewAndroid
+  //   NativeWebViewWindows
+
   declare export type ContentInsetProp = {|
     top?: number,
     left?: number,


### PR DESCRIPTION
Discussion: https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/react-native-webview.20and.20UIManager/near/1357825

When I started that thread, I assumed we'd be looking at converting the restated React Native types into actual imports of React Native types, which in particular means finding what the corresponding React Native types actually are.

Actually, I think we can just remove this stuff; see the commit messages for explanations. 🙂