### PR TITLE
unread: Finish handling mark-unread events

### DIFF
--- a/src/unread/__tests__/unreadHuddlesReducer-test.js
+++ b/src/unread/__tests__/unreadHuddlesReducer-test.js
@@ -261,11 +261,11 @@ describe('unreadHuddlesReducer', () => {
       expect(actualState).toEqual(expectedState);
     });
 
-    test('when operation is "remove" do nothing', () => {
+    test('when operation is "remove", add to unreads', () => {
       const initialState = deepFreeze([
         {
           user_ids_string: '0,1,2',
-          unread_message_ids: [1, 2, 3, 4, 5],
+          unread_message_ids: [1, 2, 3, 4, 100],
         },
       ]);
 
@@ -274,14 +274,34 @@ describe('unreadHuddlesReducer', () => {
         type: EVENT_UPDATE_MESSAGE_FLAGS,
         all: false,
         allMessages: eg.makeMessagesState([]),
-        messages: [1, 2],
+        messages: [10, 11, 12],
         flag: 'read',
         op: 'remove',
+        message_details: new Map([
+          [10, { type: 'private', user_ids: [1, 2].map(makeUserId) }],
+          [11, { type: 'private', user_ids: [1, 2].map(makeUserId) }],
+          [12, { type: 'private', user_ids: [1, 2, 3].map(makeUserId) }],
+        ]),
       });
 
-      const actualState = unreadHuddlesReducer(initialState, action, eg.plusReduxState);
+      const expectedState = [
+        {
+          user_ids_string: '0,1,2',
+          unread_message_ids: [1, 2, 3, 4, 10, 11, 100],
+        },
+        {
+          user_ids_string: '0,1,2,3',
+          unread_message_ids: [12],
+        },
+      ];
 
-      expect(actualState).toBe(initialState);
+      const actualState = unreadHuddlesReducer(
+        initialState,
+        action,
+        eg.reduxStatePlus({ realm: { ...eg.plusReduxState.realm, user_id: makeUserId(0) } }),
+      );
+
+      expect(actualState).toEqual(expectedState);
     });
 
     test('when "all" is true reset state', () => {

--- a/src/unread/__tests__/unreadHuddlesReducer-test.js
+++ b/src/unread/__tests__/unreadHuddlesReducer-test.js
@@ -24,7 +24,7 @@ describe('unreadHuddlesReducer', () => {
 
       const expectedState = [];
 
-      const actualState = unreadHuddlesReducer(initialState, action);
+      const actualState = unreadHuddlesReducer(initialState, action, eg.plusReduxState);
 
       expect(actualState).toEqual(expectedState);
     });
@@ -55,7 +55,7 @@ describe('unreadHuddlesReducer', () => {
         },
       ];
 
-      const actualState = unreadHuddlesReducer(initialState, action);
+      const actualState = unreadHuddlesReducer(initialState, action, eg.plusReduxState);
 
       expect(actualState).toEqual(expectedState);
     });
@@ -80,7 +80,7 @@ describe('unreadHuddlesReducer', () => {
 
       const action = eg.mkActionEventNewMessage(message2);
 
-      const actualState = unreadHuddlesReducer(initialState, action);
+      const actualState = unreadHuddlesReducer(initialState, action, eg.plusReduxState);
 
       expect(actualState).toBe(initialState);
     });
@@ -96,7 +96,7 @@ describe('unreadHuddlesReducer', () => {
 
       const action = eg.mkActionEventNewMessage(streamMessage);
 
-      const actualState = unreadHuddlesReducer(initialState, action);
+      const actualState = unreadHuddlesReducer(initialState, action, eg.plusReduxState);
 
       expect(actualState).toBe(initialState);
     });
@@ -116,7 +116,7 @@ describe('unreadHuddlesReducer', () => {
 
       const action = eg.mkActionEventNewMessage(message2, { ownUserId: selfUser.user_id });
 
-      const actualState = unreadHuddlesReducer(initialState, action);
+      const actualState = unreadHuddlesReducer(initialState, action, eg.plusReduxState);
 
       expect(actualState).toBe(initialState);
     });
@@ -144,7 +144,7 @@ describe('unreadHuddlesReducer', () => {
         },
       ];
 
-      const actualState = unreadHuddlesReducer(initialState, action);
+      const actualState = unreadHuddlesReducer(initialState, action, eg.plusReduxState);
 
       expect(actualState).toEqual(expectedState);
     });
@@ -175,7 +175,7 @@ describe('unreadHuddlesReducer', () => {
         },
       ];
 
-      const actualState = unreadHuddlesReducer(initialState, action);
+      const actualState = unreadHuddlesReducer(initialState, action, eg.plusReduxState);
 
       expect(actualState).toEqual(expectedState);
     });
@@ -195,7 +195,7 @@ describe('unreadHuddlesReducer', () => {
         op: 'add',
       };
 
-      const actualState = unreadHuddlesReducer(initialState, action);
+      const actualState = unreadHuddlesReducer(initialState, action, eg.plusReduxState);
 
       expect(actualState).toBe(initialState);
     });
@@ -222,7 +222,7 @@ describe('unreadHuddlesReducer', () => {
         op: 'add',
       });
 
-      const actualState = unreadHuddlesReducer(initialState, action);
+      const actualState = unreadHuddlesReducer(initialState, action, eg.plusReduxState);
 
       expect(actualState).toBe(initialState);
     });
@@ -256,7 +256,7 @@ describe('unreadHuddlesReducer', () => {
         },
       ];
 
-      const actualState = unreadHuddlesReducer(initialState, action);
+      const actualState = unreadHuddlesReducer(initialState, action, eg.plusReduxState);
 
       expect(actualState).toEqual(expectedState);
     });
@@ -279,7 +279,7 @@ describe('unreadHuddlesReducer', () => {
         op: 'remove',
       });
 
-      const actualState = unreadHuddlesReducer(initialState, action);
+      const actualState = unreadHuddlesReducer(initialState, action, eg.plusReduxState);
 
       expect(actualState).toBe(initialState);
     });
@@ -302,7 +302,7 @@ describe('unreadHuddlesReducer', () => {
         op: 'add',
       });
 
-      const actualState = unreadHuddlesReducer(initialState, action);
+      const actualState = unreadHuddlesReducer(initialState, action, eg.plusReduxState);
 
       expect(actualState).toBe(NULL_ARRAY);
     });

--- a/src/unread/__tests__/unreadHuddlesReducer-test.js
+++ b/src/unread/__tests__/unreadHuddlesReducer-test.js
@@ -304,6 +304,36 @@ describe('unreadHuddlesReducer', () => {
       expect(actualState).toEqual(expectedState);
     });
 
+    test('on "remove", drop any duplicates', () => {
+      const initialState = deepFreeze([
+        { user_ids_string: '0,1,2', unread_message_ids: [1, 2, 3, 4] },
+      ]);
+
+      const action = deepFreeze({
+        id: 1,
+        type: EVENT_UPDATE_MESSAGE_FLAGS,
+        all: false,
+        allMessages: eg.makeMessagesState([]),
+        messages: [2, 10],
+        flag: 'read',
+        op: 'remove',
+        message_details: new Map([
+          [2, { type: 'private', user_ids: [1, 2].map(makeUserId) }],
+          [10, { type: 'private', user_ids: [1, 2].map(makeUserId) }],
+        ]),
+      });
+
+      const expectedState = [{ user_ids_string: '0,1,2', unread_message_ids: [1, 2, 3, 4, 10] }];
+
+      const actualState = unreadHuddlesReducer(
+        initialState,
+        action,
+        eg.reduxStatePlus({ realm: { ...eg.plusReduxState.realm, user_id: makeUserId(0) } }),
+      );
+
+      expect(actualState).toEqual(expectedState);
+    });
+
     test('when "all" is true reset state', () => {
       const initialState = deepFreeze([
         {

--- a/src/unread/__tests__/unreadPmsReducer-test.js
+++ b/src/unread/__tests__/unreadPmsReducer-test.js
@@ -310,6 +310,33 @@ describe('unreadPmsReducer', () => {
       expect(actualState).toStrictEqual(expectedState);
     });
 
+    test('on "remove", drop any duplicates', () => {
+      const initialState = deepFreeze([
+        { sender_id: eg.otherUser.user_id, unread_message_ids: [1, 3] },
+      ]);
+
+      const action = deepFreeze({
+        id: 1,
+        type: EVENT_UPDATE_MESSAGE_FLAGS,
+        all: false,
+        allMessages: eg.makeMessagesState([]),
+        messages: [1, 4],
+        flag: 'read',
+        op: 'remove',
+        message_details: new Map([
+          [1, { type: 'private', user_ids: [eg.otherUser.user_id] }],
+          [4, { type: 'private', user_ids: [eg.otherUser.user_id] }],
+        ]),
+      });
+
+      const expectedState = deepFreeze([
+        { sender_id: eg.otherUser.user_id, unread_message_ids: [1, 3, 4] },
+      ]);
+
+      const actualState = unreadPmsReducer(initialState, action, eg.plusReduxState);
+      expect(actualState).toStrictEqual(expectedState);
+    });
+
     test('when "all" is true reset state', () => {
       const initialState = deepFreeze([
         {

--- a/src/unread/unreadHuddlesReducer.js
+++ b/src/unread/unreadHuddlesReducer.js
@@ -71,13 +71,14 @@ const eventUpdateMessageFlags = (state, action, ownUserId) => {
       }
     }
 
-    // TODO This re-sorting is pretty overkill; only the conversations we
-    //   actually touched need it.  But rather than add complications to the
-    //   `addItemsTo…` system to support that, let's spend that effort
-    //   instead to finally rip that system out in favor of Immutable.js.
+    // TODO This re-sorting/deduping is pretty overkill; only the
+    //   conversations we actually touched need it.  But rather than add
+    //   complications to the `addItemsTo…` system to support that, let's
+    //   spend that effort instead to finally rip that system out in favor
+    //   of Immutable.js.
     return newState.map(({ user_ids_string, unread_message_ids }) => ({
       user_ids_string,
-      unread_message_ids: [...unread_message_ids].sort((a, b) => a - b),
+      unread_message_ids: [...new Set(unread_message_ids)].sort((a, b) => a - b),
     }));
   }
 

--- a/src/unread/unreadHuddlesReducer.js
+++ b/src/unread/unreadHuddlesReducer.js
@@ -14,6 +14,7 @@ import {
 import { pmUnreadsKeyFromMessage, recipientsOfPrivateMessage } from '../utils/recipient';
 import { addItemsToHuddleArray, removeItemsDeeply } from './unreadHelpers';
 import { NULL_ARRAY } from '../nullObjects';
+import type { PerAccountState } from '../reduxTypes';
 
 const initialState: UnreadHuddlesState = NULL_ARRAY;
 
@@ -57,6 +58,7 @@ const eventUpdateMessageFlags = (state, action) => {
 export default (
   state: UnreadHuddlesState = initialState, // eslint-disable-line default-param-last
   action: PerAccountApplicableAction,
+  globalState: PerAccountState,
 ): UnreadHuddlesState => {
   switch (action.type) {
     case LOGOUT:

--- a/src/unread/unreadModel.js
+++ b/src/unread/unreadModel.js
@@ -250,7 +250,10 @@ function streamsReducer(
           return state;
         }
 
-        let newlyUnreadState = Immutable.Map();
+        let newlyUnreadState: Immutable.Map<
+          number,
+          Immutable.Map<string, Immutable.List<number>>,
+        > = Immutable.Map();
 
         for (const id of action.messages) {
           const message = message_details.get(id);
@@ -272,15 +275,10 @@ function streamsReducer(
         newlyUnreadState = newlyUnreadState.map(e => e.map(messages => messages.sort()));
 
         return state.mergeWith(
-          (
-            oldTopicsMap: Immutable.Map<string, Immutable.List<number>>,
-            newTopicsMap: Immutable.Map<string, Immutable.List<number>>,
-          ) =>
+          (oldTopicsMap, newTopicsMap) =>
             oldTopicsMap.mergeWith(
-              (
-                oldUnreadMessages: Immutable.List<number>,
-                newUnreadMessages: Immutable.List<number>,
-              ) => oldUnreadMessages.concat(newUnreadMessages).sort(),
+              (oldUnreadMessages, newUnreadMessages) =>
+                oldUnreadMessages.concat(newUnreadMessages).sort(),
               newTopicsMap,
             ),
           newlyUnreadState,

--- a/src/unread/unreadModel.js
+++ b/src/unread/unreadModel.js
@@ -329,7 +329,7 @@ export const reducer = (
     // Probably first push this four-part data structure down through the
     // `switch` statement, and the other logic that's duplicated between them.
     pms: unreadPmsReducer(state?.pms, action, globalState),
-    huddles: unreadHuddlesReducer(state?.huddles, action),
+    huddles: unreadHuddlesReducer(state?.huddles, action, globalState),
     mentions: unreadMentionsReducer(state?.mentions, action),
   };
 

--- a/src/unread/unreadPmsReducer.js
+++ b/src/unread/unreadPmsReducer.js
@@ -71,13 +71,14 @@ const eventUpdateMessageFlags = (state, action, ownUserId) => {
       }
     }
 
-    // TODO This re-sorting is pretty overkill; only the conversations we
-    //   actually touched need it.  But rather than add complications to the
-    //   `addItemsTo…` system to support that, let's spend that effort
-    //   instead to finally rip that system out in favor of Immutable.js.
+    // TODO This re-sorting/deduping is pretty overkill; only the
+    //   conversations we actually touched need it.  But rather than add
+    //   complications to the `addItemsTo…` system to support that, let's
+    //   spend that effort instead to finally rip that system out in favor
+    //   of Immutable.js.
     return newState.map(({ sender_id, unread_message_ids }) => ({
       sender_id,
-      unread_message_ids: [...unread_message_ids].sort((a, b) => a - b),
+      unread_message_ids: [...new Set(unread_message_ids)].sort((a, b) => a - b),
     }));
   }
 

--- a/src/unread/unreadPmsReducer.js
+++ b/src/unread/unreadPmsReducer.js
@@ -60,6 +60,9 @@ const eventUpdateMessageFlags = (state, action, ownUserId) => {
       const message = message_details.get(id);
 
       if (message && message.type === 'private') {
+        // This logic corresponds to pmUnreadsKeyFromOtherUsers, except that
+        // the latter returns a string (for the sake of group PMs) and our
+        // data structure here wants a UserId.
         if (message.user_ids.length === 1) {
           newState = addItemsToPmArray(newState, [id], message.user_ids[0]);
         } else if (message.user_ids.length === 0) {

--- a/src/unread/unreadPmsReducer.js
+++ b/src/unread/unreadPmsReducer.js
@@ -68,6 +68,10 @@ const eventUpdateMessageFlags = (state, action, ownUserId) => {
       }
     }
 
+    // TODO This re-sorting is pretty overkill; only the conversations we
+    //   actually touched need it.  But rather than add complications to the
+    //   `addItemsTo…` system to support that, let's spend that effort
+    //   instead to finally rip that system out in favor of Immutable.js.
     return newState.map(({ sender_id, unread_message_ids }) => ({
       sender_id,
       unread_message_ids: [...unread_message_ids].sort((a, b) => a - b),

--- a/src/utils/recipient.js
+++ b/src/utils/recipient.js
@@ -297,6 +297,8 @@ export const pmKeyRecipientsFromUsers = (
  *  * `pmKeyRecipientsFromMessage`, which we use for other data structures.
  *  * `pmUnreadsKeyFromPmKeyIds`, for getting one of these keys given what
  *    we use for other data structures.
+ *  * `pmUnreadsKeyFromOtherUsers`, for getting one of these keys from still
+ *    another form of input.
  *  * `UnreadState`, the type of `state.unread`, which is the data structure
  *    these keys appear in.
  *
@@ -338,6 +340,9 @@ export const pmUnreadsKeyFromMessage = (message: PmMessage, ownUserId?: UserId):
  * Careful: This is a *string key*. Don't === against numeric `.sender_id`s
  * in UnreadPmsState. You won't find the object you're looking for, and Flow
  * won't complain.
+ *
+ * See also `pmUnreadsKeyFromOtherUsers` for getting one of these keys from
+ * still another form of input.
  */
 // See comment on pmUnreadsKeyFromMessage for details on this form.
 export const pmUnreadsKeyFromPmKeyIds = (userIds: PmKeyRecipients, ownUserId: UserId): string => {
@@ -349,6 +354,32 @@ export const pmUnreadsKeyFromPmKeyIds = (userIds: PmKeyRecipients, ownUserId: Us
     // A group PM.  Our main "key" form includes just the other users;
     //   this form includes all users.
     return [...userIds, ownUserId].sort((a, b) => a - b).join(',');
+  }
+};
+
+/**
+ * The key for a PM thread in "unreads" data, given the set of non-self users.
+ *
+ * This produces the same key string that `pmUnreadsKeyFromMessage` would
+ * give, given the list of all users in the thread other than the self user.
+ *
+ * See also `pmUnreadsKeyFromPmKeyIds` for getting one of these keys from
+ * still another form of input.
+ */
+// See comment on pmUnreadsKeyFromMessage for details on this form.
+export const pmUnreadsKeyFromOtherUsers = (
+  userIds: $ReadOnlyArray<UserId>,
+  ownUserId: UserId,
+): string => {
+  if (userIds.length === 0) {
+    // Self-PM.
+    return ownUserId.toString();
+  } else if (userIds.length === 1) {
+    // Non-self 1:1 PM.
+    return userIds[0].toString();
+  } else {
+    // Group PM.
+    return [ownUserId, ...userIds].sort((a, b) => a - b).join(',');
   }
 };
 


### PR DESCRIPTION
This follows up on #4790 (/cc @WesleyAC) to handle group PMs and to add a workaround for https://github.com/zulip/zulip/issues/22164 . 

Also make a couple of small cleanups that I didn't include in the #4790 branch.

Fixes: #5361 