### PR TITLE
ios: Update "SPEC CHECKSUMS" for DoubleConversion and glog

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -645,7 +645,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
-  DoubleConversion: cf9b38bf0b2d048436d9a82ad2abe1404f11e7de
+  DoubleConversion: 831926d9b8bf8166fd87886c4abab286c2422662
   EXAppleAuthentication: 27a4f7dc44a1b510f5af945b58643165ee486d89
   EXApplication: d99a1ecb99dfb63dab8acb66d0181857ee79b25f
   EXConstants: 6d585d93723b18d7a8c283591a335609e3bc153e
@@ -670,7 +670,7 @@ SPEC CHECKSUMS:
   Flipper-RSocket: d9d9ade67cbecf6ac10730304bf5607266dd2541
   FlipperKit: aec2d931adeee48a07bab1ea8bcc8a6bb87dfce4
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
-  glog: 73c2498ac6884b13ede40eda8228cb1eee9d9d62
+  glog: 5337263514dd6f09803962437687240c5dc39aa4
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   OpenSSL-Universal: 1aa4f6a6ee7256b83db99ec1ccdaa80d10f9af9b
   RCT-Folly: 0dd9e1eb86348ecab5ba76f910b56f4b5fef3c46


### PR DESCRIPTION
These checksums appear on running `pod install` (or `yarn`, which
causes `pod install` to run), if I run it after removing
"ios/Pods/Local Podspecs". That's the case at current `main`, and
also at the recent RN v0.65 upgrade commit 72583b13c, but not just
before that commit.

Probably a4e941fe0 is related, and I should have remembered to try
clearing "Local Podspecs" when I did the RN upgrade. That would've
brought this to light at the time, and the new checksums would've
made it into the upgrade commit, where they belong.