### PR TITLE
Changed UI for Subscription status for `All streams`

### DIFF
--- a/src/common/Icons.js
+++ b/src/common/Icons.js
@@ -104,4 +104,5 @@ export const IconUserMuted: SpecificIconType = makeIcon(FontAwesome, 'user');
 export const IconAttach: SpecificIconType = makeIcon(Feather, 'paperclip');
 export const IconAttachment: SpecificIconType = makeIcon(IoniconsIcon, 'document-attach-outline');
 export const IconGroup: SpecificIconType = makeIcon(FontAwesome, 'group');
+export const IconPlus: SpecificIconType = makeIcon(Feather, 'plus');
 export const IconWebPublic: SpecificIconType = props => <ZulipIcon name="globe" {...props} />;

--- a/src/streams/StreamItem.js
+++ b/src/streams/StreamItem.js
@@ -169,26 +169,30 @@ export default function StreamItem(props: Props): Node {
           )}
         </View>
         <UnreadCount color={iconColor} count={unreadCount} />
-        {offersSubscribeButton && (
-          <Pressable
-            onPress={() => {
-              if (onSubscribeButtonPressed) {
-                onSubscribeButtonPressed({ stream_id: streamId, name }, !isSubscribed);
-              }
-            }}
-            hitSlop={12}
-            disabled={!isSubscribed && isPrivate}
-            style={{ opacity: !isSubscribed && isPrivate ? 0.1 : 1 }}
-          >
-            {({ pressed }) =>
-              isSubscribed ? (
-                <IconDone size={24} color={pressed ? HIGHLIGHT_COLOR : BRAND_COLOR} />
-              ) : (
-                <IconPlus size={24} color={pressed ? HALF_COLOR : iconColor} />
-              )
-            }
-          </Pressable>
-        )}
+        {offersSubscribeButton
+          && (() => {
+            const disabled = !isSubscribed && isPrivate;
+            return (
+              <Pressable
+                onPress={() => {
+                  if (onSubscribeButtonPressed) {
+                    onSubscribeButtonPressed({ stream_id: streamId, name }, !isSubscribed);
+                  }
+                }}
+                hitSlop={12}
+                disabled={disabled}
+                style={{ opacity: disabled ? 0.1 : 1 }}
+              >
+                {({ pressed }) =>
+                  isSubscribed ? (
+                    <IconDone size={24} color={pressed ? HIGHLIGHT_COLOR : BRAND_COLOR} />
+                  ) : (
+                    <IconPlus size={24} color={pressed ? HALF_COLOR : iconColor} />
+                  )
+                }
+              </Pressable>
+            );
+          })()}
       </View>
     </Touchable>
   );

--- a/src/streams/SubscriptionsCard.js
+++ b/src/streams/SubscriptionsCard.js
@@ -77,8 +77,8 @@ export default function SubscriptionsCard(props: Props): Node {
               color={item.color}
               unreadCount={unreadByStream[item.stream_id]}
               isMuted={item.in_home_view === false} // if 'undefined' is not muted
-              showSwitch={false}
-              // isSubscribed is ignored when showSwitch false
+              offersSubscribeButton={false}
+              // isSubscribed is ignored when offersSubscribeButton false
               onPress={handleNarrow}
             />
           )}

--- a/src/subscriptions/StreamListCard.js
+++ b/src/subscriptions/StreamListCard.js
@@ -51,9 +51,9 @@ export default function StreamListCard(props: Props): Node {
     [streams],
   );
 
-  const handleSwitchChange = useCallback(
-    (stream, switchValue: boolean) => {
-      if (switchValue) {
+  const handleSubscribeButtonPressed = useCallback(
+    (stream, value: boolean) => {
+      if (value) {
         // This still uses a stream name (#3918) because the API method does; see there.
         api.subscriptionAdd(auth, [{ name: stream.name }]);
       } else {
@@ -110,10 +110,10 @@ export default function StreamListCard(props: Props): Node {
                    But in this UI, we don't show that distinction. */
                 false
               }
-              showSwitch
+              offersSubscribeButton
               isSubscribed={subscriptions.has(item.stream_id)}
               onPress={handleNarrow}
-              onSwitch={handleSwitchChange}
+              onSubscribeButtonPressed={handleSubscribeButtonPressed}
             />
           )}
         />

--- a/src/utils/info.js
+++ b/src/utils/info.js
@@ -1,10 +1,36 @@
 /* @flow strict-local */
+import invariant from 'invariant';
 import { Alert } from 'react-native';
 import Toast from 'react-native-simple-toast';
+
+import type { GlobalSettingsState } from '../types';
+import { openLinkWithUserPreference } from './openLink';
 
 export const showToast = (message: string) => {
   Toast.show(message);
 };
 
-export const showErrorAlert = (title: string, message?: string): void =>
-  Alert.alert(title, message, [{ text: 'OK', onPress: () => {} }], { cancelable: true });
+export const showErrorAlert = (
+  title: string,
+  message?: string,
+  learnMoreURL?: URL,
+
+  // Required if learnMoreURL passed (used to open the link)
+  globalSettings?: GlobalSettingsState,
+): void => {
+  // TODO: Translate button text
+
+  const buttons = [];
+  if (learnMoreURL) {
+    invariant(globalSettings !== undefined, 'learnMoreURL is passed; globalSettings should be too');
+    buttons.push({
+      text: 'Learn more',
+      onPress: () => {
+        openLinkWithUserPreference(learnMoreURL.toString(), globalSettings);
+      },
+    });
+  }
+  buttons.push({ text: 'OK', onPress: () => {} });
+
+  Alert.alert(title, message, buttons, { cancelable: true });
+};

--- a/static/translations/messages_en.json
+++ b/static/translations/messages_en.json
@@ -1,4 +1,6 @@
 {
+  "Cannot subscribe to stream": "Cannot subscribe to stream",
+  "Stream #{name} is private.": "Stream #{name} is private.",
   "See details": "See details",
   "Failed to show details": "Failed to show details",
   "Share canceled": "Share canceled",


### PR DESCRIPTION
Fixes: #4658

Hey @chrisbobbe!,

* I've tested the functionality and it is working, though it took so much time but I was able to complete. It would be a great help if you take a look at that.
* Here, I've used `Pressable` component of `react-native` instead of `TouchableOpacity`, because, when I looked into the docs there was not any prop named `disabled` for `TouchableOpacity`. So, I thought, may be `Pressable` would be a great choice.
* I will change the variable names, once the review will be done.
* Also, It would be great help if you could give me the idea of size of the icons, because when I looked into the [Switch](https://github.com/facebook/react-native/blob/main/Libraries/Components/Switch/Switch.js) component of `react-native`, there was no any reference of size of the `Switch` component.

**Below is the preview:**

https://user-images.githubusercontent.com/48220369/162817634-6f331475-c506-4241-b371-219ba48c5412.mp4


