### PR TITLE
SubscriptionsScreen: Fix iOS regression where title looks wrong

### DIFF
--- a/src/account-info/ProfileScreen.js
+++ b/src/account-info/ProfileScreen.js
@@ -2,6 +2,7 @@
 import React, { useContext } from 'react';
 import type { Node } from 'react';
 import { ScrollView, View, Alert } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 
 import { type UserId } from '../api/idTypes';
 import { TranslationContext } from '../boot/TranslationProvider';
@@ -131,22 +132,24 @@ export default function ProfileScreen(props: Props): Node {
   const ownUser = useSelector(getOwnUser);
 
   return (
-    <ScrollView>
-      <AccountDetails user={ownUser} />
-      <AwayStatusSwitch />
-      <View style={styles.buttonRow}>
-        <SetStatusButton />
-      </View>
-      <View style={styles.buttonRow}>
-        <ProfileButton ownUserId={ownUser.user_id} />
-      </View>
-      <View style={styles.buttonRow}>
-        <SettingsButton />
-      </View>
-      <View style={styles.buttonRow}>
-        <SwitchAccountButton />
-        <LogoutButton />
-      </View>
-    </ScrollView>
+    <SafeAreaView mode="padding" edges={['top']} style={{ flex: 1 }}>
+      <ScrollView>
+        <AccountDetails user={ownUser} />
+        <AwayStatusSwitch />
+        <View style={styles.buttonRow}>
+          <SetStatusButton />
+        </View>
+        <View style={styles.buttonRow}>
+          <ProfileButton ownUserId={ownUser.user_id} />
+        </View>
+        <View style={styles.buttonRow}>
+          <SettingsButton />
+        </View>
+        <View style={styles.buttonRow}>
+          <SwitchAccountButton />
+          <LogoutButton />
+        </View>
+      </ScrollView>
+    </SafeAreaView>
   );
 }

--- a/src/main/HomeScreen.js
+++ b/src/main/HomeScreen.js
@@ -3,6 +3,7 @@
 import React from 'react';
 import type { Node } from 'react';
 import { View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 
 import type { RouteProp } from '../react-navigation';
 import type { MainTabsNavigationProp } from './MainTabsScreen';
@@ -38,7 +39,7 @@ export default function HomeScreen(props: Props): Node {
   const dispatch = useDispatch();
 
   return (
-    <View style={styles.wrapper}>
+    <SafeAreaView mode="padding" edges={['top']} style={styles.wrapper}>
       <View style={styles.iconList}>
         <TopTabButton
           name="globe"
@@ -70,6 +71,6 @@ export default function HomeScreen(props: Props): Node {
       <ServerPushSetupBanner />
       <LoadingBanner />
       <UnreadCards />
-    </View>
+    </SafeAreaView>
   );
 }

--- a/src/main/MainTabsScreen.js
+++ b/src/main/MainTabsScreen.js
@@ -1,11 +1,11 @@
 /* @flow strict-local */
 import React, { useContext } from 'react';
 import type { Node } from 'react';
+import { View } from 'react-native';
 import {
   createBottomTabNavigator,
   type BottomTabNavigationProp,
 } from '@react-navigation/bottom-tabs';
-import { SafeAreaView } from 'react-native-safe-area-context';
 import type { RouteProp, RouteParamsOf } from '../react-navigation';
 import { getUnreadHuddlesTotal, getUnreadPmsTotal } from '../selectors';
 import { useSelector } from '../react-redux';
@@ -53,7 +53,7 @@ export default function MainTabsScreen(props: Props): Node {
   const unreadPmsCount = useSelector(getUnreadHuddlesTotal) + useSelector(getUnreadPmsTotal);
 
   return (
-    <SafeAreaView mode="padding" edges={['top']} style={[styles.flexed, { backgroundColor }]}>
+    <View style={[styles.flexed, { backgroundColor }]}>
       <OfflineNotice />
       <Tab.Navigator {...bottomTabNavigatorConfig()} lazy={false} backBehavior="none">
         <Tab.Screen
@@ -94,6 +94,6 @@ export default function MainTabsScreen(props: Props): Node {
           }}
         />
       </Tab.Navigator>
-    </SafeAreaView>
+    </View>
   );
 }

--- a/src/nav/ModalNavBar.js
+++ b/src/nav/ModalNavBar.js
@@ -1,10 +1,10 @@
 /* @flow strict-local */
-import React, { useContext } from 'react';
+import React, { useContext, useMemo } from 'react';
 import type { Node } from 'react';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 import type { LocalizableReactText } from '../types';
-import styles, { ThemeContext, NAVBAR_SIZE } from '../styles';
+import globalStyles, { ThemeContext, NAVBAR_SIZE } from '../styles';
 import ZulipTextIntl from '../common/ZulipTextIntl';
 import NavBarBackButton from './NavBarBackButton';
 
@@ -32,11 +32,17 @@ export default function ModalNavBar(props: Props): Node {
 
   const { canGoBack, title } = props;
   const { backgroundColor } = useContext(ThemeContext);
-  const textStyle = [
-    styles.navTitle,
-    { flex: 1 },
-    canGoBack ? { marginStart: 20, marginEnd: 8 } : { marginHorizontal: 8 },
-  ];
+
+  const styles = useMemo(
+    () => ({
+      text: [
+        globalStyles.navTitle,
+        { flex: 1 },
+        canGoBack ? { marginStart: 20, marginEnd: 8 } : { marginHorizontal: 8 },
+      ],
+    }),
+    [canGoBack],
+  );
 
   return (
     <SafeAreaView
@@ -53,7 +59,7 @@ export default function ModalNavBar(props: Props): Node {
       }}
     >
       {canGoBack && <NavBarBackButton />}
-      <ZulipTextIntl style={textStyle} text={title} numberOfLines={1} ellipsizeMode="tail" />
+      <ZulipTextIntl style={styles.text} text={title} numberOfLines={1} ellipsizeMode="tail" />
     </SafeAreaView>
   );
 }

--- a/src/nav/ModalNavBar.js
+++ b/src/nav/ModalNavBar.js
@@ -40,15 +40,7 @@ export default function ModalNavBar(props: Props): Node {
         { flex: 1 },
         canGoBack ? { marginStart: 20, marginEnd: 8 } : { marginHorizontal: 8 },
       ],
-    }),
-    [canGoBack],
-  );
-
-  return (
-    <SafeAreaView
-      mode="padding"
-      edges={['top', 'right', 'left']}
-      style={{
+      safeAreaView: {
         minHeight: NAVBAR_SIZE,
         borderColor: 'hsla(0, 0%, 50%, 0.25)',
         borderBottomWidth: 1,
@@ -56,8 +48,13 @@ export default function ModalNavBar(props: Props): Node {
         paddingHorizontal: 4,
         flexDirection: 'row',
         alignItems: 'center',
-      }}
-    >
+      },
+    }),
+    [canGoBack, backgroundColor],
+  );
+
+  return (
+    <SafeAreaView mode="padding" edges={['top', 'right', 'left']} style={styles.safeAreaView}>
       {canGoBack && <NavBarBackButton />}
       <ZulipTextIntl style={styles.text} text={title} numberOfLines={1} ellipsizeMode="tail" />
     </SafeAreaView>

--- a/src/nav/ModalNavBar.js
+++ b/src/nav/ModalNavBar.js
@@ -1,6 +1,7 @@
 /* @flow strict-local */
 import React, { useContext, useMemo } from 'react';
 import type { Node } from 'react';
+import { View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 import type { LocalizableReactText } from '../types';
@@ -41,11 +42,19 @@ export default function ModalNavBar(props: Props): Node {
         canGoBack ? { marginStart: 20, marginEnd: 8 } : { marginHorizontal: 8 },
       ],
       safeAreaView: {
-        minHeight: NAVBAR_SIZE,
         borderColor: 'hsla(0, 0%, 50%, 0.25)',
         borderBottomWidth: 1,
         backgroundColor,
         paddingHorizontal: 4,
+      },
+      contentArea: {
+        // We should really be able to put this in styles.safeAreaView, and
+        // it should control the height of the "content area" of that view,
+        // excluding padding. But SafeAreaView seems to take `height` and
+        // `minHeight` as controlling the height of everything including the
+        // automatic vertical padding. So, we've added this separate View.
+        minHeight: NAVBAR_SIZE,
+
         flexDirection: 'row',
         alignItems: 'center',
       },
@@ -55,8 +64,11 @@ export default function ModalNavBar(props: Props): Node {
 
   return (
     <SafeAreaView mode="padding" edges={['top', 'right', 'left']} style={styles.safeAreaView}>
-      {canGoBack && <NavBarBackButton />}
-      <ZulipTextIntl style={styles.text} text={title} numberOfLines={1} ellipsizeMode="tail" />
+      {/* See comment on styles.contentArea.minHeight. */}
+      <View style={styles.contentArea}>
+        {canGoBack && <NavBarBackButton />}
+        <ZulipTextIntl style={styles.text} text={title} numberOfLines={1} ellipsizeMode="tail" />
+      </View>
     </SafeAreaView>
   );
 }

--- a/src/nav/ModalSearchNavBar.js
+++ b/src/nav/ModalSearchNavBar.js
@@ -29,11 +29,19 @@ export default function ModalSearchNavBar(props: Props): Node {
   const styles = useMemo(
     () => ({
       safeAreaView: {
-        minHeight: NAVBAR_SIZE,
         borderColor: 'hsla(0, 0%, 50%, 0.25)',
         borderBottomWidth: 1,
         backgroundColor,
         paddingHorizontal: 4,
+      },
+      contentArea: {
+        // We should really be able to put this in styles.safeAreaView, and
+        // it should control the height of the "content area" of that view,
+        // excluding padding. But SafeAreaView seems to take `height` and
+        // `minHeight` as controlling the height of everything including the
+        // automatic vertical padding. So, we've added this separate View.
+        minHeight: NAVBAR_SIZE,
+
         flexDirection: 'row',
         alignItems: 'center',
       },
@@ -43,18 +51,21 @@ export default function ModalSearchNavBar(props: Props): Node {
 
   return (
     <SafeAreaView mode="padding" edges={['top', 'right', 'left']} style={styles.safeAreaView}>
-      {canGoBack && (
-        <>
-          <NavBarBackButton />
-          <View style={{ width: 20 }} />
-        </>
-      )}
-      <SearchInput
-        autoFocus={autoFocus}
-        onChangeText={searchBarOnChange}
-        onSubmitEditing={searchBarOnSubmit}
-        placeholder={placeholder}
-      />
+      {/* See comment on styles.contentArea.minHeight. */}
+      <View style={styles.contentArea}>
+        {canGoBack && (
+          <>
+            <NavBarBackButton />
+            <View style={{ width: 20 }} />
+          </>
+        )}
+        <SearchInput
+          autoFocus={autoFocus}
+          onChangeText={searchBarOnChange}
+          onSubmitEditing={searchBarOnSubmit}
+          placeholder={placeholder}
+        />
+      </View>
     </SafeAreaView>
   );
 }

--- a/src/nav/ModalSearchNavBar.js
+++ b/src/nav/ModalSearchNavBar.js
@@ -1,5 +1,5 @@
 /* @flow strict-local */
-import React, { useContext } from 'react';
+import React, { useContext, useMemo } from 'react';
 import type { Node } from 'react';
 import { View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
@@ -25,11 +25,10 @@ export default function ModalSearchNavBar(props: Props): Node {
 
   const { autoFocus, searchBarOnChange, canGoBack = true, searchBarOnSubmit, placeholder } = props;
   const { backgroundColor } = useContext(ThemeContext);
-  return (
-    <SafeAreaView
-      mode="padding"
-      edges={['top', 'right', 'left']}
-      style={{
+
+  const styles = useMemo(
+    () => ({
+      safeAreaView: {
         minHeight: NAVBAR_SIZE,
         borderColor: 'hsla(0, 0%, 50%, 0.25)',
         borderBottomWidth: 1,
@@ -37,8 +36,13 @@ export default function ModalSearchNavBar(props: Props): Node {
         paddingHorizontal: 4,
         flexDirection: 'row',
         alignItems: 'center',
-      }}
-    >
+      },
+    }),
+    [backgroundColor],
+  );
+
+  return (
+    <SafeAreaView mode="padding" edges={['top', 'right', 'left']} style={styles.safeAreaView}>
       {canGoBack && (
         <>
           <NavBarBackButton />

--- a/src/pm-conversations/PmConversationsScreen.js
+++ b/src/pm-conversations/PmConversationsScreen.js
@@ -3,6 +3,7 @@
 import React, { useContext } from 'react';
 import type { Node } from 'react';
 import { View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 
 import type { RouteProp } from '../react-navigation';
 import type { MainTabsNavigationProp } from '../main/MainTabsScreen';
@@ -48,7 +49,11 @@ export default function PmConversationsScreen(props: Props): Node {
   const context = useContext(ThemeContext);
 
   return (
-    <View style={[styles.container, { backgroundColor: context.backgroundColor }]}>
+    <SafeAreaView
+      mode="padding"
+      edges={['top']}
+      style={[styles.container, { backgroundColor: context.backgroundColor }]}
+    >
       <View style={styles.row}>
         <ZulipButton
           secondary
@@ -75,6 +80,6 @@ export default function PmConversationsScreen(props: Props): Node {
       ) : (
         <PmConversationList conversations={conversations} />
       )}
-    </View>
+    </SafeAreaView>
   );
 }

--- a/src/streams/SubscriptionsScreen.js
+++ b/src/streams/SubscriptionsScreen.js
@@ -94,7 +94,9 @@ export default function SubscriptionsScreen(props: Props): Node {
 
   return (
     <View style={styles.container}>
+      {/* Consumes the top inset. */}
       <ModalNavBar canGoBack={false} title="Streams" />
+
       <LoadingBanner />
       {subscriptions.length === 0 ? (
         <SearchEmptyState text="No streams found" />


### PR DESCRIPTION
From discussion: https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/Regression.20in.20.22Streams.22.20screen/near/1412459

Regression introduced in 9d11e787f and not yet released.

There was [another thing going wrong](https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/Regression.20in.20.22Streams.22.20screen/near/1412491) which we fixed by upgrading `react-native-safe-area-context` to latest, in #5455.

The first commit is a rewrite of https://github.com/zulip/zulip-mobile/pull/5197/commits/1b5506a2f184cb28e7504cbae04a7012a4c8d8ff (on a draft PR) for current `main`.

Screenshots below, from my iPhone 13 Pro. You'll have to use your imagination to fill in the physical features of the screen that occupy the insets: the four corners are rounded, and there's a notch in the middle of the top where the camera is. Or I can start up an iOS simulator on my laptop, and use my laptop's screenshot feature to capture a simulation of those physical features.