### PR TITLE
UnreadNotice: Pass `values` in pluralized unread-count string, fixing bug

### DIFF
--- a/src/chat/UnreadNotice.js
+++ b/src/chat/UnreadNotice.js
@@ -49,11 +49,14 @@ export default function UnreadNotice(props: Props): Node {
       <View style={styles.unreadTextWrapper}>
         <ZulipTextIntl
           style={styles.unreadText}
-          text={`\
+          text={{
+            text: `\
 {unreadCount, plural,
   one {{unreadCount} unread message}
   other {{unreadCount} unread messages}
-}`}
+}`,
+            values: { unreadCount },
+          }}
         />
       </View>
       <MarkAsReadButton narrow={narrow} />


### PR DESCRIPTION
Starting in the unreleased commit 35129e50e, the unread notice would literally say:

  {unreadCount, plural,
    one {{unreadCount} unread message}
    other {{unreadCount} unread messages}
  }

because we forgot to give `values`. Oops; fixed now.