### PR TITLE
android: compileSdkVersion to 34 (Android 14)

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -19,7 +19,7 @@ buildscript {
         //   https://medium.com/androiddevelopers/picking-your-compilesdkversion-minsdkversion-targetsdkversion-a098a0341ebd
         // What's the latest?  Consult this list:
         //   https://developer.android.com/studio/releases/platforms
-        compileSdkVersion = 33
+        compileSdkVersion = 34
     }
     repositories {
         google()


### PR DESCRIPTION
As we said on the last one of these, fc2dab717:

  This setting is not to be confused with the targetSdkVersion. The
  latter goes into the built manifest, and affects a wide range of
  behavior, so bumping it requires careful testing. This is used
  purely at build time, and should have no effect on runtime
  behavior.

This value needs to be at least as high as targetSdkVersion, and we need to bump that to 34 soon (#5877). So, do this to prepare for that.

No build failures or warnings appeared for me with
  tools/test native --all-files
.

Related: #5877