### PR TITLE
flow: Upgrade to v0.170

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -125,4 +125,4 @@ exact_by_default=true
 enums=true
 
 [version]
-^0.162.0
+^0.170.0

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "eslint-plugin-react": "^7.24.0",
     "eslint-plugin-react-hooks": "^4.5.0",
     "expo-cli": "^6.0.5",
-    "flow-bin": "^0.162.0",
+    "flow-bin": "^0.170.0",
     "flow-coverage-report": "^0.8.0",
     "flow-typed": "^3.3.1",
     "hermes-eslint": "^0.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7377,10 +7377,10 @@ flow-annotation-check@^1.8.1:
     glob "7.1.6"
     load-pkg "^4.0.0"
 
-flow-bin@^0.162.0:
-  version "0.162.1"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.162.1.tgz#5aaac790dab8664ce363fd0f09764fb9f0daed20"
-  integrity sha512-gFNWkEzBuQ9YzQcPKcVL16V5MZixbiQ+Kn867iwaCfs1TAFuhQQcng4vX3Rtyd7JI3O+g8jToEX7pEDhdzG80Q==
+flow-bin@^0.170.0:
+  version "0.170.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.170.0.tgz#1da264de9868cc20a338f801bedc370e3e06f5cc"
+  integrity sha512-h4qy4f5loKdeLhj7TRM6XQWhmPpnfjDcOg6GPDuJnLAQuB60LJIHZ8QL3hxMf0oA++NkiYx62Vr8oHu+UZ2bGQ==
 
 flow-coverage-report@^0.8.0:
   version "0.8.0"


### PR DESCRIPTION
This is the Flow version used by React Native 68.

It's a surprisingly easy upgrade this time, following the recent Expo 45 upgrade (#5507), which caused `fbemitter` to be bumped such that it no longer used Flow's legacy "weak" mode, removed in Flow v0.166.