### PR TITLE
api: On reaction events, stop assuming old `user` object is present

### DIFF
--- a/src/api/modelTypes.js
+++ b/src/api/modelTypes.js
@@ -719,9 +719,6 @@ export type ReactionType = 'unicode_emoji' | 'realm_emoji' | 'zulip_extra_emoji'
 
 /**
  * An emoji reaction to a message.
- *
- * The raw JSON from the server may have a different structure, but we
- * normalize it to this form.
  */
 export type Reaction = $ReadOnly<{|
   user_id: UserId,

--- a/src/events/eventToAction.js
+++ b/src/events/eventToAction.js
@@ -341,14 +341,6 @@ export default (state: PerAccountState, event: $FlowFixMe): EventAction | null =
     case 'reaction':
       return {
         ...event,
-
-        // Raw reaction events from the server have a variation on the
-        // properties of `Reaction`: instead of `user_id: UserId`, they have
-        // `user: {| email: string, full_name: string, user_id: UserId |}`.
-        // NB this is different from the reactions in a `/messages` response;
-        // see `getMessages` to compare.
-        user_id: event.user.user_id,
-
         type: opToActionReaction[event.op],
       };
 


### PR DESCRIPTION
Tested on an iPhone simulator, connected to CZO. Before this change, I saw the message list not updating on reaction events (as Greg highlighted in the [chat thread](https://chat.zulip.org/#narrow/channel/378-api-design/topic/reaction.20data/near/2037736)). After this change, I saw the message list updating as expected when I added/removed reactions.

Fixes: #5911