### PR TITLE
Show "(guest)" by guest users' names, when setting enabled

### DIFF
--- a/src/__tests__/lib/exampleData.js
+++ b/src/__tests__/lib/exampleData.js
@@ -131,6 +131,7 @@ type UserOrBotPropertiesArgs = {|
   email?: string,
   full_name?: string,
   avatar_url?: AvatarURL,
+  role?: Role,
 |};
 
 /**
@@ -161,7 +162,7 @@ const userOrBotProperties = (args: UserOrBotPropertiesArgs) => {
 
     email: args.email ?? `${randName}@example.org`,
     full_name: args.full_name ?? `${randName} User`,
-    role: Role.Member,
+    role: args.role ?? Role.Member,
     timezone: 'UTC',
     user_id,
   });

--- a/src/__tests__/lib/exampleData.js
+++ b/src/__tests__/lib/exampleData.js
@@ -21,7 +21,7 @@ import { randString, randInt } from '../../utils/misc';
 import { makeUserId } from '../../api/idTypes';
 import type { InitialData } from '../../api/apiTypes';
 import { EventTypes, type UpdateMessageEvent } from '../../api/eventTypes';
-import { CreateWebPublicStreamPolicy } from '../../api/permissionsTypes';
+import { CreateWebPublicStreamPolicy, Role } from '../../api/permissionsTypes';
 import type {
   AccountSwitchAction,
   LoginSuccessAction,
@@ -161,7 +161,7 @@ const userOrBotProperties = (args: UserOrBotPropertiesArgs) => {
 
     email: args.email ?? `${randName}@example.org`,
     full_name: args.full_name ?? `${randName} User`,
-    is_admin: false,
+    role: Role.Member,
     timezone: 'UTC',
     user_id,
   });
@@ -175,8 +175,6 @@ export const makeUser = (args: UserOrBotPropertiesArgs = Object.freeze({})): Use
     is_bot: false,
     bot_type: null,
     // bot_owner omitted
-
-    is_guest: false,
     profile_data: {},
   });
 
@@ -860,10 +858,7 @@ export const action = Object.freeze({
       can_create_web_public_streams: false,
       can_subscribe_other_users: false,
       can_invite_others_to_realm: false,
-
-      // $FlowIgnore[cannot-read]: Faithfully representing what servers send
-      is_admin: selfUser.is_admin,
-
+      is_admin: false,
       is_owner: false,
       is_billing_admin: selfUser.is_billing_admin,
       is_moderator: false,

--- a/src/__tests__/lib/intl.js
+++ b/src/__tests__/lib/intl.js
@@ -3,4 +3,17 @@
 import type { GetText } from '../../types';
 
 // Our translation function, usually given the name _.
-export const mock_: GetText = m => (typeof m === 'object' ? m.text : m); // eslint-disable-line no-underscore-dangle
+// eslint-disable-next-line no-underscore-dangle
+export const mock_: GetText = m => {
+  if (typeof m === 'object') {
+    if (m.text === '{_}') {
+      // $FlowIgnore[incompatible-indexer]
+      /* $FlowIgnore[incompatible-cast]
+         We expect an `m.values` that corresponds to `m.text`. */
+      const values = (m.values: {| +_: string |});
+      return values._;
+    }
+    return m.text;
+  }
+  return m;
+};

--- a/src/__tests__/lib/intl.js
+++ b/src/__tests__/lib/intl.js
@@ -1,0 +1,6 @@
+/* @flow strict-local */
+
+import type { GetText } from '../../types';
+
+// Our translation function, usually given the name _.
+export const mock_: GetText = m => (typeof m === 'object' ? m.text : m); // eslint-disable-line no-underscore-dangle

--- a/src/account-info/AccountDetails.js
+++ b/src/account-info/AccountDetails.js
@@ -16,8 +16,6 @@ import PresenceStatusIndicator from '../common/PresenceStatusIndicator';
 import { getDisplayEmailForUser } from '../selectors';
 import { Role } from '../api/permissionsTypes';
 import ZulipTextIntl from '../common/ZulipTextIntl';
-import { getOwnUserId } from '../users/userSelectors';
-import { getOwnUserRole } from '../permissionSelectors';
 
 const componentStyles = createStyleSheet({
   componentListItem: {
@@ -71,16 +69,6 @@ export default function AccountDetails(props: Props): Node {
   );
   const realm = useSelector(state => state.realm);
   const displayEmail = getDisplayEmailForUser(realm, user);
-  const ownUserId = useSelector(getOwnUserId);
-  const ownUserRole = useSelector(getOwnUserRole);
-
-  // user.role will be missing when the server has feature level <59. For
-  // those old servers, we can use getOwnUserRole for the "own" (or "self")
-  // user's role, but nothing will give us the role of a non-"own" user, so
-  // we just won't show any role in that case.
-  // TODO(server-4.0): user.role will never be missing; use that for "own"
-  //   and non-"own" users.
-  const role = user.user_id === ownUserId ? ownUserRole : user.role;
 
   return (
     <ComponentList outerSpacing itemStyle={componentStyles.componentListItem}>
@@ -105,14 +93,9 @@ export default function AccountDetails(props: Props): Node {
           <ZulipText selectable style={styles.largerText} text={displayEmail} />
         </View>
       )}
-      {
-        // TODO(server-4.0): Remove conditional; we'll always know the role.
-        role != null && (
-          <View>
-            <ZulipTextIntl selectable style={styles.largerText} text={getRoleText(role)} />
-          </View>
-        )
-      }
+      <View>
+        <ZulipTextIntl selectable style={styles.largerText} text={getRoleText(user.role)} />
+      </View>
       {showStatus && (
         <View style={componentStyles.statusWrapper}>
           {userStatusEmoji && (

--- a/src/account-info/AccountDetails.js
+++ b/src/account-info/AccountDetails.js
@@ -16,7 +16,7 @@ import PresenceStatusIndicator from '../common/PresenceStatusIndicator';
 import { getDisplayEmailForUser } from '../selectors';
 import { Role } from '../api/permissionsTypes';
 import ZulipTextIntl from '../common/ZulipTextIntl';
-import { getFullNameText } from '../users/userSelectors';
+import { getFullNameReactText } from '../users/userSelectors';
 
 const componentStyles = createStyleSheet({
   componentListItem: {
@@ -69,6 +69,7 @@ export default function AccountDetails(props: Props): Node {
     state => getUserStatus(state, props.user.user_id).status_emoji,
   );
   const realm = useSelector(state => state.realm);
+  const { enableGuestUserIndicator } = realm;
   const displayEmail = getDisplayEmailForUser(realm, user);
 
   return (
@@ -86,7 +87,7 @@ export default function AccountDetails(props: Props): Node {
         <ZulipTextIntl
           selectable
           style={[styles.largerText, componentStyles.boldText]}
-          text={getFullNameText({ user })}
+          text={getFullNameReactText({ user, enableGuestUserIndicator })}
         />
       </View>
       {displayEmail !== null && showEmail && (

--- a/src/account-info/AccountDetails.js
+++ b/src/account-info/AccountDetails.js
@@ -16,6 +16,7 @@ import PresenceStatusIndicator from '../common/PresenceStatusIndicator';
 import { getDisplayEmailForUser } from '../selectors';
 import { Role } from '../api/permissionsTypes';
 import ZulipTextIntl from '../common/ZulipTextIntl';
+import { getFullNameText } from '../users/userSelectors';
 
 const componentStyles = createStyleSheet({
   componentListItem: {
@@ -82,10 +83,10 @@ export default function AccountDetails(props: Props): Node {
           hideIfOffline={false}
           useOpaqueBackground={false}
         />
-        <ZulipText
+        <ZulipTextIntl
           selectable
           style={[styles.largerText, componentStyles.boldText]}
-          text={user.full_name}
+          text={getFullNameText({ user })}
         />
       </View>
       {displayEmail !== null && showEmail && (

--- a/src/account-info/AccountDetailsScreen.js
+++ b/src/account-info/AccountDetailsScreen.js
@@ -83,7 +83,7 @@ export default function AccountDetailsScreen(props: Props): Node {
     text: '{_}',
     values: {
       // This causes the name not to get translated.
-      _: user.full_name || ' ',
+      _: user.full_name,
     },
   };
 

--- a/src/account-info/AccountDetailsScreen.js
+++ b/src/account-info/AccountDetailsScreen.js
@@ -18,7 +18,7 @@ import AccountDetails from './AccountDetails';
 import ZulipText from '../common/ZulipText';
 import ActivityText from '../title/ActivityText';
 import { doNarrow } from '../actions';
-import { getUserIsActive, tryGetUserForId } from '../users/userSelectors';
+import { getFullNameText, getUserIsActive, tryGetUserForId } from '../users/userSelectors';
 import { nowInTimeZone } from '../utils/date';
 import CustomProfileFields from './CustomProfileFields';
 
@@ -79,16 +79,8 @@ export default function AccountDetailsScreen(props: Props): Node {
     }
   }
 
-  const title = {
-    text: '{_}',
-    values: {
-      // This causes the name not to get translated.
-      _: user.full_name,
-    },
-  };
-
   return (
-    <Screen title={title}>
+    <Screen title={getFullNameText({ user })}>
       <AccountDetails user={user} showEmail showStatus />
       <View style={styles.itemWrapper}>
         <ActivityText style={globalStyles.largerText} user={user} />

--- a/src/account-info/AccountDetailsScreen.js
+++ b/src/account-info/AccountDetailsScreen.js
@@ -18,9 +18,10 @@ import AccountDetails from './AccountDetails';
 import ZulipText from '../common/ZulipText';
 import ActivityText from '../title/ActivityText';
 import { doNarrow } from '../actions';
-import { getFullNameText, getUserIsActive, tryGetUserForId } from '../users/userSelectors';
+import { getFullNameReactText, getUserIsActive, tryGetUserForId } from '../users/userSelectors';
 import { nowInTimeZone } from '../utils/date';
 import CustomProfileFields from './CustomProfileFields';
+import { getRealm } from '../directSelectors';
 
 const styles = createStyleSheet({
   errorText: {
@@ -54,6 +55,7 @@ export default function AccountDetailsScreen(props: Props): Node {
   const dispatch = useDispatch();
   const user = useSelector(state => tryGetUserForId(state, props.route.params.userId));
   const isActive = useSelector(state => getUserIsActive(state, props.route.params.userId));
+  const enableGuestUserIndicator = useSelector(state => getRealm(state).enableGuestUserIndicator);
 
   const handleChatPress = useCallback(() => {
     invariant(user, 'Callback handleChatPress is used only if user is known');
@@ -80,7 +82,7 @@ export default function AccountDetailsScreen(props: Props): Node {
   }
 
   return (
-    <Screen title={getFullNameText({ user })}>
+    <Screen title={getFullNameReactText({ user, enableGuestUserIndicator })}>
       <AccountDetails user={user} showEmail showStatus />
       <View style={styles.itemWrapper}>
         <ActivityText style={globalStyles.largerText} user={user} />

--- a/src/account-info/CustomProfileFields.js
+++ b/src/account-info/CustomProfileFields.js
@@ -5,10 +5,8 @@ import { View } from 'react-native';
 import { type UserOrBot, type UserId } from '../api/modelTypes';
 import WebLink from '../common/WebLink';
 import ZulipText from '../common/ZulipText';
-import ZulipTextIntl from '../common/ZulipTextIntl';
 import { ensureUnreachable } from '../generics';
 import { useSelector } from '../react-redux';
-import { tryGetUserForId } from '../selectors';
 import {
   type CustomProfileFieldValue,
   getCustomProfileFieldsForUser,
@@ -16,15 +14,12 @@ import {
 import UserItem from '../users/UserItem';
 import { useNavigation } from '../react-navigation';
 
-/* eslint-disable no-shadow */
-
 type Props = {|
   +user: UserOrBot,
 |};
 
 function CustomProfileFieldUser(props: {| +userId: UserId |}): React.Node {
   const { userId } = props;
-  const user = useSelector(state => tryGetUserForId(state, userId));
 
   const navigation = useNavigation();
   const onPress = React.useCallback(
@@ -33,10 +28,6 @@ function CustomProfileFieldUser(props: {| +userId: UserId |}): React.Node {
     },
     [navigation],
   );
-
-  if (!user) {
-    return <ZulipTextIntl text="(unknown user)" />;
-  }
 
   return <UserItem userId={userId} onPress={onPress} size="medium" />;
 }

--- a/src/account-info/ProfileScreen.js
+++ b/src/account-info/ProfileScreen.js
@@ -6,6 +6,7 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 
 import { type UserId } from '../api/idTypes';
 import { TranslationContext } from '../boot/TranslationProvider';
+import { noTranslation } from '../i18n/i18n';
 import type { RouteProp } from '../react-navigation';
 import type { MainTabsNavigationProp } from '../main/MainTabsScreen';
 import { createStyleSheet } from '../styles';
@@ -146,7 +147,7 @@ export default function ProfileScreen(props: Props): Node {
               : undefined
           }
           title="Set your status"
-          subtitle={status_text != null ? { text: '{_}', values: { _: status_text } } : undefined}
+          subtitle={status_text != null ? noTranslation(status_text) : undefined}
           onPress={() => {
             navigation.push('user-status');
           }}

--- a/src/action-sheets/index.js
+++ b/src/action-sheets/index.js
@@ -47,6 +47,7 @@ import { roleIsAtLeast } from '../permissionSelectors';
 import { kNotificationBotEmail } from '../api/constants';
 import type { AppNavigationMethods } from '../nav/AppNavigator';
 import { type ImperativeHandle as ComposeBoxImperativeHandle } from '../compose/ComposeBox';
+import { getFullNameText } from '../users/userSelectors';
 
 // TODO really this belongs in a libdef.
 export type ShowActionSheetWithOptions = (
@@ -1011,7 +1012,7 @@ export const showPmConversationActionSheet = (args: {|
       .map(userId => {
         const user = backgroundData.allUsersById.get(userId);
         invariant(user, 'allUsersById incomplete; could not show PM action sheet');
-        return user.full_name;
+        return callbacks._(getFullNameText({ user }));
       })
       .sort()
       .join(', '),

--- a/src/action-sheets/index.js
+++ b/src/action-sheets/index.js
@@ -999,10 +999,16 @@ export const showPmConversationActionSheet = (args: {|
     navigation: AppNavigationMethods,
     _: GetText,
   |},
-  backgroundData: $ReadOnly<{ ownUser: User, allUsersById: Map<UserId, UserOrBot>, ... }>,
+  backgroundData: $ReadOnly<{
+    ownUser: User,
+    allUsersById: Map<UserId, UserOrBot>,
+    enableGuestUserIndicator: boolean,
+    ...
+  }>,
   pmKeyRecipients: PmKeyRecipients,
 |}): void => {
   const { showActionSheetWithOptions, callbacks, backgroundData, pmKeyRecipients } = args;
+  const { enableGuestUserIndicator } = backgroundData;
   showActionSheet({
     showActionSheetWithOptions,
     // TODO(ios-14.5): Check for Intl.ListFormat support in all environments
@@ -1012,7 +1018,7 @@ export const showPmConversationActionSheet = (args: {|
       .map(userId => {
         const user = backgroundData.allUsersById.get(userId);
         invariant(user, 'allUsersById incomplete; could not show PM action sheet');
-        return callbacks._(getFullNameText({ user }));
+        return callbacks._(getFullNameText({ user, enableGuestUserIndicator }));
       })
       .sort()
       .join(', '),

--- a/src/api/modelTypes.js
+++ b/src/api/modelTypes.js
@@ -287,14 +287,6 @@ export type User = {|
   // FL 121. The doc wrongly says it always appears. See
   //   https://chat.zulip.org/#narrow/stream/412-api-documentation/topic/.60is_active.60.20in.20.60.2Fregister.60.20response/near/1371606
 
-  // Deprecated (by us); these don't have events to update them. Use the
-  // `role` property when available. For the self user, use getOwnUserRole,
-  // which has a fallback for when `role` is absent.
-  // TODO(server-4.0): Remove these and rely on `role`.
-  -is_owner?: boolean, // TODO(server-3.0): New in FL 8
-  -is_admin: boolean,
-  -is_guest?: boolean, // TODO(server-1.9): New; if absent, treat as false.
-
   // TODO(server-5.0): New in FL 73
   +is_billing_admin?: boolean,
 
@@ -311,8 +303,7 @@ export type User = {|
   // TODO(server-3.0): Replaced in FL 1 by bot_owner_id
   +bot_owner?: string,
 
-  // TODO(server-4.0): New in FL 59
-  +role?: Role,
+  +role: Role,
 
   // The ? is for future-proofing. Greg explains in 2020-02, at
   // https://github.com/zulip/zulip-mobile/pull/3789#discussion_r378554698 ,
@@ -373,13 +364,6 @@ export type CrossRealmBot = {|
   // FL 121. The doc wrongly says it always appears. See
   //   https://chat.zulip.org/#narrow/stream/412-api-documentation/topic/.60is_active.60.20in.20.60.2Fregister.60.20response/near/1371606
 
-  // Deprecated (by us); these don't have events to update them. Use the
-  // `role` property when available.
-  // TODO(server-4.0): Remove these and rely on `role`.
-  -is_owner?: boolean, // TODO(server-3.0): New in FL 8
-  -is_admin: boolean,
-  -is_guest?: boolean, // TODO(server-1.9): New; if absent, treat as false.
-
   // TODO(server-5.0): New in FL 73
   +is_billing_admin?: boolean,
 
@@ -399,8 +383,7 @@ export type CrossRealmBot = {|
   // TODO(server-3.0): Replaced in FL 1 by bot_owner_id
   // +bot_owner?: string,
 
-  // TODO(server-4.0): New in FL 59
-  +role?: Role,
+  +role: Role,
 
   // The ? is for future-proofing.  For bots it's always '':
   //   https://github.com/zulip/zulip-mobile/pull/3789#issuecomment-581218576

--- a/src/common/SelectableOptionsScreen.js
+++ b/src/common/SelectableOptionsScreen.js
@@ -12,6 +12,7 @@ import SelectableOptionRow from './SelectableOptionRow';
 import ZulipTextIntl from './ZulipTextIntl';
 import { createStyleSheet } from '../styles';
 import { TranslationContext } from '../boot/TranslationProvider';
+import { noTranslation } from '../i18n/i18n';
 
 type Item<TKey> = $ReadOnly<{|
   key: TKey,
@@ -100,9 +101,9 @@ export default function SelectableOptionsScreen<TItemKey: string | number>(
 
           /* eslint-disable prefer-template */
           const itemData =
-            _(item.subtitle ?? { text: '{_}', values: { _: '' } }).toUpperCase()
+            _(item.subtitle ?? noTranslation('')).toUpperCase()
             + ' '
-            + _(item.title ?? { text: '{_}', values: { _: '' } }).toUpperCase();
+            + _(item.title ?? noTranslation('')).toUpperCase();
           /* eslint-enable prefer-template */
 
           const filterData = filter.toUpperCase();

--- a/src/common/ServerCompatBanner.js
+++ b/src/common/ServerCompatBanner.js
@@ -5,12 +5,13 @@ import type { Node } from 'react';
 
 import ZulipBanner from './ZulipBanner';
 import { useSelector, useGlobalSelector, useDispatch } from '../react-redux';
+import { getOwnUser } from '../selectors';
 import { getIdentity, getServerVersion } from '../account/accountsSelectors';
 import { getSession, getGlobalSettings } from '../directSelectors';
 import { dismissCompatNotice } from '../session/sessionActions';
 import { openLinkWithUserPreference } from '../utils/openLink';
 import { ZulipVersion } from '../utils/zulipVersion';
-import { getOwnUserRole, roleIsAtLeast } from '../permissionSelectors';
+import { roleIsAtLeast } from '../permissionSelectors';
 import { Role } from '../api/permissionsTypes';
 
 /**
@@ -52,7 +53,7 @@ export default function ServerCompatBanner(props: Props): Node {
   );
   const zulipVersion = useSelector(getServerVersion);
   const realm = useSelector(state => getIdentity(state).realm);
-  const isAtLeastAdmin = useSelector(state => roleIsAtLeast(getOwnUserRole(state), Role.Admin));
+  const isAtLeastAdmin = useSelector(state => roleIsAtLeast(getOwnUser(state).role, Role.Admin));
   const settings = useGlobalSelector(getGlobalSettings);
 
   let visible = false;

--- a/src/compose/ComposeBox.js
+++ b/src/compose/ComposeBox.js
@@ -714,7 +714,7 @@ const ComposeBox: React$AbstractComponent<Props, ImperativeHandle> = forwardRef(
     return <AnnouncementOnly />;
   }
 
-  const placeholder = getComposeInputPlaceholder(narrow, ownUserId, allUsersById, streamsById);
+  const placeholder = getComposeInputPlaceholder(narrow, ownUserId, allUsersById, streamsById, _);
 
   const SubmitButtonIcon = isEditing ? IconDone : IconSend;
 

--- a/src/compose/ComposeBox.js
+++ b/src/compose/ComposeBox.js
@@ -196,7 +196,7 @@ const ComposeBox: React$AbstractComponent<Props, ImperativeHandle> = forwardRef(
   const stream = useSelector(state => getStreamInNarrow(state, props.narrow));
   const streamsById = useSelector(getStreamsById);
   const videoChatProvider = useSelector(getVideoChatProvider);
-  const mandatoryTopics = useSelector(state => getRealm(state).mandatoryTopics);
+  const { mandatoryTopics, enableGuestUserIndicator } = useSelector(getRealm);
 
   const mentionWarnings = React.useRef<React$ElementRef<typeof MentionWarnings> | null>(null);
 
@@ -714,7 +714,14 @@ const ComposeBox: React$AbstractComponent<Props, ImperativeHandle> = forwardRef(
     return <AnnouncementOnly />;
   }
 
-  const placeholder = getComposeInputPlaceholder(narrow, ownUserId, allUsersById, streamsById, _);
+  const placeholder = getComposeInputPlaceholder(
+    narrow,
+    ownUserId,
+    allUsersById,
+    streamsById,
+    enableGuestUserIndicator,
+    _,
+  );
 
   const SubmitButtonIcon = isEditing ? IconDone : IconSend;
 

--- a/src/compose/ComposeBox.js
+++ b/src/compose/ComposeBox.js
@@ -51,6 +51,7 @@ import AnnouncementOnly from '../message/AnnouncementOnly';
 import MentionWarnings from './MentionWarnings';
 import {
   getAuth,
+  getOwnUser,
   getStreamInNarrow,
   getStreamsById,
   getVideoChatProvider,
@@ -66,7 +67,7 @@ import AutocompleteView from '../autocomplete/AutocompleteView';
 import { getAllUsersById, getOwnUserId } from '../users/userSelectors';
 import * as api from '../api';
 import { ensureUnreachable } from '../generics';
-import { getOwnUserRole, roleIsAtLeast } from '../permissionSelectors';
+import { roleIsAtLeast } from '../permissionSelectors';
 import { Role } from '../api/permissionsTypes';
 import useUncontrolledInput from '../useUncontrolledInput';
 import { tryFetch } from '../message/fetchActions';
@@ -187,7 +188,7 @@ const ComposeBox: React$AbstractComponent<Props, ImperativeHandle> = forwardRef(
   const zulipFeatureLevel = useSelector(getZulipFeatureLevel);
   const ownUserId = useSelector(getOwnUserId);
   const allUsersById = useSelector(getAllUsersById);
-  const isAtLeastAdmin = useSelector(state => roleIsAtLeast(getOwnUserRole(state), Role.Admin));
+  const isAtLeastAdmin = useSelector(state => roleIsAtLeast(getOwnUser(state).role, Role.Admin));
   const isAnnouncementOnly = useSelector(state =>
     getIsActiveStreamAnnouncementOnly(state, props.narrow),
   );

--- a/src/compose/MentionWarnings.js
+++ b/src/compose/MentionWarnings.js
@@ -14,6 +14,7 @@ import { showToast } from '../utils/info';
 import MentionedUserNotSubscribed from '../message/MentionedUserNotSubscribed';
 import { makeUserId } from '../api/idTypes';
 import { getFullNameText } from '../users/userSelectors';
+import { getRealm } from '../directSelectors';
 
 type Props = $ReadOnly<{|
   narrow: Narrow,
@@ -43,6 +44,7 @@ function MentionWarningsInner(props: Props, ref): Node {
 
   const auth = useSelector(getAuth);
   const allUsersById = useSelector(getAllUsersById);
+  const enableGuestUserIndicator = useSelector(state => getRealm(state).enableGuestUserIndicator);
 
   const [unsubscribedMentions, setUnsubscribedMentions] = useState<$ReadOnlyArray<UserId>>([]);
 
@@ -87,11 +89,11 @@ function MentionWarningsInner(props: Props, ref): Node {
     (mentionedUser: UserOrBot) => {
       showToast(
         _('Couldn’t load information about {fullName}', {
-          fullName: _(getFullNameText({ user: mentionedUser })),
+          fullName: _(getFullNameText({ user: mentionedUser, enableGuestUserIndicator })),
         }),
       );
     },
-    [_],
+    [enableGuestUserIndicator, _],
   );
 
   useImperativeHandle(

--- a/src/compose/MentionWarnings.js
+++ b/src/compose/MentionWarnings.js
@@ -13,6 +13,7 @@ import { showToast } from '../utils/info';
 
 import MentionedUserNotSubscribed from '../message/MentionedUserNotSubscribed';
 import { makeUserId } from '../api/idTypes';
+import { getFullNameText } from '../users/userSelectors';
 
 type Props = $ReadOnly<{|
   narrow: Narrow,
@@ -86,7 +87,7 @@ function MentionWarningsInner(props: Props, ref): Node {
     (mentionedUser: UserOrBot) => {
       showToast(
         _('Couldn’t load information about {fullName}', {
-          fullName: mentionedUser.full_name,
+          fullName: _(getFullNameText({ user: mentionedUser })),
         }),
       );
     },

--- a/src/compose/__tests__/getComposeInputPlaceholder-test.js
+++ b/src/compose/__tests__/getComposeInputPlaceholder-test.js
@@ -10,6 +10,7 @@ import {
 } from '../../utils/narrow';
 import * as eg from '../../__tests__/lib/exampleData';
 import { getStreamsById } from '../../selectors';
+import { mock_ } from '../../__tests__/lib/intl';
 
 describe('getComposeInputPlaceholder', () => {
   const usersById = new Map([eg.selfUser, eg.otherUser, eg.thirdUser].map(u => [u.user_id, u]));
@@ -18,7 +19,13 @@ describe('getComposeInputPlaceholder', () => {
 
   test('returns "Message This Person" object for person narrow', () => {
     const narrow = deepFreeze(pm1to1NarrowFromUser(eg.otherUser));
-    const placeholder = getComposeInputPlaceholder(narrow, ownUserId, usersById, streamsById);
+    const placeholder = getComposeInputPlaceholder(
+      narrow,
+      ownUserId,
+      usersById,
+      streamsById,
+      mock_,
+    );
     expect(placeholder).toEqual({
       text: 'Message {recipient}',
       values: { recipient: eg.otherUser.full_name },
@@ -27,13 +34,25 @@ describe('getComposeInputPlaceholder', () => {
 
   test('returns "Jot down something" object for self narrow', () => {
     const narrow = deepFreeze(pm1to1NarrowFromUser(eg.selfUser));
-    const placeholder = getComposeInputPlaceholder(narrow, ownUserId, usersById, streamsById);
+    const placeholder = getComposeInputPlaceholder(
+      narrow,
+      ownUserId,
+      usersById,
+      streamsById,
+      mock_,
+    );
     expect(placeholder).toEqual({ text: 'Jot down something' });
   });
 
   test('returns "Message #streamName" for stream narrow', () => {
     const narrow = deepFreeze(streamNarrow(eg.stream.stream_id));
-    const placeholder = getComposeInputPlaceholder(narrow, ownUserId, usersById, streamsById);
+    const placeholder = getComposeInputPlaceholder(
+      narrow,
+      ownUserId,
+      usersById,
+      streamsById,
+      mock_,
+    );
     expect(placeholder).toEqual({
       text: 'Message {recipient}',
       values: { recipient: `#${eg.stream.name}` },
@@ -42,13 +61,25 @@ describe('getComposeInputPlaceholder', () => {
 
   test('returns properly for topic narrow', () => {
     const narrow = deepFreeze(topicNarrow(eg.stream.stream_id, 'Copenhagen'));
-    const placeholder = getComposeInputPlaceholder(narrow, ownUserId, usersById, streamsById);
+    const placeholder = getComposeInputPlaceholder(
+      narrow,
+      ownUserId,
+      usersById,
+      streamsById,
+      mock_,
+    );
     expect(placeholder).toEqual({ text: 'Reply' });
   });
 
   test('returns "Message group" object for group narrow', () => {
     const narrow = deepFreeze(pmNarrowFromUsersUnsafe([eg.otherUser, eg.thirdUser]));
-    const placeholder = getComposeInputPlaceholder(narrow, ownUserId, usersById, streamsById);
+    const placeholder = getComposeInputPlaceholder(
+      narrow,
+      ownUserId,
+      usersById,
+      streamsById,
+      mock_,
+    );
     expect(placeholder).toEqual({ text: 'Message group' });
   });
 });

--- a/src/compose/__tests__/getComposeInputPlaceholder-test.js
+++ b/src/compose/__tests__/getComposeInputPlaceholder-test.js
@@ -24,6 +24,7 @@ describe('getComposeInputPlaceholder', () => {
       ownUserId,
       usersById,
       streamsById,
+      false,
       mock_,
     );
     expect(placeholder).toEqual({
@@ -39,6 +40,7 @@ describe('getComposeInputPlaceholder', () => {
       ownUserId,
       usersById,
       streamsById,
+      false,
       mock_,
     );
     expect(placeholder).toEqual({ text: 'Jot down something' });
@@ -51,6 +53,7 @@ describe('getComposeInputPlaceholder', () => {
       ownUserId,
       usersById,
       streamsById,
+      false,
       mock_,
     );
     expect(placeholder).toEqual({
@@ -66,6 +69,7 @@ describe('getComposeInputPlaceholder', () => {
       ownUserId,
       usersById,
       streamsById,
+      false,
       mock_,
     );
     expect(placeholder).toEqual({ text: 'Reply' });
@@ -78,6 +82,7 @@ describe('getComposeInputPlaceholder', () => {
       ownUserId,
       usersById,
       streamsById,
+      false,
       mock_,
     );
     expect(placeholder).toEqual({ text: 'Message group' });

--- a/src/compose/__tests__/getComposeInputPlaceholder-test.js
+++ b/src/compose/__tests__/getComposeInputPlaceholder-test.js
@@ -16,12 +16,12 @@ describe('getComposeInputPlaceholder', () => {
   const ownUserId = eg.selfUser.user_id;
   const streamsById = getStreamsById(eg.plusReduxState);
 
-  test('returns "Message @ThisPerson" object for person narrow', () => {
+  test('returns "Message This Person" object for person narrow', () => {
     const narrow = deepFreeze(pm1to1NarrowFromUser(eg.otherUser));
     const placeholder = getComposeInputPlaceholder(narrow, ownUserId, usersById, streamsById);
     expect(placeholder).toEqual({
       text: 'Message {recipient}',
-      values: { recipient: `@${eg.otherUser.full_name}` },
+      values: { recipient: eg.otherUser.full_name },
     });
   });
 

--- a/src/compose/getComposeInputPlaceholder.js
+++ b/src/compose/getComposeInputPlaceholder.js
@@ -28,7 +28,7 @@ export default (
 
         return {
           text: 'Message {recipient}',
-          values: { recipient: `@${user.full_name}` },
+          values: { recipient: user.full_name },
         };
       },
       stream: streamId => {

--- a/src/compose/getComposeInputPlaceholder.js
+++ b/src/compose/getComposeInputPlaceholder.js
@@ -8,6 +8,7 @@ export default (
   ownUserId: UserId,
   allUsersById: Map<UserId, UserOrBot>,
   streamsById: Map<number, Stream>,
+  enableGuestUserIndicator: boolean,
   _: GetText,
 ): LocalizableText =>
   caseNarrowDefault(
@@ -30,7 +31,7 @@ export default (
 
         return {
           text: 'Message {recipient}',
-          values: { recipient: _(getFullNameText({ user })) },
+          values: { recipient: _(getFullNameText({ user, enableGuestUserIndicator })) },
         };
       },
       stream: streamId => {

--- a/src/compose/getComposeInputPlaceholder.js
+++ b/src/compose/getComposeInputPlaceholder.js
@@ -1,5 +1,6 @@
 /* @flow strict-local */
-import type { Narrow, Stream, UserId, UserOrBot, LocalizableText } from '../types';
+import type { Narrow, Stream, UserId, UserOrBot, LocalizableText, GetText } from '../types';
+import { getFullNameText } from '../users/userSelectors';
 import { caseNarrowDefault } from '../utils/narrow';
 
 export default (
@@ -7,6 +8,7 @@ export default (
   ownUserId: UserId,
   allUsersById: Map<UserId, UserOrBot>,
   streamsById: Map<number, Stream>,
+  _: GetText,
 ): LocalizableText =>
   caseNarrowDefault(
     narrow,
@@ -28,7 +30,7 @@ export default (
 
         return {
           text: 'Message {recipient}',
-          values: { recipient: user.full_name },
+          values: { recipient: _(getFullNameText({ user })) },
         };
       },
       stream: streamId => {

--- a/src/events/eventActions.js
+++ b/src/events/eventActions.js
@@ -14,9 +14,9 @@ import { REGISTER_START, REGISTER_ABORT, REGISTER_COMPLETE, DEAD_QUEUE } from '.
 import { logout } from '../account/logoutActions';
 import eventToAction from './eventToAction';
 import doEventActionSideEffects from './doEventActionSideEffects';
-import { getAccount, tryGetAuth, getIdentity } from '../selectors';
+import { getAccount, tryGetAuth, getOwnUser, getIdentity } from '../selectors';
 import { getHaveServerData } from '../haveServerDataSelectors';
-import { getOwnUserRole, roleIsAtLeast } from '../permissionSelectors';
+import { roleIsAtLeast } from '../permissionSelectors';
 import { Role } from '../api/permissionsTypes';
 import { authOfAccount, identityOfAccount, identityOfAuth } from '../account/accountMisc';
 import { BackoffMachine, TimeoutError } from '../utils/async';
@@ -77,7 +77,7 @@ const registerAbort =
           const realmStr = getIdentity(getState()).realm.toString();
           switch (reason) {
             case 'server':
-              return roleIsAtLeast(getOwnUserRole(getState()), Role.Admin)
+              return roleIsAtLeast(getOwnUser(getState()).role, Role.Admin)
                 ? `Could not connect to ${realmStr} because the server encountered an error. Please check the server logs.`
                 : `Could not connect to ${realmStr} because the server encountered an error. Please ask an admin to check the server logs.`;
             case 'network':

--- a/src/i18n/i18n.js
+++ b/src/i18n/i18n.js
@@ -1,0 +1,12 @@
+/* @flow strict-local */
+import type { LocalizableText } from '../types';
+
+/**
+ * A LocalizableText that always resolves to the given string.
+ *
+ * Useful for wrapping user data, like the name of a user or a stream,
+ * in a context where we sometimes also show a string that needs translation.
+ */
+export function noTranslation(value: string): LocalizableText {
+  return { text: '{_}', values: { _: value } };
+}

--- a/src/lightbox/Lightbox.js
+++ b/src/lightbox/Lightbox.js
@@ -111,9 +111,7 @@ export default function Lightbox(props: Props): Node {
             onPressBack={() => {
               navigation.dispatch(navigateBack());
             }}
-            timestamp={message.timestamp}
-            senderName={message.sender_full_name}
-            senderId={message.sender_id}
+            message={message}
           />
         </View>
         <View style={styles.footer}>

--- a/src/lightbox/LightboxHeader.js
+++ b/src/lightbox/LightboxHeader.js
@@ -10,9 +10,10 @@ import UserAvatarWithPresence from '../common/UserAvatarWithPresence';
 import { Icon } from '../common/Icons';
 import { OfflineNoticePlaceholder } from '../boot/OfflineNoticeProvider';
 import { useSelector } from '../react-redux';
-import { tryGetUserForId } from '../users/userSelectors';
+import { getFullNameText, tryGetUserForId } from '../users/userSelectors';
 import type { Message } from '../api/modelTypes';
 import ZulipText from '../common/ZulipText';
+import ZulipTextIntl from '../common/ZulipTextIntl';
 
 const styles = createStyleSheet({
   text: {
@@ -64,9 +65,15 @@ export default function LightboxHeader(props: Props): Node {
       <SafeAreaView mode="padding" edges={['right', 'left']} style={styles.contentArea}>
         <UserAvatarWithPresence size={36} userId={senderId} />
         <View style={styles.text}>
-          <ZulipText style={styles.name} numberOfLines={1}>
-            {sender?.full_name ?? message.sender_full_name}
-          </ZulipText>
+          {sender != null ? (
+            <ZulipTextIntl
+              style={styles.name}
+              numberOfLines={1}
+              text={getFullNameText({ user: sender })}
+            />
+          ) : (
+            <ZulipText style={styles.name} numberOfLines={1} text={message.sender_full_name} />
+          )}
           <ZulipText style={styles.subheader} numberOfLines={1}>
             {subheader}
           </ZulipText>

--- a/src/lightbox/LightboxHeader.js
+++ b/src/lightbox/LightboxHeader.js
@@ -10,7 +10,8 @@ import UserAvatarWithPresence from '../common/UserAvatarWithPresence';
 import { Icon } from '../common/Icons';
 import { OfflineNoticePlaceholder } from '../boot/OfflineNoticeProvider';
 import { useSelector } from '../react-redux';
-import { getFullNameText, tryGetUserForId } from '../users/userSelectors';
+import { getFullNameReactText, tryGetUserForId } from '../users/userSelectors';
+import { getRealm } from '../directSelectors';
 import type { Message } from '../api/modelTypes';
 import ZulipText from '../common/ZulipText';
 import ZulipTextIntl from '../common/ZulipTextIntl';
@@ -58,6 +59,7 @@ export default function LightboxHeader(props: Props): Node {
   const subheader = `${displayDate} at ${time}`;
 
   const sender = useSelector(state => tryGetUserForId(state, senderId));
+  const enableGuestUserIndicator = useSelector(state => getRealm(state).enableGuestUserIndicator);
 
   return (
     <SafeAreaView mode="padding" edges={['top']}>
@@ -69,7 +71,7 @@ export default function LightboxHeader(props: Props): Node {
             <ZulipTextIntl
               style={styles.name}
               numberOfLines={1}
-              text={getFullNameText({ user: sender })}
+              text={getFullNameReactText({ user: sender, enableGuestUserIndicator })}
             />
           ) : (
             <ZulipText style={styles.name} numberOfLines={1} text={message.sender_full_name} />

--- a/src/lightbox/LightboxHeader.js
+++ b/src/lightbox/LightboxHeader.js
@@ -9,7 +9,9 @@ import { createStyleSheet } from '../styles';
 import UserAvatarWithPresence from '../common/UserAvatarWithPresence';
 import { Icon } from '../common/Icons';
 import { OfflineNoticePlaceholder } from '../boot/OfflineNoticeProvider';
-import type { UserId } from '../api/idTypes';
+import { useSelector } from '../react-redux';
+import { tryGetUserForId } from '../users/userSelectors';
+import type { Message } from '../api/modelTypes';
 
 const styles = createStyleSheet({
   text: {
@@ -39,25 +41,21 @@ const styles = createStyleSheet({
 });
 
 type Props = $ReadOnly<{|
-  senderName: string,
-  senderId: UserId,
-  timestamp: number,
+  message: Message,
   onPressBack: () => void,
 |}>;
 
 /**
  * Shows sender's name and date of photo being displayed.
- *
- * @prop [senderName] - The sender's full name.
- * @prop [avatarUrl]
- * @prop [timestamp]
- * @prop [onPressBack]
  */
 export default function LightboxHeader(props: Props): Node {
-  const { onPressBack, senderName, senderId, timestamp } = props;
+  const { onPressBack, message } = props;
+  const { timestamp, sender_id: senderId } = message;
   const displayDate = humanDate(new Date(timestamp * 1000));
   const time = shortTime(new Date(timestamp * 1000));
   const subheader = `${displayDate} at ${time}`;
+
+  const sender = useSelector(state => tryGetUserForId(state, senderId));
 
   return (
     <SafeAreaView mode="padding" edges={['top']}>
@@ -66,7 +64,7 @@ export default function LightboxHeader(props: Props): Node {
         <UserAvatarWithPresence size={36} userId={senderId} />
         <View style={styles.text}>
           <Text style={styles.name} numberOfLines={1}>
-            {senderName}
+            {sender?.full_name ?? message.sender_full_name}
           </Text>
           <Text style={styles.subheader} numberOfLines={1}>
             {subheader}

--- a/src/lightbox/LightboxHeader.js
+++ b/src/lightbox/LightboxHeader.js
@@ -1,7 +1,7 @@
 /* @flow strict-local */
 import React from 'react';
 import type { Node } from 'react';
-import { View, Text, Pressable } from 'react-native';
+import { View, Pressable } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 import { shortTime, humanDate } from '../utils/date';
@@ -12,6 +12,7 @@ import { OfflineNoticePlaceholder } from '../boot/OfflineNoticeProvider';
 import { useSelector } from '../react-redux';
 import { tryGetUserForId } from '../users/userSelectors';
 import type { Message } from '../api/modelTypes';
+import ZulipText from '../common/ZulipText';
 
 const styles = createStyleSheet({
   text: {
@@ -63,12 +64,12 @@ export default function LightboxHeader(props: Props): Node {
       <SafeAreaView mode="padding" edges={['right', 'left']} style={styles.contentArea}>
         <UserAvatarWithPresence size={36} userId={senderId} />
         <View style={styles.text}>
-          <Text style={styles.name} numberOfLines={1}>
+          <ZulipText style={styles.name} numberOfLines={1}>
             {sender?.full_name ?? message.sender_full_name}
-          </Text>
-          <Text style={styles.subheader} numberOfLines={1}>
+          </ZulipText>
+          <ZulipText style={styles.subheader} numberOfLines={1}>
             {subheader}
-          </Text>
+          </ZulipText>
         </View>
         <Pressable style={styles.rightIconTouchTarget} onPress={onPressBack} hitSlop={12}>
           {({ pressed }) => <Icon size={24} color={pressed ? 'gray' : 'white'} name="x" />}

--- a/src/lightbox/LightboxHeader.js
+++ b/src/lightbox/LightboxHeader.js
@@ -67,15 +67,15 @@ export default function LightboxHeader(props: Props): Node {
       <SafeAreaView mode="padding" edges={['right', 'left']} style={styles.contentArea}>
         <UserAvatarWithPresence size={36} userId={senderId} />
         <View style={styles.text}>
-          {sender != null ? (
-            <ZulipTextIntl
-              style={styles.name}
-              numberOfLines={1}
-              text={getFullNameReactText({ user: sender, enableGuestUserIndicator })}
-            />
-          ) : (
-            <ZulipText style={styles.name} numberOfLines={1} text={message.sender_full_name} />
-          )}
+          <ZulipTextIntl
+            style={styles.name}
+            numberOfLines={1}
+            text={getFullNameReactText({
+              user: sender,
+              enableGuestUserIndicator,
+              fallback: message.sender_full_name,
+            })}
+          />
           <ZulipText style={styles.subheader} numberOfLines={1}>
             {subheader}
           </ZulipText>

--- a/src/message/MentionedUserNotSubscribed.js
+++ b/src/message/MentionedUserNotSubscribed.js
@@ -12,6 +12,7 @@ import ZulipButton from '../common/ZulipButton';
 import ZulipTextIntl from '../common/ZulipTextIntl';
 import { getAuth } from '../selectors';
 import { kWarningColor } from '../styles/constants';
+import { getFullNameText } from '../users/userSelectors';
 
 type Props = $ReadOnly<{|
   user: UserOrBot,
@@ -72,7 +73,11 @@ export default function MentionedUserNotSubscribed(props: Props): Node {
         <ZulipTextIntl
           text={{
             text: '{username} will not be notified unless you subscribe them to this stream.',
-            values: { username: user.full_name },
+            values: {
+              username: (
+                <ZulipTextIntl inheritColor inheritFontSize text={getFullNameText({ user })} />
+              ),
+            },
           }}
           style={styles.text}
         />

--- a/src/message/MentionedUserNotSubscribed.js
+++ b/src/message/MentionedUserNotSubscribed.js
@@ -12,7 +12,8 @@ import ZulipButton from '../common/ZulipButton';
 import ZulipTextIntl from '../common/ZulipTextIntl';
 import { getAuth } from '../selectors';
 import { kWarningColor } from '../styles/constants';
-import { getFullNameText } from '../users/userSelectors';
+import { getFullNameReactText } from '../users/userSelectors';
+import { getRealm } from '../directSelectors';
 
 type Props = $ReadOnly<{|
   user: UserOrBot,
@@ -56,6 +57,7 @@ const styles = createStyleSheet({
 export default function MentionedUserNotSubscribed(props: Props): Node {
   const { user, stream, onDismiss } = props;
   const auth = useSelector(getAuth);
+  const enableGuestUserIndicator = useSelector(state => getRealm(state).enableGuestUserIndicator);
 
   const handleDismiss = useCallback(() => {
     onDismiss(user);
@@ -75,7 +77,11 @@ export default function MentionedUserNotSubscribed(props: Props): Node {
             text: '{username} will not be notified unless you subscribe them to this stream.',
             values: {
               username: (
-                <ZulipTextIntl inheritColor inheritFontSize text={getFullNameText({ user })} />
+                <ZulipTextIntl
+                  inheritColor
+                  inheritFontSize
+                  text={getFullNameReactText({ user, enableGuestUserIndicator })}
+                />
               ),
             },
           }}

--- a/src/pm-conversations/GroupPmConversationItem.js
+++ b/src/pm-conversations/GroupPmConversationItem.js
@@ -12,8 +12,12 @@ import Touchable from '../common/Touchable';
 import UnreadCount from '../common/UnreadCount';
 import { getMutedUsers } from '../selectors';
 import { TranslationContext } from '../boot/TranslationProvider';
-import { getFullNameOrMutedUserText } from '../users/userSelectors';
+import {
+  getFullNameOrMutedUserReactText,
+  getFullNameOrMutedUserText,
+} from '../users/userSelectors';
 import ZulipTextIntl from '../common/ZulipTextIntl';
+import { getRealm } from '../directSelectors';
 
 const componentStyles = createStyleSheet({
   text: {
@@ -43,7 +47,10 @@ export default function GroupPmConversationItem<U: $ReadOnlyArray<UserOrBot>>(
 
   const _ = useContext(TranslationContext);
   const mutedUsers = useSelector(getMutedUsers);
-  const names = users.map(user => _(getFullNameOrMutedUserText({ user, mutedUsers })));
+  const enableGuestUserIndicator = useSelector(state => getRealm(state).enableGuestUserIndicator);
+  const names = users.map(user =>
+    _(getFullNameOrMutedUserText({ user, mutedUsers, enableGuestUserIndicator })),
+  );
 
   const namesReact = [];
   users.forEach((user, i) => {
@@ -57,7 +64,7 @@ export default function GroupPmConversationItem<U: $ReadOnlyArray<UserOrBot>>(
         key={`${user.user_id}`}
         inheritColor
         inheritFontSize
-        text={getFullNameOrMutedUserText({ user, mutedUsers })}
+        text={getFullNameOrMutedUserReactText({ user, mutedUsers, enableGuestUserIndicator })}
       />,
     );
   });

--- a/src/pm-conversations/GroupPmConversationItem.js
+++ b/src/pm-conversations/GroupPmConversationItem.js
@@ -12,6 +12,7 @@ import Touchable from '../common/Touchable';
 import UnreadCount from '../common/UnreadCount';
 import { getMutedUsers } from '../selectors';
 import { TranslationContext } from '../boot/TranslationProvider';
+import { getFullNameOrMutedUserText } from '../users/userSelectors';
 
 const componentStyles = createStyleSheet({
   text: {
@@ -41,9 +42,7 @@ export default function GroupPmConversationItem<U: $ReadOnlyArray<UserOrBot>>(
 
   const _ = useContext(TranslationContext);
   const mutedUsers = useSelector(getMutedUsers);
-  const names = users.map(user =>
-    mutedUsers.has(user.user_id) ? _('Muted user') : user.full_name,
-  );
+  const names = users.map(user => _(getFullNameOrMutedUserText({ user, mutedUsers })));
 
   return (
     <Touchable onPress={handlePress}>

--- a/src/pm-conversations/GroupPmConversationItem.js
+++ b/src/pm-conversations/GroupPmConversationItem.js
@@ -13,6 +13,7 @@ import UnreadCount from '../common/UnreadCount';
 import { getMutedUsers } from '../selectors';
 import { TranslationContext } from '../boot/TranslationProvider';
 import { getFullNameOrMutedUserText } from '../users/userSelectors';
+import ZulipTextIntl from '../common/ZulipTextIntl';
 
 const componentStyles = createStyleSheet({
   text: {
@@ -44,16 +45,30 @@ export default function GroupPmConversationItem<U: $ReadOnlyArray<UserOrBot>>(
   const mutedUsers = useSelector(getMutedUsers);
   const names = users.map(user => _(getFullNameOrMutedUserText({ user, mutedUsers })));
 
+  const namesReact = [];
+  users.forEach((user, i) => {
+    if (i !== 0) {
+      namesReact.push(
+        <ZulipText key={`${user.user_id}-comma`} inheritColor inheritFontSize text=", " />,
+      );
+    }
+    namesReact.push(
+      <ZulipTextIntl
+        key={`${user.user_id}`}
+        inheritColor
+        inheritFontSize
+        text={getFullNameOrMutedUserText({ user, mutedUsers })}
+      />,
+    );
+  });
+
   return (
     <Touchable onPress={handlePress}>
       <View style={styles.listItem}>
         <GroupAvatar size={48} names={names} />
-        <ZulipText
-          style={componentStyles.text}
-          numberOfLines={2}
-          ellipsizeMode="tail"
-          text={names.join(', ')}
-        />
+        <ZulipText style={componentStyles.text} numberOfLines={2} ellipsizeMode="tail">
+          {namesReact}
+        </ZulipText>
         <UnreadCount count={unreadCount} />
       </View>
     </Touchable>

--- a/src/realm/__tests__/realmReducer-test.js
+++ b/src/realm/__tests__/realmReducer-test.js
@@ -75,10 +75,6 @@ describe('realmReducer', () => {
         //
 
         canCreateStreams: action.data.can_create_streams,
-        isAdmin: action.data.is_admin,
-        isOwner: action.data.is_owner,
-        isModerator: action.data.is_moderator,
-        isGuest: action.data.is_guest,
         user_id: action.data.user_id,
         email: action.data.email,
         crossRealmBots: action.data.cross_realm_bots,
@@ -238,12 +234,6 @@ describe('realmReducer', () => {
     type EventUpdatableRealmState = $Rest<
       RealmState,
       {|
-        // TODO(server-4.0): Remove these four deprecated properties.
-        isOwner: mixed,
-        isAdmin: mixed,
-        isModerator: mixed,
-        isGuest: mixed,
-
         serverEmojiData: mixed,
 
         // Incomplete; add others as needed to satisfy Flow.

--- a/src/realm/__tests__/realmReducer-test.js
+++ b/src/realm/__tests__/realmReducer-test.js
@@ -69,6 +69,7 @@ describe('realmReducer', () => {
         allowEditHistory: action.data.realm_allow_edit_history,
         enableReadReceipts: action.data.realm_enable_read_receipts,
         emailAddressVisibility: null,
+        enableGuestUserIndicator: true,
 
         //
         // InitialDataRealmUser
@@ -553,6 +554,14 @@ describe('realmReducer', () => {
         check(Moderators, Admins);
         check(Moderators, Members);
         check(Moderators, Nobody);
+      });
+
+      describe('enableGuestUserIndicator / enable_guest_user_indicator', () => {
+        const check = mkCheck('enableGuestUserIndicator', 'enable_guest_user_indicator');
+        check(true, true);
+        check(true, false);
+        check(false, true);
+        check(false, false);
       });
     });
   });

--- a/src/realm/realmReducer.js
+++ b/src/realm/realmReducer.js
@@ -59,10 +59,6 @@ const initialState = {
   //
 
   canCreateStreams: true,
-  isAdmin: false,
-  isOwner: false,
-  isModerator: false,
-  isGuest: false,
   user_id: undefined,
   email: undefined,
   crossRealmBots: [],
@@ -173,10 +169,6 @@ export default (
         //
 
         canCreateStreams: action.data.can_create_streams,
-        isAdmin: action.data.is_admin,
-        isOwner: action.data.is_owner,
-        isModerator: action.data.is_moderator ?? action.data.is_admin,
-        isGuest: action.data.is_guest,
         user_id: action.data.user_id,
         email: action.data.email,
         crossRealmBots: action.data.cross_realm_bots,

--- a/src/realm/realmReducer.js
+++ b/src/realm/realmReducer.js
@@ -53,6 +53,7 @@ const initialState = {
   allowEditHistory: false,
   enableReadReceipts: false,
   emailAddressVisibility: null,
+  enableGuestUserIndicator: false,
 
   //
   // InitialDataRealmUser
@@ -163,6 +164,7 @@ export default (
         allowEditHistory: action.data.realm_allow_edit_history,
         enableReadReceipts: action.data.realm_enable_read_receipts ?? false,
         emailAddressVisibility: action.data.realm_email_address_visibility ?? null,
+        enableGuestUserIndicator: action.data.realm_enable_guest_user_indicator ?? true,
 
         //
         // InitialDataRealmUser
@@ -282,6 +284,9 @@ export default (
             }
             if (data.email_address_visibility !== undefined) {
               result.emailAddressVisibility = data.email_address_visibility;
+            }
+            if (data.enable_guest_user_indicator !== undefined) {
+              result.enableGuestUserIndicator = data.enable_guest_user_indicator;
             }
 
             return result;

--- a/src/reduxTypes.js
+++ b/src/reduxTypes.js
@@ -311,6 +311,7 @@ export type RealmState = {|
   +allowEditHistory: boolean,
   +enableReadReceipts: boolean,
   +emailAddressVisibility: EmailAddressVisibility | null,
+  +enableGuestUserIndicator: boolean,
 
   //
   // InitialDataRealmUser

--- a/src/reduxTypes.js
+++ b/src/reduxTypes.js
@@ -317,16 +317,6 @@ export type RealmState = {|
   //
 
   +canCreateStreams: boolean,
-
-  // Deprecated; these don't have events to update them. Use getOwnUserRole,
-  // which uses the self-user's live-updating `role` property when
-  // available.
-  // TODO(server-4.0): Remove these and rely on self-user's `role`.
-  -isAdmin: boolean,
-  -isOwner: boolean,
-  -isModerator: boolean,
-  -isGuest: boolean,
-
   +user_id: UserId | void,
   +email: string | void,
   +crossRealmBots: $ReadOnlyArray<CrossRealmBot>,

--- a/src/settings/SettingsScreen.js
+++ b/src/settings/SettingsScreen.js
@@ -34,6 +34,7 @@ import {
   chooseNotifProblemForShortText,
   notifProblemShortReactText,
 } from './NotifTroubleshootingScreen';
+import { noTranslation } from '../i18n/i18n';
 import { keyOfIdentity } from '../account/accountMisc';
 import languages from './languages';
 import { getRealmName } from '../directSelectors';
@@ -118,8 +119,8 @@ export default function SettingsScreen(props: Props): Node {
         valueKey={language}
         items={languages.map(l => ({
           key: l.tag,
-          title: { text: '{_}', values: { _: l.selfname } },
-          subtitle: { text: '{_}', values: { _: l.name } },
+          title: noTranslation(l.selfname),
+          subtitle: noTranslation(l.name),
         }))}
         onValueChange={value => {
           dispatch(setGlobalSettings({ language: value }));
@@ -136,12 +137,12 @@ export default function SettingsScreen(props: Props): Node {
       <TextRow
         icon={{ Component: IconSmartphone }}
         title="App version"
-        subtitle={{ text: '{_}', values: { _: `v${nativeApplicationVersion ?? '?.?.?'}` } }}
+        subtitle={noTranslation(`v${nativeApplicationVersion ?? '?.?.?'}`)}
       />
       <TextRow
         icon={{ Component: IconServer }}
         title="Server version"
-        subtitle={{ text: '{_}', values: { _: zulipVersion.raw() } }}
+        subtitle={noTranslation(zulipVersion.raw())}
         {...(!zulipVersion.isAtLeast(kMinSupportedVersion) && {
           icon: { Component: IconAlertTriangle, color: kWarningColor },
           onPress: () => {

--- a/src/storage/__tests__/migrations-test.js
+++ b/src/storage/__tests__/migrations-test.js
@@ -102,11 +102,17 @@ describe('migrations', () => {
     },
   };
 
-  // What `base` becomes after all migrations.
-  const endBase = {
+  // What `base` becomes after migrations up through 62.
+  const base62 = {
     ...base52,
     migrations: { version: 62 },
     accounts: base52.accounts.map(a => ({ ...a, silenceServerPushSetupWarnings: false })),
+  };
+
+  // What `base` becomes after all migrations.
+  const endBase = {
+    ...base62,
+    migrations: { version: 63 },
   };
 
   for (const [desc, before, after] of [
@@ -129,9 +135,9 @@ describe('migrations', () => {
     // redundant with this one, because none of the migration steps notice
     // whether any properties outside `storeKeys` are present or not.
     [
-      'check dropCache at 61',
+      'check dropCache at 63',
       // Just before the `dropCache`, plus a `cacheKeys` property, plus junk.
-      { ...base52, migrations: { version: 60 }, mute: [], nonsense: [1, 2, 3] },
+      { ...base62, migrations: { version: 62 }, mute: [], nonsense: [1, 2, 3] },
       // Should wind up with the same result as without the extra properties.
       endBase,
     ],

--- a/src/storage/__tests__/migrations-test.js
+++ b/src/storage/__tests__/migrations-test.js
@@ -112,7 +112,7 @@ describe('migrations', () => {
   // What `base` becomes after all migrations.
   const endBase = {
     ...base62,
-    migrations: { version: 63 },
+    migrations: { version: 64 },
   };
 
   for (const [desc, before, after] of [
@@ -135,9 +135,9 @@ describe('migrations', () => {
     // redundant with this one, because none of the migration steps notice
     // whether any properties outside `storeKeys` are present or not.
     [
-      'check dropCache at 63',
+      'check dropCache at 64',
       // Just before the `dropCache`, plus a `cacheKeys` property, plus junk.
-      { ...base62, migrations: { version: 62 }, mute: [], nonsense: [1, 2, 3] },
+      { ...base62, migrations: { version: 63 }, mute: [], nonsense: [1, 2, 3] },
       // Should wind up with the same result as without the extra properties.
       endBase,
     ],

--- a/src/storage/migrations.js
+++ b/src/storage/migrations.js
@@ -526,6 +526,9 @@ const migrationsInner: {| [string]: (LessPartialState) => LessPartialState |} = 
     accounts: state.accounts.map(a => ({ ...a, silenceServerPushSetupWarnings: false })),
   }),
 
+  // Made UserOrBot.role required; removed is_owner, is_admin, is_guest
+  '63': dropCache,
+
   // TIP: When adding a migration, consider just using `dropCache`.
   //   (See its jsdoc for guidance on when that's the right answer.)
 };

--- a/src/storage/migrations.js
+++ b/src/storage/migrations.js
@@ -529,6 +529,9 @@ const migrationsInner: {| [string]: (LessPartialState) => LessPartialState |} = 
   // Made UserOrBot.role required; removed is_owner, is_admin, is_guest
   '63': dropCache,
 
+  // Add enableGuestUserIndicator to state.realm
+  '64': dropCache,
+
   // TIP: When adding a migration, consider just using `dropCache`.
   //   (See its jsdoc for guidance on when that's the right answer.)
 };

--- a/src/streams/EditStreamCard.js
+++ b/src/streams/EditStreamCard.js
@@ -16,7 +16,6 @@ import {
   getCanCreatePublicStreams,
   getCanCreatePrivateStreams,
   getCanCreateWebPublicStreams,
-  getOwnUserRole,
   roleIsAtLeast,
 } from '../permissionSelectors';
 import type { AppNavigationMethods } from '../nav/AppNavigator';
@@ -28,6 +27,7 @@ import styles from '../styles';
 import { TranslationContext } from '../boot/TranslationProvider';
 import type { LocalizableText } from '../types';
 import { showConfirmationDialog } from '../utils/info';
+import { getOwnUser } from '../users/userSelectors';
 
 type PropsBase = $ReadOnly<{|
   navigation: AppNavigationMethods,
@@ -165,7 +165,7 @@ function useStreamPrivacyOptions(initialValue: Privacy, isNewStream: boolean) {
   const canCreatePublicStreams = useSelector(getCanCreatePublicStreams);
   const canCreatePrivateStreams = useSelector(getCanCreatePrivateStreams);
   const canCreateWebPublicStreams = useSelector(getCanCreateWebPublicStreams);
-  const ownUserRole = useSelector(getOwnUserRole);
+  const ownUserRole = useSelector(getOwnUser).role;
   const realmUrl = useSelector(getRealmUrl);
 
   const shouldDisableIfNotInitialValue = useCallback(

--- a/src/streams/StreamSettingsScreen.js
+++ b/src/streams/StreamSettingsScreen.js
@@ -11,14 +11,14 @@ import SwitchRow from '../common/SwitchRow';
 import Screen from '../common/Screen';
 import ZulipButton from '../common/ZulipButton';
 import { getSettings } from '../directSelectors';
-import { getAuth, getStreamForId } from '../selectors';
+import { getAuth, getOwnUser, getStreamForId } from '../selectors';
 import StreamCard from './StreamCard';
 import { IconPin, IconMute, IconNotifications, IconEdit, IconPlusSquare } from '../common/Icons';
 import styles from '../styles';
 import { getSubscriptionsById } from '../subscriptions/subscriptionSelectors';
 import * as api from '../api';
 import getIsNotificationEnabled from './getIsNotificationEnabled';
-import { getOwnUserRole, roleIsAtLeast } from '../permissionSelectors';
+import { roleIsAtLeast } from '../permissionSelectors';
 import { Role } from '../api/permissionsTypes';
 
 type Props = $ReadOnly<{|
@@ -29,7 +29,7 @@ type Props = $ReadOnly<{|
 export default function StreamSettingsScreen(props: Props): Node {
   const { navigation } = props;
   const auth = useSelector(getAuth);
-  const isAtLeastAdmin = useSelector(state => roleIsAtLeast(getOwnUserRole(state), Role.Admin));
+  const isAtLeastAdmin = useSelector(state => roleIsAtLeast(getOwnUser(state).role, Role.Admin));
   const stream = useSelector(state => getStreamForId(state, props.route.params.streamId));
   const subscription = useSelector(state =>
     getSubscriptionsById(state).get(props.route.params.streamId),

--- a/src/streams/TopicItem.js
+++ b/src/streams/TopicItem.js
@@ -24,7 +24,6 @@ import {
 } from '../selectors';
 import { getMute, isTopicFollowed } from '../mute/muteModel';
 import { getUnread } from '../unread/unreadModel';
-import { getOwnUserRole } from '../permissionSelectors';
 import { useNavigation } from '../react-navigation';
 import { ThemeContext } from '../styles/theme';
 
@@ -78,17 +77,20 @@ export default function TopicItem(props: Props): Node {
   const _ = useContext(TranslationContext);
   const navigation = useNavigation();
   const dispatch = useDispatch();
-  const backgroundData = useSelector(state => ({
-    auth: getAuth(state),
-    mute: getMute(state),
-    streams: getStreamsById(state),
-    subscriptions: getSubscriptionsById(state),
-    unread: getUnread(state),
-    ownUser: getOwnUser(state),
-    ownUserRole: getOwnUserRole(state),
-    flags: getFlags(state),
-    zulipFeatureLevel: getZulipFeatureLevel(state),
-  }));
+  const backgroundData = useSelector(state => {
+    const ownUser = getOwnUser(state);
+    return {
+      auth: getAuth(state),
+      mute: getMute(state),
+      streams: getStreamsById(state),
+      subscriptions: getSubscriptionsById(state),
+      unread: getUnread(state),
+      ownUser,
+      ownUserRole: ownUser.role,
+      flags: getFlags(state),
+      zulipFeatureLevel: getZulipFeatureLevel(state),
+    };
+  });
 
   const theme = useContext(ThemeContext);
   const iconColor = theme.themeName === 'dark' ? 'white' : 'black';

--- a/src/title/TitlePrivate.js
+++ b/src/title/TitlePrivate.js
@@ -11,9 +11,10 @@ import Touchable from '../common/Touchable';
 import ViewPlaceholder from '../common/ViewPlaceholder';
 import UserAvatarWithPresence from '../common/UserAvatarWithPresence';
 import ActivityText from './ActivityText';
-import { getFullNameText, tryGetUserForId } from '../users/userSelectors';
+import { getFullNameReactText, tryGetUserForId } from '../users/userSelectors';
 import { useNavigation } from '../react-navigation';
 import ZulipTextIntl from '../common/ZulipTextIntl';
+import { getRealm } from '../directSelectors';
 
 type Props = $ReadOnly<{|
   userId: UserId,
@@ -29,6 +30,7 @@ const componentStyles = createStyleSheet({
 export default function TitlePrivate(props: Props): Node {
   const { userId, color } = props;
   const user = useSelector(state => tryGetUserForId(state, userId));
+  const enableGuestUserIndicator = useSelector(state => getRealm(state).enableGuestUserIndicator);
   const navigation = useNavigation();
   if (!user) {
     return null;
@@ -52,7 +54,7 @@ export default function TitlePrivate(props: Props): Node {
             style={[styles.navTitle, { color }]}
             numberOfLines={1}
             ellipsizeMode="tail"
-            text={getFullNameText({ user })}
+            text={getFullNameReactText({ user, enableGuestUserIndicator })}
           />
           <ActivityText style={[styles.navSubtitle, { color }]} user={user} />
         </View>

--- a/src/title/TitlePrivate.js
+++ b/src/title/TitlePrivate.js
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import type { Node } from 'react';
-import { Text, View } from 'react-native';
+import { View } from 'react-native';
 
 import type { UserId } from '../types';
 import styles, { createStyleSheet } from '../styles';
@@ -11,8 +11,9 @@ import Touchable from '../common/Touchable';
 import ViewPlaceholder from '../common/ViewPlaceholder';
 import UserAvatarWithPresence from '../common/UserAvatarWithPresence';
 import ActivityText from './ActivityText';
-import { tryGetUserForId } from '../users/userSelectors';
+import { getFullNameText, tryGetUserForId } from '../users/userSelectors';
 import { useNavigation } from '../react-navigation';
+import ZulipTextIntl from '../common/ZulipTextIntl';
 
 type Props = $ReadOnly<{|
   userId: UserId,
@@ -47,9 +48,12 @@ export default function TitlePrivate(props: Props): Node {
         <UserAvatarWithPresence size={32} userId={user.user_id} />
         <ViewPlaceholder width={8} />
         <View style={componentStyles.textWrapper}>
-          <Text style={[styles.navTitle, { color }]} numberOfLines={1} ellipsizeMode="tail">
-            {user.full_name}
-          </Text>
+          <ZulipTextIntl
+            style={[styles.navTitle, { color }]}
+            numberOfLines={1}
+            ellipsizeMode="tail"
+            text={getFullNameText({ user })}
+          />
           <ActivityText style={[styles.navSubtitle, { color }]} user={user} />
         </View>
       </View>

--- a/src/title/TitleStream.js
+++ b/src/title/TitleStream.js
@@ -26,7 +26,6 @@ import { getMute, isTopicFollowed } from '../mute/muteModel';
 import { showStreamActionSheet, showTopicActionSheet } from '../action-sheets';
 import type { ShowActionSheetWithOptions } from '../action-sheets';
 import { getUnread } from '../unread/unreadModel';
-import { getOwnUserRole } from '../permissionSelectors';
 import { useNavigation } from '../react-navigation';
 import { IconFollow } from '../common/Icons';
 
@@ -62,18 +61,21 @@ export default function TitleStream(props: Props): Node {
   const dispatch = useDispatch();
   const navigation = useNavigation();
   const stream = useSelector(state => getStreamInNarrow(state, narrow));
-  const backgroundData = useSelector(state => ({
-    auth: getAuth(state),
-    mute: getMute(state),
-    streams: getStreamsById(state),
-    subscriptions: getSubscriptionsById(state),
-    unread: getUnread(state),
-    ownUser: getOwnUser(state),
-    ownUserRole: getOwnUserRole(state),
-    flags: getFlags(state),
-    userSettingStreamNotification: getSettings(state).streamNotification,
-    zulipFeatureLevel: getZulipFeatureLevel(state),
-  }));
+  const backgroundData = useSelector(state => {
+    const ownUser = getOwnUser(state);
+    return {
+      auth: getAuth(state),
+      mute: getMute(state),
+      streams: getStreamsById(state),
+      subscriptions: getSubscriptionsById(state),
+      unread: getUnread(state),
+      ownUser,
+      ownUserRole: ownUser.role,
+      flags: getFlags(state),
+      userSettingStreamNotification: getSettings(state).streamNotification,
+      zulipFeatureLevel: getZulipFeatureLevel(state),
+    };
+  });
 
   const showActionSheetWithOptions: ShowActionSheetWithOptions =
     useActionSheet().showActionSheetWithOptions;

--- a/src/user-picker/AvatarItem.js
+++ b/src/user-picker/AvatarItem.js
@@ -1,5 +1,5 @@
 /* @flow strict-local */
-import React, { PureComponent } from 'react';
+import React from 'react';
 import type { Node } from 'react';
 import { View } from 'react-native';
 
@@ -38,31 +38,27 @@ type Props = $ReadOnly<{|
 /**
  * Pressable avatar for items in the user-picker card.
  */
-export default class AvatarItem extends PureComponent<Props> {
-  handlePress: () => void = () => {
-    const { user, onPress } = this.props;
+export default function AvatarItem(props: Props): Node {
+  const { user, onPress } = props;
+  const handlePress = React.useCallback(() => {
     onPress(user.user_id);
-  };
+  }, [onPress, user.user_id]);
 
-  render(): Node {
-    const { user } = this.props;
-
-    return (
-      <View style={styles.wrapper}>
-        <Touchable onPress={this.handlePress}>
-          <ComponentWithOverlay
-            overlaySize={20}
-            overlayColor="white"
-            overlayPosition="bottom-right"
-            overlay={<IconCancel color="gray" size={20} />}
-          >
-            <UserAvatarWithPresence key={user.user_id} size={50} userId={user.user_id} />
-          </ComponentWithOverlay>
-        </Touchable>
-        <View style={styles.textFrame}>
-          <ZulipTextIntl style={styles.text} text={getFullNameText({ user })} />
-        </View>
+  return (
+    <View style={styles.wrapper}>
+      <Touchable onPress={handlePress}>
+        <ComponentWithOverlay
+          overlaySize={20}
+          overlayColor="white"
+          overlayPosition="bottom-right"
+          overlay={<IconCancel color="gray" size={20} />}
+        >
+          <UserAvatarWithPresence key={user.user_id} size={50} userId={user.user_id} />
+        </ComponentWithOverlay>
+      </Touchable>
+      <View style={styles.textFrame}>
+        <ZulipTextIntl style={styles.text} text={getFullNameText({ user })} />
       </View>
-    );
-  }
+    </View>
+  );
 }

--- a/src/user-picker/AvatarItem.js
+++ b/src/user-picker/AvatarItem.js
@@ -25,7 +25,6 @@ const styles = createStyleSheet({
     textAlign: 'center',
   },
   textFrame: {
-    height: 20,
     width: 50,
     flexDirection: 'row',
   },
@@ -66,7 +65,6 @@ export default class AvatarItem extends PureComponent<Props> {
     const animatedStyle = {
       transform: [{ scale: this.animatedValue }],
     };
-    const firstName = user.full_name.trim().split(' ')[0];
 
     return (
       <Animated.View style={[styles.wrapper, animatedStyle]}>
@@ -81,7 +79,7 @@ export default class AvatarItem extends PureComponent<Props> {
           </ComponentWithOverlay>
         </Touchable>
         <View style={styles.textFrame}>
-          <ZulipText style={styles.text} text={firstName} numberOfLines={1} />
+          <ZulipText style={styles.text} text={user.full_name} />
         </View>
       </Animated.View>
     );

--- a/src/user-picker/AvatarItem.js
+++ b/src/user-picker/AvatarItem.js
@@ -7,10 +7,11 @@ import type AnimatedValue from 'react-native/Libraries/Animated/nodes/AnimatedVa
 import type { UserId, UserOrBot } from '../types';
 import UserAvatarWithPresence from '../common/UserAvatarWithPresence';
 import ComponentWithOverlay from '../common/ComponentWithOverlay';
-import ZulipText from '../common/ZulipText';
 import Touchable from '../common/Touchable';
 import { createStyleSheet } from '../styles';
 import { IconCancel } from '../common/Icons';
+import { getFullNameText } from '../users/userSelectors';
+import ZulipTextIntl from '../common/ZulipTextIntl';
 
 const styles = createStyleSheet({
   wrapper: {
@@ -79,7 +80,7 @@ export default class AvatarItem extends PureComponent<Props> {
           </ComponentWithOverlay>
         </Touchable>
         <View style={styles.textFrame}>
-          <ZulipText style={styles.text} text={user.full_name} />
+          <ZulipTextIntl style={styles.text} text={getFullNameText({ user })} />
         </View>
       </Animated.View>
     );

--- a/src/user-picker/AvatarItem.js
+++ b/src/user-picker/AvatarItem.js
@@ -1,8 +1,7 @@
 /* @flow strict-local */
 import React, { PureComponent } from 'react';
 import type { Node } from 'react';
-import { Animated, Easing, View } from 'react-native';
-import type AnimatedValue from 'react-native/Libraries/Animated/nodes/AnimatedValue';
+import { View } from 'react-native';
 
 import type { UserId, UserOrBot } from '../types';
 import UserAvatarWithPresence from '../common/UserAvatarWithPresence';
@@ -40,35 +39,16 @@ type Props = $ReadOnly<{|
  * Pressable avatar for items in the user-picker card.
  */
 export default class AvatarItem extends PureComponent<Props> {
-  animatedValue: AnimatedValue = new Animated.Value(0);
-
-  componentDidMount() {
-    Animated.timing(this.animatedValue, {
-      toValue: 1,
-      duration: 300,
-      useNativeDriver: true,
-      easing: Easing.elastic(),
-    }).start();
-  }
-
   handlePress: () => void = () => {
     const { user, onPress } = this.props;
-    Animated.timing(this.animatedValue, {
-      toValue: 0,
-      duration: 300,
-      useNativeDriver: true,
-      easing: Easing.elastic(),
-    }).start(() => onPress(user.user_id));
+    onPress(user.user_id);
   };
 
   render(): Node {
     const { user } = this.props;
-    const animatedStyle = {
-      transform: [{ scale: this.animatedValue }],
-    };
 
     return (
-      <Animated.View style={[styles.wrapper, animatedStyle]}>
+      <View style={styles.wrapper}>
         <Touchable onPress={this.handlePress}>
           <ComponentWithOverlay
             overlaySize={20}
@@ -82,7 +62,7 @@ export default class AvatarItem extends PureComponent<Props> {
         <View style={styles.textFrame}>
           <ZulipTextIntl style={styles.text} text={getFullNameText({ user })} />
         </View>
-      </Animated.View>
+      </View>
     );
   }
 }

--- a/src/user-picker/AvatarItem.js
+++ b/src/user-picker/AvatarItem.js
@@ -9,8 +9,10 @@ import ComponentWithOverlay from '../common/ComponentWithOverlay';
 import Touchable from '../common/Touchable';
 import { createStyleSheet } from '../styles';
 import { IconCancel } from '../common/Icons';
-import { getFullNameText } from '../users/userSelectors';
+import { getFullNameReactText } from '../users/userSelectors';
 import ZulipTextIntl from '../common/ZulipTextIntl';
+import { useSelector } from '../react-redux';
+import { getRealm } from '../directSelectors';
 
 const styles = createStyleSheet({
   wrapper: {
@@ -40,6 +42,9 @@ type Props = $ReadOnly<{|
  */
 export default function AvatarItem(props: Props): Node {
   const { user, onPress } = props;
+
+  const enableGuestUserIndicator = useSelector(state => getRealm(state).enableGuestUserIndicator);
+
   const handlePress = React.useCallback(() => {
     onPress(user.user_id);
   }, [onPress, user.user_id]);
@@ -57,7 +62,10 @@ export default function AvatarItem(props: Props): Node {
         </ComponentWithOverlay>
       </Touchable>
       <View style={styles.textFrame}>
-        <ZulipTextIntl style={styles.text} text={getFullNameText({ user })} />
+        <ZulipTextIntl
+          style={styles.text}
+          text={getFullNameReactText({ user, enableGuestUserIndicator })}
+        />
       </View>
     </View>
   );

--- a/src/user-statuses/UserStatusScreen.js
+++ b/src/user-statuses/UserStatusScreen.js
@@ -6,6 +6,7 @@ import type { Node } from 'react';
 import { FlatList, View, Pressable } from 'react-native';
 
 import { TranslationContext } from '../boot/TranslationProvider';
+import { noTranslation } from '../i18n/i18n';
 import { createStyleSheet, BRAND_COLOR, HIGHLIGHT_COLOR } from '../styles';
 import type { RouteProp } from '../react-navigation';
 import type { AppNavigationProp } from '../nav/AppNavigator';
@@ -180,15 +181,12 @@ export default function UserStatusScreen(props: Props): Node {
               itemKey={index}
               title={
                 serverSupportsEmojiStatus
-                  ? {
-                      text: '{_}',
-                      values: {
-                        _: `${displayCharacterForUnicodeEmojiCode(
-                          emoji.emoji_code,
-                          serverEmojiData,
-                        )} ${translatedText}`,
-                      },
-                    }
+                  ? noTranslation(
+                      `${displayCharacterForUnicodeEmojiCode(
+                        emoji.emoji_code,
+                        serverEmojiData,
+                      )} ${translatedText}`,
+                    )
                   : text
               }
               selected={

--- a/src/users/UserItem.js
+++ b/src/users/UserItem.js
@@ -11,12 +11,13 @@ import UnreadCount from '../common/UnreadCount';
 import UserAvatarWithPresence from '../common/UserAvatarWithPresence';
 import { createStyleSheet, BRAND_COLOR } from '../styles';
 import { useSelector } from '../react-redux';
-import { getFullNameOrMutedUserText, tryGetUserForId } from './userSelectors';
+import { getFullNameOrMutedUserReactText, tryGetUserForId } from './userSelectors';
 import { getMutedUsers } from '../selectors';
 import { getUserStatus } from '../user-statuses/userStatusesModel';
 import { emojiTypeFromReactionType } from '../emoji/data';
 import Emoji from '../emoji/Emoji';
 import ZulipTextIntl from '../common/ZulipTextIntl';
+import { getRealm } from '../directSelectors';
 
 type Props = $ReadOnly<{|
   userId: UserId,
@@ -40,6 +41,8 @@ export default function UserItem(props: Props): Node {
     size = 'large',
   } = props;
 
+  const enableGuestUserIndicator = useSelector(state => getRealm(state).enableGuestUserIndicator);
+
   const user = useSelector(state => tryGetUserForId(state, userId));
 
   const mutedUsers = useSelector(getMutedUsers);
@@ -56,7 +59,11 @@ export default function UserItem(props: Props): Node {
   }, [onPress, user]);
   const handlePress = onPress && user ? _handlePress : undefined;
 
-  const displayName = getFullNameOrMutedUserText({ user, mutedUsers });
+  const displayName = getFullNameOrMutedUserReactText({
+    user,
+    mutedUsers,
+    enableGuestUserIndicator,
+  });
   let displayEmail = null;
   if (user != null && !isMuted && showEmail) {
     displayEmail = user.email;

--- a/src/users/userSelectors.js
+++ b/src/users/userSelectors.js
@@ -18,6 +18,7 @@ import * as logging from '../utils/logging';
 import { ensureUnreachable } from '../generics';
 import { EmailAddressVisibility, Role } from '../api/permissionsTypes';
 import ZulipText from '../common/ZulipText';
+import { noTranslation } from '../i18n/i18n';
 
 /**
  * All users in this Zulip org (aka realm).
@@ -359,7 +360,7 @@ export function getFullNameText(args: {|
     return { text: '{userFullName} (guest)', values: { userFullName: user.full_name } };
   }
 
-  return { text: '{_}', values: { _: user.full_name } };
+  return noTranslation(user.full_name);
 }
 
 const italicTextStyle = { fontStyle: 'italic' };
@@ -393,7 +394,7 @@ export function getFullNameReactText(args: {|
     };
   }
 
-  return { text: '{_}', values: { _: user.full_name } };
+  return noTranslation(user.full_name);
 }
 
 /**

--- a/src/users/userSelectors.js
+++ b/src/users/userSelectors.js
@@ -338,7 +338,8 @@ export function getDisplayEmailForUser(realm: RealmState, user: UserOrBot): stri
 /**
  * Display text for a user's name, ignoring muting, as LocalizableText.
  *
- * Accepts `null` for the `user` argument; in that case, the text is
+ * Accepts `null` for the `user` argument; in that case, the name is
+ * taken from `fallback` if present, and otherwise the text is
  * "(unknown user)".
  *
  * For the same text as LocalizableReactText, see getFullNameReactText.
@@ -349,11 +350,12 @@ export function getDisplayEmailForUser(realm: RealmState, user: UserOrBot): stri
 export function getFullNameText(args: {|
   user: UserOrBot | null,
   enableGuestUserIndicator: boolean,
+  fallback?: string,
 |}): LocalizableText {
-  const { user, enableGuestUserIndicator } = args;
+  const { user, enableGuestUserIndicator, fallback } = args;
 
   if (user == null) {
-    return '(unknown user)';
+    return fallback != null ? noTranslation(fallback) : '(unknown user)';
   }
 
   if (user.role === Role.Guest && enableGuestUserIndicator) {
@@ -373,11 +375,12 @@ const italicTextStyle = { fontStyle: 'italic' };
 export function getFullNameReactText(args: {|
   +user: UserOrBot | null,
   +enableGuestUserIndicator: boolean,
+  +fallback?: string,
 |}): LocalizableReactText {
-  const { user, enableGuestUserIndicator } = args;
+  const { user, enableGuestUserIndicator, fallback } = args;
 
   if (user == null) {
-    return '(unknown user)';
+    return fallback != null ? noTranslation(fallback) : '(unknown user)';
   }
 
   if (user.role === Role.Guest && enableGuestUserIndicator) {
@@ -400,7 +403,8 @@ export function getFullNameReactText(args: {|
 /**
  * Display text for a user's name, as LocalizableText.
  *
- * Accepts `null` for the `user` argument; in that case, the text is
+ * Accepts `null` for the `user` argument; in that case, the name is
+ * taken from `fallback` if present, and otherwise the text is
  * "(unknown user)".
  *
  * If the user is muted, gives "Muted user".
@@ -414,11 +418,12 @@ export function getFullNameOrMutedUserText(args: {|
   user: UserOrBot | null,
   mutedUsers: MutedUsersState,
   enableGuestUserIndicator: boolean,
+  fallback?: string,
 |}): LocalizableText {
-  const { user, mutedUsers, enableGuestUserIndicator } = args;
+  const { user, mutedUsers, enableGuestUserIndicator, fallback } = args;
 
   if (user == null) {
-    return '(unknown user)';
+    return fallback != null ? noTranslation(fallback) : '(unknown user)';
   }
 
   if (mutedUsers.has(user.user_id)) {
@@ -437,11 +442,12 @@ export function getFullNameOrMutedUserReactText(args: {|
   user: UserOrBot | null,
   mutedUsers: MutedUsersState,
   enableGuestUserIndicator: boolean,
+  fallback?: string,
 |}): LocalizableReactText {
-  const { user, mutedUsers, enableGuestUserIndicator } = args;
+  const { user, mutedUsers, enableGuestUserIndicator, fallback } = args;
 
   if (user == null) {
-    return '(unknown user)';
+    return fallback != null ? noTranslation(fallback) : '(unknown user)';
   }
 
   if (mutedUsers.has(user.user_id)) {

--- a/src/users/userSelectors.js
+++ b/src/users/userSelectors.js
@@ -8,8 +8,9 @@ import type {
   Selector,
   User,
   UserId,
+  LocalizableText,
 } from '../types';
-import type { RealmState } from '../reduxTypes';
+import type { MutedUsersState, RealmState } from '../reduxTypes';
 import { getUsers, getCrossRealmBots, getNonActiveUsers } from '../directSelectors';
 import * as logging from '../utils/logging';
 import { ensureUnreachable } from '../generics';
@@ -328,4 +329,50 @@ export function getDisplayEmailForUser(realm: RealmState, user: UserOrBot): stri
   } else {
     return null;
   }
+}
+
+/**
+ * Display text for a user's name, ignoring muting, as LocalizableText.
+ *
+ * Accepts `null` for the `user` argument; in that case, the text is
+ * "(unknown user)".
+ *
+ * For a function that gives "Muted user" if the user is muted, see
+ * getFullNameOrMutedUserText.
+ */
+export function getFullNameText(args: {| user: UserOrBot | null |}): LocalizableText {
+  const { user } = args;
+
+  if (user == null) {
+    return '(unknown user)';
+  }
+
+  return { text: '{_}', values: { _: user.full_name } };
+}
+
+/**
+ * Display text for a user's name, as LocalizableText.
+ *
+ * Accepts `null` for the `user` argument; in that case, the text is
+ * "(unknown user)".
+ *
+ * If the user is muted, gives "Muted user".
+ *
+ * For a function that ignores muting, see getFullNameOrMutedUserText.
+ */
+export function getFullNameOrMutedUserText(args: {|
+  user: UserOrBot | null,
+  mutedUsers: MutedUsersState,
+|}): LocalizableText {
+  const { user, mutedUsers } = args;
+
+  if (user == null) {
+    return '(unknown user)';
+  }
+
+  if (mutedUsers.has(user.user_id)) {
+    return 'Muted user';
+  }
+
+  return getFullNameText({ user });
 }

--- a/src/webview/__tests__/__snapshots__/generateInboundEventEditSequence-test.js.snap.android
+++ b/src/webview/__tests__/__snapshots__/generateInboundEventEditSequence-test.js.snap.android
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`getEditSequence correct for interesting changes DM recipient headers recipient user's name changed 1`] = `1`;
+
 exports[`getEditSequence correct for interesting changes from empty to empty 1`] = `0`;
 
 exports[`getEditSequence correct for interesting changes from empty to many messages 1`] = `40`;

--- a/src/webview/__tests__/__snapshots__/generateInboundEventEditSequence-test.js.snap.android
+++ b/src/webview/__tests__/__snapshots__/generateInboundEventEditSequence-test.js.snap.android
@@ -1,5 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`getEditSequence correct for interesting changes DM recipient headers enableGuestUserIndicator turns on, affecting a recipient user 1`] = `3`;
+
+exports[`getEditSequence correct for interesting changes DM recipient headers recipient user became guest 1`] = `1`;
+
 exports[`getEditSequence correct for interesting changes DM recipient headers recipient user's name changed 1`] = `1`;
 
 exports[`getEditSequence correct for interesting changes from empty to empty 1`] = `0`;
@@ -70,6 +74,8 @@ exports[`getEditSequence correct for interesting changes within a given message 
 
 exports[`getEditSequence correct for interesting changes within a given message add/remove/change emoji status status emoji: zulip extra -> zulip extra (no change) 1`] = `0`;
 
+exports[`getEditSequence correct for interesting changes within a given message enableGuestUserIndicator turns on, and sender is guest 1`] = `3`;
+
 exports[`getEditSequence correct for interesting changes within a given message follow a topic 1`] = `1`;
 
 exports[`getEditSequence correct for interesting changes within a given message mute a sender 1`] = `1`;
@@ -79,6 +85,8 @@ exports[`getEditSequence correct for interesting changes within a given message 
 exports[`getEditSequence correct for interesting changes within a given message polls vote added 1`] = `3`;
 
 exports[`getEditSequence correct for interesting changes within a given message remove reactions from a message 1`] = `3`;
+
+exports[`getEditSequence correct for interesting changes within a given message sender becomes guest 1`] = `1`;
 
 exports[`getEditSequence correct for interesting changes within a given message sender's name changed 1`] = `1`;
 
@@ -1534,6 +1542,38 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm
 </div>"
 `;
 
+exports[`messages -> piece descriptors -> content HTML is stable/sensible other interesting cases (single messages) guest sender, with enableGuestUserIndicator 1`] = `
+"<div class=\\"msglist-element timerow\\" data-msg-id=\\"1\\">
+  <div class=\\"timerow-left\\"></div>
+  Dec 31, 1969
+  <div class=\\"timerow-right\\"></div>
+</div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"1\\" data-narrow=\\"dG9waWM6MTpleGFtcGxlIHRvcGlj\\">
+  <div class=\\"header stream-text\\" style=\\"color: black;
+              background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
+    # stream 1
+  </div>
+  <div class=\\"topic-text\\" data-followed=\\"false\\">example topic</div>
+  <div class=\\"topic-date\\">Dec 31, 1969</div>
+</div><div class=\\"msglist-element message message-full\\" id=\\"msg-1\\" data-msg-id=\\"1\\" data-mute-state=\\"shown\\">
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-10.png\\" alt=\\"{userFullName} (guest)\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
+  </div>
+  <div class=\\"content\\">
+    <div class=\\"subheader\\">
+  <div class=\\"name-and-status-emoji\\" data-sender-id=\\"10\\">
+    {userFullName} (guest)
+  </div>
+  <div class=\\"static-timestamp\\">11:59 PM</div>
+</div>
+    <p>This is an example stream message.</p>
+
+
+
+  </div>
+  
+</div>"
+`;
+
 exports[`messages -> piece descriptors -> content HTML is stable/sensible other interesting cases (single messages) message in followed topic 1`] = `
 "<div class=\\"msglist-element timerow\\" data-msg-id=\\"1\\">
   <div class=\\"timerow-left\\"></div>
@@ -2051,6 +2091,38 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible other 
 
 
 <div class=\\"reaction-list\\"><span onclick=\\"\\" class=\\"reaction self-voted\\" data-name=\\"thumbs_up\\" data-code=\\"1f44d\\" data-type=\\"unicode_emoji\\">👍&nbsp;4</span></div>
+  </div>
+  
+</div>"
+`;
+
+exports[`messages -> piece descriptors -> content HTML is stable/sensible other interesting cases (single messages) message with reactions displayEmojiReactionUsers: true guest user reacts 1`] = `
+"<div class=\\"msglist-element timerow\\" data-msg-id=\\"1\\">
+  <div class=\\"timerow-left\\"></div>
+  Dec 31, 1969
+  <div class=\\"timerow-right\\"></div>
+</div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"1\\" data-narrow=\\"dG9waWM6MTpleGFtcGxlIHRvcGlj\\">
+  <div class=\\"header stream-text\\" style=\\"color: black;
+              background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
+    # stream 1
+  </div>
+  <div class=\\"topic-text\\" data-followed=\\"false\\">example topic</div>
+  <div class=\\"topic-date\\">Dec 31, 1969</div>
+</div><div class=\\"msglist-element message message-full\\" id=\\"msg-1\\" data-msg-id=\\"1\\" data-mute-state=\\"shown\\">
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-10.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
+  </div>
+  <div class=\\"content\\">
+    <div class=\\"subheader\\">
+  <div class=\\"name-and-status-emoji\\" data-sender-id=\\"10\\">
+    Nonrandom name sender User
+  </div>
+  <div class=\\"static-timestamp\\">11:59 PM</div>
+</div>
+    <p>This is an example stream message.</p>
+
+
+<div class=\\"reaction-list\\"><span onclick=\\"\\" class=\\"reaction\\" data-name=\\"github_parrot\\" data-code=\\"80\\" data-type=\\"realm_emoji\\"><img src=\\"https://zulip.example.org/user_avatars/2/emoji/images/80.gif\\">&nbsp;{userFullName} (guest)</span></div>
   </div>
   
 </div>"

--- a/src/webview/__tests__/__snapshots__/generateInboundEventEditSequence-test.js.snap.android
+++ b/src/webview/__tests__/__snapshots__/generateInboundEventEditSequence-test.js.snap.android
@@ -80,6 +80,8 @@ exports[`getEditSequence correct for interesting changes within a given message 
 
 exports[`getEditSequence correct for interesting changes within a given message remove reactions from a message 1`] = `3`;
 
+exports[`getEditSequence correct for interesting changes within a given message sender's name changed 1`] = `1`;
+
 exports[`getEditSequence correct for interesting changes within a given message star a message 1`] = `1`;
 
 exports[`getEditSequence correct for interesting changes within a given message unfollow a topic 1`] = `1`;

--- a/src/webview/__tests__/__snapshots__/generateInboundEventEditSequence-test.js.snap.ios
+++ b/src/webview/__tests__/__snapshots__/generateInboundEventEditSequence-test.js.snap.ios
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`getEditSequence correct for interesting changes DM recipient headers recipient user's name changed 1`] = `1`;
+
 exports[`getEditSequence correct for interesting changes from empty to empty 1`] = `0`;
 
 exports[`getEditSequence correct for interesting changes from empty to many messages 1`] = `40`;

--- a/src/webview/__tests__/__snapshots__/generateInboundEventEditSequence-test.js.snap.ios
+++ b/src/webview/__tests__/__snapshots__/generateInboundEventEditSequence-test.js.snap.ios
@@ -1,5 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`getEditSequence correct for interesting changes DM recipient headers enableGuestUserIndicator turns on, affecting a recipient user 1`] = `3`;
+
+exports[`getEditSequence correct for interesting changes DM recipient headers recipient user became guest 1`] = `1`;
+
 exports[`getEditSequence correct for interesting changes DM recipient headers recipient user's name changed 1`] = `1`;
 
 exports[`getEditSequence correct for interesting changes from empty to empty 1`] = `0`;
@@ -70,6 +74,8 @@ exports[`getEditSequence correct for interesting changes within a given message 
 
 exports[`getEditSequence correct for interesting changes within a given message add/remove/change emoji status status emoji: zulip extra -> zulip extra (no change) 1`] = `0`;
 
+exports[`getEditSequence correct for interesting changes within a given message enableGuestUserIndicator turns on, and sender is guest 1`] = `3`;
+
 exports[`getEditSequence correct for interesting changes within a given message follow a topic 1`] = `1`;
 
 exports[`getEditSequence correct for interesting changes within a given message mute a sender 1`] = `1`;
@@ -79,6 +85,8 @@ exports[`getEditSequence correct for interesting changes within a given message 
 exports[`getEditSequence correct for interesting changes within a given message polls vote added 1`] = `3`;
 
 exports[`getEditSequence correct for interesting changes within a given message remove reactions from a message 1`] = `3`;
+
+exports[`getEditSequence correct for interesting changes within a given message sender becomes guest 1`] = `1`;
 
 exports[`getEditSequence correct for interesting changes within a given message sender's name changed 1`] = `1`;
 
@@ -1534,6 +1542,38 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible all-pm
 </div>"
 `;
 
+exports[`messages -> piece descriptors -> content HTML is stable/sensible other interesting cases (single messages) guest sender, with enableGuestUserIndicator 1`] = `
+"<div class=\\"msglist-element timerow\\" data-msg-id=\\"1\\">
+  <div class=\\"timerow-left\\"></div>
+  Dec 31, 1969
+  <div class=\\"timerow-right\\"></div>
+</div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"1\\" data-narrow=\\"dG9waWM6MTpleGFtcGxlIHRvcGlj\\">
+  <div class=\\"header stream-text\\" style=\\"color: black;
+              background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
+    # stream 1
+  </div>
+  <div class=\\"topic-text\\" data-followed=\\"false\\">example topic</div>
+  <div class=\\"topic-date\\">Dec 31, 1969</div>
+</div><div class=\\"msglist-element message message-full\\" id=\\"msg-1\\" data-msg-id=\\"1\\" data-mute-state=\\"shown\\">
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-10.png\\" alt=\\"{userFullName} (guest)\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
+  </div>
+  <div class=\\"content\\">
+    <div class=\\"subheader\\">
+  <div class=\\"name-and-status-emoji\\" data-sender-id=\\"10\\">
+    {userFullName} (guest)
+  </div>
+  <div class=\\"static-timestamp\\">11:59 PM</div>
+</div>
+    <p>This is an example stream message.</p>
+
+
+
+  </div>
+  
+</div>"
+`;
+
 exports[`messages -> piece descriptors -> content HTML is stable/sensible other interesting cases (single messages) message in followed topic 1`] = `
 "<div class=\\"msglist-element timerow\\" data-msg-id=\\"1\\">
   <div class=\\"timerow-left\\"></div>
@@ -2051,6 +2091,38 @@ exports[`messages -> piece descriptors -> content HTML is stable/sensible other 
 
 
 <div class=\\"reaction-list\\"><span onclick=\\"\\" class=\\"reaction self-voted\\" data-name=\\"thumbs_up\\" data-code=\\"1f44d\\" data-type=\\"unicode_emoji\\">👍&nbsp;4</span></div>
+  </div>
+  
+</div>"
+`;
+
+exports[`messages -> piece descriptors -> content HTML is stable/sensible other interesting cases (single messages) message with reactions displayEmojiReactionUsers: true guest user reacts 1`] = `
+"<div class=\\"msglist-element timerow\\" data-msg-id=\\"1\\">
+  <div class=\\"timerow-left\\"></div>
+  Dec 31, 1969
+  <div class=\\"timerow-right\\"></div>
+</div><div class=\\"msglist-element header-wrapper header stream-header topic-header\\" data-msg-id=\\"1\\" data-narrow=\\"dG9waWM6MTpleGFtcGxlIHRvcGlj\\">
+  <div class=\\"header stream-text\\" style=\\"color: black;
+              background: hsl(0, 0%, 80%)\\" data-narrow=\\"c3RyZWFtOjE=\\">
+    # stream 1
+  </div>
+  <div class=\\"topic-text\\" data-followed=\\"false\\">example topic</div>
+  <div class=\\"topic-date\\">Dec 31, 1969</div>
+</div><div class=\\"msglist-element message message-full\\" id=\\"msg-1\\" data-msg-id=\\"1\\" data-mute-state=\\"shown\\">
+  <div class=\\"avatar\\">
+    <img src=\\"https://zulip.example.org/yo/avatar-10.png\\" alt=\\"Nonrandom name sender User\\" class=\\"avatar-img\\" data-sender-id=\\"10\\">
+  </div>
+  <div class=\\"content\\">
+    <div class=\\"subheader\\">
+  <div class=\\"name-and-status-emoji\\" data-sender-id=\\"10\\">
+    Nonrandom name sender User
+  </div>
+  <div class=\\"static-timestamp\\">11:59 PM</div>
+</div>
+    <p>This is an example stream message.</p>
+
+
+<div class=\\"reaction-list\\"><span onclick=\\"\\" class=\\"reaction\\" data-name=\\"github_parrot\\" data-code=\\"80\\" data-type=\\"realm_emoji\\"><img src=\\"https://zulip.example.org/user_avatars/2/emoji/images/80.gif\\">&nbsp;{userFullName} (guest)</span></div>
   </div>
   
 </div>"

--- a/src/webview/__tests__/__snapshots__/generateInboundEventEditSequence-test.js.snap.ios
+++ b/src/webview/__tests__/__snapshots__/generateInboundEventEditSequence-test.js.snap.ios
@@ -80,6 +80,8 @@ exports[`getEditSequence correct for interesting changes within a given message 
 
 exports[`getEditSequence correct for interesting changes within a given message remove reactions from a message 1`] = `3`;
 
+exports[`getEditSequence correct for interesting changes within a given message sender's name changed 1`] = `1`;
+
 exports[`getEditSequence correct for interesting changes within a given message star a message 1`] = `1`;
 
 exports[`getEditSequence correct for interesting changes within a given message unfollow a topic 1`] = `1`;

--- a/src/webview/__tests__/generateInboundEventEditSequence-test.js
+++ b/src/webview/__tests__/generateInboundEventEditSequence-test.js
@@ -31,13 +31,11 @@ import { getBackgroundData } from '../backgroundData';
 import { randString } from '../../utils/misc';
 import { makeMuteState } from '../../mute/__tests__/mute-testlib';
 import { UserTopicVisibilityPolicy } from '../../api/modelTypes';
+import { mock_ } from '../../__tests__/lib/intl';
 
 // Tell ESLint to recognize `check` as a helper function that runs
 // assertions.
 /* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["expect", "check"] }] */
-
-// Our translation function, usually given the name _.
-const mock_ = m => (typeof m === 'object' ? m.text : m); // eslint-disable-line no-underscore-dangle
 
 const user1 = eg.makeUser({ user_id: 1, full_name: 'Nonrandom name one User' });
 const user2 = eg.makeUser({ user_id: 2, full_name: 'Nonrandom name two User' });

--- a/src/webview/__tests__/generateInboundEventEditSequence-test.js
+++ b/src/webview/__tests__/generateInboundEventEditSequence-test.js
@@ -1065,8 +1065,26 @@ describe('getEditSequence correct for interesting changes', () => {
       );
     });
 
-    // TODO(#5208): We haven't settled how we want to track name/avatar
-    test.todo("sender's name/avatar changed");
+    test("sender's name changed", () => {
+      const baseUsers = eg.plusReduxState.users;
+      const sender = eg.makeUser();
+      const message = eg.streamMessage({ sender });
+      check(
+        {
+          messages: [message],
+          state: eg.reduxStatePlus({ users: [...baseUsers, sender] }),
+        },
+        {
+          messages: [message],
+          state: eg.reduxStatePlus({
+            users: [...baseUsers, { ...sender, full_name: `${sender.full_name}, Jr.` }],
+          }),
+        },
+      );
+    });
+
+    // TODO(#5208)
+    test.todo("sender's avatar changed");
 
     test('mute a sender', () => {
       const message = eg.streamMessage();

--- a/src/webview/__tests__/generateInboundEventEditSequence-test.js
+++ b/src/webview/__tests__/generateInboundEventEditSequence-test.js
@@ -904,6 +904,25 @@ describe('getEditSequence correct for interesting changes', () => {
     });
   });
 
+  describe('DM recipient headers', () => {
+    test("recipient user's name changed", () => {
+      const sender = eg.selfUser;
+      const message = eg.pmMessage({ sender, recipients: [eg.selfUser, eg.otherUser] });
+      check(
+        {
+          messages: [message],
+          state: eg.reduxStatePlus({ users: [eg.selfUser, eg.otherUser] }),
+        },
+        {
+          messages: [message],
+          state: eg.reduxStatePlus({
+            users: [eg.selfUser, { ...eg.otherUser, full_name: `${sender.full_name}, Jr.` }],
+          }),
+        },
+      );
+    });
+  });
+
   describe('within a given message', () => {
     test('add reactions to a message', () => {
       const message = eg.streamMessage();

--- a/src/webview/__tests__/generateInboundEvents-test.js
+++ b/src/webview/__tests__/generateInboundEvents-test.js
@@ -6,6 +6,7 @@ import { flagsStateToStringList } from '../html/message';
 import { HOME_NARROW } from '../../utils/narrow';
 import * as eg from '../../__tests__/lib/exampleData';
 import type { Props } from '../MessageList';
+import { mock_ } from '../../__tests__/lib/intl';
 
 describe('generateInboundEvents', () => {
   const baseSelectorProps = deepFreeze({
@@ -18,14 +19,7 @@ describe('generateInboundEvents', () => {
     doNotMarkMessagesAsRead: false,
   });
 
-  type FudgedProps = {|
-    ...Props,
-
-    // `intl` property is complicated and not worth testing
-    _: $FlowFixMe,
-  |};
-
-  const baseProps: FudgedProps = deepFreeze({
+  const baseProps: Props = deepFreeze({
     narrow: HOME_NARROW,
     showMessagePlaceholders: false,
     startEditMessage: jest.fn(),
@@ -36,7 +30,7 @@ describe('generateInboundEvents', () => {
     fetchOlder: jest.fn(),
     fetchNewer: jest.fn(),
 
-    _: jest.fn(),
+    _: mock_,
     setDoNotMarkMessagesAsRead: jest.fn(),
   });
 

--- a/src/webview/__tests__/generateInboundEvents-test.js
+++ b/src/webview/__tests__/generateInboundEvents-test.js
@@ -118,7 +118,7 @@ describe('generateInboundEvents', () => {
   });
 
   test('when the rendered messages differ (even deeply) a "content" message is returned', () => {
-    const message = eg.streamMessage();
+    const message = eg.streamMessage({ sender: eg.selfUser });
 
     const prevProps = {
       ...baseProps,

--- a/src/webview/backgroundData.js
+++ b/src/webview/backgroundData.js
@@ -66,6 +66,7 @@ export type BackgroundData = $ReadOnly<{|
   zulipFeatureLevel: number,
   serverEmojiData: ServerEmojiData | null,
   enableReadReceipts: boolean,
+  enableGuestUserIndicator: boolean,
 |}>;
 
 // TODO: Ideally this ought to be a caching selector that doesn't change
@@ -99,5 +100,6 @@ export const getBackgroundData = (
     zulipFeatureLevel: getZulipFeatureLevel(state),
     serverEmojiData: getRealm(state).serverEmojiData,
     enableReadReceipts: getRealm(state).enableReadReceipts,
+    enableGuestUserIndicator: getRealm(state).enableGuestUserIndicator,
   };
 };

--- a/src/webview/backgroundData.js
+++ b/src/webview/backgroundData.js
@@ -34,7 +34,6 @@ import { getUnread } from '../unread/unreadModel';
 import { getUserStatuses } from '../user-statuses/userStatusesModel';
 import { type UserStatusesState } from '../user-statuses/userStatusesCore';
 import { Role } from '../api/permissionsTypes';
-import { getOwnUserRole } from '../permissionSelectors';
 import type { ServerEmojiData } from '../api/modelTypes';
 
 /**
@@ -78,24 +77,27 @@ export type BackgroundData = $ReadOnly<{|
 export const getBackgroundData = (
   state: PerAccountState,
   globalSettings: GlobalSettingsState,
-): BackgroundData => ({
-  alertWords: state.alertWords,
-  allImageEmojiById: getAllImageEmojiById(state),
-  auth: getAuth(state),
-  flags: getFlags(state),
-  mute: getMute(state),
-  allUsersById: getAllUsersById(state),
-  mutedUsers: getMutedUsers(state),
-  ownUser: getOwnUser(state),
-  ownUserRole: getOwnUserRole(state),
-  streams: getStreamsById(state),
-  subscriptions: getSubscriptionsById(state),
-  unread: getUnread(state),
-  twentyFourHourTime: getRealm(state).twentyFourHourTime,
-  userSettingStreamNotification: getSettings(state).streamNotification,
-  displayEmojiReactionUsers: getSettings(state).displayEmojiReactionUsers,
-  userStatuses: getUserStatuses(state),
-  zulipFeatureLevel: getZulipFeatureLevel(state),
-  serverEmojiData: getRealm(state).serverEmojiData,
-  enableReadReceipts: getRealm(state).enableReadReceipts,
-});
+): BackgroundData => {
+  const ownUser = getOwnUser(state);
+  return {
+    alertWords: state.alertWords,
+    allImageEmojiById: getAllImageEmojiById(state),
+    auth: getAuth(state),
+    flags: getFlags(state),
+    mute: getMute(state),
+    allUsersById: getAllUsersById(state),
+    mutedUsers: getMutedUsers(state),
+    ownUser,
+    ownUserRole: ownUser.role,
+    streams: getStreamsById(state),
+    subscriptions: getSubscriptionsById(state),
+    unread: getUnread(state),
+    twentyFourHourTime: getRealm(state).twentyFourHourTime,
+    userSettingStreamNotification: getSettings(state).streamNotification,
+    displayEmojiReactionUsers: getSettings(state).displayEmojiReactionUsers,
+    userStatuses: getUserStatuses(state),
+    zulipFeatureLevel: getZulipFeatureLevel(state),
+    serverEmojiData: getRealm(state).serverEmojiData,
+    enableReadReceipts: getRealm(state).enableReadReceipts,
+  };
+};

--- a/src/webview/generateInboundEventEditSequence.js
+++ b/src/webview/generateInboundEventEditSequence.js
@@ -115,6 +115,11 @@ function doElementsDifferInterestingly(
     case 'message': {
       invariant(newElement.type === 'message', 'oldElement.type equals newElement.type');
 
+      const oldMessage = oldElement.message;
+      const oldSender = oldBackgroundData.allUsersById.get(oldMessage.sender_id);
+      const newMessage = newElement.message;
+      const newSender = newBackgroundData.allUsersById.get(newMessage.sender_id);
+
       return (
         !isEqual(oldElement, newElement)
         // TODO(?): Flags are metadata on a message, not "background data".
@@ -132,6 +137,7 @@ function doElementsDifferInterestingly(
             && oldBackgroundData.flags[flagName][oldElement.message.id]
               !== newBackgroundData.flags[flagName][newElement.message.id],
         )
+        || oldSender?.full_name !== newSender?.full_name
         || oldBackgroundData.mutedUsers.get(oldElement.message.sender_id)
           !== newBackgroundData.mutedUsers.get(newElement.message.sender_id)
         || getUserStatusFromModel(oldBackgroundData.userStatuses, oldElement.message.sender_id)

--- a/src/webview/html/__tests__/header-test.js
+++ b/src/webview/html/__tests__/header-test.js
@@ -4,6 +4,7 @@ import * as eg from '../../../__tests__/lib/exampleData';
 import header from '../header';
 import type { BackgroundData } from '../../backgroundData';
 import { makeMuteState } from '../../../mute/__tests__/mute-testlib';
+import { mock_ } from '../../../__tests__/lib/intl';
 
 const backgroundData: BackgroundData = ({
   mute: makeMuteState([]),
@@ -15,12 +16,16 @@ const backgroundData: BackgroundData = ({
 describe('header', () => {
   test('correctly encodes `<` in topic, in stream narrow', () => {
     const m = eg.streamMessage({ subject: '1 < 2' });
-    const h = header(backgroundData, {
-      type: 'header',
-      key: [m.id, 1],
-      style: 'topic+date',
-      subsequentMessage: m,
-    });
+    const h = header(
+      backgroundData,
+      {
+        type: 'header',
+        key: [m.id, 1],
+        style: 'topic+date',
+        subsequentMessage: m,
+      },
+      mock_,
+    );
     expect(h).not.toContain('1 < 2');
     expect(h).toContain('1 &lt; 2');
     expect(h).not.toContain('1 &amp;lt; 2');

--- a/src/webview/html/header.js
+++ b/src/webview/html/header.js
@@ -33,7 +33,7 @@ const renderTopic = message =>
  * This is a private helper of messageListElementHtml.
  */
 export default (
-  { mute, ownUser, subscriptions }: BackgroundData,
+  { mute, ownUser, subscriptions, allUsersById }: BackgroundData,
   element: HeaderMessageListElement,
 ): string => {
   const { subsequentMessage: message, style: headerStyle } = element;
@@ -97,7 +97,7 @@ export default (
   data-msg-id="${message.id}"
 >
   ${uiRecipients
-    .map(r => r.full_name)
+    .map(r => allUsersById.get(r.id)?.full_name ?? r.full_name)
     .sort()
     .join(', ')}
 </div>`;

--- a/src/webview/html/header.js
+++ b/src/webview/html/header.js
@@ -107,11 +107,16 @@ export default (
 >
   ${uiRecipients
     .map(r => {
-      const user = allUsersById.get(r.id);
+      const user = allUsersById.get(r.id) ?? null;
       // TODO use italics for "(guest)"
-      return user != null
-        ? _(getFullNameOrMutedUserText({ user, mutedUsers, enableGuestUserIndicator }))
-        : r.full_name;
+      return _(
+        getFullNameOrMutedUserText({
+          user,
+          mutedUsers,
+          enableGuestUserIndicator,
+          fallback: r.full_name,
+        }),
+      );
     })
     .sort()
     .join(', ')}

--- a/src/webview/html/header.js
+++ b/src/webview/html/header.js
@@ -34,7 +34,14 @@ const renderTopic = message =>
  * This is a private helper of messageListElementHtml.
  */
 export default (
-  { mute, ownUser, subscriptions, allUsersById, mutedUsers }: BackgroundData,
+  {
+    mute,
+    ownUser,
+    subscriptions,
+    allUsersById,
+    mutedUsers,
+    enableGuestUserIndicator,
+  }: BackgroundData,
   element: HeaderMessageListElement,
   _: GetText,
 ): string => {
@@ -101,7 +108,10 @@ export default (
   ${uiRecipients
     .map(r => {
       const user = allUsersById.get(r.id);
-      return user != null ? _(getFullNameOrMutedUserText({ user, mutedUsers })) : r.full_name;
+      // TODO use italics for "(guest)"
+      return user != null
+        ? _(getFullNameOrMutedUserText({ user, mutedUsers, enableGuestUserIndicator }))
+        : r.full_name;
     })
     .sort()
     .join(', ')}

--- a/src/webview/html/header.js
+++ b/src/webview/html/header.js
@@ -3,7 +3,7 @@ import invariant from 'invariant';
 
 import template from './template';
 import { ensureUnreachable } from '../../types';
-import type { HeaderMessageListElement } from '../../types';
+import type { GetText, HeaderMessageListElement } from '../../types';
 import type { BackgroundData } from '../backgroundData';
 import {
   streamNarrow,
@@ -33,8 +33,9 @@ const renderTopic = message =>
  * This is a private helper of messageListElementHtml.
  */
 export default (
-  { mute, ownUser, subscriptions, allUsersById }: BackgroundData,
+  { mute, ownUser, subscriptions, allUsersById, mutedUsers }: BackgroundData,
   element: HeaderMessageListElement,
+  _: GetText,
 ): string => {
   const { subsequentMessage: message, style: headerStyle } = element;
 
@@ -97,7 +98,9 @@ export default (
   data-msg-id="${message.id}"
 >
   ${uiRecipients
-    .map(r => allUsersById.get(r.id)?.full_name ?? r.full_name)
+    .map(r =>
+      mutedUsers.has(r.id) ? _('Muted user') : allUsersById.get(r.id)?.full_name ?? r.full_name,
+    )
     .sort()
     .join(', ')}
 </div>`;

--- a/src/webview/html/header.js
+++ b/src/webview/html/header.js
@@ -20,6 +20,7 @@ import {
 } from '../../utils/recipient';
 import { base64Utf8Encode } from '../../utils/encoding';
 import { isTopicFollowed } from '../../mute/muteModel';
+import { getFullNameOrMutedUserText } from '../../users/userSelectors';
 
 const renderTopic = message =>
   // TODO: pin down if '' happens, and what its proper semantics are.
@@ -98,9 +99,10 @@ export default (
   data-msg-id="${message.id}"
 >
   ${uiRecipients
-    .map(r =>
-      mutedUsers.has(r.id) ? _('Muted user') : allUsersById.get(r.id)?.full_name ?? r.full_name,
-    )
+    .map(r => {
+      const user = allUsersById.get(r.id);
+      return user != null ? _(getFullNameOrMutedUserText({ user, mutedUsers })) : r.full_name;
+    })
     .sort()
     .join(', ')}
 </div>`;

--- a/src/webview/html/message.js
+++ b/src/webview/html/message.js
@@ -282,7 +282,9 @@ $!${divOpenHtml}
 </div>`;
   }
 
-  const { sender_full_name, sender_id } = message;
+  const { sender_id } = message;
+  const sender = backgroundData.allUsersById.get(sender_id);
+  const senderFullName = sender?.full_name ?? message.sender_full_name;
   const avatarUrl = message.avatar_url
     .get(
       // 48 logical pixels; see `.avatar` and `.avatar img` in
@@ -293,7 +295,7 @@ $!${divOpenHtml}
   const subheaderHtml = template`\
 <div class="subheader">
   <div class="name-and-status-emoji" data-sender-id="${sender_id}">
-    ${sender_full_name}$!${senderEmojiStatus(
+    ${senderFullName}$!${senderEmojiStatus(
     getUserStatusFromModel(backgroundData.userStatuses, sender_id).status_emoji,
     backgroundData,
   )}
@@ -310,7 +312,7 @@ $!${divOpenHtml}
   return template`\
 $!${divOpenHtml}
   <div class="avatar">
-    <img src="${avatarUrl}" alt="${sender_full_name}" class="avatar-img" data-sender-id="${sender_id}">
+    <img src="${avatarUrl}" alt="${senderFullName}" class="avatar-img" data-sender-id="${sender_id}">
   </div>
   <div class="content">
     $!${subheaderHtml}

--- a/src/webview/html/message.js
+++ b/src/webview/html/message.js
@@ -282,16 +282,14 @@ $!${divOpenHtml}
 
   const { sender_id } = message;
   const sender = backgroundData.allUsersById.get(sender_id) ?? null;
-  const senderFullName =
-    sender != null
-      ? _(
-          // TODO use italics for "(guest)"
-          getFullNameText({
-            user: sender,
-            enableGuestUserIndicator: backgroundData.enableGuestUserIndicator,
-          }),
-        )
-      : message.sender_full_name;
+  const senderFullName = _(
+    // TODO use italics for "(guest)"
+    getFullNameText({
+      user: sender,
+      enableGuestUserIndicator: backgroundData.enableGuestUserIndicator,
+      fallback: message.sender_full_name,
+    }),
+  );
   const avatarUrl = message.avatar_url
     .get(
       // 48 logical pixels; see `.avatar` and `.avatar img` in

--- a/src/webview/html/message.js
+++ b/src/webview/html/message.js
@@ -43,7 +43,7 @@ const messageTagsAsHtml = (isStarred: boolean, timeEdited: number | void): strin
 // Like get_display_full_names in the web app's people.js, but also gives
 // "You" so callers don't have to.
 const getDisplayFullNames = (userIds, backgroundData, _) => {
-  const { allUsersById, mutedUsers, ownUser } = backgroundData;
+  const { allUsersById, mutedUsers, ownUser, enableGuestUserIndicator } = backgroundData;
   return userIds.map(id => {
     const user = allUsersById.get(id);
     if (!user) {
@@ -55,7 +55,8 @@ const getDisplayFullNames = (userIds, backgroundData, _) => {
       return _('You');
     }
 
-    return _(getFullNameOrMutedUserText({ user, mutedUsers }));
+    // TODO use italics for "(guest)"
+    return _(getFullNameOrMutedUserText({ user, mutedUsers, enableGuestUserIndicator }));
   });
 };
 
@@ -282,7 +283,15 @@ $!${divOpenHtml}
   const { sender_id } = message;
   const sender = backgroundData.allUsersById.get(sender_id) ?? null;
   const senderFullName =
-    sender != null ? _(getFullNameText({ user: sender })) : message.sender_full_name;
+    sender != null
+      ? _(
+          // TODO use italics for "(guest)"
+          getFullNameText({
+            user: sender,
+            enableGuestUserIndicator: backgroundData.enableGuestUserIndicator,
+          }),
+        )
+      : message.sender_full_name;
   const avatarUrl = message.avatar_url
     .get(
       // 48 logical pixels; see `.avatar` and `.avatar img` in

--- a/src/webview/html/message.js
+++ b/src/webview/html/message.js
@@ -26,6 +26,7 @@ import { displayCharacterForUnicodeEmojiCode } from '../../emoji/data';
 import processAlertWords from './processAlertWords';
 import * as logging from '../../utils/logging';
 import { getUserStatusFromModel } from '../../user-statuses/userStatusesCore';
+import { getFullNameOrMutedUserText, getFullNameText } from '../../users/userSelectors';
 
 const messageTagsAsHtml = (isStarred: boolean, timeEdited: number | void): string => {
   const pieces = [];
@@ -54,11 +55,7 @@ const getDisplayFullNames = (userIds, backgroundData, _) => {
       return _('You');
     }
 
-    if (mutedUsers.has(id)) {
-      return _('Muted user');
-    }
-
-    return user.full_name;
+    return _(getFullNameOrMutedUserText({ user, mutedUsers }));
   });
 };
 
@@ -283,8 +280,9 @@ $!${divOpenHtml}
   }
 
   const { sender_id } = message;
-  const sender = backgroundData.allUsersById.get(sender_id);
-  const senderFullName = sender?.full_name ?? message.sender_full_name;
+  const sender = backgroundData.allUsersById.get(sender_id) ?? null;
+  const senderFullName =
+    sender != null ? _(getFullNameText({ user: sender })) : message.sender_full_name;
   const avatarUrl = message.avatar_url
     .get(
       // 48 logical pixels; see `.avatar` and `.avatar img` in

--- a/src/webview/html/messageListElementHtml.js
+++ b/src/webview/html/messageListElementHtml.js
@@ -20,7 +20,7 @@ export default ({
     case 'time':
       return time(element);
     case 'header':
-      return header(backgroundData, element);
+      return header(backgroundData, element, _);
     case 'message':
       return message(backgroundData, element, _);
     default:

--- a/src/webview/js/rewriteHtml.js
+++ b/src/webview/js/rewriteHtml.js
@@ -145,6 +145,7 @@ const rewriteHtml = (auth: Auth, element: Element | Document = document) => {
   rewriteImageUrls(auth, element);
   rewriteTime(element);
   rewriteSpoilers(element);
+  // TODO add "(guest)" marker on @-mentions
 };
 
 export default rewriteHtml;

--- a/static/translations/messages_en.json
+++ b/static/translations/messages_en.json
@@ -359,6 +359,8 @@
   "No reactions": "No reactions",
   "See who reacted": "See who reacted",
   "Muted user": "Muted user",
+  "{userFullName} (guest)": "{userFullName} (guest)",
+  "{userFullName} <i>(guest)</i>": "{userFullName} <i>(guest)</i>",
   "Only organization admins are allowed to post to this stream.": "Only organization admins are allowed to post to this stream.",
   "Connecting...": "Connecting...",
   "Set your status": "Set your status",


### PR DESCRIPTION
Stacked on my current revision for #5806.

I've put "(guest)" in italics where it's rendered with React components, since it was possible and convenient to do it there.

### DM compose content input placeholder text before / after:

| Before | After |
| --- | --- |
| <img width="552" alt="image" src="https://github.com/zulip/zulip-mobile/assets/22248748/3a1ba9e6-5440-4631-bab5-695ad3e03f07"> | <img width="552" alt="image" src="https://github.com/zulip/zulip-mobile/assets/22248748/2ef95fbd-9eae-4f2a-b354-daf39d5935fb"> |

### Other "after" screenshots:

<img width="552" alt="image" src="https://github.com/zulip/zulip-mobile/assets/22248748/7ee8808c-5fb3-4576-abf8-35eeb4668d69">
<img width="552" alt="image" src="https://github.com/zulip/zulip-mobile/assets/22248748/0a3a6520-f242-4fec-a1ef-901799f08371">
<img width="552" alt="image" src="https://github.com/zulip/zulip-mobile/assets/22248748/e644a427-2449-40b2-b8c4-64aa18d4c4fc">
<img width="552" alt="image" src="https://github.com/zulip/zulip-mobile/assets/22248748/53c4ea54-bb28-4131-b8bf-4c960d024673">
<img width="552" alt="image" src="https://github.com/zulip/zulip-mobile/assets/22248748/4c7951f6-2bbd-4f0b-b18f-37fdb8f4fe81">
<img width="552" alt="image" src="https://github.com/zulip/zulip-mobile/assets/22248748/52ba27e6-013e-4f48-b723-41eaafcc606f">
<img width="552" alt="image" src="https://github.com/zulip/zulip-mobile/assets/22248748/aa01cdc8-4563-4859-bbc4-d9898a4a963f">
<img width="552" alt="image" src="https://github.com/zulip/zulip-mobile/assets/22248748/89f76ab0-0f3d-4d89-86fa-404884f5d566">


Fixes: #5804