### PR TITLE
api.updateMessageFlags [nfc]: Rename from messagesFlags

### DIFF
--- a/src/api/__tests__/queueMarkAsRead-test.js
+++ b/src/api/__tests__/queueMarkAsRead-test.js
@@ -1,10 +1,10 @@
 /* @flow strict-local */
 import queueMarkAsRead, { resetAll } from '../queueMarkAsRead';
-import * as messagesFlags from '../messages/messagesFlags';
+import * as updateMessageFlags from '../messages/updateMessageFlags';
 import * as eg from '../../__tests__/lib/exampleData';
 
 // $FlowFixMe[cannot-write] Make flow understand about mocking
-messagesFlags.default = jest.fn(
+updateMessageFlags.default = jest.fn(
   (auth, ids, op, flag) =>
     new Promise((resolve, reject) => {
       resolve({ messages: ids, msg: '', result: 'success' });
@@ -18,22 +18,22 @@ describe('queueMarkAsRead', () => {
     resetAll();
   });
 
-  test('should not call messagesFlags on consecutive calls of queueMarkAsRead,  setTimout on further calls', () => {
+  test('should not call updateMessageFlags on consecutive calls of queueMarkAsRead,  setTimout on further calls', () => {
     queueMarkAsRead(eg.selfAuth, [1, 2, 3]);
     queueMarkAsRead(eg.selfAuth, [4, 5, 6]);
     queueMarkAsRead(eg.selfAuth, [7, 8, 9]);
     queueMarkAsRead(eg.selfAuth, [10, 11, 12]);
 
     expect(jest.getTimerCount()).toBe(1);
-    expect(messagesFlags.default).toHaveBeenCalledTimes(1);
+    expect(updateMessageFlags.default).toHaveBeenCalledTimes(1);
   });
 
-  test('should call messagesFlags, if calls to queueMarkAsRead are 2s apart', () => {
+  test('should call updateMessageFlags, if calls to queueMarkAsRead are 2s apart', () => {
     queueMarkAsRead(eg.selfAuth, [13, 14, 15]);
     jest.advanceTimersByTime(2100);
     queueMarkAsRead(eg.selfAuth, [16, 17, 18]);
 
-    expect(messagesFlags.default).toHaveBeenCalledTimes(2);
+    expect(updateMessageFlags.default).toHaveBeenCalledTimes(2);
   });
 
   test('should set timeout for time remaining for next API call to clear queue', () => {
@@ -43,7 +43,7 @@ describe('queueMarkAsRead', () => {
     queueMarkAsRead(eg.selfAuth, [4, 5, 6]);
 
     jest.runOnlyPendingTimers();
-    expect(messagesFlags.default).toHaveBeenCalledTimes(2);
+    expect(updateMessageFlags.default).toHaveBeenCalledTimes(2);
   });
 
   test('empty array should not cause anything to happen', () => {
@@ -52,6 +52,6 @@ describe('queueMarkAsRead', () => {
     jest.advanceTimersByTime(2500);
 
     jest.runOnlyPendingTimers();
-    expect(messagesFlags.default).toHaveBeenCalledTimes(0);
+    expect(updateMessageFlags.default).toHaveBeenCalledTimes(0);
   });
 });

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -32,7 +32,7 @@ import getRawMessageContent from './messages/getRawMessageContent';
 import getMessages from './messages/getMessages';
 import getSingleMessage from './messages/getSingleMessage';
 import getMessageHistory from './messages/getMessageHistory';
-import messagesFlags from './messages/messagesFlags';
+import updateMessageFlags from './messages/updateMessageFlags';
 import sendMessage from './messages/sendMessage';
 import updateMessage from './messages/updateMessage';
 import savePushToken from './notifications/savePushToken';
@@ -83,7 +83,7 @@ export {
   getMessages,
   getSingleMessage,
   getMessageHistory,
-  messagesFlags,
+  updateMessageFlags,
   sendMessage,
   updateMessage,
   savePushToken,

--- a/src/api/messages/toggleMessageStarred.js
+++ b/src/api/messages/toggleMessageStarred.js
@@ -1,11 +1,11 @@
 /* @flow strict-local */
 import type { Auth } from '../transportTypes';
-import messagesFlags from './messagesFlags';
-import type { ApiResponseMessagesFlags } from './messagesFlags';
+import updateMessageFlags from './updateMessageFlags';
+import type { ApiResponseUpdateMessageFlags } from './updateMessageFlags';
 
 export default (
   auth: Auth,
   messageIds: $ReadOnlyArray<number>,
   starMessage: boolean,
-): Promise<ApiResponseMessagesFlags> =>
-  messagesFlags(auth, messageIds, starMessage ? 'add' : 'remove', 'starred');
+): Promise<ApiResponseUpdateMessageFlags> =>
+  updateMessageFlags(auth, messageIds, starMessage ? 'add' : 'remove', 'starred');

--- a/src/api/messages/updateMessageFlags.js
+++ b/src/api/messages/updateMessageFlags.js
@@ -3,15 +3,16 @@ import type { ApiResponseSuccess, Auth } from '../transportTypes';
 import type { UserMessageFlag } from '../modelTypes';
 import { apiPost } from '../apiFetch';
 
-export type ApiResponseMessagesFlags = {|
+export type ApiResponseUpdateMessageFlags = {|
   ...$Exact<ApiResponseSuccess>,
   messages: $ReadOnlyArray<number>,
 |};
 
+/** https://zulip.com/api/update-message-flags */
 export default (
   auth: Auth,
   messageIds: $ReadOnlyArray<number>,
   op: 'add' | 'remove',
   flag: UserMessageFlag,
-): Promise<ApiResponseMessagesFlags> =>
+): Promise<ApiResponseUpdateMessageFlags> =>
   apiPost(auth, 'messages/flags', { messages: JSON.stringify(messageIds), flag, op });

--- a/src/api/queueMarkAsRead.js
+++ b/src/api/queueMarkAsRead.js
@@ -1,6 +1,6 @@
 /* @flow strict-local */
 import type { Auth } from './transportTypes';
-import messagesFlags from './messages/messagesFlags';
+import updateMessageFlags from './messages/updateMessageFlags';
 
 /** We batch up requests to avoid sending them twice in this much time. */
 const debouncePeriodMs = 500;
@@ -31,7 +31,7 @@ const processQueue = async (auth: Auth) => {
   }
 
   lastSentTime = Date.now();
-  const response = await messagesFlags(auth, unackedMessageIds, 'add', 'read');
+  const response = await updateMessageFlags(auth, unackedMessageIds, 'add', 'read');
   const acked_messages = new Set(response.messages);
   unackedMessageIds = unackedMessageIds.filter(id => !acked_messages.has(id));
 };

--- a/src/chat/MarkAsReadButton.js
+++ b/src/chat/MarkAsReadButton.js
@@ -60,7 +60,7 @@ export default function MarkAsReadButton(props: Props): Node {
       return;
     }
 
-    api.messagesFlags(auth, messageIds, 'add', 'read');
+    api.updateMessageFlags(auth, messageIds, 'add', 'read');
   }, [auth, unread, narrow, ownUserId]);
 
   if (isHomeNarrow(narrow)) {


### PR DESCRIPTION
This matches the name in the OpenAPI description.  It also makes a more grammatical phrase, and reads more naturally and informatively at call sites.

(The old name dates from before we had OpenAPI descriptions; it seems to be based on the URL path, which was a reasonable choice at the time.)

I noticed this while writing the prototype for #5364. But the eventual real implementation of #5364 is planned to not use this endpoint at all (in favor of a new API endpoint that will better give us what we need), so that this rename would be a bit off-topic there. Hence sending this as a small separate PR.
