### PR TITLE
Follow some Expo 43 -> 44 template-app changes, belatedly

### DIFF
--- a/android/app/src/main/java/com/zulipmobile/MainActivity.kt
+++ b/android/app/src/main/java/com/zulipmobile/MainActivity.kt
@@ -1,5 +1,6 @@
 package com.zulipmobile
 
+import android.os.Build
 import android.content.Intent
 import android.os.Bundle
 import android.webkit.WebView
@@ -90,5 +91,24 @@ open class MainActivity : ReactActivity() {
             return
         }
         super.onNewIntent(intent)
+    }
+
+    /**
+     * Align the back button behavior with Android S
+     * where moving root activities to background instead of finishing activities.
+     * @see <a href="https://developer.android.com/reference/android/app/Activity#onBackPressed()">onBackPressed</a>
+     */
+    override fun invokeDefaultOnBackPressed() {
+        if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.R) {
+            if (!moveTaskToBack(false)) {
+                // For non-root activities, use the default implementation to finish them.
+                super.invokeDefaultOnBackPressed()
+            }
+            return
+        }
+
+        // Use the default back button implementation on Android S
+        // because it's doing more than {@link Activity#moveTaskToBack} in fact.
+        super.invokeDefaultOnBackPressed()
     }
 }

--- a/ios/ZulipMobile/AppDelegate.m
+++ b/ios/ZulipMobile/AppDelegate.m
@@ -87,7 +87,7 @@
    openURL:(NSURL *)url
    options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options
 {
-  return [RCTLinkingManager application:application openURL:url options:options];
+  return [super application:application openURL:url options:options] || [RCTLinkingManager application:application openURL:url options:options];
 }
 
 // Required to register for notifications


### PR DESCRIPTION
It turns out that when I did the Expo 44 upgrade in #5441, there were a few changes to Expo's template app that I didn't consider, because they weren't mentioned in the [upgrade guide](https://blog.expo.dev/expo-sdk-44-4c4b8306584a#8ff0) and I guess I didn't go and look at the actual commits.

Details [in chat](https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/Expo.2044.20small.20things/near/1452850), including the list of commits and how we filtered them down to these two changes.