### PR TITLE
AccountItem: Fix trash icon touch target's invasion of notif-warning icon's

### DIFF
--- a/src/account/AccountItem.js
+++ b/src/account/AccountItem.js
@@ -40,7 +40,7 @@ const styles = createStyleSheet({
     marginVertical: 2,
   },
   icon: {
-    marginLeft: 16,
+    marginLeft: 24,
   },
   signedOutText: {
     fontStyle: 'italic',
@@ -113,10 +113,9 @@ export default function AccountItem(props: Props): Node {
           )}
         </View>
         {notificationReport.problems.length > 0 && (
-          <Pressable hitSlop={12} onPress={handlePressNotificationWarning}>
+          <Pressable style={styles.icon} hitSlop={12} onPress={handlePressNotificationWarning}>
             {({ pressed }) => (
               <IconAlertTriangle
-                style={styles.icon}
                 size={24}
                 color={pressed ? Color(kWarningColor).fade(0.5).toString() : kWarningColor}
               />
@@ -124,11 +123,10 @@ export default function AccountItem(props: Props): Node {
           </Pressable>
         )}
         {!showDoneIcon ? (
-          <Pressable hitSlop={12} onPress={() => props.onRemove(props.account)}>
+          <Pressable style={styles.icon} hitSlop={12} onPress={() => props.onRemove(props.account)}>
             {({ pressed }) => (
               <IconTrash
                 size={24}
-                style={styles.icon}
                 color={pressed ? Color('crimson').fade(0.5).toString() : 'crimson'}
               />
             )}


### PR DESCRIPTION
### Touch targets highlighted:
| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/22248748/219826345-207ba0e4-b4d2-423a-b3aa-4be04157e182.png) | ![image](https://user-images.githubusercontent.com/22248748/219826364-da20a8b0-f0c7-41cd-8d72-7ca9e81af4a4.png) |

### Touch targets not highlighted:
| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/22248748/219826298-a532136b-e6bb-44b0-b07f-62e9caee06ff.png) | ![image](https://user-images.githubusercontent.com/22248748/219826280-8ebf8d92-2a85-4be8-9998-0b5e1e00c29b.png) |