### PR TITLE
(resumption) RealmInputScreen: Improve validation rules; give "What's this?" link about realm URL; offer dynamic suggestions

### DIFF
--- a/src/account-info/CustomProfileFields.js
+++ b/src/account-info/CustomProfileFields.js
@@ -70,9 +70,7 @@ function CustomProfileFieldRow(props: {|
       valueElement = (
         <View style={styles.valueView}>
           {value.url ? (
-            <WebLink url={value.url}>
-              <ZulipText text={value.text} />
-            </WebLink>
+            <WebLink url={value.url} text={value.text} />
           ) : (
             <ZulipText text={value.text} />
           )}

--- a/src/common/WebLink.js
+++ b/src/common/WebLink.js
@@ -23,7 +23,9 @@ const componentStyles = createStyleSheet({
 /**
  * A button styled like a web link.
  *
- * Accepts `ZulipText`s, `ZulipTextIntl`s, and strings as children.
+ * Accepts strings as children or a `text` prop, just like ZulipText.
+ *
+ * Also accepts `ZulipText`s and `ZulipTextIntl`s as children.
  *
  * Note: This sort of messes in those non-string children's business by
  *   unsetting some of their default style attributes. It does this so that

--- a/src/common/WebLink.js
+++ b/src/common/WebLink.js
@@ -3,7 +3,6 @@
 import * as React from 'react';
 
 import ZulipText from './ZulipText';
-import ZulipTextIntl from './ZulipTextIntl';
 import { openLinkWithUserPreference } from '../utils/openLink';
 import { BRAND_COLOR, createStyleSheet } from '../styles';
 import { useGlobalSelector } from '../react-redux';
@@ -25,16 +24,8 @@ const componentStyles = createStyleSheet({
  *
  * Accepts strings as children or a `text` prop, just like ZulipText.
  *
- * Also accepts `ZulipText`s and `ZulipTextIntl`s as children.
- *
- * Note: This sort of messes in those non-string children's business by
- *   unsetting some of their default style attributes. It does this so that
- *   its own special formatting can be passed down through the limited style
- *   inheritance that RN supports:
- *     https://reactnative.dev/docs/text#limited-style-inheritance
- *   See `aggressiveDefaultStyle` in ZulipText.
- *
- * TODO: Possibly there's a better way handle this.
+ * Also accepts `ZulipText`s and `ZulipTextIntl`s as children. To keep the
+ * special formatting, you have to pass `inheritColor` to those.
  */
 export default function WebLink(props: Props): React.Node {
   const { children } = props;
@@ -48,30 +39,7 @@ export default function WebLink(props: Props): React.Node {
         openLinkWithUserPreference(props.url.toString(), globalSettings);
       }}
     >
-      {React.Children.map(children, child => {
-        if (!React.isValidElement(child)) {
-          // Some React node that isn't a React element (a `React.Element`);
-          // e.g., a plain string. The enclosing ZulipText will apply its
-          // styles directly.
-          return child;
-        }
-        // `child` should be a React.Element at this point. Docs are very
-        // vague, but this sounds like it should be true, and it seems true
-        // empirically. Would at least be good to have better type checking.
-
-        if (child.type !== ZulipText && child.type !== ZulipTextIntl) {
-          return child;
-        }
-        // These element types will have a style prop that we want to add to.
-
-        return React.cloneElement(child, {
-          style: {
-            // Defeat ZulipText's aggressiveDefaultStyle.color so that our
-            // color gets applied.
-            color: undefined,
-          },
-        });
-      })}
+      {children}
     </ZulipText>
   );
 }

--- a/src/common/ZulipText.js
+++ b/src/common/ZulipText.js
@@ -3,12 +3,16 @@ import invariant from 'invariant';
 import React, { useContext } from 'react';
 import type { Node } from 'react';
 import { Text } from 'react-native';
+import type { ____TextStyle_Internal } from 'react-native/Libraries/StyleSheet/StyleSheetTypes'; // eslint-disable-line id-match
 
 import { ThemeContext } from '../styles';
 
 type Props = $ReadOnly<{|
   ...$Exact<React$ElementConfig<typeof Text>>,
   text?: string,
+
+  inheritFontSize?: boolean,
+  inheritColor?: boolean,
 |}>;
 
 /**
@@ -20,11 +24,21 @@ type Props = $ReadOnly<{|
  *
  * @prop text - Contents for Text.
  * @prop [style] - Can override our default style for this component.
+ * @prop inheritFontSize, etc. - Use instead of `styles.fontSize`, etc., to
+ *   inherit value from an ancestor Text in the layout:
+ *   https://reactnative.dev/docs/0.67/text#limited-style-inheritance
  * @prop ...all other Text props - Passed through verbatim to Text.
  *   See upstream: https://reactnative.dev/docs/text
  */
 export default function ZulipText(props: Props): Node {
-  const { text, children, style, ...restProps } = props;
+  const {
+    text,
+    children,
+    style,
+    inheritFontSize = false,
+    inheritColor = false,
+    ...restProps
+  } = props;
   const themeData = useContext(ThemeContext);
 
   invariant(
@@ -33,13 +47,21 @@ export default function ZulipText(props: Props): Node {
   );
   invariant(text == null || children == null, 'ZulipText: `text` or `children` should be nullish');
 
-  // These attributes will be applied unless specifically overridden
-  // with the `style` prop -- even if this `<ZulipText />` is nested
-  // and would otherwise inherit the attributes from its ancestors.
-  const aggressiveDefaultStyle = {
+  // These attributes will be applied unless specifically overridden with
+  // the `style` or `inherit*` props -- even if this `<ZulipText />` is
+  // nested and would otherwise inherit the attributes from its ancestors.
+  const aggressiveDefaultStyle: $Rest<____TextStyle_Internal, { ... }> = {
     fontSize: 15,
     color: themeData.color,
+    // If adding an attribute `foo`, give callers a prop `inheritFoo`.
   };
+
+  if (inheritFontSize) {
+    delete aggressiveDefaultStyle.fontSize;
+  }
+  if (inheritColor) {
+    delete aggressiveDefaultStyle.color;
+  }
 
   return (
     <Text style={[aggressiveDefaultStyle, style]} {...restProps}>

--- a/src/message/ReadReceiptsScreen.js
+++ b/src/message/ReadReceiptsScreen.js
@@ -24,7 +24,6 @@ import type { UserOrBot } from '../api/modelTypes';
 import LoadingIndicator from '../common/LoadingIndicator';
 import WebLink from '../common/WebLink';
 import { createStyleSheet } from '../styles';
-import ZulipText from '../common/ZulipText';
 
 type Props = $ReadOnly<{|
   navigation: AppNavigationProp<'read-receipts'>,
@@ -138,11 +137,7 @@ export default function ReadReceiptsScreen(props: Props): Node {
             values: {
               num_of_people: displayUserIds.length,
               'z-link': chunks => (
-                <WebLink url={new URL('/help/read-receipts', auth.realm)}>
-                  {chunks.map(chunk => (
-                    <ZulipText>{chunk}</ZulipText>
-                  ))}
-                </WebLink>
+                <WebLink url={new URL('/help/read-receipts', auth.realm)}>{chunks}</WebLink>
               ),
             },
           }

--- a/src/start/PasswordAuthScreen.js
+++ b/src/start/PasswordAuthScreen.js
@@ -144,7 +144,7 @@ class PasswordAuthScreenInner extends PureComponent<Props, State> {
         <View style={styles.linksTouchable}>
           <ZulipText style={styles.forgotPasswordText}>
             <WebLink url={new URL('/accounts/password/reset/', realm)}>
-              <ZulipTextIntl text="Forgot password?" />
+              <ZulipTextIntl inheritColor text="Forgot password?" />
             </WebLink>
           </ZulipText>
         </View>

--- a/src/start/RealmInputScreen.js
+++ b/src/start/RealmInputScreen.js
@@ -221,7 +221,7 @@ export default function RealmInputScreen(props: Props): Node {
     [themeContext],
   );
 
-  const renderedSuggestion = React.useMemo(() => {
+  const suggestionContent = React.useMemo(() => {
     if (suggestion === null) {
       // Vertical spacer so the layout doesn't jump when a suggestion
       // appears or disappears. (The empty string might be neater, but it
@@ -230,13 +230,11 @@ export default function RealmInputScreen(props: Props): Node {
       // and React or RN gave in to that. I've tried the obvious ways to use
       // RN's PixelRatio.getFontScale() and never got the right height
       // either; dunno why.)
-      return (
-        <ZulipText style={styles.suggestionText} text={'\u200b'} /* U+200B ZERO WIDTH SPACE */ />
-      );
+      return '\u200b'; // U+200B ZERO WIDTH SPACE
     } else if (typeof suggestion === 'string') {
       return (
         <ZulipTextIntl
-          style={styles.suggestionText}
+          inheritFontSize
           text={{
             text: 'Suggestion: <z-link>{suggestedServerUrl}</z-link>',
             values: {
@@ -254,7 +252,7 @@ export default function RealmInputScreen(props: Props): Node {
         />
       );
     } else {
-      return <ZulipTextIntl style={styles.suggestionText} text={validationErrorMsg(suggestion)} />;
+      return <ZulipTextIntl inheritFontSize text={validationErrorMsg(suggestion)} />;
     }
   }, [suggestion, handlePressSuggestion, styles]);
 
@@ -299,7 +297,7 @@ export default function RealmInputScreen(props: Props): Node {
           ref={textInputRef}
         />
       </View>
-      {renderedSuggestion}
+      <ZulipText style={styles.suggestionText}>{suggestionContent}</ZulipText>
       <ZulipButton
         style={styles.button}
         text="Enter"

--- a/src/start/RealmInputScreen.js
+++ b/src/start/RealmInputScreen.js
@@ -25,12 +25,15 @@ type Props = $ReadOnly<{|
 |}>;
 
 enum ValidationError {
-  InvalidUrl = 0,
-  NoUseEmail = 1,
+  Empty = 0,
+  InvalidUrl = 1,
+  NoUseEmail = 2,
 }
 
 function validationErrorMsg(validationError: ValidationError): LocalizableText {
   switch (validationError) {
+    case ValidationError.Empty:
+      return 'Please enter a URL.';
     case ValidationError.InvalidUrl:
       return 'Please enter a valid URL.';
     case ValidationError.NoUseEmail:
@@ -44,6 +47,10 @@ type MaybeParsedInput =
 
 const tryParseInput = (realmInputValue: string): MaybeParsedInput => {
   const trimmedInputValue = realmInputValue.trim();
+
+  if (trimmedInputValue.length === 0) {
+    return { valid: false, error: ValidationError.Empty };
+  }
 
   const withScheme = /^https?:\/\//.test(trimmedInputValue)
     ? trimmedInputValue

--- a/src/start/RealmInputScreen.js
+++ b/src/start/RealmInputScreen.js
@@ -52,11 +52,10 @@ const tryParseInput = (realmInputValue: string): MaybeParsedInput => {
     return { valid: false, error: ValidationError.Empty };
   }
 
-  const withScheme = /^https?:\/\//.test(trimmedInputValue)
-    ? trimmedInputValue
-    : `https://${trimmedInputValue}`;
-
-  const url = tryParseUrl(withScheme);
+  let url = tryParseUrl(trimmedInputValue);
+  if (!/^https?:\/\//.test(trimmedInputValue)) {
+    url = tryParseUrl(`https://${trimmedInputValue}`);
+  }
 
   if (!url) {
     return { valid: false, error: ValidationError.InvalidUrl };

--- a/src/start/RealmInputScreen.js
+++ b/src/start/RealmInputScreen.js
@@ -212,7 +212,6 @@ export default function RealmInputScreen(props: Props): Node {
         },
         suggestionText: { fontSize: 12, fontStyle: 'italic' },
         suggestionTextLink: {
-          fontSize: 12,
           fontStyle: 'normal',
           color: BRAND_COLOR, // chosen to mimic WebLink
         },
@@ -241,6 +240,7 @@ export default function RealmInputScreen(props: Props): Node {
               suggestedServerUrl: suggestion,
               'z-link': chunks => (
                 <ZulipText
+                  inheritFontSize
                   style={styles.suggestionTextLink}
                   onPress={() => handlePressSuggestion(suggestion)}
                 >

--- a/src/start/RealmInputScreen.js
+++ b/src/start/RealmInputScreen.js
@@ -43,9 +43,11 @@ type MaybeParsedInput =
   | {| +valid: false, error: ValidationError |};
 
 const tryParseInput = (realmInputValue: string): MaybeParsedInput => {
-  const withScheme = /^https?:\/\//.test(realmInputValue)
-    ? realmInputValue
-    : `https://${realmInputValue}`;
+  const trimmedInputValue = realmInputValue.trim();
+
+  const withScheme = /^https?:\/\//.test(trimmedInputValue)
+    ? trimmedInputValue
+    : `https://${trimmedInputValue}`;
 
   const url = tryParseUrl(withScheme);
 

--- a/src/start/RealmInputScreen.js
+++ b/src/start/RealmInputScreen.js
@@ -18,6 +18,7 @@ import { TranslationContext } from '../boot/TranslationProvider';
 import type { LocalizableText } from '../types';
 import { getGlobalSettings } from '../directSelectors';
 import { useGlobalSelector } from '../react-redux';
+import WebLink from '../common/WebLink';
 
 type Props = $ReadOnly<{|
   navigation: AppNavigationProp<'realm-input'>,
@@ -172,7 +173,18 @@ export default function RealmInputScreen(props: Props): Node {
       keyboardShouldPersistTaps="always"
       shouldShowLoadingBanner={false}
     >
-      <ZulipTextIntl text="Enter your Zulip server URL:" />
+      <ZulipTextIntl
+        text={{
+          text: 'Enter your Zulip server URL: <z-link>(What’s this?)</z-link>',
+          values: {
+            'z-link': chunks => (
+              <WebLink url={new URL('https://zulip.com/help/logging-in#find-the-zulip-log-in-url')}>
+                {chunks}
+              </WebLink>
+            ),
+          },
+        }}
+      />
       <View style={styles.inputWrapper}>
         <TextInput
           value={realmInputValue}

--- a/static/translations/messages_en.json
+++ b/static/translations/messages_en.json
@@ -106,7 +106,7 @@
   "No unread messages": "No unread messages",
   "Pick account": "Pick account",
   "Welcome": "Welcome",
-  "Enter your Zulip server URL:": "Enter your Zulip server URL:",
+  "Enter your Zulip server URL: <z-link>(What’s this?)</z-link>": "Enter your Zulip server URL: <z-link>(What’s this?)</z-link>",
   "e.g. zulip.example.com": "e.g. zulip.example.com",
   "Subscriptions": "Subscriptions",
   "Search": "Search",

--- a/static/translations/messages_en.json
+++ b/static/translations/messages_en.json
@@ -129,6 +129,7 @@
   "Chat": "Chat",
   "Sign in with {method}": "Sign in with {method}",
   "Invalid input": "Invalid input",
+  "Please enter a URL.": "Please enter a URL.",
   "Please enter a valid URL.": "Please enter a valid URL.",
   "Please enter the server URL, not your email.": "Please enter the server URL, not your email.",
   "Wrong email or password. Try again.": "Wrong email or password. Try again.",

--- a/static/translations/messages_en.json
+++ b/static/translations/messages_en.json
@@ -132,6 +132,7 @@
   "Please enter a URL.": "Please enter a URL.",
   "Please enter a valid URL.": "Please enter a valid URL.",
   "Please enter the server URL, not your email.": "Please enter the server URL, not your email.",
+  "The server URL must start with http:// or https://.": "The server URL must start with http:// or https://.",
   "Wrong email or password. Try again.": "Wrong email or password. Try again.",
   "Wrong username or password. Try again.": "Wrong username or password. Try again.",
   "Enter a valid email address": "Enter a valid email address",

--- a/static/translations/messages_en.json
+++ b/static/translations/messages_en.json
@@ -107,7 +107,6 @@
   "Pick account": "Pick account",
   "Welcome": "Welcome",
   "Enter your Zulip server URL: <z-link>(What’s this?)</z-link>": "Enter your Zulip server URL: <z-link>(What’s this?)</z-link>",
-  "e.g. zulip.example.com": "e.g. zulip.example.com",
   "Subscriptions": "Subscriptions",
   "Search": "Search",
   "Log in": "Log in",

--- a/static/translations/messages_en.json
+++ b/static/translations/messages_en.json
@@ -107,6 +107,7 @@
   "Pick account": "Pick account",
   "Welcome": "Welcome",
   "Enter your Zulip server URL: <z-link>(What’s this?)</z-link>": "Enter your Zulip server URL: <z-link>(What’s this?)</z-link>",
+  "Suggestion: <z-link>{suggestedServerUrl}</z-link>": "Suggestion: <z-link>{suggestedServerUrl}</z-link>",
   "Subscriptions": "Subscriptions",
   "Search": "Search",
   "Log in": "Log in",


### PR DESCRIPTION
A resumption of #5601, which I accidentally closed abruptly by deleting the branch on my GitHub fork. 😵 Sorry for the confusion!

-----

This revision has changes for all the reviews before https://github.com/zulip/zulip-mobile/pull/5601#issuecomment-1347898717 _except_ these two:

@gnprice said at https://github.com/zulip/zulip-mobile/pull/5601#pullrequestreview-1214148293:

> The very last bit, the "Suggestion: [link]" line, is intriguing but I feel like I want to chew on it a bit more, and on the logic for exactly when and what suggestion we show.

@alya said at https://github.com/zulip/zulip-mobile/pull/5601#issuecomment-1347632620:

> I think if you tap on the URL suggestion, it should just auto-complete, but not connect until you press the "Enter" button. Maybe you wanted to auto-fill it but were still planning on editing the URL further. What do you guys think?

For @alya's question, I guess it kind of depends on when and what suggestions we show there. 🙂 In the current revision, I think one isn't very likely to want to edit the URL after tapping the suggestion:
- No realms are just a few edits away from `chat.zulip.org`.
- A `foo.zulipchat.com` link would be given for whatever valid-looking subdomain "foo" the user has already typed. So if they want "foot" instead, the natural thing is to just type "t" and tap the new suggestion, rather than tap `foo.zulipchat.com` with a plan to splice in a "t" afterward.
- People looking for self-hosted realms are likely to ignore a `.zulipchat.com` suggestion; I don't think any self-hosted realms are just a few edits away from anything with `.zulipchat.com`.