### PR TITLE
api: Make RequestError explicitly abstract, in jsdoc

### DIFF
--- a/src/api/apiErrors.js
+++ b/src/api/apiErrors.js
@@ -6,8 +6,15 @@ import { ZulipVersion } from '../utils/zulipVersion';
 /**
  * Some kind of error from a Zulip API network request.
  *
+ * This is an abstract class: every instance should be an instance of a
+ * subclass.  Rather than construct it directly, use a subclass's
+ * constructor.
+ *
  * See subclasses: {@link ApiError}, {@link NetworkError}, {@link ServerError}.
  */
+// For why we just say "abstract" in the jsdoc without doing anything static
+// or dynamic to enforce that, see:
+//   https://github.com/zulip/zulip-mobile/pull/5664#issuecomment-1433918758
 export class RequestError extends ExtendableError {
   /** The HTTP status code in the response, if any. */
   +httpStatus: number | void;

--- a/src/api/fetchServerEmojiData.js
+++ b/src/api/fetchServerEmojiData.js
@@ -3,8 +3,8 @@ import { networkActivityStart, networkActivityStop } from '../utils/networkActiv
 import {
   MalformedResponseError,
   NetworkError,
-  RequestError,
   Server5xxError,
+  ServerError,
   UnexpectedHttpStatusError,
 } from './apiErrors';
 import type { ServerEmojiData } from './modelTypes';
@@ -70,7 +70,7 @@ export default async (emojiDataUrl: URL): Promise<ServerEmojiData> => {
 
   const httpStatus = response.status;
   if (httpStatus >= 400 && httpStatus <= 499) {
-    // Client error…?
+    // A client error, supposedly.
     //
     // If 404, maybe we had the wrong idea of what URL to request (unlikely,
     // but would be a client error). Or maybe the server failed to get
@@ -78,7 +78,7 @@ export default async (emojiDataUrl: URL): Promise<ServerEmojiData> => {
     //
     // Don't bother trying to make an ApiError by parsing JSON for `code`,
     // `msg`, or `result`; this endpoint doesn't give them.
-    throw new RequestError(httpStatus);
+    throw new ServerError('Could not get server emoji data', httpStatus);
   } else if (httpStatus >= 500 && httpStatus <= 599) {
     throw new Server5xxError(httpStatus);
   } else if (httpStatus <= 199 || (httpStatus >= 300 && httpStatus <= 399) || httpStatus >= 600) {


### PR DESCRIPTION
And choose a concrete subclass for the one place we were calling RequestError's constructor, which is really the Error class's constructor (with the one param `msg: mixed`) and so wasn't storing the passed `httpStatus` in its designated field.

See:
  https://github.com/zulip/zulip-mobile/pull/5664#issuecomment-1433918758