### PR TITLE
internalLinks [nfc]: Dissolve `getLinkType` / `LinkType` indirection

### DIFF
--- a/src/message/messagesActions.js
+++ b/src/message/messagesActions.js
@@ -229,7 +229,6 @@ export const messageLinkPress =
       showErrorAlert(_('Cannot open link'), _('Invalid URL.'));
       return;
     }
-    // TODO: Replace all uses of `href` below with `parsedUrl`.
 
     const narrow = getNarrowFromLink(parsedUrl, auth.realm, streamsById, streamsByName, ownUserId);
 

--- a/src/utils/__tests__/internalLinks-test.js
+++ b/src/utils/__tests__/internalLinks-test.js
@@ -1,6 +1,10 @@
 /* @flow strict-local */
 import invariant from 'invariant';
 
+// Tell ESLint to recognize `expectStream` as a helper function that
+// runs assertions.
+/* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["expect", "check", "expectStream"] }] */
+
 import type { Stream } from '../../types';
 import { streamNarrow, topicNarrow, pmNarrowFromUsersUnsafe, STARRED_NARROW } from '../narrow';
 import {
@@ -118,55 +122,63 @@ describe('isNarrowLink', () => {
 
 describe('getLinkType', () => {
   test('link containing "stream" is a stream link', () => {
-    expect(getLinkType(new URL('/#narrow/stream/jest', realm), realm)).toBe('stream');
-    expect(getLinkType(new URL('/#narrow/stream/stream/', realm), realm)).toBe('stream');
-    expect(getLinkType(new URL('/#narrow/stream/topic/', realm), realm)).toBe('stream');
+    const check = hash => {
+      expect(getLinkType(new URL(hash, realm), realm)).toBe('stream');
+    };
+    ['/#narrow/stream/jest', '/#narrow/stream/stream/', '/#narrow/stream/topic/'].forEach(hash =>
+      check(hash),
+    );
   });
 
   test('link containing "topic" is a topic link', () => {
-    expect(getLinkType(new URL('/#narrow/stream/jest/topic/test', realm), realm)).toBe('topic');
-    expect(
-      getLinkType(new URL('/#narrow/stream/mobile/subject/topic/near/378333', realm), realm),
-    ).toBe('topic');
-    expect(getLinkType(new URL('/#narrow/stream/mobile/topic/topic/', realm), realm)).toBe('topic');
-    expect(getLinkType(new URL('/#narrow/stream/stream/topic/topic/near/1', realm), realm)).toBe(
-      'topic',
-    );
-    expect(getLinkType(new URL('/#narrow/stream/stream/subject/topic/near/1', realm), realm)).toBe(
-      'topic',
-    );
-
-    expect(getLinkType(new URL('/#narrow/stream/stream/subject/topic', realm), realm)).toBe(
-      'topic',
-    );
+    const check = hash => {
+      expect(getLinkType(new URL(hash, realm), realm)).toBe('topic');
+    };
+    [
+      '/#narrow/stream/jest/topic/test',
+      '/#narrow/stream/mobile/subject/topic/near/378333',
+      '/#narrow/stream/mobile/topic/topic/',
+      '/#narrow/stream/stream/topic/topic/near/1',
+      '/#narrow/stream/stream/subject/topic/near/1',
+      '/#narrow/stream/stream/subject/topic',
+    ].forEach(hash => check(hash));
   });
 
   test('link containing "pm-with" is a PM link', () => {
-    expect(getLinkType(new URL('/#narrow/pm-with/1,2-group', realm), realm)).toBe('pm');
-    expect(getLinkType(new URL('/#narrow/pm-with/1,2-group/near/1', realm), realm)).toBe('pm');
-    expect(
-      getLinkType(new URL('/#narrow/pm-with/a.40b.2Ecom.2Ec.2Ed.2Ecom/near/3', realm), realm),
-    ).toBe('pm');
+    const check = hash => {
+      expect(getLinkType(new URL(hash, realm), realm)).toBe('pm');
+    };
+    [
+      '/#narrow/pm-with/1,2-group',
+      '/#narrow/pm-with/1,2-group/near/1',
+      '/#narrow/pm-with/a.40b.2Ecom.2Ec.2Ed.2Ecom/near/3',
+    ].forEach(hash => check(hash));
   });
 
   test('link containing "is" with valid operand is a special link', () => {
-    expect(getLinkType(new URL('/#narrow/is/private', realm), realm)).toBe('special');
-    expect(getLinkType(new URL('/#narrow/is/starred', realm), realm)).toBe('special');
-    expect(getLinkType(new URL('/#narrow/is/mentioned', realm), realm)).toBe('special');
+    const check = hash => {
+      expect(getLinkType(new URL(hash, realm), realm)).toBe('special');
+    };
+    ['/#narrow/is/private', '/#narrow/is/starred', '/#narrow/is/mentioned'].forEach(hash =>
+      check(hash),
+    );
   });
 
   test('unexpected link shape gives "home"', () => {
-    // `near` with no operand
-    expect(getLinkType(new URL('/#narrow/stream/stream/topic/topic/near/', realm), realm)).toBe(
-      'home',
-    );
+    const check = hash => {
+      expect(getLinkType(new URL(hash, realm), realm)).toBe('home');
+    };
+    [
+      // `near` with no operand
+      '/#narrow/stream/stream/topic/topic/near/',
 
-    // `is` with invalid operand
-    expect(getLinkType(new URL('/#narrow/is/men', realm), realm)).toBe('home');
-    expect(getLinkType(new URL('/#narrow/is/men/stream', realm), realm)).toBe('home');
+      // `is` with invalid operand
+      '/#narrow/is/men',
+      '/#narrow/is/men/stream',
 
-    // invalid operand `are`; `stream` operator with no operand
-    expect(getLinkType(new URL('/#narrow/are/men/stream', realm), realm)).toBe('home');
+      // invalid operand `are`; `stream` operator with no operand
+      '/#narrow/are/men/stream',
+    ].forEach(hash => check(hash));
   });
 });
 
@@ -209,9 +221,6 @@ describe('getNarrowFromLink', () => {
   });
 
   describe('on stream links', () => {
-    // Tell ESLint to recognize `expectStream` as a helper function that
-    // runs assertions.
-    /* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["expect", "expectStream"] }] */
     const expectStream = (operand, streams, expectedStream: null | Stream) => {
       expect(get(`#narrow/stream/${operand}`, streams)).toEqual(
         expectedStream === null ? null : streamNarrow(expectedStream.stream_id),

--- a/src/utils/__tests__/internalLinks-test.js
+++ b/src/utils/__tests__/internalLinks-test.js
@@ -117,11 +117,7 @@ describe('isNarrowLink', () => {
 });
 
 describe('getLinkType', () => {
-  test('links to a different domain are of "non-narrow" type', () => {
-    expect(getLinkType(new URL('https://google.com/some-path'), realm)).toBe('non-narrow');
-  });
-
-  test('only in-app link containing "stream" is a stream link', () => {
+  test('only link containing "stream" is a stream link', () => {
     expect(getLinkType(new URL('/#narrow/pm-with/1,2-group', realm), realm)).toBe('pm');
     expect(getLinkType(new URL('/#narrow/stream/jest', realm), realm)).toBe('stream');
     expect(getLinkType(new URL('/#narrow/stream/stream/', realm), realm)).toBe('stream');
@@ -154,7 +150,7 @@ describe('getLinkType', () => {
     );
   });
 
-  test('only in-app link containing "pm-with" is a group link', () => {
+  test('only link containing "pm-with" is a group link', () => {
     expect(getLinkType(new URL('/#narrow/stream/jest/topic/test', realm), realm)).toBe('topic');
     expect(getLinkType(new URL('/#narrow/pm-with/1,2-group', realm), realm)).toBe('pm');
     expect(getLinkType(new URL('/#narrow/pm-with/1,2-group/near/1', realm), realm)).toBe('pm');
@@ -163,7 +159,7 @@ describe('getLinkType', () => {
     ).toBe('pm');
   });
 
-  test('only in-app link containing "is" is a special link', () => {
+  test('only link containing "is" is a special link', () => {
     expect(getLinkType(new URL('/#narrow/stream/jest/topic/test', realm), realm)).toBe('topic');
     expect(getLinkType(new URL('/#narrow/is/private', realm), realm)).toBe('special');
     expect(getLinkType(new URL('/#narrow/is/starred', realm), realm)).toBe('special');

--- a/src/utils/__tests__/internalLinks-test.js
+++ b/src/utils/__tests__/internalLinks-test.js
@@ -16,6 +16,7 @@ import {
 } from '../internalLinks';
 import * as eg from '../../__tests__/lib/exampleData';
 import { isUrlRelative } from '../url';
+import type { LinkType } from '../internalLinks';
 
 const realm = new URL('https://example.com');
 const urlOnRealm = relativeUrl => {
@@ -121,19 +122,19 @@ describe('isNarrowLink', () => {
 });
 
 describe('getLinkType', () => {
+  const mkCheck = (expected: LinkType) => hash => {
+    expect(getLinkType(new URL(hash, realm), realm)).toBe(expected);
+  };
+
   test('link containing "stream" is a stream link', () => {
-    const check = hash => {
-      expect(getLinkType(new URL(hash, realm), realm)).toBe('stream');
-    };
+    const check = mkCheck('stream');
     ['/#narrow/stream/jest', '/#narrow/stream/stream/', '/#narrow/stream/topic/'].forEach(hash =>
       check(hash),
     );
   });
 
   test('link containing "topic" is a topic link', () => {
-    const check = hash => {
-      expect(getLinkType(new URL(hash, realm), realm)).toBe('topic');
-    };
+    const check = mkCheck('topic');
     [
       '/#narrow/stream/jest/topic/test',
       '/#narrow/stream/mobile/subject/topic/near/378333',
@@ -145,9 +146,7 @@ describe('getLinkType', () => {
   });
 
   test('link containing "pm-with" is a PM link', () => {
-    const check = hash => {
-      expect(getLinkType(new URL(hash, realm), realm)).toBe('pm');
-    };
+    const check = mkCheck('pm');
     [
       '/#narrow/pm-with/1,2-group',
       '/#narrow/pm-with/1,2-group/near/1',
@@ -156,18 +155,14 @@ describe('getLinkType', () => {
   });
 
   test('link containing "is" with valid operand is a special link', () => {
-    const check = hash => {
-      expect(getLinkType(new URL(hash, realm), realm)).toBe('special');
-    };
+    const check = mkCheck('special');
     ['/#narrow/is/private', '/#narrow/is/starred', '/#narrow/is/mentioned'].forEach(hash =>
       check(hash),
     );
   });
 
   test('unexpected link shape gives "home"', () => {
-    const check = hash => {
-      expect(getLinkType(new URL(hash, realm), realm)).toBe('home');
-    };
+    const check = mkCheck('home');
     [
       // `near` with no operand
       '/#narrow/stream/stream/topic/topic/near/',

--- a/src/utils/__tests__/internalLinks-test.js
+++ b/src/utils/__tests__/internalLinks-test.js
@@ -123,17 +123,19 @@ describe('isNarrowLink', () => {
 
 describe('getLinkType', () => {
   const mkCheck = (expected: LinkType) => hash => {
-    expect(getLinkType(new URL(hash, realm), realm)).toBe(expected);
+    test(`${hash} - should return ${expected}`, () => {
+      expect(getLinkType(new URL(hash, realm), realm)).toBe(expected);
+    });
   };
 
-  test('link containing "stream" is a stream link', () => {
+  describe('link containing "stream" is a stream link', () => {
     const check = mkCheck('stream');
     ['/#narrow/stream/jest', '/#narrow/stream/stream/', '/#narrow/stream/topic/'].forEach(hash =>
       check(hash),
     );
   });
 
-  test('link containing "topic" is a topic link', () => {
+  describe('link containing "topic" is a topic link', () => {
     const check = mkCheck('topic');
     [
       '/#narrow/stream/jest/topic/test',
@@ -145,7 +147,7 @@ describe('getLinkType', () => {
     ].forEach(hash => check(hash));
   });
 
-  test('link containing "pm-with" is a PM link', () => {
+  describe('link containing "pm-with" is a PM link', () => {
     const check = mkCheck('pm');
     [
       '/#narrow/pm-with/1,2-group',
@@ -154,14 +156,14 @@ describe('getLinkType', () => {
     ].forEach(hash => check(hash));
   });
 
-  test('link containing "is" with valid operand is a special link', () => {
+  describe('link containing "is" with valid operand is a special link', () => {
     const check = mkCheck('special');
     ['/#narrow/is/private', '/#narrow/is/starred', '/#narrow/is/mentioned'].forEach(hash =>
       check(hash),
     );
   });
 
-  test('unexpected link shape gives "home"', () => {
+  describe('unexpected link shape gives "home"', () => {
     const check = mkCheck('home');
     [
       // `near` with no operand

--- a/src/utils/__tests__/internalLinks-test.js
+++ b/src/utils/__tests__/internalLinks-test.js
@@ -165,6 +165,8 @@ describe('getNarrowFromLink (part 1)', () => {
     ['/#narrow/stream/jest', '/#narrow/stream/stream/', '/#narrow/stream/topic/'].forEach(hash =>
       check(hash),
     );
+
+    // TODO: Test with modern-style stream links that use stream IDs
   });
 
   describe('link containing "topic" is a topic link', () => {

--- a/src/utils/__tests__/internalLinks-test.js
+++ b/src/utils/__tests__/internalLinks-test.js
@@ -117,22 +117,13 @@ describe('isNarrowLink', () => {
 });
 
 describe('getLinkType', () => {
-  test('only link containing "stream" is a stream link', () => {
-    expect(getLinkType(new URL('/#narrow/pm-with/1,2-group', realm), realm)).toBe('pm');
+  test('link containing "stream" is a stream link', () => {
     expect(getLinkType(new URL('/#narrow/stream/jest', realm), realm)).toBe('stream');
     expect(getLinkType(new URL('/#narrow/stream/stream/', realm), realm)).toBe('stream');
-  });
-
-  test('when a url is not a topic narrow return false', () => {
-    expect(getLinkType(new URL('/#narrow/pm-with/1,2-group', realm), realm)).toBe('pm');
-    expect(getLinkType(new URL('/#narrow/stream/jest', realm), realm)).toBe('stream');
-    expect(getLinkType(new URL('/#narrow/stream/stream/topic/topic/near/', realm), realm)).toBe(
-      'home',
-    );
     expect(getLinkType(new URL('/#narrow/stream/topic/', realm), realm)).toBe('stream');
   });
 
-  test('when a url is a topic narrow return true', () => {
+  test('link containing "topic" is a topic link', () => {
     expect(getLinkType(new URL('/#narrow/stream/jest/topic/test', realm), realm)).toBe('topic');
     expect(
       getLinkType(new URL('/#narrow/stream/mobile/subject/topic/near/378333', realm), realm),
@@ -150,8 +141,7 @@ describe('getLinkType', () => {
     );
   });
 
-  test('only link containing "pm-with" is a group link', () => {
-    expect(getLinkType(new URL('/#narrow/stream/jest/topic/test', realm), realm)).toBe('topic');
+  test('link containing "pm-with" is a PM link', () => {
     expect(getLinkType(new URL('/#narrow/pm-with/1,2-group', realm), realm)).toBe('pm');
     expect(getLinkType(new URL('/#narrow/pm-with/1,2-group/near/1', realm), realm)).toBe('pm');
     expect(
@@ -159,13 +149,23 @@ describe('getLinkType', () => {
     ).toBe('pm');
   });
 
-  test('only link containing "is" is a special link', () => {
-    expect(getLinkType(new URL('/#narrow/stream/jest/topic/test', realm), realm)).toBe('topic');
+  test('link containing "is" with valid operand is a special link', () => {
     expect(getLinkType(new URL('/#narrow/is/private', realm), realm)).toBe('special');
     expect(getLinkType(new URL('/#narrow/is/starred', realm), realm)).toBe('special');
     expect(getLinkType(new URL('/#narrow/is/mentioned', realm), realm)).toBe('special');
+  });
+
+  test('unexpected link shape gives "home"', () => {
+    // `near` with no operand
+    expect(getLinkType(new URL('/#narrow/stream/stream/topic/topic/near/', realm), realm)).toBe(
+      'home',
+    );
+
+    // `is` with invalid operand
     expect(getLinkType(new URL('/#narrow/is/men', realm), realm)).toBe('home');
     expect(getLinkType(new URL('/#narrow/is/men/stream', realm), realm)).toBe('home');
+
+    // invalid operand `are`; `stream` operator with no operand
     expect(getLinkType(new URL('/#narrow/are/men/stream', realm), realm)).toBe('home');
   });
 });

--- a/src/utils/internalLinks.js
+++ b/src/utils/internalLinks.js
@@ -48,19 +48,18 @@ export const isNarrowLink = (url: URL, realm: URL): boolean =>
   && url.search === ''
   && /^#narrow\//i.test(url.hash);
 
-type LinkType = 'non-narrow' | 'home' | 'pm' | 'topic' | 'stream' | 'special';
+type LinkType = 'home' | 'pm' | 'topic' | 'stream' | 'special';
 
 /**
  * PRIVATE -- exported only for tests.
+ *
+ * The passed `url` must appear to be a link to a Zulip narrow on the given
+ * `realm`. In particular, `isNarrowLink(url, realm)` must be true.
  */
 // TODO: Work out what this does, write a jsdoc for its interface, and
 // reimplement using URL object (not just for the realm)
 export const getLinkType = (url: URL, realm: URL): LinkType => {
-  if (!isNarrowLink(url, realm)) {
-    return 'non-narrow';
-  }
-
-  // isNarrowLink(…) is true, by early return above, so this call is OK.
+  // isNarrowLink(…) is true, by jsdoc, so this call is OK.
   const hashSegments = getHashSegmentsFromNarrowLink(url, realm);
 
   if (
@@ -163,11 +162,11 @@ export const getNarrowFromLink = (
   streamsByName: Map<string, Stream>,
   ownUserId: UserId,
 ): Narrow | null => {
-  const type = getLinkType(url, realm);
-
-  if (type === 'non-narrow') {
+  if (!isNarrowLink(url, realm)) {
     return null;
   }
+
+  const type = getLinkType(url, realm);
 
   // isNarrowLink(…) is true, by early return above, so this call is OK.
   const hashSegments = getHashSegmentsFromNarrowLink(url, realm);

--- a/src/utils/internalLinks.js
+++ b/src/utils/internalLinks.js
@@ -48,7 +48,8 @@ export const isNarrowLink = (url: URL, realm: URL): boolean =>
   && url.search === ''
   && /^#narrow\//i.test(url.hash);
 
-type LinkType = 'home' | 'pm' | 'topic' | 'stream' | 'special';
+/* PRIVATE: Exported only for tests. */
+export type LinkType = 'home' | 'pm' | 'topic' | 'stream' | 'special';
 
 /**
  * PRIVATE -- exported only for tests.


### PR DESCRIPTION
I think this is another helpful simplification to this code; done when returning to this code for #5692.

-----

This puts the logic to recognize a "stream link" right next to the
logic for building a stream narrow, and likewise for topic narrows,
etc.

Now it's quicker to read what `Narrow` we construct for a given
`url` param. We don't have to click through `getLinkType` and wonder
whether anything surprising is done at that layer.