### PR TITLE
android build: Follow some changes from RN v0.68

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -130,6 +130,14 @@ def jscFlavor = 'org.webkit:android-jsc-intl:+'
  */
 def enableHermes = project.ext.react.get("enableHermes", false);
 
+/**
+ * Architectures to build native code for.
+ */
+def reactNativeArchitectures() {
+    def value = project.getProperties().get("reactNativeArchitectures")
+    return value ? value.split(",") : ["armeabi-v7a", "x86", "x86_64", "arm64-v8a"]
+}
+
 android {
     defaultConfig {
         applicationId "com.zulipmobile"
@@ -164,7 +172,7 @@ android {
             reset()
             enable true // Build a separate APK for each ABI.
             universalApk false  // If true, also generate a universal APK
-            include "armeabi-v7a", "x86", "arm64-v8a", "x86_64"
+            include (*reactNativeArchitectures())
         }
     }
     buildTypes {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -27,7 +27,7 @@ buildscript {
     }
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath 'com.android.tools.build:gradle:7.0.1'
+        classpath 'com.android.tools.build:gradle:7.0.4'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -29,3 +29,8 @@ android.enableJetifier=true
 
 # Version of flipper SDK to use with React Native
 FLIPPER_VERSION=0.99.0
+
+# Use this property to specify which architecture you want to build.
+# You can also override it from the CLI using
+# tools/gradle <task> -PreactNativeArchitectures=x86_64
+reactNativeArchitectures=armeabi-v7a,arm64-v8a,x86,x86_64

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -13,7 +13,7 @@
 #   -XX:MaxMetaspaceSize=256m -XX:+HeapDumpOnOutOfMemoryError -Xms256m -Xmx512m
 # We allow more space (no MaxMetaspaceSize; bigger -Xmx),
 # and don't litter heap dumps if that still proves insufficient.
-org.gradle.jvmargs=-Xms256m -Xmx1024m
+org.gradle.jvmargs=-Xms256m -Xmx1280m
 
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 # How to upgrade Gradle:
-#   $ ./gradlew wrapper --distribution-type=all --gradle-version=NEW_VERSION
-#   $ ./gradlew wrapper --distribution-type=all --gradle-version=NEW_VERSION
+#   $ tools/gradle wrapper --distribution-type=all --gradle-version=NEW_VERSION
+#   $ tools/gradle wrapper --distribution-type=all --gradle-version=NEW_VERSION
 # (Yep, run the same command twice.  The first updates this file so we use
 #  the new Gradle; the second updates the wrapper's jar and scripts, so that
 #  the wrapper is the one from the new Gradle too.)

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -6,6 +6,6 @@
 #  the wrapper is the one from the new Gradle too.)
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/docs/howto/build-run.md
+++ b/docs/howto/build-run.md
@@ -280,8 +280,8 @@ java.nio.file.NoSuchFileException: /Users/chrisbobbe/dev/zulip-mobile/android/ap
   at sun.nio.fs.UnixFileSystemProvider.newDirectoryStream(UnixFileSystemProvider.java:407)
 ```
 
-Try removing `android/.gradle`, running `./gradlew clean` from
-`android/`, and building again.
+Try removing `android/.gradle`, running `tools/gradle clean`,
+and building again.
 
 ### Build failure: No file known for: classes.dex
 
@@ -293,8 +293,8 @@ Execution failed for task ':app:packageDebug'.
    > No file known for: classes.dex
 ```
 
-Try removing `android/.gradle`, running `./gradlew clean` from
-`android/`, and building again.
+Try removing `android/.gradle`, running `tools/gradle clean`,
+and building again.
 
 ### Build failure: java.lang.UnsupportedClassVersionError, "Unsupported major.minor version 52.0"
 
@@ -343,7 +343,7 @@ Could not compile build file '/Users/chrisbobbe/dev/zulip-mobile/node_modules/@u
 This can sometimes happen if you're using JDK 13 to invoke the build
 command (e.g., when calling `tools/run-android`, or
 `tools/test native`, or
-`android/gradlew -p android :app:assembleDebug`). You can check the
+`tools/gradle :app:assembleDebug`). You can check the
 version by running `java -version`. It seems that upgrading to
 macOS 10.15 Catalina automatically upgrades Java to 13.
 
@@ -686,7 +686,7 @@ Sometimes, the build cache from previous builds can cause issues, and cleaning
 it can help:
 
 ```
-cd android && ./gradlew clean
+tools/gradle clean
 ```
 
 Optionally, reset iOS simulator:

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "android": "tools/run-android",
     "android-release": "react-native run-android --variant=release",
     "build:android": "tools/android apk",
-    "build:android-nokeys": "cd android && ./gradlew :app:assembleRelease",
+    "build:android-nokeys": "tools/gradle :app:assembleRelease",
     "build:ios": "cd ios && xcodebuild -scheme ZulipMobile archivexcodebuild -scheme ZulipMobile archive",
     "test": "tools/test",
     "prettier": "tools/fmt",

--- a/tools/android
+++ b/tools/android
@@ -64,14 +64,14 @@ do_apk() {
     check_yarn_link
     run_visibly yarn
 
-    run_visibly android/gradlew -p android :app:assembleRelease -Psigned -Psentry
+    run_visibly tools/gradle :app:assembleRelease -Psigned -Psentry
 }
 
 do_aab() {
     check_yarn_link
     run_visibly yarn
 
-    run_visibly android/gradlew -p android :app:bundleRelease -Psigned -Psentry
+    run_visibly tools/gradle :app:bundleRelease -Psigned -Psentry
 }
 
 case "${action}" in

--- a/tools/gradle
+++ b/tools/gradle
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+this_dir=${BASH_SOURCE[0]%/*}
+. "${this_dir}"/lib/ensure-coreutils.sh
+root_dir=$(readlink -f "${this_dir}"/..)
+
+exec "${root_dir}"/android/gradlew -p "${root_dir}"/android "$@"

--- a/tools/run-android
+++ b/tools/run-android
@@ -15,7 +15,7 @@ cd "${ROOT_DIR}"
 # These steps are based on observing `react-native run-android`
 # with a command `strace -eexecve -f react-native run-android`.
 
-run_visibly android/gradlew -p android -q :app:installDebug "$@"
+run_visibly tools/gradle -q :app:installDebug "$@"
 
 devices=(
     $(run_visibly adb devices | perl -0ne 'print "$_\n" for (/^(\S+) \s+ device$/gmx)')

--- a/tools/test
+++ b/tools/test
@@ -145,19 +145,15 @@ run_native_android() {
     files_check android/ \
         || return 0
 
-    (
-        cd android
+    tools/gradle -q :app:assembleDebug :app:assembleDebugUnitTest \
+        :app:bundleDebug || return
 
-        ./gradlew -q :app:assembleDebug :app:assembleDebugUnitTest \
-            :app:bundleDebug || exit
-
-        # The `-q` suppresses noise from warnings about obsolete build config
-        # in our dependencies from the React Native ecosystem.
-        # But it also suppresses the names of tests that failed.
-        # So on failure, rerun without it.
-        ./gradlew -q :app:testDebugUnitTest \
-            || ./gradlew :app:testDebugUnitTest || exit
-    )
+    # The `-q` suppresses noise from warnings about obsolete build config
+    # in our dependencies from the React Native ecosystem.
+    # But it also suppresses the names of tests that failed.
+    # So on failure, rerun without it.
+    tools/gradle -q :app:testDebugUnitTest \
+        || tools/gradle :app:testDebugUnitTest
 }
 
 run_native_ios() {


### PR DESCRIPTION
Part of #5344.

Plus a handly little `tools/gradle` script, to save typing `cd android` and `cd ..` all the time when running Gradle tasks (and to simplify various scripts and docs by not having to track a different working directory.)
