### PR TITLE
userAgent [nfc]: Use RN's `Platform` API; drop react-native-device-info

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -406,8 +406,6 @@ PODS:
     - React
   - RNCPushNotificationIOS (1.10.1):
     - React-Core
-  - RNDeviceInfo (8.7.1):
-    - React-Core
   - RNGestureHandler (2.9.0):
     - React-Core
   - RNReanimated (2.2.4):
@@ -537,7 +535,6 @@ DEPENDENCIES:
   - "RNCClipboard (from `../node_modules/@react-native-clipboard/clipboard`)"
   - "RNCMaskedView (from `../node_modules/@react-native-community/masked-view`)"
   - "RNCPushNotificationIOS (from `../node_modules/@react-native-community/push-notification-ios`)"
-  - RNDeviceInfo (from `../node_modules/react-native-device-info`)
   - RNGestureHandler (from `../node_modules/react-native-gesture-handler`)
   - RNReanimated (from `../node_modules/react-native-reanimated`)
   - RNScreens (from `../node_modules/react-native-screens`)
@@ -678,8 +675,6 @@ EXTERNAL SOURCES:
     :path: "../node_modules/@react-native-community/masked-view"
   RNCPushNotificationIOS:
     :path: "../node_modules/@react-native-community/push-notification-ios"
-  RNDeviceInfo:
-    :path: "../node_modules/react-native-device-info"
   RNGestureHandler:
     :path: "../node_modules/react-native-gesture-handler"
   RNReanimated:
@@ -763,7 +758,6 @@ SPEC CHECKSUMS:
   RNCClipboard: 3f0451a8100393908bea5c5c5b16f96d45f30bfc
   RNCMaskedView: 0e1bc4bfa8365eba5fbbb71e07fbdc0555249489
   RNCPushNotificationIOS: 87b8d16d3ede4532745e05b03c42cff33a36cc45
-  RNDeviceInfo: aad3c663b25752a52bf8fce93f2354001dd185aa
   RNGestureHandler: 071d7a9ad81e8b83fe7663b303d132406a7d8f39
   RNReanimated: e7d8afaf8fed4b3bf1a46e06adb2e04a2b248f1c
   RNScreens: 218801c16a2782546d30bd2026bb625c0302d70f

--- a/jest/jestSetup.js
+++ b/jest/jestSetup.js
@@ -139,11 +139,6 @@ jest.mock('react-native-simple-toast', () => ({
   showWithGravity: jest.fn(),
 }));
 
-jest.mock('react-native-device-info', () => ({
-  getSystemName: jest.fn().mockReturnValue('ios'),
-  getSystemVersion: jest.fn().mockReturnValue('13.3.1'),
-}));
-
 // Set up our `logging` module with mocks, which tests can use as desired.
 //
 // This global version just passes the calls right through to the real

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "react": "17.0.2",
     "react-intl": "5.24.6",
     "react-native": "0.68.5",
-    "react-native-device-info": "^8.1.7",
     "react-native-document-picker": "^8.1.3",
     "react-native-gesture-handler": "^2.8.0",
     "react-native-image-picker": "4.10.3",

--- a/src/reactNativeUtils.js
+++ b/src/reactNativeUtils.js
@@ -84,3 +84,20 @@ export function androidSdkVersion(): number {
   // 10 it won't be 10, it'll be 29.
   return (Platform.Version: number);
 }
+
+/**
+ * The Android user-visible version string, with no promised structure.
+ */
+// This is Build.VERSION.RELEASE as of RN v0.68.5:
+//   https://reactnative.dev/docs/platform#constants
+//   https://github.com/facebook/react-native/blob/v0.68.5/ReactAndroid/src/main/java/com/facebook/react/modules/systeminfo/AndroidInfoModule.java#L69
+//   https://developer.android.com/reference/android/os/Build.VERSION#RELEASE
+export function androidRelease(): string {
+  invariant(Platform.OS === 'android', 'androidRelease called on iOS');
+
+  // Flow isn't refining `Platform` to a type that corresponds to values
+  // we'll see on Android.
+  //
+  // (If changing the implementation, adjust comment below jsdoc.)
+  return (Platform.constants.Release: string);
+}

--- a/src/utils/userAgent.js
+++ b/src/utils/userAgent.js
@@ -1,9 +1,28 @@
 /* @flow strict-local */
-import DeviceInfo from 'react-native-device-info';
 import { nativeApplicationVersion } from 'expo-application';
+import { Platform } from 'react-native';
 
-const { getSystemName, getSystemVersion } = DeviceInfo;
+import { androidRelease } from '../reactNativeUtils';
+
+const systemName =
+  // prettier-ignore
+  Platform.OS === 'ios'
+    // Probably "iOS" on all iOS devices we support (was "iPhone OS" long ago):
+    //   https://github.com/facebook/react-native/blob/v0.68.5/React/CoreModules/RCTPlatform.mm#L68
+    //   https://developer.apple.com/documentation/uikit/uidevice/1620054-systemname?language=objc
+    ? Platform.constants.systemName
+    : 'Android';
+
+const systemVersion =
+  // prettier-ignore
+  Platform.OS === 'ios'
+    // E.g. "16.4" for iOS 16.4:
+    //   https://github.com/facebook/react-native/blob/v0.68.5/React/CoreModules/RCTPlatform.mm#L67
+    //   https://developer.apple.com/documentation/uikit/uidevice/1620043-systemversion?language=objc
+    ? `${Platform.constants.osVersion}`
+    // (E.g. '13' for Android 13 Tiramisu)
+    :  androidRelease();
 
 export default `ZulipMobile/${
   nativeApplicationVersion ?? '?.?.?'
-} (${getSystemName()} ${getSystemVersion()})`;
+} (${systemName} ${systemVersion})`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -10378,11 +10378,6 @@ react-native-codegen@^0.0.18:
     jscodeshift "^0.13.1"
     nullthrows "^1.1.1"
 
-react-native-device-info@^8.1.7:
-  version "8.7.1"
-  resolved "https://registry.yarnpkg.com/react-native-device-info/-/react-native-device-info-8.7.1.tgz#fbb06f87dbbc4423abe713874699fb2e6e99fd15"
-  integrity sha512-cVMZztFa2Qn6qpQa601W61CtUwZQ1KXfqCOeltejAWEXmgIWivC692WGSdtGudj4upSi1UgMSaGcvKjfcpdGjg==
-
 react-native-document-picker@^8.1.3:
   version "8.2.0"
   resolved "https://registry.yarnpkg.com/react-native-document-picker/-/react-native-document-picker-8.2.0.tgz#d0d2f9ff8667e90e7ff6f9733077043e3f86d1a9"


### PR DESCRIPTION
Oddly, on Android, react-native-device-info brings in some Firebase dependencies that we don't need:
  https://github.com/react-native-device-info/react-native-device-info/blob/v8.7.1/android/build.gradle#L54-L64

Also this dependency seems to have caused a fair amount of complexity to keep around; see the output of

  git log --grep='react-native-device-info'

Remove it, since we can get the same information in the same form from RN's Platform API.

To verify that it's all the same:

- For the "system name" piece (given previously by r-n-device-info's `getSystemName`):
  - iOS:
    - r-n-device-info was using Apple's UIDevice.systemName: https://github.com/react-native-device-info/react-native-device-info/blob/v8.7.1/ios/RNDeviceInfo/RNDeviceInfo.m#L142
    - `Platform.constants.systemName` uses the same thing: https://github.com/facebook/react-native/blob/v0.68.5/React/CoreModules/RCTPlatform.mm#L68
  - Android:
    - r-n-device-info was using the string 'Android': https://github.com/react-native-device-info/react-native-device-info/blob/v8.7.1/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java#L195
    - (so, copy that)
- For the "system version" piece (given previously by r-n-device-info's `getSystemVersion`:
  - iOS:
    - r-n-device-info was using Apple's UIDevice.systemVersion: https://github.com/react-native-device-info/react-native-device-info/blob/v8.7.1/ios/RNDeviceInfo/RNDeviceInfo.m#L147
    - `Platform.constants.osVersion` uses the same thing: https://github.com/facebook/react-native/blob/v0.68.5/React/CoreModules/RCTPlatform.mm#L67
  - Android:
    - r-n-device-info was using Android's Build.VERSION.RELEASE: https://github.com/react-native-device-info/react-native-device-info/blob/v8.7.1/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java#L196
    - `Platform.constants.Release` uses the same thing: https://github.com/facebook/react-native/blob/v0.68.5/ReactAndroid/src/main/java/com/facebook/react/modules/systeminfo/AndroidInfoModule.java#L69