### PR TITLE
flow [nfc]: Convert $PropertyType and $ElementType to indexed-access syntax

### DIFF
--- a/flow-typed/prettier_v1.x.x.js
+++ b/flow-typed/prettier_v1.x.x.js
@@ -122,21 +122,21 @@ declare module "prettier" {
 
   declare export type CursorOptions = {|
     cursorOffset: number,
-    printWidth?: $PropertyType<Options, "printWidth">,
-    tabWidth?: $PropertyType<Options, "tabWidth">,
-    useTabs?: $PropertyType<Options, "useTabs">,
-    semi?: $PropertyType<Options, "semi">,
-    singleQuote?: $PropertyType<Options, "singleQuote">,
-    trailingComma?: $PropertyType<Options, "trailingComma">,
-    bracketSpacing?: $PropertyType<Options, "bracketSpacing">,
-    jsxBracketSameLine?: $PropertyType<Options, "jsxBracketSameLine">,
-    arrowParens?: $PropertyType<Options, "arrowParens">,
-    parser?: $PropertyType<Options, "parser">,
-    filepath?: $PropertyType<Options, "filepath">,
-    requirePragma?: $PropertyType<Options, "requirePragma">,
-    insertPragma?: $PropertyType<Options, "insertPragma">,
-    proseWrap?: $PropertyType<Options, "proseWrap">,
-    plugins?: $PropertyType<Options, "plugins">
+    printWidth?: Options["printWidth"],
+    tabWidth?: Options["tabWidth"],
+    useTabs?: Options["useTabs"],
+    semi?: Options["semi"],
+    singleQuote?: Options["singleQuote"],
+    trailingComma?: Options["trailingComma"],
+    bracketSpacing?: Options["bracketSpacing"],
+    jsxBracketSameLine?: Options["jsxBracketSameLine"],
+    arrowParens?: Options["arrowParens"],
+    parser?: Options["parser"],
+    filepath?: Options["filepath"],
+    requirePragma?: Options["requirePragma"],
+    insertPragma?: Options["insertPragma"],
+    proseWrap?: Options["proseWrap"],
+    plugins?: Options["plugins"]
   |};
 
   declare export type CursorResult = {|

--- a/src/__tests__/lib/exampleData.js
+++ b/src/__tests__/lib/exampleData.js
@@ -187,19 +187,19 @@ export const makeCrossRealmBot = (
     bot_type: 1,
   });
 
-export const userStatusEmojiUnicode: $PropertyType<UserStatus, 'status_emoji'> = deepFreeze({
+export const userStatusEmojiUnicode: UserStatus['status_emoji'] = deepFreeze({
   reaction_type: 'unicode_emoji',
   emoji_code: '1f44d',
   emoji_name: 'thumbs_up',
 });
 
-export const userStatusEmojiZulipExtra: $PropertyType<UserStatus, 'status_emoji'> = deepFreeze({
+export const userStatusEmojiZulipExtra: UserStatus['status_emoji'] = deepFreeze({
   reaction_type: 'zulip_extra_emoji',
   emoji_code: 'zulip',
   emoji_name: 'zulip',
 });
 
-export const userStatusEmojiRealm: $PropertyType<UserStatus, 'status_emoji'> = deepFreeze({
+export const userStatusEmojiRealm: UserStatus['status_emoji'] = deepFreeze({
   reaction_type: 'realm_emoji',
   emoji_code: '80',
   emoji_name: 'github_parrot',
@@ -983,7 +983,7 @@ export const action = Object.freeze({
  */
 export const mkActionRegisterComplete = (extra: {|
   ...$Rest<InitialData, { ... }>,
-  unread_msgs?: $Rest<$PropertyType<InitialData, 'unread_msgs'>, { ... }>,
+  unread_msgs?: $Rest<InitialData['unread_msgs'], { ... }>,
 |}): PerAccountAction => {
   const { unread_msgs, ...rest } = extra;
   return deepFreeze({

--- a/src/api/eventTypes.js
+++ b/src/api/eventTypes.js
@@ -167,7 +167,7 @@ type StreamUpdateEventBase<K: $Keys<Stream>> = $ReadOnly<{|
   stream_id: number,
   name: string,
   property: K,
-  value: $ElementType<Stream, K>,
+  value: Stream[K],
 |}>;
 
 // https://zulip.com/api/get-events#stream-update
@@ -260,7 +260,7 @@ export type RealmUpdateEvent = $ReadOnly<{|
 
   // TODO(flow): `property` and `value` should correspond
   property: $Keys<RealmDataForUpdate>,
-  value: $ElementType<RealmDataForUpdate, $Keys<RealmDataForUpdate>>,
+  value: RealmDataForUpdate[$Keys<RealmDataForUpdate>],
 
   extra_data: { +upload_quota?: number, ... },
 |}>;

--- a/src/api/eventTypes.js
+++ b/src/api/eventTypes.js
@@ -175,16 +175,16 @@ export type StreamUpdateEvent =
   | {| ...StreamUpdateEventBase<'name'> |}
   | {|
       ...StreamUpdateEventBase<'description'>,
-      +rendered_description: $PropertyType<Stream, 'rendered_description'>,
+      +rendered_description: Stream['rendered_description'],
     |}
   // TODO(server-4.0): New in FL 30.
   | {| ...StreamUpdateEventBase<'date_created'> |}
   | {|
       ...StreamUpdateEventBase<'invite_only'>,
-      +history_public_to_subscribers: $PropertyType<Stream, 'history_public_to_subscribers'>,
+      +history_public_to_subscribers: Stream['history_public_to_subscribers'],
 
       // TODO(server-5.0): New in FL 71.
-      +is_web_public?: $PropertyType<Stream, 'is_web_public'>,
+      +is_web_public?: Stream['is_web_public'],
     |}
   | {| ...StreamUpdateEventBase<'rendered_description'> |}
   | {| ...StreamUpdateEventBase<'is_web_public'> |}
@@ -357,10 +357,10 @@ type PersonCommon =
   | SubsetProperties<UserOrBot, {| +user_id: mixed, +is_billing_admin: mixed |}>
   | SubsetProperties<UserOrBot, {| +user_id: mixed, +delivery_email: mixed |}>
   | {|
-      +user_id: $PropertyType<UserOrBot, 'user_id'>,
+      +user_id: UserOrBot['user_id'],
       +custom_profile_field: {| +id: number, +value: string | null, +rendered_value?: string |},
     |}
-  | {| +user_id: $PropertyType<UserOrBot, 'user_id'>, +new_email: string |};
+  | {| +user_id: UserOrBot['user_id'], +new_email: string |};
 
 /**
  * A realm_user update event, straight from the server.

--- a/src/api/modelTypes.js
+++ b/src/api/modelTypes.js
@@ -299,7 +299,7 @@ export type CrossRealmBot = {|
 
   // (We could be more specific here; but in the interest of reducing
   // differences between CrossRealmBot and User, just follow the latter.)
-  +profile_data?: $ElementType<User, 'profile_data'>,
+  +profile_data?: User['profile_data'],
 
   // We assume this is `true` when present.
   // TODO(server-5.0): New in FL 83, replacing is_cross_realm_bot

--- a/src/api/realmDataTypes.js
+++ b/src/api/realmDataTypes.js
@@ -24,111 +24,111 @@ export type RealmDataForUpdate = $ReadOnly<{
   //
 
   add_custom_emoji_policy:
-    $PropertyType<InitialDataRealm, 'realm_add_custom_emoji_policy'>,
+    InitialDataRealm['realm_add_custom_emoji_policy'],
   allow_community_topic_editing: // deprecated
-    $PropertyType<InitialDataRealm, 'realm_allow_community_topic_editing'>,
+    InitialDataRealm['realm_allow_community_topic_editing'],
   allow_edit_history:
-    $PropertyType<InitialDataRealm, 'realm_allow_edit_history'>,
+    InitialDataRealm['realm_allow_edit_history'],
   allow_message_editing:
-    $PropertyType<InitialDataRealm, 'realm_allow_message_editing'>,
+    InitialDataRealm['realm_allow_message_editing'],
   authentication_methods:
-    $PropertyType<InitialDataRealm, 'realm_authentication_methods'>,
+    InitialDataRealm['realm_authentication_methods'],
   bot_creation_policy:
-    $PropertyType<InitialDataRealm, 'realm_bot_creation_policy'>,
+    InitialDataRealm['realm_bot_creation_policy'],
   community_topic_editing_limit_seconds:
-    $PropertyType<InitialDataRealm, 'realm_community_topic_editing_limit_seconds'>,
+    InitialDataRealm['realm_community_topic_editing_limit_seconds'],
   create_private_stream_policy:
-    $PropertyType<InitialDataRealm, 'realm_create_private_stream_policy'>,
+    InitialDataRealm['realm_create_private_stream_policy'],
   create_public_stream_policy:
-    $PropertyType<InitialDataRealm, 'realm_create_public_stream_policy'>,
+    InitialDataRealm['realm_create_public_stream_policy'],
   create_web_public_stream_policy:
-    $PropertyType<InitialDataRealm, 'realm_create_web_public_stream_policy'>,
+    InitialDataRealm['realm_create_web_public_stream_policy'],
   create_stream_policy: // deprecated
-    $PropertyType<InitialDataRealm, 'realm_create_stream_policy'>,
+    InitialDataRealm['realm_create_stream_policy'],
   default_code_block_language:
-    $PropertyType<InitialDataRealm, 'realm_default_code_block_language'>,
+    InitialDataRealm['realm_default_code_block_language'],
   default_language:
-    $PropertyType<InitialDataRealm, 'realm_default_language'>,
+    InitialDataRealm['realm_default_language'],
   description:
-    $PropertyType<InitialDataRealm, 'realm_description'>,
+    InitialDataRealm['realm_description'],
   digest_emails_enabled:
-    $PropertyType<InitialDataRealm, 'realm_digest_emails_enabled'>,
+    InitialDataRealm['realm_digest_emails_enabled'],
   digest_weekday:
-    $PropertyType<InitialDataRealm, 'realm_digest_weekday'>,
+    InitialDataRealm['realm_digest_weekday'],
   disallow_disposable_email_addresses:
-    $PropertyType<InitialDataRealm, 'realm_disallow_disposable_email_addresses'>,
+    InitialDataRealm['realm_disallow_disposable_email_addresses'],
   edit_topic_policy:
-    $PropertyType<InitialDataRealm, 'realm_edit_topic_policy'>,
+    InitialDataRealm['realm_edit_topic_policy'],
   email_address_visibility:
-    $PropertyType<InitialDataRealm, 'realm_email_address_visibility'>,
+    InitialDataRealm['realm_email_address_visibility'],
   email_changes_disabled:
-    $PropertyType<InitialDataRealm, 'realm_email_changes_disabled'>,
+    InitialDataRealm['realm_email_changes_disabled'],
   emails_restricted_to_domains:
-    $PropertyType<InitialDataRealm, 'realm_emails_restricted_to_domains'>,
+    InitialDataRealm['realm_emails_restricted_to_domains'],
   enable_spectator_access:
-    $PropertyType<InitialDataRealm, 'realm_enable_spectator_access'>,
+    InitialDataRealm['realm_enable_spectator_access'],
   giphy_rating:
-    $PropertyType<InitialDataRealm, 'realm_giphy_rating'>,
+    InitialDataRealm['realm_giphy_rating'],
   icon_source:
-    $PropertyType<InitialDataRealm, 'realm_icon_source'>,
+    InitialDataRealm['realm_icon_source'],
   icon_url:
-    $PropertyType<InitialDataRealm, 'realm_icon_url'>,
+    InitialDataRealm['realm_icon_url'],
   inline_image_preview:
-    $PropertyType<InitialDataRealm, 'realm_inline_image_preview'>,
+    InitialDataRealm['realm_inline_image_preview'],
   inline_url_embed_preview:
-    $PropertyType<InitialDataRealm, 'realm_inline_url_embed_preview'>,
+    InitialDataRealm['realm_inline_url_embed_preview'],
   invite_by_admins_only: // deprecated
-    $PropertyType<InitialDataRealm, 'realm_invite_by_admins_only'>,
+    InitialDataRealm['realm_invite_by_admins_only'],
   invite_required:
-    $PropertyType<InitialDataRealm, 'realm_invite_required'>,
+    InitialDataRealm['realm_invite_required'],
   invite_to_realm_policy:
-    $PropertyType<InitialDataRealm, 'realm_invite_to_realm_policy'>,
+    InitialDataRealm['realm_invite_to_realm_policy'],
   invite_to_stream_policy:
-    $PropertyType<InitialDataRealm, 'realm_invite_to_stream_policy'>,
+    InitialDataRealm['realm_invite_to_stream_policy'],
   logo_source:
-    $PropertyType<InitialDataRealm, 'realm_logo_source'>,
+    InitialDataRealm['realm_logo_source'],
   logo_url:
-    $PropertyType<InitialDataRealm, 'realm_logo_url'>,
+    InitialDataRealm['realm_logo_url'],
   mandatory_topics:
-    $PropertyType<InitialDataRealm, 'realm_mandatory_topics'>,
+    InitialDataRealm['realm_mandatory_topics'],
   message_content_allowed_in_email_notifications:
-    $PropertyType<InitialDataRealm, 'realm_message_content_allowed_in_email_notifications'>,
+    InitialDataRealm['realm_message_content_allowed_in_email_notifications'],
   message_content_delete_limit_seconds:
-    $PropertyType<InitialDataRealm, 'realm_message_content_delete_limit_seconds'>,
+    InitialDataRealm['realm_message_content_delete_limit_seconds'],
   message_content_edit_limit_seconds:
-    $PropertyType<InitialDataRealm, 'realm_message_content_edit_limit_seconds'>,
+    InitialDataRealm['realm_message_content_edit_limit_seconds'],
   move_messages_between_streams_policy:
-    $PropertyType<InitialDataRealm, 'realm_move_messages_between_streams_policy'>,
+    InitialDataRealm['realm_move_messages_between_streams_policy'],
   name:
-    $PropertyType<InitialDataRealm, 'realm_name'>,
+    InitialDataRealm['realm_name'],
   name_changes_disabled:
-    $PropertyType<InitialDataRealm, 'realm_name_changes_disabled'>,
+    InitialDataRealm['realm_name_changes_disabled'],
   night_logo_source:
-    $PropertyType<InitialDataRealm, 'realm_night_logo_source'>,
+    InitialDataRealm['realm_night_logo_source'],
   night_logo_url:
-    $PropertyType<InitialDataRealm, 'realm_night_logo_url'>,
+    InitialDataRealm['realm_night_logo_url'],
   notifications_stream_id:
-    $PropertyType<InitialDataRealm, 'realm_notifications_stream_id'>,
+    InitialDataRealm['realm_notifications_stream_id'],
   plan_type:
-    $PropertyType<InitialDataRealm, 'realm_plan_type'>,
+    InitialDataRealm['realm_plan_type'],
   presence_disabled:
-    $PropertyType<InitialDataRealm, 'realm_presence_disabled'>,
+    InitialDataRealm['realm_presence_disabled'],
   private_message_policy:
-    $PropertyType<InitialDataRealm, 'realm_private_message_policy'>,
+    InitialDataRealm['realm_private_message_policy'],
   send_welcome_emails:
-    $PropertyType<InitialDataRealm, 'realm_send_welcome_emails'>,
+    InitialDataRealm['realm_send_welcome_emails'],
   signup_notifications_stream_id:
-    $PropertyType<InitialDataRealm, 'realm_signup_notifications_stream_id'>,
+    InitialDataRealm['realm_signup_notifications_stream_id'],
   user_group_edit_policy:
-    $PropertyType<InitialDataRealm, 'realm_user_group_edit_policy'>,
+    InitialDataRealm['realm_user_group_edit_policy'],
   video_chat_provider:
-    $PropertyType<InitialDataRealm, 'realm_video_chat_provider'>,
+    InitialDataRealm['realm_video_chat_provider'],
   waiting_period_threshold:
-    $PropertyType<InitialDataRealm, 'realm_waiting_period_threshold'>,
+    InitialDataRealm['realm_waiting_period_threshold'],
   want_advertise_in_communities_directory:
-    $PropertyType<InitialDataRealm, 'realm_want_advertise_in_communities_directory'>,
+    InitialDataRealm['realm_want_advertise_in_communities_directory'],
   wildcard_mention_policy:
-    $PropertyType<InitialDataRealm, 'realm_wildcard_mention_policy'>,
+    InitialDataRealm['realm_wildcard_mention_policy'],
 
   //
   // Keep alphabetical by the InitialDataRealm property. So by

--- a/src/api/streams/createStream.js
+++ b/src/api/streams/createStream.js
@@ -16,17 +16,17 @@ export default (
   streamAttributes: $ReadOnly<{|
     // Ordered by their appearance in the doc.
 
-    name: $PropertyType<Stream, 'name'>,
-    description?: $PropertyType<Stream, 'description'>,
-    invite_only?: $PropertyType<Stream, 'invite_only'>,
+    name: Stream['name'],
+    description?: Stream['description'],
+    invite_only?: Stream['invite_only'],
 
     // TODO(server-5.0): New in FL 98
-    is_web_public?: $PropertyType<Stream, 'is_web_public'>,
+    is_web_public?: Stream['is_web_public'],
 
-    history_public_to_subscribers?: $PropertyType<Stream, 'history_public_to_subscribers'>,
+    history_public_to_subscribers?: Stream['history_public_to_subscribers'],
 
     // TODO(server-3.0): New in FL 1; for older servers, pass is_announcement_only.
-    stream_post_policy?: $PropertyType<Stream, 'stream_post_policy'>,
+    stream_post_policy?: Stream['stream_post_policy'],
 
     // Doesn't take the same special values as Stream.message_retention_days!
     //   https://chat.zulip.org/#narrow/stream/412-api-documentation/topic/message_retention_days/near/1367895
@@ -42,7 +42,7 @@ export default (
     // TODO(server-3.0): Replaced in FL 1 by 'stream_post_policy'.
     // Commented out because this isn't actually in the doc. It probably
     // exists though? Copied from api.updateStream.
-    // is_announcement_only?: $PropertyType<Stream, 'is_announcement_only'>,
+    // is_announcement_only?: Stream['is_announcement_only'],
   |}>,
   options?: $ReadOnly<{|
     // TODO(server-3.0): Send numeric user IDs (#3764), not emails.

--- a/src/api/streams/updateStream.js
+++ b/src/api/streams/updateStream.js
@@ -16,21 +16,21 @@ export default (
     // TODO(#4659): Once we pass the feature level to API methods, this one
     //   should encapsulate a switch at FL 64 related to these two parameters.
     //   See call sites.
-    description?: $PropertyType<Stream, 'description'>,
-    new_name?: $PropertyType<Stream, 'name'>,
+    description?: Stream['description'],
+    new_name?: Stream['name'],
 
     // controls the invite_only property
-    is_private?: $PropertyType<Stream, 'invite_only'>,
+    is_private?: Stream['invite_only'],
 
     // TODO(server-5.0): New in FL 98.
-    is_web_public?: $PropertyType<Stream, 'is_web_public'>,
+    is_web_public?: Stream['is_web_public'],
 
     // TODO(server-3.0): New in FL 1; for older servers, pass is_announcement_only.
-    stream_post_policy?: $PropertyType<Stream, 'stream_post_policy'>,
+    stream_post_policy?: Stream['stream_post_policy'],
 
     // N.B.: Don't pass this without also passing is_web_public; see
     //   https://chat.zulip.org/#narrow/stream/378-api-design/topic/PATCH.20.2Fstreams.2F.7Bstream_id.7D/near/1383984
-    history_public_to_subscribers?: $PropertyType<Stream, 'history_public_to_subscribers'>,
+    history_public_to_subscribers?: Stream['history_public_to_subscribers'],
 
     // Doesn't take the same special values as Stream.message_retention_days!
     //   https://chat.zulip.org/#narrow/stream/412-api-documentation/topic/message_retention_days/near/1367895
@@ -44,6 +44,6 @@ export default (
       | 'forever',
 
     // TODO(server-3.0): Replaced in FL 1 by 'stream_post_policy'.
-    is_announcement_only?: $PropertyType<Stream, 'is_announcement_only'>,
+    is_announcement_only?: Stream['is_announcement_only'],
   |}>,
 ): Promise<ApiResponse> => apiPatch(auth, `streams/${id}`, params);

--- a/src/chat/ChatScreen.js
+++ b/src/chat/ChatScreen.js
@@ -216,7 +216,7 @@ export default function ChatScreen(props: Props): Node {
               initialScrollMessageId={
                 firstUnreadIdInNarrow
                 // `messages` might be empty
-                ?? (messages[messages.length - 1]: $ElementType<typeof messages, number> | void)?.id
+                ?? (messages[messages.length - 1]: (typeof messages)[number] | void)?.id
                 ?? null
               }
               showMessagePlaceholders={showMessagePlaceholders}

--- a/src/common/InputRowRadioButtons.js
+++ b/src/common/InputRowRadioButtons.js
@@ -104,7 +104,7 @@ export default function InputRowRadioButtons<TItemKey: string>(props: Props<TIte
     navigation.navigate({
       name: 'selectable-options',
       key: screenKey,
-      params: (screenParams: $ElementType<GlobalParamList, 'selectable-options'>),
+      params: (screenParams: GlobalParamList['selectable-options']),
     });
   }, [navigation, screenKey, screenParams]);
 

--- a/src/common/Touchable.js
+++ b/src/common/Touchable.js
@@ -9,7 +9,7 @@ import { HIGHLIGHT_COLOR } from '../styles';
 type Props = $ReadOnly<{|
   accessibilityLabel?: string,
   style?: ViewStyleProp,
-  hitSlop?: $PropertyType<ElementConfig<typeof View>, 'hitSlop'>,
+  hitSlop?: ElementConfig<typeof View>['hitSlop'],
   children: Node,
   onPress?: () => void | Promise<void>,
   onLongPress?: () => void,

--- a/src/common/ZulipStatusBar.js
+++ b/src/common/ZulipStatusBar.js
@@ -11,7 +11,7 @@ import { useGlobalSelector } from '../react-redux';
 import { foregroundColorFromBackground } from '../utils/color';
 import { getGlobalSession, getGlobalSettings } from '../selectors';
 
-type BarStyle = $PropertyType<React$ElementConfig<typeof StatusBar>, 'barStyle'>;
+type BarStyle = React$ElementConfig<typeof StatusBar>['barStyle'];
 
 export const getStatusBarColor = (backgroundColor: string | void, theme: ThemeName): string =>
   backgroundColor ?? (theme === 'night' ? 'hsl(212, 28%, 18%)' : 'white');

--- a/src/generics.js
+++ b/src/generics.js
@@ -172,7 +172,7 @@ export type ReadWrite<T: $ReadOnly<{ ... }>> = $Diff<T, {||}>;
 // $Diff and other "type destructors", which as of 2020-08 the Flow team is
 // taking up as a priority:
 //   https://github.com/facebook/flow/issues/7886#issuecomment-669977952
-export type SubsetProperties<T, U> = $ObjMapi<U, <K, V>(K) => $ElementType<T, K>>;
+export type SubsetProperties<T, U> = $ObjMapi<U, <K, V>(K) => T[K]>;
 
 /**
  * Assert a contradiction, statically.  Do nothing at runtime.

--- a/src/react-navigation.js
+++ b/src/react-navigation.js
@@ -76,10 +76,7 @@ export type RouteProp<+RouteName: string, +RouteParams: { ... } | void> = {|
 // $NonMaybeType will also eliminate: the navigator will never be interested
 // in passing one of those values anyway, so as far as it's concerned the
 // type expected for `route` might as well exclude them.)
-export type RouteParamsOf<-C> = $PropertyType<
-  $NonMaybeType<$PropertyType<ElementConfig<C>, 'route'>>,
-  'params',
->;
+export type RouteParamsOf<-C> = $NonMaybeType<ElementConfig<C>['route']>['params'];
 
 /**
  * Exactly like `useNavigation` upstream, but more typed.

--- a/src/realm/__tests__/realmReducer-test.js
+++ b/src/realm/__tests__/realmReducer-test.js
@@ -268,7 +268,7 @@ describe('realmReducer', () => {
         <S: $Keys<ReadableRealmState>, E: $Keys<UserSettings>>(
           statePropertyName: S,
           eventPropertyName: E,
-        ): (($ElementType<RealmState, S>, $ElementType<UserSettings, E>) => void) =>
+        ): ((RealmState[S], UserSettings[E]) => void) =>
         (initialStateValue, eventValue) => {
           /* prettier-ignore */ // (wants to wrap the name weirdly)
           test(`${initialStateValue?.toString() ?? '[nullish]'} → ${eventValue?.toString() ?? '[nullish]'}`, () => {
@@ -310,7 +310,7 @@ describe('realmReducer', () => {
         <S: $Keys<ReadableRealmState>, E: $Keys<RealmDataForUpdate>>(
           statePropertyName: S,
           eventPropertyName: E,
-        ): (($ElementType<RealmState, S>, $ElementType<RealmDataForUpdate, E>) => void) =>
+        ): ((RealmState[S], RealmDataForUpdate[E]) => void) =>
         (initialStateValue, eventValue) => {
           /* prettier-ignore */ // (wants to wrap the name weirdly)
           test(`${initialStateValue?.toString() ?? '[nullish]'} → ${eventValue?.toString() ?? '[nullish]'}`, () => {

--- a/src/settings/__tests__/settingsReducer-test.js
+++ b/src/settings/__tests__/settingsReducer-test.js
@@ -166,7 +166,7 @@ describe('settingsReducer', () => {
         <S: $Keys<SettingsState>, E: $Keys<UserSettings>>(
           statePropertyName: S,
           eventPropertyName: E,
-        ): (($ElementType<SettingsState, S>, $ElementType<UserSettings, E>) => void) =>
+        ): ((SettingsState[S], UserSettings[E]) => void) =>
         (initialStateValue, eventValue) => {
           test(`${initialStateValue.toString()} → ${eventValue?.toString() ?? '[nullish]'}`, () => {
             const initialState = { ...baseState };

--- a/src/types.js
+++ b/src/types.js
@@ -413,7 +413,7 @@ export type MessageListElement =
 //   type [number, number] with its two members marked as covariant. Flow
 //   has no syntax for that yet.
 // eslint-disable-next-line no-unused-expressions
-(k: $PropertyType<MessageListElement, 'key'>): $ReadOnlyArray<number> => k;
+(k: MessageListElement['key']): $ReadOnlyArray<number> => k;
 
 export type TimingItemType = {|
   text: string,

--- a/src/user-statuses/UserStatusScreen.js
+++ b/src/user-statuses/UserStatusScreen.js
@@ -74,12 +74,11 @@ type Props = $ReadOnly<{|
   route: RouteProp<'user-status', void>,
 |}>;
 
-const statusTextFromInputValue = (v: string): $PropertyType<UserStatus, 'status_text'> =>
-  v.trim() || null;
+const statusTextFromInputValue = (v: string): UserStatus['status_text'] => v.trim() || null;
 
-const inputValueFromStatusText = (t: $PropertyType<UserStatus, 'status_text'>): string => t ?? '';
+const inputValueFromStatusText = (t: UserStatus['status_text']): string => t ?? '';
 
-const statusEmojiFromInputValue = (v: EmojiInputValue): $PropertyType<UserStatus, 'status_emoji'> =>
+const statusEmojiFromInputValue = (v: EmojiInputValue): UserStatus['status_emoji'] =>
   v
     ? {
         emoji_name: v.name,
@@ -88,7 +87,7 @@ const statusEmojiFromInputValue = (v: EmojiInputValue): $PropertyType<UserStatus
       }
     : null;
 
-const inputValueFromStatusEmoji = (e: $PropertyType<UserStatus, 'status_emoji'>): EmojiInputValue =>
+const inputValueFromStatusEmoji = (e: UserStatus['status_emoji']): EmojiInputValue =>
   e
     ? {
         type: emojiTypeFromReactionType(e.reaction_type),

--- a/src/users/__tests__/usersReducer-test.js
+++ b/src/users/__tests__/usersReducer-test.js
@@ -68,7 +68,7 @@ describe('usersReducer', () => {
     // Tell ESLint to recognize `check` as a helper function that runs
     // assertions.
     /* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["expect", "check"] }] */
-    const check = <P: $PropertyType<RealmUserUpdateEvent, 'person'>>(
+    const check = <P: RealmUserUpdateEvent['person']>(
       personMaybeWithoutId: $Rest<P, {| user_id?: mixed |}>,
       expectedUser?: User,
     ) => {

--- a/src/users/userSelectors.js
+++ b/src/users/userSelectors.js
@@ -187,9 +187,9 @@ export type CustomProfileFieldValue =
   | { +displayType: 'users', +userIds: $ReadOnlyArray<UserId> };
 
 function interpretCustomProfileField(
-  realmDefaultExternalAccounts: $ElementType<RealmState, 'defaultExternalAccounts'>,
+  realmDefaultExternalAccounts: RealmState['defaultExternalAccounts'],
   realmField: CustomProfileField,
-  profileData: $ElementType<UserOrBot, 'profile_data'>,
+  profileData: UserOrBot['profile_data'],
 ): void | CustomProfileFieldValue {
   const userFieldData = profileData?.[realmField.id.toString()];
   if (!userFieldData) {

--- a/src/users/usersReducer.js
+++ b/src/users/usersReducer.js
@@ -50,7 +50,7 @@ export default (
                     profile_data: (() => {
                       if (person.custom_profile_field.value !== null) {
                         return {
-                          ...(user.profile_data: $PropertyType<User, 'profile_data'>),
+                          ...(user.profile_data: User['profile_data']),
                           [person.custom_profile_field.id]: ({
                             value: person.custom_profile_field.value,
                             rendered_value: person.custom_profile_field.rendered_value,
@@ -61,7 +61,7 @@ export default (
                             // anything with `any`. Remove when doing so
                             // doesn't stop Flow from catching something
                             // wrong on `value` or `rendered_value`.
-                          }: $Values<$NonMaybeType<$PropertyType<User, 'profile_data'>>>),
+                          }: $Values<$NonMaybeType<User['profile_data']>>),
                         };
                       } else {
                         // eslint-disable-next-line no-unused-vars

--- a/src/webview/html/message.js
+++ b/src/webview/html/message.js
@@ -183,7 +183,7 @@ export const flagsStateToStringList = (flags: FlagsState, id: number): $ReadOnly
   Object.keys(flags).filter(key => flags[key][id]);
 
 const senderEmojiStatus = (
-  emoji: $PropertyType<UserStatus, 'status_emoji'>,
+  emoji: UserStatus['status_emoji'],
   allImageEmojiById: $ReadOnly<{| [id: string]: ImageEmojiType |}>,
 ): string =>
   emoji

--- a/types/react-intl.js.flow
+++ b/types/react-intl.js.flow
@@ -146,9 +146,9 @@ interface DisplayNamesOptions {
 }
 interface DisplayNamesResolvedOptions {
   locale: string;
-  style: $NonMaybeType<$PropertyType<DisplayNamesOptions, 'style'>>;
-  type: $NonMaybeType<$PropertyType<DisplayNamesOptions, 'type'>>;
-  fallback: $NonMaybeType<$PropertyType<DisplayNamesOptions, 'fallback'>>;
+  style: $NonMaybeType<DisplayNamesOptions['style']>;
+  type: $NonMaybeType<DisplayNamesOptions['type']>;
+  fallback: $NonMaybeType<DisplayNamesOptions['fallback']>;
 }
 interface ElementPart {
   type: 'element';
@@ -218,7 +218,7 @@ declare export var FormattedDate: React$StatelessFunctionalComponent<
 declare export var FormattedDateParts: React$StatelessFunctionalComponent<
   FormatDateOptions & {
     value: Date | number | string, // Param of Intl.DateTimeFormat.prototype.format(), or `string`
-    children(val: $Call<$PropertyType<Intl$DateTimeFormat, 'formatToParts'>, mixed[]>): React$Element<React$ElementType> | null,
+    children(val: $Call<Intl$DateTimeFormat['formatToParts'], mixed[]>): React$Element<React$ElementType> | null,
     ...
   }, >;
 declare export var FormattedDisplayName: React$StatelessFunctionalComponent<
@@ -250,7 +250,7 @@ declare export var FormattedNumber: React$StatelessFunctionalComponent<
       ...
     }, >;
 declare export var FormattedNumberParts: React$StatelessFunctionalComponent<
-  $PropertyType<Formatter, 'formatNumber'> & {
+  Formatter['formatNumber'] & {
       // Param type of our IntlShape.formatNumber, alias of our
       // IntlFormatters.formatNumber
     value: number,
@@ -258,7 +258,7 @@ declare export var FormattedNumberParts: React$StatelessFunctionalComponent<
     // Callers will get a Flow error until Flow adds a built-in
     // definition for Intl.NumberFormat.prototype.formatToParts():
     //   https://github.com/facebook/flow/issues/8859
-    children(val: $Call<$PropertyType<Intl$NumberFormat, 'formatToParts'>, mixed[]>): React$Element<React$ElementType> | null,
+    children(val: $Call<Intl$NumberFormat['formatToParts'], mixed[]>): React$Element<React$ElementType> | null,
     ...
   }, >;
 declare export var FormattedPlural: React$StatelessFunctionalComponent<WithIntlProps<Props_2>> & {
@@ -287,7 +287,7 @@ declare export var FormattedTime: React$StatelessFunctionalComponent<
 declare export var FormattedTimeParts: React$StatelessFunctionalComponent<
   FormatDateOptions & {
     value: Date | number | string, // Param of Intl.DateTimeFormat.prototype.format(), or `string`
-    children(val: $Call<$PropertyType<Intl$DateTimeFormat, 'formatToParts'>, mixed[]>): React$Element<React$ElementType> | null,
+    children(val: $Call<Intl$DateTimeFormat['formatToParts'], mixed[]>): React$Element<React$ElementType> | null,
     ...
   }, >;
 type Formatter = {
@@ -393,11 +393,11 @@ export interface IntlFormatters<T = React$Node, R = T> {
   formatDateToParts(
     value: Date | number | string, // Param of Intl.DateTimeFormat.prototype.format(), or `string`
     opts?: FormatDateOptions,
-  ): $Call<$PropertyType<Intl$DateTimeFormat, 'formatToParts'>, mixed[]>;
+  ): $Call<Intl$DateTimeFormat['formatToParts'], mixed[]>;
   formatTimeToParts(
     value: Date | number | string, // Param of Intl.DateTimeFormat.prototype.format(), or `string`
     opts?: FormatDateOptions,
-  ): $Call<$PropertyType<Intl$DateTimeFormat, 'formatToParts'>, mixed[]>;
+  ): $Call<Intl$DateTimeFormat['formatToParts'], mixed[]>;
   formatRelativeTime(
     value: number, // First param of our RelativeTimeFormat.prototype.format()
     unit?: FormattableUnit, // Second param of our RelativeTimeFormat.prototype.format()
@@ -414,11 +414,11 @@ export interface IntlFormatters<T = React$Node, R = T> {
     // Callers will get a Flow error until Flow adds a built-in
     // definition for Intl.NumberFormat.prototype.formatToParts():
     //   https://github.com/facebook/flow/issues/8859
-  ): $Call<$PropertyType<Intl$NumberFormat, 'formatToParts'>, mixed[]>;
+  ): $Call<Intl$NumberFormat['formatToParts'], mixed[]>;
   formatPlural(
     value: number, // Param of Intl.PluralRules.prototype.select()
     opts?: FormatPluralOptions,
-  ): $Call<<R>((...args: $FlowFixMe[]) => R) => R, $PropertyType<typeof Intl.PluralRules, 'select'>>;
+  ): $Call<<R>((...args: $FlowFixMe[]) => R) => R, typeof Intl.PluralRules['select']>;
   formatMessage(
     descriptor: MessageDescriptor,
     // The `+` was added to make the properties covariant rather
@@ -836,7 +836,7 @@ declare var PART_TYPE: {|
 type PluralElement = {
   options: {| [key: ValidPluralRule]: PluralOrSelectOption |},
   offset: number,
-  pluralType: $PropertyType<Intl$PluralRulesOptions, 'type'>,
+  pluralType: Intl$PluralRulesOptions['type'],
   ...
 } & BaseElement<typeof TYPE.plural>;
 interface PluralOrSelectOption {
@@ -939,7 +939,7 @@ type RelativeTimeFormatNumberPart = {
   // Callers will get a Flow error until Flow adds a built-in
   // definition for Intl.NumberFormat.prototype.formatToParts():
   //   https://github.com/facebook/flow/issues/8859
-} & $ElementType<$Call<$PropertyType<Intl$NumberFormat, 'formatToParts'>, mixed[]>, number>;
+} & $ElementType<$Call<Intl$NumberFormat['formatToParts'], mixed[]>, number>;
 type RelativeTimeLocaleData = LocaleData<LocaleFieldsData>;
 interface ResolvedIntlListFormatOptions {
   /**

--- a/types/react-intl.js.flow
+++ b/types/react-intl.js.flow
@@ -939,7 +939,7 @@ type RelativeTimeFormatNumberPart = {
   // Callers will get a Flow error until Flow adds a built-in
   // definition for Intl.NumberFormat.prototype.formatToParts():
   //   https://github.com/facebook/flow/issues/8859
-} & $ElementType<$Call<Intl$NumberFormat['formatToParts'], mixed[]>, number>;
+} & $Call<Intl$NumberFormat['formatToParts'], mixed[]>[number];
 type RelativeTimeLocaleData = LocaleData<LocaleFieldsData>;
 interface ResolvedIntlListFormatOptions {
   /**


### PR DESCRIPTION
Such a nicer syntax!  This is available to us now that we've
upgraded Prettier:
  https://github.com/zulip/zulip-mobile/pull/5393#issuecomment-1151612888
and Flow before that:
  https://github.com/zulip/zulip-mobile/pull/5398#discussion_r890444882

Leave in place a number of uses of $ElementType in TsFlower output.
The right way to update those will be for TsFlower to switch to
emitting the new syntax.
