### PR TITLE
i18n [nfc]: Remove some strings that appear in messages_en.json, but not in the UI

### DIFF
--- a/static/translations/messages_en.json
+++ b/static/translations/messages_en.json
@@ -78,7 +78,6 @@
   "Welcome": "Welcome",
   "Enter your Zulip server URL:": "Enter your Zulip server URL:",
   "e.g. zulip.example.com": "e.g. zulip.example.com",
-  "Subscriptions": "Subscriptions",
   "Search": "Search",
   "Log in": "Log in",
   "Enter": "Enter",

--- a/static/translations/messages_en.json
+++ b/static/translations/messages_en.json
@@ -86,7 +86,6 @@
   "Log out?": "Log out?",
   "This will log out {email} on {realmUrl} from the mobile app on this device.": "This will log out {email} on {realmUrl} from the mobile app on this device.",
   "Add new account": "Add new account",
-  "Search messages": "Search messages",
   "Search people": "Search people",
   "All streams": "All streams",
   "Write a message...": "Write a message...",

--- a/static/translations/messages_en.json
+++ b/static/translations/messages_en.json
@@ -86,7 +86,6 @@
   "Log out?": "Log out?",
   "This will log out {email} on {realmUrl} from the mobile app on this device.": "This will log out {email} on {realmUrl} from the mobile app on this device.",
   "Add new account": "Add new account",
-  "Search people": "Search people",
   "All streams": "All streams",
   "Write a message...": "Write a message...",
   "Email": "Email",

--- a/static/translations/messages_en.json
+++ b/static/translations/messages_en.json
@@ -87,7 +87,6 @@
   "This will log out {email} on {realmUrl} from the mobile app on this device.": "This will log out {email} on {realmUrl} from the mobile app on this device.",
   "Add new account": "Add new account",
   "All streams": "All streams",
-  "Write a message...": "Write a message...",
   "Email": "Email",
   "Username": "Username",
   "Password": "Password",


### PR DESCRIPTION
From an investigation discussed on CZO: https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/Strings.20in.20messages_en.2Ejson.20but.20not.20in.20the.20app/near/1425314

This handles the first few, starting at the top of the list in that CZO message. I'm posting my progress now so we can decide if it's worth it to do a deep-dive into the commit history for every string, or if I can just look at current `main` for some/most of them. When looking at the history, my goal has been to find the origin of the string, trace the evolution of any UI it appeared in, and make sure we didn't drop any translations during that evolution.