### PR TITLE
NotifTroubleshootingScreen: Add Android manufacturer/model info to report

### DIFF
--- a/src/reactNativeUtils.js
+++ b/src/reactNativeUtils.js
@@ -101,3 +101,45 @@ export function androidRelease(): string {
   // (If changing the implementation, adjust comment below jsdoc.)
   return (Platform.constants.Release: string);
 }
+
+/**
+ * The manufacturer of the Android device.
+ *
+ * E.g., "Google", "samsung".
+ */
+// This is Build.MANUFACTURER as of RN v0.68.7:
+//   https://reactnative.dev/docs/platform#constants
+//   https://github.com/facebook/react-native/blob/v0.68.7/ReactAndroid/src/main/java/com/facebook/react/modules/systeminfo/AndroidInfoModule.java#L73
+//   https://developer.android.com/reference/android/os/Build#MANUFACTURER
+export function androidManufacturer(): string {
+  invariant(Platform.OS === 'android', 'androidManufacturer called on iOS');
+  return (Platform.constants.Manufacturer: string);
+}
+
+/**
+ * "The consumer-visible brand with which the product/hardware will be associated, if any."
+ *
+ * E.g., "google", "samsung".
+ */
+// This is Build.BRAND as of RN v0.68.7:
+//   https://reactnative.dev/docs/platform#constants
+//   https://github.com/facebook/react-native/blob/v0.68.7/ReactAndroid/src/main/java/com/facebook/react/modules/systeminfo/AndroidInfoModule.java#L74
+//   https://developer.android.com/reference/android/os/Build#BRAND
+export function androidBrand(): string {
+  invariant(Platform.OS === 'android', 'androidBrand called on iOS');
+  return (Platform.constants.Brand: string);
+}
+
+/**
+ * "The end-user-visible name for the end product."
+ *
+ * E.g., "Pixel 5", "sdk_gphone64_x86_64", "SM-G960U1".
+ */
+// This is Build.MODEL as of RN v0.68.7:
+//   https://reactnative.dev/docs/platform#constants
+//   https://github.com/facebook/react-native/blob/v0.68.7/ReactAndroid/src/main/java/com/facebook/react/modules/systeminfo/AndroidInfoModule.java#L72
+//   https://developer.android.com/reference/android/os/Build#MODEL
+export function androidModel(): string {
+  invariant(Platform.OS === 'android', 'androidModel called on iOS');
+  return (Platform.constants.Model: string);
+}

--- a/src/settings/NotifTroubleshootingScreen.js
+++ b/src/settings/NotifTroubleshootingScreen.js
@@ -38,7 +38,7 @@ import ZulipText from '../common/ZulipText';
 import type { Identity } from '../types';
 import type { SubsetProperties } from '../generics';
 import type { ZulipVersion } from '../utils/zulipVersion';
-import { useAppState } from '../reactNativeUtils';
+import { androidBrand, androidManufacturer, androidModel, useAppState } from '../reactNativeUtils';
 import * as logging from '../utils/logging';
 import { getHaveServerData } from '../haveServerDataSelectors';
 import { TranslationContext } from '../boot/TranslationProvider';
@@ -147,6 +147,9 @@ export type NotificationReport = {|
   +isSelfHosted: boolean,
   +platform: SubsetProperties<typeof Platform, {| +OS: mixed, +Version: mixed, +isPad: boolean |}>,
   +nativeApplicationVersion: string | null,
+  +manufacturer?: string,
+  +brand?: string,
+  +model?: string,
   +nativeState: NativeState,
   +problems: $ReadOnlyArray<NotificationProblem>,
   +isLoggedIn: boolean,
@@ -261,6 +264,11 @@ export function useNotificationReportsByIdentityKey(): Map<string, NotificationR
               isSelfHosted: !isAppOwnDomain(identity.realm),
               platform,
               nativeApplicationVersion,
+              ...(Platform.OS === 'android' && {
+                manufacturer: androidManufacturer(),
+                brand: androidBrand(),
+                model: androidModel(),
+              }),
               nativeState,
               problems,
               isLoggedIn,


### PR DESCRIPTION
This could provide useful context, e.g., to diagnose issues like issue #4074, "Some device vendors break notifications".

Unfortunately, in my test using an emulated Pixel XL (results recorded in jsdoc), none of these three fields actually had anything like "Pixel XL" in it. Possibly we could get that from something like Android's `Build.PRODUCT`, documented as "the name of the overall product":
  https://developer.android.com/reference/android/os/Build#PRODUCT
but React Native's Platform.constants doesn't expose that value or any other that seems likely, and we have more urgent tasks than plumbing things through React Native (like
<https://github.com/zulip/zulip-flutter>).