### PR TITLE
CustomProfileFields: Use `selectable` prop for text fields

### DIFF
--- a/src/account-info/CustomProfileFields.js
+++ b/src/account-info/CustomProfileFields.js
@@ -63,7 +63,7 @@ function CustomProfileFieldRow(props: {|
   let valueElement = undefined;
   switch (value.displayType) {
     case 'text':
-      valueElement = <ZulipText style={styles.valueText} text={value.text} />;
+      valueElement = <ZulipText selectable style={styles.valueText} text={value.text} />;
       break;
 
     case 'link':


### PR DESCRIPTION
![Dec-08-2022 14-33-22](https://user-images.githubusercontent.com/22248748/206581297-399e7284-8c8f-46cb-ba4d-7bf5dde90ae8.gif)

FYI @alya for the UX change.

Fixes: #5592