### PR TITLE
android: Fix build to get react-native only from local Maven repo

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -36,22 +36,26 @@ buildscript {
 
 allprojects {
     repositories {
-        maven {
-            // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
-            url "$rootDir/../node_modules/react-native/android"
+        exclusiveContent {
+            // We get React Native's Android binaries exclusively through npm,
+            // from a local Maven repo inside node_modules/react-native/.
+            // (The use of exclusiveContent prevents looking elsewhere like Maven Central
+            // and potentially getting a wrong version.)
+            filter {
+                includeGroup "com.facebook.react"
+            }
+            forRepository {
+                maven {
+                    url "$rootDir/../node_modules/react-native/android"
+                }
+            }
         }
         maven {
             // Android JSC is installed from npm
             url("$rootDir/../node_modules/jsc-android/dist")
         }
 
-        mavenCentral {
-            // We don't want to fetch react-native from Maven Central as there are
-            // older versions over there.
-            content {
-                excludeGroup "com.facebook.react"
-            }
-        }
+        mavenCentral()
         google()
 
         // The retired "jcenter" repo.


### PR DESCRIPTION
This fixes a build failure which started happening today due to an operational mistake in React Native release management:
  https://github.com/facebook/react-native/issues/35204

Happily Gradle gives us a way to more precisely pin down what we want it to do when finding dependencies, which makes the build robust to this and any similar issue.  I've sent the same fix upstream for the template app:
  https://github.com/facebook/react-native/pull/35208

See also where we spotted the issue in CI:
  https://github.com/zulip/zulip-mobile/pull/5524#issuecomment-1304311466
and discussion in chat:
  https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/build.20failure.3A.20libfbjni.2Eso.20duplicated/near/1459787