### PR TITLE
nav: Fix navigation-prop types; switch most NavigationService use to navigation props

### DIFF
--- a/src/account-info/CustomProfileFields.js
+++ b/src/account-info/CustomProfileFields.js
@@ -15,7 +15,6 @@ import {
 } from '../users/userSelectors';
 import UserItem from '../users/UserItem';
 import { useNavigation } from '../react-navigation';
-import { navigateToAccountDetails } from '../nav/navActions';
 
 /* eslint-disable no-shadow */
 
@@ -30,7 +29,7 @@ function CustomProfileFieldUser(props: {| +userId: UserId |}): React.Node {
   const navigation = useNavigation();
   const onPress = React.useCallback(
     (user: UserOrBot) => {
-      navigation.dispatch(navigateToAccountDetails(user.user_id));
+      navigation.push('account-details', { userId: user.user_id });
     },
     [navigation],
   );

--- a/src/account-info/ProfileScreen.js
+++ b/src/account-info/ProfileScreen.js
@@ -7,7 +7,6 @@ import { type UserId } from '../api/idTypes';
 import { TranslationContext } from '../boot/TranslationProvider';
 import type { RouteProp } from '../react-navigation';
 import type { MainTabsNavigationProp } from '../main/MainTabsScreen';
-import * as NavigationService from '../nav/NavigationService';
 import { createStyleSheet } from '../styles';
 import { useDispatch, useSelector } from '../react-redux';
 import ZulipButton from '../common/ZulipButton';
@@ -23,6 +22,7 @@ import AwayStatusSwitch from './AwayStatusSwitch';
 import { getOwnUser } from '../users/userSelectors';
 import { getIdentity } from '../account/accountsSelectors';
 import { navigateToAccountDetails } from '../nav/navActions';
+import { useNavigation } from '../react-navigation';
 
 const styles = createStyleSheet({
   buttonRow: {
@@ -36,52 +36,56 @@ const styles = createStyleSheet({
 });
 
 function SetStatusButton(props: {||}) {
+  const navigation = useNavigation();
   return (
     <ZulipButton
       style={styles.button}
       secondary
       text="Set a status"
       onPress={() => {
-        NavigationService.dispatch(navigateToUserStatus());
+        navigation.dispatch(navigateToUserStatus());
       }}
     />
   );
 }
 
 function ProfileButton(props: {| +ownUserId: UserId |}) {
+  const navigation = useNavigation();
   return (
     <ZulipButton
       style={styles.button}
       secondary
       text="Full profile"
       onPress={() => {
-        NavigationService.dispatch(navigateToAccountDetails(props.ownUserId));
+        navigation.dispatch(navigateToAccountDetails(props.ownUserId));
       }}
     />
   );
 }
 
 function SettingsButton(props: {||}) {
+  const navigation = useNavigation();
   return (
     <ZulipButton
       style={styles.button}
       secondary
       text="Settings"
       onPress={() => {
-        NavigationService.dispatch(navigateToSettings());
+        navigation.dispatch(navigateToSettings());
       }}
     />
   );
 }
 
 function SwitchAccountButton(props: {||}) {
+  const navigation = useNavigation();
   return (
     <ZulipButton
       style={styles.button}
       secondary
       text="Switch account"
       onPress={() => {
-        NavigationService.dispatch(navigateToAccountPicker());
+        navigation.dispatch(navigateToAccountPicker());
       }}
     />
   );

--- a/src/account-info/ProfileScreen.js
+++ b/src/account-info/ProfileScreen.js
@@ -10,18 +10,12 @@ import type { MainTabsNavigationProp } from '../main/MainTabsScreen';
 import { createStyleSheet } from '../styles';
 import { useDispatch, useSelector } from '../react-redux';
 import ZulipButton from '../common/ZulipButton';
-import {
-  logout,
-  navigateToAccountPicker,
-  navigateToUserStatus,
-  navigateToSettings,
-} from '../actions';
+import { logout } from '../actions';
 import { tryStopNotifications } from '../notification/notifTokens';
 import AccountDetails from './AccountDetails';
 import AwayStatusSwitch from './AwayStatusSwitch';
 import { getOwnUser } from '../users/userSelectors';
 import { getIdentity } from '../account/accountsSelectors';
-import { navigateToAccountDetails } from '../nav/navActions';
 import { useNavigation } from '../react-navigation';
 
 const styles = createStyleSheet({
@@ -43,7 +37,7 @@ function SetStatusButton(props: {||}) {
       secondary
       text="Set a status"
       onPress={() => {
-        navigation.dispatch(navigateToUserStatus());
+        navigation.push('user-status');
       }}
     />
   );
@@ -57,7 +51,7 @@ function ProfileButton(props: {| +ownUserId: UserId |}) {
       secondary
       text="Full profile"
       onPress={() => {
-        navigation.dispatch(navigateToAccountDetails(props.ownUserId));
+        navigation.push('account-details', { userId: props.ownUserId });
       }}
     />
   );
@@ -71,7 +65,7 @@ function SettingsButton(props: {||}) {
       secondary
       text="Settings"
       onPress={() => {
-        navigation.dispatch(navigateToSettings());
+        navigation.push('settings');
       }}
     />
   );
@@ -85,7 +79,7 @@ function SwitchAccountButton(props: {||}) {
       secondary
       text="Switch account"
       onPress={() => {
-        navigation.dispatch(navigateToAccountPicker());
+        navigation.push('account-pick');
       }}
     />
   );

--- a/src/account/AccountPickScreen.js
+++ b/src/account/AccountPickScreen.js
@@ -8,7 +8,6 @@ import * as api from '../api';
 import { TranslationContext } from '../boot/TranslationProvider';
 import type { RouteProp } from '../react-navigation';
 import type { AppNavigationProp } from '../nav/AppNavigator';
-import * as NavigationService from '../nav/NavigationService';
 import { useGlobalSelector, useGlobalDispatch } from '../react-redux';
 import { getAccountStatuses } from '../selectors';
 import Centerer from '../common/Centerer';
@@ -47,14 +46,14 @@ export default function AccountPickScreen(props: Props): Node {
       } else {
         try {
           const serverSettings: ApiResponseServerSettings = await api.getServerSettings(realm);
-          NavigationService.dispatch(navigateToAuth(serverSettings));
+          navigation.dispatch(navigateToAuth(serverSettings));
         } catch {
           // TODO: show specific error message from error object
           showErrorAlert(_('Failed to connect to server: {realm}', { realm: realm.toString() }));
         }
       }
     },
-    [accounts, _, dispatch],
+    [accounts, dispatch, navigation, _],
   );
 
   const handleAccountRemove = useCallback(
@@ -101,7 +100,7 @@ export default function AccountPickScreen(props: Props): Node {
         <ZulipButton
           text="Add new account"
           onPress={() => {
-            NavigationService.dispatch(navigateToRealmInputScreen());
+            navigation.dispatch(navigateToRealmInputScreen());
           }}
         />
       </Centerer>

--- a/src/account/AccountPickScreen.js
+++ b/src/account/AccountPickScreen.js
@@ -16,12 +16,7 @@ import Logo from '../common/Logo';
 import Screen from '../common/Screen';
 import ViewPlaceholder from '../common/ViewPlaceholder';
 import AccountList from './AccountList';
-import {
-  navigateToRealmInputScreen,
-  accountSwitch,
-  removeAccount,
-  navigateToAuth,
-} from '../actions';
+import { accountSwitch, removeAccount } from '../actions';
 import type { ApiResponseServerSettings } from '../api/settings/getServerSettings';
 import { showErrorAlert } from '../utils/info';
 
@@ -46,7 +41,7 @@ export default function AccountPickScreen(props: Props): Node {
       } else {
         try {
           const serverSettings: ApiResponseServerSettings = await api.getServerSettings(realm);
-          navigation.dispatch(navigateToAuth(serverSettings));
+          navigation.push('auth', { serverSettings });
         } catch {
           // TODO: show specific error message from error object
           showErrorAlert(_('Failed to connect to server: {realm}', { realm: realm.toString() }));
@@ -100,7 +95,7 @@ export default function AccountPickScreen(props: Props): Node {
         <ZulipButton
           text="Add new account"
           onPress={() => {
-            navigation.dispatch(navigateToRealmInputScreen());
+            navigation.push('realm-input', { initial: undefined });
           }}
         />
       </Centerer>

--- a/src/chat/PmConversationDetailsScreen.js
+++ b/src/chat/PmConversationDetailsScreen.js
@@ -10,7 +10,6 @@ import type { UserOrBot } from '../types';
 import { pmUiRecipientsFromKeyRecipients, type PmKeyRecipients } from '../utils/recipient';
 import Screen from '../common/Screen';
 import UserItem from '../users/UserItem';
-import { navigateToAccountDetails } from '../actions';
 import { getOwnUserId } from '../selectors';
 
 type Props = $ReadOnly<{|
@@ -25,7 +24,7 @@ export default function PmConversationDetailsScreen(props: Props): Node {
 
   const handlePress = useCallback(
     (user: UserOrBot) => {
-      navigation.dispatch(navigateToAccountDetails(user.user_id));
+      navigation.push('account-details', { userId: user.user_id });
     },
     [navigation],
   );

--- a/src/chat/PmConversationDetailsScreen.js
+++ b/src/chat/PmConversationDetailsScreen.js
@@ -5,7 +5,6 @@ import { FlatList } from 'react-native';
 
 import type { RouteProp } from '../react-navigation';
 import type { AppNavigationProp } from '../nav/AppNavigator';
-import * as NavigationService from '../nav/NavigationService';
 import { useSelector } from '../react-redux';
 import type { UserOrBot } from '../types';
 import { pmUiRecipientsFromKeyRecipients, type PmKeyRecipients } from '../utils/recipient';
@@ -20,12 +19,16 @@ type Props = $ReadOnly<{|
 |}>;
 
 export default function PmConversationDetailsScreen(props: Props): Node {
+  const { navigation } = props;
   const { recipients } = props.route.params;
   const ownUserId = useSelector(getOwnUserId);
 
-  const handlePress = useCallback((user: UserOrBot) => {
-    NavigationService.dispatch(navigateToAccountDetails(user.user_id));
-  }, []);
+  const handlePress = useCallback(
+    (user: UserOrBot) => {
+      navigation.dispatch(navigateToAccountDetails(user.user_id));
+    },
+    [navigation],
+  );
 
   return (
     <Screen title="Recipients" scrollEnabled={false}>

--- a/src/common/InputRowRadioButtons.js
+++ b/src/common/InputRowRadioButtons.js
@@ -12,7 +12,7 @@ import { BRAND_COLOR, createStyleSheet } from '../styles';
 import Touchable from './Touchable';
 import ZulipTextIntl from './ZulipTextIntl';
 import { IconRight } from './Icons';
-import type { AppNavigationProp } from '../nav/AppNavigator';
+import type { AppNavigationMethods } from '../nav/AppNavigator';
 
 type Item<TKey> = $ReadOnly<{|
   key: TKey,
@@ -33,7 +33,7 @@ type Props<TItemKey> = $ReadOnly<{|
    *
    * Pass this down from props or `useNavigation`.
    */
-  navigation: AppNavigationProp<>,
+  navigation: AppNavigationMethods,
 
   /** What the setting is about, e.g., "Theme". */
   label: LocalizableText,

--- a/src/diagnostics/DiagnosticsScreen.js
+++ b/src/diagnostics/DiagnosticsScreen.js
@@ -11,12 +11,6 @@ import NestedNavRow from '../common/NestedNavRow';
 import OptionDivider from '../common/OptionDivider';
 import Screen from '../common/Screen';
 import ZulipText from '../common/ZulipText';
-import {
-  navigateToDebug,
-  navigateToStorage,
-  navigateToTiming,
-  navigateToVariables,
-} from '../actions';
 
 const styles = createStyleSheet({
   versionLabel: {
@@ -39,25 +33,25 @@ export default class DiagnosticsScreen extends PureComponent<Props> {
         <NestedNavRow
           label="Variables"
           onPress={() => {
-            this.props.navigation.dispatch(navigateToVariables());
+            this.props.navigation.push('variables');
           }}
         />
         <NestedNavRow
           label="Timing"
           onPress={() => {
-            this.props.navigation.dispatch(navigateToTiming());
+            this.props.navigation.push('timing');
           }}
         />
         <NestedNavRow
           label="Storage"
           onPress={() => {
-            this.props.navigation.dispatch(navigateToStorage());
+            this.props.navigation.push('storage');
           }}
         />
         <NestedNavRow
           label="Debug"
           onPress={() => {
-            this.props.navigation.dispatch(navigateToDebug());
+            this.props.navigation.push('debug');
           }}
         />
       </Screen>

--- a/src/diagnostics/DiagnosticsScreen.js
+++ b/src/diagnostics/DiagnosticsScreen.js
@@ -6,7 +6,6 @@ import { nativeApplicationVersion } from 'expo-application';
 
 import type { RouteProp } from '../react-navigation';
 import type { AppNavigationProp } from '../nav/AppNavigator';
-import * as NavigationService from '../nav/NavigationService';
 import { createStyleSheet } from '../styles';
 import NestedNavRow from '../common/NestedNavRow';
 import OptionDivider from '../common/OptionDivider';
@@ -40,25 +39,25 @@ export default class DiagnosticsScreen extends PureComponent<Props> {
         <NestedNavRow
           label="Variables"
           onPress={() => {
-            NavigationService.dispatch(navigateToVariables());
+            this.props.navigation.dispatch(navigateToVariables());
           }}
         />
         <NestedNavRow
           label="Timing"
           onPress={() => {
-            NavigationService.dispatch(navigateToTiming());
+            this.props.navigation.dispatch(navigateToTiming());
           }}
         />
         <NestedNavRow
           label="Storage"
           onPress={() => {
-            NavigationService.dispatch(navigateToStorage());
+            this.props.navigation.dispatch(navigateToStorage());
           }}
         />
         <NestedNavRow
           label="Debug"
           onPress={() => {
-            NavigationService.dispatch(navigateToDebug());
+            this.props.navigation.dispatch(navigateToDebug());
           }}
         />
       </Screen>

--- a/src/lightbox/Lightbox.js
+++ b/src/lightbox/Lightbox.js
@@ -8,7 +8,6 @@ import PhotoView from 'react-native-photo-view';
 // $FlowFixMe[untyped-import]
 import { useActionSheet } from '@expo/react-native-action-sheet';
 
-import * as NavigationService from '../nav/NavigationService';
 import type { Message } from '../types';
 import { useGlobalSelector, useSelector } from '../react-redux';
 import type { ShowActionSheetWithOptions } from '../action-sheets';
@@ -21,6 +20,7 @@ import { createStyleSheet } from '../styles';
 import { navigateBack } from '../actions';
 import { streamNameOfStreamMessage } from '../utils/recipient';
 import ZulipStatusBar from '../common/ZulipStatusBar';
+import { useNavigation } from '../react-navigation';
 
 const styles = createStyleSheet({
   img: {
@@ -46,6 +46,7 @@ type Props = $ReadOnly<{|
 |}>;
 
 export default function Lightbox(props: Props): Node {
+  const navigation = useNavigation();
   const [headerFooterVisible, setHeaderFooterVisible] = useState<boolean>(true);
   const showActionSheetWithOptions: ShowActionSheetWithOptions =
     useActionSheet().showActionSheetWithOptions;
@@ -102,7 +103,7 @@ export default function Lightbox(props: Props): Node {
         >
           <LightboxHeader
             onPressBack={() => {
-              NavigationService.dispatch(navigateBack());
+              navigation.dispatch(navigateBack());
             }}
             timestamp={message.timestamp}
             avatarUrl={message.avatar_url}

--- a/src/main/HomeScreen.js
+++ b/src/main/HomeScreen.js
@@ -10,7 +10,7 @@ import { useDispatch } from '../react-redux';
 import { HOME_NARROW, MENTIONED_NARROW, STARRED_NARROW } from '../utils/narrow';
 import { TopTabButton, TopTabButtonGeneral } from '../nav/TopTabButton';
 import UnreadCards from '../unread/UnreadCards';
-import { doNarrow, navigateToSearch } from '../actions';
+import { doNarrow } from '../actions';
 import IconUnreadMentions from '../nav/IconUnreadMentions';
 import { BRAND_COLOR, createStyleSheet } from '../styles';
 import LoadingBanner from '../common/LoadingBanner';
@@ -62,7 +62,7 @@ export default function HomeScreen(props: Props): Node {
         <TopTabButton
           name="search"
           onPress={() => {
-            navigation.dispatch(navigateToSearch());
+            navigation.push('search-messages');
           }}
         />
       </View>

--- a/src/main/HomeScreen.js
+++ b/src/main/HomeScreen.js
@@ -6,7 +6,6 @@ import { View } from 'react-native';
 
 import type { RouteProp } from '../react-navigation';
 import type { MainTabsNavigationProp } from './MainTabsScreen';
-import * as NavigationService from '../nav/NavigationService';
 import { useDispatch } from '../react-redux';
 import { HOME_NARROW, MENTIONED_NARROW, STARRED_NARROW } from '../utils/narrow';
 import { TopTabButton, TopTabButtonGeneral } from '../nav/TopTabButton';
@@ -35,6 +34,7 @@ type Props = $ReadOnly<{|
 |}>;
 
 export default function HomeScreen(props: Props): Node {
+  const { navigation } = props;
   const dispatch = useDispatch();
 
   return (
@@ -62,7 +62,7 @@ export default function HomeScreen(props: Props): Node {
         <TopTabButton
           name="search"
           onPress={() => {
-            NavigationService.dispatch(navigateToSearch());
+            navigation.dispatch(navigateToSearch());
           }}
         />
       </View>

--- a/src/main/MainTabsScreen.js
+++ b/src/main/MainTabsScreen.js
@@ -10,8 +10,7 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import type { RouteProp, RouteParamsOf } from '../react-navigation';
 import { getUnreadHuddlesTotal, getUnreadPmsTotal } from '../selectors';
 import { useSelector } from '../react-redux';
-import type { AppNavigationProp } from '../nav/AppNavigator';
-import type { GlobalParamList } from '../nav/globalTypes';
+import type { AppNavigationMethods, AppNavigationProp } from '../nav/AppNavigator';
 import { bottomTabNavigatorConfig } from '../styles/tabs';
 import HomeScreen from './HomeScreen';
 import StreamTabsScreen from './StreamTabsScreen';
@@ -31,10 +30,15 @@ export type MainTabsNavigatorParamList = {|
 
 export type MainTabsNavigationProp<
   +RouteName: $Keys<MainTabsNavigatorParamList> = $Keys<MainTabsNavigatorParamList>,
-> = BottomTabNavigationProp<GlobalParamList, RouteName>;
+> =
+  // Screens on this navigator will get a `navigation` prop that reflects
+  // this navigator itself…
+  BottomTabNavigationProp<MainTabsNavigatorParamList, RouteName> &
+    // … plus the methods it gets from its parent navigator.
+    AppNavigationMethods;
 
 const Tab = createBottomTabNavigator<
-  GlobalParamList,
+  MainTabsNavigatorParamList,
   MainTabsNavigatorParamList,
   MainTabsNavigationProp<>,
 >();

--- a/src/main/StreamTabsScreen.js
+++ b/src/main/StreamTabsScreen.js
@@ -10,10 +10,10 @@ import ZulipTextIntl from '../common/ZulipTextIntl';
 import { createStyleSheet } from '../styles';
 import type { RouteProp, RouteParamsOf } from '../react-navigation';
 import type { MainTabsNavigationProp } from './MainTabsScreen';
-import type { GlobalParamList } from '../nav/globalTypes';
 import { materialTopTabNavigatorConfig } from '../styles/tabs';
 import SubscriptionsCard from '../streams/SubscriptionsCard';
 import StreamListCard from '../subscriptions/StreamListCard';
+import type { AppNavigationMethods } from '../nav/AppNavigator';
 
 export type StreamTabsNavigatorParamList = {|
   +subscribed: RouteParamsOf<typeof SubscriptionsCard>,
@@ -22,9 +22,14 @@ export type StreamTabsNavigatorParamList = {|
 
 export type StreamTabsNavigationProp<
   +RouteName: $Keys<StreamTabsNavigatorParamList> = $Keys<StreamTabsNavigatorParamList>,
-> = MaterialTopTabNavigationProp<GlobalParamList, RouteName>;
+> =
+  // Screens on this navigator will get a `navigation` prop that reflects
+  // this navigator itself…
+  MaterialTopTabNavigationProp<StreamTabsNavigatorParamList, RouteName> &
+    // … plus the methods it gets from its parent navigator.
+    AppNavigationMethods;
 
-const Tab = createMaterialTopTabNavigator<GlobalParamList>();
+const Tab = createMaterialTopTabNavigator<StreamTabsNavigatorParamList>();
 
 const styles = createStyleSheet({
   tab: {

--- a/src/nav/ChatNavBar.js
+++ b/src/nav/ChatNavBar.js
@@ -24,12 +24,13 @@ import {
   navigateToTopicList,
   doNarrow,
 } from '../actions';
-import * as NavigationService from './NavigationService';
 import { isNarrowValid as getIsNarrowValid } from '../selectors';
 import NavButton from './NavButton';
+import { useNavigation } from '../react-navigation';
 
 function ExtraNavButtonStream(props: {| +color: string, +narrow: Narrow |}): Node {
   const { color, narrow } = props;
+  const navigation = useNavigation();
 
   const isNarrowValid = useSelector(state => getIsNarrowValid(state, narrow));
   if (!isNarrowValid) {
@@ -41,7 +42,7 @@ function ExtraNavButtonStream(props: {| +color: string, +narrow: Narrow |}): Nod
       name="list"
       color={color}
       onPress={() => {
-        NavigationService.dispatch(navigateToTopicList(streamIdOfNarrow(narrow)));
+        navigation.dispatch(navigateToTopicList(streamIdOfNarrow(narrow)));
       }}
     />
   );
@@ -60,6 +61,7 @@ function ExtraNavButtonTopic(props: {| +color: string, +narrow: Narrow |}): Node
 
 function InfoNavButtonStream(props: {| +color: string, +narrow: Narrow |}): Node {
   const { color, narrow } = props;
+  const navigation = useNavigation();
 
   const isNarrowValid = useSelector(state => getIsNarrowValid(state, narrow));
   if (!isNarrowValid) {
@@ -71,7 +73,7 @@ function InfoNavButtonStream(props: {| +color: string, +narrow: Narrow |}): Node
       name="info"
       color={color}
       onPress={() => {
-        NavigationService.dispatch(navigateToStream(streamIdOfNarrow(narrow)));
+        navigation.dispatch(navigateToStream(streamIdOfNarrow(narrow)));
       }}
     />
   );
@@ -79,12 +81,13 @@ function InfoNavButtonStream(props: {| +color: string, +narrow: Narrow |}): Node
 
 function InfoNavButtonPrivate(props: {| +color: string, +userId: UserId |}): Node {
   const { color, userId } = props;
+  const navigation = useNavigation();
   return (
     <NavButton
       name="info"
       color={color}
       onPress={() => {
-        NavigationService.dispatch(navigateToAccountDetails(userId));
+        navigation.dispatch(navigateToAccountDetails(userId));
       }}
     />
   );
@@ -92,12 +95,13 @@ function InfoNavButtonPrivate(props: {| +color: string, +userId: UserId |}): Nod
 
 function InfoNavButtonGroup(props: {| +color: string, +userIds: PmKeyRecipients |}): Node {
   const { color, userIds } = props;
+  const navigation = useNavigation();
   return (
     <NavButton
       name="info"
       color={color}
       onPress={() => {
-        NavigationService.dispatch(navigateToPmConversationDetails(userIds));
+        navigation.dispatch(navigateToPmConversationDetails(userIds));
       }}
     />
   );

--- a/src/nav/ChatNavBar.js
+++ b/src/nav/ChatNavBar.js
@@ -17,13 +17,7 @@ import NavBarBackButton from './NavBarBackButton';
 import { getStreamColorForNarrow } from '../subscriptions/subscriptionSelectors';
 import { foregroundColorFromBackground } from '../utils/color';
 import { caseNarrowDefault, streamIdOfNarrow, streamNarrow } from '../utils/narrow';
-import {
-  navigateToStream,
-  navigateToAccountDetails,
-  navigateToPmConversationDetails,
-  navigateToTopicList,
-  doNarrow,
-} from '../actions';
+import { doNarrow } from '../actions';
 import { isNarrowValid as getIsNarrowValid } from '../selectors';
 import NavButton from './NavButton';
 import { useNavigation } from '../react-navigation';
@@ -42,7 +36,7 @@ function ExtraNavButtonStream(props: {| +color: string, +narrow: Narrow |}): Nod
       name="list"
       color={color}
       onPress={() => {
-        navigation.dispatch(navigateToTopicList(streamIdOfNarrow(narrow)));
+        navigation.push('topic-list', { streamId: streamIdOfNarrow(narrow) });
       }}
     />
   );
@@ -73,7 +67,7 @@ function InfoNavButtonStream(props: {| +color: string, +narrow: Narrow |}): Node
       name="info"
       color={color}
       onPress={() => {
-        navigation.dispatch(navigateToStream(streamIdOfNarrow(narrow)));
+        navigation.push('stream-settings', { streamId: streamIdOfNarrow(narrow) });
       }}
     />
   );
@@ -87,7 +81,7 @@ function InfoNavButtonPrivate(props: {| +color: string, +userId: UserId |}): Nod
       name="info"
       color={color}
       onPress={() => {
-        navigation.dispatch(navigateToAccountDetails(userId));
+        navigation.push('account-details', { userId });
       }}
     />
   );
@@ -101,7 +95,7 @@ function InfoNavButtonGroup(props: {| +color: string, +userIds: PmKeyRecipients 
       name="info"
       color={color}
       onPress={() => {
-        navigation.dispatch(navigateToPmConversationDetails(userIds));
+        navigation.push('pm-conversation-details', { recipients: userIds });
       }}
     />
   );

--- a/src/nav/NavBarBackButton.js
+++ b/src/nav/NavBarBackButton.js
@@ -5,7 +5,7 @@ import { Platform } from 'react-native';
 
 import { navigateBack } from '../actions';
 import NavButton from './NavButton';
-import * as NavigationService from './NavigationService';
+import { useNavigation } from '../react-navigation';
 
 /**
  * The button for the start of the app bar, to return to previous screen.
@@ -26,13 +26,14 @@ export default function NavBarBackButton(props: {| +color?: string |}): Node {
   const { color } = props;
   const iconName = Platform.OS === 'android' ? 'arrow-left' : 'chevron-left';
 
+  const navigation = useNavigation();
   return (
     <NavButton
       name={iconName}
       accessibilityLabel="Navigate up"
       color={color}
       onPress={() => {
-        NavigationService.dispatch(navigateBack());
+        navigation.dispatch(navigateBack());
       }}
     />
   );

--- a/src/nav/navActions.js
+++ b/src/nav/navActions.js
@@ -10,7 +10,6 @@ import * as NavigationService from './NavigationService';
 import type { Message, Narrow, UserId, EmojiType } from '../types';
 import type { PmKeyRecipients } from '../utils/recipient';
 import type { SharedData } from '../sharing/types';
-import type { ApiResponseServerSettings } from '../api/settings/getServerSettings';
 
 // TODO: Probably just do a StackActions.pop()?
 export const navigateBack = (): StackActionType => {
@@ -48,30 +47,9 @@ export const navigateToChat = (narrow: Narrow): NavigationAction =>
 export const replaceWithChat = (narrow: Narrow): NavigationAction =>
   StackActions.replace('chat', { narrow, editMessage: null });
 
-export const navigateToUsersScreen = (): NavigationAction => StackActions.push('users');
-
-export const navigateToSearch = (): NavigationAction => StackActions.push('search-messages');
-
 export const navigateToEmojiPicker = (
   onPressEmoji: ({| +type: EmojiType, +code: string, +name: string |}) => void,
 ): NavigationAction => StackActions.push('emoji-picker', { onPressEmoji });
-
-export const navigateToAuth = (serverSettings: ApiResponseServerSettings): NavigationAction =>
-  StackActions.push('auth', { serverSettings });
-
-export const navigateToDevAuth = (args: {| realm: URL |}): NavigationAction =>
-  StackActions.push('dev-auth', { realm: args.realm });
-
-export const navigateToPasswordAuth = (args: {|
-  realm: URL,
-  requireEmailFormat: boolean,
-|}): NavigationAction =>
-  StackActions.push('password-auth', {
-    realm: args.realm,
-    requireEmailFormat: args.requireEmailFormat,
-  });
-
-export const navigateToAccountPicker = (): NavigationAction => StackActions.push('account-pick');
 
 export const navigateToAccountDetails = (userId: UserId): NavigationAction =>
   StackActions.push('account-details', { userId });
@@ -79,52 +57,16 @@ export const navigateToAccountDetails = (userId: UserId): NavigationAction =>
 export const navigateToPmConversationDetails = (recipients: PmKeyRecipients): NavigationAction =>
   StackActions.push('pm-conversation-details', { recipients });
 
-export const navigateToRealmInputScreen = (): NavigationAction =>
-  StackActions.push('realm-input', { initial: undefined });
-
 export const navigateToLightbox = (src: string, message: Message): NavigationAction =>
   StackActions.push('lightbox', { src, message });
 
-export const navigateToLanguage = (): NavigationAction => StackActions.push('language');
-
-export const navigateToCreateGroup = (): NavigationAction => StackActions.push('create-group');
-
-export const navigateToDiagnostics = (): NavigationAction => StackActions.push('diagnostics');
-
-export const navigateToVariables = (): NavigationAction => StackActions.push('variables');
-
-export const navigateToTiming = (): NavigationAction => StackActions.push('timing');
-
-export const navigateToStorage = (): NavigationAction => StackActions.push('storage');
-
-export const navigateToDebug = (): NavigationAction => StackActions.push('debug');
-
 export const navigateToStream = (streamId: number): NavigationAction =>
   StackActions.push('stream-settings', { streamId });
-
-export const navigateToTopicList = (streamId: number): NavigationAction =>
-  StackActions.push('topic-list', { streamId });
-
-export const navigateToCreateStream = (): NavigationAction => StackActions.push('create-stream');
-
-export const navigateToEditStream = (streamId: number): NavigationAction =>
-  StackActions.push('edit-stream', { streamId });
-
-export const navigateToStreamSubscribers = (streamId: number): NavigationAction =>
-  StackActions.push('invite-users', { streamId });
-
-export const navigateToNotifications = (): NavigationAction => StackActions.push('notifications');
 
 export const navigateToMessageReactionScreen = (
   messageId: number,
   reactionName?: string,
 ): NavigationAction => StackActions.push('message-reactions', { messageId, reactionName });
 
-export const navigateToLegal = (): NavigationAction => StackActions.push('legal');
-
-export const navigateToUserStatus = (): NavigationAction => StackActions.push('user-status');
-
 export const navigateToSharing = (sharedData: SharedData): NavigationAction =>
   StackActions.push('sharing', { sharedData });
-
-export const navigateToSettings = (): NavigationAction => StackActions.push('settings');

--- a/src/pm-conversations/PmConversationsScreen.js
+++ b/src/pm-conversations/PmConversationsScreen.js
@@ -14,7 +14,6 @@ import LoadingBanner from '../common/LoadingBanner';
 import { IconPeople, IconPerson } from '../common/Icons';
 import PmConversationList from './PmConversationList';
 import { getRecentConversations } from '../selectors';
-import { navigateToCreateGroup, navigateToUsersScreen } from '../actions';
 
 const styles = createStyleSheet({
   container: {
@@ -57,7 +56,7 @@ export default function PmConversationsScreen(props: Props): Node {
           style={styles.button}
           text="New PM"
           onPress={() => {
-            setTimeout(() => navigation.dispatch(navigateToUsersScreen()));
+            setTimeout(() => navigation.push('users'));
           }}
         />
         <ZulipButton
@@ -66,7 +65,7 @@ export default function PmConversationsScreen(props: Props): Node {
           style={styles.button}
           text="New group PM"
           onPress={() => {
-            setTimeout(() => navigation.dispatch(navigateToCreateGroup()));
+            setTimeout(() => navigation.push('create-group'));
           }}
         />
       </View>

--- a/src/pm-conversations/PmConversationsScreen.js
+++ b/src/pm-conversations/PmConversationsScreen.js
@@ -6,7 +6,6 @@ import { View } from 'react-native';
 
 import type { RouteProp } from '../react-navigation';
 import type { MainTabsNavigationProp } from '../main/MainTabsScreen';
-import * as NavigationService from '../nav/NavigationService';
 import { ThemeContext, createStyleSheet } from '../styles';
 import { useSelector } from '../react-redux';
 import ZulipTextIntl from '../common/ZulipTextIntl';
@@ -45,6 +44,7 @@ type Props = $ReadOnly<{|
  * The "PMs" page in the main tabs navigation.
  * */
 export default function PmConversationsScreen(props: Props): Node {
+  const { navigation } = props;
   const conversations = useSelector(getRecentConversations);
   const context = useContext(ThemeContext);
 
@@ -57,7 +57,7 @@ export default function PmConversationsScreen(props: Props): Node {
           style={styles.button}
           text="New PM"
           onPress={() => {
-            setTimeout(() => NavigationService.dispatch(navigateToUsersScreen()));
+            setTimeout(() => navigation.dispatch(navigateToUsersScreen()));
           }}
         />
         <ZulipButton
@@ -66,7 +66,7 @@ export default function PmConversationsScreen(props: Props): Node {
           style={styles.button}
           text="New group PM"
           onPress={() => {
-            setTimeout(() => NavigationService.dispatch(navigateToCreateGroup()));
+            setTimeout(() => navigation.dispatch(navigateToCreateGroup()));
           }}
         />
       </View>

--- a/src/react-navigation.js
+++ b/src/react-navigation.js
@@ -26,15 +26,9 @@ import type { AppNavigationMethods } from './nav/AppNavigator';
  * @param {RouteParams} - The type to use for `props.route.params`.
  */
 export type RouteProp<+RouteName: string, +RouteParams: { ... } | void> = {|
-  ...Route<RouteName>,
+  ...$Exact<Route<RouteName>>,
   +params: RouteParams,
-|} /* FlowIssue: This intersection seems redundant -- the first operand
-        should already be a subtype of the second.  But (once we switch to
-        react-navigation types generated from upstream) it fixes a bunch of
-        puzzling errors. */ & {
-  +params: RouteParams,
-  ...
-};
+|};
 
 /**
  * The type of the route params on the given screen component.

--- a/src/react-navigation.js
+++ b/src/react-navigation.js
@@ -5,13 +5,9 @@
  */
 
 import { type ElementConfig } from 'react';
-import {
-  useNavigation as useNavigationInner,
-  type Route,
-  type NavigationProp,
-} from '@react-navigation/native';
+import { useNavigation as useNavigationInner, type Route } from '@react-navigation/native';
 
-import type { GlobalParamList } from './nav/globalTypes';
+import type { AppNavigationMethods } from './nav/AppNavigator';
 
 /**
  * A type to use for the `route` prop on a screen component.
@@ -81,14 +77,20 @@ export type RouteParamsOf<-C> = $NonMaybeType<ElementConfig<C>['route']>['params
 /**
  * Exactly like `useNavigation` upstream, but more typed.
  *
- * In particular, we use our `GlobalParamList` type.
+ * In particular, this provides a type that should be accurate when used on
+ * any screen in the app, with methods only for using the app's main
+ * navigator (which is an ancestor of all our other navigators.)
+ *
+ * This doesn't describe parts of the returned object that will exist only
+ * when on a particular navigator.  If we start needing those, we can make
+ * type-wrappers for them too.
  */
-export function useNavigation(): NavigationProp<GlobalParamList> {
+export function useNavigation(): AppNavigationMethods {
   // The upstream type sure isn't very informative: it lets us do this.
   return useNavigationInner<empty>();
   // The intended way to call it looks to be like this:
-  //     useNavigationInner<NavigationProp<GlobalParamList>>()
-  // But that gives a large number of puzzling errors.  And the one thing it
+  //     useNavigationInner<AppNavigationMethods>()
+  // But that gives a number of puzzling errors.  And the one thing it
   // actually does with the type argument is to determine the return type,
   // anyway.  We know what that should be, so just handle it ourselves.
 }

--- a/src/reactions/MessageReactionsScreen.js
+++ b/src/reactions/MessageReactionsScreen.js
@@ -6,7 +6,6 @@ import { createMaterialTopTabNavigator } from '@react-navigation/material-top-ta
 
 import type { RouteProp } from '../react-navigation';
 import type { AppNavigationProp } from '../nav/AppNavigator';
-import * as NavigationService from '../nav/NavigationService';
 import * as logging from '../utils/logging';
 import ReactionUserList from './ReactionUserList';
 import { useSelector } from '../react-redux';
@@ -40,6 +39,7 @@ type Props = $ReadOnly<{|
  * screen first appears.
  */
 export default function MessageReactionsScreen(props: Props): Node {
+  const { navigation } = props;
   const { messageId, reactionName } = props.route.params;
   const message = useSelector(state => state.messages.get(messageId));
   const ownUserId = useSelector(getOwnUserId);
@@ -59,9 +59,9 @@ export default function MessageReactionsScreen(props: Props): Node {
     if (prevMessage !== undefined && message === undefined) {
       // The message was present, but got purged (currently only caused by a
       // REGISTER_COMPLETE following a dead event queue), so go back.
-      NavigationService.dispatch(navigateBack());
+      navigation.dispatch(navigateBack());
     }
-  }, [prevMessage, message]);
+  }, [prevMessage, message, navigation]);
 
   const content: Node = (() => {
     if (message === undefined) {

--- a/src/reactions/ReactionUserList.js
+++ b/src/reactions/ReactionUserList.js
@@ -5,7 +5,6 @@ import { FlatList } from 'react-native';
 
 import type { UserId, UserOrBot } from '../types';
 import UserItem from '../users/UserItem';
-import { navigateToAccountDetails } from '../actions';
 import { useNavigation } from '../react-navigation';
 
 type Props = $ReadOnly<{|
@@ -30,7 +29,7 @@ export default function ReactionUserList(props: Props): Node {
           key={item}
           userId={item}
           onPress={(user: UserOrBot) => {
-            navigation.dispatch(navigateToAccountDetails(user.user_id));
+            navigation.push('account-details', { userId: user.user_id });
           }}
         />
       )}

--- a/src/reactions/ReactionUserList.js
+++ b/src/reactions/ReactionUserList.js
@@ -3,10 +3,10 @@ import React from 'react';
 import type { Node } from 'react';
 import { FlatList } from 'react-native';
 
-import * as NavigationService from '../nav/NavigationService';
 import type { UserId, UserOrBot } from '../types';
 import UserItem from '../users/UserItem';
 import { navigateToAccountDetails } from '../actions';
+import { useNavigation } from '../react-navigation';
 
 type Props = $ReadOnly<{|
   reactedUserIds: $ReadOnlyArray<UserId>,
@@ -19,6 +19,7 @@ type Props = $ReadOnly<{|
  */
 export default function ReactionUserList(props: Props): Node {
   const { reactedUserIds } = props;
+  const navigation = useNavigation();
 
   return (
     <FlatList
@@ -29,7 +30,7 @@ export default function ReactionUserList(props: Props): Node {
           key={item}
           userId={item}
           onPress={(user: UserOrBot) => {
-            NavigationService.dispatch(navigateToAccountDetails(user.user_id));
+            navigation.dispatch(navigateToAccountDetails(user.user_id));
           }}
         />
       )}

--- a/src/settings/SettingsScreen.js
+++ b/src/settings/SettingsScreen.js
@@ -5,7 +5,6 @@ import type { Node } from 'react';
 
 import type { RouteProp } from '../react-navigation';
 import type { AppNavigationProp } from '../nav/AppNavigator';
-import * as NavigationService from '../nav/NavigationService';
 import { useGlobalSelector, useDispatch } from '../react-redux';
 import { getGlobalSettings } from '../selectors';
 import NestedNavRow from '../common/NestedNavRow';
@@ -38,6 +37,7 @@ export default function SettingsScreen(props: Props): Node {
     state => getGlobalSettings(state).doNotMarkMessagesAsRead,
   );
   const dispatch = useDispatch();
+  const { navigation } = props;
 
   const handleThemeChange = useCallback(() => {
     dispatch(setGlobalSettings({ theme: theme === 'default' ? 'night' : 'default' }));
@@ -64,28 +64,28 @@ export default function SettingsScreen(props: Props): Node {
         Icon={IconNotifications}
         label="Notifications"
         onPress={() => {
-          NavigationService.dispatch(navigateToNotifications());
+          navigation.dispatch(navigateToNotifications());
         }}
       />
       <NestedNavRow
         Icon={IconLanguage}
         label="Language"
         onPress={() => {
-          NavigationService.dispatch(navigateToLanguage());
+          navigation.dispatch(navigateToLanguage());
         }}
       />
       <NestedNavRow
         Icon={IconDiagnostics}
         label="Diagnostics"
         onPress={() => {
-          NavigationService.dispatch(navigateToDiagnostics());
+          navigation.dispatch(navigateToDiagnostics());
         }}
       />
       <NestedNavRow
         Icon={IconMoreHorizontal}
         label="Legal"
         onPress={() => {
-          NavigationService.dispatch(navigateToLegal());
+          navigation.dispatch(navigateToLegal());
         }}
       />
     </Screen>

--- a/src/settings/SettingsScreen.js
+++ b/src/settings/SettingsScreen.js
@@ -4,7 +4,7 @@ import React, { useCallback } from 'react';
 import type { Node } from 'react';
 
 import type { RouteProp } from '../react-navigation';
-import type { MainTabsNavigationProp } from '../main/MainTabsScreen';
+import type { AppNavigationProp } from '../nav/AppNavigator';
 import * as NavigationService from '../nav/NavigationService';
 import { useGlobalSelector, useDispatch } from '../react-redux';
 import { getGlobalSettings } from '../selectors';
@@ -27,7 +27,7 @@ import {
 import { shouldUseInAppBrowser } from '../utils/openLink';
 
 type Props = $ReadOnly<{|
-  navigation: MainTabsNavigationProp<'settings'>,
+  navigation: AppNavigationProp<'settings'>,
   route: RouteProp<'settings', void>,
 |}>;
 

--- a/src/settings/SettingsScreen.js
+++ b/src/settings/SettingsScreen.js
@@ -16,13 +16,7 @@ import {
   IconLanguage,
   IconMoreHorizontal,
 } from '../common/Icons';
-import {
-  setGlobalSettings,
-  navigateToNotifications,
-  navigateToLanguage,
-  navigateToDiagnostics,
-  navigateToLegal,
-} from '../actions';
+import { setGlobalSettings } from '../actions';
 import { shouldUseInAppBrowser } from '../utils/openLink';
 
 type Props = $ReadOnly<{|
@@ -64,28 +58,28 @@ export default function SettingsScreen(props: Props): Node {
         Icon={IconNotifications}
         label="Notifications"
         onPress={() => {
-          navigation.dispatch(navigateToNotifications());
+          navigation.push('notifications');
         }}
       />
       <NestedNavRow
         Icon={IconLanguage}
         label="Language"
         onPress={() => {
-          navigation.dispatch(navigateToLanguage());
+          navigation.push('language');
         }}
       />
       <NestedNavRow
         Icon={IconDiagnostics}
         label="Diagnostics"
         onPress={() => {
-          navigation.dispatch(navigateToDiagnostics());
+          navigation.push('diagnostics');
         }}
       />
       <NestedNavRow
         Icon={IconMoreHorizontal}
         label="Legal"
         onPress={() => {
-          navigation.dispatch(navigateToLegal());
+          navigation.push('legal');
         }}
       />
     </Screen>

--- a/src/sharing/ShareToPm.js
+++ b/src/sharing/ShareToPm.js
@@ -97,6 +97,7 @@ export default class ShareToPm extends React.Component<Props, State> {
 
     return (
       <ShareWrapper
+        navigation={this.props.navigation}
         getValidationErrors={this.getValidationErrors}
         sharedData={sharedData}
         sendTo={sendTo}

--- a/src/sharing/ShareToStream.js
+++ b/src/sharing/ShareToStream.js
@@ -18,7 +18,6 @@ import { fetchTopicsForStream } from '../topics/topicActions';
 import ShareWrapper from './ShareWrapper';
 
 type OuterProps = $ReadOnly<{|
-  // These should be passed from React Navigation
   navigation: SharingNavigationProp<'share-to-stream'>,
   route: RouteProp<'share-to-stream', {| sharedData: SharedData |}>,
 |}>;
@@ -157,6 +156,7 @@ class ShareToStreamInner extends React.Component<Props, State> {
 
     return (
       <ShareWrapper
+        navigation={this.props.navigation}
         sharedData={sharedData}
         getValidationErrors={this.getValidationErrors}
         sendTo={sendTo}

--- a/src/sharing/ShareWrapper.js
+++ b/src/sharing/ShareWrapper.js
@@ -13,7 +13,6 @@ import Input from '../common/Input';
 import ZulipButton from '../common/ZulipButton';
 import ComponentWithOverlay from '../common/ComponentWithOverlay';
 import { TranslationContext } from '../boot/TranslationProvider';
-import * as NavigationService from '../nav/NavigationService';
 import { navigateBack, replaceWithChat } from '../nav/navActions';
 import { showToast, showErrorAlert } from '../utils/info';
 import { getAuth, getOwnUserId } from '../selectors';
@@ -22,6 +21,7 @@ import { streamNarrow, pmNarrowFromRecipients } from '../utils/narrow';
 import { pmKeyRecipientsFromIds } from '../utils/recipient';
 import { ensureUnreachable } from '../generics';
 import { IconAttachment, IconCancel } from '../common/Icons';
+import type { AppNavigationMethods } from '../nav/AppNavigator';
 
 type SendTo =
   | {| type: 'pm', selectedRecipients: $ReadOnlyArray<UserId> |}
@@ -69,6 +69,7 @@ export type ValidationError =
   | 'message-empty';
 
 type OuterProps = $ReadOnly<{|
+  navigation: AppNavigationMethods,
   children: Node,
   getValidationErrors: (message: string) => $ReadOnlyArray<ValidationError>,
   sendTo: SendTo,
@@ -198,7 +199,7 @@ class ShareWrapperInner extends React.Component<Props, State> {
     // it from its parameter (just like `onShareSuccess` does) and not from
     // the props.  That's because the props may have changed since the
     // actual send request we just made.
-    NavigationService.dispatch(navigateBack());
+    this.props.navigation.dispatch(navigateBack());
   };
 
   onShareSuccess = sendTo => {
@@ -208,14 +209,14 @@ class ShareWrapperInner extends React.Component<Props, State> {
         const { ownUserId } = this.props;
         const recipients = pmKeyRecipientsFromIds(selectedRecipients, ownUserId);
         const narrow = pmNarrowFromRecipients(recipients);
-        NavigationService.dispatch(replaceWithChat(narrow));
+        this.props.navigation.dispatch(replaceWithChat(narrow));
         break;
       }
 
       case 'stream': {
         const { streamId } = sendTo;
         const narrow = streamNarrow(streamId);
-        NavigationService.dispatch(replaceWithChat(narrow));
+        this.props.navigation.dispatch(replaceWithChat(narrow));
         break;
       }
 

--- a/src/sharing/SharingScreen.js
+++ b/src/sharing/SharingScreen.js
@@ -6,10 +6,8 @@ import {
   type MaterialTopTabNavigationProp,
 } from '@react-navigation/material-top-tabs';
 
-import type { GlobalParamList } from '../nav/globalTypes';
 import type { RouteParamsOf, RouteProp } from '../react-navigation';
-
-import type { AppNavigationProp } from '../nav/AppNavigator';
+import type { AppNavigationMethods, AppNavigationProp } from '../nav/AppNavigator';
 import * as NavigationService from '../nav/NavigationService';
 import type { SharedData } from './types';
 import { createStyleSheet } from '../styles';
@@ -30,9 +28,14 @@ export type SharingNavigatorParamList = {|
 
 export type SharingNavigationProp<
   +RouteName: $Keys<SharingNavigatorParamList> = $Keys<SharingNavigatorParamList>,
-> = MaterialTopTabNavigationProp<GlobalParamList, RouteName>;
+> =
+  // Screens on this navigator will get a `navigation` prop that reflects
+  // this navigator itself…
+  MaterialTopTabNavigationProp<SharingNavigatorParamList, RouteName> &
+    // … plus the methods it gets from its parent navigator.
+    AppNavigationMethods;
 
-const Tab = createMaterialTopTabNavigator<GlobalParamList>();
+const Tab = createMaterialTopTabNavigator<SharingNavigatorParamList>();
 
 type Props = $ReadOnly<{|
   navigation: AppNavigationProp<'sharing'>,

--- a/src/sharing/SharingScreen.js
+++ b/src/sharing/SharingScreen.js
@@ -8,7 +8,6 @@ import {
 
 import type { RouteParamsOf, RouteProp } from '../react-navigation';
 import type { AppNavigationMethods, AppNavigationProp } from '../nav/AppNavigator';
-import * as NavigationService from '../nav/NavigationService';
 import type { SharedData } from './types';
 import { createStyleSheet } from '../styles';
 import { materialTopTabNavigatorConfig } from '../styles/tabs';
@@ -51,6 +50,7 @@ const styles = createStyleSheet({
 
 export default function SharingScreen(props: Props): Node {
   const { params } = props.route;
+  const { navigation } = props;
   const hasAuth = useGlobalSelector(getHasAuth);
 
   useEffect(() => {
@@ -58,9 +58,9 @@ export default function SharingScreen(props: Props): Node {
       // If there is no active logged-in account, abandon the sharing attempt,
       // and present the account picker screen to the user.
       // TODO(?): Offer to come back and finish the share after auth
-      NavigationService.dispatch(resetToAccountPicker());
+      navigation.dispatch(resetToAccountPicker());
     }
-  }, [hasAuth]);
+  }, [hasAuth, navigation]);
 
   return (
     <Screen canGoBack={false} title="Share on Zulip" shouldShowLoadingBanner={false}>

--- a/src/start/AuthScreen.js
+++ b/src/start/AuthScreen.js
@@ -13,7 +13,6 @@ import type {
 } from '../api/settings/getServerSettings';
 import type { RouteProp } from '../react-navigation';
 import type { AppNavigationProp } from '../nav/AppNavigator';
-import * as NavigationService from '../nav/NavigationService';
 import isAppOwnDomain from '../isAppOwnDomain';
 import type { Dispatch } from '../types';
 import {
@@ -252,13 +251,13 @@ class AuthScreenInner extends PureComponent<Props> {
   };
 
   handleDevAuth = () => {
-    NavigationService.dispatch(navigateToDevAuth({ realm: this.props.realm }));
+    this.props.navigation.dispatch(navigateToDevAuth({ realm: this.props.realm }));
   };
 
   handlePassword = () => {
     const { serverSettings } = this.props.route.params;
     const { realm } = this.props;
-    NavigationService.dispatch(
+    this.props.navigation.dispatch(
       navigateToPasswordAuth({
         realm,
         requireEmailFormat: serverSettings.require_email_format_usernames,

--- a/src/start/AuthScreen.js
+++ b/src/start/AuthScreen.js
@@ -32,7 +32,7 @@ import ZulipButton from '../common/ZulipButton';
 import RealmInfo from './RealmInfo';
 import { encodeParamsForUrl } from '../utils/url';
 import * as webAuth from './webAuth';
-import { loginSuccess, navigateToDevAuth, navigateToPasswordAuth } from '../actions';
+import { loginSuccess } from '../actions';
 import IosCompliantAppleAuthButton from './IosCompliantAppleAuthButton';
 import { openLinkEmbedded } from '../utils/openLink';
 
@@ -251,18 +251,16 @@ class AuthScreenInner extends PureComponent<Props> {
   };
 
   handleDevAuth = () => {
-    this.props.navigation.dispatch(navigateToDevAuth({ realm: this.props.realm }));
+    this.props.navigation.push('dev-auth', { realm: this.props.realm });
   };
 
   handlePassword = () => {
     const { serverSettings } = this.props.route.params;
     const { realm } = this.props;
-    this.props.navigation.dispatch(
-      navigateToPasswordAuth({
-        realm,
-        requireEmailFormat: serverSettings.require_email_format_usernames,
-      }),
-    );
+    this.props.navigation.push('password-auth', {
+      realm,
+      requireEmailFormat: serverSettings.require_email_format_usernames,
+    });
   };
 
   handleNativeAppleAuth = async () => {

--- a/src/start/RealmInputScreen.js
+++ b/src/start/RealmInputScreen.js
@@ -13,7 +13,6 @@ import Screen from '../common/Screen';
 import ZulipButton from '../common/ZulipButton';
 import { tryParseUrl } from '../utils/url';
 import * as api from '../api';
-import { navigateToAuth } from '../actions';
 
 type Props = $ReadOnly<{|
   navigation: AppNavigationProp<'realm-input'>,
@@ -60,7 +59,7 @@ export default class RealmInputScreen extends PureComponent<Props, State> {
     });
     try {
       const serverSettings: ApiResponseServerSettings = await api.getServerSettings(parsedRealm);
-      this.props.navigation.dispatch(navigateToAuth(serverSettings));
+      this.props.navigation.push('auth', { serverSettings });
       Keyboard.dismiss();
     } catch (errorIllTyped) {
       const err: mixed = errorIllTyped; // https://github.com/facebook/flow/issues/2470

--- a/src/start/RealmInputScreen.js
+++ b/src/start/RealmInputScreen.js
@@ -5,7 +5,6 @@ import { Keyboard } from 'react-native';
 
 import type { RouteProp } from '../react-navigation';
 import type { AppNavigationProp } from '../nav/AppNavigator';
-import * as NavigationService from '../nav/NavigationService';
 import type { ApiResponseServerSettings } from '../api/settings/getServerSettings';
 import ErrorMsg from '../common/ErrorMsg';
 import ZulipTextIntl from '../common/ZulipTextIntl';
@@ -61,7 +60,7 @@ export default class RealmInputScreen extends PureComponent<Props, State> {
     });
     try {
       const serverSettings: ApiResponseServerSettings = await api.getServerSettings(parsedRealm);
-      NavigationService.dispatch(navigateToAuth(serverSettings));
+      this.props.navigation.dispatch(navigateToAuth(serverSettings));
       Keyboard.dismiss();
     } catch (errorIllTyped) {
       const err: mixed = errorIllTyped; // https://github.com/facebook/flow/issues/2470

--- a/src/streams/EditStreamCard.js
+++ b/src/streams/EditStreamCard.js
@@ -13,7 +13,7 @@ import {
   getOwnUserRole,
   roleIsAtLeast,
 } from '../permissionSelectors';
-import type { AppNavigationProp } from '../nav/AppNavigator';
+import type { AppNavigationMethods } from '../nav/AppNavigator';
 import Input from '../common/Input';
 import InputRowRadioButtons from '../common/InputRowRadioButtons';
 import ZulipTextIntl from '../common/ZulipTextIntl';
@@ -22,7 +22,7 @@ import styles from '../styles';
 import { TranslationContext } from '../boot/TranslationProvider';
 
 type PropsBase = $ReadOnly<{|
-  navigation: AppNavigationProp<'edit-stream' | 'create-stream'>,
+  navigation: AppNavigationMethods,
 
   initialValues: {|
     name: string,

--- a/src/streams/InviteUsersScreen.js
+++ b/src/streams/InviteUsersScreen.js
@@ -4,7 +4,6 @@ import type { Node } from 'react';
 
 import type { RouteProp } from '../react-navigation';
 import type { AppNavigationProp } from '../nav/AppNavigator';
-import * as NavigationService from '../nav/NavigationService';
 import type { UserOrBot } from '../types';
 import { useSelector } from '../react-redux';
 import Screen from '../common/Screen';
@@ -19,6 +18,7 @@ type Props = $ReadOnly<{|
 |}>;
 
 export default function InviteUsersScreen(props: Props): Node {
+  const { navigation } = props;
   const auth = useSelector(getAuth);
   const stream = useSelector(state => getStreamForId(state, props.route.params.streamId));
 
@@ -29,9 +29,9 @@ export default function InviteUsersScreen(props: Props): Node {
       const recipients = selected.map(user => user.email);
       // This still uses a stream name (#3918) because the API method does; see there.
       api.subscriptionAdd(auth, [{ name: stream.name }], recipients);
-      NavigationService.dispatch(navigateBack());
+      navigation.dispatch(navigateBack());
     },
-    [auth, stream],
+    [auth, navigation, stream.name],
   );
 
   return (

--- a/src/streams/StreamSettingsScreen.js
+++ b/src/streams/StreamSettingsScreen.js
@@ -14,7 +14,6 @@ import { getSettings } from '../directSelectors';
 import { getAuth, getStreamForId } from '../selectors';
 import StreamCard from './StreamCard';
 import { IconPin, IconMute, IconNotifications, IconEdit, IconPlusSquare } from '../common/Icons';
-import { navigateToEditStream, navigateToStreamSubscribers } from '../actions';
 import styles from '../styles';
 import { getSubscriptionsById } from '../subscriptions/subscriptionSelectors';
 import * as api from '../api';
@@ -52,11 +51,11 @@ export default function StreamSettingsScreen(props: Props): Node {
   );
 
   const handlePressEdit = useCallback(() => {
-    navigation.dispatch(navigateToEditStream(stream.stream_id));
+    navigation.push('edit-stream', { streamId: stream.stream_id });
   }, [navigation, stream.stream_id]);
 
   const handlePressEditSubscribers = useCallback(() => {
-    navigation.dispatch(navigateToStreamSubscribers(stream.stream_id));
+    navigation.push('invite-users', { streamId: stream.stream_id });
   }, [navigation, stream.stream_id]);
 
   const handlePressSubscribe = useCallback(() => {

--- a/src/streams/StreamSettingsScreen.js
+++ b/src/streams/StreamSettingsScreen.js
@@ -5,7 +5,6 @@ import { View } from 'react-native';
 
 import type { RouteProp } from '../react-navigation';
 import type { AppNavigationProp } from '../nav/AppNavigator';
-import * as NavigationService from '../nav/NavigationService';
 import { useSelector } from '../react-redux';
 import { delay } from '../utils/async';
 import SwitchRow from '../common/SwitchRow';
@@ -29,6 +28,7 @@ type Props = $ReadOnly<{|
 |}>;
 
 export default function StreamSettingsScreen(props: Props): Node {
+  const { navigation } = props;
   const auth = useSelector(getAuth);
   const isAtLeastAdmin = useSelector(state => roleIsAtLeast(getOwnUserRole(state), Role.Admin));
   const stream = useSelector(state => getStreamForId(state, props.route.params.streamId));
@@ -52,12 +52,12 @@ export default function StreamSettingsScreen(props: Props): Node {
   );
 
   const handlePressEdit = useCallback(() => {
-    NavigationService.dispatch(navigateToEditStream(stream.stream_id));
-  }, [stream]);
+    navigation.dispatch(navigateToEditStream(stream.stream_id));
+  }, [navigation, stream.stream_id]);
 
   const handlePressEditSubscribers = useCallback(() => {
-    NavigationService.dispatch(navigateToStreamSubscribers(stream.stream_id));
-  }, [stream]);
+    navigation.dispatch(navigateToStreamSubscribers(stream.stream_id));
+  }, [navigation, stream.stream_id]);
 
   const handlePressSubscribe = useCallback(() => {
     // This still uses a stream name (#3918) because the API method does; see there.

--- a/src/subscriptions/StreamListCard.js
+++ b/src/subscriptions/StreamListCard.js
@@ -6,7 +6,6 @@ import { View, FlatList } from 'react-native';
 
 import type { RouteProp } from '../react-navigation';
 import type { StreamTabsNavigationProp } from '../main/StreamTabsScreen';
-import * as NavigationService from '../nav/NavigationService';
 import { createStyleSheet } from '../styles';
 import { useDispatch, useSelector } from '../react-redux';
 import ZulipButton from '../common/ZulipButton';
@@ -40,6 +39,7 @@ type Props = $ReadOnly<{|
 |}>;
 
 export default function StreamListCard(props: Props): Node {
+  const { navigation } = props;
   const dispatch = useDispatch();
   const auth = useSelector(getAuth);
   const canCreateStreams = useSelector(getCanCreateStreams);
@@ -79,7 +79,7 @@ export default function StreamListCard(props: Props): Node {
           text="Create new stream"
           onPress={() =>
             delay(() => {
-              NavigationService.dispatch(navigateToCreateStream());
+              navigation.dispatch(navigateToCreateStream());
             })
           }
         />

--- a/src/subscriptions/StreamListCard.js
+++ b/src/subscriptions/StreamListCard.js
@@ -15,7 +15,7 @@ import * as api from '../api';
 import { delay } from '../utils/async';
 import { streamNarrow } from '../utils/narrow';
 import { getAuth, getCanCreateStreams, getStreams } from '../selectors';
-import { doNarrow, navigateToCreateStream } from '../actions';
+import { doNarrow } from '../actions';
 import { caseInsensitiveCompareFunc } from '../utils/misc';
 import StreamItem from '../streams/StreamItem';
 import { getSubscriptionsById } from './subscriptionSelectors';
@@ -79,7 +79,7 @@ export default function StreamListCard(props: Props): Node {
           text="Create new stream"
           onPress={() =>
             delay(() => {
-              navigation.dispatch(navigateToCreateStream());
+              navigation.push('create-stream');
             })
           }
         />

--- a/src/title/TitleGroup.js
+++ b/src/title/TitleGroup.js
@@ -6,11 +6,11 @@ import { View } from 'react-native';
 
 import { useSelector } from '../react-redux';
 import { getMutedUsers, getOwnUserId } from '../selectors';
-import * as NavigationService from '../nav/NavigationService';
 import { pmUiRecipientsFromKeyRecipients, type PmKeyRecipients } from '../utils/recipient';
 import styles, { createStyleSheet } from '../styles';
 import { UserAvatarWithPresenceById } from '../common/UserAvatarWithPresence';
 import { navigateToAccountDetails } from '../nav/navActions';
+import { useNavigation } from '../react-navigation';
 
 type Props = $ReadOnly<{|
   recipients: PmKeyRecipients,
@@ -27,6 +27,7 @@ export default function TitleGroup(props: Props): Node {
   const mutedUsers = useSelector(getMutedUsers);
   const ownUserId = useSelector(getOwnUserId);
   const userIds = pmUiRecipientsFromKeyRecipients(recipients, ownUserId);
+  const navigation = useNavigation();
 
   return (
     <View style={styles.navWrapper}>
@@ -34,7 +35,7 @@ export default function TitleGroup(props: Props): Node {
         <View key={userId} style={componentStyles.titleAvatar}>
           <UserAvatarWithPresenceById
             onPress={() => {
-              NavigationService.dispatch(navigateToAccountDetails(userId));
+              navigation.dispatch(navigateToAccountDetails(userId));
             }}
             size={32}
             userId={userId}

--- a/src/title/TitleGroup.js
+++ b/src/title/TitleGroup.js
@@ -9,7 +9,6 @@ import { getMutedUsers, getOwnUserId } from '../selectors';
 import { pmUiRecipientsFromKeyRecipients, type PmKeyRecipients } from '../utils/recipient';
 import styles, { createStyleSheet } from '../styles';
 import { UserAvatarWithPresenceById } from '../common/UserAvatarWithPresence';
-import { navigateToAccountDetails } from '../nav/navActions';
 import { useNavigation } from '../react-navigation';
 
 type Props = $ReadOnly<{|
@@ -35,7 +34,7 @@ export default function TitleGroup(props: Props): Node {
         <View key={userId} style={componentStyles.titleAvatar}>
           <UserAvatarWithPresenceById
             onPress={() => {
-              navigation.dispatch(navigateToAccountDetails(userId));
+              navigation.push('account-details', { userId });
             }}
             size={32}
             userId={userId}

--- a/src/title/TitlePrivate.js
+++ b/src/title/TitlePrivate.js
@@ -4,7 +4,6 @@ import React from 'react';
 import type { Node } from 'react';
 import { Text, View } from 'react-native';
 
-import * as NavigationService from '../nav/NavigationService';
 import type { UserId } from '../types';
 import styles, { createStyleSheet } from '../styles';
 import { useSelector } from '../react-redux';
@@ -14,6 +13,7 @@ import { UserAvatarWithPresenceById } from '../common/UserAvatarWithPresence';
 import ActivityText from './ActivityText';
 import { tryGetUserForId } from '../users/userSelectors';
 import { navigateToAccountDetails } from '../nav/navActions';
+import { useNavigation } from '../react-navigation';
 
 type Props = $ReadOnly<{|
   userId: UserId,
@@ -29,6 +29,7 @@ const componentStyles = createStyleSheet({
 export default function TitlePrivate(props: Props): Node {
   const { userId, color } = props;
   const user = useSelector(state => tryGetUserForId(state, userId));
+  const navigation = useNavigation();
   if (!user) {
     return null;
   }
@@ -39,7 +40,7 @@ export default function TitlePrivate(props: Props): Node {
         if (!user) {
           return;
         }
-        NavigationService.dispatch(navigateToAccountDetails(user.user_id));
+        navigation.dispatch(navigateToAccountDetails(user.user_id));
       }}
       style={componentStyles.outer}
     >

--- a/src/title/TitlePrivate.js
+++ b/src/title/TitlePrivate.js
@@ -12,7 +12,6 @@ import ViewPlaceholder from '../common/ViewPlaceholder';
 import { UserAvatarWithPresenceById } from '../common/UserAvatarWithPresence';
 import ActivityText from './ActivityText';
 import { tryGetUserForId } from '../users/userSelectors';
-import { navigateToAccountDetails } from '../nav/navActions';
 import { useNavigation } from '../react-navigation';
 
 type Props = $ReadOnly<{|
@@ -40,7 +39,7 @@ export default function TitlePrivate(props: Props): Node {
         if (!user) {
           return;
         }
-        navigation.dispatch(navigateToAccountDetails(user.user_id));
+        navigation.push('account-details', { userId: user.user_id });
       }}
       style={componentStyles.outer}
     >

--- a/src/user-groups/CreateGroupScreen.js
+++ b/src/user-groups/CreateGroupScreen.js
@@ -4,7 +4,6 @@ import type { Node } from 'react';
 
 import type { RouteProp } from '../react-navigation';
 import type { AppNavigationProp } from '../nav/AppNavigator';
-import * as NavigationService from '../nav/NavigationService';
 import type { UserOrBot } from '../types';
 import { useSelector, useDispatch } from '../react-redux';
 import Screen from '../common/Screen';
@@ -20,6 +19,7 @@ type Props = $ReadOnly<{|
 |}>;
 
 export default function CreateGroupScreen(props: Props): Node {
+  const { navigation } = props;
   const dispatch = useDispatch();
   const ownUserId = useSelector(getOwnUserId);
 
@@ -27,10 +27,10 @@ export default function CreateGroupScreen(props: Props): Node {
 
   const handleCreateGroup = useCallback(
     (selected: $ReadOnlyArray<UserOrBot>) => {
-      NavigationService.dispatch(navigateBack());
+      navigation.dispatch(navigateBack());
       dispatch(doNarrow(pmNarrowFromRecipients(pmKeyRecipientsFromUsers(selected, ownUserId))));
     },
-    [dispatch, ownUserId],
+    [dispatch, navigation, ownUserId],
   );
 
   return (

--- a/src/users/UsersCard.js
+++ b/src/users/UsersCard.js
@@ -3,13 +3,13 @@
 import React, { useCallback } from 'react';
 import type { Node } from 'react';
 
-import * as NavigationService from '../nav/NavigationService';
 import type { UserOrBot } from '../types';
 import { useSelector, useDispatch } from '../react-redux';
 import { pm1to1NarrowFromUser } from '../utils/narrow';
 import UserList from './UserList';
 import { getUsers, getPresence } from '../selectors';
 import { navigateBack, doNarrow } from '../actions';
+import { useNavigation } from '../react-navigation';
 
 type Props = $ReadOnly<{|
   filter: string,
@@ -21,12 +21,13 @@ export default function UsersCard(props: Props): Node {
   const users = useSelector(getUsers);
   const presences = useSelector(getPresence);
 
+  const navigation = useNavigation();
   const handleUserNarrow = useCallback(
     (user: UserOrBot) => {
-      NavigationService.dispatch(navigateBack());
+      navigation.dispatch(navigateBack());
       dispatch(doNarrow(pm1to1NarrowFromUser(user)));
     },
-    [dispatch],
+    [dispatch, navigation],
   );
 
   return (

--- a/types/@react-navigation/core/lib/typescript/src/types.js.flow
+++ b/types/@react-navigation/core/lib/typescript/src/types.js.flow
@@ -291,7 +291,7 @@ export type RouteConfig<
         ...
       }) => ScreenListeners<State, EventMap>),
   getId?: ({ params: $ElementType<ParamList, RouteName>, ... }) => string | void,
-  initialParams?: Partial<$ElementType<ParamList, RouteName>>,
+  initialParams?: $ElementType<ParamList, RouteName>,
   ...
 } & (
   | {

--- a/types/@react-navigation/routers/lib/typescript/src/StackRouter.js.flow
+++ b/types/@react-navigation/routers/lib/typescript/src/StackRouter.js.flow
@@ -60,13 +60,13 @@ export type StackNavigationState<ParamList: ParamListBase> = NavigationState<Par
 };
 
 export type StackActionHelpers<ParamList: ParamListBase> = {
-  // prettier-ignore
   replace<RouteName: $Keys<ParamList>>(
-    ...args: $FlowFixMe /*  undefined extends ParamList[RouteName] ? [RouteName] | [RouteName, ParamList[RouteName]] : [RouteName, ParamList[RouteName]] */ /* tsflower-unimplemented: ConditionalType */
+    name: RouteName,
+    params: $ElementType<ParamList, RouteName>,
   ): void,
-  // prettier-ignore
   push<RouteName: $Keys<ParamList>>(
-    ...args: $FlowFixMe /*  undefined extends ParamList[RouteName] ? [RouteName] | [RouteName, ParamList[RouteName]] : [RouteName, ParamList[RouteName]] */ /* tsflower-unimplemented: ConditionalType */
+    name: RouteName,
+    params: $ElementType<ParamList, RouteName>,
   ): void,
   pop(count?: number): void,
   popToTop(): void,

--- a/types/patches/0025-adhoc-rnav-Manually-implement-conditionals-in-functi.patch
+++ b/types/patches/0025-adhoc-rnav-Manually-implement-conditionals-in-functi.patch
@@ -1,0 +1,40 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Greg Price <greg@zulip.com>
+Date: Wed, 8 Jun 2022 10:44:44 -0700
+Subject: [adhoc] rnav: Manually implement conditionals in function param lists
+
+In Flow, this conditional is completely unnecessary: if a function
+accepts void/undefined in its last parameter, then callers can omit
+that parameter just fine.
+
+That makes this a case that TsFlower could potentially just handle
+automatically, if it turns out to keep coming up in practice.
+---
+ .../routers/lib/typescript/src/StackRouter.js.flow        | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git types/@react-navigation/routers/lib/typescript/src/StackRouter.js.flow types/@react-navigation/routers/lib/typescript/src/StackRouter.js.flow
+index cce94da4b..5d79cf4a3 100644
+--- types/@react-navigation/routers/lib/typescript/src/StackRouter.js.flow
++++ types/@react-navigation/routers/lib/typescript/src/StackRouter.js.flow
+@@ -60,13 +60,13 @@ export type StackNavigationState<ParamList: ParamListBase> = NavigationState<Par
+ };
+ 
+ export type StackActionHelpers<ParamList: ParamListBase> = {
+-  // prettier-ignore
+   replace<RouteName: $Keys<ParamList>>(
+-    ...args: $FlowFixMe /*  undefined extends ParamList[RouteName] ? [RouteName] | [RouteName, ParamList[RouteName]] : [RouteName, ParamList[RouteName]] */ /* tsflower-unimplemented: ConditionalType */
++    name: RouteName,
++    params: $ElementType<ParamList, RouteName>,
+   ): void,
+-  // prettier-ignore
+   push<RouteName: $Keys<ParamList>>(
+-    ...args: $FlowFixMe /*  undefined extends ParamList[RouteName] ? [RouteName] | [RouteName, ParamList[RouteName]] : [RouteName, ParamList[RouteName]] */ /* tsflower-unimplemented: ConditionalType */
++    name: RouteName,
++    params: $ElementType<ParamList, RouteName>,
+   ): void,
+   pop(count?: number): void,
+   popToTop(): void,
+-- 
+2.32.0
+

--- a/types/patches/0026-upstream-rnav-Can-initialParams-really-be-partial.patch
+++ b/types/patches/0026-upstream-rnav-Can-initialParams-really-be-partial.patch
@@ -1,0 +1,30 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Greg Price <greg@zulip.com>
+Date: Wed, 8 Jun 2022 14:40:53 -0700
+Subject: [upstream?] rnav: Can initialParams really be partial?
+
+If true, that'd mean that a screen could never actually count on
+getting the route params its type says it should get.  Right?
+
+Even if upstream really does want this API, I'm pretty sure *we*
+don't want it.  We can eliminate it by tightening this type here.
+---
+ types/@react-navigation/core/lib/typescript/src/types.js.flow | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git types/@react-navigation/core/lib/typescript/src/types.js.flow types/@react-navigation/core/lib/typescript/src/types.js.flow
+index b1232ee31..b48b4f6fb 100644
+--- types/@react-navigation/core/lib/typescript/src/types.js.flow
++++ types/@react-navigation/core/lib/typescript/src/types.js.flow
+@@ -291,7 +291,7 @@ export type RouteConfig<
+         ...
+       }) => ScreenListeners<State, EventMap>),
+   getId?: ({ params: $ElementType<ParamList, RouteName>, ... }) => string | void,
+-  initialParams?: Partial<$ElementType<ParamList, RouteName>>,
++  initialParams?: $ElementType<ParamList, RouteName>,
+   ...
+ } & (
+   | {
+-- 
+2.32.0
+


### PR DESCRIPTION
(Note this branch sits atop #5407.)

This branch does several related things in sequence:
 * Fix the type of `useNavigation` to contain less information (for accuracy) and of our navigation props to contain more information (also accurate, but for usefulness.)
 * Switch most uses of `NavigationService` to instead use a component's `navigation` prop, or else `useNavigation`.
 * Replace all the resulting `navigation.dispatch(navigateToFoo(…))` calls with `navigation.push(…)`. (But the `NavigationService.dispatch` calls that remained after the previous step stay in place.)
 * Delete all the `navigateToFoo` nav-action creators (in `navActions.js`) that are no longer used -- which is 22 out of the 34 -- leaving only the ones that are used with `NavigationService.dispatch`.

Switching away from `NavigationService` is recommended by React Navigation upstream, as described at #4417. We also now get type-checking on those `navigation.push` calls -- Flow is able to check that the route params we pass line up with what the route in question expects -- which wasn't/isn't the case for the implementations of the `navActions` functions.

Fixes: #4417
