### PR TITLE
api: Don't allow connecting to servers <5.0; show nag banner on <7.0

### DIFF
--- a/src/api/apiErrors.js
+++ b/src/api/apiErrors.js
@@ -182,7 +182,7 @@ export const interpretApiResponse = (httpStatus: number, data: mixed): mixed => 
  */
 // This should lag a bit behind the threshold version for ServerCompatBanner
 // (kMinSupportedVersion), to give users time to see and act on the banner.
-export const kMinAllowedServerVersion: ZulipVersion = new ZulipVersion('4.0');
+export const kMinAllowedServerVersion: ZulipVersion = new ZulipVersion('5.0');
 
 /**
  * An error we throw in API bindings on finding a server is too old.

--- a/src/common/ServerCompatBanner.js
+++ b/src/common/ServerCompatBanner.js
@@ -32,14 +32,14 @@ export const kServerSupportDocUrl: URL = new URL(
  * See also kMinAllowedServerVersion in apiErrors.js, for the version below
  * which we just refuse to connect.
  */
-export const kMinSupportedVersion: ZulipVersion = new ZulipVersion('5.0');
+export const kMinSupportedVersion: ZulipVersion = new ZulipVersion('7.0');
 
 /**
  * The next value we'll give to kMinSupportedVersion in the future.
  *
  * This should be the next major Zulip Server version after kMinSupportedVersion.
  */
-export const kNextMinSupportedVersion: ZulipVersion = new ZulipVersion('6.0');
+export const kNextMinSupportedVersion: ZulipVersion = new ZulipVersion('8.0');
 
 type Props = $ReadOnly<{||}>;
 


### PR DESCRIPTION
(The branch is misnamed; I realized after writing it that we can show the nag banner on 6.x too. 🙂)

    api: Don't allow connecting to servers <5.0; show nag banner on <7.0
    
    See 8552afce9 for the previous one of these.
    
    The Zulip Server 5 release went out over 3 years ago, so the 4.x
    releases are all long out of our announced 18-month compatibility
    window:
      https://blog.zulip.com/2022/03/29/zulip-5-0-released/
      https://zulip.readthedocs.io/en/latest/overview/release-lifecycle.html#client-apps
    
    So we can cheerfully refuse to connect to 4.x releases; our "Server
    not supported" nag banner has been asking server admins on those
    versions to upgrade since 8552afce9, which the changelog says went
    out in v27.216, dated 2023-10-10.
    
    The last 6.x release, 6.2, went out on 2023-05-19. That's also
    outside the 18-month window, so it's time to start showing the nag
    banner on 5.x and 6.x.
    
    The last 7.x release, 7.5, went out on 2023-11-16, which is a month
    and a bit shy of 18 months, so it's not yet time to show the banner
    for versions 7.x.