### PR TITLE
api: Don't allow connecting to servers <4.0; show nag banner on <5.0

### DIFF
--- a/src/api/apiErrors.js
+++ b/src/api/apiErrors.js
@@ -182,7 +182,7 @@ export const interpretApiResponse = (httpStatus: number, data: mixed): mixed => 
  */
 // This should lag a bit behind the threshold version for ServerCompatBanner
 // (kMinSupportedVersion), to give users time to see and act on the banner.
-export const kMinAllowedServerVersion: ZulipVersion = new ZulipVersion('3.0');
+export const kMinAllowedServerVersion: ZulipVersion = new ZulipVersion('4.0');
 
 /**
  * An error we throw in API bindings on finding a server is too old.

--- a/src/common/ServerCompatBanner.js
+++ b/src/common/ServerCompatBanner.js
@@ -31,14 +31,14 @@ export const kServerSupportDocUrl: URL = new URL(
  * See also kMinAllowedServerVersion in apiErrors.js, for the version below
  * which we just refuse to connect.
  */
-export const kMinSupportedVersion: ZulipVersion = new ZulipVersion('4.10');
+export const kMinSupportedVersion: ZulipVersion = new ZulipVersion('5.0');
 
 /**
  * The next value we'll give to kMinSupportedVersion in the future.
  *
  * This should be the next major Zulip Server version after kMinSupportedVersion.
  */
-export const kNextMinSupportedVersion: ZulipVersion = new ZulipVersion('5.0');
+export const kNextMinSupportedVersion: ZulipVersion = new ZulipVersion('6.0');
 
 type Props = $ReadOnly<{||}>;
 


### PR DESCRIPTION
The latest 4.x, which is 4.11, was released on 2022-03-15, so it will turn 18 months old -- and so, become unsupported -- four days from now:
  https://zulip.readthedocs.io/en/latest/overview/release-lifecycle.html#compatibility-and-upgrading
  https://blog.zulip.com/tag/release-announcements/
So it's time to start nudging server admins to upgrade, with the nag banner.