### PR TITLE
android: Work around issue with "open failed: EACCES (Permission denied)"

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -202,6 +202,15 @@ dependencies {
     //noinspection GradleDynamicVersion
     implementation "com.facebook.react:react-native:+"  // From node_modules
 
+    // Workaround for facebook/react-native#32735; see
+    //   https://github.com/facebook/react-native/issues/32735#issue-1077061487
+    // TODO(react-native-68): Remove; fixed in facebook/react-native@f45889ef9
+    implementation('com.facebook.soloader:soloader:0.10.3') {
+        version {
+            strictly '0.10.3'
+        }
+    }
+
     debugImplementation("com.facebook.flipper:flipper:${FLIPPER_VERSION}") {
         exclude group: 'com.facebook.fbjni'
     }


### PR DESCRIPTION
See
  https://github.com/facebook/react-native/issues/32735#issue-1077061487
, where this workaround is copied from, and see a later comment on
the same issue saying that the official fix will arrive in RN v0.68.

Using Android Studio, Greg and I found that the version of soloader
that was pulled in before was 0.10.1. (Under the Packages list, we
went to Libraries/com/facebook/soloader, opened a random file, and
saw the version in Android Studio's title bar.)