### PR TITLE
streamsReducer tests [nfc]: Factor out a mkAction helper

### DIFF
--- a/src/streams/__tests__/streamsReducer-test.js
+++ b/src/streams/__tests__/streamsReducer-test.js
@@ -3,9 +3,12 @@
 import deepFreeze from 'deep-freeze';
 
 import * as eg from '../../__tests__/lib/exampleData';
-import { EventTypes } from '../../api/eventTypes';
+import { EventTypes, type StreamEvent } from '../../api/eventTypes';
 import { EVENT } from '../../actionConstants';
 import streamsReducer from '../streamsReducer';
+
+const mkAction = <E: $Diff<StreamEvent, {| id: mixed, type: mixed |}>>(event: E) =>
+  deepFreeze({ type: EVENT, event: { id: 0, type: EventTypes.stream, ...event } });
 
 describe('streamsReducer', () => {
   describe('ACCOUNT_SWITCH', () => {
@@ -21,10 +24,7 @@ describe('streamsReducer', () => {
       const stream1 = eg.makeStream({ name: 'some stream', stream_id: 1 });
       const stream2 = eg.makeStream({ name: 'some other stream', stream_id: 2 });
 
-      const action = deepFreeze({
-        type: EVENT,
-        event: { id: 0, type: EventTypes.stream, op: 'create', streams: [stream1, stream2] },
-      });
+      const action = mkAction({ op: 'create', streams: [stream1, stream2] });
       expect(streamsReducer([], action)).toEqual([stream1, stream2]);
     });
 
@@ -36,10 +36,7 @@ describe('streamsReducer', () => {
       });
       const stream2 = eg.makeStream({ name: 'some other stream', stream_id: 2 });
 
-      const action = deepFreeze({
-        type: EVENT,
-        event: { id: 0, type: EventTypes.stream, op: 'create', streams: [stream1, stream2] },
-      });
+      const action = mkAction({ op: 'create', streams: [stream1, stream2] });
       expect(streamsReducer([stream1], action)).toEqual([stream1, stream2]);
     });
   });
@@ -62,10 +59,7 @@ describe('streamsReducer', () => {
         name: 'third stream',
       });
 
-      const action = deepFreeze({
-        type: EVENT,
-        event: { id: 0, type: EventTypes.stream, op: 'delete', streams: [stream1, stream2] },
-      });
+      const action = mkAction({ op: 'delete', streams: [stream1, stream2] });
       const newState = streamsReducer([stream1, stream2, stream3], action);
 
       expect(newState).toEqual([stream3]);
@@ -75,10 +69,7 @@ describe('streamsReducer', () => {
       const stream1 = eg.makeStream({ name: 'some stream', stream_id: 1 });
       const stream2 = eg.makeStream({ name: 'some other stream', stream_id: 2 });
 
-      const action = deepFreeze({
-        type: EVENT,
-        event: { id: 0, type: EventTypes.stream, op: 'delete', streams: [stream1, stream2] },
-      });
+      const action = mkAction({ op: 'delete', streams: [stream1, stream2] });
       expect(streamsReducer([stream1], action)).toEqual([]);
     });
   });
@@ -89,17 +80,12 @@ describe('streamsReducer', () => {
       const stream67 = eg.makeStream({ stream_id: 67, name: 'design' });
       const stream53 = eg.makeStream({ stream_id: 53, name: 'mobile' });
 
-      const action = deepFreeze({
-        type: EVENT,
-        event: {
-          id: 2,
-          type: EventTypes.stream,
-          op: 'update',
-          stream_id: 123,
-          name: 'competition',
-          property: 'name',
-          value: 'real competition',
-        },
+      const action = mkAction({
+        op: 'update',
+        stream_id: 123,
+        name: 'competition',
+        property: 'name',
+        value: 'real competition',
       });
       expect(streamsReducer([stream123, stream67, stream53], action)).toEqual([
         { ...stream123, name: 'real competition' },
@@ -121,18 +107,13 @@ describe('streamsReducer', () => {
       });
       const stream53 = eg.makeStream({ stream_id: 53, name: 'mobile', description: 'android' });
 
-      const action = deepFreeze({
-        type: EVENT,
-        event: {
-          id: 2,
-          type: EventTypes.stream,
-          op: 'update',
-          stream_id: 53,
-          name: 'mobile',
-          property: 'description',
-          value: 'iOS + android',
-          rendered_description: '<p>iOS + android</p>',
-        },
+      const action = mkAction({
+        op: 'update',
+        stream_id: 53,
+        name: 'mobile',
+        property: 'description',
+        value: 'iOS + android',
+        rendered_description: '<p>iOS + android</p>',
       });
       expect(streamsReducer([stream123, stream67, stream53], action)).toEqual([
         stream123,
@@ -157,19 +138,14 @@ describe('streamsReducer', () => {
         history_public_to_subscribers: true,
       });
 
-      const action = deepFreeze({
-        type: EVENT,
-        event: {
-          id: 0,
-          type: EventTypes.stream,
-          op: 'update',
-          stream_id: stream1.stream_id,
-          name: stream1.name,
-          property: 'invite_only',
-          value: true,
-          is_web_public: false,
-          history_public_to_subscribers: false,
-        },
+      const action = mkAction({
+        op: 'update',
+        stream_id: stream1.stream_id,
+        name: stream1.name,
+        property: 'invite_only',
+        value: true,
+        is_web_public: false,
+        history_public_to_subscribers: false,
       });
       expect(streamsReducer([stream1, stream2], action)).toEqual([
         {


### PR DESCRIPTION
From discussion: https://github.com/zulip/zulip-mobile/pull/5346#discussion_r854633431

When writing this helper, if we leave out an annotation on its
parameter `event`, then we end up with a bunch of Flow errors:

 * The type-checker sees that `event` can be any of several different
   shapes, from the different call sites.

 * It assumes that the type of `event` should be some one type -- just
   as it normally assumes that any given parameter, variable, etc.,
   should be some one type.  That type must therefore be a supertype
   of all of those types from the call sites -- so, a supertype of
   the union of those.

 * Then that doesn't work (when the result of `mkAction` is eventually
   fed to `streamsReducer`, which expects an `Action`), because there
   is no branch of `Action` where that union type can go.

   In particular, there's no branch of the `event` property on
   `EventAction` that's both able to have a `streams` property and
   able to have a `name` property, each of which appears at some of
   the call sites of `mkAction`.  This is what the error message
   focuses on:

       Cannot call streamsReducer with action bound to action because
       in property event: [incompatible-call]
        • Either property name is missing in object type [1] but
          exists in object literal [2].
        • Or property name is missing in object type [3] but exists
          in object literal [2].
        […]
        • Or property streams is missing in object type [6] but
          exists in object literal [2].

The solution is to tell Flow that the type of `event` won't actually
be any single type, but may be a different type at different call
sites: in other words, that `mkAction` is generic.

This is something that the type-checker won't reach for on its own,
because to have it try to guess where such a generalization will
actually help would mean giving it a much harder problem to solve --
would edge toward making it a full-blown theorem prover, rather than
a proof checker.  So when we do need it to generalize in that
direction, we have to give it a hint.

In particular, the types only work out because there is *some*
commonality between the call sites, some commonality which is
relevant in making sense of the definition.  So we have to identify
what that commonality is and provide it as a bound for the generic.
That's this:

    const mkAction = <E: $Diff<StreamEvent, {| id: mixed, type: mixed |}>>(event: E) =>

which says that when checking the body of `mkAction`, Flow should use
the assumption that `event` is a value (of some subtype `E`) of the
type `$Diff<StreamEvent, {| id: mixed, type: mixed |}>`.