### PR TITLE
internalLinks: Fix bugs in getMessageIdFromLink

### DIFF
--- a/src/message/messagesActions.js
+++ b/src/message/messagesActions.js
@@ -36,6 +36,7 @@ export const messageLinkPress =
     //   perhaps give an error instead of falling back to opening in browser,
     //   which should be futile.
     if (narrow) {
+      // This call is OK: `narrow` is truthy, so isNarrowLink(…) was true.
       const anchor = getMessageIdFromLink(href, auth.realm);
       dispatch(doNarrow(narrow, anchor));
     } else if (!isUrlOnRealm(href, auth.realm)) {

--- a/src/utils/__tests__/internalLinks-test.js
+++ b/src/utils/__tests__/internalLinks-test.js
@@ -170,7 +170,7 @@ describe('isNarrowLink', () => {
 describe('isMessageLink', () => {
   test('only in-app link containing "near/<message-id>" is a message link', () => {
     expect(isMessageLink('https://example.com/#narrow/stream/jest', realm)).toBe(false);
-    expect(isMessageLink('https://example.com/#narrow/#near/1', realm)).toBe(true);
+    expect(isMessageLink('https://example.com/#narrow/near/1', realm)).toBe(true);
   });
 });
 

--- a/src/utils/__tests__/internalLinks-test.js
+++ b/src/utils/__tests__/internalLinks-test.js
@@ -4,7 +4,6 @@ import type { Stream } from '../../types';
 import { streamNarrow, topicNarrow, pmNarrowFromUsersUnsafe, STARRED_NARROW } from '../narrow';
 import {
   isNarrowLink,
-  isMessageLink,
   getLinkType,
   getNarrowFromLink,
   getMessageIdFromLink,
@@ -165,13 +164,6 @@ describe('isNarrowLink', () => {
       expect(isNarrowLink(url, realm_ ?? realm)).toBe(expected);
     });
   }
-});
-
-describe('isMessageLink', () => {
-  test('only in-app link containing "near/<message-id>" is a message link', () => {
-    expect(isMessageLink('https://example.com/#narrow/stream/jest', realm)).toBe(false);
-    expect(isMessageLink('https://example.com/#narrow/near/1', realm)).toBe(true);
-  });
 });
 
 describe('getLinkType', () => {
@@ -429,6 +421,11 @@ describe('getNarrowFromLink', () => {
 describe('getMessageIdFromLink', () => {
   test('not message link', () => {
     expect(getMessageIdFromLink('https://example.com/#narrow/is/private', realm)).toBe(0);
+    expect(getMessageIdFromLink('https://example.com/#narrow/stream/jest', realm)).toBe(0);
+  });
+
+  test('`near` is the only operator', () => {
+    expect(getMessageIdFromLink('https://example.com/#narrow/near/1', realm)).toBe(1);
   });
 
   test('when link is a group link, return anchor message id', () => {

--- a/src/utils/__tests__/internalLinks-test.js
+++ b/src/utils/__tests__/internalLinks-test.js
@@ -3,7 +3,7 @@
 import type { Stream } from '../../types';
 import { streamNarrow, topicNarrow, pmNarrowFromUsersUnsafe, STARRED_NARROW } from '../narrow';
 import {
-  isInternalLink,
+  isNarrowLink,
   isMessageLink,
   getLinkType,
   getNarrowFromLink,
@@ -14,7 +14,7 @@ import * as eg from '../../__tests__/lib/exampleData';
 
 const realm = new URL('https://example.com');
 
-describe('isInternalLink', () => {
+describe('isNarrowLink', () => {
   const cases: $ReadOnlyArray<[boolean, string, string] | [boolean, string, string, URL]> = [
     [true, 'fragment-only, to a narrow', '#narrow/stream/jest/topic/topic1'],
     [false, 'fragment-only, wrong fragment', '#nope'],
@@ -162,7 +162,7 @@ describe('isInternalLink', () => {
      realm_ is URL | void, but complains of out-of-bounds access */
   for (const [expected, description, url, realm_] of cases) {
     test(`${expected ? 'accept' : 'reject'} ${description}: ${url}`, () => {
-      expect(isInternalLink(url, realm_ ?? realm)).toBe(expected);
+      expect(isNarrowLink(url, realm_ ?? realm)).toBe(expected);
     });
   }
 });
@@ -175,8 +175,8 @@ describe('isMessageLink', () => {
 });
 
 describe('getLinkType', () => {
-  test('links to a different domain are of "external" type', () => {
-    expect(getLinkType('https://google.com/some-path', realm)).toBe('external');
+  test('links to a different domain are of "non-narrow" type', () => {
+    expect(getLinkType('https://google.com/some-path', realm)).toBe('non-narrow');
   });
 
   test('only in-app link containing "stream" is a stream link', () => {

--- a/src/utils/internalLinks.js
+++ b/src/utils/internalLinks.js
@@ -41,18 +41,6 @@ export const isNarrowLink = (url: string, realm: URL): boolean => {
   );
 };
 
-/**
- * PRIVATE -- exported only for tests.
- *
- * This performs a call to `new URL` and therefore may take a fraction of a
- * millisecond.  Avoid using in a context where it might be called more than
- * 10 or 100 times per user action.
- */
-// TODO: Work out what this does, write a jsdoc for its interface, and
-// reimplement using URL object (not just for the realm)
-export const isMessageLink = (url: string, realm: URL): boolean =>
-  isNarrowLink(url, realm) && url.includes('near');
-
 type LinkType = 'non-narrow' | 'home' | 'pm' | 'topic' | 'stream' | 'special';
 
 /**
@@ -213,7 +201,12 @@ export const getNarrowFromLink = (
 export const getMessageIdFromLink = (url: string, realm: URL): number => {
   const paths = getPathsFromUrl(url, realm);
 
-  return isMessageLink(url, realm) ? parseInt(paths[paths.lastIndexOf('near') + 1], 10) : 0;
+  const isMessageLink =
+    isNarrowLink(url, realm)
+    // TODO: Very wrong; inspect `paths` for this, not all of `url`.
+    && url.includes('near');
+
+  return isMessageLink ? parseInt(paths[paths.lastIndexOf('near') + 1], 10) : 0;
 };
 
 export const getStreamTopicUrl = (

--- a/src/utils/internalLinks.js
+++ b/src/utils/internalLinks.js
@@ -31,7 +31,7 @@ const getPathsFromUrl = (url: string, realm: URL) => {
  * millisecond.  Avoid using in a context where it might be called more than
  * 10 or 100 times per user action.
  */
-export const isInternalLink = (url: string, realm: URL): boolean => {
+export const isNarrowLink = (url: string, realm: URL): boolean => {
   const resolved = new URL(url, realm);
   return (
     resolved.origin === realm.origin
@@ -51,9 +51,9 @@ export const isInternalLink = (url: string, realm: URL): boolean => {
 // TODO: Work out what this does, write a jsdoc for its interface, and
 // reimplement using URL object (not just for the realm)
 export const isMessageLink = (url: string, realm: URL): boolean =>
-  isInternalLink(url, realm) && url.includes('near');
+  isNarrowLink(url, realm) && url.includes('near');
 
-type LinkType = 'external' | 'home' | 'pm' | 'topic' | 'stream' | 'special';
+type LinkType = 'non-narrow' | 'home' | 'pm' | 'topic' | 'stream' | 'special';
 
 /**
  * PRIVATE -- exported only for tests.
@@ -65,8 +65,8 @@ type LinkType = 'external' | 'home' | 'pm' | 'topic' | 'stream' | 'special';
 // TODO: Work out what this does, write a jsdoc for its interface, and
 // reimplement using URL object (not just for the realm)
 export const getLinkType = (url: string, realm: URL): LinkType => {
-  if (!isInternalLink(url, realm)) {
-    return 'external';
+  if (!isNarrowLink(url, realm)) {
+    return 'non-narrow';
   }
 
   const paths = getPathsFromUrl(url, realm);

--- a/src/utils/internalLinks.js
+++ b/src/utils/internalLinks.js
@@ -13,7 +13,7 @@ const getPathsFromUrl = (url: string, realm: URL) => {
   const paths = url.split(realm.toString()).pop().split('#narrow/').pop()
 .split('/');
 
-  if (paths.length > 0 && paths[paths.length - 1] === '') {
+  if (paths[paths.length - 1] === '') {
     // url ends with /
     paths.splice(-1, 1);
   }

--- a/src/utils/internalLinks.js
+++ b/src/utils/internalLinks.js
@@ -22,8 +22,7 @@ import { ensureUnreachable } from '../generics';
 //   like the web app's parse_narrow in static/js/hash_util.js.
 // TODO(#3757): Use @zulip/shared for that parsing.
 const getHashSegmentsFromNarrowLink = (url: string, realm: URL) => {
-  const result = url.split(realm.toString()).pop().split('#narrow/').pop()
-.split('/');
+  const result = url.split('#narrow/').pop().split('/');
 
   if (result[result.length - 1] === '') {
     // url ends with /

--- a/src/utils/internalLinks.js
+++ b/src/utils/internalLinks.js
@@ -192,7 +192,8 @@ export const getNarrowFromLink = (
 };
 
 /**
- * TODO write jsdoc
+ * From a URL and realm with `isNarrowLink(url, realm) === true`, give
+ *   message_id if the URL ends in /near/{message_id}, otherwise give zero.
  *
  * This performs a call to `new URL` and therefore may take a fraction of a
  * millisecond.  Avoid using in a context where it might be called more than
@@ -201,10 +202,8 @@ export const getNarrowFromLink = (
 export const getMessageIdFromLink = (url: string, realm: URL): number => {
   const paths = getPathsFromUrl(url, realm);
 
-  const isMessageLink =
-    isNarrowLink(url, realm)
-    // TODO: Very wrong; inspect `paths` for this, not all of `url`.
-    && url.includes('near');
+  // TODO: Very wrong; inspect `paths` for this, not all of `url`.
+  const isMessageLink = url.includes('near');
 
   return isMessageLink ? parseInt(paths[paths.lastIndexOf('near') + 1], 10) : 0;
 };

--- a/src/utils/internalLinks.js
+++ b/src/utils/internalLinks.js
@@ -27,7 +27,10 @@ import { ensureUnreachable } from '../generics';
 //   like the web app's parse_narrow in static/js/hash_util.js.
 // TODO(#3757): Use @zulip/shared for that parsing.
 const getHashSegmentsFromNarrowLink = (url: string, realm: URL) => {
-  const result = new URL(url, realm).hash.split('#narrow/').pop().split('/');
+  const result = new URL(url, realm).hash
+    .split('/')
+    // Remove the first item, "#narrow".
+    .slice(1);
 
   if (result[result.length - 1] === '') {
     // url ends with /

--- a/src/utils/internalLinks.js
+++ b/src/utils/internalLinks.js
@@ -5,6 +5,7 @@ import { makeUserId } from '../api/idTypes';
 import type { Narrow, Stream, UserId } from '../types';
 import { topicNarrow, streamNarrow, specialNarrow, pmNarrowFromRecipients } from './narrow';
 import { pmKeyRecipientsFromIds } from './recipient';
+import { ensureUnreachable } from '../generics';
 
 // TODO: Work out what this does, write a jsdoc for its interface, and
 // reimplement using URL object (not just for the realm)
@@ -160,6 +161,11 @@ export const getNarrowFromLink = (
   ownUserId: UserId,
 ): Narrow | null => {
   const type = getLinkType(url, realm);
+
+  if (type === 'non-narrow') {
+    return null;
+  }
+
   const paths = getPathsFromUrl(url, realm);
 
   switch (type) {
@@ -186,7 +192,10 @@ export const getNarrowFromLink = (
       } catch {
         return null;
       }
+    case 'home':
+      return null; // TODO(?): Give HOME_NARROW
     default:
+      ensureUnreachable(type);
       return null;
   }
 };

--- a/src/utils/internalLinks.js
+++ b/src/utils/internalLinks.js
@@ -16,13 +16,18 @@ import { ensureUnreachable } from '../generics';
  *
  * If `url` ends with a slash, the returned array won't have '' as its last
  * element; that element is removed.
+ *
+ * This performs a call to `new URL` and therefore may take a fraction of a
+ * millisecond.  Avoid using in a context where it might be called more than
+ * 10 or 100 times per user action.
  */
-// TODO: Take a URL object for `url` instead of a string.
+// TODO: Take a URL object for `url` instead of a string, and remove
+//   performance warning in the jsdoc.
 // TODO: Parse into an array of objects with { negated, operator, operand },
 //   like the web app's parse_narrow in static/js/hash_util.js.
 // TODO(#3757): Use @zulip/shared for that parsing.
 const getHashSegmentsFromNarrowLink = (url: string, realm: URL) => {
-  const result = url.split('#narrow/').pop().split('/');
+  const result = new URL(url, realm).hash.split('#narrow/').pop().split('/');
 
   if (result[result.length - 1] === '') {
     // url ends with /


### PR DESCRIPTION
The goal of this PR is to make `getMessageIdFromLink` correctly return `message_id` from `/near/{message_id}` in a narrow link, so we can rely on it for #5306.

Since much of the work in that function is done by `getPathsFromUrl`, this gives some close attention to that function, cleaning it up and giving it a jsdoc. I've also proposed a plan for its further development with some TODOs.