### PR TITLE
docs: Update instructions for dev server and testing push notifications

### DIFF
--- a/docs/howto/dev-server.md
+++ b/docs/howto/dev-server.md
@@ -29,7 +29,7 @@ sections below.
 - [ ] Find your computer's IP address on your LAN; perhaps try
       `ip route get 8 | perl -lne '/src (\S+)/ && print $1'`.
 - [ ] Check your `~/.zulip-vagrant-config` (outside the dev VM).
-- [ ] Run the server like `EXTERNAL_HOST=${ip_address}:9991 tools/run-dev.py`.
+- [ ] Run the server like `EXTERNAL_HOST=${ip_address}:9991 tools/run-dev`.
 - [ ] Log in at `http://${ip_address}:9991`.  Type `http://` explicitly.
 
 
@@ -42,9 +42,9 @@ For most people the recommended setup uses Vagrant to manage a VM containing
 the Zulip server.  If you choose instead to run the Zulip server directly on
 your host machine, these instructions will work with some variations.
 
-You'll run the Zulip server in the dev VM with `tools/run-dev.py`, following
+You'll run the Zulip server in the dev VM with `tools/run-dev`, following
 the usual instructions for Zulip server development (linked above).  [Step
-4](#4-set-external_host) below adds some options to the `run-dev.py` command
+4](#4-set-external_host) below adds some options to the `run-dev` command
 to make it accessible from the mobile app.
 
 
@@ -154,10 +154,10 @@ Then restart the Vagrant guest using `vagrant reload`.
 ### If running server directly on host
 
 If you're running the Zulip server directly on your computer, then you
-control this by passing the option `--interface=` to `tools/run-dev.py`.
+control this by passing the option `--interface=` to `tools/run-dev`.
 For example:
 <pre>
-    $ tools/run-dev.py <strong>--interface=</strong>
+    $ tools/run-dev <strong>--interface=</strong>
 </pre>
 
 (But you'll probably add more to the command too; see step 4.)
@@ -179,13 +179,13 @@ example, if in step 2 you chose 10.0.2.2, then run the server with this
 command:
 
 <pre>
-  $ <strong>EXTERNAL_HOST=10.0.2.2:9991</strong> tools/run-dev.py
+  $ <strong>EXTERNAL_HOST=10.0.2.2:9991</strong> tools/run-dev
 </pre>
 
 or if step 3 called for `--interface=`, then
 
 <pre>
-  $ <strong>EXTERNAL_HOST=10.0.2.2:9991</strong> tools/run-dev.py --interface=
+  $ <strong>EXTERNAL_HOST=10.0.2.2:9991</strong> tools/run-dev --interface=
 </pre>
 
 (Note for Zulip server experts: This also sets `REALM_HOSTS`, via some logic

--- a/docs/howto/push-notifications.md
+++ b/docs/howto/push-notifications.md
@@ -95,13 +95,13 @@ First, three one-time setup steps:
    this command registers with the bouncer are kept in the
    `zproject/dev-secrets.conf` file.
 
-   If you were already running `tools/run-dev.py`, quit and restart it
+   If you were already running `tools/run-dev`, quit and restart it
    after these setup steps.
 
 
 Then, each time you test:
 
-1. Run `tools/run-dev.py` according to the instructions in
+1. Run `tools/run-dev` according to the instructions in
    [dev-server.md](dev-server.md).  Then follow that doc's
    instructions to log into the dev server.  Use the release build of
    the app -- that is, the Zulip app installed from the App Store or

--- a/docs/howto/push-notifications.md
+++ b/docs/howto/push-notifications.md
@@ -227,10 +227,45 @@ on that is
 
 You should now be getting notifications on your iOS development build!
 
+
+#### Troubleshooting
+
 If it's not working, first check that mobile notification settings are
-on, using the web app's settings interface.  Then please ask for help
+on, using the web app's settings interface.  See also the
+troubleshooting items below.
+
+If none of those resolve the issue, please ask for help
 in [#mobile-dev-help](https://chat.zulip.org/#narrow/stream/516-mobile-dev-help) on
 chat.zulip.org, so we can debug.
+
+
+##### Error: Your plan doesn't allow sending push notifications
+
+After the above setup is done, when the dev server tries to send a
+notification (e.g. because you had some other user send a DM to the
+user you've logged in as from the mobile app), you might get an error
+like this one (reformatted for readability):
+
+```
+INFO [zerver.lib.push_notifications] Sending push notifications to mobile clients for user 11
+INFO [zr] 127.0.0.1       POST    400   8ms (db: 3ms/6q) /api/v1/remotes/push/notify [can_push=False/Missing data] (zulip-server:… via ZulipServer/11.0-dev+git)
+INFO [zr] status=400, data=b'{"result":"error","msg":"Your plan doesn\'t allow sending push notifications.","code":"INVALID_ZULIP_SERVER"}\n', uid=zulip-server:…
+WARN [django.server] "POST /api/v1/remotes/push/notify HTTP/1.1" 400 109
+ERR  [] Problem handling data on queue missedmessage_mobile_notifications
+Traceback (most recent call last):
+…
+  File "/srv/zulip/zerver/lib/remote_server.py", line 195, in send_to_push_bouncer
+    raise PushNotificationBouncerError(
+zerver.lib.remote_server.PushNotificationBouncerError:
+  Push notifications bouncer error: Your plan doesn't allow sending push notifications.
+```
+
+It's not clear why this happens.  Try stopping the server
+(i.e. `tools/run-dev`) and starting it again.  On the
+[one occasion][error-plan-missing] this error has been seen
+as of this writing, the error went away after doing so.
+
+[error-plan-missing]: https://chat.zulip.org/#narrow/channel/243-mobile-team/topic/notifications.20from.20dev.20server/near/2163051
 
 
 ### Another workaround (if the first doesn't work)

--- a/docs/howto/push-notifications.md
+++ b/docs/howto/push-notifications.md
@@ -70,21 +70,27 @@ First, three one-time setup steps:
 2. Create a `zproject/custom_dev_settings.py` with the following line:
 
    ```python
-   PUSH_NOTIFICATION_BOUNCER_URL = 'https://push.zulipchat.com'
+   ZULIP_SERVICES_URL = 'https://push.zulipchat.com'
    ```
 
-   This matches the default setting for a production install of the
-   Zulip server (generated from `zproject/prod_settings_template.py`.)
+   This matches the normal setting for a production install of the
+   Zulip server (set by `zproject/default_settings.py`).
 
    The Zulip server will helpfully print a line on startup to remind
    you that this settings override file exists.
 
 3. Register your development server with our production bouncer by
-   running the following command:
+   running a command like this one, but with `[yourname]` replaced by
+   your name:
 
    ```
-   python manage.py register_server --agree_to_terms_of_service
+   EXTERNAL_HOST=[yourname].zulipdev.com:9991 python manage.py register_server --agree-to-terms-of-service
    ```
+
+   (The exact value of `EXTERNAL_HOST` doesn't matter; in particular
+   it doesn't need to match the `EXTERNAL_HOST` that you use when
+   actually running the server, with `tools/run-dev`.  It does need to
+   be distinct from any names that others have already registered.)
 
    This is a variation of our [instructions for production
    deployments](https://zulip.readthedocs.io/en/latest/production/mobile-push-notifications.html),
@@ -95,7 +101,7 @@ First, three one-time setup steps:
    this command registers with the bouncer are kept in the
    `zproject/dev-secrets.conf` file.
 
-   If you were already running `tools/run-dev`, quit and restart it
+4. If you were already running `tools/run-dev`, quit and restart it
    after these setup steps.
 
 


### PR DESCRIPTION
Chat thread: [#mobile-team > notifications from dev server @ 💬](https://chat.zulip.org/#narrow/channel/243-mobile-team/topic/notifications.20from.20dev.20server/near/2159855)

This is a companion change to:
* https://github.com/zulip/zulip/pull/34512

## Commit messages

#### e632d77d4 docs: Update dev-server instructions for tools/run-dev rename

This name got cleaned up, hooray.  (A couple of years ago --
zulip/zulip@43b4f1057 -- but we use these instructions only
occasionally and update them less often than that.)


#### 3fa6250b8 docs/push-notifications: Update how to register with bouncer

In particular PUSH_NOTIFICATION_BOUNCER_URL was replaced by
ZULIP_SERVICES_URL last year, in zulip/zulip@4a9314943.

I believe the need for a distinct EXTERNAL_HOST value when
registering the server with the bouncer came about as part of the
same work around the same time, though it may have been in a
different commit.

Also at some point the spelling of the flag got fixed to use
hyphens as in the normal CLI convention.

Chat thread, where I found the existing instructions no longer
worked and then we debugged:
  https://chat.zulip.org/#narrow/channel/243-mobile-team/topic/notifications.20from.20dev.20server/near/2159857

With these changes, the instructions work for me.  (I didn't wipe my
dev server to verify it works from there, but I did reset all the
state I believe is relevant: removed my old custom_dev_settings.py
and the two `zulip_org_*` items from dev-secrets.conf .)


#### 91f5c3289 docs/push-notifications: Add troubleshooting for missing "plan"
