### PR TITLE
ProfileScreen: Put status and "Set a status" link in the same row

### DIFF
--- a/src/account-info/AccountDetails.js
+++ b/src/account-info/AccountDetails.js
@@ -44,6 +44,7 @@ const componentStyles = createStyleSheet({
 type Props = $ReadOnly<{|
   user: UserOrBot,
   showEmail: boolean,
+  showStatus: boolean,
 |}>;
 
 const getRoleText = (role: Role): LocalizableText => {
@@ -62,7 +63,7 @@ const getRoleText = (role: Role): LocalizableText => {
 };
 
 export default function AccountDetails(props: Props): Node {
-  const { user, showEmail } = props;
+  const { user, showEmail, showStatus } = props;
 
   const userStatusText = useSelector(state => getUserStatus(state, props.user.user_id).status_text);
   const userStatusEmoji = useSelector(
@@ -112,22 +113,24 @@ export default function AccountDetails(props: Props): Node {
           </View>
         )
       }
-      <View style={componentStyles.statusWrapper}>
-        {userStatusEmoji && (
-          <Emoji
-            code={userStatusEmoji.emoji_code}
-            type={emojiTypeFromReactionType(userStatusEmoji.reaction_type)}
-            size={24}
-          />
-        )}
-        {userStatusEmoji && userStatusText !== null && <View style={{ width: 2 }} />}
-        {userStatusText !== null && (
-          <ZulipText
-            style={[styles.largerText, componentStyles.statusText]}
-            text={userStatusText}
-          />
-        )}
-      </View>
+      {showStatus && (
+        <View style={componentStyles.statusWrapper}>
+          {userStatusEmoji && (
+            <Emoji
+              code={userStatusEmoji.emoji_code}
+              type={emojiTypeFromReactionType(userStatusEmoji.reaction_type)}
+              size={24}
+            />
+          )}
+          {userStatusEmoji && userStatusText !== null && <View style={{ width: 2 }} />}
+          {userStatusText !== null && (
+            <ZulipText
+              style={[styles.largerText, componentStyles.statusText]}
+              text={userStatusText}
+            />
+          )}
+        </View>
+      )}
     </ComponentList>
   );
 }

--- a/src/account-info/AccountDetailsScreen.js
+++ b/src/account-info/AccountDetailsScreen.js
@@ -74,7 +74,7 @@ export default function AccountDetailsScreen(props: Props): Node {
 
   return (
     <Screen title={title}>
-      <AccountDetails user={user} showEmail />
+      <AccountDetails user={user} showEmail showStatus />
       <View style={styles.itemWrapper}>
         <ActivityText style={globalStyles.largerText} user={user} />
       </View>

--- a/src/settings/NotificationsScreen.js
+++ b/src/settings/NotificationsScreen.js
@@ -140,9 +140,10 @@ export default function NotificationsScreen(props: Props): Node {
     <Screen title="Notifications">
       <ServerPushSetupBanner isDismissable={false} />
       <NestedNavRow
-        icon={
+        leftElement={
           systemSettingsWarnings.length > 0
             ? {
+                type: 'icon',
                 Component: IconAlertTriangle,
                 color: kWarningColor,
               }
@@ -191,7 +192,11 @@ export default function NotificationsScreen(props: Props): Node {
               <NestedNavRow
                 {...(() =>
                   notificationReport.problems.length > 0 && {
-                    icon: { Component: IconAlertTriangle, color: kWarningColor },
+                    leftElement: {
+                      type: 'icon',
+                      Component: IconAlertTriangle,
+                      color: kWarningColor,
+                    },
                     subtitle: 'Notifications for this account may not arrive.',
                   })()}
                 title="Troubleshooting"
@@ -213,7 +218,11 @@ export default function NotificationsScreen(props: Props): Node {
                 }).length;
                 return problemAccountsCount > 0
                   ? {
-                      icon: { Component: IconAlertTriangle, color: kWarningColor },
+                      leftElement: {
+                        type: 'icon',
+                        Component: IconAlertTriangle,
+                        color: kWarningColor,
+                      },
                       subtitle: {
                         text: `\
 {problemAccountsCount, plural,

--- a/src/settings/SettingsScreen.js
+++ b/src/settings/SettingsScreen.js
@@ -90,11 +90,11 @@ export default function SettingsScreen(props: Props): Node {
         }}
       />
       <NestedNavRow
-        icon={{ Component: IconNotifications }}
+        leftElement={{ type: 'icon', Component: IconNotifications }}
         title="Notifications"
         {...(() =>
           notificationReport.problems.length > 0 && {
-            icon: { Component: IconAlertTriangle, color: kWarningColor },
+            leftElement: { type: 'icon', Component: IconAlertTriangle, color: kWarningColor },
             subtitle: 'Notifications for this account may not arrive.',
           })()}
         onPress={() => {
@@ -117,7 +117,7 @@ export default function SettingsScreen(props: Props): Node {
         search
       />
       <NestedNavRow
-        icon={{ Component: IconMoreHorizontal }}
+        leftElement={{ type: 'icon', Component: IconMoreHorizontal }}
         title="Legal"
         onPress={() => {
           navigation.push('legal');

--- a/src/user-statuses/UserStatusScreen.js
+++ b/src/user-statuses/UserStatusScreen.js
@@ -143,7 +143,7 @@ export default function UserStatusScreen(props: Props): Node {
   }, []);
 
   return (
-    <Screen title="User status">
+    <Screen title="Set your status">
       <View style={styles.inputRow}>
         {serverSupportsEmojiStatus && (
           <EmojiInput

--- a/static/translations/messages_en.json
+++ b/static/translations/messages_en.json
@@ -334,7 +334,6 @@
   "See who reacted": "See who reacted",
   "Muted user": "Muted user",
   "Only organization admins are allowed to post to this stream.": "Only organization admins are allowed to post to this stream.",
-  "Set a status": "Set a status",
   "Connecting...": "Connecting...",
   "Set your status": "Set your status",
   "Muted": "Muted",

--- a/static/translations/messages_en.json
+++ b/static/translations/messages_en.json
@@ -336,7 +336,7 @@
   "Only organization admins are allowed to post to this stream.": "Only organization admins are allowed to post to this stream.",
   "Set a status": "Set a status",
   "Connecting...": "Connecting...",
-  "User status": "User status",
+  "Set your status": "Set your status",
   "Muted": "Muted",
   "No topics found": "No topics found",
   "Share on Zulip": "Share on Zulip",


### PR DESCRIPTION
Before this, we were separating the line that showed the user's status from the line that led to the UI to change the status (a button linking to UserStatusScreen) -- with the "Invisible mode" switch in between.

Now, it's a single NestedNavRow that shows the emoji and status text, if any. Tapping it leads to the UserStatusScreen.

This means adapting NestedNavRow to accept an emoji or an icon, rather than just an icon, which seems fine.

-----


| Before (no status set) | After (no status set) |
| --- | --- |
| <img width=400 src="https://user-images.githubusercontent.com/22248748/219790586-d26f703f-88bc-4d54-9504-7d2335f4cb37.png" /> | <img width=400 src="https://user-images.githubusercontent.com/22248748/219790479-cb2ea8b3-2b98-46fe-8808-1535a8ca1ec9.png" /> |


Before / after (emoji status set):

<img width=400 src="https://user-images.githubusercontent.com/22248748/219791025-8d58e00a-b95f-4541-8d8f-b79f76574744.png" /> <img width=400 src="https://user-images.githubusercontent.com/22248748/219791257-aa90751f-50cf-4688-a0aa-ebb0e72741a3.png" />

Before / after (text status set):

<img width=400 src="https://user-images.githubusercontent.com/22248748/219791119-6122fc8d-1996-4a4b-a9a0-78c7171702ea.png" /> <img width=400 src="https://user-images.githubusercontent.com/22248748/219791176-af5a454d-352a-4a63-8fb4-d43e6c263444.png" />

Before / after (text and emoji status set):

<img width=400 src="https://user-images.githubusercontent.com/22248748/219790673-b26f9fcf-664b-43d8-a17b-cef88711b15d.png" /> <img width=400 src="https://user-images.githubusercontent.com/22248748/219790428-d6290833-e4a5-41d9-a924-0c6c07964887.png" />
