### PR TITLE
Re-re-enable Sentry on Android, this time with no libsentry.so

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -201,6 +201,14 @@ android {
     }
 }
 
+// Disable all Sentry's native code.  This doesn't seem to impair
+// Sentry's reporting of JVM or JS exceptions.  Suggested by
+// upstream:
+//   https://github.com/getsentry/sentry-java/issues/2955#issuecomment-1765732363
+configurations.configureEach {
+  exclude group: "io.sentry", module: "sentry-android-ndk"
+}
+
 repositories {
     mavenCentral()
 }

--- a/docs/howto/release.md
+++ b/docs/howto/release.md
@@ -102,9 +102,12 @@ simple terminology for the process we follow with both.
   tools/checkout-keystore
   ```
 
-* Do *not* apply the Sentry client key from the `release-secrets`
-  branch; if you're already on that branch (from e.g. making the iOS
-  build), move off of it.  See our issues #5757 and #5766.
+* Apply the Sentry client key (using the local branch created for this
+  in initial setup):
+
+  ```
+  git rebase @ release-secrets
+  ```
 
 * Build the app, as both good old-fashioned APKs and a fancy new AAB:
 

--- a/tools/android
+++ b/tools/android
@@ -64,16 +64,14 @@ do_apk() {
     check_yarn_link
     run_visibly yarn
 
-    # TODO(#5766): start passing -Psentry again
-    run_visibly tools/gradle :app:assembleRelease -Psigned
+    run_visibly tools/gradle :app:assembleRelease -Psigned -Psentry
 }
 
 do_aab() {
     check_yarn_link
     run_visibly yarn
 
-    # TODO(#5766): start passing -Psentry again
-    run_visibly tools/gradle :app:bundleRelease -Psigned
+    run_visibly tools/gradle :app:bundleRelease -Psigned -Psentry
 }
 
 case "${action}" in


### PR DESCRIPTION
Fixes #5782.

I've tested, on a build with these changes and Sentry enabled, that:

 * The APK is free of any native libraries that have an obvious
   relationship to Sentry, in particular `libsentry.so` and
   `libsentry-android.so` which appear without this change.

 * In brief manual testing of the app, nothing goes obviously wrong.
   So at least Sentry doesn't, say, cause a crash at startup whenever
   it can't find `libsentry.so`.

 * Upon adding some artificial warnings and errors, they show up in
   the Sentry dashboard.  This includes `logging.warn` in JS; uncaught
   exceptions in JS; `ZLog.w` in Kotlin; and an uncaught exception
   in Kotlin in handling a notification.

   I also tried an uncaught exception in Kotlin in a `@ReactMethod`
   implementation, and that one didn't work.  But I think that's
   mostly React Native's fault, and is likely not a regression:
     https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/re-enabling.20Sentry/near/1654173

The big remaining question to resolve is whether this causes some
crashes in the wild.  Given that the native code is gone, that
isn't real likely; but having been burned before, we'll want to be
a bit cautious, by validating this with a solid beta period.

