### PR TITLE
compose: Allow image multi-selection, where supported

### DIFF
--- a/src/lightbox/download.js
+++ b/src/lightbox/download.js
@@ -3,10 +3,10 @@ import { Platform, PermissionsAndroid } from 'react-native';
 import type { Rationale } from 'react-native/Libraries/PermissionsAndroid/PermissionsAndroid';
 import { CameraRoll } from '@react-native-camera-roll/camera-roll';
 import RNFetchBlob from 'rn-fetch-blob';
-import invariant from 'invariant';
 
 import type { Auth } from '../api/transportTypes';
 import { getMimeTypeFromFileExtension } from '../utils/url';
+import { androidSdkVersion } from '../reactNativeUtils';
 
 /**
  * Request permission WRITE_EXTERNAL_STORAGE if needed or throw if can't get it.
@@ -18,17 +18,7 @@ import { getMimeTypeFromFileExtension } from '../utils/url';
  * as a toast.
  */
 export const androidEnsureStoragePermission = async (rationale: Rationale): Promise<void> => {
-  invariant(
-    Platform.OS === 'android',
-    'androidEnsureStoragePermission should only be called on Android',
-  );
-  // Flow isn't refining `Platform` to a type that corresponds to values
-  // we'll see on Android. We do expect `Platform.Version` to be a number on
-  // Android; see https://reactnative.dev/docs/platform#version. Empirically
-  // (and this isn't in the doc yet), it's the SDK version, so for Android
-  // 10 it won't be 10, it'll be 29.
-  const androidSdkVersion = (Platform.Version: number);
-  if (androidSdkVersion > 28) {
+  if (androidSdkVersion() > 28) {
     return;
   }
 

--- a/src/reactNativeUtils.js
+++ b/src/reactNativeUtils.js
@@ -1,10 +1,11 @@
 /* @flow strict-local */
 
 import React from 'react';
-import { AppState } from 'react-native';
+import { AppState, Platform } from 'react-native';
 import type { AppStateValues } from 'react-native/Libraries/AppState/AppState';
 // eslint-disable-next-line id-match
 import type { ____ViewStyle_Internal } from 'react-native/Libraries/StyleSheet/StyleSheetTypes';
+import invariant from 'invariant';
 
 import * as logging from './utils/logging';
 import type { BoundedDiff } from './generics';
@@ -61,4 +62,20 @@ export function useAppState(): null | AppStateValues {
     return () => sub.remove();
   }, []);
   return value;
+}
+
+/**
+ * The Android SDK version (e.g., 33 for Android 13 a.k.a. Tiramisu).
+ *
+ * Throws if called on iOS.
+ */
+export function androidSdkVersion(): number {
+  invariant(Platform.OS === 'android', 'androidSdkVersion called on iOS');
+
+  // Flow isn't refining `Platform` to a type that corresponds to values
+  // we'll see on Android. We do expect `Platform.Version` to be a number on
+  // Android; see https://reactnative.dev/docs/platform#version. Empirically
+  // (and this isn't in the doc yet), it's the SDK version, so for Android
+  // 10 it won't be 10, it'll be 29.
+  return (Platform.Version: number);
 }

--- a/static/translations/messages_en.json
+++ b/static/translations/messages_en.json
@@ -24,6 +24,8 @@
   "No one has read this message yet.": "No one has read this message yet.",
   "Confirm": "Confirm",
   "Failed to attach your file.": "Failed to attach your file.",
+  "Failed to attach your files.": "Failed to attach your files.",
+  "Failed to attach some of your files.": "Failed to attach some of your files.",
   "Configure permissions": "Configure permissions",
   "You": "You",
   "Discard changes": "Discard changes",


### PR DESCRIPTION
Planned followup to https://github.com/zulip/zulip-mobile/pull/5474.

-----

We recently completed the feature of not immediately sending
messages with image uploads, in #5474. With that, it became possible
to send a message with multiple uploaded images in it. But you had
to go through the image-selection flow once for each of your chosen
images; see discussion:
  https://github.com/zulip/zulip-mobile/pull/5474#pullrequestreview-1246356066

This gives a smoother experience by letting you choose multiple
images in one image-selection session.

Related: #2366
Co-authored-by: Akash Dhiman <akash.d0407@gmail.com>

-----

cc @alya for the UX change