### PR TITLE
TranslationProvider: Fix crash on login, from non-null-FL invariant

### DIFF
--- a/src/boot/TranslationProvider.js
+++ b/src/boot/TranslationProvider.js
@@ -15,6 +15,7 @@ import {
   streamChannelRenameFeatureLevel,
   streamChannelRenamesMap,
 } from './streamChannelRenamesMap';
+import { getHaveServerData } from '../haveServerDataSelectors';
 
 // $FlowFixMe[incompatible-type] could put a well-typed mock value here, to help write tests
 export const TranslationContext: React.Context<GetText> = React.createContext(undefined);
@@ -103,6 +104,7 @@ export default function TranslationProvider(props: Props): React.Node {
   // TODO(server-9.0) remove "stream" terminology
   const effectiveMessagesByLanguage =
     activeAccountState == null
+    || !getHaveServerData(activeAccountState)
     || getZulipFeatureLevel(activeAccountState) >= streamChannelRenameFeatureLevel
       ? messagesByLanguageRenamed
       : messagesByLanguage;

--- a/src/boot/streamChannelRenamesMap.js
+++ b/src/boot/streamChannelRenamesMap.js
@@ -4,8 +4,9 @@
  * The feature level at which we want to say "channel" instead of "stream".
  *
  * Outside a per-account context, check the feature level of the active
- * account, if there is one. If there isn't an active account, just choose
- * "channel" terminology unconditionally.
+ * account, if there is one and it has server data. If there isn't an active
+ * account or it doesn't have server data, just choose "channel" terminology
+ * unconditionally.
  */
 // TODO(server-9.0) simplify away
 // https://chat.zulip.org/api/changelog#changes-in-zulip-90


### PR DESCRIPTION
Sentry is reminding us that we forgot to check if the active account has server data. Adding this check fixes a crash when `zulipFeatureLevel` is null because of not having server data right after login.