### PR TITLE
ServerPushSetupBanner: Fix conditional for showing admin-facing message

### DIFF
--- a/src/common/ServerPushSetupBanner.js
+++ b/src/common/ServerPushSetupBanner.js
@@ -50,11 +50,11 @@ export default function ServerPushSetupBanner(props: Props): Node {
     visible = true;
     text = isAtLeastAdmin
       ? {
-          text: 'The Zulip server at {realm} is not set up to deliver push notifications. Please contact your administrator.',
+          text: 'The Zulip server at {realm} is not set up to deliver push notifications.',
           values: { realm: realm.toString() },
         }
       : {
-          text: 'The Zulip server at {realm} is not set up to deliver push notifications.',
+          text: 'The Zulip server at {realm} is not set up to deliver push notifications. Please contact your administrator.',
           values: { realm: realm.toString() },
         };
   }


### PR DESCRIPTION
Somehow I got this conditional backwards when I wrote it in cb301ec23.