### PR TITLE
i18n [nfc]: Handle LocalizableText in `_`

### DIFF
--- a/src/boot/TranslationProvider.js
+++ b/src/boot/TranslationProvider.js
@@ -35,19 +35,23 @@ export function withGetText<P: { +_: GetText, ... }, C: ComponentType<P>>(
 }
 
 const makeGetText = (intl: IntlShape): GetText => {
-  const _ = (message, values) =>
-    intl.formatMessage(
+  const _ = (message, values_) => {
+    const text = typeof message === 'object' ? message.text : message;
+    const values = typeof message === 'object' ? message.values : values_;
+
+    return intl.formatMessage(
       {
-        id: message,
+        id: text,
 
         // If you see this in dev, it means there's a user-facing
         // string that hasn't been added to
         // static/translations/messages_en.json. Please add it! :)
         defaultMessage:
-          process.env.NODE_ENV === 'development' ? `UNTRANSLATED—${message}—UNTRANSLATED` : message,
+          process.env.NODE_ENV === 'development' ? `UNTRANSLATED—${text}—UNTRANSLATED` : text,
       },
       values,
     );
+  };
   _.intl = intl;
   return _;
 };

--- a/src/common/Input.js
+++ b/src/common/Input.js
@@ -62,15 +62,10 @@ export default function Input(props: Props): Node {
   const themeContext = useContext(ThemeContext);
   const _ = useContext(TranslationContext);
 
-  const fullPlaceholder =
-    typeof placeholder === 'object' /* force linebreak */
-      ? placeholder
-      : { text: placeholder, values: undefined };
-
   return (
     <TextInput
       style={[componentStyles.input, { color: themeContext.color }, style]}
-      placeholder={_(fullPlaceholder.text, fullPlaceholder.values)}
+      placeholder={_(placeholder)}
       placeholderTextColor={HALF_COLOR}
       underlineColorAndroid={isFocused ? BORDER_COLOR : HALF_COLOR}
       onFocus={handleFocus}

--- a/src/common/SelectableOptionRow.js
+++ b/src/common/SelectableOptionRow.js
@@ -109,17 +109,8 @@ export default function SelectableOptionRow<TItemKey: string | number>(
         if (disabled) {
           const { title, message, learnMoreUrl } = disabled; // eslint-disable-line no-shadow
           showErrorAlert(
-            typeof title === 'string' ? _(title) : _(title.text, title.values),
-            (() => {
-              switch (typeof message) {
-                case 'undefined':
-                  return undefined;
-                case 'string':
-                  return _(message);
-                default:
-                  return _(message.text, message.values);
-              }
-            })(),
+            _(title),
+            message != null ? _(message) : undefined,
             learnMoreUrl,
             globalSettings,
           );

--- a/src/types.js
+++ b/src/types.js
@@ -348,11 +348,14 @@ export type LocalizableReactText =
  *
  * Alternatively, for when `context` is already in use: use `withGetText`
  * and then say `const { _ } = this.props`.
- *
- * @prop intl - The full react-intl API, for more complex situations.
  */
 export type GetText = {|
   (message: string, values?: {| +[string]: MessageFormatPrimitiveValue |}): string,
+
+  /** Convenient in contexts where callers pass `LocalizableText`. */
+  (message: LocalizableText): string,
+
+  /** The full react-intl API, for more complex situations. */
   intl: IntlShape,
 |};
 

--- a/src/webview/__tests__/generateInboundEventEditSequence-test.js
+++ b/src/webview/__tests__/generateInboundEventEditSequence-test.js
@@ -36,7 +36,7 @@ import { randString } from '../../utils/misc';
 /* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["expect", "check"] }] */
 
 // Our translation function, usually given the name _.
-const mock_ = m => m; // eslint-disable-line no-underscore-dangle
+const mock_ = m => (typeof m === 'object' ? m.text : m); // eslint-disable-line no-underscore-dangle
 
 const user1 = eg.makeUser({ user_id: 1, full_name: 'Nonrandom name one User' });
 const user2 = eg.makeUser({ user_id: 2, full_name: 'Nonrandom name two User' });


### PR DESCRIPTION
As described at https://github.com/zulip/zulip-mobile/pull/5427#discussion_r907750949 . This encapsulates a common bit of logic needed in code that accepts a LocalizableText.

#5427 adds one more call site that would benefit from this. So after either this or #5427 is merged, the other should be updated to apply this change at that call site.
