### PR TITLE
example data: Fix date_joined on users to always be valid

### DIFF
--- a/src/__tests__/lib/exampleData.js
+++ b/src/__tests__/lib/exampleData.js
@@ -153,7 +153,7 @@ const userOrBotProperties = (args: UserOrBotPropertiesArgs) => {
     avatar_url: args.avatar_url ?? makeAvatarUrl(user_id.toString()),
     avatar_version: 0,
 
-    date_joined: `2014-04-${randInt(30).toString().padStart(2, '0')}`,
+    date_joined: `2014-04-${(randInt(30) + 1).toString().padStart(2, '0')}`,
 
     email: args.email ?? `${randName}@example.org`,
     full_name: args.full_name ?? `${randName} User`,


### PR DESCRIPTION
This was coming out as "2014-04-00" 1/30th of the time, which isn't
a valid date string.

As a result, when we go to parse that string in
getHasUserPassedWaitingPeriod or in its tests, it comes out as NaN
and things go haywire.  This caused the flake #5404.

Fix by making the day run from 1 through 30, instead of 0 through 29.

Fixes: #5404