### PR TITLE
ChatScreen: Fix blank strip between compose box and keyboard on iOS

### DIFF
--- a/src/chat/ChatScreen.js
+++ b/src/chat/ChatScreen.js
@@ -198,7 +198,14 @@ export default function ChatScreen(props: Props): Node {
   );
 
   return (
-    <KeyboardAvoider style={[componentStyles.screen, { backgroundColor }]} behavior="padding">
+    <KeyboardAvoider
+      style={[componentStyles.screen, { backgroundColor }]}
+      behavior="padding"
+      compensateOverpadding={
+        // We let the compose box pad the bottom inset.
+        showComposeBox
+      }
+    >
       <ChatNavBar narrow={narrow} editMessage={editMessage} />
       <UnreadNotice narrow={narrow} />
       {(() => {

--- a/src/compose/ComposeBox.js
+++ b/src/compose/ComposeBox.js
@@ -729,6 +729,8 @@ const ComposeBox: React$AbstractComponent<Props, ImperativeHandle> = forwardRef(
       </View>
       <SafeAreaView
         mode="padding"
+        // When the keyboard is open, this bottom padding is compensated
+        // for: we pass KeyboardAvoider's compensateOverpadding prop.
         edges={['bottom']}
         style={styles.composeBox}
         onLayout={handleLayoutChange}


### PR DESCRIPTION
Before/after:

<img width=400 src="https://user-images.githubusercontent.com/22248748/202797015-10fb1614-6fe3-4b71-af89-56f071d16bd9.png" /> <img width=400 src="https://user-images.githubusercontent.com/22248748/202796936-856989f8-c308-48b2-809e-98a3ab0427c6.png" />

Fixes: #3370