### PR TITLE
Mark as read in bounded batches; ignore "messages" in response

### DIFF
--- a/src/api/messages/updateMessageFlags.js
+++ b/src/api/messages/updateMessageFlags.js
@@ -5,7 +5,10 @@ import { apiPost } from '../apiFetch';
 
 export type ApiResponseUpdateMessageFlags = {|
   ...$Exact<ApiResponseSuccess>,
-  messages: $ReadOnlyArray<number>,
+
+  // The `messages` property is deprecated.  See discussion:
+  //   https://chat.zulip.org/#narrow/stream/378-api-design/topic/mark-as-unread.20request/near/1463920
+  -messages: $ReadOnlyArray<number>,
 |};
 
 /** https://zulip.com/api/update-message-flags */


### PR DESCRIPTION
queueMarkAsRead: Limit size of our requests

We're currently asking the server to mark a potentially unbounded
number of messages as read, all in a single request.  Instead,
limit the size of the request to 1000 messages at a time -- the
same number the web app uses.

Fixes: #3423

---

queueMarkAsRead: Stop using server's misleading "messages" list

It turns out that the actual behavior of this response property is
that it just echoes the same message IDs we listed in the request.
So we might as well use the list we sent, instead.

Moreover, if this did tell us only those messages that were actually
affected, then among the messages left out would be messages that a
retry would have no better shot at affecting: messages that are
already read, or have been deleted.

(In fact on current server behavior those are the *only* messages
that would be left out -- there is no server limit on the size of
this request, so if it succeeds at all then it will have applied
to all the given messages that such a request could apply to.)

So by retrying those, we'd end up retrying in a loop forever.
That means there's no plausible future API change where consulting
this "messages" response property as we do here would be better
than ignoring it; and in fact our plan:
  https://chat.zulip.org/#narrow/stream/378-api-design/topic/mark-as-unread.20request/near/1463920
is to remove it in the future.  Start ignoring it now.

---

Two of the complaints in #3423 remain true after these changes:

> * it doesn't prevent having several requests in flight at a time
> * if a request fails, it neither retries nor gives up -- the message IDs hang out in limbo here until the _next_ time this function is called, when the user scrolls past some other unread messages, which may happen arbitrarily far in the future or never happen.
>   
>   * For the specific semantics of "mark as read", I think we should just indefinitely retry network or server failures as long as the queue is nonempty. I.e. this isn't a case where "never" can be better than "late".

But I think the first one is actually OK. And the second one remains an issue, but #4559 is a better thread to track it in.
