### PR TITLE
android [nfc]: Move some non-notifications-specific code out of `notifications/`

### DIFF
--- a/android/app/src/main/java/com/zulipmobile/MainActivity.kt
+++ b/android/app/src/main/java/com/zulipmobile/MainActivity.kt
@@ -6,25 +6,10 @@ import android.os.Bundle
 import android.webkit.WebView
 import com.facebook.react.ReactActivity
 import com.facebook.react.ReactActivityDelegate
-import com.facebook.react.ReactApplication
 import com.facebook.react.ReactRootView
-import com.facebook.react.bridge.ReactContext
 import com.zulipmobile.notifications.*
 import com.zulipmobile.sharing.handleSend
 import expo.modules.ReactActivityDelegateWrapper
-
-// A convenience shortcut.
-fun ReactApplication.tryGetReactContext(): ReactContext? =
-    this.reactNativeHost.tryGetReactInstanceManager()?.currentReactContext
-
-/**
- * Like `.application`, but with a more specific type.
- *
- * This expresses the invariant that a ReactActivity's application
- * should always be a ReactApplication.
- */
-val ReactActivity.reactApplication: ReactApplication
-    get() = application as ReactApplication
 
 open class MainActivity : ReactActivity() {
     /**

--- a/android/app/src/main/java/com/zulipmobile/ReactExtensions.kt
+++ b/android/app/src/main/java/com/zulipmobile/ReactExtensions.kt
@@ -5,7 +5,55 @@ import com.facebook.react.ReactApplication
 import com.facebook.react.ReactInstanceManager
 import com.facebook.react.ReactNativeHost
 import com.facebook.react.bridge.ReactContext
+import com.facebook.react.common.LifecycleState
 import com.facebook.react.modules.core.DeviceEventManagerModule
+
+/**
+ * A distillation of ReactContext.getLifecycleState() and related information.
+ *
+ * See ReactContext.getAppStatus().
+ */
+enum class ReactAppStatus {
+    /**
+     * The main activity has either never yet been in the foreground,
+     * or never will again.  There might not be an active JS instance.
+     */
+    NOT_RUNNING,
+
+    /**
+     * The main activity has been in the foreground, is out of foreground
+     * now, but might come back.  There must be an active JS instance.
+     */
+    BACKGROUND,
+
+    /**
+     * The main activity is in the foreground.
+     * There must be an active JS instance.
+     */
+    FOREGROUND
+}
+
+val ReactContext.appStatus: ReactAppStatus
+    get() {
+        if (!hasActiveCatalystInstance())
+            return ReactAppStatus.NOT_RUNNING
+
+        // The RN lifecycleState:
+        //  * starts as BEFORE_CREATE
+        //  * responds to onResume, onPause, and onDestroy on the host Activity
+        //    * Android upstream docs on those:
+        //        https://developer.android.com/guide/components/activities/activity-lifecycle
+        //    * RN wires those through ReactActivity -> ReactActivityDelegate ->
+        //      ReactInstanceManager (as onHost{Resume,Pause,Destroy}) -> ReactContext
+        //  * notably goes straight BEFORE_CREATE -> RESUMED when first starting
+        //    (at least as of RN v0.59)
+        return when (lifecycleState!!) {
+            LifecycleState.BEFORE_CREATE -> ReactAppStatus.NOT_RUNNING
+            LifecycleState.BEFORE_RESUME -> ReactAppStatus.BACKGROUND
+            LifecycleState.RESUMED -> ReactAppStatus.FOREGROUND
+        }
+    }
+
 
 // A convenience shortcut.
 fun ReactContext.emitEvent(eventName: String, data: Any?) {

--- a/android/app/src/main/java/com/zulipmobile/ReactExtensions.kt
+++ b/android/app/src/main/java/com/zulipmobile/ReactExtensions.kt
@@ -5,6 +5,13 @@ import com.facebook.react.ReactApplication
 import com.facebook.react.ReactInstanceManager
 import com.facebook.react.ReactNativeHost
 import com.facebook.react.bridge.ReactContext
+import com.facebook.react.modules.core.DeviceEventManagerModule
+
+// A convenience shortcut.
+fun ReactContext.emitEvent(eventName: String, data: Any?) {
+    getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter::class.java)
+        .emit(eventName, data)
+}
 
 /**
  * Like getReactInstanceManager, but just return what exists; avoid trying to create.

--- a/android/app/src/main/java/com/zulipmobile/ReactExtensions.kt
+++ b/android/app/src/main/java/com/zulipmobile/ReactExtensions.kt
@@ -1,0 +1,30 @@
+package com.zulipmobile
+
+import com.facebook.react.ReactActivity
+import com.facebook.react.ReactApplication
+import com.facebook.react.ReactInstanceManager
+import com.facebook.react.ReactNativeHost
+import com.facebook.react.bridge.ReactContext
+
+/**
+ * Like getReactInstanceManager, but just return what exists; avoid trying to create.
+ *
+ * When there isn't already an instance manager, if we call
+ * getReactInstanceManager it'll try to create one... which asserts we're
+ * on the UI thread, which isn't true if e.g. we got here from a Service.
+ */
+fun ReactNativeHost.tryGetReactInstanceManager(): ReactInstanceManager? =
+    if (this.hasInstance()) this.reactInstanceManager else null
+
+// A convenience shortcut.
+fun ReactApplication.tryGetReactContext(): ReactContext? =
+    this.reactNativeHost.tryGetReactInstanceManager()?.currentReactContext
+
+/**
+ * Like `.application`, but with a more specific type.
+ *
+ * This expresses the invariant that a ReactActivity's application
+ * should always be a ReactApplication.
+ */
+val ReactActivity.reactApplication: ReactApplication
+    get() = application as ReactApplication

--- a/android/app/src/main/java/com/zulipmobile/notifications/NotificationsModule.kt
+++ b/android/app/src/main/java/com/zulipmobile/notifications/NotificationsModule.kt
@@ -8,6 +8,7 @@ import androidx.core.app.NotificationManagerCompat
 import com.facebook.react.bridge.*
 import com.google.android.gms.common.ConnectionResult
 import com.google.android.gms.common.GoogleApiAvailability
+import com.zulipmobile.emitEvent
 import java.lang.Exception
 
 internal class NotificationsModule(reactContext: ReactApplicationContext) :
@@ -81,7 +82,7 @@ internal class NotificationsModule(reactContext: ReactApplicationContext) :
                 return
             }
             Log.i(TAG, "Got token; emitting event")
-            emit(reactContext, "remoteNotificationsRegistered", token)
+            reactContext.emitEvent("remoteNotificationsRegistered", token)
         }
     }
 }

--- a/android/app/src/main/java/com/zulipmobile/notifications/NotifyReact.kt
+++ b/android/app/src/main/java/com/zulipmobile/notifications/NotifyReact.kt
@@ -6,7 +6,8 @@ import android.os.Bundle
 import android.util.Log
 import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.ReactContext
-import com.facebook.react.common.LifecycleState
+import com.zulipmobile.ReactAppStatus
+import com.zulipmobile.appStatus
 import com.zulipmobile.emitEvent
 
 /**
@@ -15,52 +16,6 @@ import com.zulipmobile.emitEvent
  * This logic was largely inherited from the wix library.
  * TODO: Replace this with a fresh implementation based on RN upstream docs.
  */
-
-/**
- * A distillation of ReactContext.getLifecycleState() and related information.
- *
- * See ReactContext.getAppStatus().
- */
-enum class ReactAppStatus {
-    /**
-     * The main activity has either never yet been in the foreground,
-     * or never will again.  There might not be an active JS instance.
-     */
-    NOT_RUNNING,
-
-    /**
-     * The main activity has been in the foreground, is out of foreground
-     * now, but might come back.  There must be an active JS instance.
-     */
-    BACKGROUND,
-
-    /**
-     * The main activity is in the foreground.
-     * There must be an active JS instance.
-     */
-    FOREGROUND
-}
-
-val ReactContext.appStatus: ReactAppStatus
-    get() {
-        if (!hasActiveCatalystInstance())
-            return ReactAppStatus.NOT_RUNNING
-
-        // The RN lifecycleState:
-        //  * starts as BEFORE_CREATE
-        //  * responds to onResume, onPause, and onDestroy on the host Activity
-        //    * Android upstream docs on those:
-        //        https://developer.android.com/guide/components/activities/activity-lifecycle
-        //    * RN wires those through ReactActivity -> ReactActivityDelegate ->
-        //      ReactInstanceManager (as onHost{Resume,Pause,Destroy}) -> ReactContext
-        //  * notably goes straight BEFORE_CREATE -> RESUMED when first starting
-        //    (at least as of RN v0.59)
-        return when (lifecycleState!!) {
-            LifecycleState.BEFORE_CREATE -> ReactAppStatus.NOT_RUNNING
-            LifecycleState.BEFORE_RESUME -> ReactAppStatus.BACKGROUND
-            LifecycleState.RESUMED -> ReactAppStatus.FOREGROUND
-        }
-    }
 
 internal fun notifyReact(reactContext: ReactContext?, data: Bundle) {
     // TODO deduplicate this with handleSend in SharingHelper.kt; see

--- a/android/app/src/main/java/com/zulipmobile/notifications/NotifyReact.kt
+++ b/android/app/src/main/java/com/zulipmobile/notifications/NotifyReact.kt
@@ -4,8 +4,6 @@ package com.zulipmobile.notifications
 
 import android.os.Bundle
 import android.util.Log
-import com.facebook.react.ReactInstanceManager
-import com.facebook.react.ReactNativeHost
 import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.ReactContext
 import com.facebook.react.common.LifecycleState
@@ -17,16 +15,6 @@ import com.facebook.react.modules.core.DeviceEventManagerModule
  * This logic was largely inherited from the wix library.
  * TODO: Replace this with a fresh implementation based on RN upstream docs.
  */
-
-/**
- * Like getReactInstanceManager, but just return what exists; avoid trying to create.
- *
- * When there isn't already an instance manager, if we call
- * getReactInstanceManager it'll try to create one... which asserts we're
- * on the UI thread, which isn't true if e.g. we got here from a Service.
- */
-fun ReactNativeHost.tryGetReactInstanceManager(): ReactInstanceManager? =
-    if (this.hasInstance()) this.reactInstanceManager else null
 
 /**
  * A distillation of ReactContext.getLifecycleState() and related information.

--- a/android/app/src/main/java/com/zulipmobile/notifications/NotifyReact.kt
+++ b/android/app/src/main/java/com/zulipmobile/notifications/NotifyReact.kt
@@ -7,7 +7,7 @@ import android.util.Log
 import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.ReactContext
 import com.facebook.react.common.LifecycleState
-import com.facebook.react.modules.core.DeviceEventManagerModule
+import com.zulipmobile.emitEvent
 
 /**
  * Methods for telling React about a notification.
@@ -76,12 +76,6 @@ internal fun notifyReact(reactContext: ReactContext?, data: Bundle) {
         ReactAppStatus.BACKGROUND, ReactAppStatus.FOREGROUND ->
             // JS is running and has already reached foreground.  It won't check
             // initialNotification again, but it will see a notificationOpened event.
-            emit(reactContext, "notificationOpened", Arguments.fromBundle(data))
+            reactContext.emitEvent("notificationOpened", Arguments.fromBundle(data))
     }
-}
-
-fun emit(reactContext: ReactContext, eventName: String, data: Any?) {
-    reactContext
-        .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter::class.java)
-        .emit(eventName, data)
 }

--- a/android/app/src/main/java/com/zulipmobile/sharing/SharingHelper.kt
+++ b/android/app/src/main/java/com/zulipmobile/sharing/SharingHelper.kt
@@ -10,9 +10,9 @@ import android.util.Log
 import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.ReactContext
 import com.facebook.react.bridge.WritableMap
+import com.zulipmobile.ReactAppStatus
 import com.zulipmobile.ZLog
-import com.zulipmobile.notifications.ReactAppStatus
-import com.zulipmobile.notifications.appStatus
+import com.zulipmobile.appStatus
 import com.zulipmobile.emitEvent
 
 @JvmField

--- a/android/app/src/main/java/com/zulipmobile/sharing/SharingHelper.kt
+++ b/android/app/src/main/java/com/zulipmobile/sharing/SharingHelper.kt
@@ -13,7 +13,7 @@ import com.facebook.react.bridge.WritableMap
 import com.zulipmobile.ZLog
 import com.zulipmobile.notifications.ReactAppStatus
 import com.zulipmobile.notifications.appStatus
-import com.zulipmobile.notifications.emit
+import com.zulipmobile.emitEvent
 
 @JvmField
 val TAG = "ShareToZulip"
@@ -43,7 +43,7 @@ internal fun handleSend(
         ReactAppStatus.BACKGROUND, ReactAppStatus.FOREGROUND ->
             // JS is running and has already reached foreground. It won't check
             // initialSharedData again, but it will see a shareReceived event.
-            emit(reactContext, "shareReceived", params)
+            reactContext.emitEvent("shareReceived", params)
     }
 }
 


### PR DESCRIPTION
Toward #5693.

This code is useful for the notifications subsystem, but it's not specialized to it. It's also used in our share-to-Zulip code. We want these functions to behave the same whether or not the build supports notifications, and ideally we don't want to repeat their definitions in different build variants.

So, move them out of `notifications/`.