### PR TITLE
action-sheets types: Make Button's title/errorMessage LocalizableText

### DIFF
--- a/src/action-sheets/index.js
+++ b/src/action-sheets/index.js
@@ -18,6 +18,7 @@ import type {
   UserOrBot,
   EditMessage,
   Stream,
+  LocalizableText,
 } from '../types';
 import type { UnreadState } from '../unread/unreadModelTypes';
 import {
@@ -102,7 +103,7 @@ type Button<-Args: { ... }> = {|
 
   /** The label for the button. */
   // This UI string should be represented in messages_en.json.
-  +title: string,
+  +title: LocalizableText,
 
   /** The title of the alert-box that will be displayed if the
    * callback throws. */
@@ -111,7 +112,7 @@ type Button<-Args: { ... }> = {|
   // has one.
   //
   // This UI string should be represented in messages_en.json.
-  +errorMessage: string,
+  +errorMessage: LocalizableText,
 |};
 
 //


### PR DESCRIPTION
We already have comments saying the strings are UI strings that should be represented in messages_en.json. But this reinforces the point, and also lets you pass the kind of LocalizableText that is an object with `.text and `.values`.

(I plucked this tiny PR from some work I did while dealing with #5489 but that didn't make it into #5489.)