### PR TITLE
ios: Write better permission-request strings

### DIFF
--- a/ios/ZulipMobile/Info.plist
+++ b/ios/ZulipMobile/Info.plist
@@ -49,13 +49,13 @@
 		</dict>
 	</dict>
 	<key>NSCameraUsageDescription</key>
-	<string>Take a photo and upload it to a Zulip realm</string>
+	<string>By allowing camera access, you can take photos and send them in Zulip messages.</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string></string>
 	<key>NSPhotoLibraryAddUsageDescription</key>
-	<string>Download photos from Zulip realm</string>
+	<string>Save photos you choose from Zulip to your photo library.</string>
 	<key>NSPhotoLibraryUsageDescription</key>
-	<string>Upload photos to a Zulip realm</string>
+	<string>Choose photos from your library and send them in Zulip messages.</string>
 	<key>UIAppFonts</key>
 	<array>
 		<string>zulip-icons.ttf</string>


### PR DESCRIPTION
These drop the developer-facing jargon term "realm"; connect the dots
a bit more on what you as the user might actually choose to do that
the app would need these permissions to do for you; and fit into the
syntactic shape that Apple requests in its UI guidelines:
  https://developer.apple.com/design/human-interface-guidelines/patterns/accessing-private-data#requesting-permission
by being complete sentences ending in periods.

Fixes: #4139