### PR TITLE
i18n: Update for new Transifex client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,9 +74,6 @@ android/build/
 # Expo
 .expo/
 
-# Transifex, for a maintainer syncing translations up and down
-/.transifexrc
-
 # Android release builds
 *.keystore
 *.keystore.gpg

--- a/.tx/config
+++ b/.tx/config
@@ -1,8 +1,8 @@
 [main]
 host = https://www.transifex.com
 
-[zulip.mobile]
-source_file = static/translations/messages_en.json
-source_lang = en
-type = KEYVALUEJSON
+[o:zulip:p:zulip:r:mobile]
+type        = KEYVALUEJSON
 file_filter = static/translations/messages_<lang>.json
+source_lang = en
+source_file = static/translations/messages_en.json

--- a/docs/howto/translations.md
+++ b/docs/howto/translations.md
@@ -214,20 +214,28 @@ to provide to our translators to translate.
 
 You'll want Transifex's CLI client, `tx`.
 
-* Install in your homedir with `pip3 install --user transifex-client`.  Or
-  you can use your Zulip dev server virtualenv, which has it.
+* Install according to [Transifex's instructions][tx-cli-installation].
 
-* Configure a `.transifexrc` with your API token.  See [upstream
-  instructions](https://docs.transifex.com/client/client-configuration#transifexrc).
+* Configure a `.transifexrc` with your API token.
 
-  This can go either in your homedir, or in your working tree to make
-  the configuration apply only locally; it's already ignored in our
-  `.gitignore`.
+  * First, get your Transifex API token.  See [upstream
+    instructions][tx-api-auth].
+
+  * Then, create a `~/.transifexrc` file in your homedir, in the
+    following format:
+
+    ```
+    [https://www.transifex.com]
+    rest_hostname = https://rest.api.transifex.com
+    token         = YOUR_TOKEN_HERE
+    ```
 
 * You'll need to be added [as a "maintainer"][tx-zulip-maintainers] to
   the Zulip project on Transifex.  (Upstream [recommends
   this][tx-docs-maintainers] as the set of permissions on a Transifex
   project needed for interacting with it as a developer.)
 
+[tx-cli-installation]: https://developers.transifex.com/docs/cli#installation
+[tx-api-auth]: https://developers.transifex.com/reference/api-authentication
 [tx-zulip-maintainers]: https://www.transifex.com/zulip/zulip/settings/maintainers/
 [tx-docs-maintainers]: https://docs.transifex.com/teams/understanding-user-roles#project-maintainers

--- a/tools/tx-pull
+++ b/tools/tx-pull
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 set -ex
-exec tx --quiet pull -a -f --parallel
+exec tx pull --silent --all --force

--- a/tools/tx-sync
+++ b/tools/tx-sync
@@ -139,7 +139,7 @@ fi
 err_echo
 err_echo 'Step 3: Upload strings to translate...'
 
-run_visibly tx --quiet push -s
+run_visibly tx push --silent
 run_visibly tools/tx-pull
 
 git_update_index


### PR DESCRIPTION
Transifex is turning off their old API, and in the process they're abandoning their longtime CLI client.  In its place is a new one, written in Go.  ("For speed", though hilariously it's actually a bit slower.)  Discussion here:
  https://chat.zulip.org/#narrow/stream/58-translation/topic/Transifex.20client/near/1460621

Update maintainer-facing docs to reflect the new client, and our scripts and config to be compatible with it.  The config changes came from the handy `tx migrate` provided in the new client.

Maintainers should read the new setup instructions and migrate accordingly:

 * Install the new `tx` client.

 * Update the format of the `.transifexrc` file.  (The new `token` is the old `password`.)

 * Move the `.transifexrc` file to `~/`, if it was in the worktree.