### PR TITLE
Disable Sentry for now on Android (cherry-pick from v27.213)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -39,6 +39,17 @@ It doesn't include
 
 ## Unreleased
 
+### Highlights for users
+
+* (Android) Disabled Sentry error reporting, which was causing
+  crashes following a recent Android update. (#5757)
+
+
+### Highlights for developers
+
+* Disabled Sentry on Android, as a workaround for the newly-frequent
+  crash bug #5757.
+
 
 ## 27.212 (2023-09-15)
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -39,19 +39,36 @@ It doesn't include
 
 ## Unreleased
 
-### Highlights for users
+### Highlights for users, vs. v27.213 (last prod release)
+
+
+### Highlights for developers, vs. v27.212 (last release from main)
+
+* Disabled Sentry on Android, as a workaround for the newly-frequent
+  crash bug #5757.
+
+
+## 27.213 (2023-09-20)
+
+This is an Android-only release in the v27.211 series.
+
+
+### Highlights for users, vs. v27.211
 
 * (Android) Disabled Sentry error reporting, which was causing
   crashes following a recent Android update. (#5757)
 
 
-### Highlights for developers
+### Highlights for developers, vs. v27.211
 
 * Disabled Sentry on Android, as a workaround for the newly-frequent
   crash bug #5757.
 
 
 ## 27.212 (2023-09-15)
+
+This was an alpha-only release.
+
 
 ### Highlights for users
 

--- a/docs/howto/release.md
+++ b/docs/howto/release.md
@@ -102,12 +102,9 @@ simple terminology for the process we follow with both.
   tools/checkout-keystore
   ```
 
-* Apply the Sentry client key (using the local branch created for this
-  in initial setup):
-
-  ```
-  git rebase @ release-secrets
-  ```
+* Do *not* apply the Sentry client key from the `release-secrets`
+  branch; if you're already on that branch (from e.g. making the iOS
+  build), move off of it.  See our issues #5757 and #5766.
 
 * Build the app, as both good old-fashioned APKs and a fancy new AAB:
 

--- a/tools/android
+++ b/tools/android
@@ -64,14 +64,16 @@ do_apk() {
     check_yarn_link
     run_visibly yarn
 
-    run_visibly tools/gradle :app:assembleRelease -Psigned -Psentry
+    # TODO(#5766): start passing -Psentry again
+    run_visibly tools/gradle :app:assembleRelease -Psigned
 }
 
 do_aab() {
     check_yarn_link
     run_visibly yarn
 
-    run_visibly tools/gradle :app:bundleRelease -Psigned -Psentry
+    # TODO(#5766): start passing -Psentry again
+    run_visibly tools/gradle :app:bundleRelease -Psigned
 }
 
 case "${action}" in


### PR DESCRIPTION
In the rush to get v27.213 out the door as a fix for #5757 — and partly because I was hopeful that the Sentry folks would be finding a fix soon — I made these changes directly on a release branch, rather than on main first and cherry-picking to a release branch.

Here they are for `main`, along with the changelog entry for v27.213.
