### PR TITLE
Style thumbnail placeholders nicely

### DIFF
--- a/src/webview/css/cssNight.js
+++ b/src/webview/css/cssNight.js
@@ -17,4 +17,7 @@ body {
 .highlight {
   background-color: hsla(51, 100%, 64%, 0.42);
 }
+.message_inline_image img.image-loading-placeholder {
+  content: url("images/loader-white.svg");
+}
 `;

--- a/src/webview/static/base.css
+++ b/src/webview/static/base.css
@@ -552,6 +552,9 @@ time {
   height: 160px;
   object-fit: scale-down;
 }
+.message_inline_image img.image-loading-placeholder {
+  content: url("images/loader-black.svg");
+}
 
 .message_inline_video {
   position: relative;

--- a/src/webview/static/base.css
+++ b/src/webview/static/base.css
@@ -550,7 +550,7 @@ time {
 .twitter-image img {
   width: 100%;
   height: 160px;
-  object-fit: contain;
+  object-fit: scale-down;
 }
 
 .message_inline_video {

--- a/src/webview/static/images/loader-black.svg
+++ b/src/webview/static/images/loader-black.svg
@@ -1,0 +1,49 @@
+<svg width="30px"  height="30px"  xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 100 100" preserveAspectRatio="xMidYMid" style="background: none;"><g transform="rotate(0 50 50)">
+  <rect x="47" y="15" rx="9.4" ry="3" width="6" height="20" fill="#000">
+    <animate attributeName="opacity" values="1;0" times="0;1" dur="1s" begin="-0.9166666666666666s" repeatCount="indefinite"></animate>
+  </rect>
+</g><g transform="rotate(30 50 50)">
+  <rect x="47" y="15" rx="9.4" ry="3" width="6" height="20" fill="#000">
+    <animate attributeName="opacity" values="1;0" times="0;1" dur="1s" begin="-0.8333333333333334s" repeatCount="indefinite"></animate>
+  </rect>
+</g><g transform="rotate(60 50 50)">
+  <rect x="47" y="15" rx="9.4" ry="3" width="6" height="20" fill="#000">
+    <animate attributeName="opacity" values="1;0" times="0;1" dur="1s" begin="-0.75s" repeatCount="indefinite"></animate>
+  </rect>
+</g><g transform="rotate(90 50 50)">
+  <rect x="47" y="15" rx="9.4" ry="3" width="6" height="20" fill="#000">
+    <animate attributeName="opacity" values="1;0" times="0;1" dur="1s" begin="-0.6666666666666666s" repeatCount="indefinite"></animate>
+  </rect>
+</g><g transform="rotate(120 50 50)">
+  <rect x="47" y="15" rx="9.4" ry="3" width="6" height="20" fill="#000">
+    <animate attributeName="opacity" values="1;0" times="0;1" dur="1s" begin="-0.5833333333333334s" repeatCount="indefinite"></animate>
+  </rect>
+</g><g transform="rotate(150 50 50)">
+  <rect x="47" y="15" rx="9.4" ry="3" width="6" height="20" fill="#000">
+    <animate attributeName="opacity" values="1;0" times="0;1" dur="1s" begin="-0.5s" repeatCount="indefinite"></animate>
+  </rect>
+</g><g transform="rotate(180 50 50)">
+  <rect x="47" y="15" rx="9.4" ry="3" width="6" height="20" fill="#000">
+    <animate attributeName="opacity" values="1;0" times="0;1" dur="1s" begin="-0.4166666666666667s" repeatCount="indefinite"></animate>
+  </rect>
+</g><g transform="rotate(210 50 50)">
+  <rect x="47" y="15" rx="9.4" ry="3" width="6" height="20" fill="#000">
+    <animate attributeName="opacity" values="1;0" times="0;1" dur="1s" begin="-0.3333333333333333s" repeatCount="indefinite"></animate>
+  </rect>
+</g><g transform="rotate(240 50 50)">
+  <rect x="47" y="15" rx="9.4" ry="3" width="6" height="20" fill="#000">
+    <animate attributeName="opacity" values="1;0" times="0;1" dur="1s" begin="-0.25s" repeatCount="indefinite"></animate>
+  </rect>
+</g><g transform="rotate(270 50 50)">
+  <rect x="47" y="15" rx="9.4" ry="3" width="6" height="20" fill="#000">
+    <animate attributeName="opacity" values="1;0" times="0;1" dur="1s" begin="-0.16666666666666666s" repeatCount="indefinite"></animate>
+  </rect>
+</g><g transform="rotate(300 50 50)">
+  <rect x="47" y="15" rx="9.4" ry="3" width="6" height="20" fill="#000">
+    <animate attributeName="opacity" values="1;0" times="0;1" dur="1s" begin="-0.08333333333333333s" repeatCount="indefinite"></animate>
+  </rect>
+</g><g transform="rotate(330 50 50)">
+  <rect x="47" y="15" rx="9.4" ry="3" width="6" height="20" fill="#000">
+    <animate attributeName="opacity" values="1;0" times="0;1" dur="1s" begin="0s" repeatCount="indefinite"></animate>
+  </rect>
+</g></svg>

--- a/src/webview/static/images/loader-white.svg
+++ b/src/webview/static/images/loader-white.svg
@@ -1,0 +1,49 @@
+<svg width="30px"  height="30px"  xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 100 100" preserveAspectRatio="xMidYMid" style="background: none;"><g transform="rotate(0 50 50)">
+  <rect x="47" y="15" rx="9.4" ry="3" width="6" height="20" fill="#ffffff">
+    <animate attributeName="opacity" values="1;0" times="0;1" dur="1s" begin="-0.9166666666666666s" repeatCount="indefinite"></animate>
+  </rect>
+</g><g transform="rotate(30 50 50)">
+  <rect x="47" y="15" rx="9.4" ry="3" width="6" height="20" fill="#ffffff">
+    <animate attributeName="opacity" values="1;0" times="0;1" dur="1s" begin="-0.8333333333333334s" repeatCount="indefinite"></animate>
+  </rect>
+</g><g transform="rotate(60 50 50)">
+  <rect x="47" y="15" rx="9.4" ry="3" width="6" height="20" fill="#ffffff">
+    <animate attributeName="opacity" values="1;0" times="0;1" dur="1s" begin="-0.75s" repeatCount="indefinite"></animate>
+  </rect>
+</g><g transform="rotate(90 50 50)">
+  <rect x="47" y="15" rx="9.4" ry="3" width="6" height="20" fill="#ffffff">
+    <animate attributeName="opacity" values="1;0" times="0;1" dur="1s" begin="-0.6666666666666666s" repeatCount="indefinite"></animate>
+  </rect>
+</g><g transform="rotate(120 50 50)">
+  <rect x="47" y="15" rx="9.4" ry="3" width="6" height="20" fill="#ffffff">
+    <animate attributeName="opacity" values="1;0" times="0;1" dur="1s" begin="-0.5833333333333334s" repeatCount="indefinite"></animate>
+  </rect>
+</g><g transform="rotate(150 50 50)">
+  <rect x="47" y="15" rx="9.4" ry="3" width="6" height="20" fill="#ffffff">
+    <animate attributeName="opacity" values="1;0" times="0;1" dur="1s" begin="-0.5s" repeatCount="indefinite"></animate>
+  </rect>
+</g><g transform="rotate(180 50 50)">
+  <rect x="47" y="15" rx="9.4" ry="3" width="6" height="20" fill="#ffffff">
+    <animate attributeName="opacity" values="1;0" times="0;1" dur="1s" begin="-0.4166666666666667s" repeatCount="indefinite"></animate>
+  </rect>
+</g><g transform="rotate(210 50 50)">
+  <rect x="47" y="15" rx="9.4" ry="3" width="6" height="20" fill="#ffffff">
+    <animate attributeName="opacity" values="1;0" times="0;1" dur="1s" begin="-0.3333333333333333s" repeatCount="indefinite"></animate>
+  </rect>
+</g><g transform="rotate(240 50 50)">
+  <rect x="47" y="15" rx="9.4" ry="3" width="6" height="20" fill="#ffffff">
+    <animate attributeName="opacity" values="1;0" times="0;1" dur="1s" begin="-0.25s" repeatCount="indefinite"></animate>
+  </rect>
+</g><g transform="rotate(270 50 50)">
+  <rect x="47" y="15" rx="9.4" ry="3" width="6" height="20" fill="#ffffff">
+    <animate attributeName="opacity" values="1;0" times="0;1" dur="1s" begin="-0.16666666666666666s" repeatCount="indefinite"></animate>
+  </rect>
+</g><g transform="rotate(300 50 50)">
+  <rect x="47" y="15" rx="9.4" ry="3" width="6" height="20" fill="#ffffff">
+    <animate attributeName="opacity" values="1;0" times="0;1" dur="1s" begin="-0.08333333333333333s" repeatCount="indefinite"></animate>
+  </rect>
+</g><g transform="rotate(330 50 50)">
+  <rect x="47" y="15" rx="9.4" ry="3" width="6" height="20" fill="#ffffff">
+    <animate attributeName="opacity" values="1;0" times="0;1" dur="1s" begin="0s" repeatCount="indefinite"></animate>
+  </rect>
+</g></svg>

--- a/tools/build-webview
+++ b/tools/build-webview
@@ -195,6 +195,8 @@ sync "src/webview/static" "${dest}" <<EOF
 + /base.css
 + /images/
 + /images/follow.svg
++ /images/loader-black.svg
++ /images/loader-white.svg
 + /images/play_button.svg
 - *
 EOF


### PR DESCRIPTION
As expected, the only changes we need to make for thumbnail support #5875 are to the styling for the placeholder before a thumbnail is ready.

Along the way we also fix a quirk which I'd very occasionally spotted before and always looked wrong, but hadn't been a priority.

Thanks to @alexmv for help testing these changes. Chat thread: https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/thumbnails/near/1892137

---

content: Use `object-fit: scale-down` to fit images, vs. `contain`

This matches the behavior of Zulip web.

The meaning of this value is that the image is either scaled
according to `contain`, or not scaled at all, whichever makes it
smaller.

In other words, we still scale down all the images we were scaling
down, but we stop scaling any images up, which tended to look a bit
silly.  If the user wants to see the image scaled up, they can
always tap to see it in the lightbox.

This case is about to become more common with the advent of
thumbnailing: when we get a message where the server hasn't yet
gotten to producing a thumbnail, we'll show a placeholder image.
That placeholder is a 30x30 SVG, which looks rather odder if
scaled up to 160px high.

---

content: Show spinner for thumbnail placeholders

This is a port of zulip/zulip#30477.  That PR isn't yet merged, but
it's been deployed on chat.zulip.org and I believe the styling is
unlikely to change.  (If it does get tweaked, we can always update.)

The placeholder `img` elements already come with a `src` pointing
to this same `loader-black.svg` file, but on the Zulip server.
So the effects of this change are:

 * The placeholder image is local instead of remote, which may
   improve the experience a bit on a slow connection.

 * In dark theme, we use an appropriately contrasting white spinner,
   instead of a black spinner that blends in with the background.

Fixes: #5875

---

More specifically that latter commit is a port of this commit:
[4d12bee29](https://github.com/zulip/zulip/commit/4d12bee294caef67590d05d2432255401de41958) thumbnail: Show the right spinner based on dark/light mode.

but that PR branch will presumably be rebased before merge.
