### PR TITLE
user-groups: Remove deactivated users from groups

### DIFF
--- a/src/api/eventTypes.js
+++ b/src/api/eventTypes.js
@@ -26,6 +26,7 @@ import type {
   UserSettings,
   ClientPresence,
   UserTopic,
+  User,
 } from './modelTypes';
 import type { RealmDataForUpdate } from './realmDataTypes';
 
@@ -422,7 +423,11 @@ export type RealmUserUpdateEventRaw = {|
         // the collections of users and bots in the initial data. Ignore.
         // avatar_source: string,
         // avatar_url_medium: string,
-      |},
+      |}
+    // TODO(flow) should be just one branch with `boolean` instead of
+    //   separate `true` and `false`; investigate errors
+    | {| +user_id: UserOrBot['user_id'], +is_active: true |}
+    | {| +user_id: UserOrBot['user_id'], +is_active: false |},
 |};
 
 /** A realm_user update event, after we've processed it at the edge. */
@@ -449,7 +454,8 @@ export type RealmUserUpdateEvent = {|
         // the collections of users and bots in the initial data. Ignore.
         // avatar_source: string,
         // avatar_url_medium: string,
-      |},
+      |}
+    | {| +user_id: User['user_id'], +is_active: boolean, +existingUser: User |},
 |};
 
 export type UserTopicEvent = {|

--- a/src/events/eventToAction.js
+++ b/src/events/eventToAction.js
@@ -287,6 +287,32 @@ export default (state: PerAccountState, event: $FlowFixMe): EventAction | null =
                 },
               },
             };
+          } else if (person.is_active === true) {
+            const { is_active, user_id } = person;
+            const nonActiveUser = state.realm.nonActiveUsers.find(u => u.user_id === user_id);
+            if (nonActiveUser == null) {
+              logging.warn(
+                'Got realm_user/update event to reactivate a user not found in state.realm.nonActiveUsers',
+              );
+              return null;
+            }
+            return {
+              type: EVENT,
+              event: { ...rawEvent, person: { user_id, is_active, existingUser: nonActiveUser } },
+            };
+          } else if (person.is_active === false) {
+            const { is_active, user_id } = person;
+            const activeUser = state.users.find(u => u.user_id === user_id);
+            if (activeUser == null) {
+              logging.warn(
+                'Got realm_user/update event to deactivate a user not found in state.users',
+              );
+              return null;
+            }
+            return {
+              type: EVENT,
+              event: { ...rawEvent, person: { user_id, is_active, existingUser: activeUser } },
+            };
           } else {
             return {
               type: EVENT,

--- a/src/realm/realmReducer.js
+++ b/src/realm/realmReducer.js
@@ -303,6 +303,20 @@ export default (
           //   `op: 'update_dict'` events near the edge.)
           return state;
 
+        case EventTypes.realm_user: {
+          const { person } = event;
+
+          // TODO(flow) teach Flow that the `person.existingUser != null` is redundant
+          if (person.is_active === false && person.existingUser != null) {
+            return { ...state, nonActiveUsers: [...state.nonActiveUsers, person.existingUser] };
+          } else if (person.is_active === true) {
+            const nonActiveUsers = state.nonActiveUsers.filter(u => u.user_id !== person.user_id);
+            return { ...state, nonActiveUsers };
+          }
+
+          return state;
+        }
+
         case EventTypes.user_settings:
           if (event.op === 'update') {
             const { property, value } = event;

--- a/src/user-groups/userGroupsReducer.js
+++ b/src/user-groups/userGroupsReducer.js
@@ -2,6 +2,7 @@
 import type { UserGroupsState, PerAccountApplicableAction } from '../types';
 import {
   REGISTER_COMPLETE,
+  EVENT,
   EVENT_USER_GROUP_ADD,
   EVENT_USER_GROUP_REMOVE,
   EVENT_USER_GROUP_UPDATE,
@@ -9,6 +10,7 @@ import {
   EVENT_USER_GROUP_REMOVE_MEMBERS,
   RESET_ACCOUNT_DATA,
 } from '../actionConstants';
+import { EventTypes } from '../api/eventTypes';
 import { NULL_ARRAY } from '../nullObjects';
 
 const initialState: UserGroupsState = NULL_ARRAY;
@@ -68,6 +70,33 @@ export default (
 
     case EVENT_USER_GROUP_REMOVE_MEMBERS:
       return eventUserGroupRemoveMembers(state, action);
+
+    case EVENT: {
+      const { event } = action;
+      switch (event.type) {
+        case EventTypes.realm_user: {
+          switch (event.op) {
+            case 'update': {
+              const { person } = event;
+              if (person.is_active === false) {
+                return state.map(g => ({
+                  ...g,
+                  members: g.members.filter(m => m !== person.user_id),
+                }));
+              }
+
+              return state;
+            }
+
+            default:
+              return state;
+          }
+        }
+
+        default:
+          return state;
+      }
+    }
 
     default:
       return state;

--- a/src/users/usersReducer.js
+++ b/src/users/usersReducer.js
@@ -35,8 +35,14 @@ export default (
         case EventTypes.realm_user: {
           switch (event.op) {
             case 'update': {
+              const { person } = event;
+              // TODO(flow) teach Flow that the `person.existingUser != null` is redundant
+              if (person.is_active === true && person.existingUser != null) {
+                return [...state, person.existingUser];
+              } else if (person.is_active === false) {
+                return state.filter(u => u.user_id !== person.user_id);
+              }
               return state.map(user => {
-                const { person } = event;
                 if (user.user_id !== person.user_id) {
                   return user;
                 }
@@ -70,7 +76,13 @@ export default (
                 } else if (person.new_email !== undefined) {
                   return { ...user, email: person.new_email };
                 } else {
-                  return { ...user, ...person };
+                  // eslint-disable-next-line no-unused-vars
+                  const { existingUser, is_active, ...rest } = person;
+
+                  // TODO(flow) Use `...person`, not `...rest`; teach Flow
+                  //   that existingUser and is_active are absent in `person`;
+                  //   see early-returns before the loop-through-users.
+                  return { ...user, ...rest };
                 }
               });
             }


### PR DESCRIPTION
Also move users between `state.users` and `state.realm.nonActiveUsers` in response to `realm_user`/`update` events that have `is_active`.

Fixes: #5899