### PR TITLE
messagesActions: Follow tapped /near/ links through message moves

### DIFF
--- a/src/api/messages/getSingleMessage.js
+++ b/src/api/messages/getSingleMessage.js
@@ -22,8 +22,11 @@ type ServerApiResponseSingleMessage = {|
 /**
  * See https://zulip.com/api/get-message
  *
- * Gives undefined if the `message` field is missing, which it will be for
- * FL <120.
+ * Throws an error if the message doesn't exist at all, or isn't visible to
+ * our user.
+ *
+ * Otherwise, gives undefined on old servers (FL <120) where this API
+ * endpoint doesn't return a `message` field.
  */
 // TODO(server-5.0): Simplify FL-120 condition in jsdoc and implementation.
 export default async (

--- a/src/message/messageSelectors.js
+++ b/src/message/messageSelectors.js
@@ -78,3 +78,47 @@ export const getFirstUnreadIdInNarrow: Selector<number | null, Narrow> = createS
     return firstUnread?.id ?? null;
   },
 );
+
+/**
+ * True just if we know the message has, or had, the given topic.
+ *
+ * Gives null if it doesn't have the topic now, but we can't access
+ * the message's edit history to check in the past.
+ */
+export function hasMessageEverHadTopic(message: Message, topic: string): boolean | null {
+  if (message.subject === topic) {
+    return true;
+  }
+
+  // See comments on Message['edit_history'] for the values it takes
+  // and what they mean.
+  if (message.edit_history === null) {
+    return null;
+  }
+  if (message.edit_history === undefined) {
+    return false;
+  }
+  return message.edit_history.findIndex(messageEdit => topic === messageEdit.prev_topic) >= 0;
+}
+
+/**
+ * True just if we know the message is, or was, in the given stream.
+ *
+ * Gives null if it's not in the stream now, but we can't access the
+ * message's edit history to check in the past.
+ */
+export function hasMessageEverBeenInStream(message: Message, streamId: number): boolean | null {
+  if (message.stream_id === streamId) {
+    return true;
+  }
+
+  // See comments on Message['edit_history'] for the values it takes
+  // and what they mean.
+  if (message.edit_history === null) {
+    return null;
+  }
+  if (message.edit_history === undefined) {
+    return false;
+  }
+  return message.edit_history.findIndex(messageEdit => streamId === messageEdit.prev_stream) >= 0;
+}

--- a/src/message/messagesActions.js
+++ b/src/message/messagesActions.js
@@ -38,7 +38,7 @@ export const messageLinkPress =
     if (narrow) {
       // This call is OK: `narrow` is truthy, so isNarrowLink(…) was true.
       const nearOperand = getNearOperandFromLink(href, auth.realm);
-      dispatch(doNarrow(narrow, nearOperand));
+      dispatch(doNarrow(narrow, nearOperand ?? 0));
     } else if (!isUrlOnRealm(href, auth.realm)) {
       openLinkWithUserPreference(href, getGlobalSettings());
     } else {

--- a/src/message/messagesActions.js
+++ b/src/message/messagesActions.js
@@ -2,7 +2,7 @@
 import * as NavigationService from '../nav/NavigationService';
 import type { Narrow, ThunkAction } from '../types';
 import { getAuth } from '../selectors';
-import { getMessageIdFromLink, getNarrowFromLink } from '../utils/internalLinks';
+import { getNearOperandFromLink, getNarrowFromLink } from '../utils/internalLinks';
 import { openLinkWithUserPreference } from '../utils/openLink';
 import { navigateToChat } from '../nav/navActions';
 import { FIRST_UNREAD_ANCHOR } from '../anchor';
@@ -37,8 +37,8 @@ export const messageLinkPress =
     //   which should be futile.
     if (narrow) {
       // This call is OK: `narrow` is truthy, so isNarrowLink(…) was true.
-      const anchor = getMessageIdFromLink(href, auth.realm);
-      dispatch(doNarrow(narrow, anchor));
+      const nearOperand = getNearOperandFromLink(href, auth.realm);
+      dispatch(doNarrow(narrow, nearOperand));
     } else if (!isUrlOnRealm(href, auth.realm)) {
       openLinkWithUserPreference(href, getGlobalSettings());
     } else {

--- a/src/message/messagesActions.js
+++ b/src/message/messagesActions.js
@@ -1,7 +1,8 @@
 /* @flow strict-local */
+import * as logging from '../utils/logging';
 import * as NavigationService from '../nav/NavigationService';
 import type { Narrow, ThunkAction } from '../types';
-import { getAuth } from '../selectors';
+import { getAuth, getRealm, getMessages, getZulipFeatureLevel } from '../selectors';
 import { getNearOperandFromLink, getNarrowFromLink } from '../utils/internalLinks';
 import { openLinkWithUserPreference } from '../utils/openLink';
 import { navigateToChat } from '../nav/navActions';
@@ -10,6 +11,16 @@ import { getStreamsById, getStreamsByName } from '../subscriptions/subscriptionS
 import * as api from '../api';
 import { isUrlOnRealm } from '../utils/url';
 import { getOwnUserId } from '../users/userSelectors';
+import {
+  isTopicNarrow,
+  isStreamNarrow,
+  topicNarrow,
+  streamIdOfNarrow,
+  topicOfNarrow,
+  streamNarrow,
+  caseNarrowDefault,
+} from '../utils/narrow';
+import { hasMessageEverBeenInStream, hasMessageEverHadTopic } from './messageSelectors';
 
 /**
  * Navigate to the given narrow.
@@ -19,6 +30,171 @@ export const doNarrow =
   (dispatch, getState) => {
     // TODO: Use `anchor` to open the message list to a particular message.
     NavigationService.dispatch(navigateToChat(narrow));
+  };
+
+/**
+ * Narrow to a /near/ link, possibly after reinterpreting it for a message move.
+ *
+ * It feels quite broken when a link is clearly meant to get you to a
+ * specific message, but tapping it brings you to a narrow where the message
+ * *used* to be but isn't anymore because it was moved to a new stream or
+ * topic. This was #5306.
+ *
+ * This action, when it can, recognizes when that's about to happen and
+ * instead narrows you to the message's current stream/topic.
+ *
+ * To do so, it obviously needs to know the message's current stream/topic.
+ * If those can't be gotten from Redux, we ask the server. If the server
+ * can't help us (gives an error), we can't help the user, so we won't
+ * follow a move in that case.
+ *
+ * N.B.: Gives a bad experience when the request takes a long time. We
+ * should fix that; see TODOs.
+ */
+const doNarrowNearLink =
+  (narrow: Narrow, nearOperand: number): ThunkAction<Promise<void>> =>
+  async (dispatch, getState) => {
+    const state = getState();
+
+    const auth = getAuth(state);
+    const messages = getMessages(state);
+    const zulipFeatureLevel = getZulipFeatureLevel(state);
+    const allowEditHistory = getRealm(state).allowEditHistory;
+
+    /**
+     * Narrow to the /near/ link without reinterpreting it for a message move.
+     *
+     * Use this when the link is meant to find the specific message
+     * identified by nearOperand, and:
+     * - nearOperand refers to a message that wasn't moved outside the
+     *   narrow specified by the link, or
+     * - nearOperand *might* refer to a message that was moved, but we don't
+     *   know; we've tried and failed to find out.
+     *
+     * Or, use this to insist on the traditional meaning of "near" before
+     * the message-move feature: take the narrow's stream/topic/etc.
+     * literally, and open to the message "nearest" the given ID (sent
+     * around the same time), even if the message with that ID isn't
+     * actually in the narrow [1].
+     *
+     * User docs on moving messages:
+     *   https://zulip.com/help/move-content-to-another-stream
+     *   https://zulip.com/help/move-content-to-another-topic
+     *
+     * [1] Tim points out, at
+     *       https://chat.zulip.org/#narrow/stream/101-design/topic/redirects.20from.20near.20links/near/1343095 :
+     *     "[…] useful for situations where you might replace an existing
+     *     search for `stream: 1/topic: 1/near: 15` with
+     *     `stream: 2/topic: 2/near: 15` in order to view what was happening
+     *     in another conversation at the same time as an existing
+     *     conversation."
+     */
+    const noMove = () => {
+      dispatch(doNarrow(narrow, nearOperand));
+    };
+
+    const streamIdOperand =
+      isStreamNarrow(narrow) || isTopicNarrow(narrow) ? streamIdOfNarrow(narrow) : null;
+    const topicOperand = isTopicNarrow(narrow) ? topicOfNarrow(narrow) : null;
+
+    if (streamIdOperand === null && topicOperand === null) {
+      // Message moves only happen by changing the stream and/or topic.
+      noMove();
+      return;
+    }
+
+    // Grab the message and see if it was moved, so we can follow the move
+    // if so.
+
+    // Try to get it from our local data to avoid a server round-trip…
+    let message = messages.get(nearOperand);
+
+    // …but if we have to, go and ask the server.
+    // TODO: Give feedback when the server round trip takes longer than
+    //   expected.
+    // TODO: Let the user cancel the request so we don't force a doNarrow
+    //   after they've given up on tapping the link, and perhaps forgotten
+    //   about it. Like any request, this might take well over a minute to
+    //   resolve, or never resolve.
+    // TODO: When these are fixed, remove warning in jsdoc.
+    if (!message) {
+      // TODO(server-5.0): Simplify.
+      if (zulipFeatureLevel < 120) {
+        // api.getSingleMessage won't give us the message's stream and
+        // topic; see there. Hopefully the message wasn't moved.
+        noMove();
+        return;
+      }
+      try {
+        message = await api.getSingleMessage(
+          auth,
+          { message_id: nearOperand },
+          zulipFeatureLevel,
+          allowEditHistory,
+        );
+      } catch {
+        // Hopefully the message, if it exists or ever existed, wasn't moved.
+        noMove();
+        return;
+      }
+    }
+
+    // The FL 120 condition on calling api.getSingleMessage should ensure
+    // `message` isn't void.
+    // TODO(server-5.0): Simplify away.
+    if (!message) {
+      logging.error('`message` from api.getSingleMessage unexpectedly falsy');
+      noMove();
+      return;
+    }
+
+    if (message.type === 'private') {
+      // A PM could never have been moved.
+      noMove();
+      return;
+    }
+
+    if (
+      (topicOperand === null || topicOperand === message.subject)
+      && (streamIdOperand === null || streamIdOperand === message.stream_id)
+    ) {
+      // The message is still in the stream and/or topic in the link.
+      noMove();
+      return;
+    }
+
+    if (
+      (topicOperand !== null && hasMessageEverHadTopic(message, topicOperand) === false)
+      || (streamIdOperand !== null && hasMessageEverBeenInStream(message, streamIdOperand) === false)
+    ) {
+      // The message was never in the narrow specified by the link. That'd
+      // be an odd link to put in a message…anyway, perhaps we're meant to
+      // use the traditional meaning of "near"; see noMove's jsdoc
+      // for what that is.
+      noMove();
+      return;
+    }
+    // If we couldn't access the edit history in the checks above, assume
+    // the message was moved. It's the likeliest explanation why its topic
+    // and/or stream don't match the narrow link.
+
+    const { stream_id, subject } = message;
+
+    // Reinterpret the link's narrow with the message's current stream
+    // and/or topic.
+    dispatch(
+      doNarrow(
+        caseNarrowDefault(
+          narrow,
+          {
+            stream: () => streamNarrow(stream_id),
+            topic: () => topicNarrow(stream_id, subject),
+          },
+          () => narrow,
+        ),
+        nearOperand,
+      ),
+    );
   };
 
 export const messageLinkPress =
@@ -43,7 +219,7 @@ export const messageLinkPress =
         return;
       }
 
-      dispatch(doNarrow(narrow, nearOperand));
+      await dispatch(doNarrowNearLink(narrow, nearOperand));
     } else if (!isUrlOnRealm(href, auth.realm)) {
       openLinkWithUserPreference(href, getGlobalSettings());
     } else {

--- a/src/message/messagesActions.js
+++ b/src/message/messagesActions.js
@@ -38,7 +38,12 @@ export const messageLinkPress =
     if (narrow) {
       // This call is OK: `narrow` is truthy, so isNarrowLink(…) was true.
       const nearOperand = getNearOperandFromLink(href, auth.realm);
-      dispatch(doNarrow(narrow, nearOperand ?? 0));
+      if (nearOperand === null) {
+        dispatch(doNarrow(narrow));
+        return;
+      }
+
+      dispatch(doNarrow(narrow, nearOperand));
     } else if (!isUrlOnRealm(href, auth.realm)) {
       openLinkWithUserPreference(href, getGlobalSettings());
     } else {

--- a/src/utils/__tests__/internalLinks-test.js
+++ b/src/utils/__tests__/internalLinks-test.js
@@ -6,7 +6,7 @@ import {
   isNarrowLink,
   getLinkType,
   getNarrowFromLink,
-  getMessageIdFromLink,
+  getNearOperandFromLink,
   decodeHashComponent,
 } from '../internalLinks';
 import * as eg from '../../__tests__/lib/exampleData';
@@ -418,25 +418,25 @@ describe('getNarrowFromLink', () => {
   });
 });
 
-describe('getMessageIdFromLink', () => {
+describe('getNearOperandFromLink', () => {
   test('not message link', () => {
-    expect(getMessageIdFromLink('https://example.com/#narrow/is/private', realm)).toBe(0);
-    expect(getMessageIdFromLink('https://example.com/#narrow/stream/jest', realm)).toBe(0);
+    expect(getNearOperandFromLink('https://example.com/#narrow/is/private', realm)).toBe(0);
+    expect(getNearOperandFromLink('https://example.com/#narrow/stream/jest', realm)).toBe(0);
   });
 
   test('`near` is the only operator', () => {
-    expect(getMessageIdFromLink('https://example.com/#narrow/near/1', realm)).toBe(1);
+    expect(getNearOperandFromLink('https://example.com/#narrow/near/1', realm)).toBe(1);
   });
 
   test('when link is a group link, return anchor message id', () => {
     expect(
-      getMessageIdFromLink('https://example.com/#narrow/pm-with/1,3-group/near/1/', realm),
+      getNearOperandFromLink('https://example.com/#narrow/pm-with/1,3-group/near/1/', realm),
     ).toBe(1);
   });
 
   test('when link is a topic link, return anchor message id', () => {
     expect(
-      getMessageIdFromLink('https://example.com/#narrow/stream/jest/topic/test/near/1', realm),
+      getNearOperandFromLink('https://example.com/#narrow/stream/jest/topic/test/near/1', realm),
     ).toBe(1);
   });
 });

--- a/src/utils/__tests__/internalLinks-test.js
+++ b/src/utils/__tests__/internalLinks-test.js
@@ -420,8 +420,8 @@ describe('getNarrowFromLink', () => {
 
 describe('getNearOperandFromLink', () => {
   test('not message link', () => {
-    expect(getNearOperandFromLink('https://example.com/#narrow/is/private', realm)).toBe(0);
-    expect(getNearOperandFromLink('https://example.com/#narrow/stream/jest', realm)).toBe(0);
+    expect(getNearOperandFromLink('https://example.com/#narrow/is/private', realm)).toBe(null);
+    expect(getNearOperandFromLink('https://example.com/#narrow/stream/jest', realm)).toBe(null);
   });
 
   test('`near` is the only operator', () => {

--- a/src/utils/internalLinks.js
+++ b/src/utils/internalLinks.js
@@ -227,13 +227,13 @@ export const getNarrowFromLink = (
 
 /**
  * From a URL and realm with `isNarrowLink(url, realm) === true`, give
- *   message_id if the URL has /near/{message_id}, otherwise give zero.
+ *   message_id if the URL has /near/{message_id}, otherwise give null.
  *
  * This performs a call to `new URL` and therefore may take a fraction of a
  * millisecond.  Avoid using in a context where it might be called more than
  * 10 or 100 times per user action.
  */
-export const getNearOperandFromLink = (url: string, realm: URL): number => {
+export const getNearOperandFromLink = (url: string, realm: URL): number | null => {
   // isNarrowLink(…) is true, by jsdoc, so this call is OK.
   const hashSegments = getHashSegmentsFromNarrowLink(url, realm);
 
@@ -249,7 +249,7 @@ export const getNearOperandFromLink = (url: string, realm: URL): number => {
       && str === 'near',
   );
   if (nearOperatorIndex < 0) {
-    return 0;
+    return null;
   }
 
   // We expect an operand to directly follow its operator.
@@ -258,7 +258,7 @@ export const getNearOperandFromLink = (url: string, realm: URL): number => {
   const nearOperandStr = hashSegments[nearOperandIndex];
   // Must look like a message ID
   if (!/^[0-9]+$/.test(nearOperandStr)) {
-    return 0;
+    return null;
   }
 
   return parseInt(nearOperandStr, 10);

--- a/src/utils/internalLinks.js
+++ b/src/utils/internalLinks.js
@@ -233,7 +233,7 @@ export const getNarrowFromLink = (
  * millisecond.  Avoid using in a context where it might be called more than
  * 10 or 100 times per user action.
  */
-export const getMessageIdFromLink = (url: string, realm: URL): number => {
+export const getNearOperandFromLink = (url: string, realm: URL): number => {
   // isNarrowLink(…) is true, by jsdoc, so this call is OK.
   const hashSegments = getHashSegmentsFromNarrowLink(url, realm);
 

--- a/src/utils/internalLinks.js
+++ b/src/utils/internalLinks.js
@@ -254,7 +254,14 @@ export const getNearOperandFromLink = (url: string, realm: URL): number => {
 
   // We expect an operand to directly follow its operator.
   const nearOperandIndex = nearOperatorIndex + 1;
-  return parseInt(hashSegments[nearOperandIndex], 10);
+
+  const nearOperandStr = hashSegments[nearOperandIndex];
+  // Must look like a message ID
+  if (!/^[0-9]+$/.test(nearOperandStr)) {
+    return 0;
+  }
+
+  return parseInt(nearOperandStr, 10);
 };
 
 export const getStreamTopicUrl = (


### PR DESCRIPTION
Implementing the algorithm described in the issue and on CZO:
  https://github.com/zulip/zulip-mobile/issues/5306#issuecomment-1198441223

> When a user clicks a `/near/` link in a message,
>
> 1. Get the message, either from our local data structures or
>    (failing that) from a single-message fetch, using the API added
>    in zulip/zulip#21391.
> 2. If the message is currently in the stream and topic encoded in
>    the `/near/` link, open the topic narrow for that stream/topic,
>    and scroll to the message*.
> 3. If the message was *at some point* in the stream and topic
>    encoded in the `/near/` link, according to its `edit_history`,
>    open the topic narrow for the stream/topic that the message is
>    currently in, and scroll to the message*.
> 4. Otherwise (i.e., the message was never in the stream/topic
>    encoded in the `/near/` link), open the topic narrow for the
>    stream/topic encoded in the link, and scroll to the message
>    "nearest" to the message ID*.
>
> *Actually opening a narrow scrolled to a specific message ID is
> blocked on #3604.

It actually turned out quite easy to do the special handling for
part 4, so that's included here. (The bit about blocking on #3604 is
still true.)

Fixes: #5306