### PR TITLE
notif: For test-notification button, require FL 234+ instead of 217+

### DIFF
--- a/src/settings/PerAccountNotificationSettingsGroup.js
+++ b/src/settings/PerAccountNotificationSettingsGroup.js
@@ -146,7 +146,7 @@ export default function PerAccountNotificationSettingsGroup(props: Props): Node 
   }, [_, auth, pushToken]);
 
   let testNotificationDisabled = false;
-  if (zulipFeatureLevel < 217) {
+  if (zulipFeatureLevel < 234) {
     testNotificationDisabled = {
       title: 'Feature not available',
       message: {


### PR DESCRIPTION
Servers with FL 217+ but not 234+ will send a payload to the bouncer that's missing realm_name, and the bouncer will error because it assumes realm_name is present. See API changelog:
  https://zulip.com/api/changelog

So, require 234+. Like 217, 234 was released in Zulip Server 8.0, so the error dialog we give the user should still be accurate:

> Feature not available

> This feature is only available for organizations on Zulip Server 8.0+.