### PR TITLE
msglist [nfc]: Convert the wrapper HOCs to more Hooks

### DIFF
--- a/src/webview/MessageList.js
+++ b/src/webview/MessageList.js
@@ -1,5 +1,6 @@
 /* @flow strict-local */
 import * as React from 'react';
+import { useContext } from 'react';
 import { Platform, NativeModules } from 'react-native';
 import { WebView } from 'react-native-webview';
 
@@ -24,7 +25,7 @@ import {
   getFetchingForNarrow,
   getGlobalSettings,
 } from '../selectors';
-import { withGetText } from '../boot/TranslationProvider';
+import { TranslationContext } from '../boot/TranslationProvider';
 import type { ShowActionSheetWithOptions } from '../action-sheets';
 import { getMessageListElementsMemoized } from '../message/messageSelectors';
 import type { WebViewInboundEvent } from './generateInboundEvents';
@@ -78,9 +79,6 @@ type MiddleProps = $ReadOnly<{|
 
   // From `connectActionSheet`.
   showActionSheetWithOptions: ShowActionSheetWithOptions,
-
-  // From `withGetText`.
-  _: GetText,
 |}>;
 
 /**
@@ -92,15 +90,24 @@ type MiddleProps = $ReadOnly<{|
  * as represented by outbound-events, and in action sheets -- use the data
  * and callbacks in order to do their jobs.
  *
- * This is also -- hence the name -- the React props for the inner, function
- * component, which include data obtained through the various HOCs below.
+ * This can be thought of -- hence the name -- as the React props for a
+ * notional inner component, like we'd have if we obtained this data through
+ * HOCs like `connect` and `withGetText`.  (Instead, we use Hooks, and don't
+ * have an inner component with this set of props.)
  */
 export type Props = $ReadOnly<{|
   ...MiddleProps,
+
+  _: GetText,
 |}>;
 
 function useMessageListProps(outerProps: MiddleProps): Props {
-  return outerProps;
+  const _ = useContext(TranslationContext);
+
+  return {
+    ...outerProps,
+    _,
+  };
 }
 
 /**
@@ -380,6 +387,6 @@ const MessageList: React.ComponentType<OuterProps> = connect<SelectorProps, _, _
         })(),
     };
   },
-)(connectActionSheet(withGetText(MessageListInner)));
+)(connectActionSheet(MessageListInner));
 
 export default MessageList;

--- a/src/webview/MessageList.js
+++ b/src/webview/MessageList.js
@@ -65,6 +65,25 @@ type SelectorProps = {|
 |};
 
 /**
+ * The React props for the function component MessageListInner.
+ *
+ * These consist of OuterProps plus various props supplied by the HOC
+ * wrappers below.
+ */
+type MiddleProps = $ReadOnly<{|
+  ...OuterProps,
+
+  dispatch: Dispatch,
+  ...SelectorProps,
+
+  // From `connectActionSheet`.
+  showActionSheetWithOptions: ShowActionSheetWithOptions,
+
+  // From `withGetText`.
+  _: GetText,
+|}>;
+
+/**
  * All the data for rendering the message list, and callbacks for its UI actions.
  *
  * This data gets used for rendering the initial HTML and for computing
@@ -77,17 +96,12 @@ type SelectorProps = {|
  * component, which include data obtained through the various HOCs below.
  */
 export type Props = $ReadOnly<{|
-  ...OuterProps,
-
-  dispatch: Dispatch,
-  ...SelectorProps,
-
-  // From `connectActionSheet`.
-  showActionSheetWithOptions: ShowActionSheetWithOptions,
-
-  // From `withGetText`.
-  _: GetText,
+  ...MiddleProps,
 |}>;
+
+function useMessageListProps(outerProps: MiddleProps): Props {
+  return outerProps;
+}
 
 /**
  * The URL of the platform-specific assets folder.
@@ -139,7 +153,7 @@ const webviewAssetsUrl = new URL('webview/', assetsUrl);
  */
 const baseUrl = new URL('index.html', webviewAssetsUrl);
 
-function MessageListInner(props: Props) {
+function MessageListInner(outerProps: MiddleProps) {
   // NOTE: This component has an unusual lifecycle for a React component!
   //
   // In the React element which this render function returns, the bulk of
@@ -166,6 +180,8 @@ function MessageListInner(props: Props) {
   //    changes, and send them to our code inside the webview to execute.
   //
   // See also docs/architecture/react.md .
+
+  const props = useMessageListProps(outerProps);
 
   const theme = React.useContext(ThemeContext);
 

--- a/src/webview/MessageList.js
+++ b/src/webview/MessageList.js
@@ -43,7 +43,7 @@ import SinglePageWebView from './SinglePageWebView';
 import { usePrevious } from '../reactUtils';
 
 /**
- * The actual React props for the exported MessageList component.
+ * The actual React props for the MessageList component.
  */
 type OuterProps = $ReadOnly<{|
   narrow: Narrow,
@@ -67,16 +67,6 @@ type SelectorProps = {|
 |};
 
 /**
- * The React props for the function component MessageListInner.
- *
- * These consist of OuterProps plus various props supplied by the HOC
- * wrappers below.
- */
-type MiddleProps = $ReadOnly<{|
-  ...OuterProps,
-|}>;
-
-/**
  * All the data for rendering the message list, and callbacks for its UI actions.
  *
  * This data gets used for rendering the initial HTML and for computing
@@ -88,10 +78,10 @@ type MiddleProps = $ReadOnly<{|
  * This can be thought of -- hence the name -- as the React props for a
  * notional inner component, like we'd have if we obtained this data through
  * HOCs like `connect` and `withGetText`.  (Instead, we use Hooks, and don't
- * have an inner component with this set of props.)
+ * have a separate inner component.)
  */
 export type Props = $ReadOnly<{|
-  ...MiddleProps,
+  ...OuterProps,
 
   dispatch: Dispatch,
   ...SelectorProps,
@@ -166,7 +156,7 @@ function getSelectorProps(state, props) {
   };
 }
 
-function useMessageListProps(outerProps: MiddleProps): Props {
+function useMessageListProps(outerProps: OuterProps): Props {
   const _ = useContext(TranslationContext);
   const showActionSheetWithOptions: ShowActionSheetWithOptions =
     useActionSheet().showActionSheetWithOptions;
@@ -232,7 +222,7 @@ const webviewAssetsUrl = new URL('webview/', assetsUrl);
  */
 const baseUrl = new URL('index.html', webviewAssetsUrl);
 
-function MessageListInner(outerProps: MiddleProps) {
+export default function MessageList(outerProps: OuterProps): React.Node {
   // NOTE: This component has an unusual lifecycle for a React component!
   //
   // In the React element which this render function returns, the bulk of
@@ -392,8 +382,3 @@ function MessageListInner(outerProps: MiddleProps) {
     />
   );
 }
-
-// TODO next steps: merge these wrappers into function, one at a time.
-const MessageList: React.ComponentType<OuterProps> = MessageListInner;
-
-export default MessageList;

--- a/src/webview/MessageList.js
+++ b/src/webview/MessageList.js
@@ -3,8 +3,9 @@ import * as React from 'react';
 import { useContext } from 'react';
 import { Platform, NativeModules } from 'react-native';
 import { WebView } from 'react-native-webview';
+// $FlowFixMe[untyped-import]
+import { useActionSheet } from '@expo/react-native-action-sheet';
 
-import { connectActionSheet } from '../react-native-action-sheet';
 import type {
   Dispatch,
   Fetching,
@@ -76,9 +77,6 @@ type MiddleProps = $ReadOnly<{|
 
   dispatch: Dispatch,
   ...SelectorProps,
-
-  // From `connectActionSheet`.
-  showActionSheetWithOptions: ShowActionSheetWithOptions,
 |}>;
 
 /**
@@ -98,14 +96,19 @@ type MiddleProps = $ReadOnly<{|
 export type Props = $ReadOnly<{|
   ...MiddleProps,
 
+  showActionSheetWithOptions: ShowActionSheetWithOptions,
+
   _: GetText,
 |}>;
 
 function useMessageListProps(outerProps: MiddleProps): Props {
   const _ = useContext(TranslationContext);
+  const showActionSheetWithOptions: ShowActionSheetWithOptions =
+    useActionSheet().showActionSheetWithOptions;
 
   return {
     ...outerProps,
+    showActionSheetWithOptions,
     _,
   };
 }
@@ -387,6 +390,6 @@ const MessageList: React.ComponentType<OuterProps> = connect<SelectorProps, _, _
         })(),
     };
   },
-)(connectActionSheet(MessageListInner));
+)(MessageListInner);
 
 export default MessageList;

--- a/src/webview/MessageList.js
+++ b/src/webview/MessageList.js
@@ -40,6 +40,9 @@ import { ensureUnreachable } from '../generics';
 import SinglePageWebView from './SinglePageWebView';
 import { usePrevious } from '../reactUtils';
 
+/**
+ * The actual React props for the exported MessageList component.
+ */
 type OuterProps = $ReadOnly<{|
   narrow: Narrow,
   messages: $ReadOnlyArray<Message | Outbox>,
@@ -61,6 +64,18 @@ type SelectorProps = {|
   doNotMarkMessagesAsRead: boolean,
 |};
 
+/**
+ * All the data for rendering the message list, and callbacks for its UI actions.
+ *
+ * This data gets used for rendering the initial HTML and for computing
+ * inbound-events to update the page.  Then the handlers for the message
+ * list's numerous UI actions -- both for user interactions inside the page
+ * as represented by outbound-events, and in action sheets -- use the data
+ * and callbacks in order to do their jobs.
+ *
+ * This is also -- hence the name -- the React props for the inner, function
+ * component, which include data obtained through the various HOCs below.
+ */
 export type Props = $ReadOnly<{|
   ...OuterProps,
 

--- a/src/webview/MessageList.js
+++ b/src/webview/MessageList.js
@@ -17,9 +17,8 @@ import type {
   UserOrBot,
   EditMessage,
 } from '../types';
-import { assumeSecretlyGlobalState } from '../reduxTypes';
 import { ThemeContext } from '../styles';
-import { useSelector, useDispatch } from '../react-redux';
+import { useSelector, useDispatch, useGlobalSelector } from '../react-redux';
 import {
   getCurrentTypingUsers,
   getDebug,
@@ -122,15 +121,11 @@ const marksMessagesAsRead = (narrow: Narrow): boolean =>
     mentioned: () => false,
   });
 
-function getSelectorProps(state, props) {
-  // If this were a function component with Hooks, these would be
-  // useGlobalSelector calls and would coexist perfectly smoothly with
-  // useSelector calls for the per-account data.  As long as it's not,
-  // they should probably turn into a `connectGlobal` call.
-  const globalSettings = getGlobalSettings(assumeSecretlyGlobalState(state));
-  const debug = getDebug(assumeSecretlyGlobalState(state));
+function useSelectorProps(props: OuterProps) {
+  const globalSettings = useGlobalSelector(getGlobalSettings);
+  const debug = useGlobalSelector(getDebug);
 
-  return {
+  return useSelector(state => ({
     backgroundData: getBackgroundData(state, globalSettings, debug),
     fetching: getFetchingForNarrow(state, props.narrow),
     messageListElementsForShownMessages: getMessageListElementsMemoized(
@@ -153,7 +148,7 @@ function getSelectorProps(state, props) {
             return false;
         }
       })(),
-  };
+  }));
 }
 
 function useMessageListProps(outerProps: OuterProps): Props {
@@ -161,7 +156,7 @@ function useMessageListProps(outerProps: OuterProps): Props {
   const showActionSheetWithOptions: ShowActionSheetWithOptions =
     useActionSheet().showActionSheetWithOptions;
   const dispatch = useDispatch();
-  const selectorProps = useSelector(state => getSelectorProps(state, outerProps));
+  const selectorProps = useSelectorProps(outerProps);
 
   return {
     ...outerProps,


### PR DESCRIPTION
This follows up on #5524 by replacing the various props-providing higher-order components we have wrapping this component -- `connect`, `connectActionSheet`, `withGetText` -- with just more hooks. `MessageList` is now simply a function component, rather than a series of wrappers around an inner function component.

As a bonus, we clean up a pair of calls to `assumeSecretlyGlobalState`.

Like #5524, this is on the road to #5364.