### PR TITLE
SettingsScreen: Make conversation-views-only hint text more concise

### DIFF
--- a/src/settings/SettingsScreen.js
+++ b/src/settings/SettingsScreen.js
@@ -60,7 +60,7 @@ export default function SettingsScreen(props: Props): Node {
             key: 'conversation-views-only',
             title: 'Only in conversation views',
             subtitle:
-              'Messages will be marked as read in single-topic or private-message views, but not in interleaved views, such as whole-stream views.',
+              'Messages will be automatically marked as read only when viewing a single topic or private message conversation.',
           },
         ]}
         onValueChange={value => {

--- a/static/translations/messages_en.json
+++ b/static/translations/messages_en.json
@@ -301,7 +301,7 @@
   "Always": "Always",
   "Never": "Never",
   "Only in conversation views": "Only in conversation views",
-  "Messages will be marked as read in single-topic or private-message views, but not in interleaved views, such as whole-stream views.": "Messages will be marked as read in single-topic or private-message views, but not in interleaved views, such as whole-stream views.",
+  "Messages will be automatically marked as read only when viewing a single topic or private message conversation.": "Messages will be automatically marked as read only when viewing a single topic or private message conversation.",
   "Topics": "Topics",
   "Add subscribers": "Add subscribers",
   "Subscribe": "Subscribe",


### PR DESCRIPTION
Following Alya's proposal at
  https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/mark.20as.20read.20setting.20.23M5469/near/1433721

Related: #5469