### PR TITLE
msglist: Convert MessageList to a function component with Hooks

### DIFF
--- a/docs/architecture/react.md
+++ b/docs/architecture/react.md
@@ -141,40 +141,16 @@ doc](https://reactjs.org/docs/context.html)):
 > [...])
 > is not subject to the shouldComponentUpdate method
 
-Concretely, this means that our `MessageList` component updates
-(re-`render`s) when the theme changes, since it's a `ThemeContext`
-consumer, *even though its `shouldComponentUpdate` always returns
-`false`*.  This generally isn't a problem because the UI for
-changing our own theme setting can't appear while a `MessageList` is
-in the navigation stack; so the theme can change only once we have
-#4009, via the OS-level theme changing (either automatically on
-schedule, or because the user changed it in system settings.)  When
-this does happen we see that the message list's color scheme changes
-as we'd want it to, but we also see the bad effects that
-`shouldComponentUpdate` returning `false` is meant to prevent:
-losing the scroll position, mainly (but also, we expect, discarding
-the image cache, etc.).
-
-### The exception: `MessageList`
-
-We have one React component that we wrote (beyond `connect` calls) that
-deviates from the above design: `MessageList`.  This is the only
-component that extends plain `Component` rather than `PureComponent`,
-and it's the only component in which we implement
-`shouldComponentUpdate`.
-
-In fact, `MessageList` does adhere to the Pure Component Principle -- its
-`render` method is a pure function of `this.props` and `this.context`.  So
-it could use `PureComponent`, but it doesn't -- instead we have a
-`shouldComponentUpdate` that always returns `false`, so even when `props`
-change quite materially (e.g., a new Zulip message arrives which should be
-displayed) we don't have React re-render the component. (See the note
-on the current Context API, above, for a known case where
-`shouldComponentUpdate` can be ignored.)
-
-The specifics of why not, and what we do instead, deserve an architecture
-doc of their own.  In brief: `render` returns a single React element, a
-`WebView`; on new Zulip messages or other updates to the props, we choose
-not to have React make a new `WebView` and render it in the usual way;
-instead, we use `WebView#postMessage` to send information to the JS code
-running inside the `WebView`, and that code updates the DOM accordingly.
+We also confirmed this behavior experimentally, in a 2020 version of
+`MessageList` which used `ThemeContext` to get the theme colors.
+(More recently it's not a class component at all, but a Hooks-based
+function component.)  That component re-`render`ed when the theme changed,
+*even though its `shouldComponentUpdate` always returned `false`*.
+This didn't cause a live problem because the UI doesn't
+allow changing the theme while a `MessageList` is in the navigation
+stack. If it were possible, it would be a concern: setting a short
+interval to automatically toggle the theme, we see that the message
+list's color scheme changes as we'd want it to, but we also see the
+bad effects that `shouldComponentUpdate` returning `false` is meant to
+prevent: losing the scroll position, mainly (but also, we expect,
+discarding the image cache, etc.).

--- a/src/RootErrorBoundary.js
+++ b/src/RootErrorBoundary.js
@@ -34,7 +34,7 @@ type State = $ReadOnly<{|
  *
  * [1] https://reactjs.org/docs/error-boundaries.html#how-about-event-handlers
  */
-export default class ErrorBoundary extends React.Component<Props, State> {
+export default class ErrorBoundary extends React.PureComponent<Props, State> {
   static getDerivedStateFromError(error: Error): State {
     return { error };
   }

--- a/src/boot/TranslationProvider.js
+++ b/src/boot/TranslationProvider.js
@@ -16,9 +16,10 @@ export const TranslationContext: Context<GetText> = React.createContext(undefine
 /**
  * Provide `_` to the wrapped component, passing other props through.
  *
- * This is useful when the component is already using its `context` property
- * for the legacy context API.  When that isn't the case, simply saying
- * `context: TranslationContext` may be more convenient.
+ * This can be useful when the component is already using its `context`
+ * property for a different context provider.  When that isn't the case,
+ * simply saying `context: TranslationContext` may be more convenient.
+ * Or in a function component, `const _ = useContext(TranslationContext);`.
  */
 export function withGetText<P: { +_: GetText, ... }, C: ComponentType<P>>(
   WrappedComponent: C,

--- a/src/sharing/ShareToPm.js
+++ b/src/sharing/ShareToPm.js
@@ -37,7 +37,7 @@ type State = $ReadOnly<{|
   choosingRecipients: boolean,
 |}>;
 
-export default class ShareToPm extends React.Component<Props, State> {
+export default class ShareToPm extends React.PureComponent<Props, State> {
   state: State = {
     selectedRecipients: [],
     choosingRecipients: false,

--- a/src/sharing/ShareToStream.js
+++ b/src/sharing/ShareToStream.js
@@ -47,7 +47,7 @@ type State = $ReadOnly<{|
   isTopicFocused: boolean,
 |}>;
 
-class ShareToStreamInner extends React.Component<Props, State> {
+class ShareToStreamInner extends React.PureComponent<Props, State> {
   state = {
     streamName: '',
     streamId: null,

--- a/src/sharing/ShareWrapper.js
+++ b/src/sharing/ShareWrapper.js
@@ -98,7 +98,7 @@ type State = $ReadOnly<{|
  * Wraps Around different sharing screens,
  * for minimal duplication of code.
  */
-class ShareWrapperInner extends React.Component<Props, State> {
+class ShareWrapperInner extends React.PureComponent<Props, State> {
   static contextType = TranslationContext;
   context: GetText;
 

--- a/src/webview/MessageList.js
+++ b/src/webview/MessageList.js
@@ -158,7 +158,7 @@ class MessageListInner extends React.Component<Props> {
   context: ThemeData;
 
   webviewRef = React.createRef<React$ElementRef<typeof WebView>>();
-  sendInboundEventsIsReady: boolean;
+  sendInboundEventsIsReady: boolean = false;
   unsentInboundEvents: WebViewInboundEvent[] = [];
 
   /**

--- a/src/webview/MessageList.js
+++ b/src/webview/MessageList.js
@@ -190,12 +190,14 @@ function MessageListInner(props: Props) {
     [props, sendInboundEvents],
   );
 
-  const lastProps = usePrevious(props, props);
+  const propsRef = React.useRef(props);
   React.useEffect(() => {
+    const lastProps = propsRef.current;
     if (props === lastProps) {
       // Nothing to update.  (This happens in particular on first render.)
       return;
     }
+    propsRef.current = props;
 
     // Account for the new props by sending any needed inbound-events to the
     // inside-webview code.
@@ -205,7 +207,7 @@ function MessageListInner(props: Props) {
     } else {
       unsentInboundEvents.current.push(...uevents);
     }
-  }, [lastProps, props, sendInboundEvents]);
+  }, [props, sendInboundEvents]);
 
   // We compute the page contents as an HTML string just once (*), on this
   // MessageList's first render.  See discussion at top of function.

--- a/src/webview/MessageList.js
+++ b/src/webview/MessageList.js
@@ -189,7 +189,9 @@ class MessageListInner extends React.Component<Props> {
       backgroundData.serverEmojiData,
     );
 
-    return renderSinglePageWebView(html, baseUrl, {
+    return renderSinglePageWebView({
+      html,
+      baseUrl,
       decelerationRate: 'normal',
       style: { backgroundColor: 'transparent' },
       ref: this.webviewRef,

--- a/src/webview/MessageList.js
+++ b/src/webview/MessageList.js
@@ -132,10 +132,6 @@ class MessageListInner extends React.Component<Props> {
   sendInboundEventsIsReady: boolean;
   unsentInboundEvents: WebViewInboundEvent[] = [];
 
-  handleError = (event: mixed) => {
-    console.error(event); // eslint-disable-line
-  };
-
   sendInboundEvents = (uevents: $ReadOnlyArray<WebViewInboundEvent>): void => {
     if (this.webviewRef.current !== null && uevents.length > 0) {
       /* $FlowFixMe[incompatible-type]: This `postMessage` is undocumented;
@@ -198,7 +194,9 @@ class MessageListInner extends React.Component<Props> {
       style: { backgroundColor: 'transparent' },
       ref: this.webviewRef,
       onMessage: this.handleMessage,
-      onError: this.handleError,
+      onError: event => {
+        console.error(event); // eslint-disable-line no-console
+      },
     });
   }
 }

--- a/src/webview/MessageList.js
+++ b/src/webview/MessageList.js
@@ -38,7 +38,7 @@ import { base64Utf8Encode } from '../utils/encoding';
 import { caseNarrow, isConversationNarrow } from '../utils/narrow';
 import { type BackgroundData, getBackgroundData } from './backgroundData';
 import { ensureUnreachable } from '../generics';
-import { renderSinglePageWebView } from './SinglePageWebView';
+import SinglePageWebView from './SinglePageWebView';
 
 type OuterProps = $ReadOnly<{|
   narrow: Narrow,
@@ -189,17 +189,19 @@ class MessageListInner extends React.Component<Props> {
       backgroundData.serverEmojiData,
     );
 
-    return renderSinglePageWebView({
-      html,
-      baseUrl,
-      decelerationRate: 'normal',
-      style: { backgroundColor: 'transparent' },
-      ref: this.webviewRef,
-      onMessage: this.handleMessage,
-      onError: event => {
-        console.error(event); // eslint-disable-line no-console
-      },
-    });
+    return (
+      <SinglePageWebView
+        html={html}
+        baseUrl={baseUrl}
+        decelerationRate="normal"
+        style={{ backgroundColor: 'transparent' }}
+        ref={this.webviewRef}
+        onMessage={this.handleMessage}
+        onError={event => {
+          console.error(event); // eslint-disable-line no-console
+        }}
+      />
+    );
   }
 }
 

--- a/src/webview/MessageList.js
+++ b/src/webview/MessageList.js
@@ -152,8 +152,7 @@ class MessageListInner extends React.Component<Props> {
       this.sendInboundEvents([{ type: 'ready' }, ...this.unsentInboundEvents]);
       this.unsentInboundEvents = [];
     } else {
-      const { _ } = this.props;
-      handleWebViewOutboundEvent(this.props, _, eventData);
+      handleWebViewOutboundEvent(this.props, eventData);
     }
   };
 

--- a/src/webview/SinglePageWebView.js
+++ b/src/webview/SinglePageWebView.js
@@ -71,14 +71,16 @@ function makeOnShouldStartLoadWithRequest(
 // TODO: This should ideally be a proper React component of its own.  The
 //       thing that may require care when doing that is our use of
 //       `shouldComponentUpdate` in its caller, `MessageList`.
-export const renderSinglePageWebView = (
+export const renderSinglePageWebView = (props: {
   html: string,
   baseUrl: URL,
-  moreProps: $Rest<
+  ...$Rest<
     ElementConfigFull<typeof WebView>,
     {| source: mixed, originWhitelist: mixed, onShouldStartLoadWithRequest: mixed |},
   >,
-): React.Node => (
+}): React.Node => {
+  const { html, baseUrl, ...moreProps } = props;
+
   // The `originWhitelist` and `onShouldStartLoadWithRequest` props are
   // meant to mitigate possible XSS bugs, by interrupting an attempted
   // exploit if it tries to navigate to a new URL by e.g. setting
@@ -90,10 +92,12 @@ export const renderSinglePageWebView = (
   //
   // Worse, the `originWhitelist` parameter is completely broken. See:
   // https://github.com/react-native-community/react-native-webview/pull/697
-  <WebView
-    source={{ baseUrl: (baseUrl.toString(): string), html: (html: string) }}
-    originWhitelist={['file://']}
-    onShouldStartLoadWithRequest={makeOnShouldStartLoadWithRequest(baseUrl)}
-    {...moreProps}
-  />
-);
+  return (
+    <WebView
+      source={{ baseUrl: (baseUrl.toString(): string), html: (html: string) }}
+      originWhitelist={['file://']}
+      onShouldStartLoadWithRequest={makeOnShouldStartLoadWithRequest(baseUrl)}
+      {...moreProps}
+    />
+  );
+};

--- a/src/webview/backgroundData.js
+++ b/src/webview/backgroundData.js
@@ -73,9 +73,10 @@ export type BackgroundData = $ReadOnly<{|
 
 // TODO: Ideally this ought to be a caching selector that doesn't change
 //   when the inputs don't.  Doesn't matter in a practical way as used in
-//   MessageList, because we have a `shouldComponentUpdate` that doesn't
-//   look at this prop... but it'd be better to set an example of the right
-//   general pattern.
+//   MessageList, because we memoize the expensive parts of rendering and in
+//   generateInboundEvents we check for changes to individual relevant
+//   properties of backgroundData, rather than backgroundData itself.  But
+//   it'd be better to set an example of the right general pattern.
 export const getBackgroundData = (
   state: PerAccountState,
   globalSettings: GlobalSettingsState,

--- a/src/webview/handleOutboundEvents.js
+++ b/src/webview/handleOutboundEvents.js
@@ -4,7 +4,7 @@ import { Clipboard, Alert } from 'react-native';
 import * as NavigationService from '../nav/NavigationService';
 import * as api from '../api';
 import config from '../config';
-import type { GetText, UserId } from '../types';
+import type { UserId } from '../types';
 import type { JSONableDict } from '../utils/jsonable';
 import { showToast } from '../utils/info';
 import { pmKeyRecipientsFromMessage } from '../utils/recipient';
@@ -192,7 +192,6 @@ const handleImage = (props: Props, src: string, messageId: number) => {
 
 const handleLongPress = (
   props: Props,
-  _: GetText,
   target: 'message' | 'header' | 'link',
   messageId: number,
   href: string | null,
@@ -200,6 +199,7 @@ const handleLongPress = (
   if (href !== null) {
     const url = new URL(href, props.backgroundData.auth.realm).toString();
     Clipboard.setString(url);
+    const { _ } = props;
     showToast(_('Link copied'));
     return;
   }
@@ -208,7 +208,8 @@ const handleLongPress = (
   if (!message) {
     return;
   }
-  const { dispatch, showActionSheetWithOptions, backgroundData, narrow, startEditMessage } = props;
+  const { dispatch, showActionSheetWithOptions, backgroundData, narrow, startEditMessage, _ } =
+    props;
   if (target === 'header') {
     if (message.type === 'stream') {
       showTopicActionSheet({
@@ -237,11 +238,7 @@ const handleLongPress = (
   }
 };
 
-export const handleWebViewOutboundEvent = (
-  props: Props,
-  _: GetText,
-  event: WebViewOutboundEvent,
-) => {
+export const handleWebViewOutboundEvent = (props: Props, event: WebViewOutboundEvent) => {
   switch (event.type) {
     case 'ready':
       // handled by caller
@@ -266,7 +263,7 @@ export const handleWebViewOutboundEvent = (
       break;
 
     case 'longPress':
-      handleLongPress(props, _, event.target, event.messageId, event.href);
+      handleLongPress(props, event.target, event.messageId, event.href);
       break;
 
     case 'url':
@@ -302,6 +299,7 @@ export const handleWebViewOutboundEvent = (
     }
 
     case 'time': {
+      const { _ } = props;
       const alertText = _('This time is in your timezone. Original text was “{originalText}”.', {
         originalText: event.originalText,
       });

--- a/src/webview/handleOutboundEvents.js
+++ b/src/webview/handleOutboundEvents.js
@@ -4,9 +4,7 @@ import { Clipboard, Alert } from 'react-native';
 import * as NavigationService from '../nav/NavigationService';
 import * as api from '../api';
 import config from '../config';
-import type { Dispatch, GetText, Message, Narrow, Outbox, EditMessage, UserId } from '../types';
-import type { BackgroundData } from './backgroundData';
-import type { ShowActionSheetWithOptions } from '../action-sheets';
+import type { GetText, UserId } from '../types';
 import type { JSONableDict } from '../utils/jsonable';
 import { showToast } from '../utils/info';
 import { pmKeyRecipientsFromMessage } from '../utils/recipient';
@@ -30,6 +28,7 @@ import {
 } from '../action-sheets';
 import { ensureUnreachable } from '../types';
 import { base64Utf8Decode } from '../utils/encoding';
+import type { Props } from './MessageList';
 
 type WebViewOutboundEventReady = {|
   type: 'ready',
@@ -158,19 +157,6 @@ export type WebViewOutboundEvent =
   | WebViewOutboundEventMention
   | WebViewOutboundEventTimeDetails
   | WebViewOutboundEventVote;
-
-// TODO: Consider completing this and making it exact, once
-// `MessageList`'s props are type-checked.
-type Props = $ReadOnly<{
-  backgroundData: BackgroundData,
-  dispatch: Dispatch,
-  messages: $ReadOnlyArray<Message | Outbox>,
-  narrow: Narrow,
-  doNotMarkMessagesAsRead: boolean,
-  showActionSheetWithOptions: ShowActionSheetWithOptions,
-  startEditMessage: (editMessage: EditMessage) => void,
-  ...
-}>;
 
 const fetchMore = (props: Props, event: WebViewOutboundEventScroll) => {
   const { innerHeight, offsetHeight, scrollY } = event;

--- a/src/webview/js/js.js
+++ b/src/webview/js/js.js
@@ -739,6 +739,7 @@ const inboundEventHandlers = {
 };
 
 // See `handleInitialLoad` for how this gets subscribed to events.
+// See `sendInboundEvents` on `MessageList` for where they're sent from.
 const handleMessageEvent: MessageEventListener = e => {
   scrollEventsDisabled = true;
   // This decoding inverts `base64Utf8Encode`.


### PR DESCRIPTION
A followup to #5523, as foreshadowed at https://github.com/zulip/zulip-mobile/pull/5523#discussion_r999046773 . This is the next step toward the message-list changes I'll want to make for #5364.

The tricky part here is the way we have MessageList seize the baton from React when it comes to updating the UI to reflect changes in data, and go take care of those updates by other means.

With a class component for MessageList, we've accomplished this by implementing `shouldComponentUpdate` to prevent re-renders. This has always been a bit of a latent bug, because that method's docs disclaim any guarantee of always preventing a re-render. In this branch, we:
* update some discussion around that use of `shouldComponentUpdate` to reflect changes that have already happened;
* then make some small code cleanups;
* dig into exactly what we're accomplishing by avoiding re-renders here -- to which the answer is, rerenders are fine but we're specifically avoiding recomputing the HTML text, both for performance and correctness -- and add comments explaining that;
* then make the conversion!

This PR concentrates on the `MessageListInner` component-type that does most of the work; it doesn't touch the several layers of wrappers which build up around it the actual `MessageList` component-type. I plan to tackle those for the next PR in the series.
