### PR TITLE
presence: Use server's tuning parameters

### DIFF
--- a/src/api/initialDataTypes.js
+++ b/src/api/initialDataTypes.js
@@ -61,6 +61,14 @@ export type RawInitialDataBase = $ReadOnly<{|
    * `zulip_feature_level`, above.
    */
   zulip_version: string,
+
+  /** New in FL 164; use 60 when absent. */
+  // TODO(server-7.0): simplify to always-present
+  server_presence_ping_interval_seconds?: number,
+
+  /** New in FL 164; use 140 when absent. */
+  // TODO(server-7.0): simplify to always-present
+  server_presence_offline_threshold_seconds?: number,
 |}>;
 
 /**

--- a/src/presence/PresenceHeartbeat.js
+++ b/src/presence/PresenceHeartbeat.js
@@ -1,82 +1,47 @@
 // @flow strict-local
-import { PureComponent } from 'react';
-import type { ComponentType } from 'react';
+import * as React from 'react';
 import { AppState } from 'react-native';
 
-import { assumeSecretlyGlobalState, type Dispatch } from '../reduxTypes';
-import { connect } from '../react-redux';
+import { useGlobalSelector, useDispatch } from '../react-redux';
 import { getHasAuth } from '../account/accountsSelectors';
 import { reportPresence } from '../actions';
 import Heartbeat from './heartbeat';
 
-type OuterProps = $ReadOnly<{||}>;
-
-type SelectorProps = $ReadOnly<{|
-  hasAuth: boolean,
-|}>;
-
-type Props = $ReadOnly<{|
-  ...OuterProps,
-
-  // from `connect`
-  dispatch: Dispatch,
-  ...SelectorProps,
-|}>;
+type Props = $ReadOnly<{||}>;
 
 /**
  * Component providing a recurrent `presence` signal.
  */
-// The name "PureComponent" is potentially misleading here, as this component is
-// in no reasonable sense "pure" -- its entire purpose is to emit network calls
-// for their observable side effects as a side effect of being rendered.
-//
-// (This is merely a misnomer on React's part, rather than a functional error. A
-// `PureComponent` is simply one which never updates except when its props have
-// changed -- which is exactly what we want.)
-class PresenceHeartbeatInner extends PureComponent<Props> {
-  /** Callback for Heartbeat object. */
-  onHeartbeat = () => {
-    if (this.props.hasAuth) {
-      // TODO(#5005): should ensure this gets the intended account
-      this.props.dispatch(reportPresence(true));
-    }
-  };
-
-  heartbeat: Heartbeat = new Heartbeat(this.onHeartbeat, 1000 * 60);
-
-  componentDidMount() {
-    AppState.addEventListener('change', this.updateHeartbeatState);
-    this.updateHeartbeatState(); // conditional start
-  }
-
-  componentWillUnmount() {
-    AppState.removeEventListener('change', this.updateHeartbeatState);
-    this.heartbeat.stop(); // unconditional stop
-  }
-
-  // React to any state change.
-  updateHeartbeatState = () => {
-    // heartbeat.toState is idempotent
-    this.heartbeat.toState(AppState.currentState === 'active' && this.props.hasAuth);
-  };
-
-  // React to props changes.
-  //
-  // Not dependent on `render()`'s return value, although the docs may not yet
-  // be clear on that. See: https://github.com/reactjs/reactjs.org/pull/1230.
-  componentDidUpdate() {
-    this.updateHeartbeatState();
-  }
-
-  render() {
-    return null;
-  }
-}
-
-/** (NB this is a per-account component.) */
 // TODO(#5005): either make one of these per account, or make it act on all accounts
-const PresenceHeartbeat: ComponentType<OuterProps> = connect(state => ({
-  hasAuth: getHasAuth(assumeSecretlyGlobalState(state)), // a job for withHaveServerDataGate?
-}))(PresenceHeartbeatInner);
+export default function PresenceHeartbeat(props: Props): React.Node {
+  const dispatch = useDispatch();
+  const hasAuth = useGlobalSelector(getHasAuth); // a job for withHaveServerDataGate?
 
-export default PresenceHeartbeat;
+  React.useEffect(() => {
+    if (!hasAuth) {
+      return;
+    }
+
+    const onHeartbeat = () => {
+      // TODO(#5005): should ensure this gets the intended account
+      dispatch(reportPresence(true));
+    };
+    const heartbeat = new Heartbeat(onHeartbeat, 1000 * 60);
+
+    // React to any state change.
+    const updateHeartbeatState = () => {
+      // heartbeat.toState is idempotent
+      heartbeat.toState(AppState.currentState === 'active');
+    };
+
+    const sub = AppState.addEventListener('change', updateHeartbeatState);
+    updateHeartbeatState(); // conditional start
+
+    return () => {
+      sub.remove();
+      heartbeat.stop(); // unconditional stop
+    };
+  }, [dispatch, hasAuth]);
+
+  return null;
+}

--- a/src/presence/PresenceHeartbeat.js
+++ b/src/presence/PresenceHeartbeat.js
@@ -26,6 +26,7 @@ export default function PresenceHeartbeat(props: Props): React.Node {
       // TODO(#5005): should ensure this gets the intended account
       dispatch(reportPresence(true));
     };
+    // TODO(#5669): get heartbeat interval from PresenceState
     const heartbeat = new Heartbeat(onHeartbeat, 1000 * 60);
 
     // React to any state change.

--- a/src/presence/PresenceHeartbeat.js
+++ b/src/presence/PresenceHeartbeat.js
@@ -2,10 +2,11 @@
 import * as React from 'react';
 import { AppState } from 'react-native';
 
-import { useGlobalSelector, useDispatch } from '../react-redux';
+import { useGlobalSelector, useSelector, useDispatch } from '../react-redux';
 import { getHasAuth } from '../account/accountsSelectors';
 import { reportPresence } from '../actions';
 import Heartbeat from './heartbeat';
+import { getPresence } from './presenceModel';
 
 type Props = $ReadOnly<{||}>;
 
@@ -16,6 +17,7 @@ type Props = $ReadOnly<{||}>;
 export default function PresenceHeartbeat(props: Props): React.Node {
   const dispatch = useDispatch();
   const hasAuth = useGlobalSelector(getHasAuth); // a job for withHaveServerDataGate?
+  const pingIntervalSeconds = useSelector(state => getPresence(state).pingIntervalSeconds);
 
   React.useEffect(() => {
     if (!hasAuth) {
@@ -26,8 +28,7 @@ export default function PresenceHeartbeat(props: Props): React.Node {
       // TODO(#5005): should ensure this gets the intended account
       dispatch(reportPresence(true));
     };
-    // TODO(#5669): get heartbeat interval from PresenceState
-    const heartbeat = new Heartbeat(onHeartbeat, 1000 * 60);
+    const heartbeat = new Heartbeat(onHeartbeat, pingIntervalSeconds * 1000);
 
     // React to any state change.
     const updateHeartbeatState = () => {
@@ -42,7 +43,7 @@ export default function PresenceHeartbeat(props: Props): React.Node {
       sub.remove();
       heartbeat.stop(); // unconditional stop
     };
-  }, [dispatch, hasAuth]);
+  }, [dispatch, hasAuth, pingIntervalSeconds]);
 
   return null;
 }

--- a/src/presence/__tests__/presence-testlib.js
+++ b/src/presence/__tests__/presence-testlib.js
@@ -5,11 +5,20 @@ import { reducer } from '../presenceModel';
 import * as eg from '../../__tests__/lib/exampleData';
 import { objectFromEntries } from '../../jsBackport';
 
-export function makePresenceState(data: $ReadOnlyArray<[User, UserPresence]>): PresenceState {
+export function makePresenceState(
+  data: $ReadOnlyArray<[User, UserPresence]>,
+  args?: {|
+    +offlineThresholdSeconds?: number,
+    +pingIntervalSeconds?: number,
+  |},
+): PresenceState {
+  const { offlineThresholdSeconds, pingIntervalSeconds } = args ?? {};
   return reducer(
     undefined,
     eg.mkActionRegisterComplete({
       presences: objectFromEntries(data.map(([user, presence]) => [user.email, presence])),
+      server_presence_offline_threshold_seconds: offlineThresholdSeconds ?? 140,
+      server_presence_ping_interval_seconds: pingIntervalSeconds ?? 60,
     }),
   );
 }

--- a/src/presence/__tests__/presenceModel-test.js
+++ b/src/presence/__tests__/presenceModel-test.js
@@ -243,6 +243,22 @@ describe('getPresenceOnlyStatusForUser', () => {
     ).toBe('idle');
   });
 
+  test('Use specified offline threshold', () => {
+    const userPresence = {
+      aggregated: {
+        client: 'website',
+        status: 'idle',
+        timestamp: Math.trunc(Date.now() / 1000 - 60), // 1 minute
+      },
+    };
+    expect(
+      getPresenceOnlyStatusForUser(
+        makePresenceState([[eg.otherUser, userPresence]], { offlineThresholdSeconds: 40 }),
+        eg.otherUser,
+      ),
+    ).toBe('offline');
+  });
+
   test('if status is not "offline" and last activity was less than 5min ago result is "active"', () => {
     const userPresence = {
       aggregated: {

--- a/src/presence/presenceModel.js
+++ b/src/presence/presenceModel.js
@@ -172,6 +172,12 @@ export const getPresenceStatusForUserId = (
   state: PerAccountState,
   userId: UserId,
 ): PresenceStatus | 'unavailable' | null => {
+  // TODO(server-6.0): Cut this; UserStatus['away'] was replaced by "invisible mode".
+  //   https://chat.zulip.org/#narrow/stream/2-general/topic/.22unavailable.22.20status/near/1454779
+  if (getZulipFeatureLevel(state) < 148 && getUserStatus(state, userId).away) {
+    return 'unavailable';
+  }
+
   const presence = getPresence(state);
   const user = tryGetUserForId(state, userId);
   if (!user) {
@@ -180,12 +186,6 @@ export const getPresenceStatusForUserId = (
   const userPresence = getUserPresenceByEmail(presence, user.email);
   if (!userPresence || !userPresence.aggregated) {
     return null;
-  }
-
-  // TODO(server-6.0): Cut this; UserStatus['away'] was replaced by "invisible mode".
-  //   https://chat.zulip.org/#narrow/stream/2-general/topic/.22unavailable.22.20status/near/1454779
-  if (getZulipFeatureLevel(state) < 148 && getUserStatus(state, userId).away) {
-    return 'unavailable';
   }
 
   return statusFromPresence(userPresence);

--- a/src/presence/presenceModel.js
+++ b/src/presence/presenceModel.js
@@ -54,6 +54,7 @@ const presenceStatusGeq = (a: PresenceStatus, b: PresenceStatus): boolean => {
   }
 };
 
+// TODO(#5669): get OFFLINE_THRESHOLD_SECS from PresenceState
 const OFFLINE_THRESHOLD_SECS = 140;
 
 /**
@@ -198,6 +199,8 @@ export const getPresenceStatusForUserId = (
 //
 
 const initialState: PresenceState = {
+  pingIntervalSeconds: 60,
+  offlineThresholdSeconds: 140,
   byEmail: Immutable.Map(),
 };
 
@@ -211,6 +214,8 @@ export function reducer(
 
     case REGISTER_COMPLETE:
       return {
+        pingIntervalSeconds: action.data.server_presence_ping_interval_seconds ?? 60,
+        offlineThresholdSeconds: action.data.server_presence_offline_threshold_seconds ?? 140,
         byEmail: Immutable.Map(action.data.presences),
       };
 

--- a/src/presence/presenceModel.js
+++ b/src/presence/presenceModel.js
@@ -120,7 +120,8 @@ export function getUserLastActiveAsRelativeTimeString(
   user: UserOrBot,
   dateNow: number,
 ): string | null {
-  const presence = getUserPresenceByEmail(getPresence(state), user.email);
+  const presenceState = getPresence(state);
+  const presence = getUserPresenceByEmail(presenceState, user.email);
   if (!presence) {
     return null;
   }
@@ -142,7 +143,7 @@ export function getUserLastActiveAsRelativeTimeString(
     return 'today';
   }
 
-  return differenceInSeconds(dateNow, lastTimeActive) < OFFLINE_THRESHOLD_SECS
+  return differenceInSeconds(dateNow, lastTimeActive) < presenceState.offlineThresholdSeconds
     ? 'now'
     : `${formatDistanceToNow(lastTimeActive)} ago`;
 }

--- a/src/presence/presenceModel.js
+++ b/src/presence/presenceModel.js
@@ -164,7 +164,7 @@ export const statusFromPresence = (presence: UserPresence | void): PresenceStatu
 };
 
 // TODO(server-6.0): Remove; UserStatus['away'] was deprecated at FL 148.
-export const statusFromPresenceAndUserStatus = (
+const statusFromPresenceAndUserStatus = (
   presence: UserPresence | void,
   userStatus: UserStatus,
 ): PresenceStatus | 'unavailable' =>

--- a/src/presence/presenceModel.js
+++ b/src/presence/presenceModel.js
@@ -54,9 +54,6 @@ const presenceStatusGeq = (a: PresenceStatus, b: PresenceStatus): boolean => {
   }
 };
 
-// TODO(#5669): get OFFLINE_THRESHOLD_SECS from PresenceState
-const OFFLINE_THRESHOLD_SECS = 140;
-
 /**
  * Aggregate our information on a user's presence across their clients.
  *
@@ -165,7 +162,7 @@ export function getPresenceOnlyStatusForUser(
   const timestampDate = new Date(timestamp * 1000);
   const diffToNowInSeconds = differenceInSeconds(Date.now(), timestampDate);
 
-  if (diffToNowInSeconds > OFFLINE_THRESHOLD_SECS) {
+  if (diffToNowInSeconds > state.offlineThresholdSeconds) {
     return 'offline';
   }
 

--- a/src/reduxTypes.js
+++ b/src/reduxTypes.js
@@ -218,6 +218,8 @@ export type OutboxState = $ReadOnlyArray<Outbox>;
  *   presence status.
  */
 export type PresenceState = $ReadOnly<{|
+  pingIntervalSeconds: number,
+  offlineThresholdSeconds: number,
   byEmail: Immutable.Map<string, UserPresence>,
 |}>;
 

--- a/src/storage/migrations.js
+++ b/src/storage/migrations.js
@@ -512,7 +512,7 @@ const migrationsInner: {| [string]: (LessPartialState) => LessPartialState |} = 
   // Change `state.mute` data structure: was a plain JS Map.
   '59': dropCache,
 
-  // Changed `state.presence`, but no migration because that's in `discardKeys`.
+  // Changed `state.presence` (twice), but no migration because that's in `discardKeys`.
 
   // TIP: When adding a migration, consider just using `dropCache`.
   //   (See its jsdoc for guidance on when that's the right answer.)


### PR DESCRIPTION
This follows up on #5697 with a bit more modelification, and converts PresenceHeartbeat from a React class component to a Hooks-using function component. Then it adds `server_presence_ping_interval_seconds` and `server_presence_offline_threshold_seconds` to the API types, stores them in `PresenceState`, and uses them in place of the hardcoded 60 seconds and 140 seconds.

Fixes: #5669
