### PR TITLE
NotificationsScreen: Section off per-account settings

### DIFF
--- a/src/account/accountMisc.js
+++ b/src/account/accountMisc.js
@@ -5,7 +5,7 @@ const identitySlice = ({ realm, email }): Identity => ({ realm, email });
 
 export const identityOfAuth: Auth => Identity = identitySlice;
 
-export const identityOfAccount: Account => Identity = identitySlice;
+export const identityOfAccount: ($ReadOnly<{ ...Identity, ... }>) => Identity = identitySlice;
 
 /** A string corresponding uniquely to an identity, for use in `Map`s. */
 export const keyOfIdentity = ({ realm, email }: Identity): string =>

--- a/src/message/MentionedUserNotSubscribed.js
+++ b/src/message/MentionedUserNotSubscribed.js
@@ -11,6 +11,7 @@ import * as api from '../api';
 import ZulipButton from '../common/ZulipButton';
 import ZulipTextIntl from '../common/ZulipTextIntl';
 import { getAuth } from '../selectors';
+import { kWarningColor } from '../styles/constants';
 
 type Props = $ReadOnly<{|
   user: UserOrBot,
@@ -23,7 +24,7 @@ const styles = createStyleSheet({
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'space-around',
-    backgroundColor: 'hsl(40, 100%, 60%)', // Material warning-color
+    backgroundColor: kWarningColor,
     paddingHorizontal: 16,
     paddingVertical: 8,
   },

--- a/src/settings/NotificationsScreen.js
+++ b/src/settings/NotificationsScreen.js
@@ -20,7 +20,7 @@ import type { LocalizableText } from '../types';
 import { TranslationContext } from '../boot/TranslationProvider';
 import { kWarningColor } from '../styles/constants';
 import { getIdentities, getIdentity, getIsActiveAccount } from '../account/accountsSelectors';
-import { getRealmName } from '../directSelectors';
+import { getRealm, getRealmName } from '../directSelectors';
 import ZulipText from '../common/ZulipText';
 import SettingsGroup from './SettingsGroup';
 
@@ -124,6 +124,7 @@ export default function NotificationsScreen(props: Props): Node {
     getIdentities(state).filter(identity_ => !getIsActiveAccount(state, identity_)),
   );
   const realmName = useSelector(getRealmName);
+  const pushNotificationsEnabled = useSelector(state => getRealm(state).pushNotificationsEnabled);
   const offlineNotification = useSelector(state => getSettings(state).offlineNotification);
   const onlineNotification = useSelector(state => getSettings(state).onlineNotification);
   const streamNotification = useSelector(state => getSettings(state).streamNotification);
@@ -213,31 +214,33 @@ export default function NotificationsScreen(props: Props): Node {
         })()}
         onPress={handleSystemSettingsPress}
       />
-      <SettingsGroup
-        title={{
-          text: 'Notification settings for this account ({email} in {realmName}):',
-          values: {
-            email: <ZulipText style={{ fontWeight: 'bold' }} text={identity.email} />,
-            realmName: <ZulipText style={{ fontWeight: 'bold' }} text={realmName} />,
-          },
-        }}
-      >
-        <SwitchRow
-          label="Notifications when offline"
-          value={offlineNotification}
-          onValueChange={handleOfflineNotificationChange}
-        />
-        <SwitchRow
-          label="Notifications when online"
-          value={onlineNotification}
-          onValueChange={handleOnlineNotificationChange}
-        />
-        <SwitchRow
-          label="Stream notifications"
-          value={streamNotification}
-          onValueChange={handleStreamNotificationChange}
-        />
-      </SettingsGroup>
+      {pushNotificationsEnabled && (
+        <SettingsGroup
+          title={{
+            text: 'Notification settings for this account ({email} in {realmName}):',
+            values: {
+              email: <ZulipText style={{ fontWeight: 'bold' }} text={identity.email} />,
+              realmName: <ZulipText style={{ fontWeight: 'bold' }} text={realmName} />,
+            },
+          }}
+        >
+          <SwitchRow
+            label="Notifications when offline"
+            value={offlineNotification}
+            onValueChange={handleOfflineNotificationChange}
+          />
+          <SwitchRow
+            label="Notifications when online"
+            value={onlineNotification}
+            onValueChange={handleOnlineNotificationChange}
+          />
+          <SwitchRow
+            label="Stream notifications"
+            value={streamNotification}
+            onValueChange={handleStreamNotificationChange}
+          />
+        </SettingsGroup>
+      )}
       {otherAccounts.length > 0 && (
         <NestedNavRow title="Other accounts" onPress={handleOtherAccountsPress} />
       )}

--- a/src/settings/NotificationsScreen.js
+++ b/src/settings/NotificationsScreen.js
@@ -18,6 +18,7 @@ import { useAppState } from '../reactNativeUtils';
 import { IconAlertTriangle } from '../common/Icons';
 import type { LocalizableText } from '../types';
 import { TranslationContext } from '../boot/TranslationProvider';
+import { kWarningColor } from '../styles/constants';
 
 const {
   ZLPConstants,
@@ -176,7 +177,7 @@ export default function NotificationsScreen(props: Props): Node {
           systemSettingsWarnings.length > 0
             ? {
                 Component: IconAlertTriangle,
-                color: 'hsl(40, 100%, 60%)', // Material warning-color
+                color: kWarningColor,
               }
             : undefined
         }

--- a/src/settings/SettingsGroup.js
+++ b/src/settings/SettingsGroup.js
@@ -1,0 +1,53 @@
+/* @flow strict-local */
+
+import * as React from 'react';
+import { View } from 'react-native';
+
+import SwitchRow from '../common/SwitchRow';
+import NestedNavRow from '../common/NestedNavRow';
+import type { LocalizableReactText } from '../types';
+import { createStyleSheet } from '../styles';
+import { QUARTER_COLOR } from '../styles/constants';
+import ZulipTextIntl from '../common/ZulipTextIntl';
+
+type Props = $ReadOnly<{|
+  /**
+   * The current style works best if this ends in a colon.
+   */
+  // The need to suggest a colon is probably a sign that we can improve the
+  // layout in some subtle way.
+  title: LocalizableReactText,
+
+  children: $ReadOnlyArray<React$Element<typeof SwitchRow> | React$Element<typeof NestedNavRow>>,
+|}>;
+
+export default function SettingsGroup(props: Props): React.Node {
+  const { title, children } = props;
+
+  const styles = React.useMemo(
+    () =>
+      createStyleSheet({
+        container: {
+          overflow: 'hidden',
+          backgroundColor: QUARTER_COLOR, // TODO: Better color
+          marginVertical: 4,
+        },
+        headerContainer: {
+          justifyContent: 'center',
+          paddingHorizontal: 16,
+          paddingVertical: 8,
+          minHeight: 48,
+        },
+      }),
+    [],
+  );
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.headerContainer}>
+        <ZulipTextIntl text={title} />
+      </View>
+      {children}
+    </View>
+  );
+}

--- a/src/styles/constants.js
+++ b/src/styles/constants.js
@@ -18,3 +18,6 @@ export const HIGHLIGHT_COLOR: string = Color(BRAND_COLOR).fade(0.5).toString();
 
 export const HALF_COLOR = 'hsla(0, 0%, 50%, 0.5)';
 export const QUARTER_COLOR = 'hsla(0, 0%, 50%, 0.25)';
+
+// Material warning color
+export const kWarningColor = 'hsl(40, 100%, 60%)';

--- a/src/types.js
+++ b/src/types.js
@@ -3,7 +3,7 @@ import type { Node } from 'react';
 import type { IntlShape } from 'react-intl';
 import type { DangerouslyImpreciseStyleProp } from 'react-native/Libraries/StyleSheet/StyleSheet';
 
-import type { SubsetProperties } from './generics';
+import type { BoundedDiff, SubsetProperties } from './generics';
 import type {
   Auth,
   Topic,
@@ -151,7 +151,7 @@ export type Account = {|
  * Use `identityOfAuth` or `identityOfAccount` to make one of these where
  * you have an `Auth` or `Account`.
  */
-export type Identity = $Diff<Auth, {| apiKey: string |}>;
+export type Identity = BoundedDiff<Auth, {| +apiKey: Auth['apiKey'] |}>;
 
 export type EmojiType = 'image' | 'unicode';
 

--- a/static/translations/messages_en.json
+++ b/static/translations/messages_en.json
@@ -229,6 +229,8 @@
   "System settings for Zulip": "System settings for Zulip",
   "Notifications are disabled.": "Notifications are disabled.",
   "Multiple issues. Tap to learn more.": "Multiple issues. Tap to learn more.",
+  "Notification settings for this account ({email} in {realmName}):": "Notification settings for this account ({email} in {realmName}):",
+  "Other accounts": "Other accounts",
   "Notifications when online": "Notifications when online",
   "Notifications when offline": "Notifications when offline",
   "Stream notifications": "Stream notifications",


### PR DESCRIPTION
Now that this screen can put up an app-level warning about notifications (that they're disabled in system settings; this was #5627), I think it's even easier to wrongly think that these three settings—

- Notifications when offline
- Notifications when online
- Stream notifications

—are app-level rather than account-level. So, group them together and make it clear that they're per-account.

Also hide them when the server declares that push notifications are disabled; in that case they're useless and could cause confusion.

And add an "Other accounts" row that links to `AccountPickScreen`, titled "Pick account". (I have a draft branch queued up that will put a warning on this row if the server of some other account hasn't acked the push token.)

cc @alya for the UX change.