### PR TITLE
compat: Link to latest, not stable, for server-support doc

### DIFF
--- a/src/common/ServerCompatBanner.js
+++ b/src/common/ServerCompatBanner.js
@@ -19,7 +19,7 @@ import { Role } from '../api/permissionsTypes';
 // TODO: Instead, link to new Help Center doc once we have it:
 //   https://github.com/zulip/zulip/issues/23842
 export const kServerSupportDocUrl: URL = new URL(
-  'https://zulip.readthedocs.io/en/stable/overview/release-lifecycle.html#compatibility-and-upgrading',
+  'https://zulip.readthedocs.io/en/latest/overview/release-lifecycle.html#compatibility-and-upgrading',
 );
 
 /**

--- a/src/common/ServerCompatBanner.js
+++ b/src/common/ServerCompatBanner.js
@@ -14,10 +14,18 @@ import { getOwnUserRole, roleIsAtLeast } from '../permissionSelectors';
 import { Role } from '../api/permissionsTypes';
 
 /**
+ * The doc stating our oldest supported server version.
+ */
+// TODO: Instead, link to new Help Center doc once we have it:
+//   https://github.com/zulip/zulip/issues/23842
+export const kServerSupportDocUrl: URL = new URL(
+  'https://zulip.readthedocs.io/en/stable/overview/release-lifecycle.html#compatibility-and-upgrading',
+);
+
+/**
  * The oldest version we currently support.
  *
- * Should match what we say at:
- *   https://zulip.readthedocs.io/en/stable/overview/release-lifecycle.html#compatibility-and-upgrading
+ * Should match what we say at kServerSupportDocUrl.
  *
  * See also kMinAllowedServerVersion in apiErrors.js, for the version below
  * which we just refuse to connect.
@@ -98,14 +106,7 @@ export default function ServerCompatBanner(props: Props): Node {
           id: 'learn-more',
           label: 'Learn more',
           onPress: () => {
-            openLinkWithUserPreference(
-              // TODO: Instead, link to new Help Center doc once we have it:
-              //   https://github.com/zulip/zulip/issues/23842
-              new URL(
-                'https://zulip.readthedocs.io/en/stable/overview/release-lifecycle.html#compatibility-and-upgrading',
-              ),
-              settings,
-            );
+            openLinkWithUserPreference(kServerSupportDocUrl, settings);
           },
         },
       ]}

--- a/src/events/eventActions.js
+++ b/src/events/eventActions.js
@@ -34,7 +34,11 @@ import { tryFetch, fetchPrivateMessages } from '../message/fetchActions';
 import { MIN_RECENTPMS_SERVER_VERSION } from '../pm-conversations/pmConversationsModel';
 import { sendOutbox } from '../outbox/outboxActions';
 import { initNotifications, tryStopNotifications } from '../notification/notifTokens';
-import { kMinSupportedVersion, kNextMinSupportedVersion } from '../common/ServerCompatBanner';
+import {
+  kMinSupportedVersion,
+  kNextMinSupportedVersion,
+  kServerSupportDocUrl,
+} from '../common/ServerCompatBanner';
 import { maybeRefreshServerEmojiData } from '../emoji/data';
 
 const registerStart = (): PerAccountAction => ({
@@ -171,11 +175,7 @@ export const registerAndStartPolling =
           'Could not connect',
           `${identity.realm.toString()} is running Zulip Server ${e.version.raw()}, which is unsupported. The minimum supported version is Zulip Server ${kMinSupportedVersion.raw()}.`,
           {
-            url: new URL(
-              // TODO: Instead, link to new Help Center doc once we have it:
-              //   https://github.com/zulip/zulip/issues/23842
-              'https://zulip.readthedocs.io/en/stable/overview/release-lifecycle.html#compatibility-and-upgrading',
-            ),
+            url: kServerSupportDocUrl,
             globalSettings: getGlobalSettings(),
           },
         );

--- a/src/message/fetchActions.js
+++ b/src/message/fetchActions.js
@@ -38,7 +38,11 @@ import { ALL_PRIVATE_NARROW, apiNarrowOfNarrow, caseNarrow, topicNarrow } from '
 import { BackoffMachine, promiseTimeout, TimeoutError } from '../utils/async';
 import { getAllUsersById, getOwnUserId } from '../users/userSelectors';
 import type { ServerSettings } from '../api/settings/getServerSettings';
-import { kMinSupportedVersion, kNextMinSupportedVersion } from '../common/ServerCompatBanner';
+import {
+  kMinSupportedVersion,
+  kNextMinSupportedVersion,
+  kServerSupportDocUrl,
+} from '../common/ServerCompatBanner';
 
 const messageFetchStart = (
   narrow: Narrow,
@@ -400,13 +404,7 @@ export async function fetchServerSettings(realm: URL): Promise<
           minSupportedVersion: kMinSupportedVersion.raw(),
         },
       };
-      learnMoreButton = {
-        url: new URL(
-          // TODO: Instead, link to new Help Center doc once we have it:
-          //   https://github.com/zulip/zulip/issues/23842
-          'https://zulip.readthedocs.io/en/stable/overview/release-lifecycle.html#compatibility-and-upgrading',
-        ),
-      };
+      learnMoreButton = { url: kServerSupportDocUrl };
       logging.setTagsFromServerVersion(error.version);
       logging.error(error, {
         kMinAllowedServerVersion: kMinAllowedServerVersion.raw(),

--- a/src/settings/SettingsScreen.js
+++ b/src/settings/SettingsScreen.js
@@ -25,7 +25,7 @@ import { setGlobalSettings } from '../actions';
 import { shouldUseInAppBrowser } from '../utils/openLink';
 import TextRow from '../common/TextRow';
 import { getIdentity, getServerVersion } from '../account/accountsSelectors';
-import { kMinSupportedVersion } from '../common/ServerCompatBanner';
+import { kMinSupportedVersion, kServerSupportDocUrl } from '../common/ServerCompatBanner';
 import { kWarningColor } from '../styles/constants';
 import { showErrorAlert } from '../utils/info';
 import { TranslationContext } from '../boot/TranslationProvider';
@@ -145,14 +145,7 @@ export default function SettingsScreen(props: Props): Node {
                   minSupportedVersion: kMinSupportedVersion.raw(),
                 },
               }),
-              {
-                url: new URL(
-                  // TODO: Instead, link to new Help Center doc once we have it:
-                  //   https://github.com/zulip/zulip/issues/23842
-                  'https://zulip.readthedocs.io/en/stable/overview/release-lifecycle.html#compatibility-and-upgrading',
-                ),
-                globalSettings,
-              },
+              { url: kServerSupportDocUrl, globalSettings },
             );
           },
         })}


### PR DESCRIPTION
As Greg points out:

> Fundamentally this is information that isn't tied to a Zulip
> Server release (not a *current* one, anyway), so the most relevant
> version of it is just whatever is the latest we've merged.