### PR TITLE
layout: Fix warts in NestedNavRow and SwitchRow

### DIFF
--- a/src/common/NestedNavRow.js
+++ b/src/common/NestedNavRow.js
@@ -14,7 +14,7 @@ type Props = $ReadOnly<{|
   Icon?: SpecificIconType,
   label: LocalizableReactText,
 
-  // Use this to navigate to a "nested" screen.
+  /** Use this to navigate to a "nested" screen. */
   onPress: () => void,
 |}>;
 

--- a/src/common/NestedNavRow.js
+++ b/src/common/NestedNavRow.js
@@ -40,25 +40,24 @@ export default function NestedNavRow(props: Props): Node {
         iconFromProps: {
           textAlign: 'center',
           marginRight: 8,
+          color: themeContext.color,
         },
         iconRightFacingArrow: {
           textAlign: 'center',
           marginLeft: 8,
+          color: themeContext.color,
         },
       }),
-    [],
+    [themeContext],
   );
 
   return (
     <Touchable onPress={onPress}>
       <View style={[styles.container, globalStyles.listItem]}>
-        {!!Icon && <Icon size={24} style={[styles.iconFromProps, { color: themeContext.color }]} />}
+        {!!Icon && <Icon size={24} style={styles.iconFromProps} />}
         <ZulipTextIntl text={label} />
         <View style={globalStyles.rightItem}>
-          <IconRight
-            size={24}
-            style={[styles.iconRightFacingArrow, { color: themeContext.color }]}
-          />
+          <IconRight size={24} style={styles.iconRightFacingArrow} />
         </View>
       </View>
     </Touchable>

--- a/src/common/NestedNavRow.js
+++ b/src/common/NestedNavRow.js
@@ -14,6 +14,10 @@ type Props = $ReadOnly<{|
   Icon?: SpecificIconType,
   label: LocalizableReactText,
 
+  // TODO: Should we make this unconfigurable? Should we have two reusable
+  //   components, with and without this?
+  labelBoldUppercase?: true,
+
   /** Use this to navigate to a "nested" screen. */
   onPress: () => void,
 |}>;
@@ -25,7 +29,7 @@ type Props = $ReadOnly<{|
  * selectable option row instead, use `SelectableOptionRow`.
  */
 export default function NestedNavRow(props: Props): Node {
-  const { label, onPress, Icon } = props;
+  const { label, labelBoldUppercase, onPress, Icon } = props;
 
   const themeContext = useContext(ThemeContext);
 
@@ -42,20 +46,23 @@ export default function NestedNavRow(props: Props): Node {
           marginRight: 8,
           color: themeContext.color,
         },
+        label: {
+          ...(labelBoldUppercase ? { textTransform: 'uppercase', fontWeight: '500' } : undefined),
+        },
         iconRightFacingArrow: {
           textAlign: 'center',
           marginLeft: 8,
           color: themeContext.color,
         },
       }),
-    [themeContext],
+    [themeContext, labelBoldUppercase],
   );
 
   return (
     <Touchable onPress={onPress}>
       <View style={[styles.container, globalStyles.listItem]}>
         {!!Icon && <Icon size={24} style={styles.iconFromProps} />}
-        <ZulipTextIntl text={label} />
+        <ZulipTextIntl style={styles.label} text={label} />
         <View style={globalStyles.rightItem}>
           <IconRight size={24} style={styles.iconRightFacingArrow} />
         </View>

--- a/src/common/NestedNavRow.js
+++ b/src/common/NestedNavRow.js
@@ -39,13 +39,11 @@ export default function NestedNavRow(props: Props): Node {
         },
         iconFromProps: {
           textAlign: 'center',
-          marginLeft: 8,
-          marginRight: 16,
+          marginRight: 8,
         },
         iconRightFacingArrow: {
           textAlign: 'center',
           marginLeft: 8,
-          marginRight: 16,
         },
       }),
     [],

--- a/src/common/NestedNavRow.js
+++ b/src/common/NestedNavRow.js
@@ -1,5 +1,5 @@
 /* @flow strict-local */
-import React, { useContext } from 'react';
+import React, { useContext, useMemo } from 'react';
 import type { Node } from 'react';
 import { View } from 'react-native';
 
@@ -8,7 +8,7 @@ import ZulipTextIntl from './ZulipTextIntl';
 import Touchable from './Touchable';
 import { IconRight } from './Icons';
 import type { SpecificIconType } from './Icons';
-import styles, { ThemeContext } from '../styles';
+import globalStyles, { ThemeContext, createStyleSheet } from '../styles';
 
 type Props = $ReadOnly<{|
   Icon?: SpecificIconType,
@@ -29,13 +29,35 @@ export default function NestedNavRow(props: Props): Node {
 
   const themeContext = useContext(ThemeContext);
 
+  const styles = useMemo(
+    () =>
+      createStyleSheet({
+        iconFromProps: {
+          marginVertical: 8,
+          textAlign: 'center',
+          marginLeft: 8,
+          marginRight: 16,
+        },
+        iconRightFacingArrow: {
+          marginVertical: 8,
+          textAlign: 'center',
+          marginLeft: 8,
+          marginRight: 16,
+        },
+      }),
+    [],
+  );
+
   return (
     <Touchable onPress={onPress}>
-      <View style={styles.listItem}>
-        {!!Icon && <Icon size={24} style={[styles.settingsIcon, { color: themeContext.color }]} />}
+      <View style={globalStyles.listItem}>
+        {!!Icon && <Icon size={24} style={[styles.iconFromProps, { color: themeContext.color }]} />}
         <ZulipTextIntl text={label} />
-        <View style={styles.rightItem}>
-          <IconRight size={24} style={[styles.settingsIcon, { color: themeContext.color }]} />
+        <View style={globalStyles.rightItem}>
+          <IconRight
+            size={24}
+            style={[styles.iconRightFacingArrow, { color: themeContext.color }]}
+          />
         </View>
       </View>
     </Touchable>

--- a/src/common/NestedNavRow.js
+++ b/src/common/NestedNavRow.js
@@ -32,14 +32,17 @@ export default function NestedNavRow(props: Props): Node {
   const styles = useMemo(
     () =>
       createStyleSheet({
+        container: {
+          // Minimum touch target height (and width):
+          //   https://material.io/design/usability/accessibility.html#layout-and-typography
+          minHeight: 48,
+        },
         iconFromProps: {
-          marginVertical: 8,
           textAlign: 'center',
           marginLeft: 8,
           marginRight: 16,
         },
         iconRightFacingArrow: {
-          marginVertical: 8,
           textAlign: 'center',
           marginLeft: 8,
           marginRight: 16,
@@ -50,7 +53,7 @@ export default function NestedNavRow(props: Props): Node {
 
   return (
     <Touchable onPress={onPress}>
-      <View style={globalStyles.listItem}>
+      <View style={[styles.container, globalStyles.listItem]}>
         {!!Icon && <Icon size={24} style={[styles.iconFromProps, { color: themeContext.color }]} />}
         <ZulipTextIntl text={label} />
         <View style={globalStyles.rightItem}>

--- a/src/common/SwitchRow.js
+++ b/src/common/SwitchRow.js
@@ -17,10 +17,12 @@ type Props = $ReadOnly<{|
 
 const componentStyles = createStyleSheet({
   container: {
-    height: 56,
+    // For uniformity with other rows this might share a screen with, e.g.,
+    // NestedNavRow on the settings screen. See height-related attributes on
+    // those rows.
+    minHeight: 48,
   },
   icon: {
-    marginVertical: 8,
     textAlign: 'center',
     marginLeft: 8,
     marginRight: 16,

--- a/src/common/SwitchRow.js
+++ b/src/common/SwitchRow.js
@@ -24,8 +24,7 @@ const componentStyles = createStyleSheet({
   },
   icon: {
     textAlign: 'center',
-    marginLeft: 8,
-    marginRight: 16,
+    marginRight: 8,
   },
 });
 

--- a/src/common/SwitchRow.js
+++ b/src/common/SwitchRow.js
@@ -19,6 +19,12 @@ const componentStyles = createStyleSheet({
   container: {
     height: 56,
   },
+  icon: {
+    marginVertical: 8,
+    textAlign: 'center',
+    marginLeft: 8,
+    marginRight: 16,
+  },
 });
 
 /**
@@ -31,7 +37,7 @@ export default function SwitchRow(props: Props): Node {
 
   return (
     <View style={[componentStyles.container, styles.listItem]}>
-      {!!Icon && <Icon size={24} style={[styles.settingsIcon, { color: themeContext.color }]} />}
+      {!!Icon && <Icon size={24} style={[componentStyles.icon, { color: themeContext.color }]} />}
       <ZulipTextIntl text={label} style={styles.flexed} />
       <View style={styles.rightItem}>
         <ZulipSwitch value={value} onValueChange={onValueChange} />

--- a/src/common/SwitchRow.js
+++ b/src/common/SwitchRow.js
@@ -2,7 +2,6 @@
 import React, { useContext } from 'react';
 import type { Node } from 'react';
 import { View } from 'react-native';
-import type { ViewStyleProp } from 'react-native/Libraries/StyleSheet/StyleSheet';
 
 import type { SpecificIconType } from './Icons';
 import ZulipTextIntl from './ZulipTextIntl';
@@ -13,7 +12,6 @@ type Props = $ReadOnly<{|
   Icon?: SpecificIconType,
   label: string,
   value: boolean,
-  style?: ViewStyleProp,
   onValueChange: (newValue: boolean) => void,
 |}>;
 
@@ -27,12 +25,12 @@ const componentStyles = createStyleSheet({
  * A row with a label and a switch component.
  */
 export default function SwitchRow(props: Props): Node {
-  const { label, value, onValueChange, style, Icon } = props;
+  const { label, value, onValueChange, Icon } = props;
 
   const themeContext = useContext(ThemeContext);
 
   return (
-    <View style={[componentStyles.container, styles.listItem, style]}>
+    <View style={[componentStyles.container, styles.listItem]}>
       {!!Icon && <Icon size={24} style={[styles.settingsIcon, { color: themeContext.color }]} />}
       <ZulipTextIntl text={label} style={styles.flexed} />
       <View style={styles.rightItem}>

--- a/src/streams/SubscriptionsScreen.js
+++ b/src/streams/SubscriptionsScreen.js
@@ -1,6 +1,6 @@
 /* @flow strict-local */
 
-import React, { useCallback, useMemo, useContext } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import type { Node } from 'react';
 import { View, SectionList } from 'react-native';
 
@@ -8,7 +8,7 @@ import { useNavigation } from '../react-navigation';
 import type { RouteProp } from '../react-navigation';
 import type { AppNavigationProp } from '../nav/AppNavigator';
 import type { Subscription } from '../types';
-import appStyles, { createStyleSheet, ThemeContext } from '../styles';
+import { createStyleSheet } from '../styles';
 import { useDispatch, useSelector } from '../react-redux';
 import LoadingBanner from '../common/LoadingBanner';
 import SectionSeparatorBetween from '../common/SectionSeparatorBetween';
@@ -20,9 +20,7 @@ import { doNarrow } from '../actions';
 import { caseInsensitiveCompareFunc } from '../utils/misc';
 import StreamItem from './StreamItem';
 import ModalNavBar from '../nav/ModalNavBar';
-import ZulipTextIntl from '../common/ZulipTextIntl';
-import Touchable from '../common/Touchable';
-import { IconRight } from '../common/Icons';
+import NestedNavRow from '../common/NestedNavRow';
 
 const styles = createStyleSheet({
   container: {
@@ -32,19 +30,6 @@ const styles = createStyleSheet({
   list: {
     flex: 1,
     flexDirection: 'column',
-  },
-  rightItem: {
-    marginLeft: 'auto',
-  },
-  rightIcon: {
-    marginLeft: 'auto',
-  },
-  allStreamsButton: {
-    paddingRight: 12,
-  },
-  streamsText: {
-    textTransform: 'uppercase',
-    fontWeight: '500',
   },
 });
 
@@ -57,19 +42,11 @@ type FooterProps = $ReadOnly<{||}>;
 
 function AllStreamsButton(props: FooterProps): Node {
   const navigation = useNavigation();
-  const themeContext = useContext(ThemeContext);
   const handlePressAllScreens = useCallback(() => {
     navigation.push('all-streams');
   }, [navigation]);
 
-  return (
-    <Touchable onPress={handlePressAllScreens}>
-      <View style={[appStyles.listItem, styles.allStreamsButton]}>
-        <ZulipTextIntl style={styles.streamsText} text="All streams" />
-        <IconRight size={24} style={[styles.rightIcon, { color: themeContext.color }]} />
-      </View>
-    </Touchable>
-  );
+  return <NestedNavRow label="All streams" labelBoldUppercase onPress={handlePressAllScreens} />;
 }
 
 export default function SubscriptionsScreen(props: Props): Node {

--- a/src/styles/miscStyles.js
+++ b/src/styles/miscStyles.js
@@ -10,7 +10,7 @@ export const statics = {
     alignItems: 'center',
   },
   settingsIcon: {
-    margin: 8,
+    marginVertical: 8,
     textAlign: 'center',
     marginLeft: 8,
     marginRight: 16,

--- a/src/styles/miscStyles.js
+++ b/src/styles/miscStyles.js
@@ -9,12 +9,6 @@ export const statics = {
     flexDirection: 'row',
     alignItems: 'center',
   },
-  settingsIcon: {
-    marginVertical: 8,
-    textAlign: 'center',
-    marginLeft: 8,
-    marginRight: 16,
-  },
   listItem: {
     flexDirection: 'row',
     alignItems: 'center',


### PR DESCRIPTION
And (experimental) use `NestedNavRow` in place of new duplicated code at the bottom of `SubscriptionsScreen`, from 9d11e787fd10d5ef07d7b1d8e02127c922e189c7.

See https://github.com/zulip/zulip-mobile/pull/5443#issuecomment-1192014031 for rationale.