### PR TITLE
Fixes: #5448 Rename "Conversations" to "Private messages" (tablet UI)

### DIFF
--- a/src/main/MainTabsScreen.js
+++ b/src/main/MainTabsScreen.js
@@ -76,7 +76,7 @@ export default function MainTabsScreen(props: Props): Node {
           name="pm-conversations"
           component={PmConversationsScreen}
           options={{
-            tabBarLabel: 'Conversations',
+            tabBarLabel: 'Private messages',
             tabBarIcon: ({ color }) => <IconPeople size={24} color={color} />,
             tabBarBadge: unreadPmsCount > 0 ? unreadPmsCount : undefined,
             tabBarBadgeStyle: {


### PR DESCRIPTION
Fixes: #5448 
Rename "Conversations" to "Private messages" (tablet UI).
