### PR TITLE
user status screen: Add "At the office" option, to follow web app

### DIFF
--- a/src/user-statuses/UserStatusScreen.js
+++ b/src/user-statuses/UserStatusScreen.js
@@ -40,6 +40,7 @@ const statusSuggestions: $ReadOnlyArray<StatusSuggestion> = [
   ['Out sick', { emoji_name: 'sick', emoji_code: '1f912', reaction_type: 'unicode_emoji' }],
   ['Vacationing', { emoji_name: 'palm_tree', emoji_code: '1f334', reaction_type: 'unicode_emoji' }],
   ['Working remotely', { emoji_name: 'house', emoji_code: '1f3e0', reaction_type: 'unicode_emoji' }], // prettier-ignore
+  ['At the office', { emoji_name: 'office', emoji_code: '1f3e2', reaction_type: 'unicode_emoji' }],
 ];
 
 const styles = createStyleSheet({

--- a/static/translations/messages_en.json
+++ b/static/translations/messages_en.json
@@ -315,6 +315,7 @@
   "Out sick": "Out sick",
   "Vacationing": "Vacationing",
   "Working remotely": "Working remotely",
+  "At the office": "At the office",
   "This message was hidden because it is from a user you have muted. Long-press to view.": "This message was hidden because it is from a user you have muted. Long-press to view.",
   "Signed out": "Signed out",
   "Remove account": "Remove account",


### PR DESCRIPTION
This implements the mobile counterpart to zulip/zulip#22828, 'Add an
"At the office" default status".