### PR TITLE
(More) consistently clear old data on all ways of leaving an account

### DIFF
--- a/docs/style.md
+++ b/docs/style.md
@@ -38,6 +38,8 @@
     initializer at `let`.
   * [[link](#immutable-provide-type)] Always provide a type when
     writing an empty `Immutable` value.
+  * [[link](#immutable-no-object-as-map)] Don't construct an `Immutable.Map`
+    with an object-as-map.
   * [[link](#react-function-prop-defaults)] Don't use React
     `defaultProps` for function components.
 * [Internal to Zulip and our codebase](#zulip)
@@ -540,6 +542,26 @@ This is essential in order to get effective type-checking of the
 code that uses the new collection.  (It's not clear if this is a bug
 in Flow, or a design limitation of Flow, or an issue in the Flow types
 provided by Immutable.js, or some combination.)
+
+
+<div id="immutable-no-object-as-map" />
+
+**Don't construct an `Immutable.Map` with an object-as-map**: Whenever you
+create a non-empty `Immutable.Map`, pass an array of entries instead of an
+object-as-map. For example:
+```js
+Immutable.Map([[HOME_NARROW_STR, [1, 2]]]) // good
+
+Immutable.Map({ [HOME_NARROW_STR]: [1, 2] }) // BAD -- don't do
+```
+
+This is essential in order to get effective type-checking of the value
+passed to the `Immutable.Map` function when a key is computed (like
+`HOME_NARROW_STR`) instead of literal (like 'foo'). In the Immutable type
+definition, the object-as-map branch involves an object type with an indexer
+property, and in general [Flow seems to have trouble with those][].
+
+[Flow seems to have trouble with those]: https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/.60Immutable.2EMap.28.7B.20.5BSTRING_CONST.5D.3A.20.E2.80.A6.20.7D.29.60.20busted.20by.20Flow.20bug/near/1481088
 
 
 <div id="react-function-prop-defaults" />

--- a/src/alertWords/__tests__/alertWordsReducer-test.js
+++ b/src/alertWords/__tests__/alertWordsReducer-test.js
@@ -1,65 +1,66 @@
+/* @flow strict-local */
+
 import deepFreeze from 'deep-freeze';
 
 import alertWordsReducer from '../alertWordsReducer';
-import { REGISTER_COMPLETE, EVENT_ALERT_WORDS } from '../../actionConstants';
+import { EVENT_ALERT_WORDS } from '../../actionConstants';
+import * as eg from '../../__tests__/lib/exampleData';
 
 describe('alertWordsReducer', () => {
   describe('REGISTER_COMPLETE', () => {
     test('when `alert_words` data is provided init state with it', () => {
-      const initialState = deepFreeze([]);
-      const action = deepFreeze({
-        type: REGISTER_COMPLETE,
-        data: {
-          alert_words: ['word', '@mobile-core', 'alert'],
-        },
-      });
-      const expectedState = ['word', '@mobile-core', 'alert'];
-
-      const actualState = alertWordsReducer(initialState, action);
-
-      expect(actualState).toEqual(expectedState);
+      const prevState = deepFreeze([]);
+      expect(
+        alertWordsReducer(
+          prevState,
+          eg.mkActionRegisterComplete({ alert_words: ['word', '@mobile-core', 'alert'] }),
+        ),
+      ).toEqual(['word', '@mobile-core', 'alert']);
     });
 
     // TODO(#5102): Delete; see comment on implementation.
     test('when no `alert_words` data is given reset state', () => {
-      const initialState = deepFreeze(['word']);
-      const action = deepFreeze({
-        type: REGISTER_COMPLETE,
-        data: {},
-      });
-      const expectedState = [];
+      const prevState = deepFreeze(['word']);
+      const actualState = alertWordsReducer(
+        prevState,
+        eg.mkActionRegisterComplete({
+          // Hmm, we should need a Flow suppression here. This property is
+          // marked required in InitialData, and this explicit undefined is
+          // meant to defy that; see TODO(#5102) above.
+          // mkActionRegisterComplete is designed to accept input with this or
+          // any property *omitted*… and I think, as a side effect of handling
+          // that, Flow mistakenly accepts an explicit undefined here, so it
+          // doesn't catch the resulting malformed InitialData.
+          alert_words: undefined,
+        }),
+      );
 
-      const actualState = alertWordsReducer(initialState, action);
-
-      expect(actualState).toEqual(expectedState);
+      expect(actualState).toEqual([]);
     });
   });
 
   describe('EVENT_ALERT_WORDS', () => {
     test('on first call adds new data', () => {
-      const initialState = deepFreeze([]);
-      const action = deepFreeze({
-        type: EVENT_ALERT_WORDS,
-        alert_words: ['word', '@mobile-core', 'alert'],
-      });
-      const expectedState = ['word', '@mobile-core', 'alert'];
-
-      const actualState = alertWordsReducer(initialState, action);
-
-      expect(actualState).toEqual(expectedState);
+      const prevState = deepFreeze([]);
+      expect(
+        alertWordsReducer(
+          prevState,
+          deepFreeze({ type: EVENT_ALERT_WORDS, alert_words: ['word', '@mobile-core', 'alert'] }),
+        ),
+      ).toEqual(['word', '@mobile-core', 'alert']);
     });
 
     test('subsequent calls replace existing data', () => {
-      const initialState = deepFreeze(['word', '@mobile-core', 'alert']);
-      const action = deepFreeze({
-        type: EVENT_ALERT_WORDS,
-        alert_words: ['word', '@mobile-core', 'new alert'],
-      });
-      const expectedState = ['word', '@mobile-core', 'new alert'];
-
-      const actualState = alertWordsReducer(initialState, action);
-
-      expect(actualState).toEqual(expectedState);
+      const prevState = deepFreeze(['word', '@mobile-core', 'alert']);
+      expect(
+        alertWordsReducer(
+          prevState,
+          deepFreeze({
+            type: EVENT_ALERT_WORDS,
+            alert_words: ['word', '@mobile-core', 'new alert'],
+          }),
+        ),
+      ).toEqual(['word', '@mobile-core', 'new alert']);
     });
   });
 });

--- a/src/alertWords/__tests__/alertWordsReducer-test.js
+++ b/src/alertWords/__tests__/alertWordsReducer-test.js
@@ -7,6 +7,15 @@ import { EVENT_ALERT_WORDS } from '../../actionConstants';
 import * as eg from '../../__tests__/lib/exampleData';
 
 describe('alertWordsReducer', () => {
+  describe('RESET_ACCOUNT_DATA', () => {
+    const initialState = eg.baseReduxState.alertWords;
+    const action1 = eg.mkActionRegisterComplete({ alert_words: ['word', '@mobile-core', 'alert'] });
+    const prevState = alertWordsReducer(initialState, action1);
+    expect(prevState).not.toEqual(initialState);
+
+    expect(alertWordsReducer(prevState, eg.action.reset_account_data)).toEqual(initialState);
+  });
+
   describe('REGISTER_COMPLETE', () => {
     test('when `alert_words` data is provided init state with it', () => {
       const prevState = deepFreeze([]);

--- a/src/caughtup/__tests__/caughtUpReducer-test.js
+++ b/src/caughtup/__tests__/caughtUpReducer-test.js
@@ -18,39 +18,23 @@ import { objectFromEntries } from '../../jsBackport';
 describe('caughtUpReducer', () => {
   describe('MESSAGE_FETCH_START', () => {
     test('when fetch starts caught up does not change', () => {
-      const initialState = deepFreeze({
-        [HOME_NARROW_STR]: {
-          older: true,
-          newer: true,
-        },
-      });
-
-      const action = deepFreeze({
-        ...eg.action.message_fetch_start,
-        narrow: HOME_NARROW,
-      });
-
-      const newState = caughtUpReducer(initialState, action);
-
-      expect(newState).toBe(initialState);
+      const prevState = deepFreeze({ [HOME_NARROW_STR]: { older: true, newer: true } });
+      expect(
+        caughtUpReducer(
+          prevState,
+          deepFreeze({ ...eg.action.message_fetch_start, narrow: HOME_NARROW }),
+        ),
+      ).toBe(prevState);
     });
 
     test('if fetching for a search narrow, ignore', () => {
-      const initialState = deepFreeze({
-        [HOME_NARROW_STR]: {
-          older: false,
-          newer: false,
-        },
-      });
-
-      const action = deepFreeze({
-        ...eg.action.message_fetch_start,
-        narrow: SEARCH_NARROW('some query'),
-      });
-
-      const newState = caughtUpReducer(initialState, action);
-
-      expect(newState).toEqual(initialState);
+      const prevState = deepFreeze({ [HOME_NARROW_STR]: { older: false, newer: false } });
+      expect(
+        caughtUpReducer(
+          prevState,
+          deepFreeze({ ...eg.action.message_fetch_start, narrow: SEARCH_NARROW('some query') }),
+        ),
+      ).toEqual(prevState);
     });
   });
 
@@ -67,88 +51,50 @@ describe('caughtUpReducer', () => {
       // Include some other narrow to test that the reducer doesn't go mess
       // something up there.
       const initialState = deepFreeze({ [keyFromNarrow(narrow1)]: { older: true, newer: true } });
-
-      const messageFetchStartAction = deepFreeze({
-        ...eg.action.message_fetch_start,
-        narrow: narrow2,
-      });
-
-      const state1 = caughtUpReducer(initialState, messageFetchStartAction);
-
-      const messageFetchErrorAction = deepFreeze({
-        type: MESSAGE_FETCH_ERROR,
-        narrow: narrow2,
-        error: new Error(),
-      });
-
-      const finalState = caughtUpReducer(state1, messageFetchErrorAction);
-
-      expect(finalState).toEqual(initialState);
+      expect(
+        [
+          deepFreeze({ ...eg.action.message_fetch_start, narrow: narrow2 }),
+          deepFreeze({ type: MESSAGE_FETCH_ERROR, narrow: narrow2, error: new Error() }),
+        ].reduce(caughtUpReducer, initialState),
+      ).toEqual(initialState);
     });
   });
 
   describe('MESSAGE_FETCH_COMPLETE', () => {
     test('apply `foundNewest` and `foundOldest` when true', () => {
-      const initialState = deepFreeze({});
-
-      const action = deepFreeze({
-        ...eg.action.message_fetch_complete,
-        foundNewest: true,
-        foundOldest: true,
-      });
-
-      const expectedState = {
-        [HOME_NARROW_STR]: {
-          older: true,
-          newer: true,
-        },
-      };
-
-      const newState = caughtUpReducer(initialState, action);
-
-      expect(newState).toEqual(expectedState);
+      const prevState = deepFreeze({});
+      expect(
+        caughtUpReducer(
+          prevState,
+          deepFreeze({ ...eg.action.message_fetch_complete, foundNewest: true, foundOldest: true }),
+        ),
+      ).toEqual({ [HOME_NARROW_STR]: { older: true, newer: true } });
     });
 
     test('if fetched messages are from a search narrow, ignore them', () => {
-      const initialState = deepFreeze({});
-
-      const action = deepFreeze({
-        ...eg.action.message_fetch_complete,
-        narrow: SEARCH_NARROW('some query'),
-        foundOldest: true,
-        foundNewest: true,
-      });
-
-      const newState = caughtUpReducer(initialState, action);
-
-      expect(newState).toEqual(initialState);
+      const prevState = deepFreeze({});
+      expect(
+        caughtUpReducer(
+          prevState,
+          deepFreeze({
+            ...eg.action.message_fetch_complete,
+            narrow: SEARCH_NARROW('some query'),
+            foundOldest: true,
+            foundNewest: true,
+          }),
+        ),
+      ).toEqual(prevState);
     });
   });
 
   test('new false results do not reset previous true state', () => {
-    const initialState = deepFreeze({
-      [HOME_NARROW_STR]: {
-        older: true,
-        newer: true,
-      },
-    });
-
-    const action = deepFreeze({
-      ...eg.action.message_fetch_complete,
-      foundOldest: false,
-      foundNewest: false,
-    });
-
-    const expectedState = {
-      [HOME_NARROW_STR]: {
-        older: true,
-        newer: true,
-      },
-    };
-
-    const newState = caughtUpReducer(initialState, action);
-
-    expect(newState).toEqual(expectedState);
+    const prevState = deepFreeze({ [HOME_NARROW_STR]: { older: true, newer: true } });
+    expect(
+      caughtUpReducer(
+        prevState,
+        deepFreeze({ ...eg.action.message_fetch_complete, foundOldest: false, foundNewest: false }),
+      ),
+    ).toEqual({ [HOME_NARROW_STR]: { older: true, newer: true } });
   });
 
   describe('EVENT_UPDATE_MESSAGE', () => {

--- a/src/caughtup/__tests__/caughtUpReducer-test.js
+++ b/src/caughtup/__tests__/caughtUpReducer-test.js
@@ -11,6 +11,7 @@ import {
   SEARCH_NARROW,
   streamNarrow,
   topicNarrow,
+  pm1to1NarrowFromUser,
 } from '../../utils/narrow';
 import { objectFromEntries } from '../../jsBackport';
 
@@ -59,23 +60,24 @@ describe('caughtUpReducer', () => {
       // MESSAGE_FETCH_START applies the identity function to the
       // state (i.e., it doesn't do anything to it). Reversing that
       // effect is also done with the identity function.
-      const initialState = deepFreeze({
-        [HOME_NARROW_STR]: {
-          older: true,
-          newer: true,
-        },
-      });
+
+      const narrow1 = pm1to1NarrowFromUser(eg.otherUser);
+      const narrow2 = pm1to1NarrowFromUser(eg.thirdUser);
+
+      // Include some other narrow to test that the reducer doesn't go mess
+      // something up there.
+      const initialState = deepFreeze({ [keyFromNarrow(narrow1)]: { older: true, newer: true } });
 
       const messageFetchStartAction = deepFreeze({
         ...eg.action.message_fetch_start,
-        narrow: HOME_NARROW,
+        narrow: narrow2,
       });
 
       const state1 = caughtUpReducer(initialState, messageFetchStartAction);
 
       const messageFetchErrorAction = deepFreeze({
         type: MESSAGE_FETCH_ERROR,
-        narrow: HOME_NARROW,
+        narrow: narrow2,
         error: new Error(),
       });
 

--- a/src/caughtup/__tests__/caughtUpReducer-test.js
+++ b/src/caughtup/__tests__/caughtUpReducer-test.js
@@ -16,6 +16,15 @@ import {
 import { objectFromEntries } from '../../jsBackport';
 
 describe('caughtUpReducer', () => {
+  describe('RESET_ACCOUNT_DATA', () => {
+    const initialState = eg.baseReduxState.caughtUp;
+    const action1 = { ...eg.action.message_fetch_complete, foundNewest: true, foundOldest: true };
+    const prevState = caughtUpReducer(initialState, action1);
+    expect(prevState).not.toEqual(initialState);
+
+    expect(caughtUpReducer(prevState, eg.action.reset_account_data)).toEqual(initialState);
+  });
+
   describe('MESSAGE_FETCH_START', () => {
     test('when fetch starts caught up does not change', () => {
       const prevState = deepFreeze({ [HOME_NARROW_STR]: { older: true, newer: true } });

--- a/src/chat/__tests__/fetchingReducer-test.js
+++ b/src/chat/__tests__/fetchingReducer-test.js
@@ -14,6 +14,15 @@ import { MESSAGE_FETCH_START, MESSAGE_FETCH_ERROR } from '../../actionConstants'
 import { DEFAULT_FETCHING } from '../fetchingSelectors';
 
 describe('fetchingReducer', () => {
+  describe('RESET_ACCOUNT_DATA', () => {
+    const initialState = eg.baseReduxState.fetching;
+    const action1 = { type: MESSAGE_FETCH_START, narrow: HOME_NARROW, numBefore: 10, numAfter: 10 };
+    const prevState = fetchingReducer(initialState, action1);
+    expect(prevState).not.toEqual(initialState);
+
+    expect(fetchingReducer(prevState, eg.action.reset_account_data)).toEqual(initialState);
+  });
+
   describe('MESSAGE_FETCH_START', () => {
     test('if messages are fetched before or after the corresponding flag is set', () => {
       const initialState = deepFreeze({

--- a/src/chat/__tests__/narrowsReducer-test.js
+++ b/src/chat/__tests__/narrowsReducer-test.js
@@ -320,23 +320,24 @@ describe('narrowsReducer', () => {
       // MESSAGE_FETCH_START applies the identity function to the
       // state (i.e., it doesn't do anything to it). Reversing that
       // effect is also done with the identity function.
-      const initialState = Immutable.Map({
-        [HOME_NARROW_STR]: {
-          older: true,
-          newer: true,
-        },
-      });
+
+      const narrow1 = pm1to1NarrowFromUser(eg.otherUser);
+      const narrow2 = pm1to1NarrowFromUser(eg.thirdUser);
+
+      // Include some other narrow to test that the reducer doesn't go mess
+      // something up there.
+      const initialState = Immutable.Map([[keyFromNarrow(narrow1), [1, 2]]]);
 
       const messageFetchStartAction = deepFreeze({
         ...eg.action.message_fetch_start,
-        narrow: HOME_NARROW,
+        narrow: narrow2,
       });
 
       const state1 = narrowsReducer(initialState, messageFetchStartAction);
 
       const messageFetchErrorAction = deepFreeze({
         type: MESSAGE_FETCH_ERROR,
-        narrow: HOME_NARROW,
+        narrow: narrow2,
         error: new Error(),
       });
 

--- a/src/chat/__tests__/narrowsReducer-test.js
+++ b/src/chat/__tests__/narrowsReducer-test.js
@@ -33,7 +33,7 @@ describe('narrowsReducer', () => {
 
   describe('EVENT_NEW_MESSAGE', () => {
     test('if not caught up in narrow, do not add message in home narrow', () => {
-      const initialState = Immutable.Map({ [HOME_NARROW_STR]: [1, 2] });
+      const initialState = Immutable.Map([[HOME_NARROW_STR, [1, 2]]]);
 
       const message = eg.streamMessage({ id: 3, flags: [] });
 
@@ -41,13 +41,13 @@ describe('narrowsReducer', () => {
 
       const newState = narrowsReducer(initialState, action);
 
-      const expectedState = Immutable.Map({ [HOME_NARROW_STR]: [1, 2] });
+      const expectedState = Immutable.Map([[HOME_NARROW_STR, [1, 2]]]);
 
       expect(newState).toEqual(expectedState);
     });
 
     test('appends message to state producing a copy of messages', () => {
-      const initialState = Immutable.Map({ [HOME_NARROW_STR]: [1, 2] });
+      const initialState = Immutable.Map([[HOME_NARROW_STR, [1, 2]]]);
 
       const message = eg.streamMessage({ id: 3, flags: [] });
 
@@ -60,9 +60,7 @@ describe('narrowsReducer', () => {
         },
       });
 
-      const expectedState = Immutable.Map({
-        [HOME_NARROW_STR]: [1, 2, 3],
-      });
+      const expectedState = Immutable.Map([[HOME_NARROW_STR, [1, 2, 3]]]);
 
       const newState = narrowsReducer(initialState, action);
 
@@ -71,7 +69,7 @@ describe('narrowsReducer', () => {
     });
 
     test('if new message key does not exist do not create it', () => {
-      const initialState = Immutable.Map({ [topicNarrowStr]: [1, 2] });
+      const initialState = Immutable.Map([[topicNarrowStr, [1, 2]]]);
 
       const message = eg.streamMessage({ id: 3, flags: [], stream: eg.makeStream() });
 
@@ -79,15 +77,13 @@ describe('narrowsReducer', () => {
 
       const newState = narrowsReducer(initialState, action);
 
-      const expectedState = Immutable.Map({
-        [topicNarrowStr]: [1, 2],
-      });
+      const expectedState = Immutable.Map([[topicNarrowStr, [1, 2]]]);
       expect(newState).toEqual(expectedState);
     });
   });
 
   test('if new message is private or group add it to the "allPrivate" narrow', () => {
-    const initialState = Immutable.Map({ [ALL_PRIVATE_NARROW_STR]: [] });
+    const initialState = Immutable.Map([[ALL_PRIVATE_NARROW_STR, []]]);
     const message = eg.pmMessage({
       id: 1,
       recipients: [eg.selfUser, eg.otherUser, eg.thirdUser],
@@ -98,9 +94,7 @@ describe('narrowsReducer', () => {
         [ALL_PRIVATE_NARROW_STR]: { older: true, newer: true },
       },
     });
-    const expectedState = Immutable.Map({
-      [ALL_PRIVATE_NARROW_STR]: [1],
-    });
+    const expectedState = Immutable.Map([[ALL_PRIVATE_NARROW_STR, [1]]]);
 
     const actualState = narrowsReducer(initialState, action);
 
@@ -108,7 +102,10 @@ describe('narrowsReducer', () => {
   });
 
   test('message sent to topic is stored correctly', () => {
-    const initialState = Immutable.Map({ [HOME_NARROW_STR]: [1, 2], [topicNarrowStr]: [2] });
+    const initialState = Immutable.Map([
+      [HOME_NARROW_STR, [1, 2]],
+      [topicNarrowStr, [2]],
+    ]);
 
     const message = eg.streamMessage({ id: 3, flags: [] });
 
@@ -124,10 +121,10 @@ describe('narrowsReducer', () => {
         },
       },
     });
-    const expectedState = Immutable.Map({
-      [HOME_NARROW_STR]: [1, 2],
-      [topicNarrowStr]: [2, message.id],
-    });
+    const expectedState = Immutable.Map([
+      [HOME_NARROW_STR, [1, 2]],
+      [topicNarrowStr, [2, message.id]],
+    ]);
 
     const newState = narrowsReducer(initialState, action);
 
@@ -136,10 +133,10 @@ describe('narrowsReducer', () => {
 
   test('message sent to self is stored correctly', () => {
     const narrowWithSelfStr = keyFromNarrow(pm1to1NarrowFromUser(eg.selfUser));
-    const initialState = Immutable.Map({
-      [HOME_NARROW_STR]: [],
-      [narrowWithSelfStr]: [],
-    });
+    const initialState = Immutable.Map([
+      [HOME_NARROW_STR, []],
+      [narrowWithSelfStr, []],
+    ]);
 
     const message = eg.pmMessage({
       id: 1,
@@ -155,10 +152,10 @@ describe('narrowsReducer', () => {
       },
     });
 
-    const expectedState = Immutable.Map({
-      [HOME_NARROW_STR]: [message.id],
-      [narrowWithSelfStr]: [message.id],
-    });
+    const expectedState = Immutable.Map([
+      [HOME_NARROW_STR, [message.id]],
+      [narrowWithSelfStr, [message.id]],
+    ]);
 
     const newState = narrowsReducer(initialState, action);
 
@@ -167,14 +164,14 @@ describe('narrowsReducer', () => {
   });
 
   test('appends stream message to all cached narrows that match and are caught up', () => {
-    const initialState = Immutable.Map({
-      [HOME_NARROW_STR]: [1, 2],
-      [ALL_PRIVATE_NARROW_STR]: [1, 2],
-      [streamNarrowStr]: [2, 3],
-      [topicNarrowStr]: [2, 3],
-      [privateNarrowStr]: [2, 4],
-      [groupNarrowStr]: [2, 4],
-    });
+    const initialState = Immutable.Map([
+      [HOME_NARROW_STR, [1, 2]],
+      [ALL_PRIVATE_NARROW_STR, [1, 2]],
+      [streamNarrowStr, [2, 3]],
+      [topicNarrowStr, [2, 3]],
+      [privateNarrowStr, [2, 4]],
+      [groupNarrowStr, [2, 4]],
+    ]);
 
     const message = eg.streamMessage({ id: 5, flags: [] });
 
@@ -186,14 +183,14 @@ describe('narrowsReducer', () => {
       },
     });
 
-    const expectedState = Immutable.Map({
-      [HOME_NARROW_STR]: [1, 2, message.id],
-      [ALL_PRIVATE_NARROW_STR]: [1, 2],
-      [streamNarrowStr]: [2, 3, message.id],
-      [topicNarrowStr]: [2, 3, message.id],
-      [privateNarrowStr]: [2, 4],
-      [groupNarrowStr]: [2, 4],
-    });
+    const expectedState = Immutable.Map([
+      [HOME_NARROW_STR, [1, 2, message.id]],
+      [ALL_PRIVATE_NARROW_STR, [1, 2]],
+      [streamNarrowStr, [2, 3, message.id]],
+      [topicNarrowStr, [2, 3, message.id]],
+      [privateNarrowStr, [2, 4]],
+      [groupNarrowStr, [2, 4]],
+    ]);
 
     const newState = narrowsReducer(initialState, action);
 
@@ -202,7 +199,7 @@ describe('narrowsReducer', () => {
   });
 
   test('does not append stream message to not cached narrows', () => {
-    const initialState = Immutable.Map({ [HOME_NARROW_STR]: [1] });
+    const initialState = Immutable.Map([[HOME_NARROW_STR, [1]]]);
 
     const message = eg.streamMessage({ id: 3, flags: [] });
 
@@ -212,9 +209,7 @@ describe('narrowsReducer', () => {
       },
     });
 
-    const expectedState = Immutable.Map({
-      [HOME_NARROW_STR]: [1, message.id],
-    });
+    const expectedState = Immutable.Map([[HOME_NARROW_STR, [1, message.id]]]);
 
     const newState = narrowsReducer(initialState, action);
 
@@ -223,14 +218,14 @@ describe('narrowsReducer', () => {
   });
 
   test('appends private message to multiple cached narrows', () => {
-    const initialState = Immutable.Map({
-      [HOME_NARROW_STR]: [1, 2],
-      [ALL_PRIVATE_NARROW_STR]: [1, 2],
-      [streamNarrowStr]: [2, 3],
-      [topicNarrowStr]: [2, 3],
-      [privateNarrowStr]: [2, 4],
-      [groupNarrowStr]: [2, 4],
-    });
+    const initialState = Immutable.Map([
+      [HOME_NARROW_STR, [1, 2]],
+      [ALL_PRIVATE_NARROW_STR, [1, 2]],
+      [streamNarrowStr, [2, 3]],
+      [topicNarrowStr, [2, 3]],
+      [privateNarrowStr, [2, 4]],
+      [groupNarrowStr, [2, 4]],
+    ]);
 
     const message = eg.pmMessage({
       id: 5,
@@ -243,14 +238,14 @@ describe('narrowsReducer', () => {
       caughtUp: initialState.map(_ => ({ older: false, newer: true })).toObject(),
     });
 
-    const expectedState = Immutable.Map({
-      [HOME_NARROW_STR]: [1, 2, message.id],
-      [ALL_PRIVATE_NARROW_STR]: [1, 2, message.id],
-      [streamNarrowStr]: [2, 3],
-      [topicNarrowStr]: [2, 3],
-      [privateNarrowStr]: [2, 4, message.id],
-      [groupNarrowStr]: [2, 4],
-    });
+    const expectedState = Immutable.Map([
+      [HOME_NARROW_STR, [1, 2, message.id]],
+      [ALL_PRIVATE_NARROW_STR, [1, 2, message.id]],
+      [streamNarrowStr, [2, 3]],
+      [topicNarrowStr, [2, 3]],
+      [privateNarrowStr, [2, 4, message.id]],
+      [groupNarrowStr, [2, 4]],
+    ]);
 
     const newState = narrowsReducer(initialState, action);
 
@@ -260,7 +255,10 @@ describe('narrowsReducer', () => {
 
   describe('EVENT_MESSAGE_DELETE', () => {
     test('if a message does not exist no changes are made', () => {
-      const initialState = Immutable.Map({ [HOME_NARROW_STR]: [1, 2], [privateNarrowStr]: [] });
+      const initialState = Immutable.Map([
+        [HOME_NARROW_STR, [1, 2]],
+        [privateNarrowStr, []],
+      ]);
 
       const action = deepFreeze({
         type: EVENT_MESSAGE_DELETE,
@@ -273,12 +271,18 @@ describe('narrowsReducer', () => {
     });
 
     test('if a message exists in one or more narrows delete it from there', () => {
-      const initialState = Immutable.Map({ [HOME_NARROW_STR]: [1, 2, 3], [privateNarrowStr]: [2] });
+      const initialState = Immutable.Map([
+        [HOME_NARROW_STR, [1, 2, 3]],
+        [privateNarrowStr, [2]],
+      ]);
       const action = deepFreeze({
         type: EVENT_MESSAGE_DELETE,
         messageIds: [2],
       });
-      const expectedState = Immutable.Map({ [HOME_NARROW_STR]: [1, 3], [privateNarrowStr]: [] });
+      const expectedState = Immutable.Map([
+        [HOME_NARROW_STR, [1, 3]],
+        [privateNarrowStr, []],
+      ]);
 
       const newState = narrowsReducer(initialState, action);
 
@@ -286,12 +290,18 @@ describe('narrowsReducer', () => {
     });
 
     test('if multiple messages indicated, delete the ones that exist', () => {
-      const initialState = Immutable.Map({ [HOME_NARROW_STR]: [1, 2, 3], [privateNarrowStr]: [2] });
+      const initialState = Immutable.Map([
+        [HOME_NARROW_STR, [1, 2, 3]],
+        [privateNarrowStr, [2]],
+      ]);
       const action = deepFreeze({
         type: EVENT_MESSAGE_DELETE,
         messageIds: [2, 3, 4],
       });
-      const expectedState = Immutable.Map({ [HOME_NARROW_STR]: [1], [privateNarrowStr]: [] });
+      const expectedState = Immutable.Map([
+        [HOME_NARROW_STR, [1]],
+        [privateNarrowStr, []],
+      ]);
 
       const newState = narrowsReducer(initialState, action);
 
@@ -301,7 +311,7 @@ describe('narrowsReducer', () => {
 
   describe('MESSAGE_FETCH_START', () => {
     test('if fetching for a search narrow, ignore', () => {
-      const initialState = Immutable.Map({ [HOME_NARROW_STR]: [1, 2] });
+      const initialState = Immutable.Map([[HOME_NARROW_STR, [1, 2]]]);
 
       const action = deepFreeze({
         ...eg.action.message_fetch_start,
@@ -349,7 +359,7 @@ describe('narrowsReducer', () => {
 
   describe('MESSAGE_FETCH_COMPLETE', () => {
     test('if no messages returned still create the key in state', () => {
-      const initialState = Immutable.Map({ [HOME_NARROW_STR]: [1, 2, 3] });
+      const initialState = Immutable.Map([[HOME_NARROW_STR, [1, 2, 3]]]);
 
       const action = deepFreeze({
         type: MESSAGE_FETCH_COMPLETE,
@@ -363,10 +373,10 @@ describe('narrowsReducer', () => {
         ownUserId: eg.selfUser.user_id,
       });
 
-      const expectedState = Immutable.Map({
-        [HOME_NARROW_STR]: [1, 2, 3],
-        [keyFromNarrow(pm1to1NarrowFromUser(eg.otherUser))]: [],
-      });
+      const expectedState = Immutable.Map([
+        [HOME_NARROW_STR, [1, 2, 3]],
+        [keyFromNarrow(pm1to1NarrowFromUser(eg.otherUser)), []],
+      ]);
 
       const newState = narrowsReducer(initialState, action);
 
@@ -374,7 +384,7 @@ describe('narrowsReducer', () => {
     });
 
     test('no duplicate messages', () => {
-      const initialState = Immutable.Map({ [HOME_NARROW_STR]: [1, 2, 3] });
+      const initialState = Immutable.Map([[HOME_NARROW_STR, [1, 2, 3]]]);
 
       const action = deepFreeze({
         type: MESSAGE_FETCH_COMPLETE,
@@ -392,9 +402,7 @@ describe('narrowsReducer', () => {
         ownUserId: eg.selfUser.user_id,
       });
 
-      const expectedState = Immutable.Map({
-        [HOME_NARROW_STR]: [1, 2, 3, 4],
-      });
+      const expectedState = Immutable.Map([[HOME_NARROW_STR, [1, 2, 3, 4]]]);
 
       const newState = narrowsReducer(initialState, action);
 
@@ -403,7 +411,7 @@ describe('narrowsReducer', () => {
     });
 
     test('added messages are sorted by id', () => {
-      const initialState = Immutable.Map({ [HOME_NARROW_STR]: [1, 2] });
+      const initialState = Immutable.Map([[HOME_NARROW_STR, [1, 2]]]);
 
       const action = deepFreeze({
         type: MESSAGE_FETCH_COMPLETE,
@@ -420,9 +428,7 @@ describe('narrowsReducer', () => {
         ownUserId: eg.selfUser.user_id,
       });
 
-      const expectedState = Immutable.Map({
-        [HOME_NARROW_STR]: [1, 2, 3, 4],
-      });
+      const expectedState = Immutable.Map([[HOME_NARROW_STR, [1, 2, 3, 4]]]);
 
       const newState = narrowsReducer(initialState, action);
 
@@ -431,7 +437,7 @@ describe('narrowsReducer', () => {
     });
 
     test('when anchor is FIRST_UNREAD_ANCHOR previous messages are replaced', () => {
-      const initialState = Immutable.Map({ [HOME_NARROW_STR]: [1, 2] });
+      const initialState = Immutable.Map([[HOME_NARROW_STR, [1, 2]]]);
 
       const action = deepFreeze({
         anchor: FIRST_UNREAD_ANCHOR,
@@ -448,9 +454,7 @@ describe('narrowsReducer', () => {
         ownUserId: eg.selfUser.user_id,
       });
 
-      const expectedState = Immutable.Map({
-        [HOME_NARROW_STR]: [3, 4],
-      });
+      const expectedState = Immutable.Map([[HOME_NARROW_STR, [3, 4]]]);
 
       const newState = narrowsReducer(initialState, action);
 
@@ -458,7 +462,7 @@ describe('narrowsReducer', () => {
     });
 
     test('when anchor is LAST_MESSAGE_ANCHOR previous messages are replaced', () => {
-      const initialState = Immutable.Map({ [HOME_NARROW_STR]: [1, 2] });
+      const initialState = Immutable.Map([[HOME_NARROW_STR, [1, 2]]]);
 
       const action = deepFreeze({
         anchor: LAST_MESSAGE_ANCHOR,
@@ -475,9 +479,7 @@ describe('narrowsReducer', () => {
         ownUserId: eg.selfUser.user_id,
       });
 
-      const expectedState = Immutable.Map({
-        [HOME_NARROW_STR]: [3, 4],
-      });
+      const expectedState = Immutable.Map([[HOME_NARROW_STR, [3, 4]]]);
 
       const newState = narrowsReducer(initialState, action);
 
@@ -485,7 +487,7 @@ describe('narrowsReducer', () => {
     });
 
     test('if fetched messages are from a search narrow, ignore them', () => {
-      const initialState = Immutable.Map({ [HOME_NARROW_STR]: [1, 2] });
+      const initialState = Immutable.Map([[HOME_NARROW_STR, [1, 2]]]);
 
       const action = deepFreeze({
         ...eg.action.message_fetch_complete,
@@ -575,7 +577,7 @@ describe('narrowsReducer', () => {
     ]);
 
     test('Do nothing if the is:starred narrow has not been fetched', () => {
-      const initialState = Immutable.Map({ [HOME_NARROW_STR]: [1, 2] });
+      const initialState = Immutable.Map([[HOME_NARROW_STR, [1, 2]]]);
 
       const action = deepFreeze({
         type: EVENT_UPDATE_MESSAGE_FLAGS,
@@ -593,7 +595,7 @@ describe('narrowsReducer', () => {
     });
 
     test("Do nothing if action.flag is not 'starred'", () => {
-      const initialState = Immutable.Map({ [STARRED_NARROW_STR]: [1, 2] });
+      const initialState = Immutable.Map([[STARRED_NARROW_STR, [1, 2]]]);
 
       const action = deepFreeze({
         type: EVENT_UPDATE_MESSAGE_FLAGS,
@@ -614,7 +616,7 @@ describe('narrowsReducer', () => {
       'Adds, while maintaining chronological order, '
         + 'newly starred messages to the is:starred narrow',
       () => {
-        const initialState = Immutable.Map({ [STARRED_NARROW_STR]: [1, 3, 5] });
+        const initialState = Immutable.Map([[STARRED_NARROW_STR, [1, 3, 5]]]);
 
         const action = deepFreeze({
           type: EVENT_UPDATE_MESSAGE_FLAGS,
@@ -626,9 +628,7 @@ describe('narrowsReducer', () => {
           messages: [4, 2],
         });
 
-        const expectedState = Immutable.Map({
-          [STARRED_NARROW_STR]: [1, 2, 3, 4, 5],
-        });
+        const expectedState = Immutable.Map([[STARRED_NARROW_STR, [1, 2, 3, 4, 5]]]);
 
         const newState = narrowsReducer(initialState, action);
 
@@ -640,7 +640,7 @@ describe('narrowsReducer', () => {
       'Removes, while maintaining chronological order, '
         + 'newly unstarred messages from the is:starred narrow',
       () => {
-        const initialState = Immutable.Map({ [STARRED_NARROW_STR]: [1, 2, 3, 4, 5] });
+        const initialState = Immutable.Map([[STARRED_NARROW_STR, [1, 2, 3, 4, 5]]]);
 
         const action = deepFreeze({
           type: EVENT_UPDATE_MESSAGE_FLAGS,
@@ -652,9 +652,7 @@ describe('narrowsReducer', () => {
           messages: [4, 2],
         });
 
-        const expectedState = Immutable.Map({
-          [STARRED_NARROW_STR]: [1, 3, 5],
-        });
+        const expectedState = Immutable.Map([[STARRED_NARROW_STR, [1, 3, 5]]]);
 
         const newState = narrowsReducer(initialState, action);
 

--- a/src/chat/__tests__/narrowsReducer-test.js
+++ b/src/chat/__tests__/narrowsReducer-test.js
@@ -17,7 +17,6 @@ import {
 } from '../../utils/narrow';
 import {
   MESSAGE_FETCH_ERROR,
-  MESSAGE_FETCH_COMPLETE,
   EVENT_MESSAGE_DELETE,
   EVENT_UPDATE_MESSAGE_FLAGS,
 } from '../../actionConstants';
@@ -361,17 +360,11 @@ describe('narrowsReducer', () => {
     test('if no messages returned still create the key in state', () => {
       const initialState = Immutable.Map([[HOME_NARROW_STR, [1, 2, 3]]]);
 
-      const action = deepFreeze({
-        type: MESSAGE_FETCH_COMPLETE,
-        anchor: 2,
+      const action = {
+        ...eg.action.message_fetch_complete,
         narrow: pm1to1NarrowFromUser(eg.otherUser),
         messages: [],
-        numBefore: 100,
-        numAfter: 100,
-        foundNewest: false,
-        foundOldest: false,
-        ownUserId: eg.selfUser.user_id,
-      });
+      };
 
       const expectedState = Immutable.Map([
         [HOME_NARROW_STR, [1, 2, 3]],
@@ -386,21 +379,16 @@ describe('narrowsReducer', () => {
     test('no duplicate messages', () => {
       const initialState = Immutable.Map([[HOME_NARROW_STR, [1, 2, 3]]]);
 
-      const action = deepFreeze({
-        type: MESSAGE_FETCH_COMPLETE,
-        anchor: 2,
+      const action = {
+        ...eg.action.message_fetch_complete,
         narrow: HOME_NARROW,
+        anchor: 2,
         messages: [
           eg.streamMessage({ id: 2 }),
           eg.streamMessage({ id: 3 }),
           eg.streamMessage({ id: 4 }),
         ],
-        numBefore: 100,
-        numAfter: 100,
-        foundNewest: false,
-        foundOldest: false,
-        ownUserId: eg.selfUser.user_id,
-      });
+      };
 
       const expectedState = Immutable.Map([[HOME_NARROW_STR, [1, 2, 3, 4]]]);
 
@@ -413,20 +401,15 @@ describe('narrowsReducer', () => {
     test('added messages are sorted by id', () => {
       const initialState = Immutable.Map([[HOME_NARROW_STR, [1, 2]]]);
 
-      const action = deepFreeze({
-        type: MESSAGE_FETCH_COMPLETE,
-        anchor: 2,
+      const action = {
+        ...eg.action.message_fetch_complete,
         narrow: HOME_NARROW,
+        anchor: 2,
         messages: [
           eg.streamMessage({ id: 3, timestamp: 2 }),
           eg.streamMessage({ id: 4, timestamp: 1 }),
         ],
-        numBefore: 100,
-        numAfter: 100,
-        foundNewest: false,
-        foundOldest: false,
-        ownUserId: eg.selfUser.user_id,
-      });
+      };
 
       const expectedState = Immutable.Map([[HOME_NARROW_STR, [1, 2, 3, 4]]]);
 
@@ -439,20 +422,15 @@ describe('narrowsReducer', () => {
     test('when anchor is FIRST_UNREAD_ANCHOR previous messages are replaced', () => {
       const initialState = Immutable.Map([[HOME_NARROW_STR, [1, 2]]]);
 
-      const action = deepFreeze({
-        anchor: FIRST_UNREAD_ANCHOR,
-        type: MESSAGE_FETCH_COMPLETE,
+      const action = {
+        ...eg.action.message_fetch_complete,
         narrow: HOME_NARROW,
+        anchor: FIRST_UNREAD_ANCHOR,
         messages: [
           eg.streamMessage({ id: 3, timestamp: 2 }),
           eg.streamMessage({ id: 4, timestamp: 1 }),
         ],
-        numBefore: 100,
-        numAfter: 100,
-        foundNewest: false,
-        foundOldest: false,
-        ownUserId: eg.selfUser.user_id,
-      });
+      };
 
       const expectedState = Immutable.Map([[HOME_NARROW_STR, [3, 4]]]);
 
@@ -464,20 +442,15 @@ describe('narrowsReducer', () => {
     test('when anchor is LAST_MESSAGE_ANCHOR previous messages are replaced', () => {
       const initialState = Immutable.Map([[HOME_NARROW_STR, [1, 2]]]);
 
-      const action = deepFreeze({
-        anchor: LAST_MESSAGE_ANCHOR,
-        type: MESSAGE_FETCH_COMPLETE,
+      const action = {
+        ...eg.action.message_fetch_complete,
         narrow: HOME_NARROW,
+        anchor: LAST_MESSAGE_ANCHOR,
         messages: [
           eg.streamMessage({ id: 3, timestamp: 2 }),
           eg.streamMessage({ id: 4, timestamp: 1 }),
         ],
-        numBefore: 100,
-        numAfter: 0,
-        foundNewest: true,
-        foundOldest: false,
-        ownUserId: eg.selfUser.user_id,
-      });
+      };
 
       const expectedState = Immutable.Map([[HOME_NARROW_STR, [3, 4]]]);
 
@@ -489,10 +462,7 @@ describe('narrowsReducer', () => {
     test('if fetched messages are from a search narrow, ignore them', () => {
       const initialState = Immutable.Map([[HOME_NARROW_STR, [1, 2]]]);
 
-      const action = deepFreeze({
-        ...eg.action.message_fetch_complete,
-        narrow: SEARCH_NARROW('some query'),
-      });
+      const action = { ...eg.action.message_fetch_complete, narrow: SEARCH_NARROW('some query') };
 
       const newState = narrowsReducer(initialState, action);
 

--- a/src/chat/__tests__/narrowsReducer-test.js
+++ b/src/chat/__tests__/narrowsReducer-test.js
@@ -30,6 +30,15 @@ describe('narrowsReducer', () => {
   const egTopic = eg.streamMessage().subject;
   const topicNarrowStr = keyFromNarrow(topicNarrow(eg.stream.stream_id, egTopic));
 
+  describe('RESET_ACCOUNT_DATA', () => {
+    const initialState = eg.baseReduxState.narrows;
+    const action1 = { ...eg.action.message_fetch_complete, messages: [eg.streamMessage()] };
+    const prevState = narrowsReducer(initialState, action1);
+    expect(prevState).not.toEqual(initialState);
+
+    expect(narrowsReducer(prevState, eg.action.reset_account_data)).toEqual(initialState);
+  });
+
   describe('EVENT_NEW_MESSAGE', () => {
     test('if not caught up in narrow, do not add message in home narrow', () => {
       const message = eg.streamMessage({ id: 3, flags: [] });

--- a/src/chat/__tests__/narrowsSelectors-test.js
+++ b/src/chat/__tests__/narrowsSelectors-test.js
@@ -31,9 +31,7 @@ describe('getMessagesForNarrow', () => {
 
   test('if no outbox messages returns messages with no change', () => {
     const state = eg.reduxState({
-      narrows: Immutable.Map({
-        [HOME_NARROW_STR]: [123],
-      }),
+      narrows: Immutable.Map([[HOME_NARROW_STR, [123]]]),
       messages,
       outbox: [],
       users: [eg.selfUser],
@@ -47,9 +45,7 @@ describe('getMessagesForNarrow', () => {
 
   test('combine messages and outbox in same narrow', () => {
     const state = eg.reduxState({
-      narrows: Immutable.Map({
-        [HOME_NARROW_STR]: [123],
-      }),
+      narrows: Immutable.Map([[HOME_NARROW_STR, [123]]]),
       messages,
       outbox: [outboxMessage],
       caughtUp: {
@@ -66,9 +62,7 @@ describe('getMessagesForNarrow', () => {
 
   test('do not combine messages and outbox if not caught up', () => {
     const state = eg.reduxState({
-      narrows: Immutable.Map({
-        [HOME_NARROW_STR]: [123],
-      }),
+      narrows: Immutable.Map([[HOME_NARROW_STR, [123]]]),
       messages,
       outbox: [outboxMessage],
       users: [eg.selfUser],
@@ -82,9 +76,7 @@ describe('getMessagesForNarrow', () => {
 
   test('do not combine messages and outbox in different narrow', () => {
     const state = eg.reduxState({
-      narrows: Immutable.Map({
-        [keyFromNarrow(pm1to1NarrowFromUser(eg.otherUser))]: [123],
-      }),
+      narrows: Immutable.Map([[keyFromNarrow(pm1to1NarrowFromUser(eg.otherUser)), [123]]]),
       messages,
       outbox: [outboxMessage],
       users: [eg.selfUser],
@@ -229,9 +221,7 @@ describe('getShownMessagesForNarrow', () => {
 describe('getFirstMessageId', () => {
   test('return undefined when there are no messages', () => {
     const state = eg.reduxState({
-      narrows: Immutable.Map({
-        [HOME_NARROW_STR]: [],
-      }),
+      narrows: Immutable.Map([[HOME_NARROW_STR, []]]),
       outbox: [],
     });
 
@@ -242,9 +232,7 @@ describe('getFirstMessageId', () => {
 
   test('returns first message id', () => {
     const state = eg.reduxState({
-      narrows: Immutable.Map({
-        [HOME_NARROW_STR]: [1, 2, 3],
-      }),
+      narrows: Immutable.Map([[HOME_NARROW_STR, [1, 2, 3]]]),
       messages: eg.makeMessagesState([
         eg.streamMessage({ id: 1 }),
         eg.streamMessage({ id: 2 }),
@@ -262,9 +250,7 @@ describe('getFirstMessageId', () => {
 describe('getLastMessageId', () => {
   test('return undefined when there are no messages', () => {
     const state = eg.reduxState({
-      narrows: Immutable.Map({
-        [HOME_NARROW_STR]: [],
-      }),
+      narrows: Immutable.Map([[HOME_NARROW_STR, []]]),
       messages: eg.makeMessagesState([]),
       outbox: [],
     });
@@ -276,9 +262,7 @@ describe('getLastMessageId', () => {
 
   test('returns last message id', () => {
     const state = eg.reduxState({
-      narrows: Immutable.Map({
-        [HOME_NARROW_STR]: [1, 2, 3],
-      }),
+      narrows: Immutable.Map([[HOME_NARROW_STR, [1, 2, 3]]]),
       messages: eg.makeMessagesState([
         eg.streamMessage({ id: 1 }),
         eg.streamMessage({ id: 2 }),

--- a/src/drafts/__tests__/draftsReducer-test.js
+++ b/src/drafts/__tests__/draftsReducer-test.js
@@ -1,4 +1,4 @@
-// @flow strict-local
+/* @flow strict-local */
 import deepFreeze from 'deep-freeze';
 
 import { NULL_OBJECT } from '../../nullObjects';
@@ -13,87 +13,47 @@ describe('draftsReducer', () => {
 
   describe('DRAFT_UPDATE', () => {
     test('add a new draft key drafts', () => {
-      const initialState = NULL_OBJECT;
-
-      const action = deepFreeze({
-        type: DRAFT_UPDATE,
-        content: 'Hello',
-        narrow: testNarrow,
-      });
-
-      const expectedState = {
-        [testNarrowStr]: 'Hello',
-      };
-
-      const actualState = draftsReducer(initialState, action);
-
-      expect(actualState).toEqual(expectedState);
+      const prevState = NULL_OBJECT;
+      expect(
+        draftsReducer(
+          prevState,
+          deepFreeze({ type: DRAFT_UPDATE, content: 'Hello', narrow: testNarrow }),
+        ),
+      ).toEqual({ [testNarrowStr]: 'Hello' });
     });
 
     test('adding the same draft to drafts does not mutate the state', () => {
-      const initialState = deepFreeze({
-        [testNarrowStr]: 'Hello',
-      });
-
-      const action = deepFreeze({
-        type: DRAFT_UPDATE,
-        content: 'Hello',
-        narrow: testNarrow,
-      });
-
-      const actualState = draftsReducer(initialState, action);
-
-      expect(actualState).toBe(initialState);
+      const prevState = deepFreeze({ [testNarrowStr]: 'Hello' });
+      expect(
+        draftsReducer(
+          prevState,
+          deepFreeze({ type: DRAFT_UPDATE, content: 'Hello', narrow: testNarrow }),
+        ),
+      ).toBe(prevState);
     });
 
     test('when content is empty remove draft from state', () => {
-      const initialState = deepFreeze({
-        [testNarrowStr]: 'Hello',
-      });
-
-      const action = {
-        type: DRAFT_UPDATE,
-        content: '',
-        narrow: testNarrow,
-      };
-
-      const expectedState = {};
-
-      const actualState = draftsReducer(initialState, action);
-
-      expect(actualState).toEqual(expectedState);
+      const prevState = deepFreeze({ [testNarrowStr]: 'Hello' });
+      expect(
+        draftsReducer(prevState, { type: DRAFT_UPDATE, content: '', narrow: testNarrow }),
+      ).toEqual({});
     });
 
     test('remove draft when content is white space', () => {
-      const initialState = deepFreeze({
-        [testNarrowStr]: 'Hello',
-      });
-
-      const action = {
-        type: DRAFT_UPDATE,
-        content: '   ',
-        narrow: testNarrow,
-      };
-
-      const expectedState = {};
-
-      const actualState = draftsReducer(initialState, action);
-
-      expect(actualState).toEqual(expectedState);
+      const prevState = deepFreeze({ [testNarrowStr]: 'Hello' });
+      expect(
+        draftsReducer(prevState, { type: DRAFT_UPDATE, content: '   ', narrow: testNarrow }),
+      ).toEqual({});
     });
 
     test('do not mutate state if there is nothing to remove', () => {
-      const initialState = NULL_OBJECT;
-
-      const action = deepFreeze({
-        type: DRAFT_UPDATE,
-        content: '',
-        narrow: testNarrow,
-      });
-
-      const actualState = draftsReducer(initialState, action);
-
-      expect(actualState).toBe(initialState);
+      const prevState = NULL_OBJECT;
+      expect(
+        draftsReducer(
+          prevState,
+          deepFreeze({ type: DRAFT_UPDATE, content: '', narrow: testNarrow }),
+        ),
+      ).toBe(prevState);
     });
   });
 });

--- a/src/drafts/__tests__/draftsReducer-test.js
+++ b/src/drafts/__tests__/draftsReducer-test.js
@@ -11,6 +11,15 @@ describe('draftsReducer', () => {
   const testNarrow = topicNarrow(eg.stream.stream_id, 'denmark2');
   const testNarrowStr = keyFromNarrow(testNarrow);
 
+  describe('RESET_ACCOUNT_DATA', () => {
+    const initialState = eg.baseReduxState.drafts;
+    const action1 = { type: DRAFT_UPDATE, content: 'Hello', narrow: testNarrow };
+    const prevState = draftsReducer(initialState, action1);
+    expect(prevState).not.toEqual(initialState);
+
+    expect(draftsReducer(prevState, eg.action.reset_account_data)).toEqual(initialState);
+  });
+
   describe('DRAFT_UPDATE', () => {
     test('add a new draft key drafts', () => {
       const prevState = NULL_OBJECT;

--- a/src/message/__tests__/fetchActions-test.js
+++ b/src/message/__tests__/fetchActions-test.js
@@ -53,9 +53,7 @@ describe('fetchActions', () => {
             older: true,
           },
         },
-        narrows: Immutable.Map({
-          [streamNarrowStr]: [],
-        }),
+        narrows: Immutable.Map([[streamNarrowStr, []]]),
         streams: [eg.stream],
       });
 
@@ -75,9 +73,7 @@ describe('fetchActions', () => {
             older: false,
           },
         },
-        narrows: Immutable.Map({
-          [streamNarrowStr]: [1],
-        }),
+        narrows: Immutable.Map([[streamNarrowStr, [1]]]),
         messages: eg.makeMessagesState([message1, message2]),
         streams: [eg.stream],
       });
@@ -251,9 +247,7 @@ describe('fetchActions', () => {
     };
 
     const baseState = eg.reduxStatePlus({
-      narrows: Immutable.Map({
-        [streamNarrowStr]: [message1.id],
-      }),
+      narrows: Immutable.Map([[streamNarrowStr, [message1.id]]]),
       realm: {
         ...eg.plusReduxState.realm,
         allowEditHistory: true, // TODO: test with this `false`
@@ -424,9 +418,7 @@ describe('fetchActions', () => {
     test('when messages to be fetched both before and after anchor, numBefore and numAfter are greater than zero', async () => {
       const store = mockStore<GlobalState, Action>(
         eg.reduxStatePlus({
-          narrows: Immutable.Map({
-            [streamNarrowStr]: [1],
-          }),
+          narrows: Immutable.Map([[streamNarrowStr, [1]]]),
         }),
       );
 
@@ -449,9 +441,7 @@ describe('fetchActions', () => {
     test('when no messages to be fetched before the anchor, numBefore is not greater than zero', async () => {
       const store = mockStore<GlobalState, Action>(
         eg.reduxStatePlus({
-          narrows: Immutable.Map({
-            [streamNarrowStr]: [1],
-          }),
+          narrows: Immutable.Map([[streamNarrowStr, [1]]]),
         }),
       );
 
@@ -473,9 +463,7 @@ describe('fetchActions', () => {
     test('when no messages to be fetched after the anchor, numAfter is not greater than zero', async () => {
       const store = mockStore<GlobalState, Action>(
         eg.reduxStatePlus({
-          narrows: Immutable.Map({
-            [streamNarrowStr]: [1],
-          }),
+          narrows: Immutable.Map([[streamNarrowStr, [1]]]),
         }),
       );
 
@@ -501,10 +489,10 @@ describe('fetchActions', () => {
 
     const baseState = eg.reduxStatePlus({
       narrows: eg.plusReduxState.narrows.merge(
-        Immutable.Map({
-          [streamNarrowStr]: [message2.id],
-          [HOME_NARROW_STR]: [message1.id, message2.id],
-        }),
+        Immutable.Map([
+          [streamNarrowStr, [message2.id]],
+          [HOME_NARROW_STR, [message1.id, message2.id]],
+        ]),
       ),
       messages: eg.makeMessagesState([message1, message2]),
     });
@@ -594,10 +582,10 @@ describe('fetchActions', () => {
 
     const baseState = eg.reduxStatePlus({
       narrows: eg.plusReduxState.narrows.merge(
-        Immutable.Map({
-          [streamNarrowStr]: [message2.id],
-          [HOME_NARROW_STR]: [message1.id, message2.id],
-        }),
+        Immutable.Map([
+          [streamNarrowStr, [message2.id]],
+          [HOME_NARROW_STR, [message1.id, message2.id]],
+        ]),
       ),
       messages: eg.makeMessagesState([message1, message2]),
     });

--- a/src/message/__tests__/messagesReducer-test.js
+++ b/src/message/__tests__/messagesReducer-test.js
@@ -17,6 +17,16 @@ import { makeUserId } from '../../api/idTypes';
 import { randString } from '../../utils/misc';
 
 describe('messagesReducer', () => {
+  test('RESET_ACCOUNT_DATA', () => {
+    expect(
+      messagesReducer(
+        eg.makeMessagesState([eg.streamMessage()]),
+        eg.action.reset_account_data,
+        eg.baseReduxState,
+      ),
+    ).toEqual(eg.baseReduxState.messages);
+  });
+
   describe('EVENT_NEW_MESSAGE', () => {
     test('appends message to state, if any narrow is caught up to newest', () => {
       const message1 = eg.streamMessage();

--- a/src/outbox/__tests__/outboxReducer-test.js
+++ b/src/outbox/__tests__/outboxReducer-test.js
@@ -1,4 +1,4 @@
-// @flow strict-local
+/* @flow strict-local */
 import deepFreeze from 'deep-freeze';
 
 import outboxReducer from '../outboxReducer';
@@ -12,15 +12,9 @@ describe('outboxReducer', () => {
       const message1 = eg.streamOutbox({ content: 'New one' });
       const message2 = eg.streamOutbox({ content: 'Another one' });
       const message3 = eg.streamOutbox({ content: 'Message already sent', isSent: true });
-      const initialState = deepFreeze([message1, message2, message3]);
 
-      const action = eg.action.register_complete;
-
-      const expectedState = [message1, message2];
-
-      const actualState = outboxReducer(initialState, action);
-
-      expect(actualState).toEqual(expectedState);
+      const prevState = deepFreeze([message1, message2, message3]);
+      expect(outboxReducer(prevState, eg.action.register_complete)).toEqual([message1, message2]);
     });
   });
 
@@ -28,80 +22,61 @@ describe('outboxReducer', () => {
     test('add a new message to the outbox', () => {
       const message = eg.streamOutbox({ content: 'New one' });
 
-      const initialState = deepFreeze([]);
-
-      const action = deepFreeze({
-        type: MESSAGE_SEND_START,
-        outbox: message,
-      });
-
-      const expectedState = [message];
-
-      const actualState = outboxReducer(initialState, action);
-
-      expect(actualState).toEqual(expectedState);
+      const prevState = deepFreeze([]);
+      expect(
+        outboxReducer(prevState, deepFreeze({ type: MESSAGE_SEND_START, outbox: message })),
+      ).toEqual([message]);
     });
 
     test('do not add a message with a duplicate timestamp to the outbox', () => {
       const message1 = eg.streamOutbox({ content: 'hello', timestamp: 123 });
       const message2 = eg.streamOutbox({ content: 'hello twice', timestamp: 123 });
 
-      const initialState = deepFreeze([message1]);
-
-      const action = deepFreeze({
-        type: MESSAGE_SEND_START,
-        outbox: message2,
-      });
-
-      const actualState = outboxReducer(initialState, action);
-
-      expect(actualState).toBe(initialState);
+      const prevState = deepFreeze([message1]);
+      expect(
+        outboxReducer(prevState, deepFreeze({ type: MESSAGE_SEND_START, outbox: message2 })),
+      ).toBe(prevState);
     });
   });
 
   describe('EVENT_NEW_MESSAGE', () => {
     test('do not mutate state if a message is not removed', () => {
-      const initialState = deepFreeze([eg.streamOutbox({ timestamp: 546 })]);
-
       const message = eg.streamMessage({ timestamp: 123 });
 
-      const action = eg.mkActionEventNewMessage(message, {
-        local_message_id: message.timestamp,
-      });
-
-      const actualState = outboxReducer(initialState, action);
-      expect(actualState).toBe(initialState);
+      const prevState = deepFreeze([eg.streamOutbox({ timestamp: 546 })]);
+      expect(
+        outboxReducer(
+          prevState,
+          eg.mkActionEventNewMessage(message, { local_message_id: message.timestamp }),
+        ),
+      ).toBe(prevState);
     });
 
     test('remove message if local_message_id matches', () => {
       const message1 = eg.streamOutbox({ timestamp: 546 });
       const message2 = eg.streamOutbox({ timestamp: 150238512430 });
       const message3 = eg.streamOutbox({ timestamp: 150238594540 });
-      const initialState = deepFreeze([message1, message2, message3]);
 
-      const action = eg.mkActionEventNewMessage(eg.streamMessage(), {
-        local_message_id: 546,
-      });
-
-      const expectedState = [message2, message3];
-
-      const actualState = outboxReducer(initialState, action);
-
-      expect(actualState).toEqual(expectedState);
+      const prevState = deepFreeze([message1, message2, message3]);
+      expect(
+        outboxReducer(
+          prevState,
+          eg.mkActionEventNewMessage(eg.streamMessage(), { local_message_id: 546 }),
+        ),
+      ).toEqual([message2, message3]);
     });
 
     test("remove nothing if local_message_id doesn't match", () => {
       const message1 = eg.streamOutbox({ timestamp: 546 });
       const message2 = eg.streamOutbox({ timestamp: 150238512430 });
       const message3 = eg.streamOutbox({ timestamp: 150238594540 });
-      const initialState = deepFreeze([message1, message2, message3]);
 
-      const action = eg.mkActionEventNewMessage(eg.streamMessage(), {
-        local_message_id: 15023859,
-      });
-
-      const actualState = outboxReducer(initialState, action);
-      expect(actualState).toBe(initialState);
+      const prevState = deepFreeze([message1, message2, message3]);
+      const actualState = outboxReducer(
+        prevState,
+        eg.mkActionEventNewMessage(eg.streamMessage(), { local_message_id: 15023859 }),
+      );
+      expect(actualState).toBe(prevState);
     });
   });
 });

--- a/src/outbox/__tests__/outboxReducer-test.js
+++ b/src/outbox/__tests__/outboxReducer-test.js
@@ -7,6 +7,15 @@ import { MESSAGE_SEND_START } from '../../actionConstants';
 import * as eg from '../../__tests__/lib/exampleData';
 
 describe('outboxReducer', () => {
+  describe('RESET_ACCOUNT_DATA', () => {
+    const initialState = eg.baseReduxState.outbox;
+    const action1 = { type: MESSAGE_SEND_START, outbox: eg.streamOutbox({}) };
+    const prevState = outboxReducer(initialState, action1);
+    expect(prevState).not.toEqual(initialState);
+
+    expect(outboxReducer(prevState, eg.action.reset_account_data)).toEqual(initialState);
+  });
+
   describe('REGISTER_COMPLETE', () => {
     test('filters out isSent', () => {
       const message1 = eg.streamOutbox({ content: 'New one' });

--- a/src/pm-conversations/__tests__/pmConversationsModel-test.js
+++ b/src/pm-conversations/__tests__/pmConversationsModel-test.js
@@ -23,6 +23,10 @@ describe('reducer', () => {
   const someKey = keyOfExactUsers([eg.makeUser().user_id]);
   const someState = { map: Immutable.Map([[someKey, 123]]), sorted: Immutable.List([someKey]) };
 
+  test('RESET_ACCOUNT_DATA', () => {
+    expect(reducer(someState, eg.action.reset_account_data)).toEqual(initialState);
+  });
+
   describe('REGISTER_COMPLETE', () => {
     test('no data (old server)', () => {
       /* eslint-disable-next-line no-unused-vars */

--- a/src/pm-conversations/__tests__/pmConversationsSelectors-test.js
+++ b/src/pm-conversations/__tests__/pmConversationsSelectors-test.js
@@ -72,9 +72,7 @@ describe('getRecentConversationsLegacy', () => {
       accounts,
       realm: eg.realmState({ user_id: eg.selfUser.user_id }),
       users: [eg.selfUser],
-      narrows: Immutable.Map({
-        [ALL_PRIVATE_NARROW_STR]: [],
-      }),
+      narrows: Immutable.Map([[ALL_PRIVATE_NARROW_STR, []]]),
       unread: {
         ...eg.baseReduxState.unread,
         pms: [],
@@ -92,9 +90,7 @@ describe('getRecentConversationsLegacy', () => {
       accounts,
       realm: eg.realmState({ user_id: eg.selfUser.user_id }),
       users: [eg.selfUser, userJohn, userMark],
-      narrows: Immutable.Map({
-        [ALL_PRIVATE_NARROW_STR]: [0, 1, 2, 3, 4],
-      }),
+      narrows: Immutable.Map([[ALL_PRIVATE_NARROW_STR, [0, 1, 2, 3, 4]]]),
       messages: eg.makeMessagesState([
         eg.pmMessageFromTo(userJohn, [eg.selfUser], { id: 1 }),
         eg.pmMessageFromTo(userMark, [eg.selfUser], { id: 2 }),
@@ -140,9 +136,7 @@ describe('getRecentConversationsLegacy', () => {
       accounts,
       realm: eg.realmState({ user_id: eg.selfUser.user_id }),
       users: [eg.selfUser, userJohn, userMark],
-      narrows: Immutable.Map({
-        [ALL_PRIVATE_NARROW_STR]: [1, 2, 3, 4, 5, 6],
-      }),
+      narrows: Immutable.Map([[ALL_PRIVATE_NARROW_STR, [1, 2, 3, 4, 5, 6]]]),
       messages: eg.makeMessagesState([
         eg.pmMessageFromTo(userJohn, [eg.selfUser], { id: 2 }),
         eg.pmMessageFromTo(userMark, [eg.selfUser], { id: 1 }),

--- a/src/session/__tests__/sessionReducer-test.js
+++ b/src/session/__tests__/sessionReducer-test.js
@@ -13,7 +13,7 @@ import {
   DISMISS_SERVER_COMPAT_NOTICE,
   REGISTER_START,
 } from '../../actionConstants';
-import sessionReducer from '../sessionReducer';
+import sessionReducer, { initialPerAccountSessionState } from '../sessionReducer';
 import * as eg from '../../__tests__/lib/exampleData';
 
 describe('sessionReducer', () => {
@@ -25,12 +25,12 @@ describe('sessionReducer', () => {
       loading: true,
     });
     const newState = sessionReducer(state, eg.action.account_switch);
-    expect(newState).toEqual({ ...baseState, loading: false });
+    expect(newState).toEqual({ ...baseState, ...initialPerAccountSessionState });
   });
 
   test('LOGIN_SUCCESS', () => {
     const newState = sessionReducer(baseState, eg.action.login_success);
-    expect(newState).toEqual(baseState);
+    expect(newState).toEqual({ ...baseState, ...initialPerAccountSessionState });
   });
 
   test('DEAD_QUEUE', () => {
@@ -47,7 +47,7 @@ describe('sessionReducer', () => {
     const newState = sessionReducer(state, deepFreeze({ type: LOGOUT }));
     expect(newState).toEqual({
       ...baseState,
-      loading: false,
+      ...initialPerAccountSessionState,
     });
   });
 

--- a/src/session/__tests__/sessionReducer-test.js
+++ b/src/session/__tests__/sessionReducer-test.js
@@ -3,7 +3,6 @@ import deepFreeze from 'deep-freeze';
 
 import {
   DEAD_QUEUE,
-  LOGOUT,
   APP_ONLINE,
   REGISTER_ABORT,
   APP_ORIENTATION,
@@ -19,36 +18,28 @@ import * as eg from '../../__tests__/lib/exampleData';
 describe('sessionReducer', () => {
   const baseState = eg.baseReduxState.session;
 
-  test('ACCOUNT_SWITCH', () => {
-    const state = deepFreeze({
-      ...baseState,
-      loading: true,
-    });
-    const newState = sessionReducer(state, eg.action.account_switch);
-    expect(newState).toEqual({ ...baseState, ...initialPerAccountSessionState });
-  });
+  describe('RESET_ACCOUNT_DATA', () => {
+    test('resets per-account state without touching global state', () => {
+      const prevState = [
+        // per-account
+        eg.action.register_complete,
+        { type: DISMISS_SERVER_COMPAT_NOTICE },
 
-  test('LOGIN_SUCCESS', () => {
-    const newState = sessionReducer(baseState, eg.action.login_success);
-    expect(newState).toEqual({ ...baseState, ...initialPerAccountSessionState });
+        // global
+        { type: GOT_PUSH_TOKEN, pushToken: '456' },
+        { type: APP_ORIENTATION, orientation: 'LANDSCAPE' },
+      ].reduce(sessionReducer, eg.baseReduxState.session);
+      expect(sessionReducer(prevState, eg.action.reset_account_data)).toEqual({
+        ...prevState,
+        ...initialPerAccountSessionState,
+      });
+    });
   });
 
   test('DEAD_QUEUE', () => {
     const state = deepFreeze({ ...baseState, loading: true });
     const newState = sessionReducer(state, deepFreeze({ type: DEAD_QUEUE }));
     expect(newState).toEqual({ ...baseState, loading: false });
-  });
-
-  test('LOGOUT', () => {
-    const state = deepFreeze({
-      ...baseState,
-      loading: true,
-    });
-    const newState = sessionReducer(state, deepFreeze({ type: LOGOUT }));
-    expect(newState).toEqual({
-      ...baseState,
-      ...initialPerAccountSessionState,
-    });
   });
 
   test('REGISTER_COMPLETE', () => {

--- a/src/session/sessionReducer.js
+++ b/src/session/sessionReducer.js
@@ -3,9 +3,8 @@ import type { Debug, Orientation, Action } from '../types';
 import {
   REHYDRATE,
   DEAD_QUEUE,
-  LOGIN_SUCCESS,
+  RESET_ACCOUNT_DATA,
   APP_ONLINE,
-  ACCOUNT_SWITCH,
   REGISTER_START,
   REGISTER_ABORT,
   REGISTER_COMPLETE,
@@ -13,7 +12,6 @@ import {
   TOGGLE_OUTBOX_SENDING,
   DEBUG_FLAG_TOGGLE,
   GOT_PUSH_TOKEN,
-  LOGOUT,
   DISMISS_SERVER_COMPAT_NOTICE,
 } from '../actionConstants';
 
@@ -154,41 +152,15 @@ export default (state: SessionState = initialState, action: Action): SessionStat
         eventQueueId: null,
       };
 
-    case LOGIN_SUCCESS:
+    case RESET_ACCOUNT_DATA:
       return {
         ...state,
-        loading: false,
-        outboxSending: false,
-        hasDismissedServerCompatNotice: false,
 
-        // We're about to request a new event queue; no use hanging on to
-        // any old one we might have.
-        eventQueueId: null,
-      };
-
-    case LOGOUT:
-      return {
-        ...state,
-        loading: false,
-        outboxSending: false,
-        hasDismissedServerCompatNotice: false,
-
-        // Stop polling this event queue.
-        eventQueueId: null,
-      };
-
-    case ACCOUNT_SWITCH:
-      return {
-        ...state,
-        loading: false,
-        outboxSending: false,
-        hasDismissedServerCompatNotice: false,
-
-        // Stop polling this event queue.  (We'll request a new one soon,
-        // for the new account.)
-        // TODO(#5005): Keep polling on accounts other than the active
-        //   account.
-        eventQueueId: null,
+        // Clear per-account session state. Importantly, stop polling on the
+        // account's current event queue if we had one. In the polling loop,
+        // after each server response, we check if we've dropped the queue
+        // ID from this state and break out if so.
+        ...initialPerAccountSessionState,
       };
 
     case REHYDRATE:

--- a/src/session/sessionReducer.js
+++ b/src/session/sessionReducer.js
@@ -117,20 +117,28 @@ export type SessionState = $ReadOnly<{|
 // PerAccountSessionState is inexact.)
 (s: SessionState): PerAccountSessionState => s; // eslint-disable-line no-unused-expressions
 
-const initialState: SessionState = {
-  eventQueueId: null,
-
+const initialGlobalSessionState: $Exact<GlobalSessionState> = {
   // This will be `null` on startup, while we wait to hear `true` or `false`
   // from the native module over the RN bridge; so, have it start as `null`.
   isOnline: null,
 
   isHydrated: false,
-  loading: false,
   orientation: 'PORTRAIT',
-  outboxSending: false,
   pushToken: null,
   debug: Object.freeze({}),
+};
+
+/** PRIVATE; exported only for tests. */
+export const initialPerAccountSessionState: $Exact<PerAccountSessionState> = {
+  eventQueueId: null,
+  loading: false,
+  outboxSending: false,
   hasDismissedServerCompatNotice: false,
+};
+
+const initialState: SessionState = {
+  ...initialGlobalSessionState,
+  ...initialPerAccountSessionState,
 };
 
 // eslint-disable-next-line default-param-last
@@ -149,6 +157,9 @@ export default (state: SessionState = initialState, action: Action): SessionStat
     case LOGIN_SUCCESS:
       return {
         ...state,
+        loading: false,
+        outboxSending: false,
+        hasDismissedServerCompatNotice: false,
 
         // We're about to request a new event queue; no use hanging on to
         // any old one we might have.
@@ -159,6 +170,8 @@ export default (state: SessionState = initialState, action: Action): SessionStat
       return {
         ...state,
         loading: false,
+        outboxSending: false,
+        hasDismissedServerCompatNotice: false,
 
         // Stop polling this event queue.
         eventQueueId: null,
@@ -168,6 +181,8 @@ export default (state: SessionState = initialState, action: Action): SessionStat
       return {
         ...state,
         loading: false,
+        outboxSending: false,
+        hasDismissedServerCompatNotice: false,
 
         // Stop polling this event queue.  (We'll request a new one soon,
         // for the new account.)

--- a/src/settings/__tests__/settingsReducer-test.js
+++ b/src/settings/__tests__/settingsReducer-test.js
@@ -24,17 +24,17 @@ describe('settingsReducer', () => {
         onlineNotification: false,
         streamNotification: false,
       });
-
-      const action = eg.mkActionRegisterComplete({
-        enable_offline_push_notifications: true,
-        enable_online_push_notifications: true,
-        enable_stream_push_notifications: true,
-        user_settings: undefined,
-      });
-
-      const actualState = settingsReducer(prevState, action);
-
-      expect(actualState).toMatchObject({
+      expect(
+        settingsReducer(
+          prevState,
+          eg.mkActionRegisterComplete({
+            enable_offline_push_notifications: true,
+            enable_online_push_notifications: true,
+            enable_stream_push_notifications: true,
+            user_settings: undefined,
+          }),
+        ),
+      ).toMatchObject({
         offlineNotification: true,
         onlineNotification: true,
         streamNotification: true,
@@ -77,87 +77,59 @@ describe('settingsReducer', () => {
 
   describe('SET_GLOBAL_SETTINGS', () => {
     test('changes value of a key', () => {
-      const action = deepFreeze({
-        type: SET_GLOBAL_SETTINGS,
-        update: { theme: 'night' },
-      });
-
-      const expectedState = {
-        ...baseState,
-        theme: 'night',
-      };
-
-      const actualState = settingsReducer(baseState, action);
-
-      expect(actualState).toEqual(expectedState);
+      expect(
+        settingsReducer(
+          baseState,
+          deepFreeze({ type: SET_GLOBAL_SETTINGS, update: { theme: 'night' } }),
+        ),
+      ).toEqual({ ...baseState, theme: 'night' });
     });
   });
 
   describe('EVENT_UPDATE_GLOBAL_NOTIFICATIONS_SETTINGS', () => {
     test('changes offline notification setting', () => {
-      const prevState = deepFreeze({
-        ...baseState,
-        offlineNotification: false,
-      });
-      const action = deepFreeze({
-        type: EVENT_UPDATE_GLOBAL_NOTIFICATIONS_SETTINGS,
-        id: 0,
-        notification_name: 'enable_offline_push_notifications',
-        setting: true,
-      });
-
-      const expectedState = {
-        ...baseState,
-        offlineNotification: true,
-      };
-
-      const actualState = settingsReducer(prevState, action);
-
-      expect(actualState).toEqual(expectedState);
+      const prevState = deepFreeze({ ...baseState, offlineNotification: false });
+      expect(
+        settingsReducer(
+          prevState,
+          deepFreeze({
+            type: EVENT_UPDATE_GLOBAL_NOTIFICATIONS_SETTINGS,
+            id: 0,
+            notification_name: 'enable_offline_push_notifications',
+            setting: true,
+          }),
+        ),
+      ).toEqual({ ...baseState, offlineNotification: true });
     });
 
     test('changes online notification setting', () => {
-      const prevState = deepFreeze({
-        ...baseState,
-        onlineNotification: false,
-      });
-      const action = deepFreeze({
-        type: EVENT_UPDATE_GLOBAL_NOTIFICATIONS_SETTINGS,
-        id: 0,
-        notification_name: 'enable_online_push_notifications',
-        setting: true,
-      });
-
-      const expectedState = {
-        ...baseState,
-        onlineNotification: true,
-      };
-
-      const actualState = settingsReducer(prevState, action);
-
-      expect(actualState).toEqual(expectedState);
+      const prevState = deepFreeze({ ...baseState, onlineNotification: false });
+      expect(
+        settingsReducer(
+          prevState,
+          deepFreeze({
+            type: EVENT_UPDATE_GLOBAL_NOTIFICATIONS_SETTINGS,
+            id: 0,
+            notification_name: 'enable_online_push_notifications',
+            setting: true,
+          }),
+        ),
+      ).toEqual({ ...baseState, onlineNotification: true });
     });
 
     test('changes stream notification setting', () => {
-      const prevState = deepFreeze({
-        ...baseState,
-        streamNotification: false,
-      });
-      const action = deepFreeze({
-        type: EVENT_UPDATE_GLOBAL_NOTIFICATIONS_SETTINGS,
-        id: 0,
-        notification_name: 'enable_stream_push_notifications',
-        setting: true,
-      });
-
-      const expectedState = {
-        ...baseState,
-        streamNotification: true,
-      };
-
-      const actualState = settingsReducer(prevState, action);
-
-      expect(actualState).toEqual(expectedState);
+      const prevState = deepFreeze({ ...baseState, streamNotification: false });
+      expect(
+        settingsReducer(
+          prevState,
+          deepFreeze({
+            type: EVENT_UPDATE_GLOBAL_NOTIFICATIONS_SETTINGS,
+            id: 0,
+            notification_name: 'enable_stream_push_notifications',
+            setting: true,
+          }),
+        ),
+      ).toEqual({ ...baseState, streamNotification: true });
     });
   });
 

--- a/src/settings/settingsReducer.js
+++ b/src/settings/settingsReducer.js
@@ -1,6 +1,8 @@
 /* @flow strict-local */
+import type { GlobalSettingsState, PerAccountSettingsState } from '../reduxTypes';
 import type { SettingsState, Action } from '../types';
 import {
+  RESET_ACCOUNT_DATA,
   SET_GLOBAL_SETTINGS,
   REGISTER_COMPLETE,
   EVENT_UPDATE_GLOBAL_NOTIFICATIONS_SETTINGS,
@@ -9,30 +11,33 @@ import {
 import { EventTypes } from '../api/eventTypes';
 import { ensureUnreachable } from '../types';
 
-const initialState: SettingsState = {
-  //
-  // GlobalSettingsState
-  //
-
+const initialGlobalSettingsState: $Exact<GlobalSettingsState> = {
   language: 'en',
   theme: 'default',
   browser: 'default',
   experimentalFeaturesEnabled: false,
   markMessagesReadOnScroll: 'always',
+};
 
-  //
-  // PerAccountSettingsState
-  //
-
+/** PRIVATE; exported only for tests. */
+export const initialPerAccountSettingsState: $Exact<PerAccountSettingsState> = {
   offlineNotification: true,
   onlineNotification: true,
   streamNotification: false,
   displayEmojiReactionUsers: false,
 };
 
+const initialState: SettingsState = {
+  ...initialGlobalSettingsState,
+  ...initialPerAccountSettingsState,
+};
+
 // eslint-disable-next-line default-param-last
 export default (state: SettingsState = initialState, action: Action): SettingsState => {
   switch (action.type) {
+    case RESET_ACCOUNT_DATA:
+      return { ...state, ...initialPerAccountSettingsState };
+
     case REGISTER_COMPLETE: {
       const { data } = action;
 

--- a/src/storage/__tests__/replaceRevive-test.js
+++ b/src/storage/__tests__/replaceRevive-test.js
@@ -17,14 +17,16 @@ const data = {
   jsMapNumKeys: new Map([[1, 2], [3, 4]]),
   jsSet: new Set([1, 2, 'a', null, { b: [3] }]),
   list: Immutable.List([1, 2, 'a', null]),
-  map: Immutable.Map({ a: 1, b: 2, c: 3, d: 4 }),
-  mapWithTypeKey: Immutable.Map({
-    a: 1,
-    [SERIALIZED_TYPE_FIELD_NAME]: {
-      b: [2],
-      [SERIALIZED_TYPE_FIELD_NAME]: { c: [3] },
-    },
-  }),
+  map: Immutable.Map([
+    ['a', 1],
+    ['b', 2],
+    ['c', 3],
+    ['d', 4],
+  ]),
+  mapWithTypeKey: Immutable.Map([
+    ['a', 1],
+    [SERIALIZED_TYPE_FIELD_NAME, { b: [2], [SERIALIZED_TYPE_FIELD_NAME]: { c: [3] } }],
+  ]),
   // prettier-ignore
   mapNumKeys: Immutable.Map([[1, 1], [2, 2], [3, 3], [4, 4]]),
   emptyMap: Immutable.Map([]),

--- a/src/typing/__tests__/typingReducer-test.js
+++ b/src/typing/__tests__/typingReducer-test.js
@@ -32,6 +32,20 @@ describe('typingReducer', () => {
       : { ...base, op: 'stop', type: EVENT_TYPING_STOP };
   };
 
+  describe('RESET_ACCOUNT_DATA', () => {
+    const initialState = eg.baseReduxState.typing;
+    const action1 = egTypingAction({
+      op: 'start',
+      sender: user1,
+      recipients: [user1, user2],
+      time: 123456789,
+    });
+    const prevState = typingReducer(initialState, action1);
+    expect(prevState).not.toEqual(initialState);
+
+    expect(typingReducer(prevState, eg.action.reset_account_data)).toEqual(initialState);
+  });
+
   describe('EVENT_TYPING_START', () => {
     test('adds sender as currently typing user', () => {
       const prevState = NULL_OBJECT;

--- a/src/typing/__tests__/typingReducer-test.js
+++ b/src/typing/__tests__/typingReducer-test.js
@@ -34,148 +34,118 @@ describe('typingReducer', () => {
 
   describe('EVENT_TYPING_START', () => {
     test('adds sender as currently typing user', () => {
-      const initialState = NULL_OBJECT;
-
-      const action = egTypingAction({
-        op: 'start',
-        sender: user1,
-        recipients: [user1, eg.selfUser],
-        time: 123456789,
-      });
-
-      const expectedState = {
-        '1': { time: 123456789, userIds: [user1.user_id] },
-      };
-
-      const newState = typingReducer(initialState, action);
-
-      expect(newState).toEqual(expectedState);
+      const prevState = NULL_OBJECT;
+      expect(
+        typingReducer(
+          prevState,
+          egTypingAction({
+            op: 'start',
+            sender: user1,
+            recipients: [user1, eg.selfUser],
+            time: 123456789,
+          }),
+        ),
+      ).toEqual({ '1': { time: 123456789, userIds: [user1.user_id] } });
     });
 
     test('if user is already typing, no change in userIds but update time', () => {
-      const initialState = deepFreeze({
-        '1': { time: 123456789, userIds: [user1.user_id] },
-      });
-
-      const action = egTypingAction({
-        op: 'start',
-        sender: user1,
-        recipients: [user1, eg.selfUser],
-        time: 123456889,
-      });
-
-      const expectedState = {
-        '1': { time: 123456889, userIds: [user1.user_id] },
-      };
-
-      const newState = typingReducer(initialState, action);
-
-      expect(newState).toEqual(expectedState);
+      const prevState = deepFreeze({ '1': { time: 123456789, userIds: [user1.user_id] } });
+      expect(
+        typingReducer(
+          prevState,
+          egTypingAction({
+            op: 'start',
+            sender: user1,
+            recipients: [user1, eg.selfUser],
+            time: 123456889,
+          }),
+        ),
+      ).toEqual({ '1': { time: 123456889, userIds: [user1.user_id] } });
     });
 
     test('if other people are typing in other narrows, add, do not affect them', () => {
-      const initialState = deepFreeze({
-        '1': { time: 123489, userIds: [user1.user_id] },
-      });
-
-      const action = egTypingAction({
-        op: 'start',
-        sender: user2,
-        recipients: [user1, user2, eg.selfUser],
-        time: 123456789,
-      });
-
-      const expectedState = {
+      const prevState = deepFreeze({ '1': { time: 123489, userIds: [user1.user_id] } });
+      expect(
+        typingReducer(
+          prevState,
+          egTypingAction({
+            op: 'start',
+            sender: user2,
+            recipients: [user1, user2, eg.selfUser],
+            time: 123456789,
+          }),
+        ),
+      ).toEqual({
         '1': { time: 123489, userIds: [user1.user_id] },
         '1,2': { time: 123456789, userIds: [user2.user_id] },
-      };
-
-      const newState = typingReducer(initialState, action);
-
-      expect(newState).toEqual(expectedState);
+      });
     });
 
     test('if another user is typing already, append new one', () => {
-      const initialState = deepFreeze({
-        '1,2': { time: 123489, userIds: [user1.user_id] },
-      });
-
-      const action = egTypingAction({
-        op: 'start',
-        sender: user2,
-        recipients: [user1, user2, eg.selfUser],
-        time: 123456789,
-      });
-
-      const expectedState = {
-        '1,2': { time: 123456789, userIds: [user1.user_id, user2.user_id] },
-      };
-
-      const newState = typingReducer(initialState, action);
-
-      expect(newState).toEqual(expectedState);
+      const prevState = deepFreeze({ '1,2': { time: 123489, userIds: [user1.user_id] } });
+      expect(
+        typingReducer(
+          prevState,
+          egTypingAction({
+            op: 'start',
+            sender: user2,
+            recipients: [user1, user2, eg.selfUser],
+            time: 123456789,
+          }),
+        ),
+      ).toEqual({ '1,2': { time: 123456789, userIds: [user1.user_id, user2.user_id] } });
     });
   });
 
   describe('EVENT_TYPING_STOP', () => {
     test('if after removing, key is an empty list, key is removed', () => {
-      const initialState = deepFreeze({
+      const prevState = deepFreeze({
         '1': { time: 123489, userIds: [user1.user_id] },
         '3': { time: 123489, userIds: [eg.selfUser.user_id] },
       });
-
-      const action = egTypingAction({
-        op: 'stop',
-        sender: user1,
-        recipients: [user1, eg.selfUser],
-        time: 123456789,
-      });
-
-      const expectedState = {
-        '3': { time: 123489, userIds: [eg.selfUser.user_id] },
-      };
-
-      const newState = typingReducer(initialState, action);
-
-      expect(newState).toEqual(expectedState);
+      expect(
+        typingReducer(
+          prevState,
+          egTypingAction({
+            op: 'stop',
+            sender: user1,
+            recipients: [user1, eg.selfUser],
+            time: 123456789,
+          }),
+        ),
+      ).toEqual({ '3': { time: 123489, userIds: [eg.selfUser.user_id] } });
     });
 
     test('if two people are typing, just one is removed', () => {
-      const initialState = deepFreeze({
+      const prevState = deepFreeze({
         '1': { time: 123489, userIds: [user1.user_id, eg.selfUser.user_id] },
       });
-
-      const action = egTypingAction({
-        op: 'stop',
-        sender: user1,
-        recipients: [user1, eg.selfUser],
-        time: 123456789,
-      });
-
-      const expectedState = {
-        '1': { time: 123456789, userIds: [eg.selfUser.user_id] },
-      };
-
-      const newState = typingReducer(initialState, action);
-
-      expect(newState).toEqual(expectedState);
+      expect(
+        typingReducer(
+          prevState,
+          egTypingAction({
+            op: 'stop',
+            sender: user1,
+            recipients: [user1, eg.selfUser],
+            time: 123456789,
+          }),
+        ),
+      ).toEqual({ '1': { time: 123456789, userIds: [eg.selfUser.user_id] } });
     });
 
     test('if typing state does not exist, no change is made', () => {
-      const initialState = NULL_OBJECT;
-
-      const action = egTypingAction({
-        op: 'stop',
-        sender: user1,
-        recipients: [user1, eg.selfUser],
-        time: 123456789,
-      });
-
-      const expectedState = {};
-
-      const newState = typingReducer(initialState, action);
-
-      expect(newState).toEqual(expectedState);
+      const prevState = NULL_OBJECT;
+      expect(
+        typingReducer(
+          prevState,
+          egTypingAction({
+            op: 'stop',
+            sender: user1,
+            recipients: [user1, eg.selfUser],
+            time: 123456789,
+          }),
+        ),
+      ).toEqual({});
     });
   });
 });


### PR DESCRIPTION
Oops, it seems I should have thought a bit harder for #5606. 🙂 In particular, this PR picks up some threads I dropped there:

- Give test coverage for all the reducers that use the new `RESET_ACCOUNT_DATA` action.
- Clear per-account `session` state on `RESET_ACCOUNT_DATA`
- Clear per-account `settings` state on `RESET_ACCOUNT_DATA`

Those interesting changes come after a string of code-style tightenings (and one "start using Flow" commit) for several of the test files they touch.

Fixes: #4446