### PR TITLE
docs: Replace git stash note with current information.

### DIFF
--- a/docs/howto/push-notifications.md
+++ b/docs/howto/push-notifications.md
@@ -76,7 +76,8 @@ First, three one-time setup steps:
    This matches the default setting for a production install of the
    Zulip server (generated from `zproject/prod_settings_template.py`.)
 
-   You can keep this around via `git stash`.
+   The Zulip server will helpfully print a line on startup to remind
+   you that this settings override file exists.
 
 3. Register your development server with our production bouncer by
    running the following command:


### PR DESCRIPTION
Ideally this change would have been part of a PR containing a48712a48510f7fb299611acc5d8207e2be26ff3 squashed with this, but the GitHub web UI tricked me into merging that change and I don't have permission to force-push to undo that.