### PR TITLE
Screen: Move padding into ScrollView's content area

### DIFF
--- a/src/common/Screen.js
+++ b/src/common/Screen.js
@@ -77,6 +77,7 @@ export default function Screen(props: Props): Node {
         screen: {
           flex: 1,
           flexDirection: 'column',
+          backgroundColor,
         },
         wrapper: {
           flex: 1,
@@ -91,11 +92,11 @@ export default function Screen(props: Props): Node {
           justifyContent: 'center',
         },
       }),
-    [],
+    [backgroundColor],
   );
 
   return (
-    <SafeAreaView mode="padding" edges={['bottom']} style={[styles.screen, { backgroundColor }]}>
+    <SafeAreaView mode="padding" edges={['bottom']} style={styles.screen}>
       {search ? (
         <ModalSearchNavBar
           autoFocus={autoFocus}

--- a/src/common/Screen.js
+++ b/src/common/Screen.js
@@ -109,17 +109,28 @@ export default function Screen(props: Props): Node {
         <ModalNavBar canGoBack={canGoBack} title={title} />
       )}
       {shouldShowLoadingBanner && <LoadingBanner />}
-      <KeyboardAvoider behavior="padding" style={[styles.wrapper, padding && globalStyles.padding]}>
+      <KeyboardAvoider behavior="padding" style={styles.wrapper}>
         {scrollEnabled ? (
           <ScrollView
-            contentContainerStyle={centerContent && styles.content}
+            contentContainerStyle={[
+              centerContent && styles.content,
+              padding && globalStyles.padding,
+            ]}
             style={styles.childrenWrapper}
             keyboardShouldPersistTaps={keyboardShouldPersistTaps}
           >
             {children}
           </ScrollView>
         ) : (
-          <View style={[styles.childrenWrapper, centerContent && styles.content]}>{children}</View>
+          <View
+            style={[
+              styles.childrenWrapper,
+              centerContent && styles.content,
+              padding && globalStyles.padding,
+            ]}
+          >
+            {children}
+          </View>
         )}
       </KeyboardAvoider>
     </SafeAreaView>

--- a/src/common/Screen.js
+++ b/src/common/Screen.js
@@ -6,7 +6,7 @@ import { ScrollView, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import type { EditingEvent } from 'react-native/Libraries/Components/TextInput/TextInput';
 
-import globalStyles, { createStyleSheet, ThemeContext } from '../styles';
+import { createStyleSheet, ThemeContext } from '../styles';
 import type { LocalizableText, LocalizableReactText } from '../types';
 import KeyboardAvoider from './KeyboardAvoider';
 import LoadingBanner from './LoadingBanner';
@@ -91,6 +91,9 @@ export default function Screen(props: Props): Node {
           flexGrow: 1,
           justifyContent: 'center',
         },
+        padding: {
+          padding: 16,
+        },
       }),
     [backgroundColor],
   );
@@ -114,7 +117,7 @@ export default function Screen(props: Props): Node {
           <ScrollView
             contentContainerStyle={[
               centerContent && styles.centerContent,
-              padding && globalStyles.padding,
+              padding && styles.padding,
             ]}
             style={styles.childrenWrapper}
             keyboardShouldPersistTaps={keyboardShouldPersistTaps}
@@ -126,7 +129,7 @@ export default function Screen(props: Props): Node {
             style={[
               styles.childrenWrapper,
               centerContent && styles.centerContent,
-              padding && globalStyles.padding,
+              padding && styles.padding,
             ]}
           >
             {children}

--- a/src/common/Screen.js
+++ b/src/common/Screen.js
@@ -115,7 +115,6 @@ export default function Screen(props: Props): Node {
       <KeyboardAvoider
         behavior="padding"
         style={[componentStyles.wrapper, padding && styles.padding]}
-        contentContainerStyle={[padding && styles.padding]}
       >
         {scrollEnabled ? (
           <ScrollView

--- a/src/common/Screen.js
+++ b/src/common/Screen.js
@@ -7,31 +7,12 @@ import type { ViewStyleProp } from 'react-native/Libraries/StyleSheet/StyleSheet
 import { SafeAreaView } from 'react-native-safe-area-context';
 import type { EditingEvent } from 'react-native/Libraries/Components/TextInput/TextInput';
 
-import styles, { createStyleSheet, ThemeContext } from '../styles';
+import globalStyles, { createStyleSheet, ThemeContext } from '../styles';
 import type { LocalizableText, LocalizableReactText } from '../types';
 import KeyboardAvoider from './KeyboardAvoider';
 import LoadingBanner from './LoadingBanner';
 import ModalNavBar from '../nav/ModalNavBar';
 import ModalSearchNavBar from '../nav/ModalSearchNavBar';
-
-const componentStyles = createStyleSheet({
-  screen: {
-    flex: 1,
-    flexDirection: 'column',
-  },
-  wrapper: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'stretch',
-  },
-  childrenWrapper: {
-    flex: 1,
-  },
-  content: {
-    flexGrow: 1,
-    justifyContent: 'center',
-  },
-});
 
 type Props = $ReadOnly<{|
   centerContent?: boolean,
@@ -94,12 +75,31 @@ export default function Screen(props: Props): Node {
     searchBarOnSubmit = (e: EditingEvent) => {},
   } = props;
 
+  const styles = React.useMemo(
+    () =>
+      createStyleSheet({
+        screen: {
+          flex: 1,
+          flexDirection: 'column',
+        },
+        wrapper: {
+          flex: 1,
+          justifyContent: 'center',
+          alignItems: 'stretch',
+        },
+        childrenWrapper: {
+          flex: 1,
+        },
+        content: {
+          flexGrow: 1,
+          justifyContent: 'center',
+        },
+      }),
+    [],
+  );
+
   return (
-    <SafeAreaView
-      mode="padding"
-      edges={['bottom']}
-      style={[componentStyles.screen, { backgroundColor }]}
-    >
+    <SafeAreaView mode="padding" edges={['bottom']} style={[styles.screen, { backgroundColor }]}>
       {search ? (
         <ModalSearchNavBar
           autoFocus={autoFocus}
@@ -112,26 +112,17 @@ export default function Screen(props: Props): Node {
         <ModalNavBar canGoBack={canGoBack} title={title} />
       )}
       {shouldShowLoadingBanner && <LoadingBanner />}
-      <KeyboardAvoider
-        behavior="padding"
-        style={[componentStyles.wrapper, padding && styles.padding]}
-      >
+      <KeyboardAvoider behavior="padding" style={[styles.wrapper, padding && globalStyles.padding]}>
         {scrollEnabled ? (
           <ScrollView
-            contentContainerStyle={[centerContent && componentStyles.content, style]}
-            style={componentStyles.childrenWrapper}
+            contentContainerStyle={[centerContent && styles.content, style]}
+            style={styles.childrenWrapper}
             keyboardShouldPersistTaps={keyboardShouldPersistTaps}
           >
             {children}
           </ScrollView>
         ) : (
-          <View
-            style={[
-              componentStyles.childrenWrapper,
-              centerContent && componentStyles.content,
-              style,
-            ]}
-          >
+          <View style={[styles.childrenWrapper, centerContent && styles.content, style]}>
             {children}
           </View>
         )}

--- a/src/common/Screen.js
+++ b/src/common/Screen.js
@@ -87,7 +87,7 @@ export default function Screen(props: Props): Node {
         childrenWrapper: {
           flex: 1,
         },
-        content: {
+        centerContent: {
           flexGrow: 1,
           justifyContent: 'center',
         },
@@ -113,7 +113,7 @@ export default function Screen(props: Props): Node {
         {scrollEnabled ? (
           <ScrollView
             contentContainerStyle={[
-              centerContent && styles.content,
+              centerContent && styles.centerContent,
               padding && globalStyles.padding,
             ]}
             style={styles.childrenWrapper}
@@ -125,7 +125,7 @@ export default function Screen(props: Props): Node {
           <View
             style={[
               styles.childrenWrapper,
-              centerContent && styles.content,
+              centerContent && styles.centerContent,
               padding && globalStyles.padding,
             ]}
           >

--- a/src/common/Screen.js
+++ b/src/common/Screen.js
@@ -3,7 +3,6 @@
 import React, { useContext } from 'react';
 import type { Node } from 'react';
 import { ScrollView, View } from 'react-native';
-import type { ViewStyleProp } from 'react-native/Libraries/StyleSheet/StyleSheet';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import type { EditingEvent } from 'react-native/Libraries/Components/TextInput/TextInput';
 
@@ -20,7 +19,6 @@ type Props = $ReadOnly<{|
   keyboardShouldPersistTaps?: 'never' | 'always' | 'handled',
   padding?: boolean,
   scrollEnabled?: boolean,
-  style?: ViewStyleProp,
 
   search?: boolean,
   autoFocus?: boolean,
@@ -44,7 +42,6 @@ type Props = $ReadOnly<{|
  * @prop [keyboardShouldPersistTaps] - Passed through to ScrollView.
  * @prop [padding] - Should padding be added to the contents of the screen.
  * @prop [scrollEnabled] - Whether to use a ScrollView or a normal View.
- * @prop [style] - Additional style for the ScrollView.
  *
  * @prop [search] - If 'true' show a search box in place of the title.
  * @prop [autoFocus] - If search bar enabled, should it be focused initially.
@@ -69,7 +66,6 @@ export default function Screen(props: Props): Node {
     search = false,
     searchPlaceholder,
     searchBarOnChange = (text: string) => {},
-    style: callerStyle,
     title = '',
     shouldShowLoadingBanner = true,
     searchBarOnSubmit = (e: EditingEvent) => {},
@@ -115,16 +111,14 @@ export default function Screen(props: Props): Node {
       <KeyboardAvoider behavior="padding" style={[styles.wrapper, padding && globalStyles.padding]}>
         {scrollEnabled ? (
           <ScrollView
-            contentContainerStyle={[centerContent && styles.content, callerStyle]}
+            contentContainerStyle={centerContent && styles.content}
             style={styles.childrenWrapper}
             keyboardShouldPersistTaps={keyboardShouldPersistTaps}
           >
             {children}
           </ScrollView>
         ) : (
-          <View style={[styles.childrenWrapper, centerContent && styles.content, callerStyle]}>
-            {children}
-          </View>
+          <View style={[styles.childrenWrapper, centerContent && styles.content]}>{children}</View>
         )}
       </KeyboardAvoider>
     </SafeAreaView>

--- a/src/common/Screen.js
+++ b/src/common/Screen.js
@@ -69,7 +69,7 @@ export default function Screen(props: Props): Node {
     search = false,
     searchPlaceholder,
     searchBarOnChange = (text: string) => {},
-    style,
+    style: callerStyle,
     title = '',
     shouldShowLoadingBanner = true,
     searchBarOnSubmit = (e: EditingEvent) => {},
@@ -115,14 +115,14 @@ export default function Screen(props: Props): Node {
       <KeyboardAvoider behavior="padding" style={[styles.wrapper, padding && globalStyles.padding]}>
         {scrollEnabled ? (
           <ScrollView
-            contentContainerStyle={[centerContent && styles.content, style]}
+            contentContainerStyle={[centerContent && styles.content, callerStyle]}
             style={styles.childrenWrapper}
             keyboardShouldPersistTaps={keyboardShouldPersistTaps}
           >
             {children}
           </ScrollView>
         ) : (
-          <View style={[styles.childrenWrapper, centerContent && styles.content, style]}>
+          <View style={[styles.childrenWrapper, centerContent && styles.content, callerStyle]}>
             {children}
           </View>
         )}

--- a/src/search/SearchMessagesScreen.js
+++ b/src/search/SearchMessagesScreen.js
@@ -139,6 +139,7 @@ class SearchMessagesScreenInner extends PureComponent<Props, State> {
         search
         autoFocus
         searchBarOnSubmit={this.handleQuerySubmitWrapper}
+        scrollEnabled={false}
         style={styles.flexed}
       >
         <SearchMessagesCard

--- a/src/search/SearchMessagesScreen.js
+++ b/src/search/SearchMessagesScreen.js
@@ -8,7 +8,6 @@ import type { AppNavigationProp } from '../nav/AppNavigator';
 import type { Auth, Dispatch, Message } from '../types';
 import Screen from '../common/Screen';
 import SearchMessagesCard from './SearchMessagesCard';
-import styles from '../styles';
 import { SEARCH_NARROW } from '../utils/narrow';
 import { LAST_MESSAGE_ANCHOR } from '../anchor';
 import { connect } from '../react-redux';
@@ -140,7 +139,6 @@ class SearchMessagesScreenInner extends PureComponent<Props, State> {
         autoFocus
         searchBarOnSubmit={this.handleQuerySubmitWrapper}
         scrollEnabled={false}
-        style={styles.flexed}
       >
         <SearchMessagesCard
           messages={messages}


### PR DESCRIPTION
The main change is this one:

```
Screen: Move padding into ScrollView's content area

Before, the vertical padding decreased the height of the window onto
the scrollable area.

Now, the vertical padding is *in* the scrollable area, and it can be
scrolled offscreen, giving more room for the actual content to show.
This is especially helpful on a phone in in landscape mode, where
vertical space is tight.

Affected screens are the ones where true is passed for `padding` and
`scrollEnabled` is true (or unset, because it defaults to true):

  AccountPickScreen
  AuthScreen
  PasswordAuthScreen
  RealmInputScreen
  CreateStreamScreen
  EditStreamScreen
```

All the rest are NFC refactors. Screenshots coming soon.