### PR TITLE
homescreen_icon: Swap 'globe' icon with 'list' icon.

### DIFF
--- a/src/common/Icons.js
+++ b/src/common/Icons.js
@@ -108,3 +108,4 @@ export const IconGroup: SpecificIconType = makeIcon(FontAwesome, 'group');
 export const IconPlus: SpecificIconType = makeIcon(Feather, 'plus');
 // eslint-disable-next-line react/function-component-definition
 export const IconWebPublic: SpecificIconType = props => <ZulipIcon name="globe" {...props} />;
+export const IconAllMessages: SpecificIconType = makeIcon(FontAwesome, 'align-left');

--- a/src/main/HomeScreen.js
+++ b/src/main/HomeScreen.js
@@ -16,6 +16,7 @@ import { BRAND_COLOR, createStyleSheet } from '../styles';
 import LoadingBanner from '../common/LoadingBanner';
 import ServerCompatBanner from '../common/ServerCompatBanner';
 import ServerPushSetupBanner from '../common/ServerPushSetupBanner';
+import { Icon } from '../common/Icons';
 
 const styles = createStyleSheet({
   wrapper: {
@@ -40,12 +41,18 @@ export default function HomeScreen(props: Props): Node {
   return (
     <View style={styles.wrapper}>
       <View style={styles.iconList}>
-        <TopTabButton
-          name="globe"
+        <TopTabButtonGeneral
           onPress={() => {
             dispatch(doNarrow(HOME_NARROW));
           }}
-        />
+        >
+          <Icon
+            size={24}
+            style={{ textAlign: 'center' }}
+            color={BRAND_COLOR}
+            name="globe"
+          />
+        </TopTabButtonGeneral>
         <TopTabButton
           name="star"
           onPress={() => {

--- a/src/main/HomeScreen.js
+++ b/src/main/HomeScreen.js
@@ -16,7 +16,7 @@ import { BRAND_COLOR, createStyleSheet } from '../styles';
 import LoadingBanner from '../common/LoadingBanner';
 import ServerCompatBanner from '../common/ServerCompatBanner';
 import ServerPushSetupBanner from '../common/ServerPushSetupBanner';
-import { Icon } from '../common/Icons';
+import { IconAllMessages } from '../common/Icons';
 
 const styles = createStyleSheet({
   wrapper: {
@@ -46,12 +46,7 @@ export default function HomeScreen(props: Props): Node {
             dispatch(doNarrow(HOME_NARROW));
           }}
         >
-          <Icon
-            size={24}
-            style={{ textAlign: 'center' }}
-            color={BRAND_COLOR}
-            name="globe"
-          />
+          <IconAllMessages size={24} style={{ textAlign: 'center' }} color={BRAND_COLOR} />
         </TopTabButtonGeneral>
         <TopTabButton
           name="star"


### PR DESCRIPTION
to match the all-messages icon in mobile with one found on web.

Current:
![Screen Shot 2022-07-30 at 5 41 14 PM](https://user-images.githubusercontent.com/69024992/185723271-8714b58f-256c-4622-8514-f91f22195cd8.png)

Web:
![Screen Shot 2022-08-04 at 4 55 06 PM](https://user-images.githubusercontent.com/69024992/185723295-38adb4b1-76a0-447a-ac81-fe7e5891e811.png)

Update:
![Screen Shot 2022-08-19 at 5 57 20 PM](https://user-images.githubusercontent.com/69024992/185723286-6c0719d4-d007-431d-a146-9685183a39e1.png)

Performed by switching the Icon component with IconAllMessages.

Fixes: #5303