### PR TITLE
versions: Bump kMinSupportedVersion to match kServerSupportDocUrl

### DIFF
--- a/src/common/ServerCompatBanner.js
+++ b/src/common/ServerCompatBanner.js
@@ -30,19 +30,7 @@ export const kServerSupportDocUrl: URL = new URL(
  * See also kMinAllowedServerVersion in apiErrors.js, for the version below
  * which we just refuse to connect.
  */
-// "2.2.0" is a funny way of saying "3.0", differing in that it accepts
-// versions like 2.2-dev-1234-g08192a3b4c.  Some servers running versions
-// from Git describe their versions that way: specifically those installed
-// from commits in the range 2.2-dev..3.0-dev (2019-12 to 2020-06), before
-// we decided to rename the then-upcoming release from 2.2 to 3.0; and
-// potentially upgraded since then, but not past the upgrader bugfix commit
-// 5.0~960 (2022-01).
-//
-// By the time we want to desupport 3.x circa 2022-11, it should make sense
-// to simply say 4.0 here.  By that point the affected versions from Git
-// will be nearly a year old, and it's pretty OK to just say those servers
-// should upgrade too.
-export const kMinSupportedVersion: ZulipVersion = new ZulipVersion('2.2.0');
+export const kMinSupportedVersion: ZulipVersion = new ZulipVersion('4.0');
 // Notes on known breakage at older versions:
 //  * Before 1.8, the server doesn't send found_newest / found_oldest on
 //    fetching messages, and so `state.caughtUp` will never have truthy
@@ -54,7 +42,7 @@ export const kMinSupportedVersion: ZulipVersion = new ZulipVersion('2.2.0');
  *
  * This should be the next major Zulip Server version after kMinSupportedVersion.
  */
-export const kNextMinSupportedVersion: ZulipVersion = new ZulipVersion('4.0');
+export const kNextMinSupportedVersion: ZulipVersion = new ZulipVersion('5.0');
 
 type Props = $ReadOnly<{||}>;
 


### PR DESCRIPTION
The doc at
  https://zulip.readthedocs.io/en/latest/overview/release-lifecycle.html#compatibility-and-upgrading
(kServerSupportDocUrl) now says 4.0, so bump kMinSupportedVersion to that.

And bump kNextMinSupportedVersion, which says it should be the next major version after kMinSupportedVersion.