### PR TITLE
api types: Sync User and CrossRealmBot types with the doc, as of FL 121

### DIFF
--- a/src/__tests__/lib/exampleData.js
+++ b/src/__tests__/lib/exampleData.js
@@ -174,14 +174,13 @@ export const makeUser = (args: UserOrBotPropertiesArgs = Object.freeze({})): Use
 
     // TODO: move to userOrBotProperties after syncing CrossRealmBot w/ doc.
     avatar_version: 0,
+    profile_data: {},
 
     is_bot: false,
     // bot_type omitted
     // bot_owner omitted
 
     is_guest: false,
-
-    // profile_data omitted
   });
 
 /** Beware! These values may not be representative. */

--- a/src/__tests__/lib/exampleData.js
+++ b/src/__tests__/lib/exampleData.js
@@ -177,7 +177,7 @@ export const makeUser = (args: UserOrBotPropertiesArgs = Object.freeze({})): Use
     profile_data: {},
 
     is_bot: false,
-    // bot_type omitted
+    bot_type: null,
     // bot_owner omitted
 
     is_guest: false,

--- a/src/__tests__/lib/exampleData.js
+++ b/src/__tests__/lib/exampleData.js
@@ -154,6 +154,7 @@ const userOrBotProperties = (args: UserOrBotPropertiesArgs) => {
   const randName = randString();
   return deepFreeze({
     avatar_url: args.avatar_url ?? makeAvatarUrl(user_id.toString()),
+    avatar_version: 0,
 
     date_joined: `2014-04-${randInt(30)
       .toString()
@@ -164,6 +165,7 @@ const userOrBotProperties = (args: UserOrBotPropertiesArgs) => {
     is_admin: false,
     timezone: 'UTC',
     user_id,
+    profile_data: {},
   });
 };
 
@@ -171,10 +173,6 @@ const userOrBotProperties = (args: UserOrBotPropertiesArgs) => {
 export const makeUser = (args: UserOrBotPropertiesArgs = Object.freeze({})): User =>
   deepFreeze({
     ...userOrBotProperties(args),
-
-    // TODO: move to userOrBotProperties after syncing CrossRealmBot w/ doc.
-    avatar_version: 0,
-    profile_data: {},
 
     is_bot: false,
     bot_type: null,
@@ -190,6 +188,8 @@ export const makeCrossRealmBot = (
   deepFreeze({
     ...userOrBotProperties(args),
     is_bot: true,
+
+    bot_type: 1,
   });
 
 export const userStatusEmojiUnicode: $PropertyType<UserStatus, 'status_emoji'> = deepFreeze({

--- a/src/__tests__/lib/exampleData.js
+++ b/src/__tests__/lib/exampleData.js
@@ -172,6 +172,9 @@ export const makeUser = (args: UserOrBotPropertiesArgs = Object.freeze({})): Use
   deepFreeze({
     ...userOrBotProperties(args),
 
+    // TODO: move to userOrBotProperties after syncing CrossRealmBot w/ doc.
+    avatar_version: 0,
+
     is_bot: false,
     // bot_type omitted
     // bot_owner omitted

--- a/src/actionTypes.js
+++ b/src/actionTypes.js
@@ -421,7 +421,7 @@ type EventUserUpdateAction = $ReadOnly<{|
   type: typeof EVENT_USER_UPDATE,
   userId: UserId,
   // Include only the fields that should be overwritten.
-  person: $Shape<User>,
+  person: $Rest<User, { ... }>,
 |}>;
 
 type EventMutedTopicsAction = $ReadOnly<{|

--- a/src/api/modelTypes.js
+++ b/src/api/modelTypes.js
@@ -86,37 +86,37 @@ export type DevUser = $ReadOnly<{|
  *    different part of a `/register` response
  *  * `UserOrBot` for a convenience union of the two
  */
-export type User = $ReadOnly<{|
+export type User = {|
   // Property ordering follows the doc.
 
-  user_id: UserId,
-  email: string,
-  full_name: string,
-  date_joined: string,
+  +user_id: UserId,
+  +email: string,
+  +full_name: string,
+  +date_joined: string,
 
   // is_active doesn't appear in `/register` responses -- instead,
   // users where is_active is true go in `realm_users`, and where false
   // go in `realm_non_active_users`.  Shrug.
 
-  is_admin: boolean,
+  +is_admin: boolean,
 
   // is_guest included since commit d5df0377c (in 1.9.0); before that,
   // there's no such concept, so effectively it's implicitly false.
-  is_guest?: boolean,
+  +is_guest?: boolean,
 
   // For background on the "*bot*" fields, see user docs on bots:
   //   https://zulip.com/help/add-a-bot-or-integration
   // Note that certain bots are represented by a different type entirely,
   // namely `CrossRealmBot`.
-  is_bot: boolean,
-  bot_type?: number,
-  bot_owner?: string,
+  +is_bot: boolean,
+  +bot_type?: number,
+  +bot_owner?: string,
 
   // The ? is for future-proofing. Greg explains in 2020-02, at
   // https://github.com/zulip/zulip-mobile/pull/3789#discussion_r378554698 ,
   // that both human and bot Users will likely end up having a missing
   // timezone instead of an empty string.
-  timezone?: string,
+  +timezone?: string,
 
   /**
    * Present under EVENT_USER_ADD, EVENT_USER_UPDATE (if change
@@ -126,7 +126,7 @@ export type User = $ReadOnly<{|
    * For how it appears at the edge (and how we translate) see
    * AvatarURL.fromUserOrBotData.
    */
-  avatar_url: AvatarURL,
+  +avatar_url: AvatarURL,
 
   // These properties appear in data from the server, but we ignore
   // them. If we add these, we should try to avoid `avatar_url`
@@ -138,8 +138,8 @@ export type User = $ReadOnly<{|
   // profile_data added in commit 02b845336 (in 1.8.0);
   // see also e3aed0f7b (in 2.0.0)
   // (This one doesn't appear in `/users` responses.)
-  profile_data?: empty, // When we need this, describe its actual type.
-|}>;
+  +profile_data?: empty, // When we need this, describe its actual type.
+|};
 
 /**
  * A "cross-realm bot", a bot user shared across the realms on a Zulip server.

--- a/src/api/modelTypes.js
+++ b/src/api/modelTypes.js
@@ -131,10 +131,15 @@ export type User = {|
   // If we use this, avoid `avatar_url` falling out of sync with it.
   -avatar_version: number,
 
-  // profile_data added in commit 02b845336 (in 1.8.0);
-  // see also e3aed0f7b (in 2.0.0)
-  // (This one doesn't appear in `/users` responses.)
-  +profile_data?: empty, // When we need this, describe its actual type.
+  +profile_data: {|
+    +[id: string]: {|
+      +value: string,
+      // New in server 2.0, server commit e3aed0f7b.
+      // TODO(server-2.0): Delete the server-2.0 comment, but keep the type
+      //   optional; only some custom profile field types support Markdown.
+      +rendered_value?: string,
+    |},
+  |},
 |};
 
 /**

--- a/src/api/modelTypes.js
+++ b/src/api/modelTypes.js
@@ -198,14 +198,21 @@ export type CrossRealmBot = {|
   // TODO(server-5.0): New in FL 73
   +is_billing_admin?: boolean,
 
-  +is_bot: boolean,
-  +bot_type: number | null,
+  // We assume this is `true`.
+  +is_bot: true,
 
+  // We assume this can't be `null`.
+  +bot_type: number,
+
+  // We assume this is `null` when present. (Cross-realm bots don't have
+  //   owners.)
   // TODO(server-3.0): New in FL 1, replacing bot_owner
-  +bot_owner_id?: number | null,
+  +bot_owner_id?: null,
 
+  // We assume bot_owner is never present, even on old servers. (Cross-realm
+  //   bots don't have owners.)
   // TODO(server-3.0): Replaced in FL 1 by bot_owner_id
-  +bot_owner?: string,
+  // +bot_owner?: string,
 
   // TODO(server-4.0): New in FL 59
   +role?: number,
@@ -237,11 +244,13 @@ export type CrossRealmBot = {|
     |},
   |},
 
+  // We assume this is `true` when present.
   // TODO(server-5.0): New in FL 83, replacing is_cross_realm_bot
-  +is_system_bot?: boolean,
+  +is_system_bot?: true,
 
+  // We assume this is `true` when present.
   // TODO(server-5.0): Replaced in FL 83 by is_system_bot
-  +is_cross_realm_bot?: boolean,
+  +is_cross_realm_bot?: true,
 |};
 
 /**

--- a/src/api/modelTypes.js
+++ b/src/api/modelTypes.js
@@ -98,7 +98,6 @@ export type User = $ReadOnly<{|
   // users where is_active is true go in `realm_users`, and where false
   // go in `realm_non_active_users`.  Shrug.
 
-  // is_admin corresponds to is_realm_admin in server code.
   is_admin: boolean,
 
   // is_guest included since commit d5df0377c (in 1.9.0); before that,

--- a/src/api/modelTypes.js
+++ b/src/api/modelTypes.js
@@ -128,12 +128,8 @@ export type User = {|
    */
   +avatar_url: AvatarURL,
 
-  // These properties appear in data from the server, but we ignore
-  // them. If we add these, we should try to avoid `avatar_url`
-  // falling out of sync with them.
-  // avatar_source: mixed,
-  // avatar_url_medium: mixed,
-  // avatar_version: mixed,
+  // If we use this, avoid `avatar_url` falling out of sync with it.
+  -avatar_version: number,
 
   // profile_data added in commit 02b845336 (in 1.8.0);
   // see also e3aed0f7b (in 2.0.0)

--- a/src/api/modelTypes.js
+++ b/src/api/modelTypes.js
@@ -173,27 +173,27 @@ export type User = {|
  *    realm are, like human users, represented by a `User` value.
  *  * `UserOrBot`, a convenience union
  */
-export type CrossRealmBot = $ReadOnly<{|
+export type CrossRealmBot = {|
   // Property ordering follows the doc.
 
-  user_id: UserId,
-  email: string,
-  full_name: string,
-  date_joined: string,
-  is_admin: boolean,
-  is_bot: true,
+  +user_id: UserId,
+  +email: string,
+  +full_name: string,
+  +date_joined: string,
+  +is_admin: boolean,
+  +is_bot: true,
 
   // The ? is for future-proofing.  For bots it's always '':
   //   https://github.com/zulip/zulip-mobile/pull/3789#issuecomment-581218576
   // so a future version may omit it to reduce payload sizes.  See comment
   // on the same field in User.
-  timezone?: string,
+  +timezone?: string,
 
   /**
    * See note for this property on User.
    */
-  avatar_url: AvatarURL,
-|}>;
+  +avatar_url: AvatarURL,
+|};
 
 /**
  * A Zulip user/account, which might be a cross-realm bot.

--- a/src/api/modelTypes.js
+++ b/src/api/modelTypes.js
@@ -100,8 +100,7 @@ export type User = {|
 
   +is_admin: boolean,
 
-  // is_guest included since commit d5df0377c (in 1.9.0); before that,
-  // there's no such concept, so effectively it's implicitly false.
+  // TODO(server-1.9): New in commit d5df0377c; if absent, treat as false.
   +is_guest?: boolean,
 
   // For background on the "*bot*" fields, see user docs on bots:

--- a/src/api/modelTypes.js
+++ b/src/api/modelTypes.js
@@ -94,9 +94,9 @@ export type User = {|
   +full_name: string,
   +date_joined: string,
 
-  // is_active doesn't appear in `/register` responses -- instead,
-  // users where is_active is true go in `realm_users`, and where false
-  // go in `realm_non_active_users`.  Shrug.
+  // is_active never appears in `/register` responses, at least up through
+  // FL 121. The doc wrongly says it always appears. See
+  //   https://chat.zulip.org/#narrow/stream/412-api-documentation/topic/.60is_active.60.20in.20.60.2Fregister.60.20response/near/1371606
 
   +is_admin: boolean,
 

--- a/src/api/modelTypes.js
+++ b/src/api/modelTypes.js
@@ -78,24 +78,8 @@ export type DevUser = $ReadOnly<{|
  * A Zulip user, which might be a human or a bot, as found in one realm.
  *
  * This is a user object as found in properties `realm_users` and
- * `realm_non_active_users` of a `/register` response.
- *
- * For details on the properties, see the Zulip API docs on `/users`:
- *   https://zulip.com/api/get-users#response
- * which returns almost the same set of properties.
- *
- * See also the comments on `UserProfile` in the server (lineno is approx.):
- *   https://github.com/zulip/zulip/blob/main/zerver/models.py#L734
- * Most properties correspond to fields on `UserProfile`, and many are
- * described most usefully there.
- *
- * For authoritative results, consult how `raw_users`, and then
- * `realm_users` and `realm_non_active_users`, are computed in
- * `zulip/zulip:zerver/lib/events.py` .
- *
- * Properties are listed below in the order they appear on `UserProfile`,
- * because that's the most logically-organized and also the most helpful
- * of the references above.
+ * `realm_non_active_users` of a `/register` response. See the API doc:
+ *   https://zulip.com/api/register-queue
  *
  * See also:
  *  * `CrossRealmBot` for another type of bot user, found in a
@@ -103,11 +87,11 @@ export type DevUser = $ReadOnly<{|
  *  * `UserOrBot` for a convenience union of the two
  */
 export type User = $ReadOnly<{|
+  // Property ordering follows the doc.
+
   user_id: UserId,
   email: string,
-
   full_name: string,
-
   date_joined: string,
 
   // is_active doesn't appear in `/register` responses -- instead,

--- a/src/api/modelTypes.js
+++ b/src/api/modelTypes.js
@@ -175,13 +175,40 @@ export type User = {|
  */
 export type CrossRealmBot = {|
   // Property ordering follows the doc.
+  // Current to feature level (FL) 121.
 
   +user_id: UserId,
+  +delivery_email?: string,
   +email: string,
   +full_name: string,
   +date_joined: string,
+
+  // is_active never appears in `/register` responses, at least up through
+  // FL 121. The doc wrongly says it always appears. See
+  //   https://chat.zulip.org/#narrow/stream/412-api-documentation/topic/.60is_active.60.20in.20.60.2Fregister.60.20response/near/1371606
+
+  // TODO(server-3.0): New in FL 8
+  +is_owner?: boolean,
+
   +is_admin: boolean,
-  +is_bot: true,
+
+  // TODO(server-1.9): New in commit d5df0377c; if absent, treat as false.
+  +is_guest?: boolean,
+
+  // TODO(server-5.0): New in FL 73
+  +is_billing_admin?: boolean,
+
+  +is_bot: boolean,
+  +bot_type: number | null,
+
+  // TODO(server-3.0): New in FL 1, replacing bot_owner
+  +bot_owner_id?: number | null,
+
+  // TODO(server-3.0): Replaced in FL 1 by bot_owner_id
+  +bot_owner?: string,
+
+  // TODO(server-4.0): New in FL 59
+  +role?: number,
 
   // The ? is for future-proofing.  For bots it's always '':
   //   https://github.com/zulip/zulip-mobile/pull/3789#issuecomment-581218576
@@ -193,6 +220,28 @@ export type CrossRealmBot = {|
    * See note for this property on User.
    */
   +avatar_url: AvatarURL,
+
+  // If we use this, avoid `avatar_url` falling out of sync with it.
+  -avatar_version: number,
+
+  // Empirically, this might be missing when the bot has no custom profile
+  // fields:
+  //   https://chat.zulip.org/#narrow/stream/412-api-documentation/topic/.60profile_data.60.20in.20.60.2Fregister.60.20response/near/1374170
+  +profile_data?: {|
+    +[id: string]: {|
+      +value: string,
+      // New in server 2.0, server commit e3aed0f7b.
+      // TODO(server-2.0): Delete the server-2.0 comment, but keep the type
+      //   optional; only some custom profile field types support Markdown.
+      +rendered_value?: string,
+    |},
+  |},
+
+  // TODO(server-5.0): New in FL 83, replacing is_cross_realm_bot
+  +is_system_bot?: boolean,
+
+  // TODO(server-5.0): Replaced in FL 83 by is_system_bot
+  +is_cross_realm_bot?: boolean,
 |};
 
 /**

--- a/src/api/modelTypes.js
+++ b/src/api/modelTypes.js
@@ -109,7 +109,7 @@ export type User = {|
   // Note that certain bots are represented by a different type entirely,
   // namely `CrossRealmBot`.
   +is_bot: boolean,
-  +bot_type?: number,
+  +bot_type: number | null,
   +bot_owner?: string,
 
   // The ? is for future-proofing. Greg explains in 2020-02, at

--- a/src/api/modelTypes.js
+++ b/src/api/modelTypes.js
@@ -165,7 +165,8 @@ export type User = {|
  *
  * Cross-realm bots are used for a handful of bots defined in the Zulip
  * server code, like Welcome Bot.  They're found in the `cross_realm_bots`
- * property of a `/register` response, represented with this type.
+ * property of a `/register` response, represented with this type.  Doc:
+ *   https://zulip.com/api/register-queue
  *
  * See also:
  *  * `User` and its property `is_bot`.  Bot users that appear in a single
@@ -173,23 +174,25 @@ export type User = {|
  *  * `UserOrBot`, a convenience union
  */
 export type CrossRealmBot = $ReadOnly<{|
-  /**
-   * See note for this property on User.
-   */
-  avatar_url: AvatarURL,
+  // Property ordering follows the doc.
 
-  date_joined: string,
+  user_id: UserId,
   email: string,
   full_name: string,
+  date_joined: string,
   is_admin: boolean,
   is_bot: true,
-  user_id: UserId,
 
   // The ? is for future-proofing.  For bots it's always '':
   //   https://github.com/zulip/zulip-mobile/pull/3789#issuecomment-581218576
   // so a future version may omit it to reduce payload sizes.  See comment
   // on the same field in User.
   timezone?: string,
+
+  /**
+   * See note for this property on User.
+   */
+  avatar_url: AvatarURL,
 |}>;
 
 /**

--- a/src/api/modelTypes.js
+++ b/src/api/modelTypes.js
@@ -88,8 +88,10 @@ export type DevUser = $ReadOnly<{|
  */
 export type User = {|
   // Property ordering follows the doc.
+  // Current to feature level (FL) 121.
 
   +user_id: UserId,
+  +delivery_email?: string,
   +email: string,
   +full_name: string,
   +date_joined: string,
@@ -98,10 +100,16 @@ export type User = {|
   // FL 121. The doc wrongly says it always appears. See
   //   https://chat.zulip.org/#narrow/stream/412-api-documentation/topic/.60is_active.60.20in.20.60.2Fregister.60.20response/near/1371606
 
+  // TODO(server-3.0): New in FL 8
+  +is_owner?: boolean,
+
   +is_admin: boolean,
 
   // TODO(server-1.9): New in commit d5df0377c; if absent, treat as false.
   +is_guest?: boolean,
+
+  // TODO(server-5.0): New in FL 73
+  +is_billing_admin?: boolean,
 
   // For background on the "*bot*" fields, see user docs on bots:
   //   https://zulip.com/help/add-a-bot-or-integration
@@ -109,7 +117,15 @@ export type User = {|
   // namely `CrossRealmBot`.
   +is_bot: boolean,
   +bot_type: number | null,
+
+  // TODO(server-3.0): New in FL 1, replacing bot_owner
+  +bot_owner_id?: number | null,
+
+  // TODO(server-3.0): Replaced in FL 1 by bot_owner_id
   +bot_owner?: string,
+
+  // TODO(server-4.0): New in FL 59
+  +role?: number,
 
   // The ? is for future-proofing. Greg explains in 2020-02, at
   // https://github.com/zulip/zulip-mobile/pull/3789#discussion_r378554698 ,
@@ -130,7 +146,10 @@ export type User = {|
   // If we use this, avoid `avatar_url` falling out of sync with it.
   -avatar_version: number,
 
-  +profile_data: {|
+  // Empirically, this might be missing when the user has no custom profile
+  // fields:
+  //   https://chat.zulip.org/#narrow/stream/412-api-documentation/topic/.60profile_data.60.20in.20.60.2Fregister.60.20response/near/1374170
+  +profile_data?: {|
     +[id: string]: {|
       +value: string,
       // New in server 2.0, server commit e3aed0f7b.

--- a/src/users/__tests__/usersReducer-test.js
+++ b/src/users/__tests__/usersReducer-test.js
@@ -56,7 +56,7 @@ describe('usersReducer', () => {
     // Tell ESLint to recognize `check` as a helper function that runs
     // assertions.
     /* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["expect", "check"] }] */
-    const check = (personMaybeWithoutId: $Shape<User>) => {
+    const check = (personMaybeWithoutId: $Rest<User, { ... }>) => {
       const person = {
         user_id: theUser.user_id,
         ...personMaybeWithoutId,
@@ -103,25 +103,37 @@ describe('usersReducer', () => {
     // doesn't include cross-realm bots.
 
     test('When the role of a user changes.', () => {
-      check({
-        // role: user1.role + 1,
-      });
+      check(
+        // The `Object.freeze` is to work around a Flow issue:
+        //   https://github.com/facebook/flow/issues/2386#issuecomment-695064325
+        Object.freeze({
+          // role: user1.role + 1,
+        }),
+      );
     });
 
     test('When the delivery email of a user changes.', () => {
-      check({
-        // delivery_email: eg.randString(),
-      });
+      check(
+        // The `Object.freeze` is to work around a Flow issue:
+        //   https://github.com/facebook/flow/issues/2386#issuecomment-695064325
+        Object.freeze({
+          // delivery_email: eg.randString(),
+        }),
+      );
     });
 
     test('When the user updates one of their custom profile fields.', () => {
-      check({
-        // custom_profile_field: {
-        //   id: 4,
-        //   value: eg.randString(),
-        //   rendered_value: eg.randString(),
-        // },
-      });
+      check(
+        // The `Object.freeze` is to work around a Flow issue:
+        //   https://github.com/facebook/flow/issues/2386#issuecomment-695064325
+        Object.freeze({
+          // custom_profile_field: {
+          //   id: 4,
+          //   value: eg.randString(),
+          //   rendered_value: eg.randString(),
+          // },
+        }),
+      );
     });
   });
 


### PR DESCRIPTION
After #5349, on the path to fixing #5250.