### PR TITLE
internalLinks: Parse '/dm/…' and '/is/dm' in narrow links

### DIFF
--- a/src/api/modelTypes.js
+++ b/src/api/modelTypes.js
@@ -693,8 +693,9 @@ export type NarrowElement =
  | {| +operator: 'stream', +operand: string | number |} // stream ID
  | {| +operator: 'pm-with', +operand: string | $ReadOnlyArray<UserId> |}
  | {| +operator: 'sender', +operand: string | UserId |}
- | {| +operator: 'group-pm-with', +operand: string | UserId |}
  | {| +operator: 'near' | 'id', +operand: number |} // message ID
+ // ('group-pm-with' was accepted at least through server 6.x, but support
+ // will be dropped: https://github.com/zulip/zulip/issues/24806 )
  ;
 
 /**

--- a/src/utils/__tests__/internalLinks-test.js
+++ b/src/utils/__tests__/internalLinks-test.js
@@ -15,6 +15,8 @@ import {
   isStreamNarrow,
   isTopicNarrow,
   isSpecialNarrow,
+  ALL_PRIVATE_NARROW,
+  MENTIONED_NARROW,
 } from '../narrow';
 import {
   isNarrowLink,
@@ -387,7 +389,9 @@ describe('getNarrowFromNarrowLink (part 2)', () => {
   });
 
   test('on a special link', () => {
-    expect(get('https://example.com/#narrow/is/starred', [])).toEqual(STARRED_NARROW);
+    expect(get('/#narrow/is/private', [])).toEqual(ALL_PRIVATE_NARROW);
+    expect(get('/#narrow/is/starred', [])).toEqual(STARRED_NARROW);
+    expect(get('/#narrow/is/mentioned', [])).toEqual(MENTIONED_NARROW);
   });
 
   test('on a message link', () => {

--- a/src/utils/__tests__/internalLinks-test.js
+++ b/src/utils/__tests__/internalLinks-test.js
@@ -160,7 +160,7 @@ describe('getNarrowFromNarrowLink (part 1)', () => {
     }
   };
 
-  describe('link containing "stream" is a stream link', () => {
+  describe('"/#narrow/stream/<…>" is a stream link', () => {
     const check = mkCheck(isStreamNarrow);
     ['/#narrow/stream/jest', '/#narrow/stream/stream/', '/#narrow/stream/topic/'].forEach(hash =>
       check(hash),
@@ -169,7 +169,7 @@ describe('getNarrowFromNarrowLink (part 1)', () => {
     // TODO: Test with modern-style stream links that use stream IDs
   });
 
-  describe('link containing "topic" is a topic link', () => {
+  describe('"/#narrow/stream/<…>/topic/<…>" is a topic link', () => {
     const check = mkCheck(isTopicNarrow);
     [
       '/#narrow/stream/jest/topic/test',
@@ -181,7 +181,7 @@ describe('getNarrowFromNarrowLink (part 1)', () => {
     ].forEach(hash => check(hash));
   });
 
-  describe('link containing "pm-with" is a PM link', () => {
+  describe('"/#narrow/pm-with/<…>" is a PM link', () => {
     const check = mkCheck(isPmNarrow);
     [
       '/#narrow/pm-with/1,2-group',
@@ -190,7 +190,7 @@ describe('getNarrowFromNarrowLink (part 1)', () => {
     ].forEach(hash => check(hash));
   });
 
-  describe('link containing "is" with valid operand is a special link', () => {
+  describe('"/#narrow/is/<…>" with valid operand is a special link', () => {
     const check = mkCheck(isSpecialNarrow);
     ['/#narrow/is/private', '/#narrow/is/starred', '/#narrow/is/mentioned'].forEach(hash =>
       check(hash),

--- a/src/utils/internalLinks.js
+++ b/src/utils/internalLinks.js
@@ -173,13 +173,11 @@ export const getNarrowFromNarrowLink = (
   if (
     hashSegments.length === 2
     && hashSegments[0] === 'is'
-    && /^(private|starred|mentioned)/i.test(hashSegments[1])
+    && (hashSegments[1] === 'starred'
+      || hashSegments[1] === 'mentioned'
+      || hashSegments[1] === 'private')
   ) {
-    try {
-      return specialNarrow(hashSegments[1]);
-    } catch {
-      return null;
-    }
+    return specialNarrow(hashSegments[1]);
   }
 
   return null; // TODO(?) Give HOME_NARROW

--- a/src/utils/internalLinks.js
+++ b/src/utils/internalLinks.js
@@ -144,8 +144,11 @@ export const getNarrowFromNarrowLink = (
   const hashSegments = getHashSegmentsFromNarrowLink(url, realm);
 
   if (
-    (hashSegments.length === 2 && hashSegments[0] === 'pm-with')
-    || (hashSegments.length === 4 && hashSegments[0] === 'pm-with' && hashSegments[2] === 'near')
+    // 'dm' is new in server-7.0; means the same as 'pm-with'
+    (hashSegments.length === 2 && (hashSegments[0] === 'pm-with' || hashSegments[0] === 'dm'))
+    || (hashSegments.length === 4
+      && (hashSegments[0] === 'pm-with' || hashSegments[0] === 'dm')
+      && hashSegments[2] === 'near')
   ) {
     // TODO: This case is pretty useless in practice, due to basically a
     //   bug in the webapp: the URL that appears in the location bar for a
@@ -175,9 +178,18 @@ export const getNarrowFromNarrowLink = (
     && hashSegments[0] === 'is'
     && (hashSegments[1] === 'starred'
       || hashSegments[1] === 'mentioned'
+      || hashSegments[1] === 'dm' // new in server-7.0; means the same as 'private'
       || hashSegments[1] === 'private')
   ) {
-    return specialNarrow(hashSegments[1]);
+    switch (hashSegments[1]) {
+      case 'starred':
+        return specialNarrow('starred');
+      case 'mentioned':
+        return specialNarrow('mentioned');
+      case 'dm':
+      case 'private':
+        return specialNarrow('dm');
+    }
   }
 
   return null; // TODO(?) Give HOME_NARROW

--- a/src/utils/narrow.js
+++ b/src/utils/narrow.js
@@ -13,6 +13,7 @@ import {
   makePmKeyRecipients_UNSAFE,
 } from './recipient';
 import type { UserMessageFlag } from '../api/modelTypes';
+import { ensureUnreachable } from '../generics';
 
 /* eslint-disable no-use-before-define */
 
@@ -123,17 +124,18 @@ export const pmNarrowFromUsersUnsafe = (recipients: $ReadOnlyArray<UserOrBot>): 
 export const pm1to1NarrowFromUser = (user: UserOrBot): Narrow =>
   pmNarrowInternal(pmKeyRecipientsFor1to1(user.user_id));
 
-export const specialNarrow = (operand: string): Narrow => {
-  if (operand === 'starred') {
-    return Object.freeze({ type: 'starred' });
+export const specialNarrow = (operand: 'starred' | 'mentioned' | 'private'): Narrow => {
+  switch (operand) {
+    case 'starred':
+      return Object.freeze({ type: 'starred' });
+    case 'mentioned':
+      return Object.freeze({ type: 'mentioned' });
+    case 'private':
+      return Object.freeze({ type: 'all-pm' });
+    default:
+      ensureUnreachable(operand);
+      throw new Error();
   }
-  if (operand === 'mentioned') {
-    return Object.freeze({ type: 'mentioned' });
-  }
-  if (operand === 'private') {
-    return Object.freeze({ type: 'all-pm' });
-  }
-  throw new Error(`specialNarrow: got unsupported operand: ${operand}`);
 };
 
 export const STARRED_NARROW: Narrow = specialNarrow('starred');

--- a/src/utils/narrow.js
+++ b/src/utils/narrow.js
@@ -124,13 +124,13 @@ export const pmNarrowFromUsersUnsafe = (recipients: $ReadOnlyArray<UserOrBot>): 
 export const pm1to1NarrowFromUser = (user: UserOrBot): Narrow =>
   pmNarrowInternal(pmKeyRecipientsFor1to1(user.user_id));
 
-export const specialNarrow = (operand: 'starred' | 'mentioned' | 'private'): Narrow => {
+export const specialNarrow = (operand: 'starred' | 'mentioned' | 'dm'): Narrow => {
   switch (operand) {
     case 'starred':
       return Object.freeze({ type: 'starred' });
     case 'mentioned':
       return Object.freeze({ type: 'mentioned' });
-    case 'private':
+    case 'dm':
       return Object.freeze({ type: 'all-pm' });
     default:
       ensureUnreachable(operand);
@@ -146,7 +146,7 @@ export const MENTIONED_NARROW: Narrow = specialNarrow('mentioned');
 
 export const MENTIONED_NARROW_STR: string = keyFromNarrow(MENTIONED_NARROW);
 
-export const ALL_PRIVATE_NARROW: Narrow = specialNarrow('private');
+export const ALL_PRIVATE_NARROW: Narrow = specialNarrow('dm');
 
 export const ALL_PRIVATE_NARROW_STR: string = keyFromNarrow(ALL_PRIVATE_NARROW);
 
@@ -437,6 +437,7 @@ export const apiNarrowOfNarrow = (
     ],
     pm: ids => {
       const emails = ids.map(id => get('user', allUsersById, id).email);
+      // TODO(server-7.0): send `dm` rather than `pm-with`
       // TODO(server-2.1): just send IDs instead
       return [{ operator: 'pm-with', operand: emails.join(',') }];
     },
@@ -444,6 +445,8 @@ export const apiNarrowOfNarrow = (
     home: () => [],
     starred: () => [{ operator: 'is', operand: 'starred' }],
     mentioned: () => [{ operator: 'is', operand: 'mentioned' }],
+
+    // TODO(server-7.0): send `is:dm` rather than `is:private`
     allPrivate: () => [{ operator: 'is', operand: 'private' }],
   });
 };


### PR DESCRIPTION
(This is atop #5699.)

Fixes: #5692