### PR TITLE
deps: Temporarily use fork for @react-navigation/stack

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@react-navigation/bottom-tabs": "npm:@zulip/react-navigation-bottom-tabs@5.11.16-0.zulip.1",
     "@react-navigation/material-top-tabs": "^5.2.19",
     "@react-navigation/native": "^5.7.6",
-    "@react-navigation/stack": "^5.9.3",
+    "@react-navigation/stack": "npm:@zulip/react-navigation-stack@5.14.10-0.zulip.1",
     "@sentry/react-native": "^3.1.1",
     "@zulip/shared": "0.0.18",
     "base-64": "^1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2274,10 +2274,10 @@
   dependencies:
     nanoid "^3.1.15"
 
-"@react-navigation/stack@^5.9.3":
-  version "5.14.9"
-  resolved "https://registry.yarnpkg.com/@react-navigation/stack/-/stack-5.14.9.tgz#49c7b9316e6fb456e9766c901e0d607862f0ea7d"
-  integrity sha512-DuvrT9P+Tz8ezZLQYxORZqOGqO+vEufaxlW1hSLw1knLD4jNxkz8TJDXtfKwaz//9gb43UhTNccNM02vm7iPqQ==
+"@react-navigation/stack@npm:@zulip/react-navigation-stack@5.14.10-0.zulip.1":
+  version "5.14.10-0.zulip.1"
+  resolved "https://registry.yarnpkg.com/@zulip/react-navigation-stack/-/react-navigation-stack-5.14.10-0.zulip.1.tgz#df71b85946c3deac0bbec59e40b349da77a48930"
+  integrity sha512-lZDs1CFSir3HJMhEi4Dy+AlF7o6OLAe9oNB4+c7hVdlYW4WgS0BzRBjN/lgZSWKCdx9KepeoCi6CUXS99tknkA==
   dependencies:
     color "^3.1.3"
     react-native-iphone-x-helper "^1.3.0"


### PR DESCRIPTION
(Much like we did for @react-navigation/bottom-tabs in c0b17bd32.)

To get chrisbobbe/react-navigation@a588dcee9, which I've published to NPM in @zulip/react-navigation-stack@5.14.10-0.zulip.1.

It cherry-picks react-navigation/react-navigation@5a1987708, which fixes #5486, as noted there:
  https://github.com/zulip/zulip-mobile/issues/5486#issuecomment-1261138257

So this fix will become unnecessary when we're on React Navigation 6; that's issue #4936.

Tested the bugfix on my iPhone 13 Pro running iOS 16.1, with and without "Debug with Chrome". The bug was fixed, and back navigation worked as expected, both with the swipe gesture and the back button.

Fixes: #5486