### PR TITLE
mainScreenTabs: Change All-Messages icon from globe to list.

### DIFF
--- a/src/main/HomeScreen.js
+++ b/src/main/HomeScreen.js
@@ -41,7 +41,7 @@ export default function HomeScreen(props: Props): Node {
     <View style={styles.wrapper}>
       <View style={styles.iconList}>
         <TopTabButton
-          name="globe"
+          name="align-left"
           onPress={() => {
             dispatch(doNarrow(HOME_NARROW));
           }}


### PR DESCRIPTION
To match the mobile All-Messages icon with the icon found in browser.

![Screen Shot 2022-07-30 at 5 41 49 PM](https://user-images.githubusercontent.com/69024992/182973190-b894c8a8-62eb-42c7-a7e5-a0a997a63d59.png)

![Screen Shot 2022-07-30 at 5 41 14 PM](https://user-images.githubusercontent.com/69024992/182973201-32dd35d2-3a8c-456b-9f37-639d54271557.png)

Fixes: #5303