### PR TITLE
tools [nfc]: Inline away tools/tx-pull

### DIFF
--- a/tools/tx-pull
+++ b/tools/tx-pull
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-set -ex
-exec tx pull --silent --all --force

--- a/tools/tx-sync
+++ b/tools/tx-sync
@@ -84,7 +84,7 @@ err_echo
 err_echo 'Step 1: Download translated strings...'
 
 run_visibly cd "${root_dir}"
-run_visibly tools/tx-pull
+run_visibly tx pull --silent --all --force
 
 git_update_index
 if ! git diff-files --quiet; then
@@ -140,7 +140,7 @@ err_echo
 err_echo 'Step 3: Upload strings to translate...'
 
 run_visibly tx push --silent
-run_visibly tools/tx-pull
+run_visibly tx pull --silent --all --force
 
 git_update_index
 if ! git diff-files --quiet; then


### PR DESCRIPTION
This hasn't really had any use case at an interactive CLI since the introduction of `tools/tx-sync`, in 55d25d282 and 1295fffaa a couple of years ago.  And on the other hand it makes tab-completion slightly more annoying when one wants `tools/tx-sync`.