### PR TITLE
nav: Enable react-native-screens

### DIFF
--- a/android/app/src/main/java/com/zulipmobile/MainActivity.kt
+++ b/android/app/src/main/java/com/zulipmobile/MainActivity.kt
@@ -77,7 +77,10 @@ open class MainActivity : ReactActivity() {
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
+        // Discard savedInstanceState.  This is required by react-native-screens:
+        //   https://github.com/software-mansion/react-native-screens/tree/2.18.1#android
+        super.onCreate(null)
+
         WebView.setWebContentsDebuggingEnabled(true)
 
         // Intent is reused after quitting, skip it.

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -418,6 +418,8 @@ PODS:
     - React-RCTVibration
     - ReactCommon/turbomodule/core
     - Yoga
+  - RNScreens (2.18.1):
+    - React-Core
   - RNSentry (3.4.3):
     - React-Core
     - Sentry (= 7.11.0)
@@ -511,6 +513,7 @@ DEPENDENCIES:
   - RNDeviceInfo (from `../node_modules/react-native-device-info`)
   - RNGestureHandler (from `../node_modules/react-native-gesture-handler`)
   - RNReanimated (from `../node_modules/react-native-reanimated`)
+  - RNScreens (from `../node_modules/react-native-screens`)
   - "RNSentry (from `../node_modules/@sentry/react-native`)"
   - RNVectorIcons (from `../node_modules/react-native-vector-icons`)
   - Yoga (from `../node_modules/react-native/ReactCommon/yoga`)
@@ -645,6 +648,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native-gesture-handler"
   RNReanimated:
     :path: "../node_modules/react-native-reanimated"
+  RNScreens:
+    :path: "../node_modules/react-native-screens"
   RNSentry:
     :path: "../node_modules/@sentry/react-native"
   RNVectorIcons:
@@ -721,6 +726,7 @@ SPEC CHECKSUMS:
   RNDeviceInfo: aad3c663b25752a52bf8fce93f2354001dd185aa
   RNGestureHandler: a479ebd5ed4221a810967000735517df0d2db211
   RNReanimated: e28dfaa950064b674fde0a9b736e62b9dff500a7
+  RNScreens: f7ad633b2e0190b77b6a7aab7f914fad6f198d8d
   RNSentry: 85f6525b5fe8d2ada065858026b338605b3c09da
   RNVectorIcons: 7923e585eaeb139b9f4531d25a125a1500162a0b
   Sentry: 0c5cd63d714187b4a39c331c1f0eb04ba7868341

--- a/react-native.config.js
+++ b/react-native.config.js
@@ -22,14 +22,6 @@ module.exports = {
         ios: null,
       },
     },
-    'react-native-screens': {
-      platforms: {
-        // We haven't enabled `react-native-screens` yet, that's
-        // #4111. See 250cde501.
-        android: null,
-        ios: null,
-      },
-    },
     'react-native-vector-icons': {
       platforms: {
         // We're using a setup that doesn't involve linking

--- a/src/ZulipMobile.js
+++ b/src/ZulipMobile.js
@@ -5,6 +5,8 @@ import { Platform, UIManager } from 'react-native';
 import 'react-native-url-polyfill/auto';
 // $FlowFixMe[untyped-import]
 import { ActionSheetProvider } from '@expo/react-native-action-sheet';
+// $FlowFixMe[untyped-import]
+import { enableScreens } from 'react-native-screens';
 
 import RootErrorBoundary from './RootErrorBoundary';
 import ZulipNavigationContainer from './nav/ZulipNavigationContainer';
@@ -19,6 +21,8 @@ import { initializeSentry } from './sentry';
 import ZulipSafeAreaProvider from './boot/ZulipSafeAreaProvider';
 
 initializeSentry();
+
+enableScreens();
 
 // $FlowFixMe[prop-missing]
 console.disableYellowBox = true; // eslint-disable-line

--- a/src/ZulipMobile.js
+++ b/src/ZulipMobile.js
@@ -3,12 +3,10 @@ import React from 'react';
 import type { Node } from 'react';
 import { Platform, UIManager } from 'react-native';
 import 'react-native-url-polyfill/auto';
-import { SafeAreaProvider } from 'react-native-safe-area-context';
 // $FlowFixMe[untyped-import]
 import { ActionSheetProvider } from '@expo/react-native-action-sheet';
 
 import RootErrorBoundary from './RootErrorBoundary';
-import { BRAND_COLOR } from './styles';
 import ZulipNavigationContainer from './nav/ZulipNavigationContainer';
 import StoreProvider from './boot/StoreProvider';
 import StoreHydratedGate from './boot/StoreHydratedGate';
@@ -18,6 +16,7 @@ import CompatibilityChecker from './boot/CompatibilityChecker';
 import AppEventHandlers from './boot/AppEventHandlers';
 import AppDataFetcher from './boot/AppDataFetcher';
 import { initializeSentry } from './sentry';
+import ZulipSafeAreaProvider from './boot/ZulipSafeAreaProvider';
 
 initializeSentry();
 
@@ -52,13 +51,7 @@ export default function ZulipMobile(): Node {
     <RootErrorBoundary>
       <CompatibilityChecker>
         <StoreProvider>
-          <SafeAreaProvider
-            style={{
-              // While waiting for the safe-area insets, this will
-              // show. Best for it not to be a white flicker.
-              backgroundColor: BRAND_COLOR,
-            }}
-          >
+          <ZulipSafeAreaProvider>
             <StoreHydratedGate>
               <AppEventHandlers>
                 <AppDataFetcher>
@@ -72,7 +65,7 @@ export default function ZulipMobile(): Node {
                 </AppDataFetcher>
               </AppEventHandlers>
             </StoreHydratedGate>
-          </SafeAreaProvider>
+          </ZulipSafeAreaProvider>
         </StoreProvider>
       </CompatibilityChecker>
     </RootErrorBoundary>

--- a/src/boot/ZulipSafeAreaProvider.js
+++ b/src/boot/ZulipSafeAreaProvider.js
@@ -12,10 +12,18 @@ type Props = {|
 |};
 
 export default function ZulipSafeAreaProvider(props: Props): React.Node {
-  // This background color appears in at least one situation:
+  // This background color appears in a few situations:
   //
   //  * At startup, just after the loading screen, it covers the whole
   //    screen as a brief flash, just a frame or so.
+  //
+  //  * On iOS (where the stack-navigation transition animations have the
+  //    new screen slide in from and out to the right), when the animation
+  //    has all but the leftmost few pixels covered by the new screen, this
+  //    color replaces the remaining sliver of the old screen.  In
+  //    particular this means at the very end of a push transition, and the
+  //    very beginning of a pop, particularly when the user pops by dragging
+  //    so that the animation goes at the pace of the user's finger.
   //
   // We can make this quirk virtually invisible by giving it the background
   // color used across the app.

--- a/src/boot/ZulipSafeAreaProvider.js
+++ b/src/boot/ZulipSafeAreaProvider.js
@@ -3,21 +3,31 @@ import * as React from 'react';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 
 import { BRAND_COLOR } from '../styles';
+import { useGlobalSelector } from '../react-redux';
+import { getGlobalSettings, getIsHydrated } from '../directSelectors';
+import { themeData } from '../styles/theme';
 
 type Props = {|
   +children: React.Node,
 |};
 
 export default function ZulipSafeAreaProvider(props: Props): React.Node {
-  return (
-    <SafeAreaProvider
-      style={{
-        // While waiting for the safe-area insets, this will
-        // show. Best for it not to be a white flicker.
-        backgroundColor: BRAND_COLOR,
-      }}
-    >
-      {props.children}
-    </SafeAreaProvider>
-  );
+  // This background color appears in at least one situation:
+  //
+  //  * At startup, just after the loading screen, it covers the whole
+  //    screen as a brief flash, just a frame or so.
+  //
+  // We can make this quirk virtually invisible by giving it the background
+  // color used across the app.
+  const backgroundColor = useGlobalSelector(state => {
+    if (!getIsHydrated(state)) {
+      // The only screen we'll be showing at this point is the loading
+      // screen.  Match that screen's background.
+      return BRAND_COLOR;
+    }
+
+    return themeData[getGlobalSettings(state).theme].backgroundColor;
+  });
+
+  return <SafeAreaProvider style={{ backgroundColor }}>{props.children}</SafeAreaProvider>;
 }

--- a/src/boot/ZulipSafeAreaProvider.js
+++ b/src/boot/ZulipSafeAreaProvider.js
@@ -1,0 +1,23 @@
+// @flow strict-local
+import * as React from 'react';
+import { SafeAreaProvider } from 'react-native-safe-area-context';
+
+import { BRAND_COLOR } from '../styles';
+
+type Props = {|
+  +children: React.Node,
+|};
+
+export default function ZulipSafeAreaProvider(props: Props): React.Node {
+  return (
+    <SafeAreaProvider
+      style={{
+        // While waiting for the safe-area insets, this will
+        // show. Best for it not to be a white flicker.
+        backgroundColor: BRAND_COLOR,
+      }}
+    >
+      {props.children}
+    </SafeAreaProvider>
+  );
+}


### PR DESCRIPTION
This greatly improves performance on Android with many screens on
the nav stack!  On iOS, the effect is less dramatic, but still
significant.

Chris investigated this back in 2020 (#4111), and sent a draft PR
to enable it (#4161), but we never followed up, oops.  Better late
than never.

Experiment to repro the perf difference:

  1. push like 30 ChatScreen screens to the stack, by following a
     loop of internal links;

  2. go to one with some backlog (by following the "up" icon to the
     stream message-list);

  3. try scrolling around.

Before, on Android: extremely laggy.  Also pretty laggy even just
following those links, after the first few.

After: pretty much as smooth with 30 screens on the stack as with the
first one.

On iOS, things seem to already be about as smooth with 30 screens as
with one, even before this change; in particular, scrolling through
the message list is very smooth.  (That's even though the app in my
iOS testing is fairly sluggish on the first few navigations.  I was
using the simulator on an underpowered Mac Mini, vs. the Android
emulator on my fast Linux desktop.)

But Xcode does report (under the "Debug View Hierarchy" button) that
before the change, tons and tons of views remain mounted when many
screens are on the stack; after the change, they don't.  I reproduce
the same observations Chris reported a couple of years ago here:
  https://github.com/zulip/zulip-mobile/issues/4111#issuecomment-643519230

More concretely, the memory usage (which Xcode reports at the same
time) gets cut way down: around 700 MB before, and around 300 MB
after.  If nothing else, that should mean that the app is less
likely to get killed by the OS if the user switches away -- so is
more likely to pick up immediately where they left off, rather than
have to reload from scratch, if the user switches back.

Fixes: #4111