### PR TITLE
realm: Handle missing realm_default_external_accounts before 2.1

### DIFF
--- a/src/api/initialDataTypes.js
+++ b/src/api/initialDataTypes.js
@@ -179,7 +179,9 @@ export type InitialDataRealm = $ReadOnly<{|
   realm_create_web_public_stream_policy?: CreateWebPublicStreamPolicyT,
 
   realm_default_code_block_language: string | null,
-  realm_default_external_accounts: {|
+
+  // TODO(server-2.1): Added in commit 2.1.0-rc1~1382.
+  realm_default_external_accounts?: {|
     +[site_name: string]: {|
       +name: string,
       +text: string,

--- a/src/realm/__tests__/realmReducer-test.js
+++ b/src/realm/__tests__/realmReducer-test.js
@@ -43,7 +43,7 @@ describe('realmReducer', () => {
         defaultExternalAccounts: new Map([
           [
             'github',
-            { url_pattern: action.data.realm_default_external_accounts.github.url_pattern },
+            { url_pattern: action.data.realm_default_external_accounts?.github.url_pattern },
           ],
         ]),
         videoChatProvider: null, // update as necessary if example data changes

--- a/src/realm/realmReducer.js
+++ b/src/realm/realmReducer.js
@@ -121,7 +121,7 @@ export default (
         filters: action.data.realm_filters,
         emoji: convertRealmEmoji(action.data.realm_emoji),
         defaultExternalAccounts: new Map(
-          objectEntries(action.data.realm_default_external_accounts).map(
+          objectEntries(action.data.realm_default_external_accounts ?? {}).map(
             ([name, { url_pattern }]) => [name, { url_pattern }],
           ),
         ),


### PR DESCRIPTION
The introduction of this property isn't mentioned in the API docs
(it's from just before the time when we started being systematic
about such things), which is why we'd had it unconditionally here
in the type.

But from Sentry we know that ee74a9481, which started consuming
this data (and went to beta with v27.187), introduced an error for
a small number of users.  Looking at the server's commit history,
the property was introduced at this point.  Presumably any user
seeing this error is therefore on a pre-2.1 server.  (I believe
the symptom they see is that fresh server data never loads.)

So, mark this property as optional in the types, and add the tiny
bit of fallback code required to handle its absence.

At some point in the future we'll start refusing to handle data from
very old servers (that's #5102), and giving people a reasonable
error message in that case.  When we do (and when that covers all
servers before 2.1), we can stop having this fallback logic.  Until
then, we need it so we don't just break with no explanation.