### PR TITLE
api types: Update InitialDataRealm and RealmDataForUpdate to FL 237

### DIFF
--- a/src/__tests__/lib/exampleData.js
+++ b/src/__tests__/lib/exampleData.js
@@ -21,7 +21,7 @@ import { randString, randInt } from '../../utils/misc';
 import { makeUserId } from '../../api/idTypes';
 import type { InitialData } from '../../api/apiTypes';
 import { EventTypes, type UpdateMessageEvent } from '../../api/eventTypes';
-import { CreateWebPublicStreamPolicy, EmailAddressVisibility } from '../../api/permissionsTypes';
+import { CreateWebPublicStreamPolicy } from '../../api/permissionsTypes';
 import type {
   AccountSwitchAction,
   LoginSuccessAction,
@@ -784,7 +784,6 @@ export const action = Object.freeze({
       realm_digest_weekday: 2,
       realm_disallow_disposable_email_addresses: true,
       realm_edit_topic_policy: 3,
-      realm_email_address_visibility: EmailAddressVisibility.Admins,
       realm_email_auth_enabled: true,
       realm_email_changes_disabled: true,
       realm_emails_restricted_to_domains: false,

--- a/src/__tests__/lib/exampleData.js
+++ b/src/__tests__/lib/exampleData.js
@@ -764,7 +764,6 @@ export const action = Object.freeze({
       realm_avatar_changes_disabled: false,
       realm_bot_creation_policy: 3,
       realm_bot_domain: 'example.com',
-      realm_community_topic_editing_limit_seconds: 600,
       realm_create_private_stream_policy: 3,
       realm_create_public_stream_policy: 3,
       realm_create_web_public_stream_policy: CreateWebPublicStreamPolicy.ModeratorOrAbove,

--- a/src/api/initialDataTypes.js
+++ b/src/api/initialDataTypes.js
@@ -231,7 +231,9 @@ export type InitialDataRealm = $ReadOnly<{|
   // TODO(server-5.0): Added in feat. 75, replacing realm_allow_community_topic_editing
   realm_edit_topic_policy?: number,
 
-  realm_email_address_visibility: EmailAddressVisibility,
+  // TODO(server-7.0): Removed in feat. 163
+  realm_email_address_visibility?: EmailAddressVisibility,
+
   realm_email_auth_enabled: boolean,
   realm_email_changes_disabled: boolean,
   realm_emails_restricted_to_domains: boolean,

--- a/src/api/initialDataTypes.js
+++ b/src/api/initialDataTypes.js
@@ -25,6 +25,7 @@ import type {
   EmailAddressVisibility,
 } from './permissionsTypes';
 import type { ZulipVersion } from '../utils/zulipVersion';
+import type { JSONableDict } from '../utils/jsonable';
 
 /*
    The types in this file are organized by which `fetch_event_types` values
@@ -109,7 +110,7 @@ export type AvailableVideoChatProviders = $ReadOnly<{|
   [providerName: string]: $ReadOnly<{| name: string, id: number |}>,
 |}>;
 
-// This is current to feature level 140.
+// This is current to feature level 237.
 export type InitialDataRealm = $ReadOnly<{|
   //
   // Keep alphabetical order. When changing this, also change our type for
@@ -121,7 +122,7 @@ export type InitialDataRealm = $ReadOnly<{|
   // TODO(server-5.0): Added, at feat. 74.
   event_queue_longpoll_timeout_seconds?: number,
 
-  jitsi_server_url?: string, // TODO: Really optional?
+  jitsi_server_url?: string, // deprecated
   max_avatar_file_size_mib: number,
   max_file_upload_size_mib: number,
 
@@ -173,8 +174,11 @@ export type InitialDataRealm = $ReadOnly<{|
   realm_bot_creation_policy: number,
   realm_bot_domain: string,
 
-  // TODO(server-3.0): Added in feat. 11
-  realm_community_topic_editing_limit_seconds?: number,
+  // TODO(server-8.0): Added in feat. 225
+  realm_can_access_all_users_group?: boolean,
+
+  // TODO(server-8.0): Added in feat. 209
+  realm_create_multiuse_invite_group?: number,
 
   // TODO(server-5.0): Added in feat. 102, replacing
   // realm_create_stream_policy for private streams
@@ -194,6 +198,7 @@ export type InitialDataRealm = $ReadOnly<{|
   //   CreateWebPublicStreamPolicy.Nobody.
   realm_create_web_public_stream_policy?: CreateWebPublicStreamPolicy,
 
+  // TODO(server-8.0): In feat. 195+, just `string`, not `string | null`.
   realm_default_code_block_language: string | null,
 
   // TODO(server-2.1): Added in commit 2.1.0-rc1~1382.
@@ -230,6 +235,9 @@ export type InitialDataRealm = $ReadOnly<{|
   realm_email_changes_disabled: boolean,
   realm_emails_restricted_to_domains: boolean,
 
+  // TODO(server-8.0): Added in feat. 216
+  realm_enable_guest_user_indicator?: boolean,
+
   // TODO(server-6.0): Added in feat. 137; if absent, treat as false.
   realm_enable_read_receipts?: boolean,
 
@@ -254,6 +262,10 @@ export type InitialDataRealm = $ReadOnly<{|
 
   realm_invite_to_stream_policy: number,
   realm_is_zephyr_mirror_realm: boolean,
+
+  // TODO(server-8.0): Added in feat. 212
+  realm_jitsi_server_url?: string | null,
+
   realm_logo_source: 'D' | 'U',
   realm_logo_url: string,
   realm_mandatory_topics: boolean,
@@ -274,6 +286,12 @@ export type InitialDataRealm = $ReadOnly<{|
   // TODO(server-4.0): Added in feat. 56
   realm_move_messages_between_streams_policy?: number,
 
+  // TODO(server-7.0): Added in feat. 162
+  realm_move_messages_between_streams_limit_seconds?: number | null,
+
+  // TODO(server-7.0): Added in feat. 162
+  realm_move_messages_within_stream_limit_seconds?: number | null,
+
   realm_name: string,
   realm_name_changes_disabled: boolean,
   realm_night_logo_source: 'D' | 'U',
@@ -288,6 +306,10 @@ export type InitialDataRealm = $ReadOnly<{|
   realm_presence_disabled: boolean,
   realm_private_message_policy: number,
   realm_push_notifications_enabled: boolean,
+
+  // TODO(server-8.0): Added in feat. 231
+  realm_push_notifications_enabled_end_timestamp?: number | null,
+
   realm_send_welcome_emails: boolean,
   realm_signup_notifications_stream_id: number,
 
@@ -318,6 +340,10 @@ export type InitialDataRealm = $ReadOnly<{|
   server_generation: number,
   server_inline_image_preview: boolean,
   server_inline_url_embed_preview: boolean,
+
+  // TODO(server-8.0): Added in feat. 212
+  server_jitsi_server_url?: string | null,
+
   server_name_changes_disabled: boolean,
 
   // TODO(server-5.0): Added in feat. 74
@@ -330,6 +356,18 @@ export type InitialDataRealm = $ReadOnly<{|
   // Use 60 when absent.
   // TODO(server-7.0): Added in feat. 164. (Remove comment about using 60.)
   server_presence_ping_interval_seconds?: number,
+
+  // TODO(server-8.0): Added in feat. 221
+  server_supported_permission_settings?: JSONableDict, // unstable
+
+  // TODO(server-8.0): Added in feat. 204
+  server_typing_started_expiry_period_milliseconds?: number,
+
+  // TODO(server-8.0): Added in feat. 204
+  server_typing_started_wait_period_milliseconds?: number,
+
+  // TODO(server-8.0): Added in feat. 204
+  server_typing_stopped_wait_period_milliseconds?: number,
 
   // TODO(server-5.0): Added in feat. 110; if absent, treat as false.
   server_web_public_streams_enabled?: boolean,

--- a/src/api/initialDataTypes.js
+++ b/src/api/initialDataTypes.js
@@ -61,14 +61,6 @@ export type RawInitialDataBase = $ReadOnly<{|
    * `zulip_feature_level`, above.
    */
   zulip_version: string,
-
-  /** New in FL 164; use 60 when absent. */
-  // TODO(server-7.0): simplify to always-present
-  server_presence_ping_interval_seconds?: number,
-
-  /** New in FL 164; use 140 when absent. */
-  // TODO(server-7.0): simplify to always-present
-  server_presence_offline_threshold_seconds?: number,
 |}>;
 
 /**
@@ -330,6 +322,14 @@ export type InitialDataRealm = $ReadOnly<{|
 
   // TODO(server-5.0): Added in feat. 74
   server_needs_upgrade?: boolean,
+
+  // Use 140 when absent.
+  // TODO(server-7.0): Added in feat. 164. (Remove comment about using 140.)
+  server_presence_offline_threshold_seconds?: number,
+
+  // Use 60 when absent.
+  // TODO(server-7.0): Added in feat. 164. (Remove comment about using 60.)
+  server_presence_ping_interval_seconds?: number,
 
   // TODO(server-5.0): Added in feat. 110; if absent, treat as false.
   server_web_public_streams_enabled?: boolean,

--- a/src/api/realmDataTypes.js
+++ b/src/api/realmDataTypes.js
@@ -12,7 +12,7 @@ import type { InitialDataRealm } from './initialDataTypes';
  * start with "realm_"). But we expect the values to be typed the same.
  */
 /* prettier-ignore */
-// Current to FL 140.
+// Current to FL 237.
 export type RealmDataForUpdate = $ReadOnly<{
   //
   // Keep alphabetical by the InitialDataRealm property. So by
@@ -35,8 +35,10 @@ export type RealmDataForUpdate = $ReadOnly<{
     InitialDataRealm['realm_authentication_methods'],
   bot_creation_policy:
     InitialDataRealm['realm_bot_creation_policy'],
-  community_topic_editing_limit_seconds:
-    InitialDataRealm['realm_community_topic_editing_limit_seconds'],
+  can_access_all_users_group:
+    InitialDataRealm['realm_can_access_all_users_group'],
+  create_multiuse_invite_group:
+    InitialDataRealm['realm_create_multiuse_invite_group'],
   create_private_stream_policy:
     InitialDataRealm['realm_create_private_stream_policy'],
   create_public_stream_policy:
@@ -65,6 +67,8 @@ export type RealmDataForUpdate = $ReadOnly<{
     InitialDataRealm['realm_email_changes_disabled'],
   emails_restricted_to_domains:
     InitialDataRealm['realm_emails_restricted_to_domains'],
+  enable_guest_user_indicator:
+    InitialDataRealm['realm_enable_guest_user_indicator'],
   enable_read_receipts:
     InitialDataRealm['realm_enable_read_receipts'],
   enable_spectator_access:
@@ -87,6 +91,8 @@ export type RealmDataForUpdate = $ReadOnly<{
     InitialDataRealm['realm_invite_to_realm_policy'],
   invite_to_stream_policy:
     InitialDataRealm['realm_invite_to_stream_policy'],
+  jitsi_server_url:
+    InitialDataRealm['realm_jitsi_server_url'],
   logo_source:
     InitialDataRealm['realm_logo_source'],
   logo_url:
@@ -101,6 +107,10 @@ export type RealmDataForUpdate = $ReadOnly<{
     InitialDataRealm['realm_message_content_edit_limit_seconds'],
   move_messages_between_streams_policy:
     InitialDataRealm['realm_move_messages_between_streams_policy'],
+  move_messages_between_streams_limit_seconds:
+    InitialDataRealm['realm_move_messages_between_streams_limit_seconds'],
+  move_messages_within_stream_limit_seconds:
+    InitialDataRealm['realm_move_messages_within_stream_limit_seconds'],
   name:
     InitialDataRealm['realm_name'],
   name_changes_disabled:
@@ -111,12 +121,18 @@ export type RealmDataForUpdate = $ReadOnly<{
     InitialDataRealm['realm_night_logo_url'],
   notifications_stream_id:
     InitialDataRealm['realm_notifications_stream_id'],
+  org_type:
+    InitialDataRealm['realm_org_type'],
   plan_type:
     InitialDataRealm['realm_plan_type'],
   presence_disabled:
     InitialDataRealm['realm_presence_disabled'],
   private_message_policy:
     InitialDataRealm['realm_private_message_policy'],
+  push_notifications_enabled:
+    InitialDataRealm['realm_push_notifications_enabled'],
+  push_notifications_enabled_end_timestamp:
+    InitialDataRealm['realm_push_notifications_enabled_end_timestamp'],
   send_welcome_emails:
     InitialDataRealm['realm_send_welcome_emails'],
   signup_notifications_stream_id:

--- a/src/api/realmDataTypes.js
+++ b/src/api/realmDataTypes.js
@@ -59,7 +59,7 @@ export type RealmDataForUpdate = $ReadOnly<{
     InitialDataRealm['realm_disallow_disposable_email_addresses'],
   edit_topic_policy:
     InitialDataRealm['realm_edit_topic_policy'],
-  email_address_visibility:
+  email_address_visibility: // removed in feat. 163
     InitialDataRealm['realm_email_address_visibility'],
   email_changes_disabled:
     InitialDataRealm['realm_email_changes_disabled'],

--- a/src/realm/__tests__/realmReducer-test.js
+++ b/src/realm/__tests__/realmReducer-test.js
@@ -68,7 +68,7 @@ describe('realmReducer', () => {
         waitingPeriodThreshold: action.data.realm_waiting_period_threshold,
         allowEditHistory: action.data.realm_allow_edit_history,
         enableReadReceipts: action.data.realm_enable_read_receipts,
-        emailAddressVisibility: action.data.realm_email_address_visibility,
+        emailAddressVisibility: null,
 
         //
         // InitialDataRealmUser

--- a/src/realm/realmReducer.js
+++ b/src/realm/realmReducer.js
@@ -8,7 +8,6 @@ import type {
 import {
   CreatePublicOrPrivateStreamPolicy,
   CreateWebPublicStreamPolicy,
-  EmailAddressVisibility,
 } from '../api/permissionsTypes';
 import { EventTypes } from '../api/eventTypes';
 import {
@@ -53,7 +52,7 @@ const initialState = {
   waitingPeriodThreshold: 90,
   allowEditHistory: false,
   enableReadReceipts: false,
-  emailAddressVisibility: EmailAddressVisibility.Admins,
+  emailAddressVisibility: null,
 
   //
   // InitialDataRealmUser
@@ -165,7 +164,7 @@ export default (
         waitingPeriodThreshold: action.data.realm_waiting_period_threshold,
         allowEditHistory: action.data.realm_allow_edit_history,
         enableReadReceipts: action.data.realm_enable_read_receipts ?? false,
-        emailAddressVisibility: action.data.realm_email_address_visibility,
+        emailAddressVisibility: action.data.realm_email_address_visibility ?? null,
 
         //
         // InitialDataRealmUser

--- a/src/reduxTypes.js
+++ b/src/reduxTypes.js
@@ -310,7 +310,7 @@ export type RealmState = {|
   +waitingPeriodThreshold: number,
   +allowEditHistory: boolean,
   +enableReadReceipts: boolean,
-  +emailAddressVisibility: EmailAddressVisibility,
+  +emailAddressVisibility: EmailAddressVisibility | null,
 
   //
   // InitialDataRealmUser

--- a/src/storage/__tests__/migrations-test.js
+++ b/src/storage/__tests__/migrations-test.js
@@ -105,7 +105,7 @@ describe('migrations', () => {
   // What `base` becomes after all migrations.
   const endBase = {
     ...base52,
-    migrations: { version: 60 },
+    migrations: { version: 61 },
   };
 
   for (const [desc, before, after] of [
@@ -128,9 +128,9 @@ describe('migrations', () => {
     // redundant with this one, because none of the migration steps notice
     // whether any properties outside `storeKeys` are present or not.
     [
-      'check dropCache at 60',
+      'check dropCache at 61',
       // Just before the `dropCache`, plus a `cacheKeys` property, plus junk.
-      { ...base52, migrations: { version: 59 }, mute: [], nonsense: [1, 2, 3] },
+      { ...base52, migrations: { version: 60 }, mute: [], nonsense: [1, 2, 3] },
       // Should wind up with the same result as without the extra properties.
       endBase,
     ],

--- a/src/storage/migrations.js
+++ b/src/storage/migrations.js
@@ -517,6 +517,9 @@ const migrationsInner: {| [string]: (LessPartialState) => LessPartialState |} = 
   // Discard invalid enum values from `state.mute`.
   '60': dropCache,
 
+  // Fix emailAddressVisibility accidentally being undefined/dropped
+  '61': dropCache,
+
   // TIP: When adding a migration, consider just using `dropCache`.
   //   (See its jsdoc for guidance on when that's the right answer.)
 };

--- a/src/users/userSelectors.js
+++ b/src/users/userSelectors.js
@@ -323,9 +323,7 @@ export function getDisplayEmailForUser(realm: RealmState, user: UserOrBot): stri
   if (user.delivery_email !== undefined) {
     return user.delivery_email;
   } else if (realm.emailAddressVisibility === EmailAddressVisibility.Everyone) {
-    // On future servers, we expect this case will never happen: we'll always include
-    // a delivery_email when you have access, including when the visibility is Everyone
-    // https://github.com/zulip/zulip-mobile/pull/5515#discussion_r997731727
+    // TODO(server-7.0): Not reached on FL 163+, where delivery_email is always present.
     return user.email;
   } else {
     return null;


### PR DESCRIPTION
We can use this for #5804 and #5805.

-----

Four of the nine added `/register`-response fields seem to have a small documentation issue: https://chat.zulip.org/#narrow/stream/412-api-documentation/topic/.60.2Fregister.60.3A.20fields.20missing.20.22Present.20if.20.5B.E2.80.A6.5D.22.3F/near/1707782

For three of them, I didn't find them mentioned in `#api design`:

`realm_can_access_all_users_group`
`realm_create_multiuse_invite_group`
`realm_move_messages_between_streams_limit_seconds`