### PR TITLE
Revert "android: Update targetSdkVersion to 33 (Android 13)"

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -13,7 +13,7 @@ buildscript {
         // but some testing is required and code changes are often required.
         // See upstream for background and more discussion:
         //   https://medium.com/androiddevelopers/picking-your-compilesdkversion-minsdkversion-targetsdkversion-a098a0341ebd
-        targetSdkVersion = 33
+        targetSdkVersion = 31
 
         // Should be the latest SDK version available.  See upstream recommendation:
         //   https://medium.com/androiddevelopers/picking-your-compilesdkversion-minsdkversion-targetsdkversion-a098a0341ebd


### PR DESCRIPTION
This reverts commit 6f44474a.

From a user report, we found that we now have to handle a new runtime permission for notifications, and the consequence of not doing so is that notifications stop working on Android 13. Ouch; that would have been good to see mentioned in the "behavior changes" doc:
  https://developer.android.com/about/versions/13/behavior-changes-13#notification-permission-fgs-appearance

Discussion (starting with the user report):
  https://chat.zulip.org/#narrow/stream/48-mobile/topic/.22This.20app.20does.20not.20send.20notifications.22/near/1634168