### PR TITLE
StreamSettingsScreen: s/Private/Privacy/; use radio buttons, not a switch

### DIFF
--- a/src/__tests__/lib/exampleData.js
+++ b/src/__tests__/lib/exampleData.js
@@ -17,6 +17,7 @@ import type {
   UserId,
   UserStatus,
 } from '../../api/modelTypes';
+import { randString, randInt } from '../../utils/misc';
 import { makeUserId } from '../../api/idTypes';
 import type { InitialData } from '../../api/apiTypes';
 import { EventTypes, type UpdateMessageEvent } from '../../api/eventTypes';
@@ -72,9 +73,6 @@ const makeTime: () => number = (() => {
   return () => startTime + 1000 * ++calls;
 })();
 
-/** Return an integer 0 <= N < end, roughly uniformly at random. */
-const randInt = (end: number) => Math.floor(Math.random() * end);
-
 /**
  * Return a factory for unique integers 0 <= N < end.
  *
@@ -103,9 +101,6 @@ const makeUniqueRandInt = (itemsType: string, end: number): (() => number) => {
     return leftValue;
   };
 };
-
-/** Return a string that's almost surely different every time. */
-export const randString = (): string => randInt(2 ** 54).toString(36);
 
 const intRange = (start, len) => Array.from({ length: len }, (k, i) => i + start);
 

--- a/src/account/__tests__/accountsReducer-test.js
+++ b/src/account/__tests__/accountsReducer-test.js
@@ -9,6 +9,7 @@ import {
   ACCOUNT_REMOVE,
   EVENT,
 } from '../../actionConstants';
+import { randString } from '../../utils/misc';
 import accountsReducer from '../accountsReducer';
 import { ZulipVersion } from '../../utils/zulipVersion';
 
@@ -89,17 +90,17 @@ describe('accountsReducer', () => {
   describe('LOGIN_SUCCESS', () => {
     const account1 = eg.makeAccount({
       realm: new URL('https://one.example.org'),
-      ackedPushToken: eg.randString(),
+      ackedPushToken: randString(),
     });
     const account2 = eg.makeAccount({
       realm: new URL('https://two.example.org'),
-      ackedPushToken: eg.randString(),
+      ackedPushToken: randString(),
     });
 
     const prevState = deepFreeze([account1, account2]);
 
     test('on login, if account does not exist, add as first item, with null userId, zulipVersion, zulipFeatureLevel', () => {
-      const newApiKey = eg.randString();
+      const newApiKey = randString();
       const newEmail = 'newaccount@example.com';
       const newRealm = new URL('https://new.realm.org');
 
@@ -129,7 +130,7 @@ describe('accountsReducer', () => {
     });
 
     test("on login, if account does exist, move to top, update with apiKey, set ackedPushToken to null, don't clobber anything else", () => {
-      const newApiKey = eg.randString();
+      const newApiKey = randString();
 
       const action = deepFreeze({
         type: LOGIN_SUCCESS,

--- a/src/common/Icons.js
+++ b/src/common/Icons.js
@@ -85,7 +85,10 @@ export const IconDiagnostics: SpecificIconType = makeIcon(Feather, 'activity');
 export const IconNotifications: SpecificIconType = makeIcon(Feather, 'bell');
 export const IconLanguage: SpecificIconType = makeIcon(Feather, 'globe');
 export const IconSettings: SpecificIconType = makeIcon(Feather, 'settings');
+
+// InputRowRadioButtons depends on this being square.
 export const IconRight: SpecificIconType = makeIcon(Feather, 'chevron-right');
+
 export const IconPlusCircle: SpecificIconType = makeIcon(Feather, 'plus-circle');
 export const IconLeft: SpecificIconType = makeIcon(Feather, 'chevron-left');
 export const IconPeople: SpecificIconType = makeIcon(Feather, 'users');

--- a/src/common/InputRowRadioButtons.js
+++ b/src/common/InputRowRadioButtons.js
@@ -1,0 +1,160 @@
+/* @flow strict-local */
+import React, { useCallback, useRef, useMemo, useEffect } from 'react';
+import type { Node } from 'react';
+import { View } from 'react-native';
+import invariant from 'invariant';
+import { CommonActions } from '@react-navigation/native';
+
+import type { LocalizableText } from '../types';
+import { randString } from '../utils/misc';
+import { BRAND_COLOR, createStyleSheet } from '../styles';
+import Touchable from './Touchable';
+import ZulipTextIntl from './ZulipTextIntl';
+import { IconRight } from './Icons';
+import type { AppNavigationProp } from '../nav/AppNavigator';
+
+type Item<TKey> = $ReadOnly<{|
+  key: TKey,
+  title: LocalizableText,
+  subtitle?: LocalizableText,
+|}>;
+
+type Props<TItemKey> = $ReadOnly<{|
+  /**
+   * Component must be under the stack nav with the selectable-options screen.
+   *
+   * Pass this down from props or `useNavigation`.
+   */
+  navigation: AppNavigationProp<>,
+
+  /** What the setting is about, e.g., "Theme". */
+  label: LocalizableText,
+
+  /** What the setting is about, in a short sentence or two. */
+  description?: LocalizableText,
+
+  /** The current value of the input. */
+  valueKey: TItemKey,
+
+  /**
+   * The available options to choose from, with unique `key`s, one of which
+   * must be `valueKey`.
+   */
+  items: $ReadOnlyArray<Item<TItemKey>>,
+
+  onValueChange: (newValue: TItemKey) => void,
+|}>;
+
+/**
+ * A form-input row for the user to make a choice, radio-button style.
+ *
+ * Shows the current value (the selected item), represented as the item's
+ * `.title`. When tapped, opens the selectable-options screen, where the
+ * user can change the selection or read more about each selection.
+ */
+// This has the navigate-to-nested-screen semantics of NestedNavRow,
+// represented by IconRight. NestedNavRow would probably be the wrong
+// abstraction, though, because it isn't an imput component; it doesn't have
+// a value to display.
+export default function InputRowRadioButtons<TItemKey: string>(props: Props<TItemKey>): Node {
+  const { navigation, label, description, valueKey, items, onValueChange } = props;
+
+  const screenKey = useRef(`selectable-options-${randString()}`).current;
+
+  const selectedItem = items.find(c => c.key === valueKey);
+  invariant(selectedItem != null, 'InputRowRadioButtons: exactly one choice must be selected');
+
+  const screenParams = useMemo(
+    () => ({
+      title: label,
+      description,
+      items: items.map(({ key, title, subtitle }) => ({
+        key,
+        title,
+        subtitle,
+        selected: key === valueKey,
+      })),
+      onRequestSelectionChange: (itemKey, requestedValue) => {
+        if (!requestedValue || itemKey === valueKey) {
+          // Can't unselect a radio button.
+          return;
+        }
+        navigation.goBack();
+        onValueChange(itemKey);
+      },
+    }),
+    [navigation, label, description, items, valueKey, onValueChange],
+  );
+
+  const handleRowPressed = useCallback(() => {
+    // Normally we'd use `.push`, to avoid `.navigate`'s funky
+    // rewind-history behavior. But `.push` doesn't accept a custom key, so
+    // we use `.navigate`. This is fine because the funky rewind-history
+    // behavior can't happen here; see
+    //   https://github.com/zulip/zulip-mobile/pull/5369#discussion_r868799934
+    navigation.navigate({
+      name: 'selectable-options',
+      key: screenKey,
+      params: screenParams,
+    });
+  }, [navigation, screenKey, screenParams]);
+
+  // Live-update the selectable-options screen.
+  useEffect(() => {
+    navigation.dispatch(state =>
+      /* eslint-disable operator-linebreak */
+      state.routes.find(route => route.key === screenKey)
+        ? { ...CommonActions.setParams(screenParams), source: screenKey }
+        : // A screen with key `screenKey` isn't currently mounted on the
+          // navigator. Don't refer to such a screen; that would be an
+          // error.
+          CommonActions.reset(state),
+    );
+  }, [navigation, screenParams, screenKey]);
+
+  // The desired height for IconRight, which we'll pass for its `size` prop.
+  // It'll also be its width.
+  const kRightArrowIconSize = 24;
+
+  const styles = useMemo(
+    () =>
+      createStyleSheet({
+        wrapper: {
+          flexDirection: 'row',
+          alignItems: 'center',
+          paddingVertical: 8,
+          paddingHorizontal: 16,
+        },
+        textWrapper: {
+          flex: 1,
+          flexDirection: 'column',
+        },
+        valueTitle: {
+          fontWeight: '300',
+          fontSize: 13,
+        },
+        iconRightWrapper: {
+          height: kRightArrowIconSize,
+
+          // IconRight is a square, so width equals height and this is the
+          // right amount of width to reserve.
+          width: kRightArrowIconSize,
+        },
+      }),
+    [],
+  );
+
+  return (
+    <Touchable onPress={handleRowPressed}>
+      <View style={styles.wrapper}>
+        <View style={styles.textWrapper}>
+          <ZulipTextIntl text={label} />
+          <ZulipTextIntl text={selectedItem.title} style={styles.valueTitle} />
+        </View>
+        <View style={styles.iconRightWrapper}>
+          <IconRight size={kRightArrowIconSize} color={BRAND_COLOR} />
+        </View>
+      </View>
+    </Touchable>
+  );
+}

--- a/src/common/SelectableOptionRow.js
+++ b/src/common/SelectableOptionRow.js
@@ -3,7 +3,8 @@ import React, { useMemo } from 'react';
 import type { Node } from 'react';
 import { View } from 'react-native';
 
-import ZulipText from './ZulipText';
+import type { LocalizableText } from '../types';
+import ZulipTextIntl from './ZulipTextIntl';
 import Touchable from './Touchable';
 import { BRAND_COLOR, createStyleSheet } from '../styles';
 import { IconDone } from './Icons';
@@ -16,8 +17,8 @@ type Props<TItemKey: string | number> = $ReadOnly<{|
   // position that requires it).
   itemKey: TItemKey,
 
-  title: string,
-  subtitle?: string,
+  title: LocalizableText,
+  subtitle?: LocalizableText,
   selected: boolean,
 
   // We might have called this `onPress`, but
@@ -86,8 +87,8 @@ export default function SelectableOptionRow<TItemKey: string | number>(
     <Touchable onPress={() => onRequestSelectionChange(itemKey, !selected)}>
       <View style={styles.wrapper}>
         <View style={styles.textWrapper}>
-          <ZulipText text={title} />
-          {subtitle !== undefined && <ZulipText text={subtitle} style={styles.subtitle} />}
+          <ZulipTextIntl text={title} />
+          {subtitle !== undefined && <ZulipTextIntl text={subtitle} style={styles.subtitle} />}
         </View>
         <View style={styles.checkmarkWrapper}>
           {selected && <IconDone size={kCheckmarkSize} color={BRAND_COLOR} />}

--- a/src/common/SelectableOptionsScreen.js
+++ b/src/common/SelectableOptionsScreen.js
@@ -1,0 +1,102 @@
+/* @flow strict-local */
+
+import React, { useMemo } from 'react';
+import type { Node } from 'react';
+import { LogBox, View } from 'react-native';
+
+import type { LocalizableText } from '../types';
+import type { RouteProp } from '../react-navigation';
+import type { AppNavigationProp } from '../nav/AppNavigator';
+import Screen from './Screen';
+import SelectableOptionRow from './SelectableOptionRow';
+import ZulipTextIntl from './ZulipTextIntl';
+import { createStyleSheet } from '../styles';
+
+type Item<TKey> = $ReadOnly<{|
+  key: TKey,
+  title: LocalizableText,
+  subtitle?: LocalizableText,
+  selected: boolean,
+|}>;
+
+type Props<TItemKey> = $ReadOnly<{|
+  navigation: AppNavigationProp<'selectable-options'>,
+  route: RouteProp<
+    'selectable-options',
+    {|
+      title: LocalizableText,
+
+      /**
+       * An optional explanation, to be shown before the items.
+       */
+      description?: LocalizableText,
+
+      items: $ReadOnlyArray<Item<TItemKey>>,
+
+      // This param is a function, so React Nav is right to point out that
+      // it isn't serializable. But this is fine as long as we don't try to
+      // persist navigation state for this screen or set up deep linking to
+      // it, hence the LogBox suppression below.
+      //
+      // React Navigation doesn't offer a more sensible way to have us pass
+      // the selection to the calling screen. …We could store the selection
+      // as a route param on the calling screen, or in Redux. But from this
+      // screen's perspective, that's basically just setting a global
+      // variable. Better to offer this explicit, side-effect-free way for
+      // the data to flow where it should, when it should.
+      onRequestSelectionChange: (itemKey: TItemKey, requestedValue: boolean) => void,
+    |},
+  >,
+|}>;
+
+// React Navigation would give us a console warning about non-serializable
+// route params. For more about the warning, see
+//   https://reactnavigation.org/docs/5.x/troubleshooting/#i-get-the-warning-non-serializable-values-were-found-in-the-navigation-state
+// See comment on this param, above.
+LogBox.ignoreLogs([/selectable-options > params\.onRequestSelectionChange \(Function\)/]);
+
+/**
+ * A screen for selecting items in a list, checkbox or radio-button style.
+ *
+ * The items and selection state are controlled by the route params. Callers
+ * should declare a unique key for their own use of this route, as follows,
+ * so that instances can't step on each other:
+ *
+ * navigation.push({ name: 'selectable-options', key: 'foo', params: { … } })
+ * navigation.dispatch({ ...CommonActions.setParams({ … }), source: 'foo' })
+ */
+// If we need separate components dedicated to checkboxes and radio buttons,
+// we can split this. Currently it's up to the caller to enforce the
+// radio-button invariant (exactly one item selected) if they want to.
+export default function SelectableOptionsScreen<TItemKey: string>(props: Props<TItemKey>): Node {
+  const { route } = props;
+  const { title, description, items, onRequestSelectionChange } = route.params;
+
+  const styles = useMemo(
+    () =>
+      createStyleSheet({
+        descriptionWrapper: { padding: 16 },
+      }),
+    [],
+  );
+
+  return (
+    <Screen title={title} scrollEnabled>
+      {description != null && (
+        <View style={styles.descriptionWrapper}>
+          <ZulipTextIntl text={description} />
+        </View>
+      )}
+      {items.map(item => (
+        <SelectableOptionRow
+          key={item.key}
+          itemKey={item.key}
+          title={item.title}
+          subtitle={item.subtitle}
+          selected={item.selected}
+          onRequestSelectionChange={onRequestSelectionChange}
+        />
+      ))}
+    </Screen>
+  );
+}

--- a/src/message/__tests__/messagesReducer-test.js
+++ b/src/message/__tests__/messagesReducer-test.js
@@ -14,6 +14,7 @@ import {
 import * as eg from '../../__tests__/lib/exampleData';
 import { ALL_PRIVATE_NARROW, HOME_NARROW, HOME_NARROW_STR } from '../../utils/narrow';
 import { makeUserId } from '../../api/idTypes';
+import { randString } from '../../utils/misc';
 
 describe('messagesReducer', () => {
   describe('EVENT_NEW_MESSAGE', () => {
@@ -68,7 +69,7 @@ describe('messagesReducer', () => {
         submessage_id: 2,
         sender_id: eg.otherUser.user_id,
         msg_type: 'widget',
-        content: eg.randString(),
+        content: randString(),
       });
       const newState = messagesReducer(prevState, action, eg.plusReduxState);
       expect(newState).toBe(prevState);
@@ -84,7 +85,7 @@ describe('messagesReducer', () => {
             message_id: 2,
             sender_id: eg.otherUser.user_id,
             msg_type: 'widget', // only this type is currently available
-            content: eg.randString(), // JSON string
+            content: randString(), // JSON string
           },
         ],
       });
@@ -201,11 +202,11 @@ describe('messagesReducer', () => {
       const action = mkAction({
         edit_timestamp: Date.now() - 1000,
         message: message3,
-        orig_content: eg.randString(),
-        orig_rendered_content: eg.randString(),
+        orig_content: randString(),
+        orig_rendered_content: randString(),
         prev_rendered_content_version: 0,
-        rendered_content: eg.randString(),
-        content: eg.randString(),
+        rendered_content: randString(),
+        content: randString(),
       });
       const newState = messagesReducer(prevState, action, eg.plusReduxState);
       expect(newState).toBe(prevState);

--- a/src/nav/AppNavigator.js
+++ b/src/nav/AppNavigator.js
@@ -44,6 +44,7 @@ import LegalScreen from '../settings/LegalScreen';
 import SettingsScreen from '../settings/SettingsScreen';
 import UserStatusScreen from '../user-statuses/UserStatusScreen';
 import SharingScreen from '../sharing/SharingScreen';
+import SelectableOptionsScreen from '../common/SelectableOptionsScreen';
 import { useHaveServerDataGate } from '../withHaveServerDataGate';
 
 export type AppNavigatorParamList = {|
@@ -78,6 +79,7 @@ export type AppNavigatorParamList = {|
   'user-status': RouteParamsOf<typeof UserStatusScreen>,
   sharing: RouteParamsOf<typeof SharingScreen>,
   settings: RouteParamsOf<typeof SettingsScreen>,
+  'selectable-options': RouteParamsOf<typeof SelectableOptionsScreen>,
 |};
 
 export type AppNavigationProp<
@@ -162,6 +164,7 @@ export default function AppNavigator(props: Props): Node {
         initialParams={initialRouteName === 'realm-input' ? initialRouteParams : undefined}
       />
       <Stack.Screen name="sharing" component={SharingScreen} />
+      <Stack.Screen name="selectable-options" component={SelectableOptionsScreen} />
     </Stack.Navigator>
   );
 }

--- a/src/pm-conversations/__tests__/pmConversationsModel-test.js
+++ b/src/pm-conversations/__tests__/pmConversationsModel-test.js
@@ -4,6 +4,7 @@ import Immutable from 'immutable';
 import { usersOfKey, keyOfExactUsers, reducer } from '../pmConversationsModel';
 import * as eg from '../../__tests__/lib/exampleData';
 import { makeUserId } from '../../api/idTypes';
+import { randString } from '../../utils/misc';
 
 describe('usersOfKey', () => {
   for (const [desc, ids] of [
@@ -18,7 +19,7 @@ describe('usersOfKey', () => {
 });
 
 describe('reducer', () => {
-  const initialState = reducer(undefined, ({ type: eg.randString() }: $FlowFixMe));
+  const initialState = reducer(undefined, ({ type: randString() }: $FlowFixMe));
   const someKey = keyOfExactUsers([eg.makeUser().user_id]);
   const someState = { map: Immutable.Map([[someKey, 123]]), sorted: Immutable.List([someKey]) };
 

--- a/src/settings/LanguagePicker.js
+++ b/src/settings/LanguagePicker.js
@@ -61,8 +61,8 @@ export default class LanguagePicker extends PureComponent<Props> {
             selected={item.tag === value}
             onRequestSelectionChange={onValueChange}
             itemKey={item.tag}
-            subtitle={item.name}
-            title={item.selfname}
+            subtitle={{ text: '{_}', values: { _: item.name } }}
+            title={{ text: '{_}', values: { _: item.selfname } }}
           />
         )}
       />

--- a/src/settings/LanguagePicker.js
+++ b/src/settings/LanguagePicker.js
@@ -20,7 +20,7 @@ export default class LanguagePicker extends PureComponent<Props> {
   static contextType: Context<GetText> = TranslationContext;
   context: GetText;
 
-  getTranslatedLanguages: () => Language[] = () =>
+  getTranslatedLanguages: () => $ReadOnlyArray<Language> = () =>
     languages.map((language: Language) => {
       const _ = this.context;
       const translatedName = _(language.name);
@@ -30,7 +30,7 @@ export default class LanguagePicker extends PureComponent<Props> {
       };
     });
 
-  getFilteredLanguageList: string => Language[] = filter => {
+  getFilteredLanguageList: string => $ReadOnlyArray<Language> = filter => {
     const list = this.getTranslatedLanguages();
 
     if (!filter) {

--- a/src/storage/__tests__/CompressedAsyncStorage-test.js
+++ b/src/storage/__tests__/CompressedAsyncStorage-test.js
@@ -4,7 +4,7 @@ import { Platform, NativeModules } from 'react-native';
 import { AsyncStorage } from '../AsyncStorage';
 import CompressedAsyncStorage from '../CompressedAsyncStorage';
 import * as logging from '../../utils/logging';
-import * as eg from '../../__tests__/lib/exampleData';
+import { randString } from '../../utils/misc';
 
 test('smoke-test all methods, end to end', async () => {
   await CompressedAsyncStorage.clear();
@@ -196,16 +196,16 @@ describe('getItem', () => {
 
 describe('set/get together', () => {
   test('round-tripping of single key-value pair works', async () => {
-    const key = eg.randString();
-    const value = JSON.stringify(eg.randString());
+    const key = randString();
+    const value = JSON.stringify(randString());
     await CompressedAsyncStorage.setItem(key, value);
     expect(await CompressedAsyncStorage.getItem(key)).toEqual(value);
   });
 
   test('round-tripping of multiple key-value pairs works', async () => {
     const keyValuePairs = [
-      [eg.randString(), JSON.stringify(eg.randString())],
-      [eg.randString(), JSON.stringify(eg.randString())],
+      [randString(), JSON.stringify(randString())],
+      [randString(), JSON.stringify(randString())],
     ];
     await CompressedAsyncStorage.multiSet(keyValuePairs);
     expect(

--- a/src/streams/CreateStreamScreen.js
+++ b/src/streams/CreateStreamScreen.js
@@ -23,6 +23,7 @@ type Props = $ReadOnly<{|
 
 export default function CreateStreamScreen(props: Props): Node {
   const _ = useContext(TranslationContext);
+  const { navigation } = props;
 
   const auth = useSelector(getAuth);
   const streamsByName = useSelector(getStreamsByName);
@@ -62,6 +63,7 @@ export default function CreateStreamScreen(props: Props): Node {
   return (
     <Screen title="Create new stream" padding>
       <EditStreamCard
+        navigation={navigation}
         isNewStream
         initialValues={{ name: '', description: '', privacy: 'public' }}
         onComplete={handleComplete}

--- a/src/streams/EditStreamCard.js
+++ b/src/streams/EditStreamCard.js
@@ -1,27 +1,22 @@
 /* @flow strict-local */
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, useMemo } from 'react';
 import type { Node } from 'react';
 import { View } from 'react-native';
 
+import type { AppNavigationProp } from '../nav/AppNavigator';
 import Input from '../common/Input';
+import InputRowRadioButtons from '../common/InputRowRadioButtons';
 import ZulipTextIntl from '../common/ZulipTextIntl';
-import SwitchRow from '../common/SwitchRow';
 import ZulipButton from '../common/ZulipButton';
-import styles, { createStyleSheet } from '../styles';
-import { IconPrivate } from '../common/Icons';
+import styles from '../styles';
 
 /* eslint-disable no-shadow */
-
-const componentStyles = createStyleSheet({
-  switchRow: {
-    paddingLeft: 8,
-    paddingRight: 8,
-  },
-});
 
 type Privacy = 'public' | 'private';
 
 type Props = $ReadOnly<{|
+  navigation: AppNavigationProp<'edit-stream' | 'create-stream'>,
+
   isNewStream: boolean,
   initialValues: {|
     name: string,
@@ -32,7 +27,7 @@ type Props = $ReadOnly<{|
 |}>;
 
 export default function EditStreamCard(props: Props): Node {
-  const { onComplete, initialValues, isNewStream } = props;
+  const { navigation, onComplete, initialValues, isNewStream } = props;
 
   const [name, setName] = useState<string>(props.initialValues.name);
   const [description, setDescription] = useState<string>(props.initialValues.description);
@@ -50,9 +45,17 @@ export default function EditStreamCard(props: Props): Node {
     setDescription(description);
   }, []);
 
-  const handlePrivacyChange = useCallback(isPrivate => {
-    setPrivacy(isPrivate ? 'private' : 'public');
+  const handlePrivacyChange = useCallback(privacy => {
+    setPrivacy(privacy);
   }, []);
+
+  const privacyOptions = useMemo(
+    () => [
+      { key: 'public', title: 'Public' },
+      { key: 'private', title: 'Private' },
+    ],
+    [],
+  );
 
   return (
     <View>
@@ -71,11 +74,11 @@ export default function EditStreamCard(props: Props): Node {
         defaultValue={initialValues.description}
         onChangeText={handleDescriptionChange}
       />
-      <SwitchRow
-        style={componentStyles.switchRow}
-        Icon={IconPrivate}
-        label="Private"
-        value={privacy === 'private'}
+      <InputRowRadioButtons
+        navigation={navigation}
+        label="Privacy"
+        items={privacyOptions}
+        valueKey={privacy}
         onValueChange={handlePrivacyChange}
       />
       <ZulipButton

--- a/src/streams/EditStreamCard.js
+++ b/src/streams/EditStreamCard.js
@@ -37,18 +37,6 @@ export default function EditStreamCard(props: Props): Node {
     onComplete(name, description, privacy);
   }, [onComplete, name, description, privacy]);
 
-  const handleNameChange = useCallback(name => {
-    setName(name);
-  }, []);
-
-  const handleDescriptionChange = useCallback(description => {
-    setDescription(description);
-  }, []);
-
-  const handlePrivacyChange = useCallback(privacy => {
-    setPrivacy(privacy);
-  }, []);
-
   const privacyOptions = useMemo(
     () => [
       { key: 'public', title: 'Public' },
@@ -65,21 +53,21 @@ export default function EditStreamCard(props: Props): Node {
         placeholder="Name"
         autoFocus
         defaultValue={initialValues.name}
-        onChangeText={handleNameChange}
+        onChangeText={setName}
       />
       <ZulipTextIntl text="Description" />
       <Input
         style={styles.marginBottom}
         placeholder="Description"
         defaultValue={initialValues.description}
-        onChangeText={handleDescriptionChange}
+        onChangeText={setDescription}
       />
       <InputRowRadioButtons
         navigation={navigation}
         label="Privacy"
         items={privacyOptions}
         valueKey={privacy}
-        onValueChange={handlePrivacyChange}
+        onValueChange={setPrivacy}
       />
       <ZulipButton
         style={styles.marginTop}

--- a/src/streams/EditStreamScreen.js
+++ b/src/streams/EditStreamScreen.js
@@ -17,6 +17,7 @@ type Props = $ReadOnly<{|
 |}>;
 
 export default function EditStreamScreen(props: Props): Node {
+  const { navigation } = props;
   const dispatch = useDispatch();
   const stream = useSelector(state => getStreamForId(state, props.route.params.streamId));
 
@@ -37,6 +38,7 @@ export default function EditStreamScreen(props: Props): Node {
   return (
     <Screen title="Edit stream" padding>
       <EditStreamCard
+        navigation={navigation}
         isNewStream={false}
         initialValues={{
           name: stream.name,

--- a/src/third/redux-persist/persistStore.js
+++ b/src/third/redux-persist/persistStore.js
@@ -7,6 +7,7 @@ import type { Config, OverpromisedRehydrateAction, Persistor } from './types';
 import { REHYDRATE } from './constants';
 import getStoredState from './getStoredState';
 import createPersistor from './createPersistor';
+import { randString } from '../../utils/misc';
 
 export default function persistStore<
   // The state type should have a schema version for migrations, like so.
@@ -133,7 +134,7 @@ export default function persistStore<
         ({
           // Include a random string, to be sure no other action type
           // matches this one. Like Redux does for the initial action.
-          type: `PERSIST_DUMMY/${Math.floor(Math.random() * 2 ** 54).toString(36)}`,
+          type: `PERSIST_DUMMY/${randString()}`,
 
           // The intended param type for `dispatch` would be a union where one
           // branch is "any other `type`".  There isn't a way to specify that

--- a/src/unread/__tests__/unread-testlib.js
+++ b/src/unread/__tests__/unread-testlib.js
@@ -5,10 +5,11 @@ import type { UnreadState } from '../unreadModelTypes';
 import type { Message, Stream } from '../../api/apiTypes';
 import type { PerAccountState } from '../../reduxTypes';
 import * as eg from '../../__tests__/lib/exampleData';
+import { randString } from '../../utils/misc';
 
 export const initialState: UnreadState = reducer(
   undefined,
-  ({ type: eg.randString() }: $FlowFixMe),
+  ({ type: randString() }: $FlowFixMe),
   eg.baseReduxState,
 );
 

--- a/src/user-statuses/UserStatusScreen.js
+++ b/src/user-statuses/UserStatusScreen.js
@@ -181,8 +181,11 @@ export default function UserStatusScreen(props: Props): Node {
               itemKey={index}
               title={
                 serverSupportsEmojiStatus
-                  ? `${parseUnicodeEmojiCode(emoji.emoji_code)} ${translatedText}`
-                  : translatedText
+                  ? {
+                      text: '{_}',
+                      values: { _: `${parseUnicodeEmojiCode(emoji.emoji_code)} ${translatedText}` },
+                    }
+                  : text
               }
               selected={
                 translatedText === statusTextFromInputValue(textInputValue)

--- a/src/users/__tests__/usersReducer-test.js
+++ b/src/users/__tests__/usersReducer-test.js
@@ -6,6 +6,7 @@ import type { User } from '../../types';
 import { UploadedAvatarURL } from '../../utils/avatar';
 import { EVENT_USER_ADD, EVENT_USER_UPDATE, ACCOUNT_SWITCH } from '../../actionConstants';
 import usersReducer from '../usersReducer';
+import { randString } from '../../utils/misc';
 
 describe('usersReducer', () => {
   describe('REGISTER_COMPLETE', () => {
@@ -80,23 +81,23 @@ describe('usersReducer', () => {
      */
 
     test('When a user changes their full name.', () => {
-      check({ full_name: eg.randString() });
+      check({ full_name: randString() });
     });
 
     test('When a user changes their avatar.', () => {
       check({
         avatar_url: UploadedAvatarURL.validateAndConstructInstance({
           realm: new URL('https://zulip.example.org'),
-          absoluteOrRelativeUrl: `/yo/avatar-${eg.randString()}.png`,
+          absoluteOrRelativeUrl: `/yo/avatar-${randString()}.png`,
         }),
         // avatar_source: user1.avatar_source === 'G' ? 'U' : 'G',
-        // avatar_url_medium: eg.randString(),
+        // avatar_url_medium: randString(),
         // avatar_version: user1.avatar_version + 1,
       });
     });
 
     test('When a user changes their timezone setting.', () => {
-      check({ timezone: eg.randString() });
+      check({ timezone: randString() });
     });
 
     // Excluded: "When the owner of a bot changes." The `users` state
@@ -117,7 +118,7 @@ describe('usersReducer', () => {
         // The `Object.freeze` is to work around a Flow issue:
         //   https://github.com/facebook/flow/issues/2386#issuecomment-695064325
         Object.freeze({
-          // delivery_email: eg.randString(),
+          // delivery_email: randString(),
         }),
       );
     });
@@ -129,8 +130,8 @@ describe('usersReducer', () => {
         Object.freeze({
           // custom_profile_field: {
           //   id: 4,
-          //   value: eg.randString(),
-          //   rendered_value: eg.randString(),
+          //   value: randString(),
+          //   rendered_value: randString(),
           // },
         }),
       );

--- a/src/utils/__tests__/recipient-test.js
+++ b/src/utils/__tests__/recipient-test.js
@@ -7,6 +7,7 @@ import {
 } from '../recipient';
 import * as eg from '../../__tests__/lib/exampleData';
 import { makeUserId } from '../../api/idTypes';
+import { randString } from '../misc';
 
 describe('normalizeRecipientsAsUserIdsSansMe', () => {
   test('if only self user ID provided return unmodified', () => {
@@ -65,9 +66,9 @@ describe('isSameRecipient', () => {
   });
 
   test('recipients are same for stream type if display_recipient and subject match', () => {
-    const topic = eg.randString();
-    const msg1 = eg.streamMessage({ stream: eg.stream, subject: topic, content: eg.randString() });
-    const msg2 = eg.streamMessage({ stream: eg.stream, subject: topic, content: eg.randString() });
+    const topic = randString();
+    const msg1 = eg.streamMessage({ stream: eg.stream, subject: topic, content: randString() });
+    const msg2 = eg.streamMessage({ stream: eg.stream, subject: topic, content: randString() });
     expect(isSameRecipient(msg1, msg2)).toBe(true);
   });
 });

--- a/src/utils/__tests__/zulipVersion-test.js
+++ b/src/utils/__tests__/zulipVersion-test.js
@@ -1,6 +1,6 @@
 // @flow strict-local
 
-import { randString } from '../../__tests__/lib/exampleData';
+import { randString } from '../misc';
 import { ZulipVersion } from '../zulipVersion';
 
 describe('ZulipVersion.prototype.isAtLeast(otherZulipVersion)', () => {

--- a/src/utils/misc.js
+++ b/src/utils/misc.js
@@ -28,3 +28,9 @@ export function deeperMerge<K, V>(
 }
 
 export const isValidEmailFormat = (email: string = ''): boolean => /\S+@\S+\.\S+/.test(email);
+
+/** Return an integer 0 <= N < end, roughly uniformly at random. */
+export const randInt = (end: number): number => Math.floor(Math.random() * end);
+
+/** Return a string that's almost surely different every time. */
+export const randString = (): string => randInt(2 ** 54).toString(36);

--- a/src/webview/__tests__/generateInboundEventEditSequence-test.js
+++ b/src/webview/__tests__/generateInboundEventEditSequence-test.js
@@ -29,6 +29,7 @@ import { applyEditSequence } from '../js/handleInboundEvents';
 import getMessageListElements from '../../message/getMessageListElements';
 import { getGlobalSettings, getDebug } from '../../selectors';
 import { getBackgroundData } from '../backgroundData';
+import { randString } from '../../utils/misc';
 
 // Tell ESLint to recognize `check` as a helper function that runs
 // assertions.
@@ -672,7 +673,7 @@ describe('getEditSequence correct for interesting changes', () => {
 
   const withContentReplaced = <M: Message | Outbox>(m: M): M => ({
     ...(m: M),
-    content: eg.randString(),
+    content: randString(),
   });
 
   describe('from empty', () => {

--- a/static/translations/messages_en.json
+++ b/static/translations/messages_en.json
@@ -233,6 +233,7 @@
   "Name": "Name",
   "Description": "Description",
   "Create": "Create",
+  "Privacy": "Privacy",
   "Public": "Public",
   "Private": "Private",
   "Notifications": "Notifications",


### PR DESCRIPTION
~~This includes my current revision for #5360, which we hope to merge soon.~~ Done!

-----

For #5250, we'll need to let the user choose one among more than two
options. That'll call for a radio-button-style input, rather than a
switch.

So, make a new component InputRowRadioButtons, and use it for an
input labeled "Privacy", replacing the SwitchRow input labeled
"Private".

And, to support that component, write and wire up a new
SelectableOptionsScreen.