### PR TITLE
deps [nfc]: Drop resolution for node-gyp under sqlite3

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -2,7 +2,7 @@ PODS:
   - boost (1.76.0)
   - CocoaAsyncSocket (7.6.5)
   - DoubleConversion (1.1.6)
-  - EXAppleAuthentication (4.1.0):
+  - EXAppleAuthentication (4.2.1):
     - ExpoModulesCore
   - EXApplication (3.3.0):
     - ExpoModulesCore
@@ -23,7 +23,7 @@ PODS:
   - EXScreenOrientation (4.0.3):
     - ExpoModulesCore
     - React-Core
-  - EXSQLite (10.1.1):
+  - EXSQLite (10.2.0):
     - ExpoModulesCore
   - EXWebBrowser (9.3.0):
     - ExpoModulesCore
@@ -299,7 +299,7 @@ PODS:
     - glog
   - react-native-cameraroll (4.0.4):
     - React-Core
-  - react-native-image-picker (4.7.3):
+  - react-native-image-picker (4.8.4):
     - React-Core
   - react-native-netinfo (6.0.0):
     - React-Core
@@ -310,7 +310,7 @@ PODS:
   - react-native-simple-toast (1.1.3):
     - React-Core
     - Toast (~> 4.0.0)
-  - react-native-webview (11.18.1):
+  - react-native-webview (11.22.2):
     - React-Core
   - React-perflogger (0.66.4)
   - React-RCTActionSheet (0.66.4):
@@ -379,13 +379,13 @@ PODS:
     - React-perflogger (= 0.66.4)
   - rn-fetch-blob (0.11.2):
     - React-Core
-  - RNCAsyncStorage (1.17.3):
+  - RNCAsyncStorage (1.17.6):
     - React-Core
   - RNCMaskedView (0.1.11):
     - React
   - RNCPushNotificationIOS (1.10.1):
     - React-Core
-  - RNDeviceInfo (8.7.0):
+  - RNDeviceInfo (8.7.1):
     - React-Core
   - RNGestureHandler (1.10.3):
     - React-Core
@@ -418,7 +418,7 @@ PODS:
     - React-RCTVibration
     - ReactCommon/turbomodule/core
     - Yoga
-  - RNSentry (3.4.1):
+  - RNSentry (3.4.3):
     - React-Core
     - Sentry (= 7.11.0)
   - RNVectorIcons (9.1.0):
@@ -655,7 +655,7 @@ SPEC CHECKSUMS:
   boost: a7c83b31436843459a1961bfd74b96033dc77234
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   DoubleConversion: 831926d9b8bf8166fd87886c4abab286c2422662
-  EXAppleAuthentication: 27a4f7dc44a1b510f5af945b58643165ee486d89
+  EXAppleAuthentication: 709a807fe7f48ac6986a2ceed206ee6a8baf28df
   EXApplication: d99a1ecb99dfb63dab8acb66d0181857ee79b25f
   EXConstants: 6d585d93723b18d7a8c283591a335609e3bc153e
   EXErrorRecovery: b0d7582714a2cc896e94a2308a356f94dbf14ef7
@@ -665,7 +665,7 @@ SPEC CHECKSUMS:
   Expo: d9588796cd19999da4d440d87bf7eb7ae4dbd608
   ExpoModulesCore: c9438f6add0fb7b04b7c64eb97a833d2752a7834
   EXScreenOrientation: 80c8c07ab3f2beb8e83ba94ab6ee4fb7a6bf01a6
-  EXSQLite: 908e34753a9dcfbef6a0f3a543ad32a5a6ced452
+  EXSQLite: 2b9accd925438293f9f39e0a57a08cca13bdffb2
   EXWebBrowser: f9435daf809a688e0cb63675da208196007573b6
   FBLazyVector: e5569e42a1c79ca00521846c223173a57aca1fe1
   FBReactNativeSpec: fe08c1cd7e2e205718d77ad14b34957cce949b58
@@ -695,12 +695,12 @@ SPEC CHECKSUMS:
   React-jsinspector: d0374f7509d407d2264168b6d0fad0b54e300b85
   React-logger: 933f80c97c633ee8965d609876848148e3fef438
   react-native-cameraroll: 88f4e62d9ecd0e1f253abe4f685474f2ea14bfa2
-  react-native-image-picker: 4e6008ad8c2321622affa2c85432a5ebd02d480c
+  react-native-image-picker: cffb727cf2f59bd5c0408e30b3dbe0b935f88835
   react-native-netinfo: e849fc21ca2f4128a5726c801a82fc6f4a6db50d
   react-native-photo-view: 63e9e61da873531f931008b545d8d10c5373ddf8
   react-native-safe-area-context: 9e40fb181dac02619414ba1294d6c2a807056ab9
   react-native-simple-toast: bf002828cf816775a6809f7a9ec3907509bce11f
-  react-native-webview: 0b7bd2bffced115aefd393e1841babd9b9a557b1
+  react-native-webview: 159034a856a6e95995f5bf2eed40d70b103d6572
   React-perflogger: 93075d8931c32cd1fce8a98c15d2d5ccc4d891bd
   React-RCTActionSheet: 7d3041e6761b4f3044a37079ddcb156575fb6d89
   React-RCTAnimation: 743e88b55ac62511ae5c2e22803d4f503f2a3a13
@@ -714,13 +714,13 @@ SPEC CHECKSUMS:
   React-runtimeexecutor: dec32ee6f2e2a26e13e58152271535fadff5455a
   ReactCommon: 57b69f6383eafcbd7da625bfa6003810332313c4
   rn-fetch-blob: f525a73a78df9ed5d35e67ea65e79d53c15255bc
-  RNCAsyncStorage: 005c0e2f09575360f142d0d1f1f15e4ec575b1af
+  RNCAsyncStorage: 466b9df1a14bccda91da86e0b7d9a345d78e1673
   RNCMaskedView: 0e1bc4bfa8365eba5fbbb71e07fbdc0555249489
   RNCPushNotificationIOS: 87b8d16d3ede4532745e05b03c42cff33a36cc45
-  RNDeviceInfo: 36286df381fcaf1933ff9d2d3c34ba2abeb2d8d8
+  RNDeviceInfo: aad3c663b25752a52bf8fce93f2354001dd185aa
   RNGestureHandler: a479ebd5ed4221a810967000735517df0d2db211
   RNReanimated: 65583befd5706cc9c86ae9a081786181ced37b93
-  RNSentry: fbbdcd7213058e3de5fbaa452b25a06a16b4b382
+  RNSentry: 85f6525b5fe8d2ada065858026b338605b3c09da
   RNVectorIcons: 7923e585eaeb139b9f4531d25a125a1500162a0b
   Sentry: 0c5cd63d714187b4a39c331c1f0eb04ba7868341
   Toast: 91b396c56ee72a5790816f40d3a94dd357abc196

--- a/package.json
+++ b/package.json
@@ -129,7 +129,6 @@
   "resolutions": {
     "jest-expo/react-test-renderer": "17.0.2",
     "prettier-eslint-cli/prettier-eslint": "^15.0.0",
-    "react-native/use-subscription": ">=1.0.0 <1.6.0",
-    "sqlite3/**/node-gyp": "^8"
+    "react-native/use-subscription": ">=1.0.0 <1.6.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8807,7 +8807,7 @@ node-fetch@^1.0.1:
     encoding "^0.1.11"
     is-stream "^1.0.1"
 
-node-gyp@8.x, node-gyp@^8:
+node-gyp@8.x:
   version "8.4.1"
   resolved "https://registry.yarnpkg.com/node-gyp/-/node-gyp-8.4.1.tgz#3d49308fc31f768180957d6b5746845fbd429937"
   integrity sha512-olTJRgUtAb/hOXG0E93wZDs5YiJlgbXxTwQAFHyNlRsXQnYzUaF2aGgujZbw+hR8aF4ZG/rST57bWMWD16jr9w==


### PR DESCRIPTION
We introduced this line in a7d19c0ed "deps: Force sqlite3 to use a
recent node-gyp", at a time when the sqlite3 package unnecessarily
required a much older version, node-gyp@3.x.

There's now a sqlite3 release (which we've taken) that updates that
dependency to node-gyp@8.x, the same thing our resolution was
requiring.  So drop the resolution and let the package's own metadata
govern from here.

This doesn't immediately change what version we actually use anywhere.
Before and after the change, `yarn why node-gyp` reports:

=> Found "node-gyp@8.4.1"
info Reasons this module exists
   - "sqlite3" depends on it
   - Hoisted from "sqlite3#node-gyp"
…
=> Found "ttf2woff2#node-gyp@9.0.0"
info This module exists because "@vusion#webfonts-generator#ttf2woff2" depends on it.