### PR TITLE
api: Don't allow connecting to servers <3.0

### DIFF
--- a/src/api/apiErrors.js
+++ b/src/api/apiErrors.js
@@ -180,13 +180,9 @@ export const interpretApiResponse = (httpStatus: number, data: mixed): mixed => 
 /**
  * The Zulip Server version below which we should just refuse to connect.
  */
-// Currently chosen to affect a truly tiny fraction of users, as we test the
-// feature of refusing to connect, to keep the risk small; see
-//   https://github.com/zulip/zulip-mobile/issues/5102#issuecomment-1233446360
-// In steady state, this should lag a bit behind the threshold version for
-// ServerCompatBanner (kMinSupportedVersion), to give users time to see and
-// act on the banner.
-export const kMinAllowedServerVersion: ZulipVersion = new ZulipVersion('2.0');
+// This should lag a bit behind the threshold version for ServerCompatBanner
+// (kMinSupportedVersion), to give users time to see and act on the banner.
+export const kMinAllowedServerVersion: ZulipVersion = new ZulipVersion('3.0');
 
 /**
  * An error we throw in API bindings on finding a server is too old.


### PR DESCRIPTION
As Greg suggested almost a year ago:
  https://github.com/zulip/zulip-mobile/issues/5102#issuecomment-1233446360
with the note that Server 3.0 was then over two years old.

This significantly increases the amount of backwards-compatibility code we can now simplify or sweep away: search for "TODO(server-3" or "TODO(server-2". (There are even a handful of straggling `TODO(server-1.9)`s.)

But unlocking those simplifications isn't the main aim here, since our efforts are focused on the new Flutter app, to replace this app:
  https://github.com/zulip/zulip-flutter
Rather, the goal is just to continue incrementally nudging people toward current Zulip Server versions. In particular, when we release the Flutter app, we'll want to give it a floor of Server 4.0 or later, depending on when we release it.