### PR TITLE
Use announceForAccessibilityWithOptions to queue this behind any in-progress announcements

### DIFF
--- a/src/boot/OfflineNoticeProvider.js
+++ b/src/boot/OfflineNoticeProvider.js
@@ -214,12 +214,12 @@ export function OfflineNoticeProvider(props: ProviderProps): Node {
     if (shouldShowUncertaintyNotice && !haveAnnouncedUncertain.current) {
       // TODO(react-native-68): Use announceForAccessibilityWithOptions to
       //   queue this behind any in-progress announcements
-      AccessibilityInfo.announceForAccessibility(_('Zulip’s Internet connection is uncertain.'));
+      AccessibilityInfo.announceForAccessibilityWithOptions(_('Zulip’s Internet connection is uncertain.'), { queue: true });
       haveAnnouncedUncertain.current = true;
     }
 
     if (isOnline === false && (!haveAnnouncedOffline.current || haveAnnouncedUncertain.current)) {
-      AccessibilityInfo.announceForAccessibility(_('Zulip is offline.'));
+      AccessibilityInfo.announceForAccessibilityWithOptions(_('Zulip is offline.'), { queue: false });
       haveAnnouncedOffline.current = true;
       haveAnnouncedUncertain.current = false;
     } else if (
@@ -228,7 +228,8 @@ export function OfflineNoticeProvider(props: ProviderProps): Node {
     ) {
       // TODO(react-native-68): Use announceForAccessibilityWithOptions to
       //   queue this behind any in-progress announcements
-      AccessibilityInfo.announceForAccessibility(_('Zulip is online.'));
+      AccessibilityInfo.announceForAccessibilityWithOptions(_('Zulip is online.'), { queue: true });
+
       haveAnnouncedOffline.current = false;
       haveAnnouncedUncertain.current = false;
     }


### PR DESCRIPTION
announceForAccessibility() replaced with announceForAccessibilityWithOptions().
By default, announcements will interrupt any existing speech. they can be queued behind existing speech by setting queue to true.
