### PR TITLE
urls cleanup: Fix buggy `isUrlOnRealm` function

### DIFF
--- a/src/lightbox/Lightbox.js
+++ b/src/lightbox/Lightbox.js
@@ -41,7 +41,14 @@ const styles = createStyleSheet({
 });
 
 type Props = $ReadOnly<{|
+  /**
+   * The location of the image, for presentation in the lightbox.
+   *
+   * Must be a "valid URL string" as defined by the URL standard:
+   *   https://url.spec.whatwg.org/#url-writing
+   */
   src: string,
+
   message: Message,
 |}>;
 

--- a/src/lightbox/Lightbox.js
+++ b/src/lightbox/Lightbox.js
@@ -43,11 +43,8 @@ const styles = createStyleSheet({
 type Props = $ReadOnly<{|
   /**
    * The location of the image, for presentation in the lightbox.
-   *
-   * Must be a "valid URL string" as defined by the URL standard:
-   *   https://url.spec.whatwg.org/#url-writing
    */
-  src: string,
+  src: URL,
 
   message: Message,
 |}>;

--- a/src/lightbox/LightboxActionSheet.js
+++ b/src/lightbox/LightboxActionSheet.js
@@ -8,24 +8,24 @@ import * as api from '../api';
 import { openLinkEmbedded } from '../utils/openLink';
 
 type DownloadImageType = {|
-  src: string,
+  src: URL,
   auth: Auth,
 |};
 
 type ShareLinkType = {|
-  src: string,
+  src: URL,
   auth: Auth,
 |};
 
 type ExecuteActionSheetActionType = {|
   title: string,
-  src: string,
+  src: URL,
   auth: Auth,
 |};
 
 type ButtonProps = {|
   auth: Auth,
-  src: string,
+  src: URL,
 |};
 
 type ButtonType = {|
@@ -34,13 +34,13 @@ type ButtonType = {|
 |};
 
 const tryToDownloadImage = async ({ src, auth }: DownloadImageType) => {
-  const tempUrl = await api.tryGetFileTemporaryUrl(src, auth);
+  const tempUrl = await api.tryGetFileTemporaryUrl(src.toString(), auth);
   if (tempUrl === null) {
-    openLinkEmbedded(new URL(src, auth.realm).toString());
+    openLinkEmbedded(src.toString());
     return;
   }
 
-  const fileName = src.split('/').pop();
+  const fileName = src.toString().split('/').pop(); // TODO: simplify?
   try {
     await downloadImage(tempUrl, fileName, auth);
     showToast('Download complete');
@@ -50,11 +50,11 @@ const tryToDownloadImage = async ({ src, auth }: DownloadImageType) => {
 };
 
 const shareLink = ({ src, auth }: ShareLinkType) => {
-  share(new URL(src, auth.realm).toString());
+  share(src.toString());
 };
 
 const shareImageDirectly = ({ src, auth }: DownloadImageType) => {
-  shareImage(src, auth);
+  shareImage(src.toString(), auth);
 };
 
 const actionSheetButtons: $ReadOnlyArray<ButtonType> = [

--- a/src/lightbox/LightboxScreen.js
+++ b/src/lightbox/LightboxScreen.js
@@ -23,13 +23,8 @@ type Props = $ReadOnly<{|
   route: RouteProp<
     'lightbox',
     {|
-      /**
-       * The location of the image, for presentation in the lightbox.
-       *
-       * Must be a "valid URL string" as defined by the URL standard:
-       *   https://url.spec.whatwg.org/#url-writing
-       */
-      src: string,
+      /** The location of the image, for presentation in the lightbox. */
+      src: URL,
 
       message: Message,
     |},

--- a/src/lightbox/LightboxScreen.js
+++ b/src/lightbox/LightboxScreen.js
@@ -20,7 +20,20 @@ const styles = createStyleSheet({
 
 type Props = $ReadOnly<{|
   navigation: AppNavigationProp<'lightbox'>,
-  route: RouteProp<'lightbox', {| src: string, message: Message |}>,
+  route: RouteProp<
+    'lightbox',
+    {|
+      /**
+       * The location of the image, for presentation in the lightbox.
+       *
+       * Must be a "valid URL string" as defined by the URL standard:
+       *   https://url.spec.whatwg.org/#url-writing
+       */
+      src: string,
+
+      message: Message,
+    |},
+  >,
 |}>;
 
 export default function LightboxScreen(props: Props): Node {

--- a/src/lightbox/shareImage.js
+++ b/src/lightbox/shareImage.js
@@ -10,6 +10,7 @@ import { openLinkEmbedded } from '../utils/openLink';
 import * as logging from '../utils/logging';
 
 // TODO(i18n): Wire up toasts for translation.
+// TODO: Take a URL object for `url`.
 export default async (url: string, auth: Auth) => {
   const tempUrl = await api.tryGetFileTemporaryUrl(url, auth);
 

--- a/src/message/messagesActions.js
+++ b/src/message/messagesActions.js
@@ -22,7 +22,13 @@ export const doNarrow =
   };
 
 export const messageLinkPress =
-  (href: string): ThunkAction<Promise<void>> =>
+  (
+    /**
+     * A "valid URL string" as defined by the URL standard:
+     *   https://url.spec.whatwg.org/#url-writing
+     */
+    href: string,
+  ): ThunkAction<Promise<void>> =>
   async (dispatch, getState, { getGlobalSettings }) => {
     const state = getState();
     const auth = getAuth(state);

--- a/src/nav/navActions.js
+++ b/src/nav/navActions.js
@@ -58,13 +58,8 @@ export const navigateToPmConversationDetails = (recipients: PmKeyRecipients): Na
   StackActions.push('pm-conversation-details', { recipients });
 
 export const navigateToLightbox = (
-  /**
-   * The location of the image, for presentation in the lightbox.
-   *
-   * Must be a "valid URL string" as defined by the URL standard:
-   *   https://url.spec.whatwg.org/#url-writing
-   */
-  src: string,
+  /** The location of the image, for presentation in the lightbox. */
+  src: URL,
 
   message: Message,
 ): NavigationAction => StackActions.push('lightbox', { src, message });

--- a/src/nav/navActions.js
+++ b/src/nav/navActions.js
@@ -57,8 +57,17 @@ export const navigateToAccountDetails = (userId: UserId): NavigationAction =>
 export const navigateToPmConversationDetails = (recipients: PmKeyRecipients): NavigationAction =>
   StackActions.push('pm-conversation-details', { recipients });
 
-export const navigateToLightbox = (src: string, message: Message): NavigationAction =>
-  StackActions.push('lightbox', { src, message });
+export const navigateToLightbox = (
+  /**
+   * The location of the image, for presentation in the lightbox.
+   *
+   * Must be a "valid URL string" as defined by the URL standard:
+   *   https://url.spec.whatwg.org/#url-writing
+   */
+  src: string,
+
+  message: Message,
+): NavigationAction => StackActions.push('lightbox', { src, message });
 
 export const navigateToStream = (streamId: number): NavigationAction =>
   StackActions.push('stream-settings', { streamId });

--- a/src/utils/__tests__/url-test.js
+++ b/src/utils/__tests__/url-test.js
@@ -111,9 +111,7 @@ describe('isUrlOnRealm', () => {
 
   test('when link is on realm, return true', () => {
     expect(isUrlOnRealm('/#narrow/stream/jest', realm)).toBe(true);
-
     expect(isUrlOnRealm('https://example.com/#narrow/stream/jest', realm)).toBe(true);
-
     expect(isUrlOnRealm('#narrow/#near/1', realm)).toBe(true);
 
     // This is actually a valid relative URL! Taken literally, relative to

--- a/src/utils/__tests__/url-test.js
+++ b/src/utils/__tests__/url-test.js
@@ -115,11 +115,21 @@ describe('isUrlOnRealm', () => {
     expect(isUrlOnRealm('https://example.com/#narrow/stream/jest', realm)).toBe(true);
 
     expect(isUrlOnRealm('#narrow/#near/1', realm)).toBe(true);
+
+    // This is actually a valid relative URL! Taken literally, relative to
+    // 'https://example.com/' (the realm), it means the same as
+    // 'https://example.com/www.google.com', and we'd return true for both.
+    // See the spec:
+    //   https://url.spec.whatwg.org/#path-relative-scheme-less-url-string
+    //
+    // But servers reportedly don't send ambiguous URLs that look like this.
+    // So, we don't expect a case like this in the wild:
+    //   https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/Interpreting.20links.20in.20messages/near/1410915
+    // Still, might as well include a test, since it's an interesting case.
+    expect(isUrlOnRealm('www.google.com', realm)).toBe(true);
   });
 
   test('when link is on not realm, return false', () => {
     expect(isUrlOnRealm('https://demo.example.com', realm)).toBe(false);
-
-    expect(isUrlOnRealm('www.google.com', realm)).toBe(false);
   });
 });

--- a/src/utils/__tests__/url-test.js
+++ b/src/utils/__tests__/url-test.js
@@ -74,7 +74,7 @@ describe('getResource', () => {
         Authorization: `Basic ${authEncoded}`,
       },
     };
-    const resource = getResource('https://example.com/img.gif', auth);
+    const resource = getResource(new URL('https://example.com/img.gif'), auth);
     expect(resource).toEqual(expectedResult);
   });
 
@@ -93,7 +93,7 @@ describe('getResource', () => {
         Authorization: `Basic ${authEncoded}`,
       },
     };
-    const resource = getResource('/img.gif', exampleAuth);
+    const resource = getResource(new URL('/img.gif', exampleAuth.realm), exampleAuth);
     expect(resource).toEqual(expectedResult);
   });
 
@@ -101,7 +101,7 @@ describe('getResource', () => {
     const expectedResult = {
       uri: 'https://another.com/img.gif',
     };
-    const resource = getResource('https://another.com/img.gif', exampleAuth);
+    const resource = getResource(new URL('https://another.com/img.gif'), exampleAuth);
     expect(resource).toEqual(expectedResult);
   });
 });

--- a/src/utils/__tests__/url-test.js
+++ b/src/utils/__tests__/url-test.js
@@ -110,24 +110,12 @@ describe('isUrlOnRealm', () => {
   const realm = new URL('https://example.com');
 
   test('when link is on realm, return true', () => {
-    expect(isUrlOnRealm('/#narrow/stream/jest', realm)).toBe(true);
-    expect(isUrlOnRealm('https://example.com/#narrow/stream/jest', realm)).toBe(true);
-    expect(isUrlOnRealm('#narrow/#near/1', realm)).toBe(true);
-
-    // This is actually a valid relative URL! Taken literally, relative to
-    // 'https://example.com/' (the realm), it means the same as
-    // 'https://example.com/www.google.com', and we'd return true for both.
-    // See the spec:
-    //   https://url.spec.whatwg.org/#path-relative-scheme-less-url-string
-    //
-    // But servers reportedly don't send ambiguous URLs that look like this.
-    // So, we don't expect a case like this in the wild:
-    //   https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/Interpreting.20links.20in.20messages/near/1410915
-    // Still, might as well include a test, since it's an interesting case.
-    expect(isUrlOnRealm('www.google.com', realm)).toBe(true);
+    expect(isUrlOnRealm(new URL('https://example.com/#narrow/stream/jest'), realm)).toBe(true);
+    expect(isUrlOnRealm(new URL('https://example.com/#narrow/#near/1'), realm)).toBe(true);
+    expect(isUrlOnRealm(new URL('https://example.com/www.google.com'), realm)).toBe(true);
   });
 
   test('when link is on not realm, return false', () => {
-    expect(isUrlOnRealm('https://demo.example.com', realm)).toBe(false);
+    expect(isUrlOnRealm(new URL('https://demo.example.com'), realm)).toBe(false);
   });
 });

--- a/src/utils/__tests__/url-test.js
+++ b/src/utils/__tests__/url-test.js
@@ -1,13 +1,6 @@
 /* @flow strict-local */
 import base64 from 'base-64';
-import {
-  getResource,
-  isUrlOnRealm,
-  parseProtocol,
-  isUrlAbsolute,
-  isUrlRelative,
-  isUrlPathAbsolute,
-} from '../url';
+import { getResource, isUrlOnRealm, isUrlAbsolute, isUrlRelative, isUrlPathAbsolute } from '../url';
 import type { Auth } from '../../types';
 
 const urlClassifierCases = {
@@ -128,32 +121,5 @@ describe('isUrlOnRealm', () => {
     expect(isUrlOnRealm('https://demo.example.com', realm)).toBe(false);
 
     expect(isUrlOnRealm('www.google.com', realm)).toBe(false);
-  });
-});
-
-describe('parseProtocol', () => {
-  test('rejects strings that have no http/https protocol', () => {
-    expect(parseProtocol('')).toEqual([null, '']);
-    expect(parseProtocol('chat.zulip.com')).toEqual([null, 'chat.zulip.com']);
-    expect(parseProtocol('ftp://chat.zulip.com')).toEqual([null, 'ftp://chat.zulip.com']);
-    expect(parseProtocol('localhost:9991')).toEqual([null, 'localhost:9991']);
-  });
-
-  test('accepts strings that include the http/https protocol', () => {
-    expect(parseProtocol('http://chat.zulip.com')).toEqual(['http://', 'chat.zulip.com']);
-    expect(parseProtocol('https://chat.zulip.com')).toEqual(['https://', 'chat.zulip.com']);
-    expect(parseProtocol('http://localhost:9991')).toEqual(['http://', 'localhost:9991']);
-  });
-
-  test('rejects strings that include a bogus http/https protocol indicator', () => {
-    expect(parseProtocol('chat.zulip.com/http://')).toEqual([null, 'chat.zulip.com/http://']);
-    expect(parseProtocol('example.net/https://')).toEqual([null, 'example.net/https://']);
-  });
-
-  test('accepts strings that include spaces before the protocol', () => {
-    expect(parseProtocol('   https://chat.zulip.com')).toEqual(['https://', 'chat.zulip.com']);
-    expect(parseProtocol('\t http://example.net')).toEqual(['http://', 'example.net']);
-    // non-breaking space
-    expect(parseProtocol('\xA0http://example.org')).toEqual(['http://', 'example.org']);
   });
 });

--- a/src/utils/url.js
+++ b/src/utils/url.js
@@ -96,7 +96,6 @@ export const tryParseUrl = (url: string, base?: string | URL): URL | void => {
  *
  * (If relative, we assume callers want to treat it relative to the realm.)
  */
-// TODO: Careful! Gives a false positive and false negatives; see comments.
 // TODO: reimplement using URL object (not just for the realm)
 export const isUrlOnRealm = (
   /**
@@ -107,21 +106,11 @@ export const isUrlOnRealm = (
 
   realm: URL,
 ): boolean =>
-  url.startsWith('/')
+  isUrlRelative(url)
   // TODO: False negative: an absolute URL that matches the realm, but only
   //   case-insensitively. Hopefully servers don't send URLs like that…but
   //   we might as well fix.
-  || url.startsWith(realm.toString())
-  // TODO: False positive: an "absolute-URL string"
-  //     ( https://url.spec.whatwg.org/#absolute-url-string )
-  //   with an unexpected scheme, like "ftp:" or "instagram-stories:"
-  //     ( https://developers.facebook.com/docs/instagram/sharing-to-stories/#allow-listing-instagram-s-custom-url-scheme ).
-  // TODO: False negative: a "path-relative-scheme-less-URL string"
-  //     ( https://url.spec.whatwg.org/#path-relative-scheme-less-url-string )
-  //   that happens to start with "http" or "www", case-insensitively. But
-  //   we don't expect URLs like that to come from the server; see
-  //     https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/Interpreting.20links.20in.20messages/near/1410915 .
-  || !/^(http|www.)/i.test(url);
+  || url.startsWith(realm.toString());
 
 const getResourceWithAuth = (uri: string, auth: Auth) => ({
   uri: new URL(uri, auth.realm).toString(),

--- a/src/utils/url.js
+++ b/src/utils/url.js
@@ -91,26 +91,10 @@ export const tryParseUrl = (url: string, base?: string | URL): URL | void => {
   }
 };
 
-/**
- * True if the URL is relative, or if it's absolute and on the realm.
- *
- * (If relative, we assume callers want to treat it relative to the realm.)
- */
-// TODO: reimplement using URL object (not just for the realm)
-export const isUrlOnRealm = (
-  /**
-   * A "valid URL string" as defined by the URL standard:
-   *   https://url.spec.whatwg.org/#url-writing
-   */
-  url: string,
-
-  realm: URL,
-): boolean =>
-  isUrlRelative(url)
-  // TODO: False negative: an absolute URL that matches the realm, but only
-  //   case-insensitively. Hopefully servers don't send URLs like that…but
-  //   we might as well fix.
-  || url.startsWith(realm.toString());
+// TODO: As of writing, we use this same check in 5 or so other places.
+//   Probably should consolidate those so they call this function, or else
+//   dissolve this function.
+export const isUrlOnRealm = (url: URL, realm: URL): boolean => url.origin === realm.origin;
 
 const getResourceWithAuth = (uri: URL, auth: Auth) => ({
   uri: uri.toString(),
@@ -127,10 +111,7 @@ export const getResource = (
 
   auth: Auth,
 ): {| uri: string, headers?: {| [string]: string |} |} =>
-  // TODO: isUrlOnRealm will take a URL soon; when it does, simplify.
-  isUrlOnRealm(uri.toString(), auth.realm)
-    ? getResourceWithAuth(uri, auth)
-    : getResourceNoAuth(uri);
+  isUrlOnRealm(uri, auth.realm) ? getResourceWithAuth(uri, auth) : getResourceNoAuth(uri);
 
 export const getFileExtension = (filename: string): string => filename.split('.').pop();
 

--- a/src/utils/url.js
+++ b/src/utils/url.js
@@ -111,30 +111,6 @@ export const getResource = (
 ): {| uri: string, headers?: {| [string]: string |} |} =>
   isUrlOnRealm(uri, auth.realm) ? getResourceWithAuth(uri, auth) : getResourceNoAuth(uri);
 
-export type Protocol = 'https://' | 'http://';
-
-const protocolRegex = /^\s*((?:http|https):\/\/)(.*)$/;
-
-// Split a (possible) URL into protocol and non-protocol parts.
-// The former will be null if no recognized protocol is a component
-// of the string.
-//
-// Ignores initial spaces.
-/** PRIVATE -- exported only for testing */
-export const parseProtocol = (value: string): [Protocol | null, string] => {
-  const match = protocolRegex.exec(value);
-
-  if (match) {
-    const [, protocol, rest] = match;
-    if (protocol === 'http://' || protocol === 'https://') {
-      return [protocol, rest];
-    } else {
-      throw new Error(`impossible match: protocol = '${escape(protocol)}'`);
-    }
-  }
-  return [null, value];
-};
-
 export const getFileExtension = (filename: string): string => filename.split('.').pop();
 
 export const isUrlAnImage = (url: string): boolean =>

--- a/src/utils/url.js
+++ b/src/utils/url.js
@@ -112,27 +112,25 @@ export const isUrlOnRealm = (
   //   we might as well fix.
   || url.startsWith(realm.toString());
 
-const getResourceWithAuth = (uri: string, auth: Auth) => ({
-  uri: new URL(uri, auth.realm).toString(),
+const getResourceWithAuth = (uri: URL, auth: Auth) => ({
+  uri: uri.toString(),
   headers: getAuthHeaders(auth),
 });
 
-const getResourceNoAuth = (uri: string) => ({
-  uri,
+const getResourceNoAuth = (uri: URL) => ({
+  uri: uri.toString(),
 });
 
 export const getResource = (
-  /**
-   * The location of the resource.
-   *
-   * Must be a "valid URL string" as defined by the URL standard:
-   *   https://url.spec.whatwg.org/#url-writing
-   */
-  uri: string,
+  /** The location of the resource. */
+  uri: URL,
 
   auth: Auth,
 ): {| uri: string, headers?: {| [string]: string |} |} =>
-  isUrlOnRealm(uri, auth.realm) ? getResourceWithAuth(uri, auth) : getResourceNoAuth(uri);
+  // TODO: isUrlOnRealm will take a URL soon; when it does, simplify.
+  isUrlOnRealm(uri.toString(), auth.realm)
+    ? getResourceWithAuth(uri, auth)
+    : getResourceNoAuth(uri);
 
 export const getFileExtension = (filename: string): string => filename.split('.').pop();
 

--- a/src/webview/handleOutboundEvents.js
+++ b/src/webview/handleOutboundEvents.js
@@ -72,7 +72,15 @@ type WebViewOutboundEventNarrow = {|
 
 type WebViewOutboundEventImage = {|
   type: 'image',
+
+  /**
+   * The location of the image.
+   *
+   * Must be a "valid URL string" as defined by the URL standard:
+   *   https://url.spec.whatwg.org/#url-writing
+   */
   src: string,
+
   messageId: number,
 |};
 
@@ -87,7 +95,13 @@ type WebViewOutboundEventReaction = {|
 
 type WebViewOutboundEventUrl = {|
   type: 'url',
+
+  /**
+   * A "valid URL string" as defined by the URL standard:
+   *   https://url.spec.whatwg.org/#url-writing
+   */
   href: string,
+
   messageId: number,
 |};
 
@@ -197,7 +211,18 @@ const markRead = (props: Props, event: WebViewOutboundEventScroll) => {
   api.queueMarkAsRead(auth, unreadMessageIds);
 };
 
-const handleImage = (props: Props, src: string, messageId: number) => {
+const handleImage = (
+  props: Props,
+  /**
+   * The location of the image, for presentation in the lightbox.
+   *
+   * Must be a "valid URL string" as defined by the URL standard:
+   *   https://url.spec.whatwg.org/#url-writing
+   */
+  src: string,
+
+  messageId: number,
+) => {
   const message = props.messages.find(x => x.id === messageId);
   if (message && message.isOutbox !== true) {
     NavigationService.dispatch(navigateToLightbox(src, message));

--- a/src/webview/handleOutboundEvents.js
+++ b/src/webview/handleOutboundEvents.js
@@ -10,7 +10,7 @@ import type { ShowActionSheetWithOptions } from '../action-sheets';
 import type { JSONableDict } from '../utils/jsonable';
 import { showToast } from '../utils/info';
 import { pmKeyRecipientsFromMessage } from '../utils/recipient';
-import { isUrlAnImage } from '../utils/url';
+import { isUrlAnImage, tryParseUrl } from '../utils/url';
 import * as logging from '../utils/logging';
 import { filterUnreadMessagesInRange } from '../utils/unread';
 import { parseNarrow } from '../utils/narrow';
@@ -224,8 +224,15 @@ const handleImage = (
   messageId: number,
 ) => {
   const message = props.messages.find(x => x.id === messageId);
+
+  const parsedSrc = tryParseUrl(src, props.backgroundData.auth.realm);
+  if (!parsedSrc) {
+    logging.error("An image in a message was pressed, and its URL doesn't parse.");
+    return;
+  }
+
   if (message && message.isOutbox !== true) {
-    NavigationService.dispatch(navigateToLightbox(src, message));
+    NavigationService.dispatch(navigateToLightbox(parsedSrc, message));
   }
 };
 

--- a/src/webview/js/js.js
+++ b/src/webview/js/js.js
@@ -859,7 +859,13 @@ documentBody.addEventListener('click', (e: MouseEvent) => {
   ) {
     sendMessage({
       type: 'image',
+
+      // The server is responsible for sending a "valid URL string" as
+      // defined by the URL standard:
+      //   https://url.spec.whatwg.org/#url-writing
+      // We trust that it does.
       src: requireAttribute(inlineImageLink, 'href'), // TODO: should be `src` / `data-src-fullsize`.
+
       messageId: getMessageIdFromElement(inlineImageLink),
     });
     return;
@@ -910,7 +916,13 @@ documentBody.addEventListener('click', (e: MouseEvent) => {
   if (closestA) {
     sendMessage({
       type: 'url',
+
+      // The server is responsible for sending a "valid URL string" as
+      // defined by the URL standard:
+      //   https://url.spec.whatwg.org/#url-writing
+      // We trust that it does.
       href: requireAttribute(closestA, 'href'),
+
       messageId: getMessageIdFromElement(closestA),
     });
     return;


### PR DESCRIPTION
I'm doing a cleanup of some relevant parts of our URL parsing logic, as I prepare for #5306. Inheriting priority from that.

From start to finish, this would take us from

```js
// TODO: Work out what this does, write a jsdoc for its interface, and
// reimplement using URL object (not just for the realm)
export const isUrlOnRealm = (url: string, realm: URL): boolean =>
  url.startsWith('/') || url.startsWith(realm.toString()) || !/^(http|www.)/i.test(url);
```

to

```js
// TODO: As of writing, we use this same check in 5 or so other places.
//   Probably should consolidate those so they call this function, or else
//   dissolve this function.
export const isUrlOnRealm = (url: URL, realm: URL): boolean => url.origin === realm.origin;
```

(Ah, and I think the TODO we're left with in the "after" is probably something we can resolve easily.)

Rather than making that big change in one commit, I've tried to pull out incremental changes so we can see how the behavior changes. As always, please let me know if you'd like me to be more or less incremental, or if there's a better order I can put the commits in. 🙂