### PR TITLE
react nav: Do an installation step we forgot about (oops)

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,7 @@
 /* @flow strict-local */
+// React Navigation requires this react-native-gesture-handler import,
+// as the very first import of this entry-point file.  See our #5373.
+import 'react-native-gesture-handler';
 import { AppRegistry } from 'react-native';
 import ZulipMobile from './src/ZulipMobile';
 

--- a/src/ZulipMobile.js
+++ b/src/ZulipMobile.js
@@ -38,6 +38,17 @@ if (Platform.OS === 'android') {
 }
 
 export default (): Node => (
+  // If using react-native-gesture-handler directly, not just via React
+  // Navigation, we should use a GestureHandlerRootView; see
+  //  https://docs.swmansion.com/react-native-gesture-handler/docs/1.10.3/#js
+  //
+  // React Nav seems to have followed the following advice, in that doc:
+  //   > If you're using gesture handler in your component library, you may
+  //   > want to wrap your library's code in the GestureHandlerRootView
+  //   > component. This will avoid extra configuration for the user.
+  // which I think is why they don't mention GestureHandlerRootView in their
+  // own setup doc, and why I think it's probably fine to omit it if we're
+  // not using r-n-gesture-handler directly ourselves.
   <RootErrorBoundary>
     <CompatibilityChecker>
       <StoreProvider>


### PR DESCRIPTION
And add a note about a step specific to react-native-gesture-handler
that seems fine to omit for now.

See React Navigation's setup instructions at
  https://reactnavigation.org/docs/5.x/getting-started#installing-dependencies-into-a-bare-react-native-project :

>   To finalize installation of `react-native-gesture-handler`, add
>   the following at the **top** (make sure it's at the top and
>   there's nothing else before it) of your entry file, such as
>   `index.js` or `App.js`:
> 
>   ```js
>   import 'react-native-gesture-handler';
>   ```
> 
>   > Note: If you are building for Android or iOS, do not skip this
>   > step, or your app may crash in production even if it works fine
>   > in development. This is not applicable to other platforms.

Well, better late then never, I guess. I haven't noticed anything
change with this fix, or anything in `main` that doesn't work
without the fix. But it's what we should be doing, so do it. The
latest React Nav version (currently 6.x) doesn't mention this in the
overall setup instructions, but does mention it in pages for some
individual stack navigators, including
  https://reactnavigation.org/docs/stack-navigator/ .