### PR TITLE
model: Make REGISTER_COMPLETE reset some state we forgot about

### DIFF
--- a/src/chat/__tests__/fetchingReducer-test.js
+++ b/src/chat/__tests__/fetchingReducer-test.js
@@ -25,65 +25,43 @@ describe('fetchingReducer', () => {
 
   describe('MESSAGE_FETCH_START', () => {
     test('if messages are fetched before or after the corresponding flag is set', () => {
-      const prevState = deepFreeze({
-        [HOME_NARROW_STR]: { older: false, newer: false },
-      });
-
-      const action = deepFreeze({
-        type: MESSAGE_FETCH_START,
-        narrow: HOME_NARROW,
-        numBefore: 10,
-        numAfter: 10,
-      });
-
-      const expectedState = {
-        [HOME_NARROW_STR]: { older: true, newer: true },
-      };
-
-      const newState = fetchingReducer(prevState, action);
-
-      expect(newState).toEqual(expectedState);
+      const prevState = deepFreeze({ [HOME_NARROW_STR]: { older: false, newer: false } });
+      expect(
+        fetchingReducer(
+          prevState,
+          deepFreeze({
+            type: MESSAGE_FETCH_START,
+            narrow: HOME_NARROW,
+            numBefore: 10,
+            numAfter: 10,
+          }),
+        ),
+      ).toEqual({ [HOME_NARROW_STR]: { older: true, newer: true } });
     });
 
     test('if key for narrow does not exist, it is created and corresponding flags are set', () => {
-      const prevState = deepFreeze({
-        [HOME_NARROW_STR]: { older: false, newer: false },
-      });
-
       const narrow = streamNarrow(eg.stream.stream_id);
-      const action = deepFreeze({
-        type: MESSAGE_FETCH_START,
-        narrow,
-        numBefore: 10,
-        numAfter: 0,
-      });
 
-      const expectedState = {
+      const prevState = deepFreeze({ [HOME_NARROW_STR]: { older: false, newer: false } });
+      expect(
+        fetchingReducer(
+          prevState,
+          deepFreeze({ type: MESSAGE_FETCH_START, narrow, numBefore: 10, numAfter: 0 }),
+        ),
+      ).toEqual({
         [HOME_NARROW_STR]: { older: false, newer: false },
         [keyFromNarrow(narrow)]: { older: true, newer: false },
-      };
-
-      const newState = fetchingReducer(prevState, action);
-
-      expect(newState).toEqual(expectedState);
+      });
     });
 
     test('if fetching for a search narrow, ignore', () => {
-      const prevState = deepFreeze({
-        [HOME_NARROW_STR]: {
-          older: false,
-          newer: false,
-        },
-      });
-
-      const action = deepFreeze({
-        ...eg.action.message_fetch_start,
-        narrow: SEARCH_NARROW('some query'),
-      });
-
-      const newState = fetchingReducer(prevState, action);
-
-      expect(newState).toEqual(prevState);
+      const prevState = deepFreeze({ [HOME_NARROW_STR]: { older: false, newer: false } });
+      expect(
+        fetchingReducer(
+          deepFreeze(prevState),
+          deepFreeze({ ...eg.action.message_fetch_start, narrow: SEARCH_NARROW('some query') }),
+        ),
+      ).toEqual(prevState);
     });
   });
 
@@ -91,66 +69,36 @@ describe('fetchingReducer', () => {
     test('reverses the effect of MESSAGE_FETCH_START as much as possible', () => {
       // As of the addition of this test, that means setting
       // DEFAULT_FETCHING as the key.
-      const state0 = deepFreeze({});
-
-      const messageFetchStartAction = deepFreeze({
-        ...eg.action.message_fetch_start,
-        narrow: HOME_NARROW,
-      });
-
-      const state1 = fetchingReducer(state0, messageFetchStartAction);
-
-      const messageFetchErrorAction = deepFreeze({
-        type: MESSAGE_FETCH_ERROR,
-        narrow: HOME_NARROW,
-        error: new Error(),
-      });
-
-      const finalState = fetchingReducer(state1, messageFetchErrorAction);
-
-      const expectedState = {
-        [HOME_NARROW_STR]: DEFAULT_FETCHING,
-      };
-
-      expect(finalState).toEqual(expectedState);
+      expect(
+        [
+          deepFreeze({ ...eg.action.message_fetch_start, narrow: HOME_NARROW }),
+          deepFreeze({ type: MESSAGE_FETCH_ERROR, narrow: HOME_NARROW, error: new Error() }),
+        ].reduce(fetchingReducer, eg.baseReduxState.fetching),
+      ).toEqual({ [HOME_NARROW_STR]: DEFAULT_FETCHING });
     });
   });
 
   describe('MESSAGE_FETCH_COMPLETE', () => {
     test('sets corresponding fetching flags to false, if messages are received before or after', () => {
-      const prevState = deepFreeze({
-        [HOME_NARROW_STR]: { older: true, newer: true },
-      });
-
-      const action = {
-        ...eg.action.message_fetch_complete,
-        narrow: HOME_NARROW,
-        numBefore: 10,
-        numAfter: 0,
-      };
-
-      const expectedState = {
-        [HOME_NARROW_STR]: { older: false, newer: true },
-      };
-
-      const newState = fetchingReducer(prevState, action);
-
-      expect(newState).toEqual(expectedState);
+      const prevState = deepFreeze({ [HOME_NARROW_STR]: { older: true, newer: true } });
+      expect(
+        fetchingReducer(prevState, {
+          ...eg.action.message_fetch_complete,
+          narrow: HOME_NARROW,
+          numBefore: 10,
+          numAfter: 0,
+        }),
+      ).toEqual({ [HOME_NARROW_STR]: { older: false, newer: true } });
     });
   });
 
   test('if fetched messages are from a search narrow, ignore them', () => {
-    const prevState = deepFreeze({
-      [HOME_NARROW_STR]: { older: true, newer: true },
-    });
-
-    const action = deepFreeze({
-      ...eg.action.message_fetch_complete,
-      narrow: SEARCH_NARROW('some query'),
-    });
-
-    const newState = fetchingReducer(prevState, action);
-
-    expect(newState).toEqual(prevState);
+    const prevState = deepFreeze({ [HOME_NARROW_STR]: { older: true, newer: true } });
+    expect(
+      fetchingReducer(
+        prevState,
+        deepFreeze({ ...eg.action.message_fetch_complete, narrow: SEARCH_NARROW('some query') }),
+      ),
+    ).toEqual(prevState);
   });
 });

--- a/src/chat/__tests__/fetchingReducer-test.js
+++ b/src/chat/__tests__/fetchingReducer-test.js
@@ -90,15 +90,15 @@ describe('fetchingReducer', () => {
         }),
       ).toEqual({ [HOME_NARROW_STR]: { older: false, newer: true } });
     });
-  });
 
-  test('if fetched messages are from a search narrow, ignore them', () => {
-    const prevState = deepFreeze({ [HOME_NARROW_STR]: { older: true, newer: true } });
-    expect(
-      fetchingReducer(
-        prevState,
-        deepFreeze({ ...eg.action.message_fetch_complete, narrow: SEARCH_NARROW('some query') }),
-      ),
-    ).toEqual(prevState);
+    test('if fetched messages are from a search narrow, ignore them', () => {
+      const prevState = deepFreeze({ [HOME_NARROW_STR]: { older: true, newer: true } });
+      expect(
+        fetchingReducer(
+          prevState,
+          deepFreeze({ ...eg.action.message_fetch_complete, narrow: SEARCH_NARROW('some query') }),
+        ),
+      ).toEqual(prevState);
+    });
   });
 });

--- a/src/chat/__tests__/fetchingReducer-test.js
+++ b/src/chat/__tests__/fetchingReducer-test.js
@@ -23,6 +23,15 @@ describe('fetchingReducer', () => {
     expect(fetchingReducer(prevState, eg.action.reset_account_data)).toEqual(initialState);
   });
 
+  test('REGISTER_COMPLETE', () => {
+    const initialState = eg.baseReduxState.fetching;
+    const action1 = { type: MESSAGE_FETCH_START, narrow: HOME_NARROW, numBefore: 10, numAfter: 10 };
+    const prevState = fetchingReducer(initialState, action1);
+    expect(prevState).not.toEqual(initialState);
+
+    expect(fetchingReducer(prevState, eg.action.register_complete)).toEqual(initialState);
+  });
+
   describe('MESSAGE_FETCH_START', () => {
     test('if messages are fetched before or after the corresponding flag is set', () => {
       const prevState = deepFreeze({ [HOME_NARROW_STR]: { older: false, newer: false } });

--- a/src/chat/__tests__/fetchingReducer-test.js
+++ b/src/chat/__tests__/fetchingReducer-test.js
@@ -25,7 +25,7 @@ describe('fetchingReducer', () => {
 
   describe('MESSAGE_FETCH_START', () => {
     test('if messages are fetched before or after the corresponding flag is set', () => {
-      const initialState = deepFreeze({
+      const prevState = deepFreeze({
         [HOME_NARROW_STR]: { older: false, newer: false },
       });
 
@@ -40,13 +40,13 @@ describe('fetchingReducer', () => {
         [HOME_NARROW_STR]: { older: true, newer: true },
       };
 
-      const newState = fetchingReducer(initialState, action);
+      const newState = fetchingReducer(prevState, action);
 
       expect(newState).toEqual(expectedState);
     });
 
     test('if key for narrow does not exist, it is created and corresponding flags are set', () => {
-      const initialState = deepFreeze({
+      const prevState = deepFreeze({
         [HOME_NARROW_STR]: { older: false, newer: false },
       });
 
@@ -63,13 +63,13 @@ describe('fetchingReducer', () => {
         [keyFromNarrow(narrow)]: { older: true, newer: false },
       };
 
-      const newState = fetchingReducer(initialState, action);
+      const newState = fetchingReducer(prevState, action);
 
       expect(newState).toEqual(expectedState);
     });
 
     test('if fetching for a search narrow, ignore', () => {
-      const initialState = deepFreeze({
+      const prevState = deepFreeze({
         [HOME_NARROW_STR]: {
           older: false,
           newer: false,
@@ -81,9 +81,9 @@ describe('fetchingReducer', () => {
         narrow: SEARCH_NARROW('some query'),
       });
 
-      const newState = fetchingReducer(initialState, action);
+      const newState = fetchingReducer(prevState, action);
 
-      expect(newState).toEqual(initialState);
+      expect(newState).toEqual(prevState);
     });
   });
 
@@ -91,14 +91,14 @@ describe('fetchingReducer', () => {
     test('reverses the effect of MESSAGE_FETCH_START as much as possible', () => {
       // As of the addition of this test, that means setting
       // DEFAULT_FETCHING as the key.
-      const initialState = deepFreeze({});
+      const state0 = deepFreeze({});
 
       const messageFetchStartAction = deepFreeze({
         ...eg.action.message_fetch_start,
         narrow: HOME_NARROW,
       });
 
-      const state1 = fetchingReducer(initialState, messageFetchStartAction);
+      const state1 = fetchingReducer(state0, messageFetchStartAction);
 
       const messageFetchErrorAction = deepFreeze({
         type: MESSAGE_FETCH_ERROR,
@@ -118,7 +118,7 @@ describe('fetchingReducer', () => {
 
   describe('MESSAGE_FETCH_COMPLETE', () => {
     test('sets corresponding fetching flags to false, if messages are received before or after', () => {
-      const initialState = deepFreeze({
+      const prevState = deepFreeze({
         [HOME_NARROW_STR]: { older: true, newer: true },
       });
 
@@ -133,14 +133,14 @@ describe('fetchingReducer', () => {
         [HOME_NARROW_STR]: { older: false, newer: true },
       };
 
-      const newState = fetchingReducer(initialState, action);
+      const newState = fetchingReducer(prevState, action);
 
       expect(newState).toEqual(expectedState);
     });
   });
 
   test('if fetched messages are from a search narrow, ignore them', () => {
-    const initialState = deepFreeze({
+    const prevState = deepFreeze({
       [HOME_NARROW_STR]: { older: true, newer: true },
     });
 
@@ -149,8 +149,8 @@ describe('fetchingReducer', () => {
       narrow: SEARCH_NARROW('some query'),
     });
 
-    const newState = fetchingReducer(initialState, action);
+    const newState = fetchingReducer(prevState, action);
 
-    expect(newState).toEqual(initialState);
+    expect(newState).toEqual(prevState);
   });
 });

--- a/src/chat/fetchingReducer.js
+++ b/src/chat/fetchingReducer.js
@@ -5,6 +5,7 @@ import {
   MESSAGE_FETCH_ERROR,
   MESSAGE_FETCH_COMPLETE,
   RESET_ACCOUNT_DATA,
+  REGISTER_COMPLETE,
 } from '../actionConstants';
 import { NULL_OBJECT } from '../nullObjects';
 import { DEFAULT_FETCHING } from './fetchingSelectors';
@@ -67,6 +68,15 @@ export default (
 ): FetchingState => {
   switch (action.type) {
     case RESET_ACCOUNT_DATA:
+      return initialState;
+
+    // Reset just because `fetching` is server-data metadata, and we're
+    // resetting the server data it's supposed to apply to… But really, we
+    // should have canceled any in-progress message fetches by now; that's
+    // #5623. Still, even if there is an in-progress fetch, we probably
+    // don't want to show loading indicators for it in the UI.
+    // TODO(#5623): Remove reference to #5623.
+    case REGISTER_COMPLETE:
       return initialState;
 
     case MESSAGE_FETCH_START:

--- a/src/topics/__tests__/topicsReducer-test.js
+++ b/src/topics/__tests__/topicsReducer-test.js
@@ -8,6 +8,14 @@ import { INIT_TOPICS } from '../../actionConstants';
 import { NULL_OBJECT } from '../../nullObjects';
 
 describe('topicsReducer', () => {
+  describe('REGISTER_COMPLETE', () => {
+    test('resets state to initial state', () => {
+      const prevState = deepFreeze({ [eg.stream.stream_id]: [{ max_id: 1, name: 'some topic' }] });
+      const action = eg.action.register_complete;
+      expect(topicsReducer(prevState, action)).toEqual(eg.baseReduxState.topics);
+    });
+  });
+
   describe('RESET_ACCOUNT_DATA', () => {
     test('resets state to initial state', () => {
       const prevState = deepFreeze({ [eg.stream.stream_id]: [{ max_id: 1, name: 'some topic' }] });

--- a/src/topics/topicsReducer.js
+++ b/src/topics/topicsReducer.js
@@ -1,6 +1,11 @@
 /* @flow strict-local */
 import type { TopicsState, PerAccountApplicableAction } from '../types';
-import { INIT_TOPICS, EVENT_NEW_MESSAGE, RESET_ACCOUNT_DATA } from '../actionConstants';
+import {
+  INIT_TOPICS,
+  EVENT_NEW_MESSAGE,
+  REGISTER_COMPLETE,
+  RESET_ACCOUNT_DATA,
+} from '../actionConstants';
 import { NULL_OBJECT } from '../nullObjects';
 import { replaceItemInArray } from '../utils/immutability';
 
@@ -42,6 +47,10 @@ export default (
 ): TopicsState => {
   switch (action.type) {
     case RESET_ACCOUNT_DATA:
+      return initialState;
+
+    // Reset to clear stale data; payload has no initial data for this model
+    case REGISTER_COMPLETE:
       return initialState;
 
     case INIT_TOPICS:

--- a/src/typing/__tests__/typingReducer-test.js
+++ b/src/typing/__tests__/typingReducer-test.js
@@ -46,6 +46,23 @@ describe('typingReducer', () => {
     expect(typingReducer(prevState, eg.action.reset_account_data)).toEqual(initialState);
   });
 
+  describe('REGISTER_COMPLETE', () => {
+    test('resets state to initial state', () => {
+      const initialState = eg.baseReduxState.typing;
+      const action1 = egTypingAction({
+        op: 'start',
+        sender: user1,
+        recipients: [user1, eg.selfUser],
+        time: 123456889,
+      });
+      const prevState = typingReducer(initialState, action1);
+      expect(prevState).not.toEqual(initialState);
+
+      const action2 = eg.action.register_complete;
+      expect(typingReducer(prevState, action2)).toEqual(eg.baseReduxState.typing);
+    });
+  });
+
   describe('EVENT_TYPING_START', () => {
     test('adds sender as currently typing user', () => {
       const prevState = NULL_OBJECT;

--- a/src/typing/typingReducer.js
+++ b/src/typing/typingReducer.js
@@ -6,6 +6,7 @@ import {
   CLEAR_TYPING,
   DEAD_QUEUE,
   RESET_ACCOUNT_DATA,
+  REGISTER_COMPLETE,
 } from '../actionConstants';
 import { pmTypingKeyFromRecipients } from '../utils/recipient';
 import { NULL_OBJECT } from '../nullObjects';
@@ -97,6 +98,10 @@ export default (
 
     case DEAD_QUEUE:
     case RESET_ACCOUNT_DATA:
+      return initialState;
+
+    // Reset to clear stale data; payload has no initial data for this model
+    case REGISTER_COMPLETE:
       return initialState;
 
     default:


### PR DESCRIPTION
This addresses the second item in the list at #5605:

> - [ ] `REGISTER_COMPLETE` should reset or replace all server data
>       and server-data metadata, but it isn't in some cases:
>       - server data: `topics`, `typing` (should reset)
>       - server-data metadata: `fetching` (should reset)

Although, I've left a comment on `fetchingReducer`, where doing so
felt a bit funny because morally it shouldn't be necessary.

Fixes-partly: #5605