### PR TITLE
deps: Update rollup to 3.x, from the last 2.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "react-test-renderer": "17.0.2",
     "recast": "^0.22.0",
     "redux-mock-store": "^1.5.1",
-    "rollup": "^2.26.5",
+    "rollup": "^3.29.5",
     "sqlite3": "^5.0.2",
     "tsflower": "^0.0.14",
     "typescript": "~4.3.5",

--- a/src/webview/js/generatedEs3.js
+++ b/src/webview/js/generatedEs3.js
@@ -876,8 +876,6 @@ var compiledWebviewJs = (function (exports) {
 
   exports.handleInitialLoad = handleInitialLoad;
 
-  Object.defineProperty(exports, '__esModule', { value: true });
-
   return exports;
 
 })({});

--- a/yarn.lock
+++ b/yarn.lock
@@ -11358,10 +11358,10 @@ rn-fetch-blob@^0.11.0:
     base-64 "0.1.0"
     glob "7.0.6"
 
-rollup@^2.26.5:
-  version "2.79.1"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.79.1.tgz#bedee8faef7c9f93a2647ac0108748f497f081c7"
-  integrity sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==
+rollup@^3.29.5:
+  version "3.29.5"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-3.29.5.tgz#8a2e477a758b520fb78daf04bca4c522c1da8a54"
+  integrity sha512-GVsDdsbJzzy4S/v3dqWPJ7EfvZJfCHiDqe80IyrF59LYuP+e6U1LJoUqeuqRbwAWoMNoXivMNeNAOf5E22VA1w==
   optionalDependencies:
     fsevents "~2.3.2"
 


### PR DESCRIPTION
This is a library we use in tools/generate-webview-js , for producing the generated JS code to go in the message-list webview based on our several source files for it.

This upgrade gets us a large number of changes that don't matter to us because they have no effect on the output JS.  One of those is to fix an XSS vulnerability, CVE-2024-47068:
  https://github.com/rollup/rollup/security/advisories/GHSA-gcx4-mw62-g8wm
which we learned about from Dependabot:
  https://github.com/zulip/zulip-mobile/pull/5893

Even though the vulnerability doesn't affect us, it's good to upgrade past the fix to avoid having to ever re-evaluate whether it affects us. The fix is only in 3.x+, so go to the latest 3.x.

There's also one change affecting the output, which is that the `__esModule` marker goes away.  Seems fine.  That happened in 3.0.0:
  https://github.com/rollup/rollup/blob/master/CHANGELOG.md#300