### PR TITLE
emoji: Cut `congratulations` alias to reflect server update

### DIFF
--- a/src/emoji/codePointMap.js
+++ b/src/emoji/codePointMap.js
@@ -312,7 +312,6 @@ export const unicodeCodeByName: {| [name: string]: string |} = {
   confetti: '1f38a',
   confounded: '1f616',
   confused: '1f615',
-  congratulations: '1f389',
   construction: '1f3d7',
   construction_worker: '1f477',
   construction_zone: '1f6a7',


### PR DESCRIPTION
This reflects the change made in zulip/zulip@89b5a36e1 /
zulip/zulip#19537 .  Without this change, when adding a reaction
the options on our emoji-picker screen include two with this emoji:
  🎉 congratulations
  🎉 tada
If you pick the "congratulations" version when talking to a server
that has that server-side change, then adding the reaction fails.
This produced a user bug report:
  https://chat.zulip.org/#narrow/stream/48-mobile/topic/can't.20react.20with.20emojis/near/1394252

(It's a good thing we include the emoji code as well as the name
in the request; if we didn't, the symptom would instead be that
you end up leaving the reaction ㊗ instead, which seems worse.)

There are more changes in that server commit -- among them,
assigning the name "congratulations" to that other emoji ㊗,
and "accept" to 🉑.  We'll get those soon too, via #2956 /
zulip/zulip#21037 (along with any other differences we've
accumulated from the server's list.)  In the meantime I'm not
eager to make any effort to take those other changes, because
they don't seem likely to improve people's experience.  (The
reason they were added in that server change is for the sake of
imports from Matrix and Slack.)