### PR TITLE
account [nfc]: Specialize getAccountStatuses as a view-model

### DIFF
--- a/src/account/AccountItem.js
+++ b/src/account/AccountItem.js
@@ -10,7 +10,7 @@ import ZulipTextIntl from '../common/ZulipTextIntl';
 import { IconDone, IconTrash } from '../common/Icons';
 import { useGlobalSelector } from '../react-redux';
 import { getIsActiveAccount } from './accountsSelectors';
-import type { AccountStatus } from './accountsSelectors';
+import type { AccountStatus } from './AccountPickScreen';
 
 const styles = createStyleSheet({
   wrapper: {

--- a/src/account/AccountList.js
+++ b/src/account/AccountList.js
@@ -5,7 +5,7 @@ import { View, FlatList } from 'react-native';
 
 import ViewPlaceholder from '../common/ViewPlaceholder';
 import AccountItem from './AccountItem';
-import type { AccountStatus } from './accountsSelectors';
+import type { AccountStatus } from './AccountPickScreen';
 
 type Props = $ReadOnly<{|
   accountStatuses: $ReadOnlyArray<AccountStatus>,

--- a/src/account/AccountPickScreen.js
+++ b/src/account/AccountPickScreen.js
@@ -4,12 +4,13 @@ import React, { useContext, useCallback } from 'react';
 import type { Node } from 'react';
 import invariant from 'invariant';
 
+import { createSelector } from 'reselect';
 import { fetchServerSettings } from '../message/fetchActions';
 import { TranslationContext } from '../boot/TranslationProvider';
 import type { RouteProp } from '../react-navigation';
 import type { AppNavigationProp } from '../nav/AppNavigator';
 import { useGlobalSelector, useGlobalDispatch } from '../react-redux';
-import { getAccountStatuses, getAccountsByIdentity, getGlobalSettings } from '../selectors';
+import { getAccountsByIdentity, getGlobalSettings } from '../selectors';
 import Centerer from '../common/Centerer';
 import ZulipButton from '../common/ZulipButton';
 import Logo from '../common/Logo';
@@ -19,6 +20,23 @@ import AccountList from './AccountList';
 import { accountSwitch, removeAccount } from '../actions';
 import { showConfirmationDialog, showErrorAlert } from '../utils/info';
 import { tryStopNotifications } from '../notification/notifTokens';
+import type { Identity } from '../types';
+import type { GlobalSelector } from '../reduxTypes';
+import { getAccounts } from '../directSelectors';
+
+/** The data needed for each item in the list-of-accounts UI. */
+export type AccountStatus = {| ...Identity, isLoggedIn: boolean |};
+
+/**
+ * The data needed for the list of accounts in this UI.
+ *
+ * This serves as a view-model for the use of this component.
+ */
+const getAccountStatuses: GlobalSelector<$ReadOnlyArray<AccountStatus>> = createSelector(
+  getAccounts,
+  accounts =>
+    accounts.map(({ realm, email, apiKey }) => ({ realm, email, isLoggedIn: apiKey !== '' })),
+);
 
 type Props = $ReadOnly<{|
   navigation: AppNavigationProp<'account-pick'>,

--- a/src/account/accountsSelectors.js
+++ b/src/account/accountsSelectors.js
@@ -16,21 +16,6 @@ import { getAccounts } from '../directSelectors';
 import { identityOfAccount, keyOfIdentity, identityOfAuth, authOfAccount } from './accountMisc';
 import { ZulipVersion } from '../utils/zulipVersion';
 
-/** See `getAccountStatuses`. */
-export type AccountStatus = {| ...Identity, isLoggedIn: boolean |};
-
-/**
- * The list of known accounts, with a boolean for logged-in vs. not.
- *
- * This should be used in preference to `getAccounts` where we don't
- * actually need the API keys, but just need to know whether we have them.
- */
-export const getAccountStatuses: GlobalSelector<$ReadOnlyArray<AccountStatus>> = createSelector(
-  getAccounts,
-  accounts =>
-    accounts.map(({ realm, email, apiKey }) => ({ realm, email, isLoggedIn: apiKey !== '' })),
-);
-
 /** The list of known accounts, reduced to `Identity`. */
 export const getIdentities: GlobalSelector<$ReadOnlyArray<Identity>> = createSelector(
   getAccounts,

--- a/src/sentry.js
+++ b/src/sentry.js
@@ -5,10 +5,10 @@ import { nativeApplicationVersion } from 'expo-application';
 // $FlowFixMe[untyped-import]
 import md5 from 'blueimp-md5';
 
-import type { AccountStatus } from './account/accountsSelectors';
+import type { Identity } from './types';
 import isAppOwnDomain from './isAppOwnDomain';
 import store from './boot/store';
-import { getAccountStatuses } from './account/accountsSelectors';
+import { getIdentities } from './account/accountsSelectors';
 import { sentryKey } from './sentryConfig';
 import { isUrlOnRealm } from './utils/url';
 
@@ -70,7 +70,7 @@ type HttpBreadcrumb = $ReadOnly<{|
   |},
 |}>;
 
-function shouldScrubHost(url: URL, accountStatuses: $ReadOnlyArray<AccountStatus>) {
+function shouldScrubHost(url: URL, identities: $ReadOnlyArray<Identity>) {
   if (isAppOwnDomain(url)) {
     return false;
   }
@@ -82,7 +82,7 @@ function shouldScrubHost(url: URL, accountStatuses: $ReadOnlyArray<AccountStatus
     return true;
   }
 
-  if (accountStatuses.some(({ realm }) => isUrlOnRealm(url, realm))) {
+  if (identities.some(({ realm }) => isUrlOnRealm(url, realm))) {
     // Definitely a request to a Zulip realm. Will catch requests to realms
     // in the account-statuses state, including those without `/api/v1`,
     // like `/avatar/{user_id}` (zulip/zulip@0f9970fd3 confirms that this
@@ -99,8 +99,8 @@ function scrubUrl(unscrubbedUrl: void | string): void | string {
   }
 
   const parsedUrl = new URL(unscrubbedUrl);
-  const accountStatuses = getAccountStatuses(store.getState());
-  if (!shouldScrubHost(parsedUrl, accountStatuses)) {
+  const identities = getIdentities(store.getState());
+  if (!shouldScrubHost(parsedUrl, identities)) {
     return unscrubbedUrl;
   }
 


### PR DESCRIPTION
Small follow-up from https://github.com/zulip/zulip-mobile/pull/5634#discussion_r1086139477 .