### PR TITLE
api: Don't allow connecting to servers <7.0; show nag banner on <8.0

### DIFF
--- a/src/api/apiErrors.js
+++ b/src/api/apiErrors.js
@@ -182,7 +182,7 @@ export const interpretApiResponse = (httpStatus: number, data: mixed): mixed => 
  */
 // This should lag a bit behind the threshold version for ServerCompatBanner
 // (kMinSupportedVersion), to give users time to see and act on the banner.
-export const kMinAllowedServerVersion: ZulipVersion = new ZulipVersion('5.0');
+export const kMinAllowedServerVersion: ZulipVersion = new ZulipVersion('7.0');
 
 /**
  * An error we throw in API bindings on finding a server is too old.

--- a/src/common/ServerCompatBanner.js
+++ b/src/common/ServerCompatBanner.js
@@ -32,14 +32,14 @@ export const kServerSupportDocUrl: URL = new URL(
  * See also kMinAllowedServerVersion in apiErrors.js, for the version below
  * which we just refuse to connect.
  */
-export const kMinSupportedVersion: ZulipVersion = new ZulipVersion('7.0');
+export const kMinSupportedVersion: ZulipVersion = new ZulipVersion('8.0');
 
 /**
  * The next value we'll give to kMinSupportedVersion in the future.
  *
  * This should be the next major Zulip Server version after kMinSupportedVersion.
  */
-export const kNextMinSupportedVersion: ZulipVersion = new ZulipVersion('8.0');
+export const kNextMinSupportedVersion: ZulipVersion = new ZulipVersion('9.0');
 
 type Props = $ReadOnly<{||}>;
 


### PR DESCRIPTION
The last one of these was 48f1e4724 on 2025-04-04, released in v27.234 on 2025-04-24.

As mentioned there, the last 6.x release, 6.2, went out on 2023-05-19, which is outside the 18-month window. We've been showing the nag banner for that release since v27.234, so we can expect server admins to have seen and acted on it, and we can refuse to connect.

The last 7.x release, 7.5, went out on 2023-11-16, which turns 18 months old tomorrow, 2025-05-16. So we can start to show the nag banner for that.