### PR TITLE
homescreen_tabs: Change "globe" icon to "align-left" icon.

### DIFF
--- a/src/main/HomeScreen.js
+++ b/src/main/HomeScreen.js
@@ -41,7 +41,7 @@ export default function HomeScreen(props: Props): Node {
     <View style={styles.wrapper}>
       <View style={styles.iconList}>
         <TopTabButton
-          name="globe"
+          name="align-left"
           onPress={() => {
             dispatch(doNarrow(HOME_NARROW));
           }}


### PR DESCRIPTION
This change was made to make the All-Messages icon in mobile Zulip congruent to the one found in browser Zulip.

This swap was performed by changing the `name` property of the first `TopTabButton` component found in `HomeScreen.js`. This property was changed from `globe` to `align-left`. It is worthwhile to note that this property is a string restricted by Flow's literal union type. A list of all valid strings for this property can be found in `FeatherGlyphs` type at the top of `Icons.js`.  

![Screen Shot 2022-07-30 at 5 41 14 PM](https://user-images.githubusercontent.com/69024992/182498874-77300439-79ce-4621-8f2b-86a958044a35.png)

![Screen Shot 2022-07-30 at 5 41 49 PM](https://user-images.githubusercontent.com/69024992/182498941-0359fce0-543e-465d-9a4d-44cb3bb46d6d.png)


Both previous and updated icons are a part of the Feather icons collection inside the `React-Native-Vector-Icons`. While it seems Zulip mobile uses Feather icons almost exclusively, if it is decided an icon from a different collection is more appropriate, changes must be made to the `Icon` component that consumes the `name` property. In its current state, the component contains helper functions (see: `fixIconType`) that are configured to build only from the Feather collection. 

This commit has passed the included unit tests.
![Screen Shot 2022-07-30 at 5 39 51 PM](https://user-images.githubusercontent.com/69024992/182498977-4585babc-5e70-4716-8e56-e351317dbef8.png)


Fixes: #5303.