### PR TITLE
permissions: Use live-updating `role` property for all role checks, when available

### DIFF
--- a/src/__tests__/lib/exampleData.js
+++ b/src/__tests__/lib/exampleData.js
@@ -851,7 +851,10 @@ export const action = Object.freeze({
       can_create_web_public_streams: false,
       can_subscribe_other_users: false,
       can_invite_others_to_realm: false,
+
+      // $FlowIgnore[cannot-read]: Faithfully representing what servers send
       is_admin: selfUser.is_admin,
+
       is_owner: false,
       is_billing_admin: selfUser.is_billing_admin,
       is_moderator: false,

--- a/src/action-sheets/__tests__/action-sheet-test.js
+++ b/src/action-sheets/__tests__/action-sheet-test.js
@@ -11,6 +11,7 @@ import {
 } from '../index';
 import { makeUnreadState } from '../../unread/__tests__/unread-testlib';
 import { makeMuteState } from '../../mute/__tests__/mute-testlib';
+import { Role } from '../../api/permissionsTypes';
 
 const buttonTitles = buttons => buttons.map(button => button.title);
 
@@ -102,13 +103,13 @@ describe('constructTopicActionButtons', () => {
   });
 
   test('show deleteTopic', () => {
-    const ownUser = { ...eg.selfUser, is_admin: true };
-    expect(titles({ ...eg.plusBackgroundData, ownUser })).toContain('Delete topic');
+    expect(titles({ ...eg.plusBackgroundData, ownUserRole: Role.Admin })).toContain('Delete topic');
   });
 
   test('hide deleteTopic', () => {
-    const ownUser = { ...eg.selfUser, is_admin: false };
-    expect(titles({ ...eg.plusBackgroundData, ownUser })).not.toContain('Delete topic');
+    expect(titles({ ...eg.plusBackgroundData, ownUserRole: Role.Member })).not.toContain(
+      'Delete topic',
+    );
   });
 
   test('show unmuteStream', () => {

--- a/src/action-sheets/index.js
+++ b/src/action-sheets/index.js
@@ -505,6 +505,7 @@ export const constructTopicActionButtons = (args: {|
   } else {
     buttons.push(unresolveTopic);
   }
+  // $FlowFixMe[cannot-read]: We'll fix this soon.
   if (ownUser.is_admin) {
     buttons.push(deleteTopic);
   }

--- a/src/action-sheets/index.js
+++ b/src/action-sheets/index.js
@@ -49,6 +49,8 @@ import { getUnreadCountForTopic } from '../unread/unreadModel';
 import getIsNotificationEnabled from '../streams/getIsNotificationEnabled';
 import { getStreamTopicUrl, getStreamUrl } from '../utils/internalLinks';
 import { reactionTypeFromEmojiType } from '../emoji/data';
+import { Role, type RoleT } from '../api/permissionsTypes';
+import { roleIsAtLeast } from '../permissionSelectors';
 
 // TODO really this belongs in a libdef.
 export type ShowActionSheetWithOptions = (
@@ -479,7 +481,7 @@ export const constructStreamActionButtons = (args: {|
 export const constructTopicActionButtons = (args: {|
   backgroundData: $ReadOnly<{
     mute: MuteState,
-    ownUser: User,
+    ownUserRole: RoleT,
     subscriptions: Map<number, Subscription>,
     unread: UnreadState,
     ...
@@ -488,7 +490,7 @@ export const constructTopicActionButtons = (args: {|
   topic: string,
 |}): Button<TopicArgs>[] => {
   const { backgroundData, streamId, topic } = args;
-  const { mute, ownUser, subscriptions, unread } = backgroundData;
+  const { mute, ownUserRole, subscriptions, unread } = backgroundData;
 
   const buttons = [];
   const unreadCount = getUnreadCountForTopic(unread, streamId, topic);
@@ -505,8 +507,7 @@ export const constructTopicActionButtons = (args: {|
   } else {
     buttons.push(unresolveTopic);
   }
-  // $FlowFixMe[cannot-read]: We'll fix this soon.
-  if (ownUser.is_admin) {
+  if (roleIsAtLeast(ownUserRole, Role.Admin)) {
     buttons.push(deleteTopic);
   }
   const sub = subscriptions.get(streamId);
@@ -666,6 +667,7 @@ export const showTopicActionSheet = (args: {|
     subscriptions: Map<number, Subscription>,
     unread: UnreadState,
     ownUser: User,
+    ownUserRole: RoleT,
     zulipFeatureLevel: number,
     ...
   }>,

--- a/src/api/modelTypes.js
+++ b/src/api/modelTypes.js
@@ -169,13 +169,9 @@ export type User = {|
   // FL 121. The doc wrongly says it always appears. See
   //   https://chat.zulip.org/#narrow/stream/412-api-documentation/topic/.60is_active.60.20in.20.60.2Fregister.60.20response/near/1371606
 
-  // TODO(server-3.0): New in FL 8
-  +is_owner?: boolean,
-
+  +is_owner?: boolean, // TODO(server-3.0): New in FL 8
   +is_admin: boolean,
-
-  // TODO(server-1.9): New in commit d5df0377c; if absent, treat as false.
-  +is_guest?: boolean,
+  +is_guest?: boolean, // TODO(server-1.9): New; if absent, treat as false.
 
   // TODO(server-5.0): New in FL 73
   +is_billing_admin?: boolean,
@@ -255,13 +251,9 @@ export type CrossRealmBot = {|
   // FL 121. The doc wrongly says it always appears. See
   //   https://chat.zulip.org/#narrow/stream/412-api-documentation/topic/.60is_active.60.20in.20.60.2Fregister.60.20response/near/1371606
 
-  // TODO(server-3.0): New in FL 8
-  +is_owner?: boolean,
-
+  +is_owner?: boolean, // TODO(server-3.0): New in FL 8
   +is_admin: boolean,
-
-  // TODO(server-1.9): New in commit d5df0377c; if absent, treat as false.
-  +is_guest?: boolean,
+  +is_guest?: boolean, // TODO(server-1.9): New; if absent, treat as false.
 
   // TODO(server-5.0): New in FL 73
   +is_billing_admin?: boolean,

--- a/src/api/modelTypes.js
+++ b/src/api/modelTypes.js
@@ -169,9 +169,13 @@ export type User = {|
   // FL 121. The doc wrongly says it always appears. See
   //   https://chat.zulip.org/#narrow/stream/412-api-documentation/topic/.60is_active.60.20in.20.60.2Fregister.60.20response/near/1371606
 
-  +is_owner?: boolean, // TODO(server-3.0): New in FL 8
-  +is_admin: boolean,
-  +is_guest?: boolean, // TODO(server-1.9): New; if absent, treat as false.
+  // Deprecated (by us); these don't have events to update them. Use the
+  // `role` property when available. For the self user, use getOwnUserRole,
+  // which has a fallback for when `role` is absent.
+  // TODO(server-4.0): Remove these and rely on `role`.
+  -is_owner?: boolean, // TODO(server-3.0): New in FL 8
+  -is_admin: boolean,
+  -is_guest?: boolean, // TODO(server-1.9): New; if absent, treat as false.
 
   // TODO(server-5.0): New in FL 73
   +is_billing_admin?: boolean,
@@ -251,9 +255,12 @@ export type CrossRealmBot = {|
   // FL 121. The doc wrongly says it always appears. See
   //   https://chat.zulip.org/#narrow/stream/412-api-documentation/topic/.60is_active.60.20in.20.60.2Fregister.60.20response/near/1371606
 
-  +is_owner?: boolean, // TODO(server-3.0): New in FL 8
-  +is_admin: boolean,
-  +is_guest?: boolean, // TODO(server-1.9): New; if absent, treat as false.
+  // Deprecated (by us); these don't have events to update them. Use the
+  // `role` property when available.
+  // TODO(server-4.0): Remove these and rely on `role`.
+  -is_owner?: boolean, // TODO(server-3.0): New in FL 8
+  -is_admin: boolean,
+  -is_guest?: boolean, // TODO(server-1.9): New; if absent, treat as false.
 
   // TODO(server-5.0): New in FL 73
   +is_billing_admin?: boolean,

--- a/src/common/ServerCompatBanner.js
+++ b/src/common/ServerCompatBanner.js
@@ -6,10 +6,12 @@ import type { Node } from 'react';
 import ZulipBanner from './ZulipBanner';
 import { useSelector, useGlobalSelector, useDispatch } from '../react-redux';
 import { getIdentity, getServerVersion } from '../account/accountsSelectors';
-import { getIsAdmin, getSession, getGlobalSettings } from '../directSelectors';
+import { getSession, getGlobalSettings } from '../directSelectors';
 import { dismissCompatNotice } from '../session/sessionActions';
 import { openLinkWithUserPreference } from '../utils/openLink';
 import { ZulipVersion } from '../utils/zulipVersion';
+import { getOwnUserRole, roleIsAtLeast } from '../permissionSelectors';
+import { Role } from '../api/permissionsTypes';
 
 /**
  * The oldest version we currently support.
@@ -55,7 +57,7 @@ export default function ServerCompatBanner(props: Props): Node {
   );
   const zulipVersion = useSelector(getServerVersion);
   const realm = useSelector(state => getIdentity(state).realm);
-  const isAdmin = useSelector(getIsAdmin);
+  const isAtLeastAdmin = useSelector(state => roleIsAtLeast(getOwnUserRole(state), Role.Admin));
   const settings = useGlobalSelector(getGlobalSettings);
 
   let visible = false;
@@ -66,7 +68,7 @@ export default function ServerCompatBanner(props: Props): Node {
     // don't show
   } else {
     visible = true;
-    text = isAdmin
+    text = isAtLeastAdmin
       ? {
           text:
             '{realm} is running Zulip Server {serverVersion}, which is unsupported. Please upgrade your server as soon as possible.',

--- a/src/common/ServerPushSetupBanner.js
+++ b/src/common/ServerPushSetupBanner.js
@@ -7,9 +7,11 @@ import subWeeks from 'date-fns/subWeeks';
 import ZulipBanner from './ZulipBanner';
 import { useSelector, useGlobalSelector, useDispatch } from '../react-redux';
 import { getIdentity, getAccount } from '../account/accountsSelectors';
-import { getIsAdmin, getRealm, getGlobalSettings } from '../directSelectors';
+import { getRealm, getGlobalSettings } from '../directSelectors';
 import { dismissServerPushSetupNotice } from '../account/accountActions';
 import { openLinkWithUserPreference } from '../utils/openLink';
+import { getOwnUserRole, roleIsAtLeast } from '../permissionSelectors';
+import { Role } from '../api/permissionsTypes';
 
 type Props = $ReadOnly<{|
   isDismissable?: boolean,
@@ -37,7 +39,7 @@ export default function PushNotifsSetupBanner(props: Props): Node {
   );
   const pushNotificationsEnabled = useSelector(state => getRealm(state).pushNotificationsEnabled);
   const realm = useSelector(state => getIdentity(state).realm);
-  const isAdmin = useSelector(getIsAdmin);
+  const isAtLeastAdmin = useSelector(state => roleIsAtLeast(getOwnUserRole(state), Role.Admin));
   const settings = useGlobalSelector(getGlobalSettings);
 
   let visible = false;
@@ -54,7 +56,7 @@ export default function PushNotifsSetupBanner(props: Props): Node {
     // don't show
   } else {
     visible = true;
-    text = isAdmin
+    text = isAtLeastAdmin
       ? {
           text:
             'The Zulip server at {realm} is not set up to deliver push notifications. Please contact your administrator.',

--- a/src/compose/ComposeBox.js
+++ b/src/compose/ComposeBox.js
@@ -34,7 +34,6 @@ import AnnouncementOnly from '../message/AnnouncementOnly';
 import MentionWarnings from './MentionWarnings';
 import {
   getAuth,
-  getIsAdmin,
   getStreamInNarrow,
   getStreamsById,
   getVideoChatProvider,
@@ -49,6 +48,8 @@ import AutocompleteView from '../autocomplete/AutocompleteView';
 import { getAllUsersById, getOwnUserId } from '../users/userSelectors';
 import * as api from '../api';
 import { ensureUnreachable } from '../generics';
+import { getOwnUserRole, roleIsAtLeast } from '../permissionSelectors';
+import { Role } from '../api/permissionsTypes';
 
 /* eslint-disable no-shadow */
 
@@ -183,7 +184,7 @@ export default function ComposeBox(props: Props): Node {
   const auth = useSelector(getAuth);
   const ownUserId = useSelector(getOwnUserId);
   const allUsersById = useSelector(getAllUsersById);
-  const isAdmin = useSelector(getIsAdmin);
+  const isAtLeastAdmin = useSelector(state => roleIsAtLeast(getOwnUserRole(state), Role.Admin));
   const isAnnouncementOnly = useSelector(state =>
     getIsActiveStreamAnnouncementOnly(state, props.narrow),
   );
@@ -594,7 +595,7 @@ export default function ComposeBox(props: Props): Node {
 
   if (!isSubscribed) {
     return <NotSubscribed narrow={narrow} />;
-  } else if (isAnnouncementOnly && !isAdmin) {
+  } else if (isAnnouncementOnly && !isAtLeastAdmin) {
     return <AnnouncementOnly />;
   }
 

--- a/src/directSelectors.js
+++ b/src/directSelectors.js
@@ -98,8 +98,5 @@ export const getRawRealmEmoji = (state: PerAccountState): RealmEmojiById => stat
 export const getNonActiveUsers = (state: PerAccountState): $ReadOnlyArray<User> =>
   state.realm.nonActiveUsers;
 
-// $FlowFixMe[cannot-read] - We'll remove this soon.
-export const getIsAdmin = (state: PerAccountState): boolean => state.realm.isAdmin;
-
 export const getVideoChatProvider = (state: PerAccountState): VideoChatProvider | null =>
   state.realm.videoChatProvider;

--- a/src/directSelectors.js
+++ b/src/directSelectors.js
@@ -98,6 +98,7 @@ export const getRawRealmEmoji = (state: PerAccountState): RealmEmojiById => stat
 export const getNonActiveUsers = (state: PerAccountState): $ReadOnlyArray<User> =>
   state.realm.nonActiveUsers;
 
+// $FlowFixMe[cannot-read] - We'll remove this soon.
 export const getIsAdmin = (state: PerAccountState): boolean => state.realm.isAdmin;
 
 export const getVideoChatProvider = (state: PerAccountState): VideoChatProvider | null =>

--- a/src/message/fetchActions.js
+++ b/src/message/fetchActions.js
@@ -25,7 +25,6 @@ import {
   getLastMessageId,
   getCaughtUpForNarrow,
   getFetchingForNarrow,
-  getIsAdmin,
   getIdentity,
   getStreamsById,
 } from '../selectors';
@@ -51,6 +50,8 @@ import { getAllUsersById, getOwnUserId } from '../users/userSelectors';
 import { getHaveServerData } from '../haveServerDataSelectors';
 import { MIN_RECENTPMS_SERVER_VERSION } from '../pm-conversations/pmConversationsModel';
 import { kNextMinSupportedVersion } from '../common/ServerCompatBanner';
+import { getOwnUserRole, roleIsAtLeast } from '../permissionSelectors';
+import { Role } from '../api/permissionsTypes';
 
 const messageFetchStart = (
   narrow: Narrow,
@@ -285,7 +286,7 @@ export const registerAbort = (reason: RegisterAbortReason): ThunkAction<Promise<
         const realmStr = getIdentity(getState()).realm.toString();
         switch (reason) {
           case 'server':
-            return getIsAdmin(getState())
+            return roleIsAtLeast(getOwnUserRole(getState()), Role.Admin)
               ? `Could not connect to ${realmStr} because the server encountered an error. Please check the server logs.`
               : `Could not connect to ${realmStr} because the server encountered an error. Please ask an admin to check the server logs.`;
           case 'network':

--- a/src/permissionSelectors.js
+++ b/src/permissionSelectors.js
@@ -21,6 +21,8 @@ export function getOwnUserRole(state: PerAccountState): RoleT {
   }
 
   // Servers don't send events to update these.
+  /* $FlowIgnore[cannot-read]: Write-only markers are so we don't read these
+     properties except for in this one spot, where we use them as a fallback. */
   const { isOwner, isAdmin, isModerator, isGuest } = getRealm(state);
 
   if (isOwner) {

--- a/src/realm/__tests__/realmReducer-test.js
+++ b/src/realm/__tests__/realmReducer-test.js
@@ -217,6 +217,12 @@ describe('realmReducer', () => {
   });
 
   describe('EVENT', () => {
+    // TODO(server-4.0): Remove when deprecated properties are removed
+    type ReadableRealmState = $Rest<
+      RealmState,
+      {| isOwner: mixed, isAdmin: mixed, isModerator: mixed, isGuest: mixed |},
+    >;
+
     describe('type `custom_profile_fields`', () => {
       const mkState = fields =>
         deepFreeze({ ...eg.plusReduxState.realm, customProfileFields: fields });
@@ -258,7 +264,7 @@ describe('realmReducer', () => {
     describe('type `user_settings`, op `update`', () => {
       const eventCommon = { id: 0, type: EventTypes.user_settings, op: 'update' };
 
-      const mkCheck = <S: $Keys<RealmState>, E: $Keys<UserSettings>>(
+      const mkCheck = <S: $Keys<ReadableRealmState>, E: $Keys<UserSettings>>(
         statePropertyName: S,
         eventPropertyName: E,
       ): (($ElementType<RealmState, S>, $ElementType<UserSettings, E>) => void) => (
@@ -301,7 +307,7 @@ describe('realmReducer', () => {
     describe('type `realm`, op `update_dict`', () => {
       const eventCommon = { id: 0, type: EventTypes.realm, op: 'update_dict', property: 'default' };
 
-      const mkCheck = <S: $Keys<RealmState>, E: $Keys<RealmDataForUpdate>>(
+      const mkCheck = <S: $Keys<ReadableRealmState>, E: $Keys<RealmDataForUpdate>>(
         statePropertyName: S,
         eventPropertyName: E,
       ): (($ElementType<RealmState, S>, $ElementType<RealmDataForUpdate, E>) => void) => (

--- a/src/reduxTypes.js
+++ b/src/reduxTypes.js
@@ -309,10 +309,16 @@ export type RealmState = {|
   //
 
   +canCreateStreams: boolean,
-  +isAdmin: boolean,
-  +isOwner: boolean,
-  +isModerator: boolean,
-  +isGuest: boolean,
+
+  // Deprecated; these don't have events to update them. Use getOwnUserRole,
+  // which uses the self-user's live-updating `role` property when
+  // available.
+  // TODO(server-4.0): Remove these and rely on self-user's `role`.
+  -isAdmin: boolean,
+  -isOwner: boolean,
+  -isModerator: boolean,
+  -isGuest: boolean,
+
   +user_id: UserId | void,
   +email: string | void,
   +crossRealmBots: $ReadOnlyArray<CrossRealmBot>,

--- a/src/reduxTypes.js
+++ b/src/reduxTypes.js
@@ -275,54 +275,54 @@ export type VideoChatProvider = $ReadOnly<{| name: 'jitsi_meet', jitsiServerUrl:
  * @prop canCreateStreams
  * @prop isAdmin
  */
-export type RealmState = $ReadOnly<{|
+export type RealmState = {|
   //
   // InitialDataCustomProfileFields
   //
 
-  customProfileFields: $ReadOnlyArray<CustomProfileField>,
+  +customProfileFields: $ReadOnlyArray<CustomProfileField>,
 
   //
   // InitialDataRealm
   //
 
-  name: string,
-  description: string,
-  nonActiveUsers: $ReadOnlyArray<User>,
-  filters: $ReadOnlyArray<RealmFilter>,
-  emoji: RealmEmojiById,
-  defaultExternalAccounts: Map<string, {| +url_pattern: string |}>,
-  videoChatProvider: VideoChatProvider | null,
-  mandatoryTopics: boolean,
-  messageContentDeleteLimitSeconds: number | null,
-  messageContentEditLimitSeconds: number,
-  pushNotificationsEnabled: boolean,
-  createPublicStreamPolicy: CreatePublicOrPrivateStreamPolicyT,
-  createPrivateStreamPolicy: CreatePublicOrPrivateStreamPolicyT,
-  webPublicStreamsEnabled: boolean,
-  createWebPublicStreamPolicy: CreateWebPublicStreamPolicyT,
-  enableSpectatorAccess: boolean,
-  waitingPeriodThreshold: number,
+  +name: string,
+  +description: string,
+  +nonActiveUsers: $ReadOnlyArray<User>,
+  +filters: $ReadOnlyArray<RealmFilter>,
+  +emoji: RealmEmojiById,
+  +defaultExternalAccounts: Map<string, {| +url_pattern: string |}>,
+  +videoChatProvider: VideoChatProvider | null,
+  +mandatoryTopics: boolean,
+  +messageContentDeleteLimitSeconds: number | null,
+  +messageContentEditLimitSeconds: number,
+  +pushNotificationsEnabled: boolean,
+  +createPublicStreamPolicy: CreatePublicOrPrivateStreamPolicyT,
+  +createPrivateStreamPolicy: CreatePublicOrPrivateStreamPolicyT,
+  +webPublicStreamsEnabled: boolean,
+  +createWebPublicStreamPolicy: CreateWebPublicStreamPolicyT,
+  +enableSpectatorAccess: boolean,
+  +waitingPeriodThreshold: number,
 
   //
   // InitialDataRealmUser
   //
 
-  canCreateStreams: boolean,
-  isAdmin: boolean,
-  isOwner: boolean,
-  isModerator: boolean,
-  isGuest: boolean,
-  user_id: UserId | void,
-  email: string | void,
-  crossRealmBots: $ReadOnlyArray<CrossRealmBot>,
+  +canCreateStreams: boolean,
+  +isAdmin: boolean,
+  +isOwner: boolean,
+  +isModerator: boolean,
+  +isGuest: boolean,
+  +user_id: UserId | void,
+  +email: string | void,
+  +crossRealmBots: $ReadOnlyArray<CrossRealmBot>,
 
   //
   // InitialDataUserSettings
   //
 
-  twentyFourHourTime: boolean,
-|}>;
+  +twentyFourHourTime: boolean,
+|};
 
 // TODO: Stop using the 'default' name. Any 'default' semantics should
 // only apply the device level, not within the app. See

--- a/src/streams/StreamSettingsScreen.js
+++ b/src/streams/StreamSettingsScreen.js
@@ -12,7 +12,7 @@ import SwitchRow from '../common/SwitchRow';
 import Screen from '../common/Screen';
 import ZulipButton from '../common/ZulipButton';
 import { getSettings } from '../directSelectors';
-import { getAuth, getIsAdmin, getStreamForId } from '../selectors';
+import { getAuth, getStreamForId } from '../selectors';
 import StreamCard from './StreamCard';
 import { IconPin, IconMute, IconNotifications, IconEdit, IconPlusSquare } from '../common/Icons';
 import { navigateToEditStream, navigateToStreamSubscribers } from '../actions';
@@ -20,6 +20,8 @@ import styles from '../styles';
 import { getSubscriptionsById } from '../subscriptions/subscriptionSelectors';
 import * as api from '../api';
 import getIsNotificationEnabled from './getIsNotificationEnabled';
+import { getOwnUserRole, roleIsAtLeast } from '../permissionSelectors';
+import { Role } from '../api/permissionsTypes';
 
 type Props = $ReadOnly<{|
   navigation: AppNavigationProp<'stream-settings'>,
@@ -28,7 +30,7 @@ type Props = $ReadOnly<{|
 
 export default function StreamSettingsScreen(props: Props): Node {
   const auth = useSelector(getAuth);
-  const isAdmin = useSelector(getIsAdmin);
+  const isAtLeastAdmin = useSelector(state => roleIsAtLeast(getOwnUserRole(state), Role.Admin));
   const stream = useSelector(state => getStreamForId(state, props.route.params.streamId));
   const subscription = useSelector(state =>
     getSubscriptionsById(state).get(props.route.params.streamId),
@@ -98,7 +100,7 @@ export default function StreamSettingsScreen(props: Props): Node {
         </>
       )}
       <View style={styles.padding}>
-        {isAdmin && (
+        {isAtLeastAdmin && (
           // TODO: Group all the stream's attributes together (name,
           //   description, policies, etc.), with an associated "Edit"
           //   button that gives a UI for changing those attributes. For the

--- a/src/streams/TopicItem.js
+++ b/src/streams/TopicItem.js
@@ -24,6 +24,7 @@ import {
 } from '../selectors';
 import { getMute } from '../mute/muteModel';
 import { getUnread } from '../unread/unreadModel';
+import { getOwnUserRole } from '../permissionSelectors';
 
 const componentStyles = createStyleSheet({
   selectedRow: {
@@ -76,6 +77,7 @@ export default function TopicItem(props: Props): Node {
     subscriptions: getSubscriptionsById(state),
     unread: getUnread(state),
     ownUser: getOwnUser(state),
+    ownUserRole: getOwnUserRole(state),
     flags: getFlags(state),
     zulipFeatureLevel: getZulipFeatureLevel(state),
   }));

--- a/src/title/TitleStream.js
+++ b/src/title/TitleStream.js
@@ -26,6 +26,7 @@ import { getMute } from '../mute/muteModel';
 import { showStreamActionSheet, showTopicActionSheet } from '../action-sheets';
 import type { ShowActionSheetWithOptions } from '../action-sheets';
 import { getUnread } from '../unread/unreadModel';
+import { getOwnUserRole } from '../permissionSelectors';
 
 type Props = $ReadOnly<{|
   narrow: Narrow,
@@ -57,6 +58,7 @@ export default function TitleStream(props: Props): Node {
     subscriptions: getSubscriptionsById(state),
     unread: getUnread(state),
     ownUser: getOwnUser(state),
+    ownUserRole: getOwnUserRole(state),
     flags: getFlags(state),
     userSettingStreamNotification: getSettings(state).streamNotification,
     zulipFeatureLevel: getZulipFeatureLevel(state),

--- a/src/webview/backgroundData.js
+++ b/src/webview/backgroundData.js
@@ -35,6 +35,8 @@ import { getMute } from '../mute/muteModel';
 import { getUnread } from '../unread/unreadModel';
 import { getUserStatuses } from '../user-statuses/userStatusesModel';
 import { type UserStatusesState } from '../user-statuses/userStatusesCore';
+import { type RoleT } from '../api/permissionsTypes';
+import { getOwnUserRole } from '../permissionSelectors';
 
 /**
  * Data about the user, the realm, and all known messages.
@@ -56,6 +58,7 @@ export type BackgroundData = $ReadOnly<{|
   allUsersById: Map<UserId, UserOrBot>,
   mutedUsers: MutedUsersState,
   ownUser: User,
+  ownUserRole: RoleT,
   streams: Map<number, Stream>,
   subscriptions: Map<number, Subscription>,
   unread: UnreadState,
@@ -86,6 +89,7 @@ export const getBackgroundData = (
   allUsersById: getAllUsersById(state),
   mutedUsers: getMutedUsers(state),
   ownUser: getOwnUser(state),
+  ownUserRole: getOwnUserRole(state),
   streams: getStreamsById(state),
   subscriptions: getSubscriptionsById(state),
   unread: getUnread(state),


### PR DESCRIPTION
And mark the non-live-updating properties as deprecated.