### PR TITLE
compose: Decrease jank on message-input focus

### DIFF
--- a/src/compose/ComposeBox.js
+++ b/src/compose/ComposeBox.js
@@ -486,10 +486,11 @@ const ComposeBox: React$AbstractComponent<Props, ImperativeHandle> = forwardRef(
   );
 
   const handleMessageFocus = useCallback(() => {
+    setFocusState(state => ({ ...state, message: true, either: true }));
     if (
       !isEditing
       && isStreamNarrow(narrow)
-      && !focusState.either
+      && !focusState.either // not affected by setFocusState above; React state is set asynchronously
       && topicInputState.value === ''
     ) {
       // We weren't showing the topic input when the user tapped on the input
@@ -497,7 +498,6 @@ const ComposeBox: React$AbstractComponent<Props, ImperativeHandle> = forwardRef(
       // hasn't already selected a topic.
       topicInputRef.current?.focus();
     }
-    setFocusState(state => ({ ...state, message: true, either: true }));
   }, [isEditing, narrow, focusState.either, topicInputState.value, topicInputRef]);
 
   const handleMessageBlur = useCallback(() => {

--- a/src/compose/ComposeBox.js
+++ b/src/compose/ComposeBox.js
@@ -496,9 +496,8 @@ const ComposeBox: React$AbstractComponent<Props, ImperativeHandle> = forwardRef(
       // to focus it, but we're about to show it.  Focus that, if the user
       // hasn't already selected a topic.
       topicInputRef.current?.focus();
-    } else {
-      setFocusState(state => ({ ...state, message: true, either: true }));
     }
+    setFocusState(state => ({ ...state, message: true, either: true }));
   }, [isEditing, narrow, focusState.either, topicInputState.value, topicInputRef]);
 
   const handleMessageBlur = useCallback(() => {


### PR DESCRIPTION
    compose: Decrease jank on message-input focus
    
    By doing the setFocusState call unconditionally.
    
    This piece of React state is meant to track when the topic input is
    focused, when the message input is focused, and (with the
    true-to-false transition debounced) when either is focused.
    
    So if the message input is focused and we don't set that state (as
    has sometimes been the case until now), it's not working as
    intended. Fix that by making this setFocusState call unconditional,
    like it is in handleTopicFocus.
    
    This makes a visible improvement in the situation described by this
    comment:
    
      // We weren't showing the topic input when the user tapped on the input
      // to focus it, but we're about to show it.  Focus that, if the user
      // hasn't already selected a topic.
    
    Before, focusState.either was being set later than it should be; it
    would only happen following that automatic topic focus, when
    handleTopicFocus was called. Since focusState.either controls
    whether the topic input is visible, the topic input was appearing a
    frame or two later than it should -- sometimes even after the topic
    autocomplete appeared.
    
    Eliminating that delay gives a less janky feel.