### PR TITLE
homescreen_icon: Swap All-Messages icon from 'globe' to 'list'.

### DIFF
--- a/src/common/Icons.js
+++ b/src/common/Icons.js
@@ -108,3 +108,4 @@ export const IconGroup: SpecificIconType = makeIcon(FontAwesome, 'group');
 export const IconPlus: SpecificIconType = makeIcon(Feather, 'plus');
 // eslint-disable-next-line react/function-component-definition
 export const IconWebPublic: SpecificIconType = props => <ZulipIcon name="globe" {...props} />;
+export const IconAllMessages: SpecificIconType = makeIcon(FontAwesome, 'align-left');

--- a/src/main/HomeScreen.js
+++ b/src/main/HomeScreen.js
@@ -16,6 +16,7 @@ import { BRAND_COLOR, createStyleSheet } from '../styles';
 import LoadingBanner from '../common/LoadingBanner';
 import ServerCompatBanner from '../common/ServerCompatBanner';
 import ServerPushSetupBanner from '../common/ServerPushSetupBanner';
+import { Icon } from '../common/Icons';
 
 const styles = createStyleSheet({
   wrapper: {
@@ -40,12 +41,13 @@ export default function HomeScreen(props: Props): Node {
   return (
     <View style={styles.wrapper}>
       <View style={styles.iconList}>
-        <TopTabButton
-          name="globe"
+        <TopTabButtonGeneral
           onPress={() => {
             dispatch(doNarrow(HOME_NARROW));
           }}
-        />
+        >
+          <Icon size={24} style={{ textAlign: 'center' }} color={BRAND_COLOR} name="globe" />
+        </TopTabButtonGeneral>
         <TopTabButton
           name="star"
           onPress={() => {

--- a/src/main/HomeScreen.js
+++ b/src/main/HomeScreen.js
@@ -16,7 +16,7 @@ import { BRAND_COLOR, createStyleSheet } from '../styles';
 import LoadingBanner from '../common/LoadingBanner';
 import ServerCompatBanner from '../common/ServerCompatBanner';
 import ServerPushSetupBanner from '../common/ServerPushSetupBanner';
-import { Icon } from '../common/Icons';
+import { IconAllMessages } from '../common/Icons';
 
 const styles = createStyleSheet({
   wrapper: {
@@ -46,7 +46,7 @@ export default function HomeScreen(props: Props): Node {
             dispatch(doNarrow(HOME_NARROW));
           }}
         >
-          <Icon size={24} style={{ textAlign: 'center' }} color={BRAND_COLOR} name="globe" />
+          <IconAllMessages size={24} style={{ textAlign: 'center' }} color={BRAND_COLOR} />
         </TopTabButtonGeneral>
         <TopTabButton
           name="star"


### PR DESCRIPTION
to match mobile's All Messages icon with the one found in web Zulip.

Previous Mobile:
![Screen Shot 2022-07-30 at 5 41 14 PM](https://user-images.githubusercontent.com/69024992/185726981-a811d1cf-1a75-4769-9f50-6c03392f1633.png)

Browser:
![Screen Shot 2022-08-19 at 8 19 26 PM](https://user-images.githubusercontent.com/69024992/185727036-20724d2d-192d-469e-92fb-9b213d75039d.png)


Update Mobile:
![Screen Shot 2022-08-19 at 5 57 20 PM](https://user-images.githubusercontent.com/69024992/185726960-a5f2ee2a-2fc6-4de2-8e35-d49543677d3e.png)

Fixes: #5303 

