### PR TITLE
permissionSelectors tests: Stop using date-fns to mock waiting period

### DIFF
--- a/src/__tests__/permissionSelectors-test.js
+++ b/src/__tests__/permissionSelectors-test.js
@@ -1,6 +1,5 @@
 /* @flow strict-local */
 import invariant from 'invariant';
-import addDays from 'date-fns/addDays';
 
 import { getOwnUser, tryGetActiveAccountState, getRealm } from '../selectors';
 import {
@@ -123,12 +122,10 @@ describe('getCanCreatePublicStreams', () => {
 
       if (waitingPeriodPassed !== undefined) {
         // TODO: Figure out how to jest.mock this or something instead.
-        jest.setSystemTime(
-          addDays(
-            new Date(getOwnUser(newState).date_joined),
-            getRealm(newState).waitingPeriodThreshold + (waitingPeriodPassed ? 2 : -2),
-          ),
-        );
+
+        const daysToAdd =
+          getRealm(newState).waitingPeriodThreshold + (waitingPeriodPassed ? 2 : -2);
+        jest.setSystemTime(Date.parse(getOwnUser(newState).date_joined) + daysToAdd * 86400_000);
       }
 
       expect(getCanCreatePublicStreams(newState)).toBe(expected);
@@ -210,12 +207,10 @@ describe('getCanCreatePrivateStreams', () => {
 
       if (waitingPeriodPassed !== undefined) {
         // TODO: Figure out how to jest.mock this or something instead.
-        jest.setSystemTime(
-          addDays(
-            new Date(getOwnUser(newState).date_joined),
-            getRealm(newState).waitingPeriodThreshold + (waitingPeriodPassed ? 2 : -2),
-          ),
-        );
+
+        const daysToAdd =
+          getRealm(newState).waitingPeriodThreshold + (waitingPeriodPassed ? 2 : -2);
+        jest.setSystemTime(Date.parse(getOwnUser(newState).date_joined) + daysToAdd * 86400_000);
       }
 
       expect(getCanCreatePrivateStreams(newState)).toBe(expected);

--- a/src/__tests__/permissionSelectors-test.js
+++ b/src/__tests__/permissionSelectors-test.js
@@ -121,8 +121,7 @@ describe('getCanCreatePublicStreams', () => {
       invariant(newState !== undefined, 'expected newState');
 
       if (waitingPeriodPassed !== undefined) {
-        // TODO: Figure out how to jest.mock this or something instead.
-
+        // TODO(?): jest.mock getHasUserPassedWaitingPeriod instead (how?)
         const daysToAdd =
           getRealm(newState).waitingPeriodThreshold + (waitingPeriodPassed ? 2 : -2);
         jest.setSystemTime(Date.parse(getOwnUser(newState).date_joined) + daysToAdd * 86400_000);
@@ -206,8 +205,7 @@ describe('getCanCreatePrivateStreams', () => {
       invariant(newState !== undefined, 'expected newState');
 
       if (waitingPeriodPassed !== undefined) {
-        // TODO: Figure out how to jest.mock this or something instead.
-
+        // TODO(?): jest.mock getHasUserPassedWaitingPeriod instead (how?)
         const daysToAdd =
           getRealm(newState).waitingPeriodThreshold + (waitingPeriodPassed ? 2 : -2);
         jest.setSystemTime(Date.parse(getOwnUser(newState).date_joined) + daysToAdd * 86400_000);


### PR DESCRIPTION
Could some unintended behavior in addDays have caused the flake
discussed at
  https://github.com/zulip/zulip-mobile/pull/5401#issuecomment-1148836433
?

In any case, this seems better because we don't have to think about
what special logic addDays might have.