### PR TITLE
deps: Upgrade to Node v16, in setup docs and in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Node
       uses: actions/setup-node@v2
       with:
-        node-version: '12'
+        node-version: '16'
         check-latest: true
 
     - name: Run yarn install

--- a/docs/howto/build-run.md
+++ b/docs/howto/build-run.md
@@ -51,7 +51,7 @@ details to worry about.
 Before starting, install these dependencies if you don't have them:
 * [Git](https://git-scm.com/)
 * [Node.js](https://nodejs.org/en/download/package-manager/): use the
-  **latest 12.x** version, not 14.x or later
+  **latest 16.x** version, or a later LTS version
 * [Yarn](https://yarnpkg.com/en/docs/install), latest stable version
 
 Then, run the commands below in your terminal:
@@ -148,37 +148,6 @@ Apart from the steps mentioned below, you may find the
 [React Native troubleshooting docs][] to be helpful.
 
 [React Native troubleshooting docs]: https://reactnative.dev/docs/troubleshooting
-
-
-### `yarn install` failure, at `fsevents`
-
-When running `yarn install` on initial setup, if you see an error like
-this:
-```
-warning Error running install script for optional dependency: "[...]/zulip-mobile/node_modules/fsevents: Command failed.
-Exit code: 1
-Command: node install
-Arguments:
-Directory: [...]/zulip-mobile/node_modules/fsevents
-Output:
-[... lots of output ...]
-
-../../nan/nan_maybe_43_inl.h:112:15: error: no member named 'ForceSet' in 'v8::Object'
- return obj->ForceSet(isolate->GetCurrentContext(), key, value, attribs);
-        ~~~  ^  return obj->ForceSet(isolate->GetCurrentContext(), key, value, attribs);
-
-[... lots more output ...]
-node-pre-gyp ERR! not ok
-Failed to execute [...]
-```
-then this is a known error caused by using Node 11, which one of our
-dependencies (`fsevents`) isn't yet compatible with.
-
-To fix the problem, use Node 10.x instead.
-
-The same problem has also been observed when using Node 10 on commits that were
-made when we were using Node 8, prior to Greg's recommendation to switch to Node
-10 in 4e5e31ac2. To fix the problem in that case, use Node 8.
 
 
 ### `yarn install` failure about "Detox"
@@ -680,8 +649,10 @@ This can happen if you're using an older version of Node, such as
 Node 8.  (Probably this means our Jest config doesn't have Babel set up
 quite right.  Discussion [here][jest-babel-discussion].)
 
-To fix this, use Node 10.x instead.  You can check what version is
-installed by running the command `node --version`.
+To fix this, use a current version of Node instead (the one
+recommended in our setup instructions at the top of this page.)  You
+can check what version is installed by running the command
+`node --version`.
 
 [jest-babel-discussion]: https://github.com/zulip/zulip-mobile/pull/3619#issuecomment-533349362
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
     "test:flow-todo": "eslint --no-eslintrc -c tools/flow-todo.eslintrc.yaml src/",
     "update-libdefs": "yarn install && rm -rf flow-typed/npm/ && flow-typed update"
   },
+  "engines": {
+    "node": ">=10"
+  },
   "dependencies": {
     "@expo/react-native-action-sheet": "^3.8.0",
     "@react-native-async-storage/async-storage": "^1.13.0",

--- a/tools/test
+++ b/tools/test
@@ -188,22 +188,6 @@ run_lint() {
     eslint ${fix:+--fix} --max-warnings=0 "${files[@]}"
 }
 
-check_node() {
-    local node_version
-    node_version="$(node --version)"
-    case "${node_version}" in
-        v1[0-9].*) ;;
-        *)
-            cat >&2 <<EOF
-Node 10 required; \`node --version\` says: ${node_version:-(nothing)}
-
-To run the zulip-mobile tests, please install Node v10.x .
-
-EOF
-            return 1 ;;
-    esac
-}
-
 run_jest() {
     # Unlike some others, this inspects "$files" for itself.
     local jest_args=()
@@ -236,7 +220,6 @@ run_jest() {
         sloppy) jest_args+=( --selectProjects "${platforms[RANDOM%2]}" );;
     esac
 
-    check_node || return
     jest "${jest_args[@]}"
 }
 


### PR DESCRIPTION
I've been using this for local development for a few weeks now,
and all seems well.  (That's longer than it needs to be; I just
hadn't come back to this to follow up.)

Node v12 is going EOL in just over a week, 2022-04-30, so it's
past time to make this upgrade official.

Also delete an old troubleshooting entry for a problem with Node v11
that was avoided by sticking to v10; and fix two other references to
Node v10 (where the problem was using an older version like v8) so
that they remain accurate now and for further upgrades in the future.

(At least until Node v1000.  On Node's current release cadence, that
will happen in a little under 500 years.  I think we can tolerate
having to tweak this check then.)

Fixes: #4263