### PR TITLE
Strip copyright notice from LICENSE; update the one in README

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,23 +1,3 @@
-Copyright 2016-2018 Kandra Labs, Inc., and contributors
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this software except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-
-The software includes some works released by third parties under other
-free and open source licenses. Those works are redistributed under the
-license terms under which the works were received. For more details,
-see the ``docs/THIRDPARTY`` file included with this distribution.
-
---------------------------------------------------------------------------------
 
                                  Apache License
                            Version 2.0, January 2004

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Zulip Mobile supersedes two legacy Zulip apps,
 
 ## License
 
-Copyright (c) 2016-2018 Kandra Labs, Inc., and contributors, and 2016 Dropbox, Inc.
+Copyright (c) 2016-2022 Kandra Labs, Inc., and contributors, and 2016 Dropbox, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "ZulipMobile",
   "version": "1.0.0",
+  "license": "Apache-2.0",
   "private": true,
   "scripts": {
     "postinstall": "bash tools/postinstall",


### PR DESCRIPTION
Similar to https://github.com/zulip/zulip/pull/17176 .

This makes the whole LICENSE file an exact copy of the license,
which helps some software recognize that this is indeed the
Apache 2.0 license.  In particular, the `licensee` gem, which
is what GitHub uses to identify what license to display.
