### PR TITLE
android: Update targetSdkVersion to 33 (Android 13)

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -13,7 +13,7 @@ buildscript {
         // but some testing is required and code changes are often required.
         // See upstream for background and more discussion:
         //   https://medium.com/androiddevelopers/picking-your-compilesdkversion-minsdkversion-targetsdkversion-a098a0341ebd
-        targetSdkVersion = 31
+        targetSdkVersion = 33
 
         // Should be the latest SDK version available.  See upstream recommendation:
         //   https://medium.com/androiddevelopers/picking-your-compilesdkversion-minsdkversion-targetsdkversion-a098a0341ebd


### PR DESCRIPTION
This change will be required in order to upload new releases to the Play Store, effective 2023-08-31 (or 2023-11-01 if we request an extension).

Tested on an emulated Pixel running Android 13, but testing on a real device would be good too. (The office device I use only runs Android 9, though, so I can't do that myself.)

Fixes: #5453