### PR TITLE
deps: Bump immutable range to ^4.0.0, from ^4.0.0-rc.15

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "expo-screen-orientation": ">=4.0.0 <4.1.0",
     "expo-sqlite": "^10.0.0",
     "expo-web-browser": "^9.3.0",
-    "immutable": "^4.0.0-rc.12",
+    "immutable": "^4.0.0",
     "invariant": "^2.2.4",
     "katex": "^0.11.1",
     "lodash.escape": "^4.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6184,7 +6184,7 @@ immutable-devtools@^0.1.5:
   resolved "https://registry.yarnpkg.com/immutable-devtools/-/immutable-devtools-0.1.5.tgz#32a653c8ba8258bfed37680a860a3b5fa2675693"
   integrity sha512-bgQP4q+RiD1Oolw8c0sfNrCpShQIEdqJIGmPPrcG6efyJrX00hNzzM1noe3FsQdDwj2eQqL8JEtukCrwFQbt/w==
 
-immutable@^4.0.0-rc.12:
+immutable@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/immutable/-/immutable-4.0.0.tgz#b86f78de6adef3608395efb269a91462797e2c23"
   integrity sha512-zIE9hX70qew5qTUjSS7wi1iwj/l7+m54KWU247nhM3v806UdGj1yDndXj+IOYxxtW9zyLI+xqFNZjTuDaLUqFw==


### PR DESCRIPTION
This way, we'll get new 4.x releases when we do `yarn upgrade`.

The list of changes since 4.0.0-rc.15 is very short:
  https://github.com/immutable-js/immutable-js/releases/tag/v4.0.0

  """
  - Ensure latest version docs are built by @leebyron in #1877

  - Add correct types for empty Seq and Collection by @leebyron
    in #1878

  - keep sidebar fixed + merge top and bottom sidebar by @jdeniau
    in #1868

  - Changelog 4.0.0 by @bdurrer in #1880
  """