### PR TITLE
messages state: Maintain `edit_history` to be reasonably current

### DIFF
--- a/src/api/messages/__tests__/migrateMessages-test.js
+++ b/src/api/messages/__tests__/migrateMessages-test.js
@@ -62,6 +62,7 @@ describe('recent server', () => {
     input,
     identityOfAuth(eg.selfAuth),
     eg.recentZulipFeatureLevel,
+    true,
   );
 
   test('In reactions, replace user object with `user_id`', () => {
@@ -72,8 +73,16 @@ describe('recent server', () => {
     expect(actualOutput.map(m => m.avatar_url)).toEqual(expectedOutput.map(m => m.avatar_url));
   });
 
-  test('Keeps edit_history', () => {
+  test('Keeps edit_history, if allowEditHistory is true', () => {
     expect(actualOutput.map(m => m.edit_history)).toEqual(expectedOutput.map(m => m.edit_history));
+  });
+
+  test('Drops edit_history, if allowEditHistory is false', () => {
+    expect(
+      migrateMessages(input, identityOfAuth(eg.selfAuth), eg.recentZulipFeatureLevel, false).map(
+        m => m.edit_history,
+      ),
+    ).toEqual(expectedOutput.map(m => null));
   });
 });
 
@@ -97,6 +106,7 @@ describe('drops edit_history from pre-118 server', () => {
       ],
       identityOfAuth(eg.selfAuth),
       117,
+      true,
     ).map(m => m.edit_history),
   ).toEqual([null]);
 });

--- a/src/api/modelTypes.js
+++ b/src/api/modelTypes.js
@@ -760,8 +760,6 @@ type MessageBase = $ReadOnly<{|
    *
    * Missing/undefined if, at the time we added it to the state, the realm
    * didn't allow viewing edit history.
-   *
-   * Stale if the message was updated or moved after we added it to the state.
    */
   // TODO: Keep reasonably current:
   // - Use `null` for the `allow_edit_history`-false case, to distinguish it
@@ -773,7 +771,6 @@ type MessageBase = $ReadOnly<{|
   //     particular, a restart event where the server version changed, which
   //     could mean any number of subtle changes in server behavior), and do
   //     a re-fetch of server data soon after it.
-  // - Handle update-message events, writing the FL 118+ shape.
   //
   // TODO(server-5.0): Remove FL <118 condition
   //

--- a/src/api/modelTypes.js
+++ b/src/api/modelTypes.js
@@ -750,22 +750,17 @@ type MessageBase = $ReadOnly<{|
   // display_recipient handled on PmMessage and StreamMessage separately
 
   /**
-   * A possibly incomplete view of the message's edit history.
+   * A view of the message's edit history, if available.
    *
    * This is null if it's coming from a server with FL <118; see comment on
    * MessageEdit.
    *
+   * Null if the realm doesn't allow viewing edit history.
+   *
    * Missing/undefined if the message had no edit history when we added it
    * to the state.
-   *
-   * Missing/undefined if, at the time we added it to the state, the realm
-   * didn't allow viewing edit history.
    */
-  // TODO: Keep reasonably current:
-  // - Use `null` for the `allow_edit_history`-false case, to distinguish it
-  //   from the message-never-edited case. (Handle everywhere we add/update
-  //   Messages in Redux: the get-messages response, new-message events,
-  //   update-message events.)
+  // TODO: Keep current:
   // - Handle changes to the allow_edit_history setting:
   //   - Treat an allow_edit_history change similar to a restart event (in
   //     particular, a restart event where the server version changed, which
@@ -775,8 +770,7 @@ type MessageBase = $ReadOnly<{|
   // TODO(server-5.0): Remove FL <118 condition
   //
   // (Why optional and `| void`? We convert missing to undefined at the
-  // edge, while doing the FL <118 condition, but that's incidental and
-  // could easily change.)
+  // edge, but that's incidental and could easily change.)
   edit_history?: $ReadOnlyArray<MessageEdit> | null | void,
 
   id: number,

--- a/src/events/__tests__/eventToAction-test.js
+++ b/src/events/__tests__/eventToAction-test.js
@@ -75,9 +75,25 @@ describe('eventToAction', () => {
         expect(action.message.avatar_url).toBeInstanceOf(AvatarURL);
       });
 
-      test('Keeps edit_history', () => {
+      test('Keeps edit_history if allowEditHistory is true', () => {
+        // eslint-disable-next-line no-shadow
+        const action = eventToAction(
+          eg.reduxStatePlus({ realm: { ...eg.plusReduxState.realm, allowEditHistory: true } }),
+          event,
+        );
+        invariant(actionMatchesType(action, EVENT_NEW_MESSAGE), 'EVENT_NEW_MESSAGE produced');
         expect(action.message.edit_history).not.toBeNull();
         expect(action.message.edit_history).toEqual(serverMessage.edit_history);
+      });
+
+      test('Drops edit_history if allowEditHistory is false', () => {
+        // eslint-disable-next-line no-shadow
+        const action = eventToAction(
+          eg.reduxStatePlus({ realm: { ...eg.plusReduxState.realm, allowEditHistory: false } }),
+          event,
+        );
+        invariant(actionMatchesType(action, EVENT_NEW_MESSAGE), 'EVENT_NEW_MESSAGE produced');
+        expect(action.message.edit_history).toBeNull();
       });
     });
 

--- a/src/events/eventToAction.js
+++ b/src/events/eventToAction.js
@@ -31,6 +31,7 @@ import {
   EVENT_SUBSCRIPTION,
   EVENT,
 } from '../actionConstants';
+import { getRealm } from '../selectors';
 import { getOwnUserId, tryGetUserForId } from '../users/userSelectors';
 import { AvatarURL } from '../utils/avatar';
 import { getRealmUrl, getZulipFeatureLevel } from '../account/accountsSelectors';
@@ -91,6 +92,8 @@ const actionTypeOfEventType = {
 // assumptions about the events the server sends, and doesn't check them.
 export default (state: PerAccountState, event: $FlowFixMe): EventAction | null => {
   const zulipFeatureLevel = getZulipFeatureLevel(state);
+  const allowEditHistory = getRealm(state).allowEditHistory;
+
   const type = (event.type: EventType);
   switch (type) {
     // For reference on each type of event, see:
@@ -118,8 +121,9 @@ export default (state: PerAccountState, event: $FlowFixMe): EventAction | null =
             realm: getRealmUrl(state),
           }),
           edit_history:
+            // Why condition on allowEditHistory? See MessageBase['edit_history'].
             // Why FL 118 condition? See MessageEdit type.
-            zulipFeatureLevel >= 118
+            allowEditHistory && zulipFeatureLevel >= 118
               ? (event.message.edit_history: $ReadOnlyArray<MessageEdit> | void)
               : null,
         },

--- a/src/message/__tests__/fetchActions-test.js
+++ b/src/message/__tests__/fetchActions-test.js
@@ -254,6 +254,10 @@ describe('fetchActions', () => {
       narrows: Immutable.Map({
         [streamNarrowStr]: [message1.id],
       }),
+      realm: {
+        ...eg.plusReduxState.realm,
+        allowEditHistory: true, // TODO: test with this `false`
+      },
     });
 
     describe('success', () => {

--- a/src/message/__tests__/messagesReducer-test.js
+++ b/src/message/__tests__/messagesReducer-test.js
@@ -168,6 +168,8 @@ describe('messagesReducer', () => {
       const {
         message,
         rendering_only = false,
+        message_ids = [message.id],
+        propagate_mode = 'change_one',
         user_id = message.sender_id,
         edit_timestamp = message.timestamp + 1,
         ...restArgs
@@ -175,8 +177,8 @@ describe('messagesReducer', () => {
       return eg.mkActionEventUpdateMessage({
         rendering_only,
         message_id: message.id,
-        message_ids: [message.id],
-        propagate_mode: 'change_one',
+        message_ids,
+        propagate_mode,
         user_id,
         edit_timestamp,
         is_me_message: false,

--- a/src/message/__tests__/messagesReducer-test.js
+++ b/src/message/__tests__/messagesReducer-test.js
@@ -216,9 +216,9 @@ describe('messagesReducer', () => {
       test('edited topic', () => {
         const message = eg.streamMessage();
         const newTopic = `${message.subject}abc`;
-        const action = mkMoveAction({ message, subject: newTopic });
+        const action = mkMoveAction({ message, subject: newTopic, edit_timestamp: 1000 });
         expect(messagesReducer(eg.makeMessagesState([message]), action, eg.plusReduxState)).toEqual(
-          eg.makeMessagesState([{ ...message, subject: newTopic }]),
+          eg.makeMessagesState([{ ...message, subject: newTopic, last_edit_timestamp: 1000 }]),
         );
       });
 
@@ -232,6 +232,7 @@ describe('messagesReducer', () => {
           message: message1,
           message_ids: [message1.id, message2.id],
           subject: newTopic,
+          edit_timestamp: 1000,
         });
         expect(
           messagesReducer(
@@ -241,7 +242,7 @@ describe('messagesReducer', () => {
           ),
         ).toEqual(
           eg.makeMessagesState([
-            { ...message1, subject: newTopic },
+            { ...message1, subject: newTopic, last_edit_timestamp: 1000 },
             { ...message2, subject: newTopic },
             message3,
           ]),
@@ -250,13 +251,18 @@ describe('messagesReducer', () => {
 
       test('new stream', () => {
         const message = eg.streamMessage();
-        const action = mkMoveAction({ message, new_stream_id: eg.otherStream.stream_id });
+        const action = mkMoveAction({
+          message,
+          new_stream_id: eg.otherStream.stream_id,
+          edit_timestamp: 1000,
+        });
         expect(messagesReducer(eg.makeMessagesState([message]), action, eg.plusReduxState)).toEqual(
           eg.makeMessagesState([
             {
               ...message,
               stream_id: eg.otherStream.stream_id,
               display_recipient: eg.otherStream.name,
+              last_edit_timestamp: 1000,
             },
           ]),
         );
@@ -269,6 +275,7 @@ describe('messagesReducer', () => {
           message,
           new_stream_id: eg.otherStream.stream_id,
           subject: newTopic,
+          edit_timestamp: 1000,
         });
         expect(messagesReducer(eg.makeMessagesState([message]), action, eg.plusReduxState)).toEqual(
           eg.makeMessagesState([
@@ -277,6 +284,7 @@ describe('messagesReducer', () => {
               stream_id: eg.otherStream.stream_id,
               display_recipient: eg.otherStream.name,
               subject: newTopic,
+              last_edit_timestamp: 1000,
             },
           ]),
         );
@@ -285,10 +293,19 @@ describe('messagesReducer', () => {
       test('new, unknown stream', () => {
         const message = eg.streamMessage();
         const unknownStream = eg.makeStream();
-        const action = mkMoveAction({ message, new_stream_id: unknownStream.stream_id });
+        const action = mkMoveAction({
+          message,
+          new_stream_id: unknownStream.stream_id,
+          edit_timestamp: 1000,
+        });
         expect(messagesReducer(eg.makeMessagesState([message]), action, eg.plusReduxState)).toEqual(
           eg.makeMessagesState([
-            { ...message, stream_id: unknownStream.stream_id, display_recipient: 'unknown' },
+            {
+              ...message,
+              stream_id: unknownStream.stream_id,
+              display_recipient: 'unknown',
+              last_edit_timestamp: 1000,
+            },
           ]),
         );
       });

--- a/src/message/__tests__/messagesReducer-test.js
+++ b/src/message/__tests__/messagesReducer-test.js
@@ -745,7 +745,7 @@ describe('messagesReducer', () => {
           ],
         };
 
-        test('on never-edited message, or one received with realm_allow_edit_history: false, creates one-item array', () => {
+        test('on never-edited message, creates one-item array', () => {
           expect(
             messagesReducer(
               eg.makeMessagesState([afterNoUpdates]),
@@ -762,8 +762,7 @@ describe('messagesReducer', () => {
         });
       });
 
-      // TODO(server-5.0): Simplify away.
-      test("don't touch it if we dropped it because server was FL <118", () => {
+      test("don't touch it if we dropped it", () => {
         const message1Old = eg.streamMessage({
           content: '<p>Old content</p>',
           subject: 'Old topic',

--- a/src/message/fetchActions.js
+++ b/src/message/fetchActions.js
@@ -14,6 +14,7 @@ import * as api from '../api';
 import { Server5xxError, NetworkError } from '../api/apiErrors';
 import {
   getAuth,
+  getRealm,
   getSession,
   getFirstMessageId,
   getLastMessageId,
@@ -113,6 +114,7 @@ export const fetchMessages =
               useFirstUnread: fetchArgs.anchor === FIRST_UNREAD_ANCHOR, // TODO: don't use this; see #4203
             },
             getZulipFeatureLevel(getState()),
+            getRealm(getState()).allowEditHistory,
           ),
         );
       dispatch(
@@ -223,6 +225,7 @@ export async function fetchSomeMessageIdForConversation(
       narrow: apiNarrowOfNarrow(topicNarrow(streamId, topic), new Map(), streamsById),
     },
     zulipFeatureLevel,
+    false, // chosen arbitrarily; irrelevant to this function's task
   );
   // FlowIssue: can be void because array can be empty
   const message: Message | void = data.messages[0];
@@ -308,6 +311,7 @@ export const fetchPrivateMessages =
         numAfter: 0,
       },
       getZulipFeatureLevel(getState()),
+      getRealm(getState()).allowEditHistory,
     );
     dispatch(
       messageFetchComplete({

--- a/src/message/messagesReducer.js
+++ b/src/message/messagesReducer.js
@@ -150,7 +150,17 @@ export default (
         return {
           ...(oldMessage: M),
           content: event.rendered_content ?? oldMessage.content,
-          last_edit_timestamp: event.edit_timestamp ?? oldMessage.last_edit_timestamp,
+
+          // Don't update last_edit_timestamp if it's a rendering-only
+          // event. How do we know if it is? From newer servers,
+          // rendering_only will be true; from older servers, edit_timestamp
+          // will be missing.
+          // TODO(server-5.0): Simplify away edit_timestamp-missing condition
+          last_edit_timestamp:
+            event.rendering_only === true || event.edit_timestamp == null
+              ? oldMessage.last_edit_timestamp
+              : event.edit_timestamp,
+
           // TODO(#3408): Update edit_history, too.  This is OK for now
           //   because we don't actually have any UI to expose it: #4134.
         };

--- a/src/message/messagesReducer.js
+++ b/src/message/messagesReducer.js
@@ -81,12 +81,17 @@ const editHistory = <M: Message>(args: {|
 |}) => {
   const { oldMessage, event, move, shouldApplyContentChanges } = args;
   if (oldMessage.edit_history === null) {
-    // We ignored a maybe-interesting `edit_history` when we learned about
-    // the message because the value wouldn't have been in a nice shape; see
-    // Message['edit_history']. Keep ignoring it; don't give it a partial
-    // value, such as a one-item array based on this edit, which would be
-    // corrupt.
-    // TODO(server-5.0): Simplify away.
+    // Either:
+    // - we dropped edit_history because the server was old and the value
+    //   wouldn't have been in a nice shape, or
+    // - the realm is set to not allow viewing edit history
+    //
+    // (See Message['edit_history'].) Keep maintaining nothing here; don't
+    // write a partial value, such as a one-item array based on this edit,
+    // which would be corrupt.
+    //
+    // TODO(server-5.0): Simplify away the FL condition; keep the
+    //   allowEditHistory condition.
     return null;
   }
 


### PR DESCRIPTION
Following the plan we made in #5422.

I'm not sure I'm quite happy with the last commit, where we set `edit_history` to `null` based on `allowEditHistory`. I've put the condition on `allowEditHistory` out to the edge (`eventToAction`, `api.getMessages`)…but that means plumbing `allowEditHistory` out to the edge. Is that OK? 