### PR TITLE
api: Don't allow connecting to servers <2.0

### DIFF
--- a/src/api/apiErrors.js
+++ b/src/api/apiErrors.js
@@ -1,6 +1,7 @@
 /* @flow strict-local */
 import { ExtendableError } from '../utils/logging';
 import type { ApiErrorCode, ApiResponseErrorData } from './transportTypes';
+import { ZulipVersion } from '../utils/zulipVersion';
 
 /**
  * Some kind of error from a Zulip API network request.
@@ -168,3 +169,26 @@ export const interpretApiResponse = (httpStatus: number, data: mixed): mixed => 
   // the API says that shouldn't happen.
   throw new UnexpectedHttpStatusError(httpStatus, data);
 };
+
+/**
+ * The Zulip Server version below which we should just refuse to connect.
+ */
+// Currently chosen to affect a truly tiny fraction of users, as we test the
+// feature of refusing to connect, to keep the risk small; see
+//   https://github.com/zulip/zulip-mobile/issues/5102#issuecomment-1233446360
+// In steady state, this should lag a bit behind the threshold version for
+// ServerCompatBanner (kMinSupportedVersion), to give users time to see and
+// act on the banner.
+export const kMinAllowedServerVersion: ZulipVersion = new ZulipVersion('2.0');
+
+/**
+ * An error we throw in API bindings on finding a server is too old.
+ */
+export class ServerTooOldError extends ExtendableError {
+  version: ZulipVersion;
+
+  constructor(version: ZulipVersion) {
+    super(`Unsupported Zulip Server version: ${version.raw()}`);
+    this.version = version;
+  }
+}

--- a/src/api/pollForEvents.js
+++ b/src/api/pollForEvents.js
@@ -9,6 +9,9 @@ type ApiResponsePollEvents = {|
 |};
 
 /** See https://zulip.com/api/get-events */
+// TODO: Handle downgrading server across kThresholdVersion, which we'd hear
+//   about in `restart` events, by throwing a ServerTooOldError. This case
+//   seems pretty rare but is possible.
 export default (auth: Auth, queueId: string, lastEventId: number): Promise<ApiResponsePollEvents> =>
   apiGet(
     auth,

--- a/src/common/ServerCompatBanner.js
+++ b/src/common/ServerCompatBanner.js
@@ -18,6 +18,9 @@ import { Role } from '../api/permissionsTypes';
  *
  * Should match what we say at:
  *   https://zulip.readthedocs.io/en/stable/overview/release-lifecycle.html#compatibility-and-upgrading
+ *
+ * See also kMinAllowedServerVersion in apiErrors.js, for the version below
+ * which we just refuse to connect.
  */
 // "2.2.0" is a funny way of saying "3.0", differing in that it accepts
 // versions like 2.2-dev-1234-g08192a3b4c.  Some servers running versions

--- a/src/common/ServerCompatBanner.js
+++ b/src/common/ServerCompatBanner.js
@@ -96,6 +96,8 @@ export default function ServerCompatBanner(props: Props): Node {
           label: 'Learn more',
           onPress: () => {
             openLinkWithUserPreference(
+              // TODO: Instead, link to new Help Center doc once we have it:
+              //   https://github.com/zulip/zulip/issues/23842
               'https://zulip.readthedocs.io/en/stable/overview/release-lifecycle.html#compatibility-and-upgrading',
               settings,
             );

--- a/src/haveServerDataSelectors.js
+++ b/src/haveServerDataSelectors.js
@@ -2,8 +2,13 @@
 
 import type { GlobalState, PerAccountState } from './types';
 import { getUsers } from './directSelectors';
-import { tryGetAuth, tryGetActiveAccountState } from './account/accountsSelectors';
+import {
+  tryGetAuth,
+  tryGetActiveAccountState,
+  getServerVersion,
+} from './account/accountsSelectors';
 import { getUsersById } from './users/userSelectors';
+import { kMinAllowedServerVersion } from './api/apiErrors';
 
 /**
  * Whether we have server data for the active account.
@@ -111,6 +116,12 @@ export const getHaveServerData = (state: PerAccountState): boolean => {
     //
     // For ACCOUNT_REMOVE, see the previous condition.
     // ACCOUNT_SWITCH we only do for logged-in accounts.
+    return false;
+  }
+
+  // We may have server data, but it would be from an ancient server that we
+  // don't support, so it might be malformed.
+  if (!getServerVersion(state).isAtLeast(kMinAllowedServerVersion)) {
     return false;
   }
 

--- a/static/translations/messages_en.json
+++ b/static/translations/messages_en.json
@@ -84,6 +84,7 @@
   "Could not connect": "Could not connect",
   "The server at {realm} said:\n\n{message}": "The server at {realm} said:\n\n{message}",
   "Could not connect to {realm}. Please check your network connection and try again.": "Could not connect to {realm}. Please check your network connection and try again.",
+  "{realm} is running Zulip Server {version}, which is unsupported. The minimum supported version is Zulip Server {minSupportedVersion}.": "{realm} is running Zulip Server {version}, which is unsupported. The minimum supported version is Zulip Server {minSupportedVersion}.",
   "The server at {realm} does not seem to be a Zulip server.": "The server at {realm} does not seem to be a Zulip server.",
   "Find your Zulip server URL": "Find your Zulip server URL",
   "The server at {realm} encountered an error.": "The server at {realm} encountered an error.",


### PR DESCRIPTION
With an error alert that appears at the following points:

On submitting `RealmInputScreen` (titled "Welcome"):

<img width=400 src="https://user-images.githubusercontent.com/22248748/210428378-79946574-6fd8-4a85-ae15-b582611a4f89.gif" /> 


On selecting a logged-out account in `AccountPickScreen` (titled "Pick account"):

<img width=400 src="https://user-images.githubusercontent.com/22248748/210430114-c2776b74-030a-4398-91d9-1c0648a7efcf.gif" />


When we get a `/register` response from the active account's server. (The first screenshot is what happens on launch; the second is what happens when you select a logged-in account in `AccountPickScreen`.)

<img width=400 src="https://user-images.githubusercontent.com/22248748/210430952-4231a344-b8e8-45bd-a176-623be5e14655.gif" /> <img width=400 src="https://user-images.githubusercontent.com/22248748/210431617-8f23247f-abb7-4147-aee0-7111442daf41.gif" />

The alert says:

Title:
> Could not connect

Body:
> {realm} is running Zulip Server {version}, which is unsupported.

The "Learn more" button goes to https://zulip.readthedocs.io/en/stable/overview/release-lifecycle.html#compatibility-and-upgrading but later we'll want to change that to a new page; that's https://github.com/zulip/zulip/issues/23842.

cc @alya for the UX change.

Fixes: #5102