### PR TITLE
typing model: Don't reset on DEAD_QUEUE

### DIFF
--- a/src/typing/typingReducer.js
+++ b/src/typing/typingReducer.js
@@ -4,7 +4,6 @@ import {
   EVENT_TYPING_START,
   EVENT_TYPING_STOP,
   CLEAR_TYPING,
-  DEAD_QUEUE,
   RESET_ACCOUNT_DATA,
   REGISTER_COMPLETE,
 } from '../actionConstants';
@@ -96,7 +95,6 @@ export default (
     case CLEAR_TYPING:
       return clearTyping(state, action);
 
-    case DEAD_QUEUE:
     case RESET_ACCOUNT_DATA:
       return initialState;
 


### PR DESCRIPTION
We don't clear other server data on DEAD_QUEUE, plus there's already a client-side component that makes this feature fail gracefully in the presence of stale server data (a timeout to clear typing indicators).

Fixes-partly: #5605