### PR TITLE
tools: In ensure_coreutils, add another place to look for Homebrew

### DIFF
--- a/tools/lib/ensure-coreutils.sh
+++ b/tools/lib/ensure-coreutils.sh
@@ -72,7 +72,7 @@ ensure_coreutils() {
 
     # Else try finding a Homebrew install of coreutils,
     # and putting that on the PATH.
-    homebrew_prefix=$(brew --prefix || :)
+    homebrew_prefix=$(brew --prefix || /opt/homebrew/bin/brew --prefix || :)
     if [ -n "${homebrew_prefix}" ]; then
         # Found Homebrew.  Either use that, or if we can't then
         # print an error with Homebrew-specific instructions.


### PR DESCRIPTION
It might be found at this path on Macs with Apple Silicon.

Discussion:
  https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/Xcode.20on.20new.20laptop/near/1937894