### PR TITLE
WebLink: Use openLinkWithUserPreference instead of openLinkEmbedded

### DIFF
--- a/src/common/WebLink.js
+++ b/src/common/WebLink.js
@@ -4,8 +4,10 @@ import * as React from 'react';
 
 import ZulipText from './ZulipText';
 import ZulipTextIntl from './ZulipTextIntl';
-import { openLinkEmbedded } from '../utils/openLink';
+import { openLinkWithUserPreference } from '../utils/openLink';
 import { BRAND_COLOR, createStyleSheet } from '../styles';
+import { useGlobalSelector } from '../react-redux';
+import { getGlobalSettings } from '../directSelectors';
 
 type Props = $ReadOnly<{|
   ...$Exact<React$ElementConfig<typeof ZulipText>>,
@@ -35,11 +37,13 @@ const componentStyles = createStyleSheet({
 export default function WebLink(props: Props): React.Node {
   const { children } = props;
 
+  const globalSettings = useGlobalSelector(getGlobalSettings);
+
   return (
     <ZulipText
       style={componentStyles.link}
       onPress={() => {
-        openLinkEmbedded(props.url.toString());
+        openLinkWithUserPreference(props.url.toString(), globalSettings);
       }}
     >
       {React.Children.map(children, child => {

--- a/src/settings/LegalScreen.js
+++ b/src/settings/LegalScreen.js
@@ -5,12 +5,12 @@ import type { Node } from 'react';
 
 import type { RouteProp } from '../react-navigation';
 import type { AppNavigationProp } from '../nav/AppNavigator';
-import { useSelector } from '../react-redux';
+import { useGlobalSelector, useSelector } from '../react-redux';
 import Screen from '../common/Screen';
 import NestedNavRow from '../common/NestedNavRow';
 import ZulipText from '../common/ZulipText';
-import { openLinkEmbedded } from '../utils/openLink';
-import { getRealmUrl, getRealmName } from '../selectors';
+import { openLinkWithUserPreference } from '../utils/openLink';
+import { getRealmUrl, getRealmName, getGlobalSettings } from '../selectors';
 
 type Props = $ReadOnly<{|
   navigation: AppNavigationProp<'legal'>,
@@ -22,13 +22,15 @@ export default function LegalScreen(props: Props): Node {
   const realm = useSelector(getRealmUrl);
   const realmName = useSelector(getRealmName);
 
+  const globalSettings = useGlobalSelector(getGlobalSettings);
+
   const openZulipPolicies = useCallback(() => {
-    openLinkEmbedded('https://zulip.com/policies/?nav=no');
-  }, []);
+    openLinkWithUserPreference('https://zulip.com/policies/?nav=no', globalSettings);
+  }, [globalSettings]);
 
   const openRealmPolicies = useCallback(() => {
-    openLinkEmbedded(new URL('/policies/?nav=no', realm).toString());
-  }, [realm]);
+    openLinkWithUserPreference(new URL('/policies/?nav=no', realm).toString(), globalSettings);
+  }, [realm, globalSettings]);
 
   return (
     <Screen title="Legal">


### PR DESCRIPTION
This bug was reported in chat:
  https://chat.zulip.org/#narrow/stream/48-mobile/topic/Links.20in.20user.20profile/near/1466262

While we're at it, make the same adjustment for `LegalScreen`, where presumably the user's setting should also apply. The user taps a "link" (well, a `NestedNavRow`) that's supposed to open a web page:

<img width=400 src="https://user-images.githubusercontent.com/22248748/202544750-bcb688c6-525e-48e7-b122-c95bf650b689.png" />