### PR TITLE
compose: Fix breakage of LaTeX delimiters in quote-and-reply

### DIFF
--- a/src/compose/ComposeBox.js
+++ b/src/compose/ComposeBox.js
@@ -363,7 +363,7 @@ const ComposeBox: React$AbstractComponent<Props, ImperativeHandle> = forwardRef(
             setMessageInputValue(state =>
               state.value.replace(
                 placeholder,
-                `[${_('Failed to upload file: {fileName}', { fileName })}]()`,
+                () => `[${_('Failed to upload file: {fileName}', { fileName })}]()`,
               ),
             );
             continue;
@@ -372,7 +372,7 @@ const ComposeBox: React$AbstractComponent<Props, ImperativeHandle> = forwardRef(
           const linkText = `[${fileName}](${response.uri})`;
           setMessageInputValue(state =>
             state.value.indexOf(placeholder) !== -1
-              ? state.value.replace(placeholder, linkText)
+              ? state.value.replace(placeholder, () => linkText)
               : `${state.value}\n${linkText}`,
           );
         }
@@ -448,7 +448,9 @@ const ComposeBox: React$AbstractComponent<Props, ImperativeHandle> = forwardRef(
           zulipFeatureLevel,
           _,
         });
-        setMessageInputValue(state => state.value.replace(quotingPlaceholder, quoteAndReplyText));
+        setMessageInputValue(state =>
+          state.value.replace(quotingPlaceholder, () => quoteAndReplyText),
+        );
         messageInputRef.current?.focus();
       } finally {
         setActiveQuoteAndRepliesCount(v => v - 1);

--- a/src/users/userSelectors.js
+++ b/src/users/userSelectors.js
@@ -250,7 +250,8 @@ function interpretCustomProfileField(
       );
       const { subtype, url_pattern } = realmData;
       const pattern = url_pattern ?? realmDefaultExternalAccounts.get(subtype)?.url_pattern;
-      const url = pattern == null ? undefined : new URL(pattern.replace('%(username)s', value));
+      const url =
+        pattern == null ? undefined : new URL(pattern.replace('%(username)s', () => value));
       if (!url) {
         logging.warn(
           `Missing url_pattern for custom profile field of type ExternalAccount, subtype '${subtype}'`,


### PR DESCRIPTION
String.prototype.replace and String.prototype.replaceAll interpret certain sequences such as $$ within a string provided as the replacement argument. Because of this, LaTeX delimiters $$ were turning into $, and other sequences could duplicate part of the existing draft.

Avoid this interpretation by providing a function.

Fixes: #5849