### PR TITLE
NotifTroubleshootingScreen: Make email-sent log line actually reach Sentry

### DIFF
--- a/src/settings/NotifTroubleshootingScreen.js
+++ b/src/settings/NotifTroubleshootingScreen.js
@@ -408,7 +408,7 @@ export default function NotifTroubleshootingScreen(props: Props): React.Node {
         break;
       case MailComposer.MailComposerStatus.SENT:
         showToast(_('Email sent'));
-        logging.info('NotifTroubleshootingScreen: MailComposer reports a sent email.');
+        logging.warn('NotifTroubleshootingScreen: MailComposer reports a sent email.');
         break;
       case MailComposer.MailComposerStatus.UNDETERMINED:
         logging.warn('MailComposerStatus.UNDETERMINED');


### PR DESCRIPTION
An alternative approach to #5720, to help us detect potential cases where the user thought they'd contacted support through the app, but we don't see an email on our side. (We're not aware of such cases yet, but in principle it could happen.)

It seems probably fine to do it at the "warn" level rather than "info". If someone sends one of these emails, it usually means something's not quite right with notifications somewhere, making "warn" probably at least as appropriate as "info" in more cases than not.