### PR TITLE
ios: Clean up "bridging header"; fix possible latent bug in ZLPConstants

### DIFF
--- a/ios/ZulipMobile-Bridging-Header.h
+++ b/ios/ZulipMobile-Bridging-Header.h
@@ -1,8 +1,18 @@
-#import <React/RCTBridgeModule.h>
-#import <React/RCTBridge.h>
-#import <React/RCTEventDispatcher.h>
-#import <React/RCTRootView.h>
-#import <React/RCTUtils.h>
-#import <React/RCTConvert.h>
-#import <React/RCTEventEmitter.h>
-#import <React/RCTBundleURLProvider.h>
+// To use an Objective-C module in a Swift file, first just try importing it
+// at the top of your Swift file, like so:
+//
+//   import React.RCTBridgeModule
+//
+// If you can't find an import line that Xcode understands, instead try
+// adding an import line in this file, like so:
+//
+//   #import <React/RCTBridgeModule.h>
+//
+// That should make the module (plus the modules *it* imports, actually)
+// available in all our project's Swift files, without the Swift files
+// needing an import line of their own.
+//
+// The first approach (an import line in the Swift file) is preferred
+// because it looks like how imports normally work in Swift. But sometimes
+// we can't find an import line that works; not sure why. Discussion:
+//   https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/ios.2FZulipMobile-Bridging-Header.2Eh/near/1520435

--- a/ios/ZulipMobile/ZLPConstants.swift
+++ b/ios/ZulipMobile/ZLPConstants.swift
@@ -1,4 +1,5 @@
 import Foundation
+import UIKit
 
 @objc(ZLPConstants)
 class ZLPConstants: NSObject {

--- a/ios/ZulipMobile/ZLPConstants.swift
+++ b/ios/ZulipMobile/ZLPConstants.swift
@@ -3,15 +3,16 @@ import UIKit
 
 @objc(ZLPConstants)
 class ZLPConstants: NSObject {
-
-
   // For why we include this, see
   //   https://reactnative.dev/docs/0.68/native-modules-ios#exporting-constants
   @objc
   static func requiresMainQueueSetup() -> Bool {
-    // Initialization may be done on any thread; we don't need access to
-    // UIKit.
-    return false
+    // UIApplication, which we use in `constantsToExport`, is provided by
+    // UIKit. I think that means we should return `true` here. From the doc
+    // linked above:
+    // > If your module does not require access to UIKit, then you should
+    // > respond to `+ requiresMainQueueSetup` with NO.
+    return true
   }
 
   @objc

--- a/ios/ZulipMobile/ZLPNotifications.swift
+++ b/ios/ZulipMobile/ZLPNotifications.swift
@@ -4,15 +4,6 @@ import React.RCTBridgeModule
 
 @objc(ZLPNotifications)
 class ZLPNotifications: NSObject {
-  // For why we include this, see
-  //   https://reactnative.dev/docs/0.68/native-modules-ios#exporting-constants
-  @objc
-  static func requiresMainQueueSetup() -> Bool {
-    // Initialization may be done on any thread; we don't need access to
-    // UIKit.
-    return false
-  }
-
   /// Whether the app can receive remote notifications.
   // Ideally we could subscribe to changes in this value, but there
   // doesn't seem to be an API for that. The caller can poll, e.g., by
@@ -27,10 +18,5 @@ class ZLPNotifications: NSObject {
       .getNotificationSettings(completionHandler: { (settings) -> Void in
         resolve(settings.authorizationStatus == UNAuthorizationStatus.authorized)
       })
-  }
-
-  @objc
-  func constantsToExport() -> [String: Any]! {
-    return [:]
   }
 }

--- a/ios/ZulipMobile/ZLPNotifications.swift
+++ b/ios/ZulipMobile/ZLPNotifications.swift
@@ -1,3 +1,7 @@
+import Foundation
+import UIKit
+import React.RCTBridgeModule
+
 @objc(ZLPNotifications)
 class ZLPNotifications: NSObject {
   // For why we include this, see


### PR DESCRIPTION
This makes one change discussed on a video call today, and also a followup which was basically prompted by the first change: I noticed that `ZLPConstants` was depending on something in `UIKit` (because we're now happily forced to import `UIKit` in the `ZLPConstants` file instead of it being made available as a transitive dependency of some module that used to be in the bridging header), and that suggests a small change to the implementation; details in the commit.