### PR TITLE
model [nfc]: Comment on rest of REGISTER_COMPLETE handlers that reset state

### DIFF
--- a/src/caughtup/__tests__/caughtUpReducer-test.js
+++ b/src/caughtup/__tests__/caughtUpReducer-test.js
@@ -25,6 +25,18 @@ describe('caughtUpReducer', () => {
     expect(caughtUpReducer(prevState, eg.action.reset_account_data)).toEqual(initialState);
   });
 
+  describe('REGISTER_COMPLETE', () => {
+    const initialState = eg.baseReduxState.caughtUp;
+    const prevState = caughtUpReducer(initialState, {
+      ...eg.action.message_fetch_complete,
+      foundNewest: true,
+      foundOldest: true,
+    });
+    expect(prevState).not.toEqual(initialState);
+
+    expect(caughtUpReducer(prevState, eg.action.register_complete)).toEqual(initialState);
+  });
+
   describe('MESSAGE_FETCH_START', () => {
     test('when fetch starts caught up does not change', () => {
       const prevState = deepFreeze({ [HOME_NARROW_STR]: { older: true, newer: true } });

--- a/src/caughtup/caughtUpReducer.js
+++ b/src/caughtup/caughtUpReducer.js
@@ -32,8 +32,12 @@ export default (
   action: PerAccountApplicableAction,
 ): CaughtUpState => {
   switch (action.type) {
-    case REGISTER_COMPLETE:
     case RESET_ACCOUNT_DATA:
+      return initialState;
+
+    // Reset because `caughtUp` is server-data metadata, and we're resetting
+    // the server data it's supposed to apply to: `state.narrows`.
+    case REGISTER_COMPLETE:
       return initialState;
 
     case MESSAGE_FETCH_START: {

--- a/src/chat/__tests__/flagsReducer-test.js
+++ b/src/chat/__tests__/flagsReducer-test.js
@@ -7,6 +7,17 @@ import flagsReducer from '../flagsReducer';
 import { EVENT_UPDATE_MESSAGE_FLAGS } from '../../actionConstants';
 
 describe('flagsReducer', () => {
+  describe('REGISTER_COMPLETE', () => {
+    const initialState = eg.baseReduxState.flags;
+    const prevState = flagsReducer(
+      initialState,
+      eg.mkActionEventNewMessage(eg.streamMessage({ flags: ['read', 'starred'] })),
+    );
+    expect(prevState).not.toEqual(initialState);
+
+    expect(flagsReducer(prevState, eg.action.register_complete)).toEqual(initialState);
+  });
+
   describe('MESSAGE_FETCH_COMPLETE', () => {
     test('flags from all messages are extracted and stored by id', () => {
       const message1 = eg.streamMessage();

--- a/src/chat/__tests__/narrowsReducer-test.js
+++ b/src/chat/__tests__/narrowsReducer-test.js
@@ -39,6 +39,17 @@ describe('narrowsReducer', () => {
     expect(narrowsReducer(prevState, eg.action.reset_account_data)).toEqual(initialState);
   });
 
+  describe('REGISTER_COMPLETE', () => {
+    const initialState = eg.baseReduxState.narrows;
+    const prevState = narrowsReducer(initialState, {
+      ...eg.action.message_fetch_complete,
+      messages: [eg.streamMessage()],
+    });
+    expect(prevState).not.toEqual(initialState);
+
+    expect(narrowsReducer(prevState, eg.action.register_complete)).toEqual(initialState);
+  });
+
   describe('EVENT_NEW_MESSAGE', () => {
     test('if not caught up in narrow, do not add message in home narrow', () => {
       const message = eg.streamMessage({ id: 3, flags: [] });

--- a/src/chat/fetchingReducer.js
+++ b/src/chat/fetchingReducer.js
@@ -71,10 +71,11 @@ export default (
       return initialState;
 
     // Reset just because `fetching` is server-data metadata, and we're
-    // resetting the server data it's supposed to apply to… But really, we
-    // should have canceled any in-progress message fetches by now; that's
-    // #5623. Still, even if there is an in-progress fetch, we probably
-    // don't want to show loading indicators for it in the UI.
+    // resetting the server data it's supposed to apply to
+    // (`state.narrows`)… But really, we should have canceled any
+    // in-progress message fetches by now; that's #5623. Still, even if
+    // there is an in-progress fetch, we probably don't want to show loading
+    // indicators for it in the UI.
     // TODO(#5623): Remove reference to #5623.
     case REGISTER_COMPLETE:
       return initialState;

--- a/src/chat/flagsReducer.js
+++ b/src/chat/flagsReducer.js
@@ -131,8 +131,14 @@ export default (
   action: PerAccountApplicableAction,
 ): FlagsState => {
   switch (action.type) {
-    case REGISTER_COMPLETE:
     case RESET_ACCOUNT_DATA:
+      return initialState;
+
+    // Reset to clear stale data. We don't initialize the
+    // messages/narrows/flags model using initial data; instead, we fetch
+    // chunks of data as needed with api.getMessages. See
+    //   https://zulip.readthedocs.io/en/latest/subsystems/events-system.html#messages
+    case REGISTER_COMPLETE:
       return initialState;
 
     case MESSAGE_FETCH_COMPLETE:

--- a/src/chat/narrowsReducer.js
+++ b/src/chat/narrowsReducer.js
@@ -194,8 +194,14 @@ export default (
   action: PerAccountApplicableAction,
 ): NarrowsState => {
   switch (action.type) {
-    case REGISTER_COMPLETE:
     case RESET_ACCOUNT_DATA:
+      return initialState;
+
+    // Reset to clear stale data. We don't initialize the
+    // messages/narrows/flags model using initial data; instead, we fetch
+    // chunks of data as needed with api.getMessages. See
+    //   https://zulip.readthedocs.io/en/latest/subsystems/events-system.html#messages
+    case REGISTER_COMPLETE:
       return initialState;
 
     case MESSAGE_FETCH_START: {

--- a/src/message/__tests__/messagesReducer-test.js
+++ b/src/message/__tests__/messagesReducer-test.js
@@ -27,6 +27,20 @@ describe('messagesReducer', () => {
     ).toEqual(eg.baseReduxState.messages);
   });
 
+  describe('REGISTER_COMPLETE', () => {
+    const initialState = eg.baseReduxState.messages;
+    const prevState = messagesReducer(
+      initialState,
+      { ...eg.action.message_fetch_complete, messages: [eg.streamMessage()] },
+      eg.baseReduxState,
+    );
+    expect(prevState).not.toEqual(initialState);
+
+    expect(messagesReducer(prevState, eg.action.register_complete, eg.baseReduxState)).toEqual(
+      initialState,
+    );
+  });
+
   describe('EVENT_NEW_MESSAGE', () => {
     test('appends message to state, if any narrow is caught up to newest', () => {
       const message1 = eg.streamMessage();

--- a/src/message/messagesReducer.js
+++ b/src/message/messagesReducer.js
@@ -139,8 +139,14 @@ export default (
   globalState: PerAccountState,
 ): MessagesState => {
   switch (action.type) {
-    case REGISTER_COMPLETE:
     case RESET_ACCOUNT_DATA:
+      return initialState;
+
+    // Reset to clear stale data. We don't initialize the
+    // messages/narrows/flags model using initial data; instead, we fetch
+    // chunks of data as needed with api.getMessages. See
+    //   https://zulip.readthedocs.io/en/latest/subsystems/events-system.html#messages
+    case REGISTER_COMPLETE:
       return initialState;
 
     case MESSAGE_FETCH_COMPLETE:

--- a/src/outbox/outboxReducer.js
+++ b/src/outbox/outboxReducer.js
@@ -26,6 +26,7 @@ export default (
   action: PerAccountApplicableAction,
 ): OutboxState => {
   switch (action.type) {
+    // TODO(#3881): Figure out if we want this.
     case REGISTER_COMPLETE:
       return filterArray(state, (outbox: Outbox) => !outbox.isSent);
 

--- a/src/streams/__tests__/streamsReducer-test.js
+++ b/src/streams/__tests__/streamsReducer-test.js
@@ -19,6 +19,16 @@ describe('streamsReducer', () => {
     });
   });
 
+  describe('REGISTER_COMPLETE', () => {
+    test('stores initial streams data', () => {
+      const streams = [eg.makeStream(), eg.makeStream()];
+
+      const prevState = eg.baseReduxState.streams;
+      const action = eg.mkActionRegisterComplete({ streams });
+      expect(streamsReducer(prevState, action)).toEqual(streams);
+    });
+  });
+
   describe('EVENT -> stream -> create', () => {
     test('add new stream', () => {
       const stream1 = eg.makeStream({ name: 'some stream', stream_id: 1 });


### PR DESCRIPTION
This addresses the following item in the list at #5605:

> - [ ] Some reducers don't have a comment saying why they reset
>       state on `REGISTER_COMPLETE` instead of taking data from its
>       payload:
>       - For example, `flagsReducer` should point out that
>         `messagesReducer` doesn't store messages on
>         `REGISTER_COMPLETE`, and `messagesReducer` should say that
>         it doesn't do that because we fetch messages with
>         `GET /messages`.
>       - (Probably plenty of other instances.)

Fixes-partly: #5605