### PR TITLE
[toward #5102, refuse ancient servers] Parse `zulip_version` in api.getServerSettings and api.registerForEvents

### DIFF
--- a/src/__tests__/lib/exampleData.js
+++ b/src/__tests__/lib/exampleData.js
@@ -723,7 +723,7 @@ export const action = Object.freeze({
       msg: '',
       queue_id: '1',
       zulip_feature_level: recentZulipFeatureLevel,
-      zulip_version: recentZulipVersion.raw(),
+      zulip_version: recentZulipVersion,
 
       // InitialDataAlertWords
       alert_words: [],

--- a/src/account/AccountPickScreen.js
+++ b/src/account/AccountPickScreen.js
@@ -17,7 +17,7 @@ import Screen from '../common/Screen';
 import ViewPlaceholder from '../common/ViewPlaceholder';
 import AccountList from './AccountList';
 import { accountSwitch, removeAccount } from '../actions';
-import type { ApiResponseServerSettings } from '../api/settings/getServerSettings';
+import type { ServerSettings } from '../api/settings/getServerSettings';
 import { showConfirmationDialog, showErrorAlert } from '../utils/info';
 import { tryStopNotifications } from '../notification/notifTokens';
 
@@ -46,7 +46,7 @@ export default function AccountPickScreen(props: Props): Node {
         });
       } else {
         try {
-          const serverSettings: ApiResponseServerSettings = await api.getServerSettings(realm);
+          const serverSettings: ServerSettings = await api.getServerSettings(realm);
           navigation.push('auth', { serverSettings });
         } catch {
           // TODO: show specific error message from error object

--- a/src/account/__tests__/accountsReducer-test.js
+++ b/src/account/__tests__/accountsReducer-test.js
@@ -26,7 +26,7 @@ describe('accountsReducer', () => {
       expect(
         accountsReducer(
           deepFreeze([account1, account2, account3]),
-          eg.mkActionRegisterComplete({ zulip_version: newZulipVersion.raw() }),
+          eg.mkActionRegisterComplete({ zulip_version: newZulipVersion }),
         ),
       ).toEqual([{ ...account1, zulipVersion: newZulipVersion }, account2, account3]);
     });

--- a/src/account/accountsReducer.js
+++ b/src/account/accountsReducer.js
@@ -21,8 +21,8 @@ const registerComplete = (state, action) => [
   {
     ...state[0],
     userId: action.data.user_id,
-    zulipFeatureLevel: action.data.zulip_feature_level ?? 0,
-    zulipVersion: new ZulipVersion(action.data.zulip_version),
+    zulipFeatureLevel: action.data.zulip_feature_level,
+    zulipVersion: action.data.zulip_version,
     lastDismissedServerPushSetupNotice: action.data.realm_push_notifications_enabled
       ? null
       : state[0].lastDismissedServerPushSetupNotice,

--- a/src/api/initialDataTypes.js
+++ b/src/api/initialDataTypes.js
@@ -21,6 +21,7 @@ import type {
   CreateWebPublicStreamPolicy,
   EmailAddressVisibility,
 } from './permissionsTypes';
+import type { ZulipVersion } from '../utils/zulipVersion';
 
 /*
    The types in this file are organized by which `fetch_event_types` values
@@ -29,12 +30,7 @@ import type {
    See comments at `InitialData`, at the bottom, for details.
  */
 
-/**
- * The parts of the `/register` response sent regardless of `fetch_event_types`.
- *
- * See `InitialData` for more discussion.
- */
-export type InitialDataBase = $ReadOnly<{|
+export type RawInitialDataBase = $ReadOnly<{|
   last_event_id: number,
   msg: string,
   queue_id: string,
@@ -52,7 +48,7 @@ export type InitialDataBase = $ReadOnly<{|
    * Same meaning as in the server_settings response:
    * https://zulip.com/api/get-server-settings. See also the comment above.
    */
-  // TODO(server-3.0): Mark as required.
+  // TODO(server-3.0): Mark as required; remove missing-to-zero transform
   zulip_feature_level?: number,
 
   /**
@@ -62,6 +58,20 @@ export type InitialDataBase = $ReadOnly<{|
    * `zulip_feature_level`, above.
    */
   zulip_version: string,
+|}>;
+
+/**
+ * The parts of the `/register` response sent regardless of `fetch_event_types`.
+ *
+ * Post-transformation. For what we expect directly from the server, see
+ * RawInitialDataBase.
+ *
+ * See `InitialData` for more discussion.
+ */
+export type InitialDataBase = $ReadOnly<{|
+  ...RawInitialDataBase,
+  zulip_feature_level: number, // filled in with zero if missing
+  zulip_version: ZulipVersion, // parsed from string
 |}>;
 
 export type InitialDataAlertWords = $ReadOnly<{|
@@ -716,6 +726,7 @@ export type InitialData = {|
  */
 export type RawInitialData = $ReadOnly<{|
   ...InitialData,
+  ...RawInitialDataBase,
   ...RawInitialDataRealmUser,
   ...RawInitialDataRealmFilters,
 |}>;

--- a/src/api/registerForEvents.js
+++ b/src/api/registerForEvents.js
@@ -6,6 +6,7 @@ import type { Auth } from './transportTypes';
 import type { CrossRealmBot, User } from './modelTypes';
 import { apiPost } from './apiFetch';
 import { AvatarURL } from '../utils/avatar';
+import { ZulipVersion } from '../utils/zulipVersion';
 
 const transformUser = (rawUser: {| ...User, avatar_url?: string | null |}, realm: URL): User => {
   const { avatar_url: rawAvatarUrl, email } = rawUser;
@@ -35,6 +36,9 @@ const transformCrossRealmBot = (
 
 const transform = (rawInitialData: RawInitialData, auth: Auth): InitialData => ({
   ...rawInitialData,
+
+  zulip_feature_level: rawInitialData.zulip_feature_level ?? 0,
+  zulip_version: new ZulipVersion(rawInitialData.zulip_version),
 
   // Transform the newer `realm_linkifiers` format, if present, to the
   // older `realm_filters` format. We do the same transformation on

--- a/src/api/settings/getServerSettings.js
+++ b/src/api/settings/getServerSettings.js
@@ -71,6 +71,7 @@ type ApiResponseServerSettings = {|
 
 export type ServerSettings = $ReadOnly<{|
   ...ApiResponseServerSettings,
+  +realm_uri: URL,
   +realm_name: string,
 |}>;
 
@@ -95,6 +96,7 @@ function transform(raw: ApiResponseServerSettings): ServerSettings {
 
   return {
     ...raw,
+    realm_uri: new URL(raw.realm_uri),
     realm_name,
   };
 }

--- a/src/api/settings/getServerSettings.js
+++ b/src/api/settings/getServerSettings.js
@@ -2,6 +2,7 @@
 import type { ApiResponseSuccess } from '../transportTypes';
 import { apiGet } from '../apiFetch';
 import { ApiError } from '../apiErrors';
+import { ZulipVersion } from '../../utils/zulipVersion';
 
 // This corresponds to AUTHENTICATION_FLAGS in zulip/zulip:zerver/models.py .
 export type AuthenticationMethods = {
@@ -71,8 +72,11 @@ type ApiResponseServerSettings = {|
 
 export type ServerSettings = $ReadOnly<{|
   ...ApiResponseServerSettings,
+  +zulip_feature_level: number,
+  +zulip_version: ZulipVersion,
   +realm_uri: URL,
   +realm_name: string,
+  +realm_web_public_access_enabled: boolean,
 |}>;
 
 /**
@@ -96,8 +100,11 @@ function transform(raw: ApiResponseServerSettings): ServerSettings {
 
   return {
     ...raw,
+    zulip_feature_level: raw.zulip_feature_level ?? 0,
+    zulip_version: new ZulipVersion(raw.zulip_version),
     realm_uri: new URL(raw.realm_uri),
     realm_name,
+    realm_web_public_access_enabled: raw.realm_web_public_access_enabled ?? false,
   };
 }
 

--- a/src/events/eventActions.js
+++ b/src/events/eventActions.js
@@ -23,7 +23,6 @@ import { BackoffMachine, TimeoutError } from '../utils/async';
 import { ApiError, RequestError, Server5xxError, NetworkError } from '../api/apiErrors';
 import * as logging from '../utils/logging';
 import { showErrorAlert } from '../utils/info';
-import { ZulipVersion } from '../utils/zulipVersion';
 import { tryFetch, fetchPrivateMessages } from '../message/fetchActions';
 import { MIN_RECENTPMS_SERVER_VERSION } from '../pm-conversations/pmConversationsModel';
 import { sendOutbox } from '../outbox/outboxActions';
@@ -171,7 +170,7 @@ export const registerAndStartPolling =
       return;
     }
 
-    const serverVersion = new ZulipVersion(initData.zulip_version);
+    const serverVersion = initData.zulip_version;
 
     // Set Sentry tags for the server version immediately, so they're accurate
     // in case we hit an exception in reducers on `registerComplete` below.

--- a/src/start/AuthScreen.js
+++ b/src/start/AuthScreen.js
@@ -7,7 +7,7 @@ import type { AppleAuthenticationCredential } from 'expo-apple-authentication';
 import * as AppleAuthentication from 'expo-apple-authentication';
 
 import type {
-  ApiResponseServerSettings,
+  ServerSettings,
   AuthenticationMethods,
   ExternalAuthenticationMethod,
 } from '../api/settings/getServerSettings';
@@ -173,7 +173,7 @@ export const activeAuthentications = (
 type OuterProps = $ReadOnly<{|
   // These should be passed from React Navigation
   navigation: AppNavigationProp<'auth'>,
-  route: RouteProp<'auth', {| serverSettings: ApiResponseServerSettings |}>,
+  route: RouteProp<'auth', {| serverSettings: ServerSettings |}>,
 |}>;
 
 type SelectorProps = $ReadOnly<{|

--- a/src/start/RealmInputScreen.js
+++ b/src/start/RealmInputScreen.js
@@ -6,7 +6,7 @@ import { useFocusEffect } from '@react-navigation/native';
 
 import type { RouteProp } from '../react-navigation';
 import type { AppNavigationProp } from '../nav/AppNavigator';
-import type { ApiResponseServerSettings } from '../api/settings/getServerSettings';
+import type { ServerSettings } from '../api/settings/getServerSettings';
 import ErrorMsg from '../common/ErrorMsg';
 import ZulipTextIntl from '../common/ZulipTextIntl';
 import Screen from '../common/Screen';
@@ -72,7 +72,7 @@ export default function RealmInputScreen(props: Props): Node {
     setProgress(true);
     setError(null);
     try {
-      const serverSettings: ApiResponseServerSettings = await api.getServerSettings(parsedRealm);
+      const serverSettings: ServerSettings = await api.getServerSettings(parsedRealm);
       navigation.push('auth', { serverSettings });
       Keyboard.dismiss();
     } catch (errorIllTyped) {


### PR DESCRIPTION
This will help with #5102 by making it convenient to have these API bindings validate the server version and throw a new error type with a name like `ServerTooOldError`.

(Those bindings are two of the ways we can learn about the server version. There is a third, that I know of: `'restart'` events, which happen when the server is upgraded. I suppose we'd also get one on server _downgrades_, and in theory, on downgrades where the server version crosses the two-old threshold in the wrong direction. But that seems unlikely.)