### PR TITLE
logging: Make `logging.info` log to Sentry

### DIFF
--- a/src/api/apiFetch.js
+++ b/src/api/apiFetch.js
@@ -85,7 +85,6 @@ export const apiCall = async (
     const { httpStatus, data } = error instanceof RequestError ? error : {};
 
     const response = data !== undefined ? data : '(none, or not valid JSON)';
-    logging.info({ route, params, httpStatus, response });
     Sentry.addBreadcrumb({
       category: 'api',
       level: 'info',

--- a/src/message/__tests__/fetchActions-test.js
+++ b/src/message/__tests__/fetchActions-test.js
@@ -392,19 +392,12 @@ describe('fetchActions', () => {
 
         // $FlowFixMe[prop-missing]: See mock in jest/globalFetch.js.
         fetch.mockResponseFailure(fetchError);
-        // $FlowFixMe[prop-missing]: Jest mock
-        logging.info.mockReturnValue();
 
         await expect(
           store.dispatch(
             fetchMessages({ narrow: HOME_NARROW, anchor: 0, numBefore: 1, numAfter: 1 }),
           ),
         ).rejects.toThrow(fetchError);
-
-        // $FlowFixMe[prop-missing]: Jest mock
-        expect(logging.info.mock.calls).toHaveLength(1);
-        // $FlowFixMe[prop-missing]: Jest mock
-        logging.info.mockReset();
       });
     });
 

--- a/src/utils/logging.js
+++ b/src/utils/logging.js
@@ -214,16 +214,20 @@ export const warn: (event: string | Error, extras?: Extras) => void = makeLogFun
 /**
  * Log an event at "info" severity.
  *
- * The event will be logged to the console as appropriate.
- *
- * This will *not* log any information to Sentry.  Consider also calling
- * `Sentry.addBreadcrumb`.
+ * The event will be logged to Sentry and/or the console as appropriate.
  *
  * See also:
  *  * `logging.warn` and `logging.error` for logging at higher severity
+ *  * `Sentry.addBreadcrumb`, to add background data to an eventual Sentry
+ *    report, but without causing a Sentry report.
+ *
+ * @param event A string describing the nature of the event to be logged, or an
+ *   exception whose `.message` is such a string. Related events should have
+ *   identical such strings, when feasible.
+ * @param extras Diagnostic data which may differ between separate occurrences
+ *   of the event.
  */
-export const info = (event: string | Error | { ... }) => {
-  if (config.enableErrorConsoleLogging) {
-    console.log(event);
-  }
-};
+export const info: (event: string | Error, extras?: Extras) => void = makeLogFunction({
+  consoleMethod: console.info,
+  severity: Severity.Info,
+});


### PR DESCRIPTION
We have a log line

  NotifTroubleshootingScreen: MailComposer reports a sent email.

that I'd *thought* was getting sent to Sentry, but apparently not. The line is meant to help us detect potential cases where the user thought they'd contacted support through the app, but we don't see an email on our side. We're not aware of such cases yet, but in principle it could happen.

Since it seems helpful to have a function for logging to Sentry at an "info" level, rewrite `logging.info` based on `logging.warn` and `logging.error` so it does that. That should cause that notif-troubleshooting line to go to Sentry.

The one other callsite of `logging.info` is redundant with a breadcrumb added with the same information; remove it and an unexplained test assertion about it.