### PR TITLE
redux [nfc]: Give an activeAccountDispatch to global thunk actions

### DIFF
--- a/src/account/accountActions.js
+++ b/src/account/accountActions.js
@@ -1,12 +1,6 @@
 /* @flow strict-local */
 import * as NavigationService from '../nav/NavigationService';
-import type {
-  Dispatch,
-  PerAccountAction,
-  AllAccountsAction,
-  ThunkAction,
-  GlobalThunkAction,
-} from '../types';
+import type { PerAccountAction, AllAccountsAction, ThunkAction, GlobalThunkAction } from '../types';
 import {
   ACCOUNT_SWITCH,
   ACCOUNT_REMOVE,
@@ -34,30 +28,13 @@ const accountSwitchPlain = (index: number): AllAccountsAction => ({
 
 export const accountSwitch =
   (index: number): GlobalThunkAction<Promise<void>> =>
-  async (dispatch, getState) => {
+  async (dispatch, getState, { activeAccountDispatch }) => {
     NavigationService.dispatch(resetToMainTabs());
     dispatch(accountSwitchPlain(index));
 
-    /* $FlowFixMe[incompatible-type]
-
-     This is really a GlobalDispatch, because we're in a GlobalThunkAction.
-     (It's global because it needs to know about all the accounts to set the
-     pointer to the active one). But here, we pretend it's a Dispatch.
-     That's OK, for now, because:
-
-     - Our Dispatch function is secretly the same value as our
-       GlobalDispatch.
-     - The PerAccountState that Dispatch currently acts on is the one
-       belonging to the active account.
-     - We want this dispatch to act on the active account -- the new,
-       post-switch active account.
-     - It will act on that account, because at this point we've already
-       dispatched `accountSwitchPlain`.
-
-     TODO(#5006): perhaps have an `activeAccountDispatch: Dispatch` in
-       a new GlobalThunkExtras, modeled on ThunkExtras?
-  */
-    const activeAccountDispatch: Dispatch = dispatch;
+    // Now dispatch some actions on the new, post-switch active account.
+    // Because we just dispatched `accountSwitchPlain`, that new account
+    // is now the active account, so `activeAccountDispatch` will act on it.
 
     await activeAccountDispatch(registerAndStartPolling());
 

--- a/src/boot/store.js
+++ b/src/boot/store.js
@@ -20,6 +20,7 @@ import CompressedAsyncStorage from '../storage/CompressedAsyncStorage';
 import createMigration from '../redux-persist-migrate/index';
 import { getGlobalSession, getGlobalSettings } from '../directSelectors';
 import { migrations } from '../storage/migrations';
+import type { GlobalThunkExtras } from '../reduxTypes';
 
 if (process.env.NODE_ENV === 'development') {
   // Chrome dev tools for Immutable.
@@ -72,12 +73,21 @@ export const cacheKeys: $ReadOnlyArray<$Keys<GlobalState>> = [
   'realm', 'streams', 'subscriptions', 'unread', 'userGroups', 'users',
 ];
 
-const thunkExtras: ThunkExtras = {
+const thunkExtras: $Exact<ThunkExtras> = {
   // eslint-disable-next-line no-use-before-define
   getGlobalSession: () => getGlobalSession(store.getState()),
 
   // eslint-disable-next-line no-use-before-define
   getGlobalSettings: () => getGlobalSettings(store.getState()),
+};
+
+const globalThunkExtras: $Exact<GlobalThunkExtras> = Object.freeze({
+  // TODO add things
+});
+
+const combinedThunkExtras: ThunkExtras & GlobalThunkExtras = {
+  ...thunkExtras,
+  ...globalThunkExtras,
 };
 
 /**
@@ -97,7 +107,7 @@ function listMiddleware() {
     // Handle the fancy "thunk" actions we often use, i.e. async
     // functions of `dispatch` and `state`.  See docs:
     //   https://github.com/reduxjs/redux-thunk
-    thunkMiddleware.withExtraArgument(thunkExtras),
+    thunkMiddleware.withExtraArgument(combinedThunkExtras),
   ];
 
   if (config.enableReduxLogging) {

--- a/src/notification/notifOpen.js
+++ b/src/notification/notifOpen.js
@@ -195,7 +195,7 @@ const readInitialNotification = async (): Promise<Notification | null> => {
 
 export const narrowToNotification =
   (data: ?Notification): GlobalThunkAction<void> =>
-  (dispatch, getState) => {
+  (dispatch, getState, { activeAccountDispatch }) => {
     if (!data) {
       return;
     }
@@ -228,15 +228,7 @@ export const narrowToNotification =
       getOwnUserId(state),
     );
     if (narrow) {
-      // We have a GlobalDispatch, because this is a global thunk action --
-      // at the top of the function, we didn't yet know which account was
-      // intended and had to work that out.  But now we know we're working on
-      // the active account, and want to dispatch a per-account action there.
-      // For the present, we just use the fact that our GlobalDispatch value
-      // is the same function as we use for Dispatch.
-      // TODO(#5006): perhaps have an `activeAccountDispatch: Dispatch` in a
-      //   new GlobalThunkExtras, modeled on ThunkExtras?
-      (dispatch: $FlowFixMe)(doNarrow(narrow));
+      activeAccountDispatch(doNarrow(narrow));
     }
   };
 

--- a/src/reduxTypes.js
+++ b/src/reduxTypes.js
@@ -636,6 +636,12 @@ export interface Dispatch {
 /** A per-account thunk action returning T. */
 export type ThunkAction<T> = (Dispatch, () => PerAccountState, ThunkExtras) => T;
 
+/** The extras object passed to a global thunk action. */
+export type GlobalThunkExtras = $ReadOnly<{
+  // TODO add things
+  ...
+}>;
+
 /** The Redux `dispatch` for a global context. */
 export interface GlobalDispatch {
   <A: DispatchableWithoutAccountAction>(action: A): A;
@@ -643,14 +649,13 @@ export interface GlobalDispatch {
 }
 
 /** A global thunk action returning T. */
-// This might take some extras later (e.g., to do something per-account on a
-// specific account), but for now it needs none.
-export type GlobalThunkAction<T> = (GlobalDispatch, () => GlobalState) => T;
+export type GlobalThunkAction<T> = (GlobalDispatch, () => GlobalState, GlobalThunkExtras) => T;
 
 // The two pairs of dispatch/thunk-action types aren't interchangeable,
 // in either direction.
 //   $FlowExpectedError[incompatible-return]
 (d: GlobalDispatch): Dispatch => d;
+//   $FlowExpectedError[prop-missing]
 //   $FlowExpectedError[incompatible-return]
 <T>(a: ThunkAction<T>): GlobalThunkAction<T> => a;
 //   $FlowExpectedError[incompatible-return]

--- a/src/reduxTypes.js
+++ b/src/reduxTypes.js
@@ -638,7 +638,8 @@ export type ThunkAction<T> = (Dispatch, () => PerAccountState, ThunkExtras) => T
 
 /** The extras object passed to a global thunk action. */
 export type GlobalThunkExtras = $ReadOnly<{
-  // TODO add things
+  /** A per-account `dispatch` that acts on the active account. */
+  activeAccountDispatch: Dispatch,
   ...
 }>;
 


### PR DESCRIPTION
As foreshadowed in some comments, and requested by @chrisbobbe [in chat](https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/GlobalThunkExtras/near/1476519).

This is also one of the pieces we'll need for #5006.
