### PR TITLE
realm state: Store some realm settings, and `is_owner`/`is_moderator`, for web-public streams

### DIFF
--- a/src/api/initialDataTypes.js
+++ b/src/api/initialDataTypes.js
@@ -163,7 +163,7 @@ export type InitialDataRealm = $ReadOnly<{|
   // realm_create_private_stream_policy and realm_create_public_stream_policy
   realm_create_stream_policy?: number,
 
-  // TODO(server-5.0): Added in feat. 103
+  // TODO(server-5.0): Added in feat. 103; when absent, treat as 6 (nobody).
   realm_create_web_public_stream_policy?: number,
 
   realm_default_code_block_language: string | null,
@@ -198,7 +198,7 @@ export type InitialDataRealm = $ReadOnly<{|
   realm_email_changes_disabled: boolean,
   realm_emails_restricted_to_domains: boolean,
 
-  // TODO(server-5.0): Added in feat. 109
+  // TODO(server-5.0): Added in feat. 109; if absent, treat as false.
   realm_enable_spectator_access?: boolean,
 
   // TODO(server-4.0): Added in feat. 55.
@@ -273,7 +273,7 @@ export type InitialDataRealm = $ReadOnly<{|
   // TODO(server-5.0): Added in feat. 74
   server_needs_upgrade?: boolean,
 
-  // TODO(server-5.0): Added in feat. 110
+  // TODO(server-5.0): Added in feat. 110; if absent, treat as false.
   server_web_public_streams_enabled?: boolean,
 
   settings_send_digest_emails: boolean,

--- a/src/realm/__tests__/realmReducer-test.js
+++ b/src/realm/__tests__/realmReducer-test.js
@@ -15,7 +15,9 @@ describe('realmReducer', () => {
     test('updates as appropriate on a boring but representative REGISTER_COMPLETE', () => {
       const action = eg.action.register_complete;
       expect(realmReducer(eg.baseReduxState.realm, action)).toEqual({
-        crossRealmBots: action.data.cross_realm_bots,
+        //
+        // InitialDataRealm
+        //
 
         name: action.data.realm_name,
         description: action.data.realm_description,
@@ -31,11 +33,22 @@ describe('realmReducer', () => {
         createWebPublicStreamPolicy: action.data.realm_create_web_public_stream_policy ?? 6,
         enableSpectatorAccess: action.data.realm_enable_spectator_access ?? false,
 
+        //
+        // InitialDataRealmUser
+        //
+
         email: action.data.email,
         user_id: action.data.user_id,
-        twentyFourHourTime: action.data.twenty_four_hour_time,
         canCreateStreams: action.data.can_create_streams,
         isAdmin: action.data.is_admin,
+        crossRealmBots: action.data.cross_realm_bots,
+
+        //
+        // InitialDataUpdateDisplaySettings. Deprecated!
+        //
+        // TODO(#4933): Use modern `user_settings` object for these.
+
+        twentyFourHourTime: action.data.twenty_four_hour_time,
       });
     });
   });

--- a/src/realm/__tests__/realmReducer-test.js
+++ b/src/realm/__tests__/realmReducer-test.js
@@ -39,6 +39,8 @@ describe('realmReducer', () => {
 
         canCreateStreams: action.data.can_create_streams,
         isAdmin: action.data.is_admin,
+        isOwner: action.data.is_owner,
+        isModerator: action.data.is_moderator,
         user_id: action.data.user_id,
         email: action.data.email,
         crossRealmBots: action.data.cross_realm_bots,

--- a/src/realm/__tests__/realmReducer-test.js
+++ b/src/realm/__tests__/realmReducer-test.js
@@ -27,6 +27,9 @@ describe('realmReducer', () => {
         messageContentDeleteLimitSeconds: action.data.realm_message_content_delete_limit_seconds,
         messageContentEditLimitSeconds: action.data.realm_message_content_edit_limit_seconds,
         pushNotificationsEnabled: action.data.realm_push_notifications_enabled,
+        webPublicStreamsEnabled: action.data.server_web_public_streams_enabled ?? false,
+        createWebPublicStreamPolicy: action.data.realm_create_web_public_stream_policy ?? 6,
+        enableSpectatorAccess: action.data.realm_enable_spectator_access ?? false,
 
         email: action.data.email,
         user_id: action.data.user_id,

--- a/src/realm/__tests__/realmReducer-test.js
+++ b/src/realm/__tests__/realmReducer-test.js
@@ -37,10 +37,10 @@ describe('realmReducer', () => {
         // InitialDataRealmUser
         //
 
-        email: action.data.email,
-        user_id: action.data.user_id,
         canCreateStreams: action.data.can_create_streams,
         isAdmin: action.data.is_admin,
+        user_id: action.data.user_id,
+        email: action.data.email,
         crossRealmBots: action.data.cross_realm_bots,
 
         //

--- a/src/realm/realmReducer.js
+++ b/src/realm/realmReducer.js
@@ -19,7 +19,9 @@ import {
 import { objectFromEntries } from '../jsBackport';
 
 const initialState = {
-  crossRealmBots: [],
+  //
+  // InitialDataRealm
+  //
 
   name: '',
   description: '',
@@ -35,11 +37,22 @@ const initialState = {
   createWebPublicStreamPolicy: 6,
   enableSpectatorAccess: false,
 
+  //
+  // InitialDataRealmUser
+  //
+
   email: undefined,
   user_id: undefined,
-  twentyFourHourTime: false,
   canCreateStreams: true,
   isAdmin: false,
+  crossRealmBots: [],
+
+  //
+  // InitialDataUpdateDisplaySettings. Deprecated!
+  //
+  // TODO(#4933): Use modern `user_settings` object for these.
+
+  twentyFourHourTime: false,
 };
 
 const convertRealmEmoji = (data): RealmEmojiById =>
@@ -75,7 +88,9 @@ export default (
 
     case REGISTER_COMPLETE: {
       return {
-        crossRealmBots: action.data.cross_realm_bots,
+        //
+        // InitialDataRealm
+        //
 
         name: action.data.realm_name,
         description: action.data.realm_description,
@@ -95,14 +110,22 @@ export default (
         createWebPublicStreamPolicy: action.data.realm_create_web_public_stream_policy ?? 6,
         enableSpectatorAccess: action.data.realm_enable_spectator_access ?? false,
 
+        //
+        // InitialDataRealmUser
+        //
+
         email: action.data.email,
         user_id: action.data.user_id,
-
-        // TODO(#4933): Use modern `user_settings` object for this
-        twentyFourHourTime: action.data.twenty_four_hour_time,
-
         canCreateStreams: action.data.can_create_streams,
         isAdmin: action.data.is_admin,
+        crossRealmBots: action.data.cross_realm_bots,
+
+        //
+        // InitialDataUpdateDisplaySettings. Deprecated!
+        //
+        // TODO(#4933): Use modern `user_settings` object for these.
+
+        twentyFourHourTime: action.data.twenty_four_hour_time,
       };
     }
 

--- a/src/realm/realmReducer.js
+++ b/src/realm/realmReducer.js
@@ -43,6 +43,8 @@ const initialState = {
 
   canCreateStreams: true,
   isAdmin: false,
+  isOwner: false,
+  isModerator: false,
   user_id: undefined,
   email: undefined,
   crossRealmBots: [],
@@ -116,6 +118,8 @@ export default (
 
         canCreateStreams: action.data.can_create_streams,
         isAdmin: action.data.is_admin,
+        isOwner: action.data.is_owner,
+        isModerator: action.data.is_moderator ?? action.data.is_admin,
         user_id: action.data.user_id,
         email: action.data.email,
         crossRealmBots: action.data.cross_realm_bots,

--- a/src/realm/realmReducer.js
+++ b/src/realm/realmReducer.js
@@ -41,10 +41,10 @@ const initialState = {
   // InitialDataRealmUser
   //
 
-  email: undefined,
-  user_id: undefined,
   canCreateStreams: true,
   isAdmin: false,
+  user_id: undefined,
+  email: undefined,
   crossRealmBots: [],
 
   //
@@ -114,10 +114,10 @@ export default (
         // InitialDataRealmUser
         //
 
-        email: action.data.email,
-        user_id: action.data.user_id,
         canCreateStreams: action.data.can_create_streams,
         isAdmin: action.data.is_admin,
+        user_id: action.data.user_id,
+        email: action.data.email,
         crossRealmBots: action.data.cross_realm_bots,
 
         //

--- a/src/realm/realmReducer.js
+++ b/src/realm/realmReducer.js
@@ -31,6 +31,9 @@ const initialState = {
   messageContentDeleteLimitSeconds: null,
   messageContentEditLimitSeconds: 1,
   pushNotificationsEnabled: true,
+  webPublicStreamsEnabled: false,
+  createWebPublicStreamPolicy: 6,
+  enableSpectatorAccess: false,
 
   email: undefined,
   user_id: undefined,
@@ -88,6 +91,9 @@ export default (
         messageContentDeleteLimitSeconds: action.data.realm_message_content_delete_limit_seconds,
         messageContentEditLimitSeconds: action.data.realm_message_content_edit_limit_seconds,
         pushNotificationsEnabled: action.data.realm_push_notifications_enabled,
+        webPublicStreamsEnabled: action.data.server_web_public_streams_enabled ?? false,
+        createWebPublicStreamPolicy: action.data.realm_create_web_public_stream_policy ?? 6,
+        enableSpectatorAccess: action.data.realm_enable_spectator_access ?? false,
 
         email: action.data.email,
         user_id: action.data.user_id,

--- a/src/reduxTypes.js
+++ b/src/reduxTypes.js
@@ -273,7 +273,9 @@ export type VideoChatProvider = $ReadOnly<{| name: 'jitsi_meet', jitsiServerUrl:
  * @prop isAdmin
  */
 export type RealmState = $ReadOnly<{|
-  crossRealmBots: $ReadOnlyArray<CrossRealmBot>,
+  //
+  // InitialDataRealm
+  //
 
   name: string,
   description: string,
@@ -289,11 +291,22 @@ export type RealmState = $ReadOnly<{|
   createWebPublicStreamPolicy: number,
   enableSpectatorAccess: boolean,
 
+  //
+  // InitialDataRealmUser
+  //
+
   email: string | void,
   user_id: UserId | void,
-  twentyFourHourTime: boolean,
   canCreateStreams: boolean,
   isAdmin: boolean,
+  crossRealmBots: $ReadOnlyArray<CrossRealmBot>,
+
+  //
+  // InitialDataUpdateDisplaySettings. Deprecated!
+  //
+  // TODO(#4933): Use modern `user_settings` object for these.
+
+  twentyFourHourTime: boolean,
 |}>;
 
 // TODO: Stop using the 'default' name. Any 'default' semantics should

--- a/src/reduxTypes.js
+++ b/src/reduxTypes.js
@@ -285,6 +285,9 @@ export type RealmState = $ReadOnly<{|
   messageContentDeleteLimitSeconds: number | null,
   messageContentEditLimitSeconds: number,
   pushNotificationsEnabled: boolean,
+  webPublicStreamsEnabled: boolean,
+  createWebPublicStreamPolicy: number,
+  enableSpectatorAccess: boolean,
 
   email: string | void,
   user_id: UserId | void,

--- a/src/reduxTypes.js
+++ b/src/reduxTypes.js
@@ -295,10 +295,10 @@ export type RealmState = $ReadOnly<{|
   // InitialDataRealmUser
   //
 
-  email: string | void,
-  user_id: UserId | void,
   canCreateStreams: boolean,
   isAdmin: boolean,
+  user_id: UserId | void,
+  email: string | void,
   crossRealmBots: $ReadOnlyArray<CrossRealmBot>,
 
   //

--- a/src/reduxTypes.js
+++ b/src/reduxTypes.js
@@ -297,6 +297,8 @@ export type RealmState = $ReadOnly<{|
 
   canCreateStreams: boolean,
   isAdmin: boolean,
+  isOwner: boolean,
+  isModerator: boolean,
   user_id: UserId | void,
   email: string | void,
   crossRealmBots: $ReadOnlyArray<CrossRealmBot>,

--- a/src/storage/__tests__/migrations-test.js
+++ b/src/storage/__tests__/migrations-test.js
@@ -87,7 +87,7 @@ describe('migrations', () => {
   // What `base` becomes after all migrations.
   const endBase = {
     ...base37,
-    migrations: { version: 41 },
+    migrations: { version: 42 },
   };
 
   for (const [desc, before, after] of [
@@ -110,8 +110,8 @@ describe('migrations', () => {
     // redundant with this one, because none of the migration steps notice
     // whether any properties outside `storeKeys` are present or not.
     [
-      'check dropCache at 41',
-      { ...endBase, migrations: { version: 40 }, mute: [], nonsense: [1, 2, 3] },
+      'check dropCache at 42',
+      { ...endBase, migrations: { version: 41 }, mute: [], nonsense: [1, 2, 3] },
       endBase,
     ],
 

--- a/src/storage/__tests__/migrations-test.js
+++ b/src/storage/__tests__/migrations-test.js
@@ -87,7 +87,7 @@ describe('migrations', () => {
   // What `base` becomes after all migrations.
   const endBase = {
     ...base37,
-    migrations: { version: 42 },
+    migrations: { version: 43 },
   };
 
   for (const [desc, before, after] of [
@@ -110,8 +110,8 @@ describe('migrations', () => {
     // redundant with this one, because none of the migration steps notice
     // whether any properties outside `storeKeys` are present or not.
     [
-      'check dropCache at 42',
-      { ...endBase, migrations: { version: 41 }, mute: [], nonsense: [1, 2, 3] },
+      'check dropCache at 43',
+      { ...endBase, migrations: { version: 42 }, mute: [], nonsense: [1, 2, 3] },
       endBase,
     ],
 

--- a/src/storage/migrations.js
+++ b/src/storage/migrations.js
@@ -412,6 +412,10 @@ const migrationsInner: {| [string]: (LessPartialState) => LessPartialState |} = 
   // Add is_web_public to Stream and Subscription.
   '41': dropCache,
 
+  // Add webPublicStreamsEnabled, enableSpectatorAccess, and
+  // createWebPublicStreamPolicy to state.realm.
+  '42': dropCache,
+
   // TIP: When adding a migration, consider just using `dropCache`.
   //   (See its jsdoc for guidance on when that's the right answer.)
 };

--- a/src/storage/migrations.js
+++ b/src/storage/migrations.js
@@ -416,6 +416,9 @@ const migrationsInner: {| [string]: (LessPartialState) => LessPartialState |} = 
   // createWebPublicStreamPolicy to state.realm.
   '42': dropCache,
 
+  // Add isOwner and isModerator to state.realm.
+  '43': dropCache,
+
   // TIP: When adding a migration, consider just using `dropCache`.
   //   (See its jsdoc for guidance on when that's the right answer.)
 };


### PR DESCRIPTION
Following #5376, in which we synced `InitialDataRealmUser` with the doc, so that it includes `is_moderator`.