### PR TITLE
presence tests: Start type-checking; use example data

### DIFF
--- a/src/alertWords/__tests__/alertWordsReducer-test.js
+++ b/src/alertWords/__tests__/alertWordsReducer-test.js
@@ -20,6 +20,7 @@ describe('alertWordsReducer', () => {
       expect(actualState).toEqual(expectedState);
     });
 
+    // TODO(#5102): Delete; see comment on implementation.
     test('when no `alert_words` data is given reset state', () => {
       const initialState = deepFreeze(['word']);
       const action = deepFreeze({

--- a/src/alertWords/alertWordsReducer.js
+++ b/src/alertWords/alertWordsReducer.js
@@ -15,7 +15,15 @@ export default (
       return initialState;
 
     case REGISTER_COMPLETE:
-      return action.data.alert_words || initialState;
+      return (
+        action.data.alert_words
+        // TODO(#5102): Delete fallback once we enforce any threshold for
+        //   ancient servers we refuse to connect to. It was added in #2878
+        //   (2018-11-16), but it wasn't clear even then, it seems, whether
+        //   any servers actually omit the data. The API doc doesn't mention
+        //   any servers that omit it, and our Flow types mark it required.
+        || initialState
+      );
 
     case EVENT_ALERT_WORDS:
       return action.alert_words || initialState;

--- a/src/api/eventTypes.js
+++ b/src/api/eventTypes.js
@@ -10,7 +10,7 @@
  * @flow strict-local
  */
 
-import type { SubsetProperties } from '../generics';
+import type { BoundedDiff, SubsetProperties } from '../generics';
 import { keyMirror } from '../utils/keyMirror';
 import type {
   CustomProfileField,
@@ -24,6 +24,7 @@ import type {
   UserPresence,
   UserStatusUpdate,
   UserSettings,
+  ClientPresence,
 } from './modelTypes';
 import type { RealmDataForUpdate } from './realmDataTypes';
 
@@ -135,12 +136,16 @@ export type SubmessageEvent = $ReadOnly<{|
   content: string,
 |}>;
 
+/** https://zulip.com/api/get-events#presence  */
 export type PresenceEvent = $ReadOnly<{|
   ...EventCommon,
   type: typeof EventTypes.presence,
   email: string,
   server_timestamp: number,
-  presence: UserPresence,
+
+  // Clients are asked to compute aggregated presence; the event doesn't
+  // have it.
+  presence: BoundedDiff<UserPresence, {| +aggregated: ClientPresence |}>,
 |}>;
 
 /**

--- a/src/mute/__tests__/muteModel-test.js
+++ b/src/mute/__tests__/muteModel-test.js
@@ -30,6 +30,7 @@ describe('reducer', () => {
       expect(newState && getMute(newState)).toEqual(makeMuteState([[eg.stream, 'topic']]));
     });
 
+    // TODO(#5102): Delete; see comment on implementation.
     test('when no `mute` data is given reset state', () => {
       const state = makeMuteState([[eg.stream, 'topic']]);
       const action = eg.mkActionRegisterComplete({ muted_topics: [] });

--- a/src/mute/muteModel.js
+++ b/src/mute/muteModel.js
@@ -55,7 +55,17 @@ export const reducer = (
       // We require this `globalState` to reflect the `streams` sub-reducer
       // already having run, so that `getStreamsByName` gives the data we
       // just received.  See this sub-reducer's call site in `reducers.js`.
-      return convert(action.data.muted_topics ?? [], getStreamsByName(globalState));
+      return convert(
+        action.data.muted_topics
+          // TODO(#5102): Delete fallback once we enforce any threshold for
+          //   ancient servers we refuse to connect to. It was added in
+          //   #2878 (2018-11-16), but it wasn't clear even then, it seems,
+          //   whether any servers actually omit the data. The API doc
+          //   doesn't mention any servers that omit it, and our Flow types
+          //   mark it required.
+          ?? [],
+        getStreamsByName(globalState),
+      );
 
     case EVENT_MUTED_TOPICS:
       return convert(action.muted_topics, getStreamsByName(globalState));

--- a/src/presence/__tests__/presenceReducer-test.js
+++ b/src/presence/__tests__/presenceReducer-test.js
@@ -15,11 +15,8 @@ describe('presenceReducer', () => {
     test('when `presence` data is provided init state with it', () => {
       const presenceData = {
         'email@example.com': {
-          aggregated: {
-            client: 'website',
-            status: 'active',
-            timestamp: 123,
-          },
+          aggregated: { client: 'website', status: 'active', timestamp: 123 },
+          website: { client: 'website', status: 'active', timestamp: 123 },
         },
       };
       const prevState = deepFreeze({});
@@ -39,11 +36,8 @@ describe('presenceReducer', () => {
     test('when no `presence` data is given reset state', () => {
       const prevState = deepFreeze({
         'email@example.com': {
-          aggregated: {
-            client: 'website',
-            status: 'active',
-            timestamp: 123,
-          },
+          aggregated: { client: 'website', status: 'active', timestamp: 123 },
+          website: { client: 'website', status: 'active', timestamp: 123 },
         },
       });
       const action = deepFreeze({
@@ -62,10 +56,8 @@ describe('presenceReducer', () => {
     test('merges a single user in presence response', () => {
       const presence = {
         'email@example.com': {
-          aggregated: {
-            status: 'active',
-            timestamp: 123,
-          },
+          aggregated: { status: 'active', timestamp: 123 },
+          website: { status: 'active', timestamp: 123 },
         },
       };
       const action = deepFreeze({
@@ -80,10 +72,8 @@ describe('presenceReducer', () => {
 
       const expectedState = {
         'email@example.com': {
-          aggregated: {
-            status: 'active',
-            timestamp: 123,
-          },
+          aggregated: { status: 'active', timestamp: 123 },
+          website: { status: 'active', timestamp: 123 },
         },
       };
 
@@ -100,11 +90,8 @@ describe('presenceReducer', () => {
 
       const presence = {
         'email@example.com': {
-          aggregated: {
-            client: 'website',
-            status: 'active',
-            timestamp: 123,
-          },
+          aggregated: { client: 'website', status: 'active', timestamp: 123 },
+          website: { client: 'website', status: 'active', timestamp: 123 },
         },
         'johndoe@example.com': {
           website: {
@@ -122,11 +109,8 @@ describe('presenceReducer', () => {
 
       const expectedState = {
         'email@example.com': {
-          aggregated: {
-            client: 'website',
-            status: 'active',
-            timestamp: 123,
-          },
+          aggregated: { client: 'website', status: 'active', timestamp: 123 },
+          website: { client: 'website', status: 'active', timestamp: 123 },
         },
         'johndoe@example.com': {
           website: {

--- a/src/presence/__tests__/presenceReducer-test.js
+++ b/src/presence/__tests__/presenceReducer-test.js
@@ -47,6 +47,7 @@ describe('presenceReducer', () => {
       expect(actualState).toEqual(presenceData);
     });
 
+    // TODO(#5102): Delete; see comment on implementation.
     test('when no `presence` data is given reset state', () => {
       const initialState = deepFreeze({
         'email@example.com': {

--- a/src/presence/__tests__/presenceReducer-test.js
+++ b/src/presence/__tests__/presenceReducer-test.js
@@ -22,7 +22,7 @@ describe('presenceReducer', () => {
           },
         },
       };
-      const initialState = deepFreeze({});
+      const prevState = deepFreeze({});
       const action = deepFreeze({
         type: REGISTER_COMPLETE,
         data: {
@@ -30,14 +30,14 @@ describe('presenceReducer', () => {
         },
       });
 
-      const actualState = presenceReducer(initialState, action);
+      const actualState = presenceReducer(prevState, action);
 
       expect(actualState).toEqual(presenceData);
     });
 
     // TODO(#5102): Delete; see comment on implementation.
     test('when no `presence` data is given reset state', () => {
-      const initialState = deepFreeze({
+      const prevState = deepFreeze({
         'email@example.com': {
           aggregated: {
             client: 'website',
@@ -52,7 +52,7 @@ describe('presenceReducer', () => {
       });
       const expectedState = {};
 
-      const actualState = presenceReducer(initialState, action);
+      const actualState = presenceReducer(prevState, action);
 
       expect(actualState).toEqual(expectedState);
     });
@@ -200,7 +200,7 @@ describe('presenceReducer', () => {
 
   describe('ACCOUNT_SWITCH', () => {
     test('resets state to initial state', () => {
-      const initialState = deepFreeze([
+      const prevState = deepFreeze([
         {
           full_name: 'Some Guy',
           email: 'email@example.com',
@@ -214,7 +214,7 @@ describe('presenceReducer', () => {
 
       const expectedState = {};
 
-      const actualState = presenceReducer(initialState, action);
+      const actualState = presenceReducer(prevState, action);
 
       expect(actualState).toEqual(expectedState);
     });

--- a/src/presence/__tests__/presenceReducer-test.js
+++ b/src/presence/__tests__/presenceReducer-test.js
@@ -11,18 +11,6 @@ import presenceReducer from '../presenceReducer';
 const currentTimestamp = Date.now() / 1000;
 
 describe('presenceReducer', () => {
-  test('handles unknown action and no state by returning initial state', () => {
-    const newState = presenceReducer(undefined, {});
-    expect(newState).toBeDefined();
-  });
-
-  test('on unrecognized action, returns input state unchanged', () => {
-    const prevState = deepFreeze({ hello: 'world' });
-
-    const newState = presenceReducer(prevState, {});
-    expect(newState).toBe(prevState);
-  });
-
   describe('REGISTER_COMPLETE', () => {
     test('when `presence` data is provided init state with it', () => {
       const presenceData = {

--- a/src/presence/presenceReducer.js
+++ b/src/presence/presenceReducer.js
@@ -25,7 +25,16 @@ export default (
       return initialState;
 
     case REGISTER_COMPLETE:
-      return action.data.presences || initialState;
+      return (
+        action.data.presences
+        // TODO(#5102): Delete fallback once we enforce any threshold for
+        //   ancient servers we refuse to connect to. It was added in
+        //   #2878 (2018-11-16), but it wasn't clear even then, it seems,
+        //   whether any servers actually omit the data. The API doc
+        //   doesn't mention any servers that omit it, and our Flow types
+        //   mark it required.
+        || initialState
+      );
 
     case PRESENCE_RESPONSE:
       return {

--- a/src/unread/unreadHuddlesReducer.js
+++ b/src/unread/unreadHuddlesReducer.js
@@ -96,7 +96,13 @@ export default (
       return initialState;
 
     case REGISTER_COMPLETE:
-      return (action.data.unread_msgs && action.data.unread_msgs.huddles) || initialState;
+      return (
+        (action.data.unread_msgs && action.data.unread_msgs.huddles)
+        // TODO(#5102): Delete fallback once we refuse to connect to Zulip
+        //   servers before 1.7.0, when it seems this feature was added; see
+        //   comment on InitialDataUpdateMessageFlags.
+        || initialState
+      );
 
     case EVENT_NEW_MESSAGE:
       return eventNewMessage(state, action);

--- a/src/unread/unreadMentionsReducer.js
+++ b/src/unread/unreadMentionsReducer.js
@@ -54,7 +54,13 @@ export default (
       return initialState;
 
     case REGISTER_COMPLETE:
-      return (action.data.unread_msgs && action.data.unread_msgs.mentions) || initialState;
+      return (
+        (action.data.unread_msgs && action.data.unread_msgs.mentions)
+        // TODO(#5102): Delete fallback once we refuse to connect to Zulip
+        //   servers before 1.7.0, when it seems this feature was added; see
+        //   comment on InitialDataUpdateMessageFlags.
+        || initialState
+      );
 
     case EVENT_NEW_MESSAGE: {
       const { flags } = action.message;

--- a/src/unread/unreadModel.js
+++ b/src/unread/unreadModel.js
@@ -230,8 +230,9 @@ function streamsReducer(
       return initialStreamsState;
 
     case REGISTER_COMPLETE: {
-      // This may indeed be unnecessary, but it's legacy; have not investigated
-      // if it's this bit of our API types that is too optimistic.
+      // TODO(#5102): Delete fallback once we refuse to connect to Zulip
+      //   servers before 1.7.0, when it seems this feature was added; see
+      //   comment on InitialDataUpdateMessageFlags.
       // flowlint-next-line unnecessary-optional-chain:off
       const data = action.data.unread_msgs?.streams ?? [];
 

--- a/src/unread/unreadPmsReducer.js
+++ b/src/unread/unreadPmsReducer.js
@@ -96,7 +96,13 @@ export default (
       return initialState;
 
     case REGISTER_COMPLETE:
-      return (action.data.unread_msgs && action.data.unread_msgs.pms) || initialState;
+      return (
+        (action.data.unread_msgs && action.data.unread_msgs.pms)
+        // TODO(#5102): Delete fallback once we refuse to connect to Zulip
+        //   servers before 1.7.0, when it seems this feature was added; see
+        //   comment on InitialDataUpdateMessageFlags.
+        || initialState
+      );
 
     case EVENT_NEW_MESSAGE:
       return eventNewMessage(state, action);


### PR DESCRIPTION
(Marking P1 because this came up during work toward https://github.com/zulip/zulip-mobile/issues/5102, disallow ancient servers.)