### PR TITLE
deps: Temporarily use fork for @react-navigation/bottom-tabs

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@react-native-community/masked-view": "^0.1.10",
     "@react-native-community/netinfo": "6.0.0",
     "@react-native-community/push-notification-ios": "^1.5.0",
-    "@react-navigation/bottom-tabs": "^5.10.6",
+    "@react-navigation/bottom-tabs": "npm:@zulip/react-navigation-bottom-tabs@5.11.16-0.zulip.1",
     "@react-navigation/drawer": "^5.9.3",
     "@react-navigation/material-top-tabs": "^5.2.19",
     "@react-navigation/native": "^5.7.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1987,10 +1987,10 @@
   resolved "https://registry.yarnpkg.com/@react-native/polyfills/-/polyfills-1.0.0.tgz#05bb0031533598f9458cf65a502b8df0eecae780"
   integrity sha512-0jbp4RxjYopTsIdLl+/Fy2TiwVYHy4mgeu07DG4b/LyM0OS/+lPP5c9sbnt/AMlnF6qz2JRZpPpGw1eMNS6A4w==
 
-"@react-navigation/bottom-tabs@^5.10.6":
-  version "5.11.15"
-  resolved "https://registry.yarnpkg.com/@react-navigation/bottom-tabs/-/bottom-tabs-5.11.15.tgz#f973625cc32d9c5a4067851f084cb11ccd68fe79"
-  integrity sha512-TBY419W6aN/HZg98xbVp5Bx1HEF5sXuHR5f55W6KMI4k2AvxlwelKD1wbfvEcX2iuQT0YUiiXsACRFUSECYhkw==
+"@react-navigation/bottom-tabs@npm:@zulip/react-navigation-bottom-tabs@5.11.16-0.zulip.1":
+  version "5.11.16-0.zulip.1"
+  resolved "https://registry.yarnpkg.com/@zulip/react-navigation-bottom-tabs/-/react-navigation-bottom-tabs-5.11.16-0.zulip.1.tgz#658fe0e4c468f5ede0f4bb6f7412415397d9f94d"
+  integrity sha512-C0fWmWfDMda+q06WQWtEL3x9fib0KvOOGBOxPDPfzCKlLiiVeMUGwWKaoAsEPm/d+w7Ktg3kgs9LdgM1ugWlmg==
   dependencies:
     color "^3.1.3"
     react-native-iphone-x-helper "^1.3.0"


### PR DESCRIPTION
To get chrisbobbe/react-navigation@b2343cb25, which I've published
to NPM in @zulip/react-navigation-bottom-tabs@5.11.16-0.zulip.1.

It cherry-picks react-navigation/react-navigation@d87857e5d, which
is a compatibility fix for RN v0.65 that React Navigation published
in v6 but didn't backport to v5.

So this fix will become unnecessary when we're on React Navigation
6; that's issue #4936.

A small handful of things went wrong when building the .d.ts files
for the publish to NPM, so some TypeScript types are lost, which is
fine because we don't use TypeScript. But the runtime code looks
like it's updated in the ways we'd want and expect.