### PR TITLE
accounts: Invariant that active account exists when we expect it to

### DIFF
--- a/src/account/accountsReducer.js
+++ b/src/account/accountsReducer.js
@@ -20,19 +20,6 @@ import { identityOfAccount, keyOfIdentity } from './accountMisc';
 
 const initialState = NULL_ARRAY;
 
-const registerComplete = (state, action) => [
-  {
-    ...state[0],
-    userId: action.data.user_id,
-    zulipFeatureLevel: action.data.zulip_feature_level,
-    zulipVersion: action.data.zulip_version,
-    lastDismissedServerPushSetupNotice: action.data.realm_push_notifications_enabled
-      ? null
-      : state[0].lastDismissedServerPushSetupNotice,
-  },
-  ...state.slice(1),
-];
-
 const findAccount = (state: AccountsState, identity: Identity): number => {
   const { realm, email } = identity;
   return state.findIndex(
@@ -95,7 +82,18 @@ const unackPushToken = (state, action) => {
 export default (state: AccountsState = initialState, action: Action): AccountsState => {
   switch (action.type) {
     case REGISTER_COMPLETE:
-      return registerComplete(state, action);
+      return [
+        {
+          ...state[0],
+          userId: action.data.user_id,
+          zulipFeatureLevel: action.data.zulip_feature_level,
+          zulipVersion: action.data.zulip_version,
+          lastDismissedServerPushSetupNotice: action.data.realm_push_notifications_enabled
+            ? null
+            : state[0].lastDismissedServerPushSetupNotice,
+        },
+        ...state.slice(1),
+      ];
 
     case ACCOUNT_SWITCH: {
       const index = state.findIndex(

--- a/src/account/accountsReducer.js
+++ b/src/account/accountsReducer.js
@@ -27,57 +27,6 @@ const findAccount = (state: AccountsState, identity: Identity): number => {
   );
 };
 
-const loginSuccess = (state, action) => {
-  const { realm, email, apiKey } = action;
-  const accountIndex = findAccount(state, { realm, email });
-  if (accountIndex === -1) {
-    return [
-      {
-        realm,
-        email,
-        apiKey,
-        userId: null,
-        ackedPushToken: null,
-        zulipVersion: null,
-        zulipFeatureLevel: null,
-        lastDismissedServerPushSetupNotice: null,
-      },
-      ...state,
-    ];
-  }
-  return [
-    { ...state[accountIndex], apiKey, ackedPushToken: null },
-    ...state.slice(0, accountIndex),
-    ...state.slice(accountIndex + 1),
-  ];
-};
-
-const ackPushToken = (state, action) => {
-  const { pushToken: ackedPushToken, identity } = action;
-  const accountIndex = findAccount(state, identity);
-  if (accountIndex === -1) {
-    return state;
-  }
-  return [
-    ...state.slice(0, accountIndex),
-    { ...state[accountIndex], ackedPushToken },
-    ...state.slice(accountIndex + 1),
-  ];
-};
-
-const unackPushToken = (state, action) => {
-  const { identity } = action;
-  const accountIndex = findAccount(state, identity);
-  if (accountIndex === -1) {
-    return state;
-  }
-  return [
-    ...state.slice(0, accountIndex),
-    { ...state[accountIndex], ackedPushToken: null },
-    ...state.slice(accountIndex + 1),
-  ];
-};
-
 // eslint-disable-next-line default-param-last
 export default (state: AccountsState = initialState, action: Action): AccountsState => {
   switch (action.type) {
@@ -107,14 +56,56 @@ export default (state: AccountsState = initialState, action: Action): AccountsSt
         : [account, ...state.filter(a => a !== account)]; // put account first
     }
 
-    case LOGIN_SUCCESS:
-      return loginSuccess(state, action);
+    case LOGIN_SUCCESS: {
+      const { realm, email, apiKey } = action;
+      const accountIndex = findAccount(state, { realm, email });
+      if (accountIndex === -1) {
+        return [
+          {
+            realm,
+            email,
+            apiKey,
+            userId: null,
+            ackedPushToken: null,
+            zulipVersion: null,
+            zulipFeatureLevel: null,
+            lastDismissedServerPushSetupNotice: null,
+          },
+          ...state,
+        ];
+      }
+      return [
+        { ...state[accountIndex], apiKey, ackedPushToken: null },
+        ...state.slice(0, accountIndex),
+        ...state.slice(accountIndex + 1),
+      ];
+    }
 
-    case ACK_PUSH_TOKEN:
-      return ackPushToken(state, action);
+    case ACK_PUSH_TOKEN: {
+      const { pushToken: ackedPushToken, identity } = action;
+      const accountIndex = findAccount(state, identity);
+      if (accountIndex === -1) {
+        return state;
+      }
+      return [
+        ...state.slice(0, accountIndex),
+        { ...state[accountIndex], ackedPushToken },
+        ...state.slice(accountIndex + 1),
+      ];
+    }
 
-    case UNACK_PUSH_TOKEN:
-      return unackPushToken(state, action);
+    case UNACK_PUSH_TOKEN: {
+      const { identity } = action;
+      const accountIndex = findAccount(state, identity);
+      if (accountIndex === -1) {
+        return state;
+      }
+      return [
+        ...state.slice(0, accountIndex),
+        { ...state[accountIndex], ackedPushToken: null },
+        ...state.slice(accountIndex + 1),
+      ];
+    }
 
     case LOGOUT: {
       return [{ ...state[0], apiKey: '', ackedPushToken: null }, ...state.slice(1)];

--- a/src/mute/__tests__/muteModel-test.js
+++ b/src/mute/__tests__/muteModel-test.js
@@ -25,7 +25,7 @@ describe('reducer', () => {
         subscriptions: [eg.subscription],
         muted_topics: [[eg.stream.name, 'topic']],
       });
-      const newState = tryGetActiveAccountState(fullReducer(eg.baseReduxState, action));
+      const newState = tryGetActiveAccountState(fullReducer(eg.plusReduxState, action));
       expect(newState).toBeTruthy();
       expect(newState && getMute(newState)).toEqual(makeMuteState([[eg.stream, 'topic']]));
     });

--- a/src/storage/__tests__/migrations-test.js
+++ b/src/storage/__tests__/migrations-test.js
@@ -5,6 +5,7 @@ import { historicalStoreKeys, migrations } from '../migrations';
 import { storeKeys } from '../../boot/store';
 import { createMigrationFunction } from '../../redux-persist-migrate';
 import { ZulipVersion } from '../../utils/zulipVersion';
+import * as eg from '../../__tests__/lib/exampleData';
 
 describe('historicalStoreKeys', () => {
   test('equals current storeKeys', () => {
@@ -104,7 +105,7 @@ describe('migrations', () => {
   // What `base` becomes after all migrations.
   const endBase = {
     ...base52,
-    migrations: { version: 57 },
+    migrations: { version: 58 },
   };
 
   for (const [desc, before, after] of [
@@ -281,6 +282,23 @@ describe('migrations', () => {
     [
       'check 57 with an `undefined` in state.accounts',
       { ...base52, migrations: { version: 56 }, accounts: [...base37.accounts, undefined] },
+      { ...endBase, accounts: [...base37.accounts] },
+    ],
+    [
+      'check 58 with a malformed Account in state.accounts',
+      {
+        ...base52,
+        migrations: { version: 57 },
+        accounts: [
+          {
+            userId: eg.selfUser.user_id,
+            zulipFeatureLevel: eg.recentZulipFeatureLevel,
+            zulipVersion: eg.recentZulipVersion,
+            lastDismissedServerPushSetupNotice: null,
+          },
+          ...base37.accounts,
+        ],
+      },
       { ...endBase, accounts: [...base37.accounts] },
     ],
   ]) {

--- a/src/storage/__tests__/migrations-test.js
+++ b/src/storage/__tests__/migrations-test.js
@@ -21,7 +21,7 @@ describe('migrations', () => {
   const base = {
     // Include something non-empty for each of the storeKeys.
     migrations: { version: 3 },
-    accounts: [{ email: 'me@example.com', api_key: '1234', realm: 'https://chat.example' }],
+    accounts: [{ email: 'me@example.com', apiKey: '1234', realm: 'https://chat.example' }],
     drafts: { '[]': 'draft text' },
     // Real Outbox values have more properties, but fudge that.
     outbox: [{ isOutbox: true, isSent: false, type: 'private' }],

--- a/src/storage/migrations.js
+++ b/src/storage/migrations.js
@@ -475,6 +475,33 @@ const migrationsInner: {| [string]: (LessPartialState) => LessPartialState |} = 
   // Fix tiny case where an `undefined` could sneak in on ACCOUNT_SWITCH
   '57': state => ({ ...state, accounts: state.accounts.filter(Boolean) }),
 
+  // Remove malformed partial `Account`s. Perhaps we could salvage some, if
+  // they're just missing e.g. `zulipFeatureLevel`… but we don't think the
+  // bug affected many people, and when it did, it quickly followed a state
+  // where `accounts` was empty, probably because the user asked to remove
+  // the last account.
+  '58': state => ({
+    ...state,
+    accounts: state.accounts.filter(account =>
+      [
+        'realm',
+        'apiKey',
+        'email',
+        'userId',
+        'zulipVersion',
+        'zulipFeatureLevel',
+        'ackedPushToken',
+        'lastDismissedServerPushSetupNotice',
+      ].every(key =>
+        /* $FlowIgnore[method-unbinding]: This is the standard way to call
+           `hasOwnProperty`. See discussion:
+             https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/Flow.20158.20errors/near/1375563
+         */
+        Object.prototype.hasOwnProperty.call(account, key),
+      ),
+    ),
+  }),
+
   // TIP: When adding a migration, consider just using `dropCache`.
   //   (See its jsdoc for guidance on when that's the right answer.)
 };


### PR DESCRIPTION
In its handling of the actions REGISTER_COMPLETE, LOGOUT,
DISMISS_SERVER_PUSH_SETUP_NOTICE, and EVENT, the `accounts` reducer
has been making the unchecked assumption that there is an active
account.

When there isn't an active account (perhaps because the last account
was removed with ACCOUNT_REMOVE), the reducer has been creating
badly typed partial `Account`s, by creating an object from a spread
of `state[0]` which is `undefined`. For example, with
REGISTER_COMPLETE:

```js
  {
    ...state[0],
    userId: action.data.user_id,
    zulipFeatureLevel: action.data.zulip_feature_level,
    zulipVersion: action.data.zulip_version,
    lastDismissedServerPushSetupNotice: action.data.realm_push_notifications_enabled
      ? null
      : state[0].lastDismissedServerPushSetupNotice,
  }
```

That will make an object with only userId, zulipFeatureLevel,
zulipVersion, and lastDismissedServerPushSetupNotice. When code
expects a well-formed Account including realm, apiKey, email, and
ackedPushToken, it'll error.

Flow has basically let this happen because it assumes (wrongly, in
this case) that `state[0]` is an in-bounds access that will give an
Account.

We've had a few mysterious Sentry reports where it seems `realm` is
missing in the active account. E.g., for those with access:
  https://sentry.io/organizations/zulip/issues/3900597161/?project=191284
  https://sentry.io/organizations/zulip/issues/3900597257/?project=191284
  https://sentry.io/organizations/zulip/issues/3900597246/?project=191284
  https://sentry.io/organizations/zulip/issues/3900596985/?project=191284

Seeing that the faulty reducer code could cause that symptom, add an
`invariant` that there is an active account. (And fix some
mute-model test data where the data was unrepresentative because it
was missing an active account.)

N.B.: The new invariant ensures that there *is* an active account,
but it doesn't check that it's the account the action was supposed
to act on. We should fix that (so, add TODOs about it), but at
least now we hope to be rid of these malformed `Account` objects.

Not seeing anything else that could cause these malformed Account
objects, add a migration so they don't come up from storage.