### PR TITLE
ServerCompatBanner: Bump kMinSupportedVersion to 4.10

### DIFF
--- a/src/common/ServerCompatBanner.js
+++ b/src/common/ServerCompatBanner.js
@@ -32,11 +32,6 @@ export const kServerSupportDocUrl: URL = new URL(
  * which we just refuse to connect.
  */
 export const kMinSupportedVersion: ZulipVersion = new ZulipVersion('4.0');
-// Notes on known breakage at older versions:
-//  * Before 1.8, the server doesn't send found_newest / found_oldest on
-//    fetching messages, and so `state.caughtUp` will never have truthy
-//    values.  This probably means annoying behavior in a message list,
-//    as we keep trying to fetch newer messages.
 
 /**
  * The next value we'll give to kMinSupportedVersion in the future.

--- a/src/common/ServerCompatBanner.js
+++ b/src/common/ServerCompatBanner.js
@@ -31,7 +31,7 @@ export const kServerSupportDocUrl: URL = new URL(
  * See also kMinAllowedServerVersion in apiErrors.js, for the version below
  * which we just refuse to connect.
  */
-export const kMinSupportedVersion: ZulipVersion = new ZulipVersion('4.0');
+export const kMinSupportedVersion: ZulipVersion = new ZulipVersion('4.10');
 
 /**
  * The next value we'll give to kMinSupportedVersion in the future.

--- a/src/common/ServerCompatBanner.js
+++ b/src/common/ServerCompatBanner.js
@@ -25,7 +25,8 @@ export const kServerSupportDocUrl: URL = new URL(
 /**
  * The oldest version we currently support.
  *
- * Should match what we say at kServerSupportDocUrl.
+ * Should match the policy stated at kServerSupportDocUrl: all versions
+ * below this should be older than 18 months.
  *
  * See also kMinAllowedServerVersion in apiErrors.js, for the version below
  * which we just refuse to connect.


### PR DESCRIPTION
Server 4.9 was released over 18 months ago:
  https://blog.zulip.com/2022/01/25/zulip-server-4-9-security-release/

-----

Also a comment tweak to follow zulip/zulip#26522.