### PR TITLE
emoji: Switch to shared code for finding matches in typeahead/search

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,6 +1,3 @@
-# Prettier can't handle the Unicode.
-src/emoji/__tests__/data-test.js
-
 # These are purely type definitions, no runtime code.  Most of them
 # are third-party code, too, so naturally don't match our style.
 **/flow-typed/**

--- a/docs/howto/shared.md
+++ b/docs/howto/shared.md
@@ -134,23 +134,10 @@ $ cd static/shared  # the root of the @zulip/shared package's source
 $ git checkout main
 $ git pull --ff-only
 
-   # (These steps can probably become a `version` NPM script.)
-$ npm version patch --no-git-tag-version
-   # Suppose the new version is 0.0.3.  Then:
-$ git commit -am 'shared: Bump version to 0.0.3.'
-$ git tag shared-0.0.3
-
-$ git log --stat -p upstream/main..  # check your work!
-$ git push upstream main shared-0.0.3
-
-$ npm publish --dry-run  # check your work!
-$ npm publish  # should prompt for an OTP, from your 2FA setup
+   # This bumps the version in package.json, commits that, and tags it:
+$ npm version patch
+   # Then follow the instructions it prints, which include `npm publish`.
 ```
-
-Note the convention for the name of the Git tag.  Because we don't
-organize our version control around NPM and this package isn't the
-only thing in its Git repo, we use tags like `shared-0.0.3` instead of
-NPM's built-in behavior of `v0.0.3`.
 
 
 ### Initial setup

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@react-navigation/native": "^5.7.6",
     "@react-navigation/stack": "^5.9.3",
     "@sentry/react-native": "^3.3.3",
-    "@zulip/shared": "^0.0.13",
+    "@zulip/shared": "^0.0.14",
     "base-64": "^1.0.0",
     "blueimp-md5": "^2.10.0",
     "color": "^4.0.1",

--- a/src/emoji/__tests__/data-test.js
+++ b/src/emoji/__tests__/data-test.js
@@ -76,9 +76,7 @@ describe('getFilteredEmojis', () => {
     expect(names('police_')).toEqual(['police_car', 'oncoming_police_car']);
   });
 
-  // TODO: This would be nice!  Especially in the emoji search screen for
-  //   adding a reaction.
-  describe.skip('matches query with spaces instead of underscores', () => {
+  describe('matches query with spaces instead of underscores', () => {
     for (const query of ['big smile', 'ice cream', 'blue dia', 'police ', 'police c']) {
       test(query, () => expect(names(query)).toEqual(names(query.replace(' ', '_'))));
     }

--- a/src/emoji/__tests__/data-test.js
+++ b/src/emoji/__tests__/data-test.js
@@ -28,90 +28,64 @@ describe('codeToEmojiMap', () => {
 });
 
 describe('getFilteredEmojis', () => {
+  const names = query => getFilteredEmojis(query, []).map(e => e.emoji_name);
+
   test('empty query returns many emojis', () => {
-    const list = getFilteredEmojis('', []);
     // 1400 so that we don't have to change the test every time we change the
     // emoji map, while still ensuring that enough emoji are there that we can
     // be reasonably confident it's all of them.
-    expect(list.length).toBeGreaterThan(1400);
+    expect(names('').length).toBeGreaterThan(1400);
   });
 
   test('non existing query returns empty list', () => {
-    const list = getFilteredEmojis('qwerty', []);
-    expect(list).toHaveLength(0);
+    expect(names('qwerty')).toHaveLength(0);
   });
 
   test('returns a sorted list of emojis starting with query', () => {
-    const list = getFilteredEmojis('go', []);
-    expect(list).toEqual([
-      { emoji_type: 'unicode', emoji_code: '1f3c1', emoji_name: 'go' },
-      { emoji_type: 'unicode', emoji_code: '1f945', emoji_name: 'goal' },
-      { emoji_type: 'unicode', emoji_code: '1f410', emoji_name: 'goat' },
-      { emoji_type: 'unicode', emoji_code: '1f47a', emoji_name: 'goblin' },
-      { emoji_type: 'unicode', emoji_code: '1f947', emoji_name: 'gold' },
-      { emoji_type: 'unicode', emoji_code: '1f4bd', emoji_name: 'gold_record' },
-      { emoji_type: 'unicode', emoji_code: '1f3cc', emoji_name: 'golf' },
-      { emoji_type: 'unicode', emoji_code: '1f6a0', emoji_name: 'gondola' },
-      { emoji_type: 'unicode', emoji_code: '1f31b', emoji_name: 'goodnight' },
-      { emoji_type: 'unicode', emoji_code: '1f945', emoji_name: 'gooooooooal' },
-      { emoji_type: 'unicode', emoji_code: '1f98d', emoji_name: 'gorilla' },
-      { emoji_type: 'unicode', emoji_code: '1f44c', emoji_name: 'got_it' },
-      { emoji_type: 'unicode', emoji_code: '1f616', emoji_name: 'agony' },
-      { emoji_type: 'unicode', emoji_code: '2705', emoji_name: 'all_good' },
-      { emoji_type: 'unicode', emoji_code: '1f361', emoji_name: 'dango' },
-      { emoji_type: 'unicode', emoji_code: '1f409', emoji_name: 'dragon' },
-      { emoji_type: 'unicode', emoji_code: '1f432', emoji_name: 'dragon_face' },
-      { emoji_type: 'unicode', emoji_code: '1f4b8', emoji_name: 'easy_come_easy_go' },
-      { emoji_type: 'unicode', emoji_code: '1f49b', emoji_name: 'heart_of_gold' },
-      { emoji_type: 'unicode', emoji_code: '1f3a0', emoji_name: 'merry_go_round' },
-      { emoji_type: 'unicode', emoji_code: '1f6d1', emoji_name: 'octagonal_sign' },
-      { emoji_type: 'unicode', emoji_code: '1f54d', emoji_name: 'synagogue' },
-      { emoji_type: 'unicode', emoji_code: '264d', emoji_name: 'virgo' },
+    expect(names('go')).toEqual([
+      'go',
+      'goal',
+      'goat',
+      'goblin',
+      'gold',
+      'gold_record',
+      'golf',
+      'gondola',
+      'goodnight',
+      'gooooooooal',
+      'gorilla',
+      'got_it',
+      'agony',
+      'all_good',
+      'dango',
+      'dragon',
+      'dragon_face',
+      'easy_come_easy_go',
+      'heart_of_gold',
+      'merry_go_round',
+      'octagonal_sign',
+      'synagogue',
+      'virgo',
     ]);
   });
 
   test('returns literal emoji', () => {
-    const list = getFilteredEmojis('🖤', []);
-    expect(list).toEqual([
-      { emoji_type: 'unicode', emoji_code: '1f5a4', emoji_name: 'black_heart' },
-    ]);
+    expect(names('🖤')).toEqual(['black_heart']);
   });
 
   test('returns multiple literal emoji', () => {
-    const list = getFilteredEmojis('👍', []);
-    expect(list).toEqual([
-      { emoji_type: 'unicode', emoji_code: '1f44d', emoji_name: '+1' },
-      { emoji_type: 'unicode', emoji_code: '1f44d', emoji_name: 'thumbs_up' },
-    ]);
+    expect(names('👍')).toEqual(['+1', 'thumbs_up']);
   });
 
   test('search in realm emojis as well', () => {
-    expect(
-      getFilteredEmojis('qwerty', [
-        {
-          emoji_type: 'image',
-          emoji_code: '654',
-          emoji_name: 'qwerty',
-        },
-      ]),
-    ).toEqual([{ emoji_name: 'qwerty', emoji_type: 'image', emoji_code: '654' }]);
+    const emoji = { emoji_type: 'image', emoji_code: '654', emoji_name: 'qwerty' };
+    expect(getFilteredEmojis('qwerty', [emoji])).toEqual([emoji]);
   });
 
   test('remove duplicates', () => {
-    expect(getFilteredEmojis('dog', [])).toEqual([
-      { emoji_type: 'unicode', emoji_code: '1f415', emoji_name: 'dog' },
-      { emoji_type: 'unicode', emoji_code: '1f94b', emoji_name: 'dogi' },
-      { emoji_type: 'unicode', emoji_code: '1f32d', emoji_name: 'hotdog' },
-    ]);
-    expect(
-      getFilteredEmojis('dog', [
-        {
-          emoji_type: 'image',
-          emoji_code: '345',
-          emoji_name: 'dog',
-        },
-      ]),
-    ).toEqual([
+    expect(names('dog')).toEqual(['dog', 'dogi', 'hotdog']);
+    const emoji = { emoji_type: 'image', emoji_code: '345', emoji_name: 'dog' };
+    expect(getFilteredEmojis('dog', [emoji])).toEqual([
       { emoji_type: 'image', emoji_code: '345', emoji_name: 'dog' },
       { emoji_type: 'unicode', emoji_code: '1f94b', emoji_name: 'dogi' },
       { emoji_type: 'unicode', emoji_code: '1f32d', emoji_name: 'hotdog' },
@@ -119,11 +93,8 @@ describe('getFilteredEmojis', () => {
   });
 
   test('prioritizes popular emoji', () => {
-    expect(getFilteredEmojis('oct', [])).toEqual([
-      // Octopus is prioritized, despite octagonal_sign coming first in
-      // alphabetical order.
-      { emoji_type: 'unicode', emoji_code: '1f419', emoji_name: 'octopus' },
-      { emoji_type: 'unicode', emoji_code: '1f6d1', emoji_name: 'octagonal_sign' },
-    ]);
+    // :octopus: is prioritized, despite :octagonal_sign: coming first in
+    // alphabetical order.
+    expect(names('oct')).toEqual(['octopus', 'octagonal_sign']);
   });
 });

--- a/src/emoji/__tests__/data-test.js
+++ b/src/emoji/__tests__/data-test.js
@@ -1,7 +1,6 @@
 /* @flow strict-local */
 import { codeToEmojiMap, getFilteredEmojis } from '../data';
 
-/* eslint-disable no-multi-spaces */
 describe('codeToEmojiMap', () => {
   // Tell ESLint to recognize `check` as a helper function that runs
   // assertions.

--- a/src/emoji/__tests__/data-test.js
+++ b/src/emoji/__tests__/data-test.js
@@ -1,10 +1,6 @@
 /* @flow strict-local */
 import { codeToEmojiMap, getFilteredEmojis } from '../data';
 
-// Prettier disabled in .prettierignore ; it misparses this file, apparently
-// because of the emoji.  (Even if they're tucked away in comments, it still
-// gets it wrong.)
-
 /* eslint-disable no-multi-spaces */
 describe('codeToEmojiMap', () => {
   // Tell ESLint to recognize `check` as a helper function that runs
@@ -48,19 +44,19 @@ describe('getFilteredEmojis', () => {
   test('returns a sorted list of emojis starting with query', () => {
     const list = getFilteredEmojis('go', []);
     expect(list).toEqual([
-      { emoji_type: 'unicode', emoji_code: '1f3c1',  emoji_name: 'go' },
-      { emoji_type: 'unicode', emoji_code: '1f945',  emoji_name: 'goal' },
-      { emoji_type: 'unicode', emoji_code: '1f410',  emoji_name: 'goat' },
-      { emoji_type: 'unicode', emoji_code: '1f47a',  emoji_name: 'goblin' },
-      { emoji_type: 'unicode', emoji_code: '1f947',  emoji_name: 'gold' },
-      { emoji_type: 'unicode', emoji_code: '1f4bd',  emoji_name: 'gold_record' },
-      { emoji_type: 'unicode', emoji_code: '1f3cc',  emoji_name: 'golf' },
-      { emoji_type: 'unicode', emoji_code: '1f6a0',  emoji_name: 'gondola' },
-      { emoji_type: 'unicode', emoji_code: '1f31b',  emoji_name: 'goodnight' },
-      { emoji_type: 'unicode', emoji_code: '1f945',  emoji_name: 'gooooooooal' },
-      { emoji_type: 'unicode', emoji_code: '1f98d',  emoji_name: 'gorilla' },
-      { emoji_type: 'unicode', emoji_code: '1f44c',  emoji_name: 'got_it' },
-      { emoji_type: 'unicode', emoji_code: '1f616',  emoji_name: 'agony' },
+      { emoji_type: 'unicode', emoji_code: '1f3c1', emoji_name: 'go' },
+      { emoji_type: 'unicode', emoji_code: '1f945', emoji_name: 'goal' },
+      { emoji_type: 'unicode', emoji_code: '1f410', emoji_name: 'goat' },
+      { emoji_type: 'unicode', emoji_code: '1f47a', emoji_name: 'goblin' },
+      { emoji_type: 'unicode', emoji_code: '1f947', emoji_name: 'gold' },
+      { emoji_type: 'unicode', emoji_code: '1f4bd', emoji_name: 'gold_record' },
+      { emoji_type: 'unicode', emoji_code: '1f3cc', emoji_name: 'golf' },
+      { emoji_type: 'unicode', emoji_code: '1f6a0', emoji_name: 'gondola' },
+      { emoji_type: 'unicode', emoji_code: '1f31b', emoji_name: 'goodnight' },
+      { emoji_type: 'unicode', emoji_code: '1f945', emoji_name: 'gooooooooal' },
+      { emoji_type: 'unicode', emoji_code: '1f98d', emoji_name: 'gorilla' },
+      { emoji_type: 'unicode', emoji_code: '1f44c', emoji_name: 'got_it' },
+      { emoji_type: 'unicode', emoji_code: '1f616', emoji_name: 'agony' },
       { emoji_type: 'unicode', emoji_code: '2705', emoji_name: 'all_good' },
       { emoji_type: 'unicode', emoji_code: '1f361', emoji_name: 'dango' },
       { emoji_type: 'unicode', emoji_code: '1f409', emoji_name: 'dragon' },
@@ -77,22 +73,22 @@ describe('getFilteredEmojis', () => {
   test('returns literal emoji', () => {
     const list = getFilteredEmojis('🖤', []);
     expect(list).toEqual([
-      { emoji_type: 'unicode', emoji_code: '1f5a4',  emoji_name: 'black_heart' },
+      { emoji_type: 'unicode', emoji_code: '1f5a4', emoji_name: 'black_heart' },
     ]);
   });
 
   test('returns multiple literal emoji', () => {
     const list = getFilteredEmojis('👍', []);
     expect(list).toEqual([
-      { emoji_type: 'unicode', emoji_code: '1f44d',  emoji_name: '+1' },
-      { emoji_type: 'unicode', emoji_code: '1f44d',  emoji_name: 'thumbs_up' },
+      { emoji_type: 'unicode', emoji_code: '1f44d', emoji_name: '+1' },
+      { emoji_type: 'unicode', emoji_code: '1f44d', emoji_name: 'thumbs_up' },
     ]);
   });
 
   test('search in realm emojis as well', () => {
     expect(
       getFilteredEmojis('qwerty', [
-         {
+        {
           emoji_type: 'image',
           emoji_code: '654',
           emoji_name: 'qwerty',
@@ -108,15 +104,16 @@ describe('getFilteredEmojis', () => {
       { emoji_type: 'unicode', emoji_code: '1f32d', emoji_name: 'hotdog' },
     ]);
     expect(
-      getFilteredEmojis('dog', [{
+      getFilteredEmojis('dog', [
+        {
           emoji_type: 'image',
           emoji_code: '345',
           emoji_name: 'dog',
         },
       ]),
     ).toEqual([
-      { emoji_type: 'image', emoji_code: '345', emoji_name: 'dog', },
-      { emoji_type: 'unicode', emoji_code: '1f94b', emoji_name: 'dogi', },
+      { emoji_type: 'image', emoji_code: '345', emoji_name: 'dog' },
+      { emoji_type: 'unicode', emoji_code: '1f94b', emoji_name: 'dogi' },
       { emoji_type: 'unicode', emoji_code: '1f32d', emoji_name: 'hotdog' },
     ]);
   });

--- a/src/emoji/__tests__/data-test.js
+++ b/src/emoji/__tests__/data-test.js
@@ -69,6 +69,21 @@ describe('getFilteredEmojis', () => {
     ]);
   });
 
+  test('matches starting at non-first word, too', () => {
+    expect(names('ice_cream')).toEqual(['ice_cream', 'soft_ice_cream']);
+    expect(names('blue_dia')).toEqual(['large_blue_diamond', 'small_blue_diamond']);
+    // And the prefix match comes first, even when it'd be later alphabetically:
+    expect(names('police_')).toEqual(['police_car', 'oncoming_police_car']);
+  });
+
+  // TODO: This would be nice!  Especially in the emoji search screen for
+  //   adding a reaction.
+  describe.skip('matches query with spaces instead of underscores', () => {
+    for (const query of ['big smile', 'ice cream', 'blue dia', 'police ', 'police c']) {
+      test(query, () => expect(names(query)).toEqual(names(query.replace(' ', '_'))));
+    }
+  });
+
   test('returns literal emoji', () => {
     expect(names('🖤')).toEqual(['black_heart']);
   });

--- a/src/emoji/data.js
+++ b/src/emoji/data.js
@@ -73,16 +73,13 @@ export const getFilteredEmojis = (
     // emoji with a modifier than it is to show them the non-modified
     // emoji, hence the very simple matching.
     const matchesEmojiLiteral = parseUnicodeEmojiCode(emoji.emoji_code) === query;
-    const matchesEmojiName = Math.min(1, emoji.emoji_name.indexOf(query));
-    const priority = matchesEmojiLiteral ? 0 : matchesEmojiName;
-    if (priority !== -1) {
+    if (matchesEmojiLiteral || emoji.emoji_name.includes(query)) {
       allMatchingEmoji.set(emoji.emoji_name, emoji);
     }
   }
 
   for (const emoji of activeImageEmoji) {
-    const priority = Math.min(1, emoji.emoji_name.indexOf(query));
-    if (priority !== -1) {
+    if (emoji.emoji_name.includes(query)) {
       allMatchingEmoji.set(emoji.emoji_name, emoji);
     }
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2644,10 +2644,10 @@
   resolved "https://registry.yarnpkg.com/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz#e77a97fbd345b76d83245edcd17d393b1b41fb31"
   integrity sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==
 
-"@zulip/shared@^0.0.13":
-  version "0.0.13"
-  resolved "https://registry.yarnpkg.com/@zulip/shared/-/shared-0.0.13.tgz#7f3bdfce898a31b3b71a8c39726a906c22241457"
-  integrity sha512-rXSrdmANdtj4pbwBCYkKCP4TU9Jpf0lVhH5QOgFSlmb4hCMzy5kHdC+AjnkI8BS2Bo5kThC3oId2aTQOnW9m3A==
+"@zulip/shared@^0.0.14":
+  version "0.0.14"
+  resolved "https://registry.yarnpkg.com/@zulip/shared/-/shared-0.0.14.tgz#3b660a8ea54bc915921b506ad1150184de39c13e"
+  integrity sha512-kjNJzik9VTJgHtubzUJBHiXXG27NSdZA6c+badnPz1/KvVZLK7PGlDlYPL33Q2EPWHhI3pmiNN0nf6c43YU+HQ==
   dependencies:
     katex "^0.15.3"
     lodash "^4.17.19"


### PR DESCRIPTION
This applies both to the typeahead in compose after you type a `:`,
and to the emoji search screen when you go to add a reaction to a
message.

The notable behavior change this gets us is nice behavior on spaces:
in your query you can now separate words with spaces, rather than
having to type underscores.  (It still works the same if you do type
an underscore.)

The main work here happened over on the shared side last week, where I fixed the one notable regression that the shared implementation had relative to our existing mobile implementation: https://github.com/zulip/zulip/pull/21871

Fixes: #4636
