### PR TITLE
Add "followed" user-topic state, as synonym of "unmuted"

### DIFF
--- a/src/action-sheets/__tests__/action-sheet-test.js
+++ b/src/action-sheets/__tests__/action-sheet-test.js
@@ -12,6 +12,7 @@ import {
 import { makeUnreadState } from '../../unread/__tests__/unread-testlib';
 import { makeMuteState } from '../../mute/__tests__/mute-testlib';
 import { Role } from '../../api/permissionsTypes';
+import { UserTopicVisibilityPolicy } from '../../api/modelTypes';
 
 const buttonTitles = buttons => buttons.map(button => button.title);
 
@@ -89,6 +90,11 @@ describe('constructTopicActionButtons', () => {
 
   test('show muteTopic', () => {
     const mute = makeMuteState([]);
+    expect(titles({ ...eg.plusBackgroundData, mute })).toContain('Mute topic');
+  });
+
+  test('show muteTopic on followed topic', () => {
+    const mute = makeMuteState([[eg.stream, topic, UserTopicVisibilityPolicy.Followed]]);
     expect(titles({ ...eg.plusBackgroundData, mute })).toContain('Mute topic');
   });
 

--- a/src/action-sheets/index.js
+++ b/src/action-sheets/index.js
@@ -664,6 +664,7 @@ export const constructTopicActionButtons = (args: {|
         break;
       case UserTopicVisibilityPolicy.None:
       case UserTopicVisibilityPolicy.Unmuted:
+      case UserTopicVisibilityPolicy.Followed:
         buttons.push(muteTopic);
         break;
     }
@@ -677,6 +678,7 @@ export const constructTopicActionButtons = (args: {|
           buttons.push(unmuteTopicInMutedStream);
           break;
         case UserTopicVisibilityPolicy.Unmuted:
+        case UserTopicVisibilityPolicy.Followed:
           buttons.push(muteTopic);
           break;
       }

--- a/src/api/modelTypes.js
+++ b/src/api/modelTypes.js
@@ -644,6 +644,10 @@ export enum UserTopicVisibilityPolicy {
   None = 0,
   Muted = 1,
   Unmuted = 2,
+  // Not in the API docs yet.  But it is, uh, in the server implementation:
+  //   https://github.com/zulip/zulip/blob/2ec8273c6/zerver/models.py#L2794-L2797
+  // TODO(server): delete this comment once documented
+  Followed = 3,
 }
 
 /**

--- a/src/api/modelTypes.js
+++ b/src/api/modelTypes.js
@@ -643,10 +643,6 @@ export type Topic = $ReadOnly<{|
 export enum UserTopicVisibilityPolicy {
   None = 0,
   Muted = 1,
-  // Not in the API docs yet, but the API has been agreed on:
-  //   https://chat.zulip.org/#narrow/stream/378-api-design/topic/muted.20topics/near/1501574
-  //   https://chat.zulip.org/#narrow/stream/378-api-design/topic/muted.20topics/near/1528885
-  // TODO(server): delete this comment once documented
   Unmuted = 2,
 }
 

--- a/src/mute/__tests__/muteModel-test.js
+++ b/src/mute/__tests__/muteModel-test.js
@@ -45,6 +45,13 @@ describe('getters', () => {
         UserTopicVisibilityPolicy.Unmuted,
       );
     });
+
+    test('with topic followed', () => {
+      check(
+        makeMuteState([[eg.stream, 'topic', UserTopicVisibilityPolicy.Followed]]),
+        UserTopicVisibilityPolicy.Followed,
+      );
+    });
   });
 
   describe('isTopicVisibleInStream', () => {
@@ -66,6 +73,10 @@ describe('getters', () => {
 
     test('with topic unmuted', () => {
       check(makeMuteState([[eg.stream, 'topic', UserTopicVisibilityPolicy.Unmuted]]), true);
+    });
+
+    test('with topic followed', () => {
+      check(makeMuteState([[eg.stream, 'topic', UserTopicVisibilityPolicy.Followed]]), true);
     });
   });
 
@@ -90,6 +101,10 @@ describe('getters', () => {
       check(false, UserTopicVisibilityPolicy.Unmuted, true);
     });
 
+    test('stream unmuted, topic-policy Followed', () => {
+      check(false, UserTopicVisibilityPolicy.Followed, true);
+    });
+
     test('stream muted, topic-policy None', () => {
       check(true, UserTopicVisibilityPolicy.None, false);
     });
@@ -100,6 +115,10 @@ describe('getters', () => {
 
     test('stream muted, topic-policy Unmuted', () => {
       check(true, UserTopicVisibilityPolicy.Unmuted, true);
+    });
+
+    test('stream muted, topic-policy Followed', () => {
+      check(true, UserTopicVisibilityPolicy.Followed, true);
     });
   });
 });

--- a/src/mute/muteModel.js
+++ b/src/mute/muteModel.js
@@ -62,6 +62,7 @@ export function isTopicVisibleInStream(streamId: number, topic: string, mute: Mu
     case UserTopicVisibilityPolicy.Muted:
       return false;
     case UserTopicVisibilityPolicy.Unmuted:
+    case UserTopicVisibilityPolicy.Followed:
       return true;
   }
 }
@@ -89,6 +90,7 @@ export function isTopicVisible(
     case UserTopicVisibilityPolicy.Muted:
       return false;
     case UserTopicVisibilityPolicy.Unmuted:
+    case UserTopicVisibilityPolicy.Followed:
       return true;
   }
 }

--- a/src/storage/__tests__/migrations-test.js
+++ b/src/storage/__tests__/migrations-test.js
@@ -105,7 +105,7 @@ describe('migrations', () => {
   // What `base` becomes after all migrations.
   const endBase = {
     ...base52,
-    migrations: { version: 59 },
+    migrations: { version: 60 },
   };
 
   for (const [desc, before, after] of [
@@ -128,9 +128,9 @@ describe('migrations', () => {
     // redundant with this one, because none of the migration steps notice
     // whether any properties outside `storeKeys` are present or not.
     [
-      'check dropCache at 59',
+      'check dropCache at 60',
       // Just before the `dropCache`, plus a `cacheKeys` property, plus junk.
-      { ...base52, migrations: { version: 58 }, mute: [], nonsense: [1, 2, 3] },
+      { ...base52, migrations: { version: 59 }, mute: [], nonsense: [1, 2, 3] },
       // Should wind up with the same result as without the extra properties.
       endBase,
     ],

--- a/src/storage/migrations.js
+++ b/src/storage/migrations.js
@@ -514,6 +514,9 @@ const migrationsInner: {| [string]: (LessPartialState) => LessPartialState |} = 
 
   // Changed `state.presence` (twice), but no migration because that's in `discardKeys`.
 
+  // Discard invalid enum values from `state.mute`.
+  '60': dropCache,
+
   // TIP: When adding a migration, consider just using `dropCache`.
   //   (See its jsdoc for guidance on when that's the right answer.)
 };


### PR DESCRIPTION
Fixes: #5769

This resolves the regression we would otherwise have when the server goes ahead with sending these. Our fallback behavior for values we don't recognize in the `user_topic` visibility policy (https://zulip.com/api/get-events#user_topic) is to treat them as not having a policy for that topic; which means that a followed topic in a muted stream would be treated as still muted, instead of unmuted.

There's still more to be done to fully implement this feature; that's tracked separately at #5770 and #5771.
