### PR TITLE
api types: Sync more types with the API docs

### DIFF
--- a/src/api/initialDataTypes.js
+++ b/src/api/initialDataTypes.js
@@ -332,6 +332,7 @@ export type RawInitialDataRealmUser = $ReadOnly<{|
   user_id: UserId,
 |}>;
 
+// TODO(#5250): Sync with the doc.
 export type InitialDataRealmUser = $ReadOnly<{|
   ...RawInitialDataRealmUser,
   cross_realm_bots: $ReadOnlyArray<CrossRealmBot>,

--- a/src/api/initialDataTypes.js
+++ b/src/api/initialDataTypes.js
@@ -84,7 +84,7 @@ export type AvailableVideoChatProviders = $ReadOnly<{|
   [providerName: string]: $ReadOnly<{| name: string, id: number |}>,
 |}>;
 
-// This is current to feature level 107.
+// This is current to feature level 121.
 export type InitialDataRealm = $ReadOnly<{|
   //
   // Keep alphabetical order. When changing this, also change our type for
@@ -198,6 +198,9 @@ export type InitialDataRealm = $ReadOnly<{|
   realm_email_changes_disabled: boolean,
   realm_emails_restricted_to_domains: boolean,
 
+  // TODO(server-5.0): Added in feat. 109
+  realm_enable_spectator_access?: boolean,
+
   // TODO(server-4.0): Added in feat. 55.
   realm_giphy_rating?: number,
 
@@ -269,6 +272,9 @@ export type InitialDataRealm = $ReadOnly<{|
 
   // TODO(server-5.0): Added in feat. 74
   server_needs_upgrade?: boolean,
+
+  // TODO(server-5.0): Added in feat. 110
+  server_web_public_streams_enabled?: boolean,
 
   settings_send_digest_emails: boolean,
   upgrade_text_for_wide_organization_logo: string,

--- a/src/api/realmDataTypes.js
+++ b/src/api/realmDataTypes.js
@@ -12,6 +12,7 @@ import type { InitialDataRealm } from './initialDataTypes';
  * start with "realm_"). But we expect the values to be typed the same.
  */
 /* prettier-ignore */
+// Current to FL 121.
 export type RealmDataForUpdate = $ReadOnly<{
   //
   // Keep alphabetical by the InitialDataRealm property. So by
@@ -60,6 +61,8 @@ export type RealmDataForUpdate = $ReadOnly<{
     $PropertyType<InitialDataRealm, 'realm_email_address_visibility'>,
   emails_restricted_to_domains:
     $PropertyType<InitialDataRealm, 'realm_emails_restricted_to_domains'>,
+  enable_spectator_access:
+    $PropertyType<InitialDataRealm, 'realm_enable_spectator_access'>,
   giphy_rating:
     $PropertyType<InitialDataRealm, 'realm_giphy_rating'>,
   icon_source:

--- a/src/api/settings/getServerSettings.js
+++ b/src/api/settings/getServerSettings.js
@@ -22,25 +22,34 @@ export type ExternalAuthenticationMethod = {|
   signup_url: string,
 |};
 
+/** https://zulip.com/api/get-server-settings */
+// Current to FL 121.
 export type ApiResponseServerSettings = {|
   ...$Exact<ApiResponseSuccess>,
   authentication_methods: AuthenticationMethods,
-  // external_authentication_methods added for server v2.1
+
   // TODO(server-2.1): Mark this as required; simplify downstream.
   external_authentication_methods?: $ReadOnlyArray<ExternalAuthenticationMethod>,
-  email_auth_enabled: boolean,
-  push_notifications_enabled: boolean,
-  realm_description: string,
-  realm_icon: string,
-  realm_name: string,
-  realm_uri: string,
-  require_email_format_usernames: boolean,
+
+  // TODO(server-3.0): New in FL 1. When absent, equivalent to 0.
+  zulip_feature_level?: number,
+
   zulip_version: string,
 
-  // zulip_feature_level added for server v3.0, feature level 1
-  // See https://zulip.com/api/get-server-settings
-  // When absent, equivalent to 0.
-  zulip_feature_level?: number,
+  // TODO(server-5.0): New in FL 88.
+  zulip_merge_base?: string,
+
+  push_notifications_enabled: boolean,
+  is_incompatible: boolean,
+  email_auth_enabled: boolean,
+  require_email_format_usernames: boolean,
+  realm_uri: string,
+  realm_name: string,
+  realm_icon: string,
+  realm_description: string,
+
+  // TODO(server-5.0): New in FL 116.
+  realm_web_public_access_enabled: boolean,
 |};
 
 /** See https://zulip.com/api/get-server-settings */


### PR DESCRIPTION
After #5346, on the path to fixing #5250. (#5351 is also currently open.)