### PR TITLE
notifs: Warn about notifications soon to be disabled (not yet with banner)

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "@octokit/core": "^3.4.0",
     "@rollup/plugin-babel": "^5.2.0",
     "@rollup/plugin-node-resolve": "^13.0.4",
+    "@testing-library/react-hooks": "^8.0.1",
     "@types/react-native": "~0.67.6",
     "@vusion/webfonts-generator": "^0.8.0",
     "ast-types": "^0.16.1",

--- a/src/__tests__/lib/exampleData.js
+++ b/src/__tests__/lib/exampleData.js
@@ -817,6 +817,7 @@ export const action = Object.freeze({
       realm_presence_disabled: true,
       realm_private_message_policy: 3,
       realm_push_notifications_enabled: true,
+      realm_push_notifications_enabled_end_timestamp: 1704926069,
       realm_send_welcome_emails: true,
       realm_signup_notifications_stream_id: 3,
       realm_upload_quota_mib: 10,

--- a/src/boot/TranslationProvider.js
+++ b/src/boot/TranslationProvider.js
@@ -12,27 +12,6 @@ import messages from '../i18n/messages';
 // $FlowFixMe[incompatible-type] could put a well-typed mock value here, to help write tests
 export const TranslationContext: React.Context<GetText> = React.createContext(undefined);
 
-/**
- * Provide `_` to the wrapped component, passing other props through.
- *
- * This can be useful when the component is already using its `context`
- * property for a different context provider.  When that isn't the case,
- * simply saying `context: TranslationContext` may be more convenient.
- * Or in a function component, `const _ = useContext(TranslationContext);`.
- */
-export function withGetText<P: { +_: GetText, ... }, C: React.ComponentType<P>>(
-  WrappedComponent: C,
-): React.ComponentType<$ReadOnly<$Exact<$Diff<React.ElementConfig<C>, {| _: GetText |}>>>> {
-  // eslint-disable-next-line func-names
-  return function (props: $Exact<$Diff<React.ElementConfig<C>, {| _: GetText |}>>): React.Node {
-    return (
-      <TranslationContext.Consumer>
-        {_ => <WrappedComponent _={_} {...props} />}
-      </TranslationContext.Consumer>
-    );
-  };
-}
-
 const makeGetText = (intl: IntlShape): GetText => {
   const _ = (message, values_) => {
     const text = typeof message === 'object' ? message.text : message;

--- a/src/common/ServerPushSetupBanner.js
+++ b/src/common/ServerPushSetupBanner.js
@@ -15,6 +15,7 @@ import {
   notifProblemShortReactText,
 } from '../settings/NotifTroubleshootingScreen';
 import type { AppNavigationMethods } from '../nav/AppNavigator';
+import { useDateRefreshedAtInterval } from '../reactUtils';
 
 type Props = $ReadOnly<{|
   navigation: AppNavigationMethods,
@@ -41,6 +42,8 @@ export default function ServerPushSetupBanner(props: Props): Node {
   const silenceServerPushSetupWarnings = useSelector(getSilenceServerPushSetupWarnings);
   const realmName = useSelector(getRealmName);
 
+  const dateNow = useDateRefreshedAtInterval(60_000);
+
   let visible = false;
   let text = '';
   if (pushNotificationsEnabled) {
@@ -49,9 +52,7 @@ export default function ServerPushSetupBanner(props: Props): Node {
     // don't show
   } else if (
     lastDismissedServerPushSetupNotice !== null
-    // TODO: Could rerender this component on an interval, to give an
-    //   upper bound on how outdated this `new Date()` can be.
-    && lastDismissedServerPushSetupNotice >= subWeeks(new Date(), 2)
+    && lastDismissedServerPushSetupNotice >= subWeeks(dateNow, 2)
   ) {
     // don't show
   } else {

--- a/src/reactUtils.js
+++ b/src/reactUtils.js
@@ -149,3 +149,29 @@ export const useHasStayedTrueForMs = (value: boolean, duration: number): boolean
 //   https://reactjs.org/docs/hooks-effect.html#tip-optimizing-performance-by-skipping-effects
 export const useConditionalEffect = (cb: () => void | (() => void), value: boolean): void =>
   React.useEffect(() => (value ? cb() : undefined), [value, cb]);
+
+/**
+ * A Date, as React state that refreshes regularly at an interval.
+ *
+ * Use this in a React component that relies on the current date, to make it
+ * periodically rerender with a refreshed date value.
+ *
+ * Don't change the value of refreshIntervalMs.
+ *
+ * This uses `setTimeout`, which is subject to slightly late timeouts:
+ *   https://developer.mozilla.org/en-US/docs/Web/API/setTimeout#reasons_for_delays_longer_than_specified
+ * so don't expect millisecond precision.
+ */
+export const useDateRefreshedAtInterval = (refreshIntervalMs: number): Date => {
+  useDebugAssertConstant(refreshIntervalMs);
+
+  const [date, setDate] = React.useState(new Date());
+  useConditionalEffect(
+    React.useCallback(() => {
+      setDate(new Date());
+    }, []),
+    useHasNotChangedForMs(date, refreshIntervalMs),
+  );
+
+  return date;
+};

--- a/src/realm/__tests__/realmReducer-test.js
+++ b/src/realm/__tests__/realmReducer-test.js
@@ -60,6 +60,8 @@ describe('realmReducer', () => {
         messageContentDeleteLimitSeconds: action.data.realm_message_content_delete_limit_seconds,
         messageContentEditLimitSeconds: action.data.realm_message_content_edit_limit_seconds,
         pushNotificationsEnabled: action.data.realm_push_notifications_enabled,
+        pushNotificationsEnabledEndTimestamp:
+          action.data.realm_push_notifications_enabled_end_timestamp,
         webPublicStreamsEnabled: action.data.server_web_public_streams_enabled,
         createPublicStreamPolicy: action.data.realm_create_public_stream_policy,
         createPrivateStreamPolicy: action.data.realm_create_private_stream_policy,
@@ -406,6 +408,16 @@ describe('realmReducer', () => {
         check(true, false);
         check(false, true);
         check(false, false);
+      });
+
+      describe('pushNotificationsEnabledEndTimestamp / push_notifications_enabled_end_timestamp', () => {
+        const check = mkCheck(
+          'pushNotificationsEnabledEndTimestamp',
+          'push_notifications_enabled_end_timestamp',
+        );
+        check(123, null);
+        check(null, 123);
+        check(123, 234);
       });
 
       describe('create{Private,Public}StreamPolicy / create_stream_policy', () => {

--- a/src/realm/realmReducer.js
+++ b/src/realm/realmReducer.js
@@ -44,6 +44,7 @@ const initialState = {
   messageContentDeleteLimitSeconds: null,
   messageContentEditLimitSeconds: 1,
   pushNotificationsEnabled: true,
+  pushNotificationsEnabledEndTimestamp: null,
   createPublicStreamPolicy: CreatePublicOrPrivateStreamPolicy.MemberOrAbove,
   createPrivateStreamPolicy: CreatePublicOrPrivateStreamPolicy.MemberOrAbove,
   webPublicStreamsEnabled: false,
@@ -146,6 +147,8 @@ export default (
         messageContentDeleteLimitSeconds: action.data.realm_message_content_delete_limit_seconds,
         messageContentEditLimitSeconds: action.data.realm_message_content_edit_limit_seconds,
         pushNotificationsEnabled: action.data.realm_push_notifications_enabled,
+        pushNotificationsEnabledEndTimestamp:
+          action.data.realm_push_notifications_enabled_end_timestamp ?? null,
         createPublicStreamPolicy:
           action.data.realm_create_public_stream_policy
           ?? action.data.realm_create_stream_policy
@@ -254,6 +257,10 @@ export default (
             }
             if (data.push_notifications_enabled !== undefined) {
               result.pushNotificationsEnabled = data.push_notifications_enabled;
+            }
+            if (data.push_notifications_enabled_end_timestamp !== undefined) {
+              result.pushNotificationsEnabledEndTimestamp =
+                data.push_notifications_enabled_end_timestamp;
             }
             if (data.create_stream_policy !== undefined) {
               // TODO(server-5.0): Stop expecting create_stream_policy; simplify.

--- a/src/reduxTypes.js
+++ b/src/reduxTypes.js
@@ -302,6 +302,7 @@ export type RealmState = {|
   +messageContentDeleteLimitSeconds: number | null,
   +messageContentEditLimitSeconds: number,
   +pushNotificationsEnabled: boolean,
+  +pushNotificationsEnabledEndTimestamp: number | null,
   +createPublicStreamPolicy: CreatePublicOrPrivateStreamPolicyT,
   +createPrivateStreamPolicy: CreatePublicOrPrivateStreamPolicyT,
   +webPublicStreamsEnabled: boolean,

--- a/src/settings/PerAccountNotificationSettingsGroup.js
+++ b/src/settings/PerAccountNotificationSettingsGroup.js
@@ -27,6 +27,8 @@ import {
   NotificationProblem,
   notifProblemShortReactText,
   chooseNotifProblemForShortText,
+  pushNotificationsEnabledEndTimestampWarning,
+  kPushNotificationsEnabledEndDoc,
 } from './NotifTroubleshootingScreen';
 import { keyOfIdentity } from '../account/accountMisc';
 import { ApiError } from '../api/apiErrors';
@@ -34,6 +36,7 @@ import { showErrorAlert } from '../utils/info';
 import * as logging from '../utils/logging';
 import { TranslationContext } from '../boot/TranslationProvider';
 import { setSilenceServerPushSetupWarnings } from '../account/accountActions';
+import { useDateRefreshedAtInterval } from '../reactUtils';
 
 type Props = $ReadOnly<{|
   navigation: AppNavigationMethods,
@@ -48,6 +51,8 @@ export default function PerAccountNotificationSettingsGroup(props: Props): Node 
   const dispatch = useDispatch();
   const _ = React.useContext(TranslationContext);
 
+  const dateNow = useDateRefreshedAtInterval(60_000);
+
   const auth = useSelector(getAuth);
   const identity = useSelector(getIdentity);
   const notificationReportsByIdentityKey = useNotificationReportsByIdentityKey();
@@ -59,6 +64,8 @@ export default function PerAccountNotificationSettingsGroup(props: Props): Node 
   const realmName = useSelector(getRealmName);
   const zulipFeatureLevel = useSelector(getZulipFeatureLevel);
   const pushNotificationsEnabled = useSelector(state => getRealm(state).pushNotificationsEnabled);
+  const perAccountState = useSelector(state => state);
+  const expiryWarning = pushNotificationsEnabledEndTimestampWarning(perAccountState, dateNow);
   const silenceServerPushSetupWarnings = useSelector(getSilenceServerPushSetupWarnings);
   const offlineNotification = useSelector(state => getSettings(state).offlineNotification);
   const onlineNotification = useSelector(state => getSettings(state).onlineNotification);
@@ -67,6 +74,10 @@ export default function PerAccountNotificationSettingsGroup(props: Props): Node 
   const globalSettings = useGlobalSelector(getGlobalSettings);
 
   const pushToken = useGlobalSelector(state => getGlobalSession(state).pushToken);
+
+  const handleExpiryWarningPress = React.useCallback(() => {
+    openLinkWithUserPreference(kPushNotificationsEnabledEndDoc, globalSettings);
+  }, [globalSettings]);
 
   const handleSilenceWarningsChange = React.useCallback(() => {
     dispatch(setSilenceServerPushSetupWarnings(!silenceServerPushSetupWarnings));
@@ -163,6 +174,17 @@ export default function PerAccountNotificationSettingsGroup(props: Props): Node 
   }
 
   const children = [];
+  if (expiryWarning != null) {
+    children.push(
+      <NavRow
+        key="expiry"
+        type="external"
+        leftElement={{ type: 'icon', Component: IconAlertTriangle, color: kWarningColor }}
+        title={expiryWarning.reactText}
+        onPress={handleExpiryWarningPress}
+      />,
+    );
+  }
   if (pushNotificationsEnabled) {
     children.push(
       <SwitchRow

--- a/src/storage/__tests__/migrations-test.js
+++ b/src/storage/__tests__/migrations-test.js
@@ -112,7 +112,7 @@ describe('migrations', () => {
   // What `base` becomes after all migrations.
   const endBase = {
     ...base62,
-    migrations: { version: 64 },
+    migrations: { version: 65 },
   };
 
   for (const [desc, before, after] of [
@@ -135,9 +135,9 @@ describe('migrations', () => {
     // redundant with this one, because none of the migration steps notice
     // whether any properties outside `storeKeys` are present or not.
     [
-      'check dropCache at 64',
+      'check dropCache at 65',
       // Just before the `dropCache`, plus a `cacheKeys` property, plus junk.
-      { ...base62, migrations: { version: 63 }, mute: [], nonsense: [1, 2, 3] },
+      { ...base62, migrations: { version: 64 }, mute: [], nonsense: [1, 2, 3] },
       // Should wind up with the same result as without the extra properties.
       endBase,
     ],

--- a/src/storage/migrations.js
+++ b/src/storage/migrations.js
@@ -532,6 +532,9 @@ const migrationsInner: {| [string]: (LessPartialState) => LessPartialState |} = 
   // Add enableGuestUserIndicator to state.realm
   '64': dropCache,
 
+  // Add pushNotificationsEnabledEndTimestamp to state.realm
+  '65': dropCache,
+
   // TIP: When adding a migration, consider just using `dropCache`.
   //   (See its jsdoc for guidance on when that's the right answer.)
 };

--- a/src/types.js
+++ b/src/types.js
@@ -372,15 +372,8 @@ export type LocalizableReactText =
 /**
  * Usually called `_`, and invoked like `_('Message')` -> `'Nachricht'`.
  *
- * To use, put these two lines at the top of a React component's body:
- *
- *     static contextType = TranslationContext;
- *     context: GetText;
- *
- * and then in methods, say `const _ = this.context`.
- *
- * Alternatively, for when `context` is already in use: use `withGetText`
- * and then say `const { _ } = this.props`.
+ * To use:
+ *   const _ = React.useContext(TranslationContext);
  */
 export type GetText = {|
   (message: string, values?: {| +[string]: MessageFormatPrimitiveValue |}): string,

--- a/src/webview/MessageList.js
+++ b/src/webview/MessageList.js
@@ -65,8 +65,8 @@ type OuterProps = $ReadOnly<{|
  *
  * This can be thought of -- hence the name -- as the React props for a
  * notional inner component, like we'd have if we obtained this data through
- * HOCs like `connect` and `withGetText`.  (Instead, we use Hooks, and don't
- * have a separate inner component.)
+ * HOCs like `connect`.  (Instead, we use Hooks, and don't have a separate
+ * inner component.)
  */
 export type Props = $ReadOnly<{|
   ...OuterProps,

--- a/static/translations/messages_en.json
+++ b/static/translations/messages_en.json
@@ -77,6 +77,8 @@
   "Terms for {realmName}": "Terms for {realmName}",
   "Dismiss": "Dismiss",
   "Push notifications are not enabled for {realmName}.": "Push notifications are not enabled for {realmName}.",
+  "On {endTimestamp, date, short} at {endTimestamp, time, ::H:mm z}, push notifications will be disabled for {realmName}.": "On {endTimestamp, date, short} at {endTimestamp, time, ::H:mm z}, push notifications will be disabled for {realmName}.",
+  "On {endTimestamp, date, short} at {endTimestamp, time, ::h:mm z}, push notifications will be disabled for {realmName}.": "On {endTimestamp, date, short} at {endTimestamp, time, ::h:mm z}, push notifications will be disabled for {realmName}.",
   "The Zulip server at {realm} has not yet registered your device token. A request is in progress.": "The Zulip server at {realm} has not yet registered your device token. A request is in progress.",
   "The Zulip server at {realm} has not yet registered your device token.": "The Zulip server at {realm} has not yet registered your device token.",
   "Registration failed": "Registration failed",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2595,6 +2595,14 @@
   dependencies:
     defer-to-connect "^2.0.0"
 
+"@testing-library/react-hooks@^8.0.1":
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/react-hooks/-/react-hooks-8.0.1.tgz#0924bbd5b55e0c0c0502d1754657ada66947ca12"
+  integrity sha512-Aqhl2IVmLt8IovEVarNDFuJDVWVvhnr9/GCU6UUnrYXwgDFF9h2L2o2P9KBni1AST5sT6riAyoukFLyjQUgD/g==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    react-error-boundary "^3.1.0"
+
 "@tootallnate/once@1":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
@@ -10459,6 +10467,13 @@ react-dom@^16.13.1:
     object-assign "^4.1.1"
     prop-types "^15.6.2"
     scheduler "^0.19.1"
+
+react-error-boundary@^3.1.0:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-3.1.4.tgz#255db92b23197108757a888b01e5b729919abde0"
+  integrity sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
 
 react-freeze@^1.0.0:
   version "1.0.3"


### PR DESCRIPTION
Soon, we'll add a snoozable banner. But for now:

- Warning icon / subtitle text on the "Notifications" row on the settings screen
- Warning row in the notification-settings screen
- Warning icon on the "Pick account" screen

-----

(I reused some React Hooks testing infrastructure from an old draft branch I had lying around.)