### PR TITLE
[wip] Cut various support for ancient servers

### DIFF
--- a/android/app/src/main/java/com/zulipmobile/notifications/FcmMessage.kt
+++ b/android/app/src/main/java/com/zulipmobile/notifications/FcmMessage.kt
@@ -24,7 +24,7 @@ data class Identity(
 
     /// This user's ID within the server.  Useful mainly in the case where
     /// the user has multiple accounts in the same org.
-    val userId: Int?,
+    val userId: Int,
 )
 
 /**
@@ -120,7 +120,7 @@ data class MessageFcmMessage(
         // NOTE: Keep the JS-side type definition in sync with this code.
         buildArray { list ->
             list.add("realm_uri" to identity.realmUri.toString())
-            identity.userId?.let { list.add("user_id" to it) }
+            list.add("user_id" to identity.userId)
             when (recipient) {
                 is Recipient.Stream -> {
                     list.add("recipient_type" to "stream")
@@ -203,18 +203,8 @@ private fun extractIdentity(data: Map<String, String>): Identity =
         // `realm_uri` was added in server version 1.9.0
         realmUri = data.require("realm_uri").parseUrl("realm_uri"),
 
-        // Server versions from 1.6.0 up to 3.0~6772 send the user's email
-        // address, as `user`.  We *could* use this as a substitute for
-        // `user_id` when that's missing...  but it'd be inherently buggy,
-        // and the bug it'd introduce seems likely to affect more users
-        // than the bug it'd fix.  So just ignore.
-        // TODO(server-2.1): Delete this comment, relying on user_id.
-        // (data["user"] ignored)
-
-        // `user_id` was added in server version 2.1.0 (released 2019-12-12;
-        // commit 447a517e6, PR #12172.)
-        // TODO(server-2.1): Require this.
-        userId = data["user_id"]?.parseInt("user_id")
+        // `user_id` was added in server version 2.1.0.
+        userId = data.require("user_id").parseInt("user_id")
     )
 
 private fun Map<String, String>.require(key: String): String =

--- a/android/app/src/main/java/com/zulipmobile/notifications/FcmMessage.kt
+++ b/android/app/src/main/java/com/zulipmobile/notifications/FcmMessage.kt
@@ -183,9 +183,6 @@ data class RemoveFcmMessage(
     companion object {
         fun fromFcmData(data: Map<String, String>): RemoveFcmMessage {
             val messageIds = HashSet<Int>()
-            data["zulip_message_id"]?.parseInt("zulip_message_id")?.let {
-                messageIds.add(it)
-            }
             data["zulip_message_ids"]?.parseCommaSeparatedInts("zulip_message_ids")?.let {
                 messageIds.addAll(it)
             }

--- a/android/app/src/main/java/com/zulipmobile/notifications/FcmMessage.kt
+++ b/android/app/src/main/java/com/zulipmobile/notifications/FcmMessage.kt
@@ -203,12 +203,12 @@ private fun extractIdentity(data: Map<String, String>): Identity =
         // `realm_uri` was added in server version 1.9.0
         realmUri = data.require("realm_uri").parseUrl("realm_uri"),
 
-        // Server versions from 1.6.0 through 2.0.0 (and possibly earlier
-        // and later) send the user's email address, as `user`.  We *could*
-        // use this as a substitute for `user_id` when that's missing...
-        // but it'd be inherently buggy, and the bug it'd introduce seems
-        // likely to affect more users than the bug it'd fix.  So just ignore.
-        // TODO(server-2.0): Delete this comment.
+        // Server versions from 1.6.0 up to 3.0~6772 send the user's email
+        // address, as `user`.  We *could* use this as a substitute for
+        // `user_id` when that's missing...  but it'd be inherently buggy,
+        // and the bug it'd introduce seems likely to affect more users
+        // than the bug it'd fix.  So just ignore.
+        // TODO(server-2.1): Delete this comment, relying on user_id.
         // (data["user"] ignored)
 
         // `user_id` was added in server version 2.1.0 (released 2019-12-12;

--- a/android/app/src/test/java/com/zulipmobile/notifications/FcmMessageTest.kt
+++ b/android/app/src/test/java/com/zulipmobile/notifications/FcmMessageTest.kt
@@ -179,7 +179,6 @@ class MessageFcmMessageTest : FcmMessageTestBase() {
             streamName = Example.stream["stream"]!!,
             topic = Example.stream["topic"]!!
         ))
-        expect.that(parse(Example.pm.minus("user_id")).identity.userId).isNull()
     }
 
     @Test
@@ -192,8 +191,6 @@ class MessageFcmMessageTest : FcmMessageTestBase() {
             "stream_name" to Example.stream["stream"]!!,
             "topic" to Example.stream["topic"]!!,
         )
-        expect.that(dataForOpen(Example.stream.minus("user_id")))
-            .isEqualTo(baseExpected.minus("user_id"))
         expect.that(dataForOpen(Example.stream.minus("stream_id")))
             .isEqualTo(baseExpected.minus("stream_id"))
     }
@@ -215,6 +212,7 @@ class MessageFcmMessageTest : FcmMessageTestBase() {
         assertParseFails(Example.pm.minus("realm_uri"))
         assertParseFails(Example.pm.plus("realm_uri" to "zulip.example.com"))
         assertParseFails(Example.pm.plus("realm_uri" to "/examplecorp"))
+        assertParseFails(Example.pm.minus("user_id"))
 
         assertParseFails(Example.stream.minus("recipient_type"))
         assertParseFails(Example.stream.plus("stream_id" to "12,34"))
@@ -294,11 +292,6 @@ class RemoveFcmMessageTest : FcmMessageTestBase() {
     }
 
     @Test
-    fun `optional fields missing cause no error`() {
-        expect.that(parse(Example.hybrid.minus("user_id")).identity.userId).isNull()
-    }
-
-    @Test
     fun `parse failures on malformed data`() {
         assertParseFails(Example.hybrid.minus("server"))
         assertParseFails(Example.hybrid.minus("realm_id"))
@@ -307,6 +300,7 @@ class RemoveFcmMessageTest : FcmMessageTestBase() {
         assertParseFails(Example.hybrid.minus("realm_uri"))
         assertParseFails(Example.hybrid.plus("realm_uri" to "zulip.example.com"))
         assertParseFails(Example.hybrid.plus("realm_uri" to "/examplecorp"))
+        assertParseFails(Example.hybrid.minus("user_id"))
 
         for (badIntList in sequenceOf(
             "abc,34",

--- a/src/action-sheets/index.js
+++ b/src/action-sheets/index.js
@@ -343,7 +343,7 @@ const toggleResolveTopic = async ({ auth, streamId, topic, _, streams, zulipFeat
 
   await api.updateMessage(auth, messageId, {
     propagate_mode: 'change_all',
-    subject: newTopic,
+    topic: newTopic,
     ...(zulipFeatureLevel >= 9 && {
       send_notification_to_old_thread: false,
       send_notification_to_new_thread: true,

--- a/src/api/initialDataTypes.js
+++ b/src/api/initialDataTypes.js
@@ -663,14 +663,9 @@ export type InitialDataUserStatus = $ReadOnly<{|
    * status is the zero status), the server may omit that user's record
    * entirely.
    *
-   * New in Zulip 2.0.  Older servers don't send this, so it's natural
-   * to treat them as if all users have the zero status; and that gives
-   * correct behavior for this feature.
-   *
    * See UserStatusEvent for the event that carries updates to this data.
    */
-  // TODO(server-2.0): Make required.
-  user_status?: $ReadOnly<{|
+  user_status: $ReadOnly<{|
     // Keys are UserId encoded as strings (just because JS objects are
     // string-keyed).
     [userId: string]: UserStatusUpdate,

--- a/src/api/messages/sendMessage.js
+++ b/src/api/messages/sendMessage.js
@@ -20,8 +20,7 @@ export default async (
   apiPost(auth, 'messages', {
     type: params.type,
     to: JSON.stringify(params.to),
-    // TODO(server-2.0): say "topic" instead
-    subject: (params: { +topic?: string, ... }).topic,
+    topic: (params: { +topic?: string, ... }).topic,
     content: params.content,
     local_id: params.localId,
     queue_id: params.eventQueueId,

--- a/src/api/messages/sendMessage.js
+++ b/src/api/messages/sendMessage.js
@@ -1,6 +1,7 @@
 /* @flow strict-local */
 
 import type { ApiResponse, Auth } from '../transportTypes';
+import type { UserId } from '../idTypes';
 import { apiPost } from '../apiFetch';
 
 type CommonParams = {|
@@ -15,12 +16,12 @@ export default async (
   // prettier-ignore
   params:
     // TODO(server-2.0): Say "topic", not "subject"
-    | {| ...CommonParams, type: 'stream', to: string, subject: string |}
-    | {| ...CommonParams, type: 'private', to: string |},
+    | {| ...CommonParams, type: 'stream', to: number, subject: string |}
+    | {| ...CommonParams, type: 'private', to: $ReadOnlyArray<UserId> |},
 ): Promise<ApiResponse> =>
   apiPost(auth, 'messages', {
     type: params.type,
-    to: params.to,
+    to: JSON.stringify(params.to),
     subject: (params: { +subject?: string, ... }).subject,
     content: params.content,
     local_id: params.localId,

--- a/src/api/messages/sendMessage.js
+++ b/src/api/messages/sendMessage.js
@@ -3,23 +3,25 @@
 import type { ApiResponse, Auth } from '../transportTypes';
 import { apiPost } from '../apiFetch';
 
+type CommonParams = {|
+  content: string,
+  localId?: number,
+  eventQueueId?: string,
+|};
+
 /** See https://zulip.com/api/send-message */
 export default async (
   auth: Auth,
-  params: {|
-    type: 'private' | 'stream',
-    to: string,
+  // prettier-ignore
+  params:
     // TODO(server-2.0): Say "topic", not "subject"
-    subject?: string,
-    content: string,
-    localId?: number,
-    eventQueueId?: string,
-  |},
+    | {| ...CommonParams, type: 'stream', to: string, subject: string |}
+    | {| ...CommonParams, type: 'private', to: string |},
 ): Promise<ApiResponse> =>
   apiPost(auth, 'messages', {
     type: params.type,
     to: params.to,
-    subject: params.subject,
+    subject: (params: { +subject?: string, ... }).subject,
     content: params.content,
     local_id: params.localId,
     queue_id: params.eventQueueId,

--- a/src/api/messages/sendMessage.js
+++ b/src/api/messages/sendMessage.js
@@ -13,16 +13,15 @@ type CommonParams = {|
 /** See https://zulip.com/api/send-message */
 export default async (
   auth: Auth,
-  // prettier-ignore
   params:
-    // TODO(server-2.0): Say "topic", not "subject"
-    | {| ...CommonParams, type: 'stream', to: number, subject: string |}
+    | {| ...CommonParams, type: 'stream', to: number, topic: string |}
     | {| ...CommonParams, type: 'private', to: $ReadOnlyArray<UserId> |},
 ): Promise<ApiResponse> =>
   apiPost(auth, 'messages', {
     type: params.type,
     to: JSON.stringify(params.to),
-    subject: (params: { +subject?: string, ... }).subject,
+    // TODO(server-2.0): say "topic" instead
+    subject: (params: { +topic?: string, ... }).topic,
     content: params.content,
     local_id: params.localId,
     queue_id: params.eventQueueId,

--- a/src/api/messages/updateMessage.js
+++ b/src/api/messages/updateMessage.js
@@ -17,9 +17,7 @@ export default async (
   auth: Auth,
   messageId: number,
   params: $ReadOnly<{|
-    // TODO(server-2.0): Say "topic", not "subject"
-    subject?: string,
-
+    topic?: string,
     propagate_mode?: PropagateMode,
     content?: string,
 

--- a/src/api/modelTypes.js
+++ b/src/api/modelTypes.js
@@ -1062,6 +1062,7 @@ export type StreamMessage = $ReadOnly<{|
    *   https://chat.zulip.org/#narrow/stream/19-documentation/topic/.60orig_subject.60.20in.20.60update_message.60.20events/near/1112709
    * (see point 4). We assume this has always been the case.
    */
+  // Still "subject", as of 2022: https://github.com/zulip/zulip/issues/1192
   subject: string,
 
   // We don't actually use this property.  If and when we do, we'll probably

--- a/src/api/modelTypes.js
+++ b/src/api/modelTypes.js
@@ -1029,6 +1029,9 @@ export type PmMessage = $ReadOnly<{|
    *
    * The ordering is less well specified; if it matters, sort first.
    */
+  // TODO: We frequently do `.map(r => r.id)` on this, via `recipientIdsOfPrivateMessage`.
+  //   Instead of making a new array every time, it'd be good to do that
+  //   once, up front, at the edge.
   display_recipient: $ReadOnlyArray<PmRecipientUser>,
 
   /**

--- a/src/api/notificationTypes.js
+++ b/src/api/notificationTypes.js
@@ -32,9 +32,7 @@ type BaseData = {|
    *
    * (This lets us distinguish different accounts in the same realm.)
    */
-  // added 2.1-dev-540-g447a517e6f, release 2.1.0+
-  // TODO(server-2.1): Mark required; simplify comment.
-  +user_id?: UserId,
+  +user_id: UserId,
 
   // The rest of the data is about the Zulip message we're being notified
   // about.

--- a/src/api/typing.js
+++ b/src/api/typing.js
@@ -1,12 +1,17 @@
 /* @flow strict-local */
 import type { ApiResponse, Auth } from './transportTypes';
+import type { UserId } from './idTypes';
 import { apiPost } from './apiFetch';
 
 type TypingOperation = 'start' | 'stop';
 
 /** See https://zulip.com/api/set-typing-status */
-export default (auth: Auth, recipients: string, operation: TypingOperation): Promise<ApiResponse> =>
+export default (
+  auth: Auth,
+  recipients: $ReadOnlyArray<UserId>,
+  operation: TypingOperation,
+): Promise<ApiResponse> =>
   apiPost(auth, 'typing', {
-    to: recipients,
+    to: JSON.stringify(recipients),
     op: operation,
   });

--- a/src/chat/ChatScreen.js
+++ b/src/chat/ChatScreen.js
@@ -201,7 +201,7 @@ export default function ChatScreen(props: Props): Node {
         );
 
         if ((content !== undefined && content !== '') || (topic !== undefined && topic !== '')) {
-          api.updateMessage(auth, editMessage.id, { content, subject: topic }).catch(error => {
+          api.updateMessage(auth, editMessage.id, { content, topic }).catch(error => {
             showErrorAlert(_('Failed to edit message'), error.message);
           });
         }

--- a/src/notification/__tests__/notification-test.js
+++ b/src/notification/__tests__/notification-test.js
@@ -196,12 +196,7 @@ describe('extract iOS notification data', () => {
         /invalid/,
       );
       expect(
-        make({
-          realm_uri,
-          recipient_type: 'stream',
-          stream: { name: 'somewhere' },
-          topic: 'no',
-        }),
+        make({ realm_uri, recipient_type: 'stream', stream: { name: 'somewhere' }, topic: 'no' }),
       ).toThrow(/invalid/);
     });
 

--- a/src/notification/__tests__/notification-test.js
+++ b/src/notification/__tests__/notification-test.js
@@ -128,10 +128,6 @@ describe('extract iOS notification data', () => {
         const msg = data;
         test('baseline', () => expect(verify(msg)).toEqual(expected));
 
-        const { user_id: _ignore, ...msg1 } = msg; // eslint-disable-line no-unused-vars
-        const { user_id: _ignore_, ...expected1 } = expected; // eslint-disable-line no-unused-vars
-        test('pre-2.1 message missing user_id', () => expect(verify(msg1)).toEqual(expected1));
-
         const msg2 = { ...msg, realm_id: 8675309 };
         test('unused fields are not copied', () => expect(verify(msg2)).toEqual(expected));
 
@@ -161,42 +157,48 @@ describe('extract iOS notification data', () => {
       expect(make({ sender_email })).toThrow(/archaic/);
       // pre-1.9
       expect(make({ recipient_type: 'private', sender_email })).toThrow(/archaic/);
+      // pre-2.1
+      expect(make({ realm_uri, recipient_type: 'private', sender_email })).toThrow(/archaic/);
       // baseline, for comparison
-      expect(make({ realm_uri, recipient_type: 'private', sender_email })()).toBeTruthy();
+      expect(make({ realm_uri, user_id, recipient_type: 'private', sender_email })()).toBeTruthy();
     });
 
     test('broken or partial messages', () => {
-      expect(make({ realm_uri, recipient_type: 'huddle' })).toThrow(/invalid/);
+      expect(make({ ...identity, recipient_type: 'huddle' })).toThrow(/invalid/);
 
       expect(
-        make({ realm_uri, recipient_type: 'stream', stream: 'stream name', topic: 'topic' })(),
+        make({ ...identity, recipient_type: 'stream', stream: 'stream name', topic: 'topic' })(),
       ).toBeTruthy();
-      expect(make({ realm_uri, recipient_type: 'stream', stream: 'stream name' })).toThrow(
+      expect(make({ ...identity, recipient_type: 'stream', stream: 'stream name' })).toThrow(
         /invalid/,
       );
-      expect(make({ realm_uri, recipient_type: 'stream', subject: 'topic' })).toThrow(/invalid/);
-      expect(make({ realm_uri, recipient_type: 'stream' })).toThrow(/invalid/);
+      expect(make({ ...identity, recipient_type: 'stream', subject: 'topic' })).toThrow(/invalid/);
+      expect(make({ ...identity, recipient_type: 'stream' })).toThrow(/invalid/);
 
-      expect(make({ realm_uri, recipient_type: 'private', sender_email })()).toBeTruthy();
-      expect(make({ realm_uri, recipient_type: 'private' })).toThrow(/invalid/);
-      expect(make({ realm_uri, recipient_type: 'private', subject: 'topic' })).toThrow(/invalid/);
+      expect(make({ ...identity, recipient_type: 'private', sender_email })()).toBeTruthy();
+      expect(make({ ...identity, recipient_type: 'private' })).toThrow(/invalid/);
+      expect(make({ ...identity, recipient_type: 'private', subject: 'topic' })).toThrow(/invalid/);
 
-      expect(make({ realm_uri, recipient_type: 'private', pm_users: '12,345' })()).toBeTruthy();
-      expect(make({ realm_uri, recipient_type: 'private', pm_users: 123 })).toThrow(/invalid/);
-      expect(make({ realm_uri, recipient_type: 'private', pm_users: [1, 23] })).toThrow(/invalid/);
-      expect(make({ realm_uri, recipient_type: 'private', pm_users: '12,ab' })).toThrow(/invalid/);
-      expect(make({ realm_uri, recipient_type: 'private', pm_users: '12,' })).toThrow(/invalid/);
+      expect(make({ ...identity, recipient_type: 'private', pm_users: '12,345' })()).toBeTruthy();
+      expect(make({ ...identity, recipient_type: 'private', pm_users: 123 })).toThrow(/invalid/);
+      expect(make({ ...identity, recipient_type: 'private', pm_users: [1, 23] })).toThrow(
+        /invalid/,
+      );
+      expect(make({ ...identity, recipient_type: 'private', pm_users: '12,ab' })).toThrow(
+        /invalid/,
+      );
+      expect(make({ ...identity, recipient_type: 'private', pm_users: '12,' })).toThrow(/invalid/);
     });
 
     test('values of incorrect type', () => {
-      expect(make({ realm_uri, recipient_type: 'private', pm_users: [1, 2, 3] })).toThrow(
+      expect(make({ ...identity, recipient_type: 'private', pm_users: [1, 2, 3] })).toThrow(
         /invalid/,
       );
-      expect(make({ realm_uri, recipient_type: 'stream', stream: [], topic: 'yes' })).toThrow(
+      expect(make({ ...identity, recipient_type: 'stream', stream: [], topic: 'yes' })).toThrow(
         /invalid/,
       );
       expect(
-        make({ realm_uri, recipient_type: 'stream', stream: { name: 'somewhere' }, topic: 'no' }),
+        make({ ...identity, recipient_type: 'stream', stream: { name: 'somewhere' }, topic: 'no' }),
       ).toThrow(/invalid/);
     });
 

--- a/src/notification/__tests__/notification-test.js
+++ b/src/notification/__tests__/notification-test.js
@@ -154,14 +154,14 @@ describe('extract iOS notification data', () => {
       expect(makeRaw({ initechData: 'everything' })).toThrow(/alien/);
     });
 
-    test('very-old-style messages', () => {
+    test('unsupported old-style messages', () => {
       const sender_email = 'nobody@example.com';
-      // baseline
-      expect(make({ realm_uri, recipient_type: 'private', sender_email })()).toBeTruthy();
-      // missing recipient_type
-      expect(make({ realm_uri, sender_email })).toThrow(/archaic/);
-      // missing realm_uri
+      // pre-1.8
+      expect(make({ sender_email })).toThrow(/archaic/);
+      // pre-1.9
       expect(make({ recipient_type: 'private', sender_email })).toThrow(/archaic/);
+      // baseline, for comparison
+      expect(make({ realm_uri, recipient_type: 'private', sender_email })()).toBeTruthy();
     });
 
     test('broken or partial messages', () => {

--- a/src/notification/__tests__/notification-test.js
+++ b/src/notification/__tests__/notification-test.js
@@ -119,28 +119,25 @@ describe('extract iOS notification data', () => {
     const verify = (data: JSONableDict) => extractIosNotificationData({ zulip: data });
 
     for (const [type, data] of objectEntries(cases)) {
-      test(`${type} notification`, () => {
+      describe(`${type} notification`, () => {
         const expected = (() => {
           const { stream: stream_name = undefined, ...rest } = data;
           return stream_name !== undefined ? { ...rest, stream_name } : data;
         })();
 
-        // baseline message is accepted
         const msg = data;
-        expect(verify(msg)).toEqual(expected);
+        test('baseline', () => expect(verify(msg)).toEqual(expected));
 
-        // pre-2.1 message missing user_id is accepted
         const { user_id: _ignore, ...msg1 } = msg; // eslint-disable-line no-unused-vars
         const { user_id: _ignore_, ...expected1 } = expected; // eslint-disable-line no-unused-vars
-        expect(verify(msg1)).toEqual(expected1);
+        test('pre-2.1 message missing user_id', () => expect(verify(msg1)).toEqual(expected1));
 
-        // unused fields are not copied
         const msg2 = { ...msg, realm_id: 8675309 };
-        expect(verify(msg2)).toEqual(expected);
+        test('unused fields are not copied', () => expect(verify(msg2)).toEqual(expected));
 
-        // unknown fields are ignored and not copied
         const msg2a = { ...msg, unknown_data: ['unknown_data'] };
-        expect(verify(msg2a)).toEqual(expected);
+        test('unknown fields are ignored and not copied', () =>
+          expect(verify(msg2a)).toEqual(expected));
       });
     }
   });

--- a/src/notification/__tests__/notification-test.js
+++ b/src/notification/__tests__/notification-test.js
@@ -29,6 +29,7 @@ describe('getNarrowFromNotificationData', () => {
     const streamsByName = new Map([[stream.name, stream]]);
     const notification = {
       realm_uri,
+      user_id,
       recipient_type: 'stream',
       stream_id: eg.stream.stream_id,
       // Name points to some other stream, but the ID prevails.
@@ -45,6 +46,7 @@ describe('getNarrowFromNotificationData', () => {
     const streamsByName = new Map([[stream.name, stream]]);
     const notification = {
       realm_uri,
+      user_id,
       recipient_type: 'stream',
       stream_name: 'some stream',
       topic: 'some topic',
@@ -58,6 +60,7 @@ describe('getNarrowFromNotificationData', () => {
     const allUsersByEmail: Map<string, UserOrBot> = new Map(users.map(u => [u.email, u]));
     const notification = {
       realm_uri,
+      user_id,
       recipient_type: 'private',
       sender_email: eg.otherUser.email,
     };
@@ -76,6 +79,7 @@ describe('getNarrowFromNotificationData', () => {
 
     const notification = {
       realm_uri,
+      user_id,
       recipient_type: 'private',
       pm_users: users.map(u => u.user_id).join(','),
     };

--- a/src/notification/extract.js
+++ b/src/notification/extract.js
@@ -103,14 +103,13 @@ export const fromAPNsImpl = (data: ?JSONableDict): Notification | void => {
   if (typeof realm_uri !== 'string') {
     throw err('invalid');
   }
-  if (user_id !== undefined && typeof user_id !== 'number') {
+  if (user_id === undefined) {
+    throw err('archaic (pre-2.1)');
+  }
+  if (typeof user_id !== 'number') {
     throw err('invalid');
   }
-
-  const identity = {
-    realm_uri,
-    ...(user_id === undefined ? Object.freeze({}) : { user_id: makeUserId(user_id) }),
-  };
+  const identity = { realm_uri, user_id: makeUserId(user_id) };
 
   if (recipient_type === 'stream') {
     const { stream: stream_name, stream_id, topic } = zulip;

--- a/src/notification/notifOpen.js
+++ b/src/notification/notifOpen.js
@@ -43,12 +43,6 @@ export const getAccountFromNotificationData = (
   accounts: $ReadOnlyArray<Account>,
 ): Identity | null => {
   const { realm_uri, user_id } = data;
-  if (realm_uri == null) {
-    // Old server, no realm info included.  This field appeared in
-    // Zulip 1.8, so we don't support these servers anyway.
-    logging.warn('notification missing field: realm_uri');
-    return null;
-  }
 
   const realmUrl = tryParseUrl(realm_uri);
   if (realmUrl === undefined) {

--- a/src/notification/notifOpen.js
+++ b/src/notification/notifOpen.js
@@ -72,24 +72,6 @@ export const getAccountFromNotificationData = (
     return null;
   }
 
-  // TODO(server-2.1): Remove this, because user_id will always be present
-  if (user_id === undefined) {
-    if (urlMatches.length > 1) {
-      logging.warn(
-        'notification realm_uri ambiguous; multiple matches found; user_id missing (old server)',
-        {
-          realm_uri,
-          parsed_url: realmUrl.toString(),
-          match_count: urlMatches.length,
-          unique_identities_count: new Set(urlMatches.map(account => account.email)).size,
-        },
-      );
-      return null;
-    } else {
-      return identityOfAccount(urlMatches[0]);
-    }
-  }
-
   // There may be multiple accounts in the notification's realm. Pick one
   // based on the notification's `user_id`.
   const userMatch = urlMatches.find(account => account.userId === user_id);

--- a/src/notification/types.js
+++ b/src/notification/types.js
@@ -3,7 +3,7 @@ import type { UserId } from '../types';
 
 type NotificationBase = {|
   realm_uri: string,
-  user_id?: UserId,
+  user_id: UserId,
 |};
 
 /**

--- a/src/outbox/outboxActions.js
+++ b/src/outbox/outboxActions.js
@@ -72,8 +72,7 @@ const trySendMessages = (dispatch, getState): boolean => {
       // prettier-ignore
       const to =
         item.type === 'private'
-            // TODO(server-2.0): switch to numeric user IDs (#3764), not emails.
-          ? recipientsOfPrivateMessage(item).map(r => r.email).join(',')
+          ? JSON.stringify(recipientsOfPrivateMessage(item).map(r => r.id))
           : JSON.stringify(item.stream_id);
 
       await api.sendMessage(auth, {

--- a/src/outbox/outboxActions.js
+++ b/src/outbox/outboxActions.js
@@ -29,7 +29,7 @@ import { getAllUsersById, getOwnUser } from '../users/userSelectors';
 import { makeUserId } from '../api/idTypes';
 import { caseNarrowPartial, isConversationNarrow } from '../utils/narrow';
 import { BackoffMachine } from '../utils/async';
-import { recipientsOfPrivateMessage } from '../utils/recipient';
+import { recipientIdsOfPrivateMessage } from '../utils/recipient';
 
 export const messageSendStart = (outbox: Outbox): PerAccountAction => ({
   type: MESSAGE_SEND_START,
@@ -77,11 +77,7 @@ const trySendMessages = (dispatch, getState): boolean => {
 
       const params =
         item.type === 'private'
-          ? {
-              ...commonParams,
-              type: 'private',
-              to: recipientsOfPrivateMessage(item).map(r => r.id),
-            }
+          ? { ...commonParams, type: 'private', to: recipientIdsOfPrivateMessage(item) }
           : { ...commonParams, type: 'stream', to: item.stream_id, topic: item.subject };
       await api.sendMessage(auth, params);
       dispatch(messageSendComplete(item.timestamp));

--- a/src/outbox/outboxActions.js
+++ b/src/outbox/outboxActions.js
@@ -82,7 +82,7 @@ const trySendMessages = (dispatch, getState): boolean => {
               type: 'private',
               to: recipientsOfPrivateMessage(item).map(r => r.id),
             }
-          : { ...commonParams, type: 'stream', to: item.stream_id, subject: item.subject };
+          : { ...commonParams, type: 'stream', to: item.stream_id, topic: item.subject };
       await api.sendMessage(auth, params);
       dispatch(messageSendComplete(item.timestamp));
     });

--- a/src/outbox/outboxActions.js
+++ b/src/outbox/outboxActions.js
@@ -80,14 +80,9 @@ const trySendMessages = (dispatch, getState): boolean => {
           ? {
               ...commonParams,
               type: 'private',
-              to: JSON.stringify(recipientsOfPrivateMessage(item).map(r => r.id)),
+              to: recipientsOfPrivateMessage(item).map(r => r.id),
             }
-          : {
-              ...commonParams,
-              type: 'stream',
-              to: JSON.stringify(item.stream_id),
-              subject: item.subject,
-            };
+          : { ...commonParams, type: 'stream', to: item.stream_id, subject: item.subject };
       await api.sendMessage(auth, params);
       dispatch(messageSendComplete(item.timestamp));
     });

--- a/src/outbox/outboxActions.js
+++ b/src/outbox/outboxActions.js
@@ -29,7 +29,7 @@ import { getAllUsersById, getOwnUser } from '../users/userSelectors';
 import { makeUserId } from '../api/idTypes';
 import { caseNarrowPartial, isConversationNarrow } from '../utils/narrow';
 import { BackoffMachine } from '../utils/async';
-import { recipientsOfPrivateMessage, streamNameOfStreamMessage } from '../utils/recipient';
+import { recipientsOfPrivateMessage } from '../utils/recipient';
 
 export const messageSendStart = (outbox: Outbox): PerAccountAction => ({
   type: MESSAGE_SEND_START,
@@ -74,10 +74,7 @@ const trySendMessages = (dispatch, getState): boolean => {
         item.type === 'private'
             // TODO(server-2.0): switch to numeric user IDs (#3764), not emails.
           ? recipientsOfPrivateMessage(item).map(r => r.email).join(',')
-            // TODO(server-2.0): switch to numeric stream IDs (#3918), not names.
-            // HACK: the server attempts to interpret this argument as JSON, then
-            //   CSV, then a literal. To avoid misparsing, always use JSON.
-          : JSON.stringify([streamNameOfStreamMessage(item)]);
+          : JSON.stringify(item.stream_id);
 
       await api.sendMessage(auth, {
         type: item.type,

--- a/src/outbox/outboxActions.js
+++ b/src/outbox/outboxActions.js
@@ -69,20 +69,26 @@ const trySendMessages = (dispatch, getState): boolean => {
         return; // i.e., continue
       }
 
-      // prettier-ignore
-      const to =
-        item.type === 'private'
-          ? JSON.stringify(recipientsOfPrivateMessage(item).map(r => r.id))
-          : JSON.stringify(item.stream_id);
-
-      await api.sendMessage(auth, {
-        type: item.type,
-        to,
-        subject: item.subject,
+      const commonParams = {
         content: item.markdownContent,
         localId: item.timestamp,
         eventQueueId: state.session.eventQueueId ?? undefined,
-      });
+      };
+
+      const params =
+        item.type === 'private'
+          ? {
+              ...commonParams,
+              type: 'private',
+              to: JSON.stringify(recipientsOfPrivateMessage(item).map(r => r.id)),
+            }
+          : {
+              ...commonParams,
+              type: 'stream',
+              to: JSON.stringify(item.stream_id),
+              subject: item.subject,
+            };
+      await api.sendMessage(auth, params);
       dispatch(messageSendComplete(item.timestamp));
     });
     return true;

--- a/src/pm-conversations/pmConversationsModel.js
+++ b/src/pm-conversations/pmConversationsModel.js
@@ -10,7 +10,7 @@ import {
 import { makeUserId } from '../api/idTypes';
 
 import type { PerAccountApplicableAction, PmMessage, PmOutbox, UserId } from '../types';
-import { recipientsOfPrivateMessage } from '../utils/recipient';
+import { recipientIdsOfPrivateMessage } from '../utils/recipient';
 import { ZulipVersion } from '../utils/zulipVersion';
 
 /** The minimum server version to expect this data to be available. */
@@ -45,10 +45,7 @@ function keyOfUsers(ids: $ReadOnlyArray<UserId>, ownUserId: UserId): PmConversat
 }
 
 function keyOfPrivateMessage(msg: PmMessage | PmOutbox, ownUserId: UserId): PmConversationKey {
-  return keyOfUsers(
-    recipientsOfPrivateMessage(msg).map(r => r.id),
-    ownUserId,
-  );
+  return keyOfUsers(recipientIdsOfPrivateMessage(msg), ownUserId);
 }
 
 /** The users in the conversation, other than self. */

--- a/src/sharing/ShareToStream.js
+++ b/src/sharing/ShareToStream.js
@@ -144,7 +144,6 @@ class ShareToStreamInner extends React.PureComponent<Props, State> {
     const { streamName, streamId, topic, isStreamFocused, isTopicFocused } = this.state;
     const narrow = streamId !== null ? streamNarrow(streamId) : null;
     const sendTo = {
-      streamName,
       /* $FlowFixMe[incompatible-cast]: ShareWrapper will only look at this
        *   if getValidationErrors returns empty, so only if streamId is
        *   indeed not null.  Should make that logic less indirected and more

--- a/src/sharing/ShareWrapper.js
+++ b/src/sharing/ShareWrapper.js
@@ -193,13 +193,13 @@ class ShareWrapperInner extends React.PureComponent<Props, State> {
         ? {
             content: messageToSend,
             type: 'private',
-            to: JSON.stringify(sendTo.selectedRecipients),
+            to: sendTo.selectedRecipients,
           }
         : {
             content: messageToSend,
             type: 'stream',
             subject: sendTo.topic || apiConstants.kNoTopicTopic,
-            to: JSON.stringify(sendTo.streamId),
+            to: sendTo.streamId,
           };
 
     try {

--- a/src/sharing/ShareWrapper.js
+++ b/src/sharing/ShareWrapper.js
@@ -26,8 +26,7 @@ import { ApiError, RequestError } from '../api/apiErrors';
 
 type SendTo =
   | {| type: 'pm', selectedRecipients: $ReadOnlyArray<UserId> |}
-  // TODO(server-2.0): Drop streamName (#3918).  Used below for sending.
-  | {| type: 'stream', streamName: string, streamId: number, topic: string |};
+  | {| type: 'stream', streamId: number, topic: string |};
 
 const styles = createStyleSheet({
   wrapper: {
@@ -200,9 +199,7 @@ class ShareWrapperInner extends React.PureComponent<Props, State> {
             content: messageToSend,
             type: 'stream',
             subject: sendTo.topic || apiConstants.kNoTopicTopic,
-            // TODO(server-2.0): switch to numeric stream ID (#3918), not name;
-            //   then drop streamName from SendTo
-            to: sendTo.streamName,
+            to: JSON.stringify(sendTo.streamId),
           };
 
     try {

--- a/src/sharing/ShareWrapper.js
+++ b/src/sharing/ShareWrapper.js
@@ -198,7 +198,7 @@ class ShareWrapperInner extends React.PureComponent<Props, State> {
         : {
             content: messageToSend,
             type: 'stream',
-            subject: sendTo.topic || apiConstants.kNoTopicTopic,
+            topic: sendTo.topic || apiConstants.kNoTopicTopic,
             to: sendTo.streamId,
           };
 

--- a/src/user-statuses/userStatusesModel.js
+++ b/src/user-statuses/userStatusesModel.js
@@ -69,6 +69,8 @@ export const reducer = (
     case REGISTER_COMPLETE: {
       const { user_status } = action.data;
       if (!user_status) {
+        // This fallback is unnecessary for server 2.0+, which includes all
+        // versions we support.  But it's so cheap.
         // TODO(server-2.0): Drop this.
         return initialState;
       }

--- a/src/users/usersActions.js
+++ b/src/users/usersActions.js
@@ -31,11 +31,11 @@ const typingWorker = (state: PerAccountState) => {
     get_current_time: () => new Date().getTime(),
 
     notify_server_start: (user_ids_array: $ReadOnlyArray<UserId>) => {
-      api.typing(auth, JSON.stringify(user_ids_array), 'start');
+      api.typing(auth, user_ids_array, 'start');
     },
 
     notify_server_stop: (user_ids_array: $ReadOnlyArray<UserId>) => {
-      api.typing(auth, JSON.stringify(user_ids_array), 'stop');
+      api.typing(auth, user_ids_array, 'stop');
     },
   };
 };

--- a/src/utils/narrow.js
+++ b/src/utils/narrow.js
@@ -5,7 +5,7 @@ import type { ApiNarrow, Message, Outbox, Stream, UserId, UserOrBot } from '../t
 import {
   normalizeRecipientsAsUserIdsSansMe,
   pmKeyRecipientsFromMessage,
-  recipientsOfPrivateMessage,
+  recipientIdsOfPrivateMessage,
   type PmKeyRecipients,
   type PmKeyUsers,
   pmKeyRecipientsFromPmKeyUsers,
@@ -475,11 +475,9 @@ export const isMessageInNarrow = (
       if (message.type !== 'private') {
         return false;
       }
-      const recipients = recipientsOfPrivateMessage(message).map(r => r.id);
-      const narrowAsRecipients = ids;
       return (
-        normalizeRecipientsAsUserIdsSansMe(recipients, ownUserId)
-        === normalizeRecipientsAsUserIdsSansMe(narrowAsRecipients, ownUserId)
+        normalizeRecipientsAsUserIdsSansMe(recipientIdsOfPrivateMessage(message), ownUserId)
+        === normalizeRecipientsAsUserIdsSansMe(ids, ownUserId)
       );
     },
     starred: () => flags.includes('starred'),


### PR DESCRIPTION
This is a rebase of the draft branch I wrote a little over a year ago for this purpose. After writing it I realized that much of it should block on refusing to connect to ancient servers. We've now done that, in #5633.

This still needs some polishing-up, and the last few commits are to rely on server 2.1 which should wait for a sequel to #5633. But other than those last few, I think it's pretty close to mergeable.
