### PR TITLE
ComposeBox: Show more information on file-upload errors

### DIFF
--- a/src/compose/ComposeBox.js
+++ b/src/compose/ComposeBox.js
@@ -33,7 +33,7 @@ import { TranslationContext } from '../boot/TranslationProvider';
 import { draftUpdate, sendTypingStart, sendTypingStop } from '../actions';
 import Touchable from '../common/Touchable';
 import Input from '../common/Input';
-import { showToast, showErrorAlert } from '../utils/info';
+import { showErrorAlert } from '../utils/info';
 import { IconDone, IconSend } from '../common/Icons';
 import {
   isConversationNarrow,
@@ -340,7 +340,7 @@ const ComposeBox: React$AbstractComponent<Props, ImperativeHandle> = forwardRef(
           try {
             response = await api.uploadFile(auth, attachments[i].url, fileName);
           } catch {
-            showToast(_('Failed to upload file: {fileName}', { fileName }));
+            showErrorAlert(_('Failed to upload file: {fileName}', { fileName }));
             setMessageInputValue(state =>
               state.value.replace(
                 placeholder,


### PR DESCRIPTION
(This is a follow-up to #5661, in which we started showing similar feedback in the share-to-Zulip flow.)

Related: #5660