### PR TITLE
api: Stop assuming fetched messages' reactions have deprecated `user` field

### DIFF
--- a/src/api/__tests__/rawModelTypes-test.js
+++ b/src/api/__tests__/rawModelTypes-test.js
@@ -1,31 +1,14 @@
 /* @flow strict-local */
-import {
-  transformFetchedMessage,
-  type FetchedMessage,
-  type FetchedReaction,
-} from '../rawModelTypes';
+import { transformFetchedMessage, type FetchedMessage } from '../rawModelTypes';
 import { identityOfAuth } from '../../account/accountMisc';
 import * as eg from '../../__tests__/lib/exampleData';
 import type { Message } from '../modelTypes';
 import { GravatarURL } from '../../utils/avatar';
 
 describe('transformFetchedMessage', () => {
-  const reactingUser = eg.makeUser();
-
-  const serverReaction: FetchedReaction = {
-    emoji_name: '+1',
-    reaction_type: 'unicode_emoji',
-    emoji_code: '1f44d',
-    user: {
-      email: reactingUser.email,
-      full_name: reactingUser.full_name,
-      id: reactingUser.user_id,
-    },
-  };
-
   const fetchedMessage: FetchedMessage = {
     ...eg.streamMessage(),
-    reactions: [serverReaction],
+    reactions: [eg.unicodeEmojiReaction],
     avatar_url: null,
     edit_history: [
       {
@@ -46,14 +29,6 @@ describe('transformFetchedMessage', () => {
 
     const expectedOutput: Message = {
       ...fetchedMessage,
-      reactions: [
-        {
-          user_id: reactingUser.user_id,
-          emoji_name: serverReaction.emoji_name,
-          reaction_type: serverReaction.reaction_type,
-          emoji_code: serverReaction.emoji_code,
-        },
-      ],
       avatar_url: GravatarURL.validateAndConstructInstance({ email: fetchedMessage.sender_email }),
       edit_history:
         // $FlowIgnore[incompatible-cast] - See MessageEdit type
@@ -66,10 +41,6 @@ describe('transformFetchedMessage', () => {
       eg.recentZulipFeatureLevel,
       true,
     );
-
-    test('In reactions, replace user object with `user_id`', () => {
-      expect(actualOutput.reactions).toEqual(expectedOutput.reactions);
-    });
 
     test('Converts avatar_url correctly', () => {
       expect(actualOutput.avatar_url).toEqual(expectedOutput.avatar_url);

--- a/src/api/rawModelTypes.js
+++ b/src/api/rawModelTypes.js
@@ -1,34 +1,8 @@
 /* @flow strict-local */
 
 import type { Identity } from '../types';
-import type {
-  PmMessage,
-  StreamMessage,
-  Message,
-  MessageEdit,
-  Reaction,
-  UserId,
-} from './modelTypes';
+import type { PmMessage, StreamMessage, Message, MessageEdit, UserId } from './modelTypes';
 import { AvatarURL } from '../utils/avatar';
-
-/**
- * The variant of `Reaction` found in a fetch-message(s) response.
- *
- * Note that reaction events have a *different* variation; see their
- * handling in `eventToAction`.
- */
-// We shouldn't have to rely on this format on servers at feature
-// level 2+; those newer servers include a top-level `user_id` field
-// in addition to the `user` object. See #4072.
-// TODO(server-3.0): Simplify this away.
-export type FetchedReaction = $ReadOnly<{|
-  ...$Diff<Reaction, {| user_id: mixed |}>,
-  user: $ReadOnly<{|
-    email: string,
-    full_name: string,
-    id: UserId,
-  |}>,
-|}>;
 
 /**
  * The elements of Message.edit_history found in a fetch-message(s) response.
@@ -56,7 +30,6 @@ export type FetchedMessageEdit = $ReadOnly<{|
 type FetchedMessageOf<M: Message> = $ReadOnly<{|
   ...$Exact<M>,
   avatar_url: string | null,
-  reactions: $ReadOnlyArray<FetchedReaction>,
 
   // Unlike Message['edit_history'], this can't be `null`.
   edit_history?: $ReadOnlyArray<FetchedMessageEdit>,
@@ -79,13 +52,6 @@ export const transformFetchedMessage = <M: Message>(
     email: message.sender_email,
     userId: message.sender_id,
     realm: identity.realm,
-  }),
-  reactions: message.reactions.map(reaction => {
-    const { user, ...restReaction } = reaction;
-    return {
-      ...restReaction,
-      user_id: user.id,
-    };
   }),
 
   // Why condition on allowEditHistory? See MessageBase['edit_history'].


### PR DESCRIPTION
Our code at the edge for transforming the old format of reactions,
with `user`, into the new format, with `user_id`, was depending on
`user` always being present.

Since `user_id` is documented as being added in Zulip 3.0:
  https://zulip.com/api/get-messages#response
, and since #5747 we've been refusing to connect to servers pre-3.0,
we can assume `user_id` is always present and stop reading `user`.

Fixes: #4072