### PR TITLE
api errors: Give RequestError a constructor that writes httpStatus and data

### DIFF
--- a/src/api/apiErrors.js
+++ b/src/api/apiErrors.js
@@ -21,6 +21,12 @@ export class RequestError extends ExtendableError {
    * as JSON, this value is `undefined`.
    */
   +data: mixed;
+
+  constructor(msg?: string, httpStatus?: number, data?: mixed) {
+    super(msg);
+    this.httpStatus = httpStatus;
+    this.data = data;
+  }
 }
 
 /**
@@ -54,10 +60,8 @@ export class ApiError extends RequestError {
   constructor(httpStatus: number, data: $ReadOnly<ApiResponseErrorData>) {
     // eslint-disable-next-line no-unused-vars
     const { result, code, msg, ...rest } = data;
-    super(msg);
-    this.data = rest;
+    super(msg, httpStatus, rest);
     this.code = code;
-    this.httpStatus = httpStatus;
   }
 }
 
@@ -76,10 +80,10 @@ export class NetworkError extends RequestError {}
 export class ServerError extends RequestError {
   +httpStatus: number;
 
+  // Not useless: makes `msg` and `httpStatus` required
+  // eslint-disable-next-line no-useless-constructor
   constructor(msg: string, httpStatus: number, data?: mixed) {
-    super(msg);
-    this.httpStatus = httpStatus;
-    this.data = data;
+    super(msg, httpStatus, data);
   }
 }
 

--- a/src/api/apiErrors.js
+++ b/src/api/apiErrors.js
@@ -76,9 +76,10 @@ export class NetworkError extends RequestError {}
 export class ServerError extends RequestError {
   +httpStatus: number;
 
-  constructor(msg: string, httpStatus: number) {
+  constructor(msg: string, httpStatus: number, data?: mixed) {
     super(msg);
     this.httpStatus = httpStatus;
+    this.data = data;
   }
 }
 
@@ -101,8 +102,7 @@ export class Server5xxError extends ServerError {
  */
 export class MalformedResponseError extends ServerError {
   constructor(httpStatus: number, data?: mixed) {
-    super(`Server responded with invalid message; HTTP status ${httpStatus}`, httpStatus);
-    this.data = data;
+    super(`Server responded with invalid message; HTTP status ${httpStatus}`, httpStatus, data);
   }
 }
 
@@ -114,8 +114,7 @@ export class MalformedResponseError extends ServerError {
  */
 export class UnexpectedHttpStatusError extends ServerError {
   constructor(httpStatus: number, data?: mixed) {
-    super(`Server gave unexpected HTTP status: ${httpStatus}`, httpStatus);
-    this.data = data;
+    super(`Server gave unexpected HTTP status: ${httpStatus}`, httpStatus, data);
   }
 }
 

--- a/src/api/apiErrors.js
+++ b/src/api/apiErrors.js
@@ -113,7 +113,7 @@ export class MalformedResponseError extends ServerError {
  * give: https://zulip.com/api/rest-error-handling
  */
 export class UnexpectedHttpStatusError extends ServerError {
-  constructor(httpStatus: number, data: mixed) {
+  constructor(httpStatus: number, data?: mixed) {
     super(`Server gave unexpected HTTP status: ${httpStatus}`, httpStatus);
     this.data = data;
   }

--- a/src/api/apiErrors.js
+++ b/src/api/apiErrors.js
@@ -100,7 +100,7 @@ export class Server5xxError extends ServerError {
  * as documented at the page https://zulip.com/api/rest-error-handling .
  */
 export class MalformedResponseError extends ServerError {
-  constructor(httpStatus: number, data: mixed) {
+  constructor(httpStatus: number, data?: mixed) {
     super(`Server responded with invalid message; HTTP status ${httpStatus}`, httpStatus);
     this.data = data;
   }

--- a/src/api/fetchServerEmojiData.js
+++ b/src/api/fetchServerEmojiData.js
@@ -78,7 +78,7 @@ export default async (emojiDataUrl: URL): Promise<ServerEmojiData> => {
     //
     // Don't bother trying to make an ApiError by parsing JSON for `code`,
     // `msg`, or `result`; this endpoint doesn't give them.
-    throw new RequestError(httpStatus);
+    throw new RequestError('Failed to fetch emoji data.', httpStatus);
   } else if (httpStatus >= 500 && httpStatus <= 599) {
     throw new Server5xxError(httpStatus);
   } else if (httpStatus <= 199 || (httpStatus >= 300 && httpStatus <= 399) || httpStatus >= 600) {

--- a/src/api/fetchServerEmojiData.js
+++ b/src/api/fetchServerEmojiData.js
@@ -84,8 +84,8 @@ export default async (emojiDataUrl: URL): Promise<ServerEmojiData> => {
   } else if (httpStatus <= 199 || (httpStatus >= 300 && httpStatus <= 399) || httpStatus >= 600) {
     // Seems like a server error; the endpoint doesn't document sending
     // these statuses. No reason to think parsing JSON would give anything
-    // useful; just say `data` is undefined.
-    throw new UnexpectedHttpStatusError(httpStatus, undefined);
+    // useful; just omit `data`.
+    throw new UnexpectedHttpStatusError(httpStatus);
   }
 
   let json = undefined;

--- a/src/api/fetchServerEmojiData.js
+++ b/src/api/fetchServerEmojiData.js
@@ -92,7 +92,7 @@ export default async (emojiDataUrl: URL): Promise<ServerEmojiData> => {
   try {
     json = (await response.json(): ServerEmojiDataRaw);
   } catch {
-    throw new MalformedResponseError(httpStatus, undefined);
+    throw new MalformedResponseError(httpStatus);
   }
 
   const transformed = tryTransform(json);


### PR DESCRIPTION
And adapt RequestError's callers to use the new constructor instead
of the Error class's constructor, which is pretty generic and just
takes `message?: mixed`.

This means one functional change, which seems like a bug fix: the
RequestError we construct in fetchServerEmojiData now stores the
http status code, instead of dropping it on the floor.