### PR TITLE
ci: Update to use JDK 17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,10 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Set up JDK
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v4.2.1
       with:
-        java-version: 11
+        java-version: 17
+        distribution: temurin
 
     - name: Set up Android SDK
       uses: android-actions/setup-android@v2


### PR DESCRIPTION
JDK 11 is quite old now.

While here, update all the details of this stanza to match what we do in the zulip-flutter CI.

Fixes: #5913