### PR TITLE
permissionSelectors: Add getCanCreatePrivateStreams and getCanCreatePublicStreams

### DIFF
--- a/src/__tests__/permissionSelectors-test.js
+++ b/src/__tests__/permissionSelectors-test.js
@@ -49,6 +49,8 @@ describe('roleIsAtLeast', () => {
   });
 });
 
+// TODO(?): Could deduplicate with the other getCanCreate*Streams; see
+//     https://github.com/zulip/zulip-mobile/pull/5394#discussion_r883215288
 describe('getCanCreatePublicStreams', () => {
   const {
     MemberOrAbove,
@@ -134,6 +136,8 @@ describe('getCanCreatePublicStreams', () => {
   );
 });
 
+// TODO(?): Could deduplicate with the other getCanCreate*Streams; see
+//     https://github.com/zulip/zulip-mobile/pull/5394#discussion_r883215288
 describe('getCanCreatePrivateStreams', () => {
   const {
     MemberOrAbove,
@@ -219,6 +223,8 @@ describe('getCanCreatePrivateStreams', () => {
   );
 });
 
+// TODO(?): Could deduplicate with the other getCanCreate*Streams; see
+//     https://github.com/zulip/zulip-mobile/pull/5394#discussion_r883215288
 describe('getCanCreateWebPublicStreams', () => {
   const { AdminOrAbove, ModeratorOrAbove, Nobody, OwnerOnly } = CreateWebPublicStreamPolicy;
   const { Owner, Admin, Moderator, Member, Guest } = Role;

--- a/src/__tests__/permissionSelectors-test.js
+++ b/src/__tests__/permissionSelectors-test.js
@@ -1,16 +1,20 @@
 /* @flow strict-local */
 import invariant from 'invariant';
+import addDays from 'date-fns/addDays';
 
-import { tryGetActiveAccountState } from '../selectors';
+import { getOwnUser, tryGetActiveAccountState, getRealm } from '../selectors';
 import {
   Role,
   RoleValues,
   type RoleT,
+  CreatePublicOrPrivateStreamPolicy,
+  type CreatePublicOrPrivateStreamPolicyT,
   CreateWebPublicStreamPolicy,
   type CreateWebPublicStreamPolicyT,
 } from '../api/permissionsTypes';
 import {
   getHasUserPassedWaitingPeriod,
+  getCanCreatePublicStreams,
   getCanCreateWebPublicStreams,
   roleIsAtLeast,
 } from '../permissionSelectors';
@@ -42,6 +46,91 @@ describe('roleIsAtLeast', () => {
       });
     });
   });
+});
+
+describe('getCanCreatePublicStreams', () => {
+  const {
+    MemberOrAbove,
+    AdminOrAbove,
+    FullMemberOrAbove,
+    ModeratorOrAbove,
+  } = CreatePublicOrPrivateStreamPolicy;
+  const { Owner, Admin, Moderator, Member, Guest } = Role;
+
+  test.each`
+    policy               | role         | waitingPeriodPassed | expected
+    ${MemberOrAbove}     | ${Owner}     | ${undefined}        | ${true}
+    ${MemberOrAbove}     | ${Admin}     | ${undefined}        | ${true}
+    ${MemberOrAbove}     | ${Moderator} | ${undefined}        | ${true}
+    ${MemberOrAbove}     | ${Member}    | ${undefined}        | ${true}
+    ${MemberOrAbove}     | ${Guest}     | ${undefined}        | ${false}
+    ${AdminOrAbove}      | ${Owner}     | ${undefined}        | ${true}
+    ${AdminOrAbove}      | ${Admin}     | ${undefined}        | ${true}
+    ${AdminOrAbove}      | ${Moderator} | ${undefined}        | ${false}
+    ${AdminOrAbove}      | ${Member}    | ${undefined}        | ${false}
+    ${AdminOrAbove}      | ${Guest}     | ${undefined}        | ${false}
+    ${FullMemberOrAbove} | ${Owner}     | ${undefined}        | ${true}
+    ${FullMemberOrAbove} | ${Admin}     | ${undefined}        | ${true}
+    ${FullMemberOrAbove} | ${Moderator} | ${undefined}        | ${true}
+    ${FullMemberOrAbove} | ${Member}    | ${true}             | ${true}
+    ${FullMemberOrAbove} | ${Member}    | ${false}            | ${false}
+    ${FullMemberOrAbove} | ${Guest}     | ${undefined}        | ${false}
+    ${ModeratorOrAbove}  | ${Owner}     | ${undefined}        | ${true}
+    ${ModeratorOrAbove}  | ${Admin}     | ${undefined}        | ${true}
+    ${ModeratorOrAbove}  | ${Moderator} | ${undefined}        | ${true}
+    ${ModeratorOrAbove}  | ${Member}    | ${undefined}        | ${false}
+    ${ModeratorOrAbove}  | ${Guest}     | ${undefined}        | ${false}
+  `(
+    'returns $expected when policy is $policy; role is $role; waitingPeriodPassed is $waitingPeriodPassed',
+    async ({
+      policy,
+      role,
+      waitingPeriodPassed,
+      expected,
+    }: {
+      policy: CreatePublicOrPrivateStreamPolicyT,
+      role: RoleT,
+      waitingPeriodPassed: boolean | void,
+      expected: boolean,
+    }) => {
+      const globalState = [
+        {
+          type: EVENT,
+          event: {
+            id: 1,
+            type: EventTypes.realm_user,
+            op: 'update',
+            person: { user_id: eg.selfUser.user_id, role },
+          },
+        },
+        {
+          type: EVENT,
+          event: {
+            id: 0,
+            type: EventTypes.realm,
+            property: 'default',
+            op: 'update_dict',
+            data: { create_public_stream_policy: policy },
+          },
+        },
+      ].reduce(rootReducer, eg.plusReduxState);
+
+      const newState = tryGetActiveAccountState(globalState);
+      invariant(newState !== undefined, 'expected newState');
+
+      if (waitingPeriodPassed !== undefined) {
+        // TODO: Figure out how to jest.mock this or something instead.
+        jest.setSystemTime(
+          addDays(
+            new Date(getOwnUser(newState).date_joined),
+            getRealm(newState).waitingPeriodThreshold + (waitingPeriodPassed ? 2 : -2),
+          ),
+        );
+      }
+
+      expect(getCanCreatePublicStreams(newState)).toBe(expected);
+    },
+  );
 });
 
 describe('getCanCreateWebPublicStreams', () => {

--- a/src/api/initialDataTypes.js
+++ b/src/api/initialDataTypes.js
@@ -165,6 +165,8 @@ export type InitialDataRealm = $ReadOnly<{|
 
   // TODO(server-5.0): Replaced in feat. 102 by
   // realm_create_private_stream_policy and realm_create_public_stream_policy
+  // TODO(?): Do we support any servers released before this was added? (No
+  //   entry in API doc or changelog.)
   realm_create_stream_policy?: CreatePublicOrPrivateStreamPolicyT,
 
   // TODO(server-5.0): Added in feat. 103; when absent, treat as

--- a/src/api/initialDataTypes.js
+++ b/src/api/initialDataTypes.js
@@ -16,7 +16,10 @@ import type {
   UserGroup,
   UserId,
 } from './apiTypes';
-import type { CreateWebPublicStreamPolicyT } from './permissionsTypes';
+import type {
+  CreatePublicOrPrivateStreamPolicyT,
+  CreateWebPublicStreamPolicyT,
+} from './permissionsTypes';
 
 /*
    The types in this file are organized by which `fetch_event_types` values
@@ -154,15 +157,15 @@ export type InitialDataRealm = $ReadOnly<{|
 
   // TODO(server-5.0): Added in feat. 102, replacing
   // realm_create_stream_policy for private streams
-  realm_create_private_stream_policy?: number,
+  realm_create_private_stream_policy?: CreatePublicOrPrivateStreamPolicyT,
 
   // TODO(server-5.0): Added in feat. 102, replacing
   // realm_create_stream_policy for public streams
-  realm_create_public_stream_policy?: number,
+  realm_create_public_stream_policy?: CreatePublicOrPrivateStreamPolicyT,
 
   // TODO(server-5.0): Replaced in feat. 102 by
   // realm_create_private_stream_policy and realm_create_public_stream_policy
-  realm_create_stream_policy?: number,
+  realm_create_stream_policy?: CreatePublicOrPrivateStreamPolicyT,
 
   // TODO(server-5.0): Added in feat. 103; when absent, treat as
   //   CreateWebPublicStreamPolicy.Nobody.

--- a/src/api/modelTypes.js
+++ b/src/api/modelTypes.js
@@ -95,6 +95,8 @@ export type User = {|
   +delivery_email?: string,
   +email: string,
   +full_name: string,
+
+  // We expect ISO 8601; that's in the doc's example response.
   +date_joined: string,
 
   // is_active never appears in `/register` responses, at least up through
@@ -179,6 +181,8 @@ export type CrossRealmBot = {|
   +delivery_email?: string,
   +email: string,
   +full_name: string,
+
+  // We expect ISO 8601; that's in the doc's example response.
   +date_joined: string,
 
   // is_active never appears in `/register` responses, at least up through

--- a/src/api/permissionsTypes.js
+++ b/src/api/permissionsTypes.js
@@ -41,6 +41,52 @@ typesEquivalent<RoleT, $Values<typeof Role>>();
 export const RoleValues: $ReadOnlyArray<RoleT> = objectValues(Role);
 
 /**
+ * This organization's policy for which users can create public streams, or
+ *   its policy for which users can create private streams.
+ *
+ * (These policies could be set differently, but their types are the same,
+ * so it's convenient to have just one definition.)
+ *
+ * For the policy for web-public streams, see CreateWebPublicStreamPolicyT.
+ */
+// eslint-disable-next-line flowtype/type-id-match
+export type CreatePublicOrPrivateStreamPolicyT = 1 | 2 | 3 | 4;
+
+/**
+ * An enum of all valid values for `CreatePublicOrPrivateStreamPolicyT`.
+ *
+ * See CreatePublicOrPrivateStreamPolicyValues for the list of values.
+ */
+// Ideally both the type and enum would have the simple name; but a type
+// and value sharing a name is one nice TS feature that Flow lacks.
+// Or we could leapfrog TS and make this a Flow enum:
+//   https://flow.org/en/docs/enums/
+// (TS has its own enums, but they are a mess.)
+// eslint-disable-next-line flowtype/type-id-match
+export const CreatePublicOrPrivateStreamPolicy = {
+  MemberOrAbove: (1: 1),
+  AdminOrAbove: (2: 2),
+  FullMemberOrAbove: (3: 3),
+  ModeratorOrAbove: (4: 4),
+};
+
+// Check that the enum indeed has all and exactly the values of the type.
+typesEquivalent<
+  CreatePublicOrPrivateStreamPolicyT,
+  $Values<typeof CreatePublicOrPrivateStreamPolicy>,
+>();
+
+/**
+ * A list of all valid values for `CreatePublicOrPrivateStreamPolicyT`.
+ *
+ * See CreatePublicOrPrivateStreamPolicy for an enum to refer to these by
+ * meaningful names.
+ */
+export const CreatePublicOrPrivateStreamPolicyValues: $ReadOnlyArray<CreatePublicOrPrivateStreamPolicyT> = objectValues(
+  CreatePublicOrPrivateStreamPolicy,
+);
+
+/**
  * The policy for which users can create web public streams in this
  * organization. Ignore if the server hasn't opted into the concept of
  * web-public streams.

--- a/src/permissionSelectors.js
+++ b/src/permissionSelectors.js
@@ -102,6 +102,35 @@ export function getCanCreatePublicStreams(state: PerAccountState): boolean {
 }
 
 /**
+ * Whether the self-user is authorized to create or edit a stream to be
+ *   private.
+ */
+export function getCanCreatePrivateStreams(state: PerAccountState): boolean {
+  const { createPrivateStreamPolicy } = getRealm(state);
+  const ownUser = getOwnUser(state);
+  const role = getOwnUserRole(state);
+
+  switch (createPrivateStreamPolicy) {
+    case 4: // ModeratorOrAbove
+      return roleIsAtLeast(role, Moderator);
+    case 3: // FullMemberOrAbove
+      return role === Member
+        ? getHasUserPassedWaitingPeriod(state, ownUser.user_id)
+        : roleIsAtLeast(role, Member);
+    case 2: // AdminOrAbove
+      return roleIsAtLeast(role, Admin);
+    case 1: // MemberOrAbove
+      return roleIsAtLeast(role, Member);
+    default: {
+      ensureUnreachable(createPrivateStreamPolicy);
+
+      // (Unreachable as long as the cases are exhaustive.)
+      return false;
+    }
+  }
+}
+
+/**
  * Whether the self-user can create or edit a stream to be web-public.
  *
  * True just if:

--- a/src/permissionSelectors.js
+++ b/src/permissionSelectors.js
@@ -76,6 +76,8 @@ export function getHasUserPassedWaitingPeriod(state: PerAccountState, userId: Us
  * Note: This isn't about web-public streams. For those, see
  * getCanCreateWebPublicStreams.
  */
+// TODO(?): Could deduplicate with the other getCanCreate*Streams; see
+//     https://github.com/zulip/zulip-mobile/pull/5394#discussion_r883215288
 export function getCanCreatePublicStreams(state: PerAccountState): boolean {
   const { createPublicStreamPolicy } = getRealm(state);
   const ownUser = getOwnUser(state);
@@ -105,6 +107,8 @@ export function getCanCreatePublicStreams(state: PerAccountState): boolean {
  * Whether the self-user is authorized to create or edit a stream to be
  *   private.
  */
+// TODO(?): Could deduplicate with the other getCanCreate*Streams; see
+//     https://github.com/zulip/zulip-mobile/pull/5394#discussion_r883215288
 export function getCanCreatePrivateStreams(state: PerAccountState): boolean {
   const { createPrivateStreamPolicy } = getRealm(state);
   const ownUser = getOwnUser(state);
@@ -146,6 +150,8 @@ export function getCanCreatePrivateStreams(state: PerAccountState): boolean {
  * Like user_can_create_web_public_streams in the web-app's
  * static/js/settings_data.ts.
  */
+// TODO(?): Could deduplicate with the other getCanCreate*Streams; see
+//     https://github.com/zulip/zulip-mobile/pull/5394#discussion_r883215288
 export function getCanCreateWebPublicStreams(state: PerAccountState): boolean {
   const { webPublicStreamsEnabled, enableSpectatorAccess, createWebPublicStreamPolicy } = getRealm(
     state,

--- a/src/realm/__tests__/realmReducer-test.js
+++ b/src/realm/__tests__/realmReducer-test.js
@@ -43,6 +43,7 @@ describe('realmReducer', () => {
         createPrivateStreamPolicy: action.data.realm_create_private_stream_policy,
         createWebPublicStreamPolicy: action.data.realm_create_web_public_stream_policy,
         enableSpectatorAccess: action.data.realm_enable_spectator_access,
+        waitingPeriodThreshold: action.data.realm_waiting_period_threshold,
 
         //
         // InitialDataRealmUser
@@ -404,6 +405,12 @@ describe('realmReducer', () => {
         check(ModeratorOrAbove, MemberOrAbove);
         check(ModeratorOrAbove, AdminOrAbove);
         check(ModeratorOrAbove, FullMemberOrAbove);
+      });
+
+      describe('waitingPeriodThreshold / waiting_period_threshold', () => {
+        const check = mkCheck('waitingPeriodThreshold', 'waiting_period_threshold');
+        check(90, 90);
+        check(90, 30);
       });
     });
   });

--- a/src/realm/__tests__/realmReducer-test.js
+++ b/src/realm/__tests__/realmReducer-test.js
@@ -12,7 +12,10 @@ import {
 } from '../../actionConstants';
 import type { UserSettings } from '../../api/initialDataTypes';
 import type { RealmDataForUpdate } from '../../api/realmDataTypes';
-import { CreateWebPublicStreamPolicy } from '../../api/permissionsTypes';
+import {
+  CreatePublicOrPrivateStreamPolicy,
+  CreateWebPublicStreamPolicy,
+} from '../../api/permissionsTypes';
 import { EventTypes } from '../../api/eventTypes';
 import * as eg from '../../__tests__/lib/exampleData';
 
@@ -36,6 +39,8 @@ describe('realmReducer', () => {
         messageContentEditLimitSeconds: action.data.realm_message_content_edit_limit_seconds,
         pushNotificationsEnabled: action.data.realm_push_notifications_enabled,
         webPublicStreamsEnabled: action.data.server_web_public_streams_enabled,
+        createPublicStreamPolicy: action.data.realm_create_public_stream_policy,
+        createPrivateStreamPolicy: action.data.realm_create_private_stream_policy,
         createWebPublicStreamPolicy: action.data.realm_create_web_public_stream_policy,
         enableSpectatorAccess: action.data.realm_enable_spectator_access,
 
@@ -311,6 +316,94 @@ describe('realmReducer', () => {
         check(OwnerOnly, AdminOrAbove);
         check(OwnerOnly, ModeratorOrAbove);
         check(OwnerOnly, Nobody);
+      });
+
+      describe('createPublicStreamPolicy / create_public_stream_policy', () => {
+        const {
+          MemberOrAbove,
+          AdminOrAbove,
+          FullMemberOrAbove,
+          ModeratorOrAbove,
+        } = CreatePublicOrPrivateStreamPolicy;
+        const check = mkCheck('createPublicStreamPolicy', 'create_public_stream_policy');
+        check(MemberOrAbove, AdminOrAbove);
+        check(MemberOrAbove, FullMemberOrAbove);
+        check(MemberOrAbove, ModeratorOrAbove);
+        check(AdminOrAbove, MemberOrAbove);
+        check(AdminOrAbove, FullMemberOrAbove);
+        check(AdminOrAbove, ModeratorOrAbove);
+        check(FullMemberOrAbove, MemberOrAbove);
+        check(FullMemberOrAbove, AdminOrAbove);
+        check(FullMemberOrAbove, ModeratorOrAbove);
+        check(ModeratorOrAbove, MemberOrAbove);
+        check(ModeratorOrAbove, AdminOrAbove);
+        check(ModeratorOrAbove, FullMemberOrAbove);
+      });
+
+      describe('createPrivateStreamPolicy / create_private_stream_policy', () => {
+        const {
+          MemberOrAbove,
+          AdminOrAbove,
+          FullMemberOrAbove,
+          ModeratorOrAbove,
+        } = CreatePublicOrPrivateStreamPolicy;
+        const check = mkCheck('createPrivateStreamPolicy', 'create_private_stream_policy');
+        check(MemberOrAbove, AdminOrAbove);
+        check(MemberOrAbove, FullMemberOrAbove);
+        check(MemberOrAbove, ModeratorOrAbove);
+        check(AdminOrAbove, MemberOrAbove);
+        check(AdminOrAbove, FullMemberOrAbove);
+        check(AdminOrAbove, ModeratorOrAbove);
+        check(FullMemberOrAbove, MemberOrAbove);
+        check(FullMemberOrAbove, AdminOrAbove);
+        check(FullMemberOrAbove, ModeratorOrAbove);
+        check(ModeratorOrAbove, MemberOrAbove);
+        check(ModeratorOrAbove, AdminOrAbove);
+        check(ModeratorOrAbove, FullMemberOrAbove);
+      });
+
+      describe('create{Private,Public}StreamPolicy / create_stream_policy', () => {
+        // TODO(server-5.0): Stop expecting create_stream_policy; remove.
+
+        const {
+          MemberOrAbove,
+          AdminOrAbove,
+          FullMemberOrAbove,
+          ModeratorOrAbove,
+        } = CreatePublicOrPrivateStreamPolicy;
+        const check = (initialStateValue, eventValue) => {
+          test(`${initialStateValue.toString()} → ${eventValue.toString()}`, () => {
+            const initialState = {
+              ...eg.plusReduxState.realm,
+              createPublicStreamPolicy: initialStateValue,
+              createPrivateStreamPolicy: initialStateValue,
+            };
+
+            expect(
+              realmReducer(initialState, {
+                type: EVENT,
+                event: { ...eventCommon, data: { create_stream_policy: eventValue } },
+              }),
+            ).toEqual({
+              ...initialState,
+              createPublicStreamPolicy: eventValue,
+              createPrivateStreamPolicy: eventValue,
+            });
+          });
+        };
+
+        check(MemberOrAbove, AdminOrAbove);
+        check(MemberOrAbove, FullMemberOrAbove);
+        check(MemberOrAbove, ModeratorOrAbove);
+        check(AdminOrAbove, MemberOrAbove);
+        check(AdminOrAbove, FullMemberOrAbove);
+        check(AdminOrAbove, ModeratorOrAbove);
+        check(FullMemberOrAbove, MemberOrAbove);
+        check(FullMemberOrAbove, AdminOrAbove);
+        check(FullMemberOrAbove, ModeratorOrAbove);
+        check(ModeratorOrAbove, MemberOrAbove);
+        check(ModeratorOrAbove, AdminOrAbove);
+        check(ModeratorOrAbove, FullMemberOrAbove);
       });
     });
   });

--- a/src/realm/realmReducer.js
+++ b/src/realm/realmReducer.js
@@ -42,6 +42,7 @@ const initialState = {
   webPublicStreamsEnabled: false,
   createWebPublicStreamPolicy: CreateWebPublicStreamPolicy.Nobody,
   enableSpectatorAccess: false,
+  waitingPeriodThreshold: 90,
 
   //
   // InitialDataRealmUser
@@ -128,6 +129,7 @@ export default (
         createWebPublicStreamPolicy:
           action.data.realm_create_web_public_stream_policy ?? CreateWebPublicStreamPolicy.Nobody,
         enableSpectatorAccess: action.data.realm_enable_spectator_access ?? false,
+        waitingPeriodThreshold: action.data.realm_waiting_period_threshold,
 
         //
         // InitialDataRealmUser
@@ -208,6 +210,9 @@ export default (
             }
             if (data.enable_spectator_access !== undefined) {
               result.enableSpectatorAccess = data.enable_spectator_access;
+            }
+            if (data.waiting_period_threshold !== undefined) {
+              result.waitingPeriodThreshold = data.waiting_period_threshold;
             }
 
             return result;

--- a/src/realm/realmReducer.js
+++ b/src/realm/realmReducer.js
@@ -5,7 +5,10 @@ import type {
   RealmEmojiById,
   VideoChatProvider,
 } from '../types';
-import { CreateWebPublicStreamPolicy } from '../api/permissionsTypes';
+import {
+  CreatePublicOrPrivateStreamPolicy,
+  CreateWebPublicStreamPolicy,
+} from '../api/permissionsTypes';
 import { EventTypes } from '../api/eventTypes';
 import {
   REGISTER_COMPLETE,
@@ -34,6 +37,8 @@ const initialState = {
   messageContentDeleteLimitSeconds: null,
   messageContentEditLimitSeconds: 1,
   pushNotificationsEnabled: true,
+  createPublicStreamPolicy: CreatePublicOrPrivateStreamPolicy.MemberOrAbove,
+  createPrivateStreamPolicy: CreatePublicOrPrivateStreamPolicy.MemberOrAbove,
   webPublicStreamsEnabled: false,
   createWebPublicStreamPolicy: CreateWebPublicStreamPolicy.Nobody,
   enableSpectatorAccess: false,
@@ -109,6 +114,16 @@ export default (
         messageContentDeleteLimitSeconds: action.data.realm_message_content_delete_limit_seconds,
         messageContentEditLimitSeconds: action.data.realm_message_content_edit_limit_seconds,
         pushNotificationsEnabled: action.data.realm_push_notifications_enabled,
+        createPublicStreamPolicy:
+          action.data.realm_create_public_stream_policy
+          ?? action.data.realm_create_stream_policy
+          // https://github.com/zulip/zulip-mobile/pull/5394#discussion_r883208179
+          ?? CreatePublicOrPrivateStreamPolicy.MemberOrAbove,
+        createPrivateStreamPolicy:
+          action.data.realm_create_private_stream_policy
+          ?? action.data.realm_create_stream_policy
+          // https://github.com/zulip/zulip-mobile/pull/5394#discussion_r883208179
+          ?? CreatePublicOrPrivateStreamPolicy.MemberOrAbove,
         webPublicStreamsEnabled: action.data.server_web_public_streams_enabled ?? false,
         createWebPublicStreamPolicy:
           action.data.realm_create_web_public_stream_policy ?? CreateWebPublicStreamPolicy.Nobody,
@@ -176,6 +191,17 @@ export default (
             }
             if (data.description !== undefined) {
               result.description = data.description;
+            }
+            if (data.create_stream_policy !== undefined) {
+              // TODO(server-5.0): Stop expecting create_stream_policy; simplify.
+              result.createPublicStreamPolicy = data.create_stream_policy;
+              result.createPrivateStreamPolicy = data.create_stream_policy;
+            }
+            if (data.create_public_stream_policy !== undefined) {
+              result.createPublicStreamPolicy = data.create_public_stream_policy;
+            }
+            if (data.create_private_stream_policy !== undefined) {
+              result.createPrivateStreamPolicy = data.create_private_stream_policy;
             }
             if (data.create_web_public_stream_policy !== undefined) {
               result.createWebPublicStreamPolicy = data.create_web_public_stream_policy;

--- a/src/reduxTypes.js
+++ b/src/reduxTypes.js
@@ -294,6 +294,7 @@ export type RealmState = $ReadOnly<{|
   webPublicStreamsEnabled: boolean,
   createWebPublicStreamPolicy: CreateWebPublicStreamPolicyT,
   enableSpectatorAccess: boolean,
+  waitingPeriodThreshold: number,
 
   //
   // InitialDataRealmUser

--- a/src/reduxTypes.js
+++ b/src/reduxTypes.js
@@ -24,6 +24,7 @@ import type {
   UserGroup,
   UserId,
   UserPresence,
+  CreatePublicOrPrivateStreamPolicyT,
   CreateWebPublicStreamPolicyT,
 } from './api/apiTypes';
 import type {
@@ -288,6 +289,8 @@ export type RealmState = $ReadOnly<{|
   messageContentDeleteLimitSeconds: number | null,
   messageContentEditLimitSeconds: number,
   pushNotificationsEnabled: boolean,
+  createPublicStreamPolicy: CreatePublicOrPrivateStreamPolicyT,
+  createPrivateStreamPolicy: CreatePublicOrPrivateStreamPolicyT,
   webPublicStreamsEnabled: boolean,
   createWebPublicStreamPolicy: CreateWebPublicStreamPolicyT,
   enableSpectatorAccess: boolean,

--- a/src/storage/__tests__/migrations-test.js
+++ b/src/storage/__tests__/migrations-test.js
@@ -87,7 +87,7 @@ describe('migrations', () => {
   // What `base` becomes after all migrations.
   const endBase = {
     ...base37,
-    migrations: { version: 44 },
+    migrations: { version: 45 },
   };
 
   for (const [desc, before, after] of [
@@ -110,8 +110,8 @@ describe('migrations', () => {
     // redundant with this one, because none of the migration steps notice
     // whether any properties outside `storeKeys` are present or not.
     [
-      'check dropCache at 44',
-      { ...endBase, migrations: { version: 43 }, mute: [], nonsense: [1, 2, 3] },
+      'check dropCache at 45',
+      { ...endBase, migrations: { version: 44 }, mute: [], nonsense: [1, 2, 3] },
       endBase,
     ],
 

--- a/src/storage/__tests__/migrations-test.js
+++ b/src/storage/__tests__/migrations-test.js
@@ -87,7 +87,7 @@ describe('migrations', () => {
   // What `base` becomes after all migrations.
   const endBase = {
     ...base37,
-    migrations: { version: 45 },
+    migrations: { version: 46 },
   };
 
   for (const [desc, before, after] of [
@@ -110,8 +110,8 @@ describe('migrations', () => {
     // redundant with this one, because none of the migration steps notice
     // whether any properties outside `storeKeys` are present or not.
     [
-      'check dropCache at 45',
-      { ...endBase, migrations: { version: 44 }, mute: [], nonsense: [1, 2, 3] },
+      'check dropCache at 46',
+      { ...endBase, migrations: { version: 45 }, mute: [], nonsense: [1, 2, 3] },
       endBase,
     ],
 

--- a/src/storage/migrations.js
+++ b/src/storage/migrations.js
@@ -425,6 +425,9 @@ const migrationsInner: {| [string]: (LessPartialState) => LessPartialState |} = 
   // Add createPublicStreamPolicy and createPrivateStreamPolicy to state.realm.
   '45': dropCache,
 
+  // Add waitingPeriodThreshold to state.realm.
+  '46': dropCache,
+
   // TIP: When adding a migration, consider just using `dropCache`.
   //   (See its jsdoc for guidance on when that's the right answer.)
 };

--- a/src/storage/migrations.js
+++ b/src/storage/migrations.js
@@ -422,6 +422,9 @@ const migrationsInner: {| [string]: (LessPartialState) => LessPartialState |} = 
   // Add isGuest to state.realm.
   '44': dropCache,
 
+  // Add createPublicStreamPolicy and createPrivateStreamPolicy to state.realm.
+  '45': dropCache,
+
   // TIP: When adding a migration, consider just using `dropCache`.
   //   (See its jsdoc for guidance on when that's the right answer.)
 };


### PR DESCRIPTION
Things to call attention to in review:

- To duplicate code or not (esp. look at `permissionsSelectors` tests)
- `FullMemberOrAbove` not yet implemented correctly (!)—err on the side of more or less permissive? Or go ahead and implement properly?
- Bit of awkward realmReducer code, handling the event, explained by comment "Ignore create_stream_policy, if offered for backwards compatibility, if one of these is present." Keep, just to be safe, or verify that we can simplify?

Thanks!