### PR TITLE
fix: Overlap for long passwords and show/hide button in Password Auth Screen Issue #: 5614

### DIFF
--- a/src/common/PasswordInput.js
+++ b/src/common/PasswordInput.js
@@ -5,7 +5,7 @@ import { View } from 'react-native';
 
 import Input from './Input';
 import type { Props as InputProps } from './Input';
-import { BRAND_COLOR, createStyleSheet } from '../styles';
+import { BORDER_COLOR, BRAND_COLOR, createStyleSheet } from '../styles';
 import ZulipTextIntl from './ZulipTextIntl';
 import Touchable from './Touchable';
 
@@ -16,11 +16,20 @@ const styles = createStyleSheet({
     top: 0,
     bottom: 0,
     justifyContent: 'center',
+    borderTopWidth: 1,
+    borderColor: BORDER_COLOR,
+    borderBottomWidth: 1,
+    borderRightWidth: 1
+
   },
   showPasswordButtonText: {
     margin: 8,
     color: BRAND_COLOR,
   },
+  passwordTextInput: {
+    width: '87.5%',
+    borderRightWidth: 0,
+  }
 });
 
 // Prettier wants a ", >" here, which is silly.
@@ -44,8 +53,17 @@ export default function PasswordInput(props: Props): Node {
   }, []);
 
   return (
-    <View>
-      <Input {...props} secureTextEntry={isHidden} autoCorrect={false} autoCapitalize="none" />
+    <View style={{
+      width: '100%'
+    }}
+    >
+      <Input
+        {...props}
+        secureTextEntry={isHidden}
+        autoCorrect={false}
+        autoCapitalize="none"
+        style={styles.passwordTextInput}
+      />
       <Touchable style={styles.showPasswordButton} onPress={handleShow}>
         <ZulipTextIntl style={styles.showPasswordButtonText} text={isHidden ? 'show' : 'hide'} />
       </Touchable>


### PR DESCRIPTION
In the Password Auth Screen, when you type a long password, it overlaps with the show/hide button.

I fixed this issue by creating a new stylesheet for the password text input field. I added a padding-right property of 15% to its style. This fix will ensure that the text input in the password field will never exceed a width of 85% of the text input field.

I tested this commit by viewing the password auth screen in horizontal and vertical views. The password input field is working fine in both instances.

Please let me know if you have any questions.

Thank you.

Fixes: #5614.