### PR TITLE
Clean up set of message flags

### DIFF
--- a/src/actionTypes.js
+++ b/src/actionTypes.js
@@ -60,6 +60,7 @@ import {
   DISMISS_SERVER_COMPAT_NOTICE,
 } from './actionConstants';
 
+import type { UserMessageFlag } from './api/modelTypes';
 import type {
   CustomProfileFieldsEvent,
   MessageEvent,
@@ -413,7 +414,7 @@ type EventUpdateMessageFlagsAction = $ReadOnly<{|
   type: typeof EVENT_UPDATE_MESSAGE_FLAGS,
   all: boolean,
   allMessages: MessagesState,
-  flag: string,
+  flag: UserMessageFlag,
   messages: $ReadOnlyArray<number>,
   op: 'add' | 'remove',
   message_details?: Map<number, UpdateMessageFlagsMessageDetails>,

--- a/src/api/eventTypes.js
+++ b/src/api/eventTypes.js
@@ -20,6 +20,7 @@ import type {
   PropagateMode,
   Stream,
   UserId,
+  UserMessageFlag,
   UserPresence,
   UserStatusUpdate,
 } from './modelTypes';
@@ -106,7 +107,7 @@ export type MessageEvent = $ReadOnly<{|
   message: Message,
 
   /** See the same-named property on `Message`. */
-  flags?: $ReadOnlyArray<string>,
+  flags?: $ReadOnlyArray<UserMessageFlag>,
 
   /**
    * When the message was sent by this client (with `queue_id` this queue),
@@ -335,7 +336,7 @@ export type UpdateMessageEvent = $ReadOnly<{|
   //   guarantee of that in the API nor, apparently, in the implementation.
   message_ids: $ReadOnlyArray<number>,
 
-  flags: $ReadOnlyArray<string>,
+  flags: $ReadOnlyArray<UserMessageFlag>,
 
   // TODO(server-5.0): Always present as of FL 114; make required.
   edit_timestamp?: number,

--- a/src/api/messages/messagesFlags.js
+++ b/src/api/messages/messagesFlags.js
@@ -11,7 +11,7 @@ export type ApiResponseMessagesFlags = {|
 export default (
   auth: Auth,
   messageIds: $ReadOnlyArray<number>,
-  op: string,
+  op: 'add' | 'remove',
   flag: UserMessageFlag,
 ): Promise<ApiResponseMessagesFlags> =>
   apiPost(auth, 'messages/flags', { messages: JSON.stringify(messageIds), flag, op });

--- a/src/api/messages/messagesFlags.js
+++ b/src/api/messages/messagesFlags.js
@@ -10,8 +10,8 @@ export type ApiResponseMessagesFlags = {|
 
 export default (
   auth: Auth,
-  messages: $ReadOnlyArray<number>,
+  messageIds: $ReadOnlyArray<number>,
   op: string,
   flag: UserMessageFlag,
 ): Promise<ApiResponseMessagesFlags> =>
-  apiPost(auth, 'messages/flags', { messages: JSON.stringify(messages), flag, op });
+  apiPost(auth, 'messages/flags', { messages: JSON.stringify(messageIds), flag, op });

--- a/src/api/messages/messagesFlags.js
+++ b/src/api/messages/messagesFlags.js
@@ -1,5 +1,6 @@
 /* @flow strict-local */
 import type { ApiResponseSuccess, Auth } from '../transportTypes';
+import type { UserMessageFlag } from '../modelTypes';
 import { apiPost } from '../apiFetch';
 
 export type ApiResponseMessagesFlags = {|
@@ -11,6 +12,6 @@ export default (
   auth: Auth,
   messages: $ReadOnlyArray<number>,
   op: string,
-  flag: string,
+  flag: UserMessageFlag,
 ): Promise<ApiResponseMessagesFlags> =>
   apiPost(auth, 'messages/flags', { messages: JSON.stringify(messages), flag, op });

--- a/src/api/modelTypes.js
+++ b/src/api/modelTypes.js
@@ -750,6 +750,21 @@ export type Submessage = $ReadOnly<{|
 |}>;
 
 /**
+ * A flag that can be set on a message for a user.
+ *
+ * See:
+ *   https://zulip.com/api/update-message-flags#available-flags
+ */
+export type UserMessageFlag =
+  | 'read'
+  | 'starred'
+  | 'collapsed'
+  | 'mentioned'
+  | 'wildcard_mentioned'
+  | 'has_alert_word'
+  | 'historical';
+
+/**
  * Properties in common among the two different flavors of a
  * `Message`: `PmMessage` and `StreamMessage`.
  */
@@ -845,7 +860,7 @@ type MessageBase = $ReadOnly<{|
    *  * Absent in the Redux `state.messages`; we move the information to a
    *    separate subtree `state.flags`.
    */
-  flags?: $ReadOnlyArray<string>,
+  flags?: $ReadOnlyArray<UserMessageFlag>,
 
   /** Our own flag; if true, really type `Outbox`. */
   isOutbox?: false,

--- a/src/chat/__tests__/flagsReducer-test.js
+++ b/src/chat/__tests__/flagsReducer-test.js
@@ -323,13 +323,8 @@ describe('flagsReducer', () => {
         collapsed: { 1: true },
         mentioned: { 1: true },
         wildcard_mentioned: { 1: true },
-        summarize_in_home: { 1: true },
-        summarize_in_stream: { 1: true },
-        force_expand: { 1: true },
-        force_collapse: { 1: true },
         has_alert_word: { 1: true },
         historical: { 1: true },
-        is_me_message: { 1: true },
       });
 
       const action = deepFreeze({
@@ -342,13 +337,8 @@ describe('flagsReducer', () => {
         collapsed: {},
         mentioned: {},
         wildcard_mentioned: {},
-        summarize_in_home: {},
-        summarize_in_stream: {},
-        force_expand: {},
-        force_collapse: {},
         has_alert_word: {},
         historical: {},
-        is_me_message: {},
       };
 
       const actualState = flagsReducer(prevState, action);

--- a/src/chat/flagsReducer.js
+++ b/src/chat/flagsReducer.js
@@ -24,13 +24,8 @@ const initialState = {
   collapsed: {},
   mentioned: {},
   wildcard_mentioned: {},
-  summarize_in_home: {},
-  summarize_in_stream: {},
-  force_expand: {},
-  force_collapse: {},
   has_alert_word: {},
   historical: {},
-  is_me_message: {},
 };
 
 const addFlagsForMessages = (

--- a/src/chat/flagsReducer.js
+++ b/src/chat/flagsReducer.js
@@ -13,6 +13,7 @@ import {
   ACCOUNT_SWITCH,
 } from '../actionConstants';
 import { deeperMerge } from '../utils/misc';
+import type { UserMessageFlag } from '../api/modelTypes';
 
 type ReadWriteFlagsState = $Rest<ReadWrite<$ObjMap<FlagsState, <V>(V) => ReadWrite<V>>>, { ... }>;
 type ReadWritePerFlagState = $Values<ReadWriteFlagsState>;
@@ -35,7 +36,7 @@ const initialState = {
 const addFlagsForMessages = (
   state: FlagsState,
   messages: $ReadOnlyArray<number>,
-  flags: $ReadOnlyArray<string>,
+  flags: $ReadOnlyArray<UserMessageFlag>,
 ): FlagsState => {
   if (messages.length === 0 || flags.length === 0) {
     return state;
@@ -117,7 +118,7 @@ const eventUpdateMessageFlags = (state, action) => {
       // know about. After all, we can't have any code intending to do
       // anything with them. Flow should be complaining here:
       //   https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/Flow.20spread.20bug/near/1318081
-      return { ...state, [action.flag]: {} };
+      return { ...state, [(action.flag: string)]: {} };
     }
   }
 

--- a/src/reduxTypes.js
+++ b/src/reduxTypes.js
@@ -37,12 +37,15 @@ import type { MuteState } from './mute/muteModelTypes';
 import type { PmConversationsState } from './pm-conversations/pmConversationsModel';
 import type { UnreadState } from './unread/unreadModelTypes';
 import type { UserStatusesState } from './user-statuses/userStatusesCore';
-import type { ServerEmojiData } from './api/modelTypes';
+import type { ServerEmojiData, UserMessageFlag } from './api/modelTypes';
 import type { EmailAddressVisibility } from './api/permissionsTypes';
+import { typesEquivalent } from './generics';
 
 export type { MuteState } from './mute/muteModelTypes';
 export type { UserStatusesState } from './user-statuses/userStatusesCore';
 export type * from './actionTypes';
+
+/* eslint-disable no-unused-expressions */
 
 /**
  * The list of known accounts, with the active account first.
@@ -129,9 +132,6 @@ export type FetchingState = $ReadOnly<{|
  * `state.messages`.
  */
 export type FlagsState = $ReadOnly<{|
-  // Flags that are currently documented in the API:
-  //   https://zulip.com/api/update-message-flags#available-flags
-  // i.e., those found in `UserMessageFlag`.
   read: {| +[messageId: number]: true |},
   starred: {| +[messageId: number]: true |},
   collapsed: {| +[messageId: number]: true |},
@@ -139,17 +139,11 @@ export type FlagsState = $ReadOnly<{|
   wildcard_mentioned: {| +[messageId: number]: true |},
   has_alert_word: {| +[messageId: number]: true |},
   historical: {| +[messageId: number]: true |},
-
-  // Flags not documented in the API.
-  // TODO(server): Do these ever exist?  Did they use to and get removed?
-  summarize_in_home: {| +[messageId: number]: true |},
-  summarize_in_stream: {| +[messageId: number]: true |},
-  force_expand: {| +[messageId: number]: true |},
-  force_collapse: {| +[messageId: number]: true |},
-  is_me_message: {| +[messageId: number]: true |},
 |}>;
 
-export type FlagName = $Keys<FlagsState>;
+// The flags in FlagsState correspond with those in the server API,
+// as expressed by UserMessageFlag.
+typesEquivalent<$Keys<FlagsState>, UserMessageFlag>();
 
 /**
  * A map with all messages we've stored locally, indexed by ID.
@@ -427,7 +421,7 @@ export type SettingsState = $ReadOnly<{|
 // As part of letting GlobalState freely convert to PerAccountState,
 // we'll want the same for SettingsState.  (This is also why
 // PerAccountSettingsState is inexact.)
-(s: SettingsState): PerAccountSettingsState => s; // eslint-disable-line no-unused-expressions
+(s: SettingsState): PerAccountSettingsState => s;
 
 export type StreamsState = $ReadOnlyArray<Stream>;
 
@@ -587,7 +581,7 @@ export function dubJointState(state: GlobalState): GlobalState & PerAccountState
 type NonMaybeProperties<O: { ... }> = $ObjMap<O, <V>(V) => $NonMaybeType<V>>;
 type NonMaybeGlobalState = NonMaybeProperties<GlobalState>;
 // This function definition will fail typechecking if GlobalState is wrong.
-(s: GlobalState): NonMaybeGlobalState => s; // eslint-disable-line no-unused-expressions
+(s: GlobalState): NonMaybeGlobalState => s;
 
 /** A per-account selector returning TResult, with extra parameter TParam. */
 // Seems like this should be OutputSelector... but for whatever reason,
@@ -632,7 +626,6 @@ export interface GlobalDispatch {
 // specific account), but for now it needs none.
 export type GlobalThunkAction<T> = (GlobalDispatch, () => GlobalState) => T;
 
-/* eslint-disable no-unused-expressions */
 // The two pairs of dispatch/thunk-action types aren't interchangeable,
 // in either direction.
 //   $FlowExpectedError[incompatible-return]

--- a/src/reduxTypes.js
+++ b/src/reduxTypes.js
@@ -129,17 +129,23 @@ export type FetchingState = $ReadOnly<{|
  * `state.messages`.
  */
 export type FlagsState = $ReadOnly<{|
+  // Flags that are currently documented in the API:
+  //   https://zulip.com/api/update-message-flags#available-flags
+  // i.e., those found in `UserMessageFlag`.
   read: {| +[messageId: number]: true |},
   starred: {| +[messageId: number]: true |},
   collapsed: {| +[messageId: number]: true |},
   mentioned: {| +[messageId: number]: true |},
   wildcard_mentioned: {| +[messageId: number]: true |},
+  has_alert_word: {| +[messageId: number]: true |},
+  historical: {| +[messageId: number]: true |},
+
+  // Flags not documented in the API.
+  // TODO(server): Do these ever exist?  Did they use to and get removed?
   summarize_in_home: {| +[messageId: number]: true |},
   summarize_in_stream: {| +[messageId: number]: true |},
   force_expand: {| +[messageId: number]: true |},
   force_collapse: {| +[messageId: number]: true |},
-  has_alert_word: {| +[messageId: number]: true |},
-  historical: {| +[messageId: number]: true |},
   is_me_message: {| +[messageId: number]: true |},
 |}>;
 

--- a/src/storage/__tests__/migrations-test.js
+++ b/src/storage/__tests__/migrations-test.js
@@ -104,7 +104,7 @@ describe('migrations', () => {
   // What `base` becomes after all migrations.
   const endBase = {
     ...base52,
-    migrations: { version: 54 },
+    migrations: { version: 55 },
   };
 
   for (const [desc, before, after] of [
@@ -127,8 +127,8 @@ describe('migrations', () => {
     // redundant with this one, because none of the migration steps notice
     // whether any properties outside `storeKeys` are present or not.
     [
-      'check dropCache at 54',
-      { ...endBase, migrations: { version: 53 }, mute: [], nonsense: [1, 2, 3] },
+      'check dropCache at 55',
+      { ...endBase, migrations: { version: 54 }, mute: [], nonsense: [1, 2, 3] },
       endBase,
     ],
 

--- a/src/storage/migrations.js
+++ b/src/storage/migrations.js
@@ -466,6 +466,9 @@ const migrationsInner: {| [string]: (LessPartialState) => LessPartialState |} = 
   // Add emailAddressVisibility to state.realm
   '54': dropCache,
 
+  // Drop old never-used message flags from state.flags.
+  '55': dropCache,
+
   // TIP: When adding a migration, consider just using `dropCache`.
   //   (See its jsdoc for guidance on when that's the right answer.)
 };

--- a/src/unread/__tests__/unreadHuddlesReducer-test.js
+++ b/src/unread/__tests__/unreadHuddlesReducer-test.js
@@ -191,7 +191,7 @@ describe('unreadHuddlesReducer', () => {
         all: false,
         allMessages: eg.makeMessagesState([]),
         messages: [1, 2, 3],
-        flag: 'star',
+        flag: 'starred',
         op: 'add',
       };
 

--- a/src/unread/__tests__/unreadMentionsReducer-test.js
+++ b/src/unread/__tests__/unreadMentionsReducer-test.js
@@ -97,7 +97,7 @@ describe('unreadMentionsReducer', () => {
         all: false,
         allMessages: Immutable.Map(),
         messages: [1, 2, 3],
-        flag: 'star',
+        flag: 'starred',
         op: 'add',
       };
 

--- a/src/unread/__tests__/unreadModel-test.js
+++ b/src/unread/__tests__/unreadModel-test.js
@@ -294,7 +294,7 @@ describe('stream substate', () => {
     });
 
     test('when operation is "add" but flag is not "read" do not mutate state', () => {
-      const action = mkAction({ messages: [1, 2, 3], flag: 'star' });
+      const action = mkAction({ messages: [1, 2, 3], flag: 'starred' });
       expect(reducer(initialState, action, eg.plusReduxState)).toBe(initialState);
     });
 

--- a/src/unread/__tests__/unreadPmsReducer-test.js
+++ b/src/unread/__tests__/unreadPmsReducer-test.js
@@ -201,7 +201,7 @@ describe('unreadPmsReducer', () => {
         all: false,
         allMessages: eg.makeMessagesState([]),
         messages: [1, 2, 3],
-        flag: 'star',
+        flag: 'starred',
         op: 'add',
       };
 

--- a/src/utils/narrow.js
+++ b/src/utils/narrow.js
@@ -12,6 +12,7 @@ import {
   pmKeyRecipientsFor1to1,
   makePmKeyRecipients_UNSAFE,
 } from './recipient';
+import type { UserMessageFlag } from '../api/modelTypes';
 
 /* eslint-disable no-use-before-define */
 
@@ -461,7 +462,7 @@ export const apiNarrowOfNarrow = (
  */
 export const isMessageInNarrow = (
   message: Message | Outbox,
-  flags: $ReadOnlyArray<string>,
+  flags: $ReadOnlyArray<UserMessageFlag>,
   narrow: Narrow,
   ownUserId: UserId,
 ): boolean =>
@@ -524,7 +525,7 @@ export const showComposeBoxOnNarrow = (narrow: Narrow): boolean =>
 export const getNarrowsForMessage = (
   message: Message | Outbox,
   ownUserId: UserId,
-  flags: $ReadOnlyArray<string>,
+  flags: $ReadOnlyArray<UserMessageFlag>,
 ): $ReadOnlyArray<Narrow> => {
   const result = [];
 

--- a/src/webview/__tests__/__snapshots__/generateInboundEventEditSequence-test.js.snap.android
+++ b/src/webview/__tests__/__snapshots__/generateInboundEventEditSequence-test.js.snap.android
@@ -1632,70 +1632,6 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible other 
 </div>"
 `;
 
-exports[`messages -> piece descriptors -> content HTML is stable/sensible other interesting cases (single messages) message with flag: force_collapse 1`] = `
-"<div class=\\"msglist-element timerow\\" data-msg-id=\\"1\\">
-  <div class=\\"timerow-left\\"></div>
-  Dec 31, 1969
-  <div class=\\"timerow-right\\"></div>
-</div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"1\\" data-narrow=\\"dG9waWM6MTpleGFtcGxlIHRvcGlj\\">
-  <div class=\\"header stream-text\\" style=\\"color: black;
-              background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
-    # stream 1
-  </div>
-  <div class=\\"topic-text\\">example topic</div>
-  <div class=\\"topic-date\\">Dec 31, 1969</div>
-</div><div class=\\"msglist-element message message-full\\" id=\\"msg-1\\" data-msg-id=\\"1\\" data-mute-state=\\"shown\\" data-force_collapse=\\"true\\">
-  <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-10.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
-  </div>
-  <div class=\\"content\\">
-    <div class=\\"subheader\\">
-  <div class=\\"name-and-status-emoji\\" data-sender-id=\\"10\\">
-    Nonrandom name sender User
-  </div>
-  <div class=\\"static-timestamp\\">11:59 PM</div>
-</div>
-    <p>This is an example stream message.</p>
-
-
-
-  </div>
-  
-</div>"
-`;
-
-exports[`messages -> piece descriptors -> content HTML is stable/sensible other interesting cases (single messages) message with flag: force_expand 1`] = `
-"<div class=\\"msglist-element timerow\\" data-msg-id=\\"1\\">
-  <div class=\\"timerow-left\\"></div>
-  Dec 31, 1969
-  <div class=\\"timerow-right\\"></div>
-</div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"1\\" data-narrow=\\"dG9waWM6MTpleGFtcGxlIHRvcGlj\\">
-  <div class=\\"header stream-text\\" style=\\"color: black;
-              background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
-    # stream 1
-  </div>
-  <div class=\\"topic-text\\">example topic</div>
-  <div class=\\"topic-date\\">Dec 31, 1969</div>
-</div><div class=\\"msglist-element message message-full\\" id=\\"msg-1\\" data-msg-id=\\"1\\" data-mute-state=\\"shown\\" data-force_expand=\\"true\\">
-  <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-10.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
-  </div>
-  <div class=\\"content\\">
-    <div class=\\"subheader\\">
-  <div class=\\"name-and-status-emoji\\" data-sender-id=\\"10\\">
-    Nonrandom name sender User
-  </div>
-  <div class=\\"static-timestamp\\">11:59 PM</div>
-</div>
-    <p>This is an example stream message.</p>
-
-
-
-  </div>
-  
-</div>"
-`;
-
 exports[`messages -> piece descriptors -> content HTML is stable/sensible other interesting cases (single messages) message with flag: has_alert_word 1`] = `
 "<div class=\\"msglist-element timerow\\" data-msg-id=\\"1\\">
   <div class=\\"timerow-left\\"></div>
@@ -1741,38 +1677,6 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible other 
   <div class=\\"topic-text\\">example topic</div>
   <div class=\\"topic-date\\">Dec 31, 1969</div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-1\\" data-msg-id=\\"1\\" data-mute-state=\\"shown\\" data-historical=\\"true\\">
-  <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-10.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
-  </div>
-  <div class=\\"content\\">
-    <div class=\\"subheader\\">
-  <div class=\\"name-and-status-emoji\\" data-sender-id=\\"10\\">
-    Nonrandom name sender User
-  </div>
-  <div class=\\"static-timestamp\\">11:59 PM</div>
-</div>
-    <p>This is an example stream message.</p>
-
-
-
-  </div>
-  
-</div>"
-`;
-
-exports[`messages -> piece descriptors -> content HTML is stable/sensible other interesting cases (single messages) message with flag: is_me_message 1`] = `
-"<div class=\\"msglist-element timerow\\" data-msg-id=\\"1\\">
-  <div class=\\"timerow-left\\"></div>
-  Dec 31, 1969
-  <div class=\\"timerow-right\\"></div>
-</div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"1\\" data-narrow=\\"dG9waWM6MTpleGFtcGxlIHRvcGlj\\">
-  <div class=\\"header stream-text\\" style=\\"color: black;
-              background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
-    # stream 1
-  </div>
-  <div class=\\"topic-text\\">example topic</div>
-  <div class=\\"topic-date\\">Dec 31, 1969</div>
-</div><div class=\\"msglist-element message message-full\\" id=\\"msg-1\\" data-msg-id=\\"1\\" data-mute-state=\\"shown\\" data-is_me_message=\\"true\\">
   <div class=\\"avatar\\">
     <img src=\\"https://zulip.example.org/yo/avatar-10.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
   </div>
@@ -1882,70 +1786,6 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible other 
     <p>This is an example stream message.</p>
 
 <div class=\\"message-tags\\"><span class=\\"message-tag\\">starred</span></div>
-
-  </div>
-  
-</div>"
-`;
-
-exports[`messages -> piece descriptors -> content HTML is stable/sensible other interesting cases (single messages) message with flag: summarize_in_home 1`] = `
-"<div class=\\"msglist-element timerow\\" data-msg-id=\\"1\\">
-  <div class=\\"timerow-left\\"></div>
-  Dec 31, 1969
-  <div class=\\"timerow-right\\"></div>
-</div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"1\\" data-narrow=\\"dG9waWM6MTpleGFtcGxlIHRvcGlj\\">
-  <div class=\\"header stream-text\\" style=\\"color: black;
-              background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
-    # stream 1
-  </div>
-  <div class=\\"topic-text\\">example topic</div>
-  <div class=\\"topic-date\\">Dec 31, 1969</div>
-</div><div class=\\"msglist-element message message-full\\" id=\\"msg-1\\" data-msg-id=\\"1\\" data-mute-state=\\"shown\\" data-summarize_in_home=\\"true\\">
-  <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-10.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
-  </div>
-  <div class=\\"content\\">
-    <div class=\\"subheader\\">
-  <div class=\\"name-and-status-emoji\\" data-sender-id=\\"10\\">
-    Nonrandom name sender User
-  </div>
-  <div class=\\"static-timestamp\\">11:59 PM</div>
-</div>
-    <p>This is an example stream message.</p>
-
-
-
-  </div>
-  
-</div>"
-`;
-
-exports[`messages -> piece descriptors -> content HTML is stable/sensible other interesting cases (single messages) message with flag: summarize_in_stream 1`] = `
-"<div class=\\"msglist-element timerow\\" data-msg-id=\\"1\\">
-  <div class=\\"timerow-left\\"></div>
-  Dec 31, 1969
-  <div class=\\"timerow-right\\"></div>
-</div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"1\\" data-narrow=\\"dG9waWM6MTpleGFtcGxlIHRvcGlj\\">
-  <div class=\\"header stream-text\\" style=\\"color: black;
-              background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
-    # stream 1
-  </div>
-  <div class=\\"topic-text\\">example topic</div>
-  <div class=\\"topic-date\\">Dec 31, 1969</div>
-</div><div class=\\"msglist-element message message-full\\" id=\\"msg-1\\" data-msg-id=\\"1\\" data-mute-state=\\"shown\\" data-summarize_in_stream=\\"true\\">
-  <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-10.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
-  </div>
-  <div class=\\"content\\">
-    <div class=\\"subheader\\">
-  <div class=\\"name-and-status-emoji\\" data-sender-id=\\"10\\">
-    Nonrandom name sender User
-  </div>
-  <div class=\\"static-timestamp\\">11:59 PM</div>
-</div>
-    <p>This is an example stream message.</p>
-
-
 
   </div>
   

--- a/src/webview/__tests__/__snapshots__/generateInboundEventEditSequence-test.js.snap.ios
+++ b/src/webview/__tests__/__snapshots__/generateInboundEventEditSequence-test.js.snap.ios
@@ -1632,70 +1632,6 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible other 
 </div>"
 `;
 
-exports[`messages -> piece descriptors -> content HTML is stable/sensible other interesting cases (single messages) message with flag: force_collapse 1`] = `
-"<div class=\\"msglist-element timerow\\" data-msg-id=\\"1\\">
-  <div class=\\"timerow-left\\"></div>
-  Dec 31, 1969
-  <div class=\\"timerow-right\\"></div>
-</div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"1\\" data-narrow=\\"dG9waWM6MTpleGFtcGxlIHRvcGlj\\">
-  <div class=\\"header stream-text\\" style=\\"color: black;
-              background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
-    # stream 1
-  </div>
-  <div class=\\"topic-text\\">example topic</div>
-  <div class=\\"topic-date\\">Dec 31, 1969</div>
-</div><div class=\\"msglist-element message message-full\\" id=\\"msg-1\\" data-msg-id=\\"1\\" data-mute-state=\\"shown\\" data-force_collapse=\\"true\\">
-  <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-10.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
-  </div>
-  <div class=\\"content\\">
-    <div class=\\"subheader\\">
-  <div class=\\"name-and-status-emoji\\" data-sender-id=\\"10\\">
-    Nonrandom name sender User
-  </div>
-  <div class=\\"static-timestamp\\">11:59 PM</div>
-</div>
-    <p>This is an example stream message.</p>
-
-
-
-  </div>
-  
-</div>"
-`;
-
-exports[`messages -> piece descriptors -> content HTML is stable/sensible other interesting cases (single messages) message with flag: force_expand 1`] = `
-"<div class=\\"msglist-element timerow\\" data-msg-id=\\"1\\">
-  <div class=\\"timerow-left\\"></div>
-  Dec 31, 1969
-  <div class=\\"timerow-right\\"></div>
-</div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"1\\" data-narrow=\\"dG9waWM6MTpleGFtcGxlIHRvcGlj\\">
-  <div class=\\"header stream-text\\" style=\\"color: black;
-              background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
-    # stream 1
-  </div>
-  <div class=\\"topic-text\\">example topic</div>
-  <div class=\\"topic-date\\">Dec 31, 1969</div>
-</div><div class=\\"msglist-element message message-full\\" id=\\"msg-1\\" data-msg-id=\\"1\\" data-mute-state=\\"shown\\" data-force_expand=\\"true\\">
-  <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-10.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
-  </div>
-  <div class=\\"content\\">
-    <div class=\\"subheader\\">
-  <div class=\\"name-and-status-emoji\\" data-sender-id=\\"10\\">
-    Nonrandom name sender User
-  </div>
-  <div class=\\"static-timestamp\\">11:59 PM</div>
-</div>
-    <p>This is an example stream message.</p>
-
-
-
-  </div>
-  
-</div>"
-`;
-
 exports[`messages -> piece descriptors -> content HTML is stable/sensible other interesting cases (single messages) message with flag: has_alert_word 1`] = `
 "<div class=\\"msglist-element timerow\\" data-msg-id=\\"1\\">
   <div class=\\"timerow-left\\"></div>
@@ -1741,38 +1677,6 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible other 
   <div class=\\"topic-text\\">example topic</div>
   <div class=\\"topic-date\\">Dec 31, 1969</div>
 </div><div class=\\"msglist-element message message-full\\" id=\\"msg-1\\" data-msg-id=\\"1\\" data-mute-state=\\"shown\\" data-historical=\\"true\\">
-  <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-10.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
-  </div>
-  <div class=\\"content\\">
-    <div class=\\"subheader\\">
-  <div class=\\"name-and-status-emoji\\" data-sender-id=\\"10\\">
-    Nonrandom name sender User
-  </div>
-  <div class=\\"static-timestamp\\">11:59 PM</div>
-</div>
-    <p>This is an example stream message.</p>
-
-
-
-  </div>
-  
-</div>"
-`;
-
-exports[`messages -> piece descriptors -> content HTML is stable/sensible other interesting cases (single messages) message with flag: is_me_message 1`] = `
-"<div class=\\"msglist-element timerow\\" data-msg-id=\\"1\\">
-  <div class=\\"timerow-left\\"></div>
-  Dec 31, 1969
-  <div class=\\"timerow-right\\"></div>
-</div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"1\\" data-narrow=\\"dG9waWM6MTpleGFtcGxlIHRvcGlj\\">
-  <div class=\\"header stream-text\\" style=\\"color: black;
-              background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
-    # stream 1
-  </div>
-  <div class=\\"topic-text\\">example topic</div>
-  <div class=\\"topic-date\\">Dec 31, 1969</div>
-</div><div class=\\"msglist-element message message-full\\" id=\\"msg-1\\" data-msg-id=\\"1\\" data-mute-state=\\"shown\\" data-is_me_message=\\"true\\">
   <div class=\\"avatar\\">
     <img src=\\"https://zulip.example.org/yo/avatar-10.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
   </div>
@@ -1882,70 +1786,6 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible other 
     <p>This is an example stream message.</p>
 
 <div class=\\"message-tags\\"><span class=\\"message-tag\\">starred</span></div>
-
-  </div>
-  
-</div>"
-`;
-
-exports[`messages -> piece descriptors -> content HTML is stable/sensible other interesting cases (single messages) message with flag: summarize_in_home 1`] = `
-"<div class=\\"msglist-element timerow\\" data-msg-id=\\"1\\">
-  <div class=\\"timerow-left\\"></div>
-  Dec 31, 1969
-  <div class=\\"timerow-right\\"></div>
-</div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"1\\" data-narrow=\\"dG9waWM6MTpleGFtcGxlIHRvcGlj\\">
-  <div class=\\"header stream-text\\" style=\\"color: black;
-              background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
-    # stream 1
-  </div>
-  <div class=\\"topic-text\\">example topic</div>
-  <div class=\\"topic-date\\">Dec 31, 1969</div>
-</div><div class=\\"msglist-element message message-full\\" id=\\"msg-1\\" data-msg-id=\\"1\\" data-mute-state=\\"shown\\" data-summarize_in_home=\\"true\\">
-  <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-10.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
-  </div>
-  <div class=\\"content\\">
-    <div class=\\"subheader\\">
-  <div class=\\"name-and-status-emoji\\" data-sender-id=\\"10\\">
-    Nonrandom name sender User
-  </div>
-  <div class=\\"static-timestamp\\">11:59 PM</div>
-</div>
-    <p>This is an example stream message.</p>
-
-
-
-  </div>
-  
-</div>"
-`;
-
-exports[`messages -> piece descriptors -> content HTML is stable/sensible other interesting cases (single messages) message with flag: summarize_in_stream 1`] = `
-"<div class=\\"msglist-element timerow\\" data-msg-id=\\"1\\">
-  <div class=\\"timerow-left\\"></div>
-  Dec 31, 1969
-  <div class=\\"timerow-right\\"></div>
-</div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"1\\" data-narrow=\\"dG9waWM6MTpleGFtcGxlIHRvcGlj\\">
-  <div class=\\"header stream-text\\" style=\\"color: black;
-              background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
-    # stream 1
-  </div>
-  <div class=\\"topic-text\\">example topic</div>
-  <div class=\\"topic-date\\">Dec 31, 1969</div>
-</div><div class=\\"msglist-element message message-full\\" id=\\"msg-1\\" data-msg-id=\\"1\\" data-mute-state=\\"shown\\" data-summarize_in_stream=\\"true\\">
-  <div class=\\"avatar\\">
-    <img src=\\"https://zulip.example.org/yo/avatar-10.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
-  </div>
-  <div class=\\"content\\">
-    <div class=\\"subheader\\">
-  <div class=\\"name-and-status-emoji\\" data-sender-id=\\"10\\">
-    Nonrandom name sender User
-  </div>
-  <div class=\\"static-timestamp\\">11:59 PM</div>
-</div>
-    <p>This is an example stream message.</p>
-
-
 
   </div>
   


### PR DESCRIPTION
We hadn't actually written down in our API types the set of valid flags on a message. Do that, and make some related cleanups along the way.

In particular, also cut from our `state.flags` type a bunch of flags that existed in 2017 but are now long dead, and which the mobile app never used.

This all came up in the course of working on #5364, as I looked at the `messagesFlags` API binding. I think in the end we [likely won't use](https://chat.zulip.org/#narrow/stream/378-api-design/topic/mark-as-unread.20request/near/1431173) that binding for implementing that feature, but the cleanups seem helpful anyway.