### PR TITLE
types: Make Account object type read-only

### DIFF
--- a/src/types.js
+++ b/src/types.js
@@ -58,7 +58,7 @@ export type InputSelection = {|
  * with `identityOfAccount` to convert at the boundary.
  * TODO: move more code that way.
  */
-export type Account = {|
+export type Account = $ReadOnly<{|
   ...Auth,
 
   /**
@@ -142,7 +142,7 @@ export type Account = {|
    * apply.
    */
   lastDismissedServerPushSetupNotice: Date | null,
-|};
+|}>;
 
 /**
  * An identity belonging to this user in some Zulip org, with no secrets.


### PR DESCRIPTION
At some point this was on the path to my work to warn about push-token ack problems, but it seems not to be. Still, nice and easy to do.