### PR TITLE
user: Show highlighted custom profile fields first

### DIFF
--- a/src/api/modelTypes.js
+++ b/src/api/modelTypes.js
@@ -81,6 +81,7 @@ export type CustomProfileField = {|
    * it's a string, one serializing a JSON object.
    */
   +field_data: string,
+  +display_in_profile_summary?: true,
 |};
 
 export type ImageEmojiType = $ReadOnly<{|

--- a/src/users/__tests__/userSelectors-test.js
+++ b/src/users/__tests__/userSelectors-test.js
@@ -247,6 +247,36 @@ describe('getCustomProfileFieldsForUser', () => {
     ]);
   });
 
+  test('put highlighted fields first', () => {
+    expect(
+      getCustomProfileFieldsForUser(
+        mkRealm([
+          { id: 1, name: 'name one', type: CustomProfileFieldType.ShortText },
+          {
+            id: 2,
+            name: 'name two',
+            type: CustomProfileFieldType.ShortText,
+          },
+          {
+            id: 3,
+            name: 'name three',
+            type: CustomProfileFieldType.ShortText,
+            display_in_profile_summary: true,
+          },
+        ]),
+        mkUser({
+          '1': { value: 'value one' },
+          '2': { value: 'value two' },
+          '3': { value: 'value three' },
+        }),
+      ),
+    ).toEqual([
+      { fieldId: 3, name: 'name three', value: { displayType: 'text', text: 'value three' } },
+      { fieldId: 1, name: 'name one', value: { displayType: 'text', text: 'value one' } },
+      { fieldId: 2, name: 'name two', value: { displayType: 'text', text: 'value two' } },
+    ]);
+  });
+
   test('omit unset fields', () => {
     expect(
       getCustomProfileFieldsForUser(

--- a/src/users/userSelectors.js
+++ b/src/users/userSelectors.js
@@ -285,8 +285,17 @@ export function getCustomProfileFieldsForUser(
   //   the order they appear in the array (`custom_profile_fields` in the
   //   API; our `realmFields` array here.)  See chat thread:
   //     https://chat.zulip.org/#narrow/stream/378-api-design/topic/custom.20profile.20fields/near/1382982
+  //
+  // We go on to put at the start of the list any fields that are marked for
+  // displaying in the "profile summary".  (Possibly they should be at the
+  // start of the list in the first place, but make sure just in case.)
+  const sortedRealmFields = [
+    ...realmFields.filter(f => f.display_in_profile_summary),
+    ...realmFields.filter(f => !f.display_in_profile_summary),
+  ];
+
   const fields = [];
-  for (const realmField of realmFields) {
+  for (const realmField of sortedRealmFields) {
     const value = interpretCustomProfileField(
       realmDefaultExternalAccounts,
       realmField,


### PR DESCRIPTION
Draft PR because the API isn't yet final. This uses the API from the current server-side prototype, https://github.com/zulip/zulip/pull/21588 .

Fixes: #5363
