### PR TITLE
NotificationsScreen: Show server-setup alert like other per-account alerts

### DIFF
--- a/src/account-info/ProfileScreen.js
+++ b/src/account-info/ProfileScreen.js
@@ -24,7 +24,7 @@ import { getUserStatus } from '../user-statuses/userStatusesModel';
 import SwitchRow from '../common/SwitchRow';
 import * as api from '../api';
 import { identityOfAccount } from '../account/accountMisc';
-import NestedNavRow from '../common/NestedNavRow';
+import NavRow from '../common/NavRow';
 import { emojiTypeFromReactionType } from '../emoji/data';
 
 const styles = createStyleSheet({
@@ -135,7 +135,7 @@ export default function ProfileScreen(props: Props): Node {
       <OfflineNoticePlaceholder />
       <ScrollView>
         <AccountDetails user={ownUser} showEmail={false} showStatus={false} />
-        <NestedNavRow
+        <NavRow
           leftElement={
             status_emoji != null
               ? {

--- a/src/common/InputRowRadioButtons.js
+++ b/src/common/InputRowRadioButtons.js
@@ -77,10 +77,10 @@ type Props<TItemKey> = $ReadOnly<{|
  * `.title`. When tapped, opens the selectable-options screen, where the
  * user can change the selection or read more about each selection.
  */
-// This has the navigate-to-nested-screen semantics of NestedNavRow,
-// represented by IconRight. NestedNavRow would probably be the wrong
-// abstraction, though, because it isn't an imput component; it doesn't have
-// a value to display.
+// This has the navigate-to-nested-screen semantics of
+// <NavRow type="nested" … />, represented by IconRight. NavRow would
+// probably be the wrong abstraction, though, because it isn't an input
+// component; it doesn't have a value to display.
 export default function InputRowRadioButtons<TItemKey: string | number>(
   props: Props<TItemKey>,
 ): Node {

--- a/src/common/NavRow.js
+++ b/src/common/NavRow.js
@@ -6,7 +6,7 @@ import { View } from 'react-native';
 import type { EmojiType, LocalizableReactText } from '../types';
 import ZulipTextIntl from './ZulipTextIntl';
 import Touchable from './Touchable';
-import { IconRight } from './Icons';
+import { Icon, IconRight } from './Icons';
 import type { SpecificIconType } from './Icons';
 import globalStyles, { ThemeContext, createStyleSheet } from '../styles';
 import Emoji from '../emoji/Emoji';
@@ -33,18 +33,28 @@ type Props = $ReadOnly<{|
   //   components, with and without this?
   titleBoldUppercase?: true,
 
-  /** Use this to navigate to a "nested" screen. */
+  type?: 'nested' | 'external',
+
+  /**
+   * Press handler for the whole row.
+   *
+   * The behavior should correspond to `type`:
+   * 'nested': navigate to a "nested" screen.
+   * 'external': open a URL with the user's `BrowserPreference`
+   */
   onPress: () => void,
 |}>;
 
 /**
- * A button that navigates to a "nested" screen.
+ * When tapped, this row navigates to a "nested" screen or opens a URL.
  *
- * Shows a right-facing arrow to indicate its purpose. If you need a
- * selectable option row instead, use `SelectableOptionRow`.
+ * 'nested' type: shows a right-facing arrow.
+ * 'external' type: shows an "external link" icon.
+ *
+ * If you need a selectable option row instead, use `SelectableOptionRow`.
  */
-export default function NestedNavRow(props: Props): Node {
-  const { title, subtitle, titleBoldUppercase, onPress, leftElement } = props;
+export default function NavRow(props: Props): Node {
+  const { title, subtitle, titleBoldUppercase, type = 'nested', onPress, leftElement } = props;
 
   const themeContext = useContext(ThemeContext);
 
@@ -77,7 +87,7 @@ export default function NestedNavRow(props: Props): Node {
           fontWeight: '300',
           fontSize: 13,
         },
-        iconRightFacingArrow: {
+        iconRight: {
           textAlign: 'center',
           marginLeft: 8,
           color: themeContext.color,
@@ -117,7 +127,11 @@ export default function NestedNavRow(props: Props): Node {
           {subtitle !== undefined && <ZulipTextIntl style={styles.subtitle} text={subtitle} />}
         </View>
         <View style={globalStyles.rightItem}>
-          <IconRight size={24} style={styles.iconRightFacingArrow} />
+          {type === 'nested' ? (
+            <IconRight size={24} style={styles.iconRight} />
+          ) : (
+            <Icon name="external-link" size={24} style={styles.iconRight} />
+          )}
         </View>
       </View>
     </Touchable>

--- a/src/common/ServerPushSetupBanner.js
+++ b/src/common/ServerPushSetupBanner.js
@@ -13,25 +13,18 @@ import { openLinkWithUserPreference } from '../utils/openLink';
 import { getOwnUserRole, roleIsAtLeast } from '../permissionSelectors';
 import { Role } from '../api/permissionsTypes';
 
-type Props = $ReadOnly<{|
-  isDismissable?: boolean,
-|}>;
+type Props = $ReadOnly<{||}>;
 
 /**
  * A "nag banner" saying the server hasn't enabled push notifications, if so
  *
- * If `isDismissable` is false, the banner is always visible unless the
- * server is set up for push notifications.
- *
- * Otherwise, it offers a dismiss button. If this notice is dismissed, it
- * sleeps for two weeks, then reappears if the server hasn't gotten set up
- * for push notifications in that time. ("This notice" means the currently
- * applicable notice. If the server does get setup for push notifications,
- * then gets un-setup, a new notice will apply.)
+ * Offers a dismiss button. If this notice is dismissed, it sleeps for two
+ * weeks, then reappears if the server hasn't gotten set up for push
+ * notifications in that time. ("This notice" means the currently applicable
+ * notice. If the server does get setup for push notifications, then gets
+ * un-setup, a new notice will apply.)
  */
 export default function ServerPushSetupBanner(props: Props): Node {
-  const { isDismissable = true } = props;
-
   const dispatch = useDispatch();
 
   const lastDismissedServerPushSetupNotice = useSelector(
@@ -47,8 +40,7 @@ export default function ServerPushSetupBanner(props: Props): Node {
   if (pushNotificationsEnabled) {
     // don't show
   } else if (
-    isDismissable
-    && lastDismissedServerPushSetupNotice !== null
+    lastDismissedServerPushSetupNotice !== null
     // TODO: Could rerender this component on an interval, to give an
     //   upper bound on how outdated this `new Date()` can be.
     && lastDismissedServerPushSetupNotice >= subWeeks(new Date(), 2)
@@ -68,15 +60,13 @@ export default function ServerPushSetupBanner(props: Props): Node {
   }
 
   const buttons = [];
-  if (isDismissable) {
-    buttons.push({
-      id: 'dismiss',
-      label: 'Remind me later',
-      onPress: () => {
-        dispatch(dismissServerPushSetupNotice());
-      },
-    });
-  }
+  buttons.push({
+    id: 'dismiss',
+    label: 'Remind me later',
+    onPress: () => {
+      dispatch(dismissServerPushSetupNotice());
+    },
+  });
   buttons.push({
     id: 'learn-more',
     label: 'Learn more',

--- a/src/common/SwitchRow.js
+++ b/src/common/SwitchRow.js
@@ -23,7 +23,7 @@ const componentStyles = createStyleSheet({
     paddingHorizontal: 16,
 
     // For uniformity with other rows this might share a screen with, e.g.,
-    // NestedNavRow and InputRowRadioButtons on the settings screen. See
+    // NavRow and InputRowRadioButtons on the settings screen. See
     // height-related attributes on those rows.
     minHeight: 48,
   },

--- a/src/common/TextRow.js
+++ b/src/common/TextRow.js
@@ -24,7 +24,7 @@ type Props = $ReadOnly<{|
 /**
  * A row with a title, and optional icon, subtitle, and press handler.
  *
- * See also NestedNavRow, SwitchRow, etc.
+ * See also NavRow, SwitchRow, etc.
  */
 export default function TextRow(props: Props): React.Node {
   const { title, subtitle, onPress, icon } = props;

--- a/src/settings/LegalScreen.js
+++ b/src/settings/LegalScreen.js
@@ -7,7 +7,7 @@ import type { RouteProp } from '../react-navigation';
 import type { AppNavigationProp } from '../nav/AppNavigator';
 import { useGlobalSelector, useSelector } from '../react-redux';
 import Screen from '../common/Screen';
-import NestedNavRow from '../common/NestedNavRow';
+import NavRow from '../common/NavRow';
 import ZulipText from '../common/ZulipText';
 import { openLinkWithUserPreference } from '../utils/openLink';
 import { getRealmUrl, getRealmName, getGlobalSettings } from '../selectors';
@@ -34,8 +34,8 @@ export default function LegalScreen(props: Props): Node {
 
   return (
     <Screen title="Legal">
-      <NestedNavRow title="Zulip terms" onPress={openZulipPolicies} />
-      <NestedNavRow
+      <NavRow title="Zulip terms" onPress={openZulipPolicies} type="external" />
+      <NavRow
         // These are really terms set by the server admin responsible for
         // hosting the org, and that server admin may or may not represent
         // the org itself, as this text might be read to imply. (E.g.,
@@ -51,6 +51,7 @@ export default function LegalScreen(props: Props): Node {
           values: { realmName: <ZulipText style={{ fontWeight: 'bold' }} text={realmName} /> },
         }}
         onPress={openRealmPolicies}
+        type="external"
       />
     </Screen>
   );

--- a/src/settings/NotificationsScreen.js
+++ b/src/settings/NotificationsScreen.js
@@ -9,14 +9,12 @@ import type { RouteProp } from '../react-navigation';
 import type { AppNavigationProp } from '../nav/AppNavigator';
 import { useGlobalSelector, useSelector } from '../react-redux';
 import Screen from '../common/Screen';
-import ServerPushSetupBanner from '../common/ServerPushSetupBanner';
 import NavRow from '../common/NavRow';
 import { IconAlertTriangle } from '../common/Icons';
 import type { LocalizableText } from '../types';
 import { TranslationContext } from '../boot/TranslationProvider';
 import { kWarningColor } from '../styles/constants';
 import { getIdentities, getIdentity, getIsActiveAccount } from '../account/accountsSelectors';
-import { getRealm } from '../directSelectors';
 import { openSystemNotificationSettings } from '../utils/openLink';
 import {
   useNotificationReportsByIdentityKey,
@@ -62,8 +60,6 @@ export default function NotificationsScreen(props: Props): Node {
   const otherAccounts = useGlobalSelector(state =>
     getIdentities(state).filter(identity_ => !getIsActiveAccount(state, identity_)),
   );
-  const pushNotificationsEnabled = useSelector(state => getRealm(state).pushNotificationsEnabled);
-
   const systemSettingsWarnings = notificationReport.problems
     .map(systemSettingsWarning)
     .filter(Boolean);
@@ -98,7 +94,6 @@ export default function NotificationsScreen(props: Props): Node {
 
   return (
     <Screen title="Notifications">
-      <ServerPushSetupBanner isDismissable={false} />
       <NavRow
         leftElement={
           systemSettingsWarnings.length > 0
@@ -125,9 +120,7 @@ export default function NotificationsScreen(props: Props): Node {
       />
       {!notificationReport.problems.includes(NotificationProblem.SystemSettingsDisabled) && (
         <>
-          {pushNotificationsEnabled && (
-            <PerAccountNotificationSettingsGroup navigation={navigation} />
-          )}
+          <PerAccountNotificationSettingsGroup navigation={navigation} />
           {otherAccounts.length > 0 && (
             <NavRow
               {...(() => {

--- a/src/settings/NotificationsScreen.js
+++ b/src/settings/NotificationsScreen.js
@@ -13,7 +13,7 @@ import SwitchRow from '../common/SwitchRow';
 import Screen from '../common/Screen';
 import * as api from '../api';
 import ServerPushSetupBanner from '../common/ServerPushSetupBanner';
-import NestedNavRow from '../common/NestedNavRow';
+import NavRow from '../common/NavRow';
 import { IconAlertTriangle } from '../common/Icons';
 import type { LocalizableText } from '../types';
 import { TranslationContext } from '../boot/TranslationProvider';
@@ -139,7 +139,7 @@ export default function NotificationsScreen(props: Props): Node {
   return (
     <Screen title="Notifications">
       <ServerPushSetupBanner isDismissable={false} />
-      <NestedNavRow
+      <NavRow
         leftElement={
           systemSettingsWarnings.length > 0
             ? {
@@ -161,6 +161,7 @@ export default function NotificationsScreen(props: Props): Node {
           }
         })()}
         onPress={handleSystemSettingsPress}
+        type="external"
       />
       {!notificationReport.problems.includes(NotificationProblem.SystemSettingsDisabled) && (
         <>
@@ -189,7 +190,7 @@ export default function NotificationsScreen(props: Props): Node {
                 value={streamNotification}
                 onValueChange={handleStreamNotificationChange}
               />
-              <NestedNavRow
+              <NavRow
                 {...(() =>
                   notificationReport.problems.length > 0 && {
                     leftElement: {
@@ -205,7 +206,7 @@ export default function NotificationsScreen(props: Props): Node {
             </SettingsGroup>
           )}
           {otherAccounts.length > 0 && (
-            <NestedNavRow
+            <NavRow
               {...(() => {
                 const problemAccountsCount = otherAccounts.filter(a => {
                   // eslint-disable-next-line no-underscore-dangle

--- a/src/settings/PerAccountNotificationSettingsGroup.js
+++ b/src/settings/PerAccountNotificationSettingsGroup.js
@@ -1,0 +1,116 @@
+/* @flow strict-local */
+
+import React, { useCallback } from 'react';
+import type { Node } from 'react';
+import invariant from 'invariant';
+
+import type { AppNavigationMethods } from '../nav/AppNavigator';
+import { useSelector } from '../react-redux';
+import { getAuth, getSettings } from '../selectors';
+import SwitchRow from '../common/SwitchRow';
+import * as api from '../api';
+import NavRow from '../common/NavRow';
+import { IconAlertTriangle } from '../common/Icons';
+import { kWarningColor } from '../styles/constants';
+import { getIdentity } from '../account/accountsSelectors';
+import { getRealmName } from '../directSelectors';
+import ZulipText from '../common/ZulipText';
+import SettingsGroup from './SettingsGroup';
+import { useNotificationReportsByIdentityKey } from './NotifTroubleshootingScreen';
+import { keyOfIdentity } from '../account/accountMisc';
+
+type Props = $ReadOnly<{|
+  navigation: AppNavigationMethods,
+|}>;
+
+/**
+ * A SettingsGroup with per-account settings for NotificationsScreen.
+ */
+export default function PerAccountNotificationSettingsGroup(props: Props): Node {
+  const { navigation } = props;
+
+  const auth = useSelector(getAuth);
+  const identity = useSelector(getIdentity);
+  const notificationReportsByIdentityKey = useNotificationReportsByIdentityKey();
+  const notificationReport = notificationReportsByIdentityKey.get(keyOfIdentity(identity));
+  invariant(
+    notificationReport,
+    'NotificationsScreen: expected notificationReport for current account',
+  );
+  const realmName = useSelector(getRealmName);
+  const offlineNotification = useSelector(state => getSettings(state).offlineNotification);
+  const onlineNotification = useSelector(state => getSettings(state).onlineNotification);
+  const streamNotification = useSelector(state => getSettings(state).streamNotification);
+
+  const handleTroubleshootingPress = useCallback(() => {
+    navigation.push('notif-troubleshooting');
+  }, [navigation]);
+
+  // TODO(#3999): It'd be good to show "working on it" UI feedback while a
+  //   request is pending, after the user touches a switch.
+
+  const handleOfflineNotificationChange = useCallback(() => {
+    api.toggleMobilePushSettings({
+      auth,
+      opp: 'offline_notification_change',
+      value: !offlineNotification,
+    });
+  }, [offlineNotification, auth]);
+
+  const handleOnlineNotificationChange = useCallback(() => {
+    api.toggleMobilePushSettings({
+      auth,
+      opp: 'online_notification_change',
+      value: !onlineNotification,
+    });
+  }, [onlineNotification, auth]);
+
+  const handleStreamNotificationChange = useCallback(() => {
+    api.toggleMobilePushSettings({
+      auth,
+      opp: 'stream_notification_change',
+      value: !streamNotification,
+    });
+  }, [streamNotification, auth]);
+
+  return (
+    <SettingsGroup
+      title={{
+        text: 'Notification settings for this account ({email} in {realmName}):',
+        values: {
+          email: <ZulipText style={{ fontWeight: 'bold' }} text={identity.email} />,
+          realmName: <ZulipText style={{ fontWeight: 'bold' }} text={realmName} />,
+        },
+      }}
+    >
+      <SwitchRow
+        label="Notifications when offline"
+        value={offlineNotification}
+        onValueChange={handleOfflineNotificationChange}
+      />
+      <SwitchRow
+        label="Notifications when online"
+        value={onlineNotification}
+        onValueChange={handleOnlineNotificationChange}
+      />
+      <SwitchRow
+        label="Stream notifications"
+        value={streamNotification}
+        onValueChange={handleStreamNotificationChange}
+      />
+      <NavRow
+        {...(() =>
+          notificationReport.problems.length > 0 && {
+            leftElement: {
+              type: 'icon',
+              Component: IconAlertTriangle,
+              color: kWarningColor,
+            },
+            subtitle: 'Notifications for this account may not arrive.',
+          })()}
+        title="Troubleshooting"
+        onPress={handleTroubleshootingPress}
+      />
+    </SettingsGroup>
+  );
+}

--- a/src/settings/SettingsGroup.js
+++ b/src/settings/SettingsGroup.js
@@ -4,7 +4,7 @@ import * as React from 'react';
 import { View } from 'react-native';
 
 import SwitchRow from '../common/SwitchRow';
-import NestedNavRow from '../common/NestedNavRow';
+import NavRow from '../common/NavRow';
 import type { LocalizableReactText } from '../types';
 import { createStyleSheet } from '../styles';
 import { QUARTER_COLOR } from '../styles/constants';
@@ -18,7 +18,7 @@ type Props = $ReadOnly<{|
   // layout in some subtle way.
   title: LocalizableReactText,
 
-  children: $ReadOnlyArray<React$Element<typeof SwitchRow> | React$Element<typeof NestedNavRow>>,
+  children: $ReadOnlyArray<React$Element<typeof SwitchRow> | React$Element<typeof NavRow>>,
 |}>;
 
 export default function SettingsGroup(props: Props): React.Node {

--- a/src/settings/SettingsScreen.js
+++ b/src/settings/SettingsScreen.js
@@ -9,7 +9,7 @@ import type { RouteProp } from '../react-navigation';
 import type { AppNavigationProp } from '../nav/AppNavigator';
 import { useSelector, useGlobalSelector, useDispatch } from '../react-redux';
 import { getGlobalSettings } from '../selectors';
-import NestedNavRow from '../common/NestedNavRow';
+import NavRow from '../common/NavRow';
 import InputRowRadioButtons from '../common/InputRowRadioButtons';
 import SwitchRow from '../common/SwitchRow';
 import Screen from '../common/Screen';
@@ -89,7 +89,7 @@ export default function SettingsScreen(props: Props): Node {
           dispatch(setGlobalSettings({ markMessagesReadOnScroll: value }));
         }}
       />
-      <NestedNavRow
+      <NavRow
         leftElement={{ type: 'icon', Component: IconNotifications }}
         title="Notifications"
         {...(() =>
@@ -116,7 +116,7 @@ export default function SettingsScreen(props: Props): Node {
         }}
         search
       />
-      <NestedNavRow
+      <NavRow
         leftElement={{ type: 'icon', Component: IconMoreHorizontal }}
         title="Legal"
         onPress={() => {

--- a/src/streams/SubscriptionsScreen.js
+++ b/src/streams/SubscriptionsScreen.js
@@ -20,7 +20,7 @@ import { doNarrow } from '../actions';
 import { caseInsensitiveCompareFunc } from '../utils/misc';
 import StreamItem from './StreamItem';
 import ModalNavBar from '../nav/ModalNavBar';
-import NestedNavRow from '../common/NestedNavRow';
+import NavRow from '../common/NavRow';
 
 const styles = createStyleSheet({
   container: {
@@ -46,7 +46,7 @@ function AllStreamsButton(props: FooterProps): Node {
     navigation.push('all-streams');
   }, [navigation]);
 
-  return <NestedNavRow title="All streams" titleBoldUppercase onPress={handlePressAllScreens} />;
+  return <NavRow title="All streams" titleBoldUppercase onPress={handlePressAllScreens} />;
 }
 
 export default function SubscriptionsScreen(props: Props): Node {

--- a/static/translations/messages_en.json
+++ b/static/translations/messages_en.json
@@ -253,6 +253,8 @@
   "Notifications are disabled.": "Notifications are disabled.",
   "Multiple issues. Tap to learn more.": "Multiple issues. Tap to learn more.",
   "Notification settings for this account ({email} in {realmName}):": "Notification settings for this account ({email} in {realmName}):",
+  "{realmName} is not set up to deliver push notifications. Please contact your administrator.": "{realmName} is not set up to deliver push notifications. Please contact your administrator.",
+  "{realmName} is not set up to deliver push notifications.": "{realmName} is not set up to deliver push notifications.",
   "Other accounts": "Other accounts",
   "Notifications when online": "Notifications when online",
   "Notifications when offline": "Notifications when offline",


### PR DESCRIPTION
This makes two small UI changes:

- Nav rows that link to something outside the app, like the system settings app or a website, are marked with an "external-link" icon instead of the right-facing arrow icon.
- In the in-app notification setting screen, if the server isn't set up for push notifications, we now alert the user in the same way we show other per-account alerts, with a row in the "Notification settings for this account […]" section. Before, we were sticking a non-dismissable version of the `ServerPushSetupBanner` at the top of the screen. (The remaining, dismissable `ServerPushSetupBanner` on the home screen is untouched.)

Screenshots coming soon.