### PR TITLE
flow: Forbid object-as-map when constructing `Immutable.Map`s

### DIFF
--- a/docs/style.md
+++ b/docs/style.md
@@ -38,6 +38,8 @@
     initializer at `let`.
   * [[link](#immutable-provide-type)] Always provide a type when
     writing an empty `Immutable` value.
+  * [[link](#immutable-no-object-as-map)] Don't construct an `Immutable.Map`
+    with an object-as-map.
   * [[link](#react-function-prop-defaults)] Don't use React
     `defaultProps` for function components.
 * [Internal to Zulip and our codebase](#zulip)
@@ -540,6 +542,26 @@ This is essential in order to get effective type-checking of the
 code that uses the new collection.  (It's not clear if this is a bug
 in Flow, or a design limitation of Flow, or an issue in the Flow types
 provided by Immutable.js, or some combination.)
+
+
+<div id="immutable-no-object-as-map" />
+
+**Don't construct an `Immutable.Map` with an object-as-map**: Whenever you
+create a non-empty `Immutable.Map`, pass an array of entries instead of an
+object-as-map. For example:
+```js
+Immutable.Map([[HOME_NARROW_STR, [1, 2]]]) // good
+
+Immutable.Map({ [HOME_NARROW_STR]: [1, 2] }) // BAD -- don't do
+```
+
+This is essential in order to get effective type-checking of the value
+passed to the `Immutable.Map` function when a key is computed (like
+`HOME_NARROW_STR`) instead of literal (like 'foo'). In the Immutable type
+definition, the object-as-map branch involves an object type with an indexer
+property, and in general [Flow seems to have trouble with those][].
+
+[Flow seems to have trouble with those]: https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/.60Immutable.2EMap.28.7B.20.5BSTRING_CONST.5D.3A.20.E2.80.A6.20.7D.29.60.20busted.20by.20Flow.20bug/near/1481088
 
 
 <div id="react-function-prop-defaults" />

--- a/src/chat/__tests__/narrowsReducer-test.js
+++ b/src/chat/__tests__/narrowsReducer-test.js
@@ -320,23 +320,24 @@ describe('narrowsReducer', () => {
       // MESSAGE_FETCH_START applies the identity function to the
       // state (i.e., it doesn't do anything to it). Reversing that
       // effect is also done with the identity function.
-      const initialState = Immutable.Map({
-        [HOME_NARROW_STR]: {
-          older: true,
-          newer: true,
-        },
-      });
+
+      const narrow1 = pm1to1NarrowFromUser(eg.otherUser);
+      const narrow2 = pm1to1NarrowFromUser(eg.thirdUser);
+
+      // Include some other narrow to test that the reducer doesn't go mess
+      // something up there.
+      const initialState = Immutable.Map([[keyFromNarrow(narrow1), [1, 2]]]);
 
       const messageFetchStartAction = deepFreeze({
         ...eg.action.message_fetch_start,
-        narrow: HOME_NARROW,
+        narrow: narrow2,
       });
 
       const state1 = narrowsReducer(initialState, messageFetchStartAction);
 
       const messageFetchErrorAction = deepFreeze({
         type: MESSAGE_FETCH_ERROR,
-        narrow: HOME_NARROW,
+        narrow: narrow2,
         error: new Error(),
       });
 

--- a/src/chat/__tests__/narrowsReducer-test.js
+++ b/src/chat/__tests__/narrowsReducer-test.js
@@ -33,7 +33,7 @@ describe('narrowsReducer', () => {
 
   describe('EVENT_NEW_MESSAGE', () => {
     test('if not caught up in narrow, do not add message in home narrow', () => {
-      const initialState = Immutable.Map({ [HOME_NARROW_STR]: [1, 2] });
+      const initialState = Immutable.Map([[HOME_NARROW_STR, [1, 2]]]);
 
       const message = eg.streamMessage({ id: 3, flags: [] });
 
@@ -41,13 +41,13 @@ describe('narrowsReducer', () => {
 
       const newState = narrowsReducer(initialState, action);
 
-      const expectedState = Immutable.Map({ [HOME_NARROW_STR]: [1, 2] });
+      const expectedState = Immutable.Map([[HOME_NARROW_STR, [1, 2]]]);
 
       expect(newState).toEqual(expectedState);
     });
 
     test('appends message to state producing a copy of messages', () => {
-      const initialState = Immutable.Map({ [HOME_NARROW_STR]: [1, 2] });
+      const initialState = Immutable.Map([[HOME_NARROW_STR, [1, 2]]]);
 
       const message = eg.streamMessage({ id: 3, flags: [] });
 
@@ -60,9 +60,7 @@ describe('narrowsReducer', () => {
         },
       });
 
-      const expectedState = Immutable.Map({
-        [HOME_NARROW_STR]: [1, 2, 3],
-      });
+      const expectedState = Immutable.Map([[HOME_NARROW_STR, [1, 2, 3]]]);
 
       const newState = narrowsReducer(initialState, action);
 
@@ -71,7 +69,7 @@ describe('narrowsReducer', () => {
     });
 
     test('if new message key does not exist do not create it', () => {
-      const initialState = Immutable.Map({ [topicNarrowStr]: [1, 2] });
+      const initialState = Immutable.Map([[topicNarrowStr, [1, 2]]]);
 
       const message = eg.streamMessage({ id: 3, flags: [], stream: eg.makeStream() });
 
@@ -79,15 +77,13 @@ describe('narrowsReducer', () => {
 
       const newState = narrowsReducer(initialState, action);
 
-      const expectedState = Immutable.Map({
-        [topicNarrowStr]: [1, 2],
-      });
+      const expectedState = Immutable.Map([[topicNarrowStr, [1, 2]]]);
       expect(newState).toEqual(expectedState);
     });
   });
 
   test('if new message is private or group add it to the "allPrivate" narrow', () => {
-    const initialState = Immutable.Map({ [ALL_PRIVATE_NARROW_STR]: [] });
+    const initialState = Immutable.Map([[ALL_PRIVATE_NARROW_STR, []]]);
     const message = eg.pmMessage({
       id: 1,
       recipients: [eg.selfUser, eg.otherUser, eg.thirdUser],
@@ -98,9 +94,7 @@ describe('narrowsReducer', () => {
         [ALL_PRIVATE_NARROW_STR]: { older: true, newer: true },
       },
     });
-    const expectedState = Immutable.Map({
-      [ALL_PRIVATE_NARROW_STR]: [1],
-    });
+    const expectedState = Immutable.Map([[ALL_PRIVATE_NARROW_STR, [1]]]);
 
     const actualState = narrowsReducer(initialState, action);
 
@@ -108,7 +102,10 @@ describe('narrowsReducer', () => {
   });
 
   test('message sent to topic is stored correctly', () => {
-    const initialState = Immutable.Map({ [HOME_NARROW_STR]: [1, 2], [topicNarrowStr]: [2] });
+    const initialState = Immutable.Map([
+      [HOME_NARROW_STR, [1, 2]],
+      [topicNarrowStr, [2]],
+    ]);
 
     const message = eg.streamMessage({ id: 3, flags: [] });
 
@@ -124,10 +121,10 @@ describe('narrowsReducer', () => {
         },
       },
     });
-    const expectedState = Immutable.Map({
-      [HOME_NARROW_STR]: [1, 2],
-      [topicNarrowStr]: [2, message.id],
-    });
+    const expectedState = Immutable.Map([
+      [HOME_NARROW_STR, [1, 2]],
+      [topicNarrowStr, [2, message.id]],
+    ]);
 
     const newState = narrowsReducer(initialState, action);
 
@@ -136,10 +133,10 @@ describe('narrowsReducer', () => {
 
   test('message sent to self is stored correctly', () => {
     const narrowWithSelfStr = keyFromNarrow(pm1to1NarrowFromUser(eg.selfUser));
-    const initialState = Immutable.Map({
-      [HOME_NARROW_STR]: [],
-      [narrowWithSelfStr]: [],
-    });
+    const initialState = Immutable.Map([
+      [HOME_NARROW_STR, []],
+      [narrowWithSelfStr, []],
+    ]);
 
     const message = eg.pmMessage({
       id: 1,
@@ -155,10 +152,10 @@ describe('narrowsReducer', () => {
       },
     });
 
-    const expectedState = Immutable.Map({
-      [HOME_NARROW_STR]: [message.id],
-      [narrowWithSelfStr]: [message.id],
-    });
+    const expectedState = Immutable.Map([
+      [HOME_NARROW_STR, [message.id]],
+      [narrowWithSelfStr, [message.id]],
+    ]);
 
     const newState = narrowsReducer(initialState, action);
 
@@ -167,14 +164,14 @@ describe('narrowsReducer', () => {
   });
 
   test('appends stream message to all cached narrows that match and are caught up', () => {
-    const initialState = Immutable.Map({
-      [HOME_NARROW_STR]: [1, 2],
-      [ALL_PRIVATE_NARROW_STR]: [1, 2],
-      [streamNarrowStr]: [2, 3],
-      [topicNarrowStr]: [2, 3],
-      [privateNarrowStr]: [2, 4],
-      [groupNarrowStr]: [2, 4],
-    });
+    const initialState = Immutable.Map([
+      [HOME_NARROW_STR, [1, 2]],
+      [ALL_PRIVATE_NARROW_STR, [1, 2]],
+      [streamNarrowStr, [2, 3]],
+      [topicNarrowStr, [2, 3]],
+      [privateNarrowStr, [2, 4]],
+      [groupNarrowStr, [2, 4]],
+    ]);
 
     const message = eg.streamMessage({ id: 5, flags: [] });
 
@@ -186,14 +183,14 @@ describe('narrowsReducer', () => {
       },
     });
 
-    const expectedState = Immutable.Map({
-      [HOME_NARROW_STR]: [1, 2, message.id],
-      [ALL_PRIVATE_NARROW_STR]: [1, 2],
-      [streamNarrowStr]: [2, 3, message.id],
-      [topicNarrowStr]: [2, 3, message.id],
-      [privateNarrowStr]: [2, 4],
-      [groupNarrowStr]: [2, 4],
-    });
+    const expectedState = Immutable.Map([
+      [HOME_NARROW_STR, [1, 2, message.id]],
+      [ALL_PRIVATE_NARROW_STR, [1, 2]],
+      [streamNarrowStr, [2, 3, message.id]],
+      [topicNarrowStr, [2, 3, message.id]],
+      [privateNarrowStr, [2, 4]],
+      [groupNarrowStr, [2, 4]],
+    ]);
 
     const newState = narrowsReducer(initialState, action);
 
@@ -202,7 +199,7 @@ describe('narrowsReducer', () => {
   });
 
   test('does not append stream message to not cached narrows', () => {
-    const initialState = Immutable.Map({ [HOME_NARROW_STR]: [1] });
+    const initialState = Immutable.Map([[HOME_NARROW_STR, [1]]]);
 
     const message = eg.streamMessage({ id: 3, flags: [] });
 
@@ -212,9 +209,7 @@ describe('narrowsReducer', () => {
       },
     });
 
-    const expectedState = Immutable.Map({
-      [HOME_NARROW_STR]: [1, message.id],
-    });
+    const expectedState = Immutable.Map([[HOME_NARROW_STR, [1, message.id]]]);
 
     const newState = narrowsReducer(initialState, action);
 
@@ -223,14 +218,14 @@ describe('narrowsReducer', () => {
   });
 
   test('appends private message to multiple cached narrows', () => {
-    const initialState = Immutable.Map({
-      [HOME_NARROW_STR]: [1, 2],
-      [ALL_PRIVATE_NARROW_STR]: [1, 2],
-      [streamNarrowStr]: [2, 3],
-      [topicNarrowStr]: [2, 3],
-      [privateNarrowStr]: [2, 4],
-      [groupNarrowStr]: [2, 4],
-    });
+    const initialState = Immutable.Map([
+      [HOME_NARROW_STR, [1, 2]],
+      [ALL_PRIVATE_NARROW_STR, [1, 2]],
+      [streamNarrowStr, [2, 3]],
+      [topicNarrowStr, [2, 3]],
+      [privateNarrowStr, [2, 4]],
+      [groupNarrowStr, [2, 4]],
+    ]);
 
     const message = eg.pmMessage({
       id: 5,
@@ -243,14 +238,14 @@ describe('narrowsReducer', () => {
       caughtUp: initialState.map(_ => ({ older: false, newer: true })).toObject(),
     });
 
-    const expectedState = Immutable.Map({
-      [HOME_NARROW_STR]: [1, 2, message.id],
-      [ALL_PRIVATE_NARROW_STR]: [1, 2, message.id],
-      [streamNarrowStr]: [2, 3],
-      [topicNarrowStr]: [2, 3],
-      [privateNarrowStr]: [2, 4, message.id],
-      [groupNarrowStr]: [2, 4],
-    });
+    const expectedState = Immutable.Map([
+      [HOME_NARROW_STR, [1, 2, message.id]],
+      [ALL_PRIVATE_NARROW_STR, [1, 2, message.id]],
+      [streamNarrowStr, [2, 3]],
+      [topicNarrowStr, [2, 3]],
+      [privateNarrowStr, [2, 4, message.id]],
+      [groupNarrowStr, [2, 4]],
+    ]);
 
     const newState = narrowsReducer(initialState, action);
 
@@ -260,7 +255,10 @@ describe('narrowsReducer', () => {
 
   describe('EVENT_MESSAGE_DELETE', () => {
     test('if a message does not exist no changes are made', () => {
-      const initialState = Immutable.Map({ [HOME_NARROW_STR]: [1, 2], [privateNarrowStr]: [] });
+      const initialState = Immutable.Map([
+        [HOME_NARROW_STR, [1, 2]],
+        [privateNarrowStr, []],
+      ]);
 
       const action = deepFreeze({
         type: EVENT_MESSAGE_DELETE,
@@ -273,12 +271,18 @@ describe('narrowsReducer', () => {
     });
 
     test('if a message exists in one or more narrows delete it from there', () => {
-      const initialState = Immutable.Map({ [HOME_NARROW_STR]: [1, 2, 3], [privateNarrowStr]: [2] });
+      const initialState = Immutable.Map([
+        [HOME_NARROW_STR, [1, 2, 3]],
+        [privateNarrowStr, [2]],
+      ]);
       const action = deepFreeze({
         type: EVENT_MESSAGE_DELETE,
         messageIds: [2],
       });
-      const expectedState = Immutable.Map({ [HOME_NARROW_STR]: [1, 3], [privateNarrowStr]: [] });
+      const expectedState = Immutable.Map([
+        [HOME_NARROW_STR, [1, 3]],
+        [privateNarrowStr, []],
+      ]);
 
       const newState = narrowsReducer(initialState, action);
 
@@ -286,12 +290,18 @@ describe('narrowsReducer', () => {
     });
 
     test('if multiple messages indicated, delete the ones that exist', () => {
-      const initialState = Immutable.Map({ [HOME_NARROW_STR]: [1, 2, 3], [privateNarrowStr]: [2] });
+      const initialState = Immutable.Map([
+        [HOME_NARROW_STR, [1, 2, 3]],
+        [privateNarrowStr, [2]],
+      ]);
       const action = deepFreeze({
         type: EVENT_MESSAGE_DELETE,
         messageIds: [2, 3, 4],
       });
-      const expectedState = Immutable.Map({ [HOME_NARROW_STR]: [1], [privateNarrowStr]: [] });
+      const expectedState = Immutable.Map([
+        [HOME_NARROW_STR, [1]],
+        [privateNarrowStr, []],
+      ]);
 
       const newState = narrowsReducer(initialState, action);
 
@@ -301,7 +311,7 @@ describe('narrowsReducer', () => {
 
   describe('MESSAGE_FETCH_START', () => {
     test('if fetching for a search narrow, ignore', () => {
-      const initialState = Immutable.Map({ [HOME_NARROW_STR]: [1, 2] });
+      const initialState = Immutable.Map([[HOME_NARROW_STR, [1, 2]]]);
 
       const action = deepFreeze({
         ...eg.action.message_fetch_start,
@@ -349,7 +359,7 @@ describe('narrowsReducer', () => {
 
   describe('MESSAGE_FETCH_COMPLETE', () => {
     test('if no messages returned still create the key in state', () => {
-      const initialState = Immutable.Map({ [HOME_NARROW_STR]: [1, 2, 3] });
+      const initialState = Immutable.Map([[HOME_NARROW_STR, [1, 2, 3]]]);
 
       const action = deepFreeze({
         type: MESSAGE_FETCH_COMPLETE,
@@ -363,10 +373,10 @@ describe('narrowsReducer', () => {
         ownUserId: eg.selfUser.user_id,
       });
 
-      const expectedState = Immutable.Map({
-        [HOME_NARROW_STR]: [1, 2, 3],
-        [keyFromNarrow(pm1to1NarrowFromUser(eg.otherUser))]: [],
-      });
+      const expectedState = Immutable.Map([
+        [HOME_NARROW_STR, [1, 2, 3]],
+        [keyFromNarrow(pm1to1NarrowFromUser(eg.otherUser)), []],
+      ]);
 
       const newState = narrowsReducer(initialState, action);
 
@@ -374,7 +384,7 @@ describe('narrowsReducer', () => {
     });
 
     test('no duplicate messages', () => {
-      const initialState = Immutable.Map({ [HOME_NARROW_STR]: [1, 2, 3] });
+      const initialState = Immutable.Map([[HOME_NARROW_STR, [1, 2, 3]]]);
 
       const action = deepFreeze({
         type: MESSAGE_FETCH_COMPLETE,
@@ -392,9 +402,7 @@ describe('narrowsReducer', () => {
         ownUserId: eg.selfUser.user_id,
       });
 
-      const expectedState = Immutable.Map({
-        [HOME_NARROW_STR]: [1, 2, 3, 4],
-      });
+      const expectedState = Immutable.Map([[HOME_NARROW_STR, [1, 2, 3, 4]]]);
 
       const newState = narrowsReducer(initialState, action);
 
@@ -403,7 +411,7 @@ describe('narrowsReducer', () => {
     });
 
     test('added messages are sorted by id', () => {
-      const initialState = Immutable.Map({ [HOME_NARROW_STR]: [1, 2] });
+      const initialState = Immutable.Map([[HOME_NARROW_STR, [1, 2]]]);
 
       const action = deepFreeze({
         type: MESSAGE_FETCH_COMPLETE,
@@ -420,9 +428,7 @@ describe('narrowsReducer', () => {
         ownUserId: eg.selfUser.user_id,
       });
 
-      const expectedState = Immutable.Map({
-        [HOME_NARROW_STR]: [1, 2, 3, 4],
-      });
+      const expectedState = Immutable.Map([[HOME_NARROW_STR, [1, 2, 3, 4]]]);
 
       const newState = narrowsReducer(initialState, action);
 
@@ -431,7 +437,7 @@ describe('narrowsReducer', () => {
     });
 
     test('when anchor is FIRST_UNREAD_ANCHOR previous messages are replaced', () => {
-      const initialState = Immutable.Map({ [HOME_NARROW_STR]: [1, 2] });
+      const initialState = Immutable.Map([[HOME_NARROW_STR, [1, 2]]]);
 
       const action = deepFreeze({
         anchor: FIRST_UNREAD_ANCHOR,
@@ -448,9 +454,7 @@ describe('narrowsReducer', () => {
         ownUserId: eg.selfUser.user_id,
       });
 
-      const expectedState = Immutable.Map({
-        [HOME_NARROW_STR]: [3, 4],
-      });
+      const expectedState = Immutable.Map([[HOME_NARROW_STR, [3, 4]]]);
 
       const newState = narrowsReducer(initialState, action);
 
@@ -458,7 +462,7 @@ describe('narrowsReducer', () => {
     });
 
     test('when anchor is LAST_MESSAGE_ANCHOR previous messages are replaced', () => {
-      const initialState = Immutable.Map({ [HOME_NARROW_STR]: [1, 2] });
+      const initialState = Immutable.Map([[HOME_NARROW_STR, [1, 2]]]);
 
       const action = deepFreeze({
         anchor: LAST_MESSAGE_ANCHOR,
@@ -475,9 +479,7 @@ describe('narrowsReducer', () => {
         ownUserId: eg.selfUser.user_id,
       });
 
-      const expectedState = Immutable.Map({
-        [HOME_NARROW_STR]: [3, 4],
-      });
+      const expectedState = Immutable.Map([[HOME_NARROW_STR, [3, 4]]]);
 
       const newState = narrowsReducer(initialState, action);
 
@@ -485,7 +487,7 @@ describe('narrowsReducer', () => {
     });
 
     test('if fetched messages are from a search narrow, ignore them', () => {
-      const initialState = Immutable.Map({ [HOME_NARROW_STR]: [1, 2] });
+      const initialState = Immutable.Map([[HOME_NARROW_STR, [1, 2]]]);
 
       const action = deepFreeze({
         ...eg.action.message_fetch_complete,
@@ -575,7 +577,7 @@ describe('narrowsReducer', () => {
     ]);
 
     test('Do nothing if the is:starred narrow has not been fetched', () => {
-      const initialState = Immutable.Map({ [HOME_NARROW_STR]: [1, 2] });
+      const initialState = Immutable.Map([[HOME_NARROW_STR, [1, 2]]]);
 
       const action = deepFreeze({
         type: EVENT_UPDATE_MESSAGE_FLAGS,
@@ -593,7 +595,7 @@ describe('narrowsReducer', () => {
     });
 
     test("Do nothing if action.flag is not 'starred'", () => {
-      const initialState = Immutable.Map({ [STARRED_NARROW_STR]: [1, 2] });
+      const initialState = Immutable.Map([[STARRED_NARROW_STR, [1, 2]]]);
 
       const action = deepFreeze({
         type: EVENT_UPDATE_MESSAGE_FLAGS,
@@ -614,7 +616,7 @@ describe('narrowsReducer', () => {
       'Adds, while maintaining chronological order, '
         + 'newly starred messages to the is:starred narrow',
       () => {
-        const initialState = Immutable.Map({ [STARRED_NARROW_STR]: [1, 3, 5] });
+        const initialState = Immutable.Map([[STARRED_NARROW_STR, [1, 3, 5]]]);
 
         const action = deepFreeze({
           type: EVENT_UPDATE_MESSAGE_FLAGS,
@@ -626,9 +628,7 @@ describe('narrowsReducer', () => {
           messages: [4, 2],
         });
 
-        const expectedState = Immutable.Map({
-          [STARRED_NARROW_STR]: [1, 2, 3, 4, 5],
-        });
+        const expectedState = Immutable.Map([[STARRED_NARROW_STR, [1, 2, 3, 4, 5]]]);
 
         const newState = narrowsReducer(initialState, action);
 
@@ -640,7 +640,7 @@ describe('narrowsReducer', () => {
       'Removes, while maintaining chronological order, '
         + 'newly unstarred messages from the is:starred narrow',
       () => {
-        const initialState = Immutable.Map({ [STARRED_NARROW_STR]: [1, 2, 3, 4, 5] });
+        const initialState = Immutable.Map([[STARRED_NARROW_STR, [1, 2, 3, 4, 5]]]);
 
         const action = deepFreeze({
           type: EVENT_UPDATE_MESSAGE_FLAGS,
@@ -652,9 +652,7 @@ describe('narrowsReducer', () => {
           messages: [4, 2],
         });
 
-        const expectedState = Immutable.Map({
-          [STARRED_NARROW_STR]: [1, 3, 5],
-        });
+        const expectedState = Immutable.Map([[STARRED_NARROW_STR, [1, 3, 5]]]);
 
         const newState = narrowsReducer(initialState, action);
 

--- a/src/chat/__tests__/narrowsSelectors-test.js
+++ b/src/chat/__tests__/narrowsSelectors-test.js
@@ -31,9 +31,7 @@ describe('getMessagesForNarrow', () => {
 
   test('if no outbox messages returns messages with no change', () => {
     const state = eg.reduxState({
-      narrows: Immutable.Map({
-        [HOME_NARROW_STR]: [123],
-      }),
+      narrows: Immutable.Map([[HOME_NARROW_STR, [123]]]),
       messages,
       outbox: [],
       users: [eg.selfUser],
@@ -47,9 +45,7 @@ describe('getMessagesForNarrow', () => {
 
   test('combine messages and outbox in same narrow', () => {
     const state = eg.reduxState({
-      narrows: Immutable.Map({
-        [HOME_NARROW_STR]: [123],
-      }),
+      narrows: Immutable.Map([[HOME_NARROW_STR, [123]]]),
       messages,
       outbox: [outboxMessage],
       caughtUp: {
@@ -66,9 +62,7 @@ describe('getMessagesForNarrow', () => {
 
   test('do not combine messages and outbox if not caught up', () => {
     const state = eg.reduxState({
-      narrows: Immutable.Map({
-        [HOME_NARROW_STR]: [123],
-      }),
+      narrows: Immutable.Map([[HOME_NARROW_STR, [123]]]),
       messages,
       outbox: [outboxMessage],
       users: [eg.selfUser],
@@ -82,9 +76,7 @@ describe('getMessagesForNarrow', () => {
 
   test('do not combine messages and outbox in different narrow', () => {
     const state = eg.reduxState({
-      narrows: Immutable.Map({
-        [keyFromNarrow(pm1to1NarrowFromUser(eg.otherUser))]: [123],
-      }),
+      narrows: Immutable.Map([[keyFromNarrow(pm1to1NarrowFromUser(eg.otherUser)), [123]]]),
       messages,
       outbox: [outboxMessage],
       users: [eg.selfUser],
@@ -229,9 +221,7 @@ describe('getShownMessagesForNarrow', () => {
 describe('getFirstMessageId', () => {
   test('return undefined when there are no messages', () => {
     const state = eg.reduxState({
-      narrows: Immutable.Map({
-        [HOME_NARROW_STR]: [],
-      }),
+      narrows: Immutable.Map([[HOME_NARROW_STR, []]]),
       outbox: [],
     });
 
@@ -242,9 +232,7 @@ describe('getFirstMessageId', () => {
 
   test('returns first message id', () => {
     const state = eg.reduxState({
-      narrows: Immutable.Map({
-        [HOME_NARROW_STR]: [1, 2, 3],
-      }),
+      narrows: Immutable.Map([[HOME_NARROW_STR, [1, 2, 3]]]),
       messages: eg.makeMessagesState([
         eg.streamMessage({ id: 1 }),
         eg.streamMessage({ id: 2 }),
@@ -262,9 +250,7 @@ describe('getFirstMessageId', () => {
 describe('getLastMessageId', () => {
   test('return undefined when there are no messages', () => {
     const state = eg.reduxState({
-      narrows: Immutable.Map({
-        [HOME_NARROW_STR]: [],
-      }),
+      narrows: Immutable.Map([[HOME_NARROW_STR, []]]),
       messages: eg.makeMessagesState([]),
       outbox: [],
     });
@@ -276,9 +262,7 @@ describe('getLastMessageId', () => {
 
   test('returns last message id', () => {
     const state = eg.reduxState({
-      narrows: Immutable.Map({
-        [HOME_NARROW_STR]: [1, 2, 3],
-      }),
+      narrows: Immutable.Map([[HOME_NARROW_STR, [1, 2, 3]]]),
       messages: eg.makeMessagesState([
         eg.streamMessage({ id: 1 }),
         eg.streamMessage({ id: 2 }),

--- a/src/message/__tests__/fetchActions-test.js
+++ b/src/message/__tests__/fetchActions-test.js
@@ -53,9 +53,7 @@ describe('fetchActions', () => {
             older: true,
           },
         },
-        narrows: Immutable.Map({
-          [streamNarrowStr]: [],
-        }),
+        narrows: Immutable.Map([[streamNarrowStr, []]]),
         streams: [eg.stream],
       });
 
@@ -75,9 +73,7 @@ describe('fetchActions', () => {
             older: false,
           },
         },
-        narrows: Immutable.Map({
-          [streamNarrowStr]: [1],
-        }),
+        narrows: Immutable.Map([[streamNarrowStr, [1]]]),
         messages: eg.makeMessagesState([message1, message2]),
         streams: [eg.stream],
       });
@@ -251,9 +247,7 @@ describe('fetchActions', () => {
     };
 
     const baseState = eg.reduxStatePlus({
-      narrows: Immutable.Map({
-        [streamNarrowStr]: [message1.id],
-      }),
+      narrows: Immutable.Map([[streamNarrowStr, [message1.id]]]),
       realm: {
         ...eg.plusReduxState.realm,
         allowEditHistory: true, // TODO: test with this `false`
@@ -424,9 +418,7 @@ describe('fetchActions', () => {
     test('when messages to be fetched both before and after anchor, numBefore and numAfter are greater than zero', async () => {
       const store = mockStore<GlobalState, Action>(
         eg.reduxStatePlus({
-          narrows: Immutable.Map({
-            [streamNarrowStr]: [1],
-          }),
+          narrows: Immutable.Map([[streamNarrowStr, [1]]]),
         }),
       );
 
@@ -449,9 +441,7 @@ describe('fetchActions', () => {
     test('when no messages to be fetched before the anchor, numBefore is not greater than zero', async () => {
       const store = mockStore<GlobalState, Action>(
         eg.reduxStatePlus({
-          narrows: Immutable.Map({
-            [streamNarrowStr]: [1],
-          }),
+          narrows: Immutable.Map([[streamNarrowStr, [1]]]),
         }),
       );
 
@@ -473,9 +463,7 @@ describe('fetchActions', () => {
     test('when no messages to be fetched after the anchor, numAfter is not greater than zero', async () => {
       const store = mockStore<GlobalState, Action>(
         eg.reduxStatePlus({
-          narrows: Immutable.Map({
-            [streamNarrowStr]: [1],
-          }),
+          narrows: Immutable.Map([[streamNarrowStr, [1]]]),
         }),
       );
 
@@ -501,10 +489,10 @@ describe('fetchActions', () => {
 
     const baseState = eg.reduxStatePlus({
       narrows: eg.plusReduxState.narrows.merge(
-        Immutable.Map({
-          [streamNarrowStr]: [message2.id],
-          [HOME_NARROW_STR]: [message1.id, message2.id],
-        }),
+        Immutable.Map([
+          [streamNarrowStr, [message2.id]],
+          [HOME_NARROW_STR, [message1.id, message2.id]],
+        ]),
       ),
       messages: eg.makeMessagesState([message1, message2]),
     });
@@ -594,10 +582,10 @@ describe('fetchActions', () => {
 
     const baseState = eg.reduxStatePlus({
       narrows: eg.plusReduxState.narrows.merge(
-        Immutable.Map({
-          [streamNarrowStr]: [message2.id],
-          [HOME_NARROW_STR]: [message1.id, message2.id],
-        }),
+        Immutable.Map([
+          [streamNarrowStr, [message2.id]],
+          [HOME_NARROW_STR, [message1.id, message2.id]],
+        ]),
       ),
       messages: eg.makeMessagesState([message1, message2]),
     });

--- a/src/pm-conversations/__tests__/pmConversationsSelectors-test.js
+++ b/src/pm-conversations/__tests__/pmConversationsSelectors-test.js
@@ -72,9 +72,7 @@ describe('getRecentConversationsLegacy', () => {
       accounts,
       realm: eg.realmState({ user_id: eg.selfUser.user_id }),
       users: [eg.selfUser],
-      narrows: Immutable.Map({
-        [ALL_PRIVATE_NARROW_STR]: [],
-      }),
+      narrows: Immutable.Map([[ALL_PRIVATE_NARROW_STR, []]]),
       unread: {
         ...eg.baseReduxState.unread,
         pms: [],
@@ -92,9 +90,7 @@ describe('getRecentConversationsLegacy', () => {
       accounts,
       realm: eg.realmState({ user_id: eg.selfUser.user_id }),
       users: [eg.selfUser, userJohn, userMark],
-      narrows: Immutable.Map({
-        [ALL_PRIVATE_NARROW_STR]: [0, 1, 2, 3, 4],
-      }),
+      narrows: Immutable.Map([[ALL_PRIVATE_NARROW_STR, [0, 1, 2, 3, 4]]]),
       messages: eg.makeMessagesState([
         eg.pmMessageFromTo(userJohn, [eg.selfUser], { id: 1 }),
         eg.pmMessageFromTo(userMark, [eg.selfUser], { id: 2 }),
@@ -140,9 +136,7 @@ describe('getRecentConversationsLegacy', () => {
       accounts,
       realm: eg.realmState({ user_id: eg.selfUser.user_id }),
       users: [eg.selfUser, userJohn, userMark],
-      narrows: Immutable.Map({
-        [ALL_PRIVATE_NARROW_STR]: [1, 2, 3, 4, 5, 6],
-      }),
+      narrows: Immutable.Map([[ALL_PRIVATE_NARROW_STR, [1, 2, 3, 4, 5, 6]]]),
       messages: eg.makeMessagesState([
         eg.pmMessageFromTo(userJohn, [eg.selfUser], { id: 2 }),
         eg.pmMessageFromTo(userMark, [eg.selfUser], { id: 1 }),

--- a/src/storage/__tests__/replaceRevive-test.js
+++ b/src/storage/__tests__/replaceRevive-test.js
@@ -17,14 +17,16 @@ const data = {
   jsMapNumKeys: new Map([[1, 2], [3, 4]]),
   jsSet: new Set([1, 2, 'a', null, { b: [3] }]),
   list: Immutable.List([1, 2, 'a', null]),
-  map: Immutable.Map({ a: 1, b: 2, c: 3, d: 4 }),
-  mapWithTypeKey: Immutable.Map({
-    a: 1,
-    [SERIALIZED_TYPE_FIELD_NAME]: {
-      b: [2],
-      [SERIALIZED_TYPE_FIELD_NAME]: { c: [3] },
-    },
-  }),
+  map: Immutable.Map([
+    ['a', 1],
+    ['b', 2],
+    ['c', 3],
+    ['d', 4],
+  ]),
+  mapWithTypeKey: Immutable.Map([
+    ['a', 1],
+    [SERIALIZED_TYPE_FIELD_NAME, { b: [2], [SERIALIZED_TYPE_FIELD_NAME]: { c: [3] } }],
+  ]),
   // prettier-ignore
   mapNumKeys: Immutable.Map([[1, 1], [2, 2], [3, 3], [4, 4]]),
   emptyMap: Immutable.Map([]),


### PR DESCRIPTION
From discussion: https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/.60Immutable.2EMap.28.7B.20.5BSTRING_CONST.5D.3A.20.E2.80.A6.20.7D.29.60.20busted.20by.20Flow.20bug/near/1481093