### PR TITLE
Add user email to profile display

### DIFF
--- a/src/__tests__/lib/exampleData.js
+++ b/src/__tests__/lib/exampleData.js
@@ -21,7 +21,7 @@ import { randString, randInt } from '../../utils/misc';
 import { makeUserId } from '../../api/idTypes';
 import type { InitialData } from '../../api/apiTypes';
 import { EventTypes, type UpdateMessageEvent } from '../../api/eventTypes';
-import { CreateWebPublicStreamPolicy } from '../../api/permissionsTypes';
+import { CreateWebPublicStreamPolicy, EmailAddressVisibility } from '../../api/permissionsTypes';
 import type {
   AccountSwitchAction,
   LoginSuccessAction,
@@ -785,7 +785,7 @@ export const action = Object.freeze({
       realm_digest_weekday: 2,
       realm_disallow_disposable_email_addresses: true,
       realm_edit_topic_policy: 3,
-      realm_email_address_visibility: 3,
+      realm_email_address_visibility: EmailAddressVisibility.Admins,
       realm_email_auth_enabled: true,
       realm_email_changes_disabled: true,
       realm_emails_restricted_to_domains: false,

--- a/src/account-info/AccountDetails.js
+++ b/src/account-info/AccountDetails.js
@@ -13,6 +13,7 @@ import ComponentList from '../common/ComponentList';
 import ZulipText from '../common/ZulipText';
 import { getUserStatus } from '../user-statuses/userStatusesModel';
 import PresenceStatusIndicator from '../common/PresenceStatusIndicator';
+import { getDisplayEmailForUser } from '../selectors';
 
 const componentStyles = createStyleSheet({
   componentListItem: {
@@ -31,19 +32,25 @@ const componentStyles = createStyleSheet({
   statusText: {
     textAlign: 'center',
   },
+  boldText: {
+    fontWeight: 'bold',
+  },
 });
 
 type Props = $ReadOnly<{|
   user: UserOrBot,
+  showEmail: boolean,
 |}>;
 
 export default function AccountDetails(props: Props): Node {
-  const { user } = props;
+  const { user, showEmail } = props;
 
   const userStatusText = useSelector(state => getUserStatus(state, props.user.user_id).status_text);
   const userStatusEmoji = useSelector(
     state => getUserStatus(state, props.user.user_id).status_emoji,
   );
+  const realm = useSelector(state => state.realm);
+  const displayEmail = getDisplayEmailForUser(realm, user);
 
   return (
     <ComponentList outerSpacing itemStyle={componentStyles.componentListItem}>
@@ -59,10 +66,19 @@ export default function AccountDetails(props: Props): Node {
         />
         <ZulipText
           selectable
-          style={[styles.largerText, styles.halfMarginRight]}
+          style={[styles.largerText, componentStyles.boldText, styles.halfMarginRight]}
           text={user.full_name}
         />
       </View>
+      {displayEmail !== null && showEmail && (
+        <View>
+          <ZulipText
+            selectable
+            style={[styles.largerText, styles.halfMarginRight]}
+            text={displayEmail}
+          />
+        </View>
+      )}
       <View style={componentStyles.statusWrapper}>
         {userStatusEmoji && (
           <Emoji

--- a/src/account-info/AccountDetailsScreen.js
+++ b/src/account-info/AccountDetailsScreen.js
@@ -74,7 +74,7 @@ export default function AccountDetailsScreen(props: Props): Node {
 
   return (
     <Screen title={title}>
-      <AccountDetails user={user} />
+      <AccountDetails user={user} showEmail />
       <View style={styles.itemWrapper}>
         <ActivityText style={globalStyles.largerText} user={user} />
       </View>

--- a/src/account-info/ProfileScreen.js
+++ b/src/account-info/ProfileScreen.js
@@ -131,7 +131,7 @@ export default function ProfileScreen(props: Props): Node {
     <SafeAreaView mode="padding" edges={['top']} style={{ flex: 1 }}>
       <OfflineNoticePlaceholder />
       <ScrollView>
-        <AccountDetails user={ownUser} />
+        <AccountDetails user={ownUser} showEmail={false} />
         <AwayStatusSwitch />
         <View style={styles.buttonRow}>
           <SetStatusButton />

--- a/src/api/initialDataTypes.js
+++ b/src/api/initialDataTypes.js
@@ -19,6 +19,7 @@ import type {
 import type {
   CreatePublicOrPrivateStreamPolicyT,
   CreateWebPublicStreamPolicy,
+  EmailAddressVisibility,
 } from './permissionsTypes';
 
 /*
@@ -207,7 +208,7 @@ export type InitialDataRealm = $ReadOnly<{|
   // TODO(server-5.0): Added in feat. 75, replacing realm_allow_community_topic_editing
   realm_edit_topic_policy?: number,
 
-  realm_email_address_visibility: number,
+  realm_email_address_visibility: EmailAddressVisibility,
   realm_email_auth_enabled: boolean,
   realm_email_changes_disabled: boolean,
   realm_emails_restricted_to_domains: boolean,

--- a/src/api/modelTypes.js
+++ b/src/api/modelTypes.js
@@ -177,8 +177,14 @@ export type User = {|
   // Current to feature level (FL) 121.
 
   +user_id: UserId,
-  +delivery_email?: string,
+
+  // Currently `delivery_email` is always `string` if present.  A planned
+  // future API may make it sometimes `null`, to explicitly indicate that no
+  // delivery email for this user is visible to us:
+  //   https://chat.zulip.org/#narrow/stream/378-api-design/topic/email.20address.20visibility/near/1296132
+  +delivery_email?: string | null,
   +email: string,
+
   +full_name: string,
 
   // We expect ISO 8601; that's in the doc's example response.
@@ -263,7 +269,7 @@ export type CrossRealmBot = {|
   // Current to feature level (FL) 121.
 
   +user_id: UserId,
-  +delivery_email?: string,
+  +delivery_email?: string | null,
   +email: string,
   +full_name: string,
 

--- a/src/api/permissionsTypes.js
+++ b/src/api/permissionsTypes.js
@@ -95,3 +95,14 @@ export enum CreateWebPublicStreamPolicy {
   Nobody = 6,
   OwnerOnly = 7,
 }
+
+/**
+ * The policy for who in the organization has access to users' actual email
+ */
+export enum EmailAddressVisibility {
+  Everyone = 1,
+  Members = 2,
+  Admins = 3,
+  Nobody = 4,
+  Moderators = 5,
+}

--- a/src/realm/__tests__/realmReducer-test.js
+++ b/src/realm/__tests__/realmReducer-test.js
@@ -15,6 +15,7 @@ import type { RealmDataForUpdate } from '../../api/realmDataTypes';
 import {
   CreatePublicOrPrivateStreamPolicy,
   CreateWebPublicStreamPolicy,
+  EmailAddressVisibility,
 } from '../../api/permissionsTypes';
 import { CustomProfileFieldType } from '../../api/modelTypes';
 import { EventTypes } from '../../api/eventTypes';
@@ -68,6 +69,7 @@ describe('realmReducer', () => {
         waitingPeriodThreshold: action.data.realm_waiting_period_threshold,
         allowEditHistory: action.data.realm_allow_edit_history,
         enableReadReceipts: action.data.realm_enable_read_receipts,
+        emailAddressVisibility: action.data.realm_email_address_visibility,
 
         //
         // InitialDataRealmUser
@@ -499,6 +501,31 @@ describe('realmReducer', () => {
         check(true, false);
         check(false, true);
         check(false, false);
+      });
+
+      describe('emailAddressVisibility / email_address_visibility', () => {
+        const { Everyone, Members, Admins, Nobody, Moderators } = EmailAddressVisibility;
+        const check = mkCheck('emailAddressVisibility', 'email_address_visibility');
+        check(Everyone, Members);
+        check(Everyone, Admins);
+        check(Everyone, Nobody);
+        check(Everyone, Moderators);
+        check(Members, Everyone);
+        check(Members, Admins);
+        check(Members, Nobody);
+        check(Members, Moderators);
+        check(Admins, Everyone);
+        check(Admins, Members);
+        check(Admins, Nobody);
+        check(Admins, Moderators);
+        check(Nobody, Everyone);
+        check(Nobody, Admins);
+        check(Nobody, Members);
+        check(Nobody, Moderators);
+        check(Moderators, Everyone);
+        check(Moderators, Admins);
+        check(Moderators, Members);
+        check(Moderators, Nobody);
       });
     });
   });

--- a/src/realm/realmReducer.js
+++ b/src/realm/realmReducer.js
@@ -8,6 +8,7 @@ import type {
 import {
   CreatePublicOrPrivateStreamPolicy,
   CreateWebPublicStreamPolicy,
+  EmailAddressVisibility,
 } from '../api/permissionsTypes';
 import { EventTypes } from '../api/eventTypes';
 import {
@@ -54,6 +55,7 @@ const initialState = {
   waitingPeriodThreshold: 90,
   allowEditHistory: false,
   enableReadReceipts: false,
+  emailAddressVisibility: EmailAddressVisibility.Admins,
 
   //
   // InitialDataRealmUser
@@ -162,6 +164,7 @@ export default (
         waitingPeriodThreshold: action.data.realm_waiting_period_threshold,
         allowEditHistory: action.data.realm_allow_edit_history,
         enableReadReceipts: action.data.realm_enable_read_receipts ?? false,
+        emailAddressVisibility: action.data.realm_email_address_visibility,
 
         //
         // InitialDataRealmUser
@@ -264,6 +267,9 @@ export default (
             }
             if (data.enable_read_receipts !== undefined) {
               result.enableReadReceipts = data.enable_read_receipts;
+            }
+            if (data.email_address_visibility !== undefined) {
+              result.emailAddressVisibility = data.email_address_visibility;
             }
 
             return result;

--- a/src/reduxTypes.js
+++ b/src/reduxTypes.js
@@ -38,6 +38,7 @@ import type { PmConversationsState } from './pm-conversations/pmConversationsMod
 import type { UnreadState } from './unread/unreadModelTypes';
 import type { UserStatusesState } from './user-statuses/userStatusesCore';
 import type { ServerEmojiData } from './api/modelTypes';
+import type { EmailAddressVisibility } from './api/permissionsTypes';
 
 export type { MuteState } from './mute/muteModelTypes';
 export type { UserStatusesState } from './user-statuses/userStatusesCore';
@@ -307,6 +308,7 @@ export type RealmState = {|
   +waitingPeriodThreshold: number,
   +allowEditHistory: boolean,
   +enableReadReceipts: boolean,
+  +emailAddressVisibility: EmailAddressVisibility,
 
   //
   // InitialDataRealmUser

--- a/src/storage/__tests__/migrations-test.js
+++ b/src/storage/__tests__/migrations-test.js
@@ -104,7 +104,7 @@ describe('migrations', () => {
   // What `base` becomes after all migrations.
   const endBase = {
     ...base52,
-    migrations: { version: 53 },
+    migrations: { version: 54 },
   };
 
   for (const [desc, before, after] of [
@@ -127,8 +127,8 @@ describe('migrations', () => {
     // redundant with this one, because none of the migration steps notice
     // whether any properties outside `storeKeys` are present or not.
     [
-      'check dropCache at 53',
-      { ...endBase, migrations: { version: 52 }, mute: [], nonsense: [1, 2, 3] },
+      'check dropCache at 54',
+      { ...endBase, migrations: { version: 53 }, mute: [], nonsense: [1, 2, 3] },
       endBase,
     ],
 

--- a/src/storage/migrations.js
+++ b/src/storage/migrations.js
@@ -463,6 +463,9 @@ const migrationsInner: {| [string]: (LessPartialState) => LessPartialState |} = 
   // Add enableReadReceipts to state.realm.
   '53': dropCache,
 
+  // Add emailAddressVisibility to state.realm
+  '54': dropCache,
+
   // TIP: When adding a migration, consider just using `dropCache`.
   //   (See its jsdoc for guidance on when that's the right answer.)
 };

--- a/src/users/userSelectors.js
+++ b/src/users/userSelectors.js
@@ -13,6 +13,7 @@ import type { RealmState } from '../reduxTypes';
 import { getUsers, getCrossRealmBots, getNonActiveUsers } from '../directSelectors';
 import * as logging from '../utils/logging';
 import { ensureUnreachable } from '../generics';
+import { EmailAddressVisibility } from '../api/permissionsTypes';
 
 /**
  * All users in this Zulip org (aka realm).
@@ -307,4 +308,22 @@ export function getCustomProfileFieldsForUser(
     }
   }
   return fields;
+}
+
+/**
+ * The given user's real email address, if known, for displaying in the UI.
+ *
+ * Null if our user isn't able to see this user's real email address.
+ */
+export function getDisplayEmailForUser(realm: RealmState, user: UserOrBot): string | null {
+  if (user.delivery_email !== undefined) {
+    return user.delivery_email;
+  } else if (realm.emailAddressVisibility === EmailAddressVisibility.Everyone) {
+    // On future servers, we expect this case will never happen: we'll always include
+    // a delivery_email when you have access, including when the visibility is Everyone
+    // https://github.com/zulip/zulip-mobile/pull/5515#discussion_r997731727
+    return user.email;
+  } else {
+    return null;
+  }
 }


### PR DESCRIPTION
Add prop showEmail to AccountDetails component.  When showEmail is true Account details will attempt to display the user email if available.
Add getDisplayEmailForUser to userSelectors which returns the user email if available or null if not defined or available by realm policy.
Add unit tests for above function.

Tested in iOS simulator 15.2 using using the chat.zulip.org
server and the recurse.zulipchat.com server.

Fixes: #5400